### PR TITLE
MAPREDUCE-6096.SummarizedJob Class Improvment

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/HistoryViewer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/HistoryViewer.java
@@ -602,7 +602,7 @@ public class HistoryViewer {
         for (JobHistoryParser.TaskAttemptInfo attempt : attempts.values()) {
           long startTime = attempt.getStartTime(); 
           long finishTime = attempt.getFinishTime();
-          if (attempt.getTaskType().equals(TaskType.MAP)) {
+          if (TaskType.MAP.equals(attempt.getTaskType())) {
             if (mapStarted== 0 || mapStarted > startTime) {
               mapStarted = startTime; 
             }
@@ -610,14 +610,13 @@ public class HistoryViewer {
               mapFinished = finishTime; 
             }
             totalMaps++; 
-            if (attempt.getTaskStatus().equals
-                (TaskStatus.State.FAILED.toString())) {
+            if (TaskStatus.State.FAILED.toString().equals(attempt.getTaskStatus())) {
               numFailedMaps++; 
             } else if (attempt.getTaskStatus().equals
                 (TaskStatus.State.KILLED.toString())) {
               numKilledMaps++;
             }
-          } else if (attempt.getTaskType().equals(TaskType.REDUCE)) {
+          } else if (TaskType.REDUCE.equals(attempt.getTaskType())) {
             if (reduceStarted==0||reduceStarted > startTime) {
               reduceStarted = startTime; 
             }
@@ -625,14 +624,14 @@ public class HistoryViewer {
               reduceFinished = finishTime; 
             }
             totalReduces++; 
-            if (attempt.getTaskStatus().equals
-                (TaskStatus.State.FAILED.toString())) {
+            if (TaskStatus.State.FAILED.toString().equals
+                    (attempt.getTaskStatus())) {
               numFailedReduces++; 
-            } else if (attempt.getTaskStatus().equals
-                (TaskStatus.State.KILLED.toString())) {
+            } else if (TaskStatus.State.KILLED.toString().equals
+                (attempt.getTaskStatus())) {
               numKilledReduces++;
             }
-          } else if (attempt.getTaskType().equals(TaskType.JOB_CLEANUP)) {
+          } else if (TaskType.JOB_CLEANUP.equals(attempt.getTaskType())) {
             if (cleanupStarted==0||cleanupStarted > startTime) {
               cleanupStarted = startTime; 
             }
@@ -640,17 +639,17 @@ public class HistoryViewer {
               cleanupFinished = finishTime; 
             }
             totalCleanups++; 
-            if (attempt.getTaskStatus().equals
-                (TaskStatus.State.SUCCEEDED.toString())) {
+            if (TaskStatus.State.SUCCEEDED.toString().equals
+                (attempt.getTaskStatus())) {
               numFinishedCleanups++; 
-            } else if (attempt.getTaskStatus().equals
-                (TaskStatus.State.FAILED.toString())) {
+            } else if (TaskStatus.State.FAILED.toString().equals
+                (attempt.getTaskStatus())) {
               numFailedCleanups++;
-            } else if (attempt.getTaskStatus().equals
-                (TaskStatus.State.KILLED.toString())) {
+            } else if (TaskStatus.State.KILLED.toString().equals
+                (attempt.getTaskStatus())) {
               numKilledCleanups++;
             }
-          } else if (attempt.getTaskType().equals(TaskType.JOB_SETUP)) {
+          } else if (TaskType.JOB_SETUP.equals(attempt.getTaskType())) {
             if (setupStarted==0||setupStarted > startTime) {
               setupStarted = startTime; 
             }
@@ -658,14 +657,14 @@ public class HistoryViewer {
               setupFinished = finishTime; 
             }
             totalSetups++; 
-            if (attempt.getTaskStatus().equals
-                (TaskStatus.State.SUCCEEDED.toString())) {
+            if (TaskStatus.State.SUCCEEDED.toString().equals
+                (attempt.getTaskStatus())) {
               numFinishedSetups++;
-            } else if (attempt.getTaskStatus().equals
-                (TaskStatus.State.FAILED.toString())) {
+            } else if (TaskStatus.State.FAILED.toString().equals
+                (attempt.getTaskStatus())) {
               numFailedSetups++;
-            } else if (attempt.getTaskStatus().equals
-                (TaskStatus.State.KILLED.toString())) {
+            } else if (TaskStatus.State.KILLED.toString().equals
+                (attempt.getTaskStatus())) {
               numKilledSetups++;
             }
           }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MAPREDUCE-6096

SummarizedJob class should be Improvment

When I Parse the JobHistory in the HistoryFile,I use the Hadoop System's map-reduce-client-core project org.apache.hadoop.mapreduce.jobhistory.JobHistoryParser class and HistoryViewer$SummarizedJob to Parse the JobHistoryFile(Just Like job_1408862281971_489761-1410883171851_XXX.jhist) 
and it throw an Exception Just Like 
Exception in thread "pool-1-thread-1" java.lang.NullPointerException
at org.apache.hadoop.mapreduce.jobhistory.HistoryViewer$SummarizedJob.<init>(HistoryViewer.java:626)
at com.jd.hadoop.log.parse.ParseLogService.getJobDetail(ParseLogService.java:70)

After I'm see the SummarizedJob class I find that attempt.getTaskStatus() is NULL ，
So I change the order of attempt.getTaskStatus().equals (TaskStatus.State.FAILED.toString()) to 
TaskStatus.State.FAILED.toString().equals(attempt.getTaskStatus()) 
and it works well .
