### PR TITLE
YARN-3126. FairScheduler: queue's usedResource is always more than the maxResource limit.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueue.java
@@ -265,6 +265,21 @@ public abstract class FSQueue implements Queue, Schedulable {
     }
     return true;
   }
+  
+  /**
+   * helper method to check if this resource request should be assigned <br/>
+   * this check based on a equation:  resourceRequest + resourceUsed should be less than resourceMaxLimit
+   * @param resource
+   * @return   
+   */
+  public boolean checkQueueResourceLimit(Resource resource) {
+	Resource resourceWillUse = Resources.add(resource, getResourceUsage());
+	if ( !Resources.fitsIn( resourceWillUse,
+		scheduler.getAllocationConfiguration().getMaxResources(getName())) ) {
+		return false; 
+	}
+	return true; 
+  }
 
   /**
    * Returns true if queue has at least one app running.


### PR DESCRIPTION
This change add a check, for whether queue's usedResource may run over its maxResource Limit after a new resource allocation. 