### PR TITLE
[HADOOP-12081] Support Hadoop on zLinux - fix JAAS authentication issue

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -368,8 +368,12 @@ public class UserGroupInformation {
   
   private static final boolean windows =
       System.getProperty("os.name").startsWith("Windows");
+
+  // s390x for zLinux (64 bit)
   private static final boolean is64Bit =
-      System.getProperty("os.arch").contains("64");
+      System.getProperty("os.arch").contains("64") || 
+      System.getProperty("os.arch").contains("s390x");
+      
   private static final boolean aix = System.getProperty("os.name").equals("AIX");
 
   /* Return the OS login module class name */


### PR DESCRIPTION
Currently the 64 bit check in security/UserGroupInformation.java uses os.arch and checks for "64". s390x is returned on IBM's z platform: s390x is 64 bit. Without this change, if we try to use HDFS with Spark, we get a fatal error (unable to login as we can't find a login class).
This address fixes said issue by identifying s390x as a 64 bit platform and thus allowing Spark to run on zLinux. A simple fix with very big implications!

I've tested this builds and works as expected on zLinux.