### PR TITLE
update Shell.java to avoid OOM

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -421,7 +421,7 @@ abstract public class Shell {
   /** Token separator regex used to parse Shell tool outputs */
   public static final String TOKEN_SEPARATOR_REGEX
                 = WINDOWS ? "[|\n\r]" : "[ \t\n\r\f]";
-
+  private static final int ERROR_MSG_MAX_LENGTH = 1024 * 1024;
   private long    interval;   // refresh interval in msec
   private long    lastTime;   // last time the command was performed
   final private boolean redirectErrorStream; // merge stdout and stderr
@@ -528,6 +528,8 @@ abstract public class Shell {
           while((line != null) && !isInterrupted()) {
             errMsg.append(line);
             errMsg.append(System.getProperty("line.separator"));
+            errMsg.delete(0, (errMsg.length() - ERROR_MSG_MAX_LENGTH < 0) ? 0
+              : (errMsg.length() - ERROR_MSG_MAX_LENGTH));
             line = errReader.readLine();
           }
         } catch(IOException ioe) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -422,6 +422,7 @@ abstract public class Shell {
   public static final String TOKEN_SEPARATOR_REGEX
                 = WINDOWS ? "[|\n\r]" : "[ \t\n\r\f]";
   private static final int ERROR_MSG_MAX_LENGTH = 1024 * 1024;
+  
   private long    interval;   // refresh interval in msec
   private long    lastTime;   // last time the command was performed
   final private boolean redirectErrorStream; // merge stdout and stderr


### PR DESCRIPTION
avoid out of memory(such as NodeManager OOM), in case running a command which has verbose error log continuously