### PR TITLE
Showing the path is empty message in ls command

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Ls.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Ls.java
@@ -216,6 +216,10 @@ class Ls extends FsCommand {
       if (!pathOnly) {
         out.println("Found " + items.length + " items");
       }
+      else if (items.length == 0)
+      {
+        out.println("The path is empty.");
+      }
       Arrays.sort(items, getOrderComparator());
     }
     if (!pathOnly) {


### PR DESCRIPTION
When the user lists an empty folder with 'hadoop fs -ls /tmp/emptyfolder', a message will apear that says 'The path is empty'. Otherwise, nothing will appear and the user does not know it has been done or not.