### PR TITLE
remove space before colon in decommission status

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DatanodeInfo.java
@@ -339,7 +339,7 @@ public class DatanodeInfo extends DatanodeID implements Node {
     if (!NetworkTopology.DEFAULT_RACK.equals(location)) {
       buffer.append("Rack: "+location+"\n");
     }
-    buffer.append("Decommission Status : ");
+    buffer.append("Decommission Status: ");
     if (isDecommissioned()) {
       buffer.append("Decommissioned\n");
     } else if (isDecommissionInProgress()) {


### PR DESCRIPTION
Not sure if this was intentional but can imagine it complicates things for anyone trying to parse reports