### PR TITLE
YARN-3477 TimelineClientImpl swallows exceptions

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
@@ -338,7 +338,7 @@ public class YarnClientImpl extends YarnClient {
     }
     credentials.addToken(timelineService, timelineDelegationToken);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Add timline delegation token into credentials: "
+      LOG.debug("Add timeline delegation token to credentials: "
           + timelineDelegationToken);
     }
     DataOutputBuffer dob = new DataOutputBuffer();
@@ -354,8 +354,10 @@ public class YarnClientImpl extends YarnClient {
           return timelineClient.getDelegationToken(timelineDTRenewer);
         } catch (Exception e ) {
           if (timelineServiceBestEffort) {
-            LOG.warn("Failed to get delegation token from the timeline server: "
+            LOG.warn("Failed to get delegation token from the timeline server;" +
+                " timeline client no longer publishing data: "
                 + e.getMessage());
+            LOG.debug("Full exception details", e);
             return null;
           }
           throw e;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineClientImpl.java
@@ -93,7 +93,8 @@ public class TimelineClientImpl extends TimelineClient {
   public final static int DEFAULT_SOCKET_TIMEOUT = 1 * 60 * 1000; // 1 minute
   public static final String ERROR_NO_ATS_RESPONSE
       = "Failed to get the response from the timeline server";
-  public static final String ERROR_RETRIES_EXCEEDED = "Failed to connect to timeline server";
+  public static final String ERROR_RETRIES_EXCEEDED =
+    "Failed to connect to timeline server";
 
   private static Options opts;
   private static final String ENTITY_DATA_TYPE = "entity";
@@ -214,8 +215,8 @@ public class TimelineClientImpl extends TimelineClient {
       // reached only if the retry count has been exceeded.
       // therefore, lastException no-null
       String message = ERROR_RETRIES_EXCEEDED
-          + "Connection retries limit (" + maxRetries + ") exceeded. "
-          + "The posted timeline event may be missing : " + lastException;
+          + " Connection retries limit (" + maxRetries + ") exceeded."
+          + " The posted timeline event may be missing : " + lastException;
       LOG.warn(message, lastException);
 
       throw new RuntimeException(message, lastException);


### PR DESCRIPTION
YARN-3477 timeline diagnostics: add more details on why things are failing, including stack traces (at debug level sometimes)
