### PR TITLE
HADOOP-12587 Hadoop auth token refused to work without a maxinactive attribute in issued token

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/AuthToken.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/AuthToken.java
@@ -210,7 +210,19 @@ public class AuthToken implements Principal {
     map.remove("s");
 
     if (!map.keySet().equals(ATTRIBUTES)) {
-      throw new AuthenticationException("Invalid token string, missing attributes");
+      StringBuilder missing = new StringBuilder();
+      StringBuilder present = new StringBuilder();
+      for (String attribute : ATTRIBUTES) {
+        String val = map.get(attribute);
+        if (val != null) {
+          present.append(attribute + "= " + val + "; ");
+        } else {
+          missing.append(attribute).append(" ");
+        }
+      }
+      throw new AuthenticationException("Incomplete token string"
+        + " -present: " + present
+        + " Missing attributes: [ " + missing + "]");
     }
     long maxInactives = Long.parseLong(map.get(MAX_INACTIVES));
     long expires = Long.parseLong(map.get(EXPIRES));


### PR DESCRIPTION
This initial patch is not a fix. This is the patch to diagnose why I cannot submit work to a secure cluster and so identify the change that actually broke things.

I would propose that the max-inactive value is considered optional, defaulting to -1 as the code itself appears to do elsewhere.