### PR TITLE
HDFS-9443. Disabling HDFS client socket cache causes logging message …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PeerCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PeerCache.java
@@ -100,7 +100,7 @@ public class PeerCache {
     this.expiryPeriod = e;
 
     if (capacity == 0 ) {
-      LOG.info("SocketCache disabled.");
+      LOG.debug("SocketCache disabled.");
     } else if (expiryPeriod == 0) {
       throw new IllegalStateException("Cannot initialize expiryPeriod to " +
          expiryPeriod + " when cache is enabled.");


### PR DESCRIPTION
…printed to console for CLI commands.

This is a trivial patch to change the log statement to debug level.
