### PR TITLE
HADOOP-11601 FileStatus.getBlocksize() >0 for non-empty files

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -456,7 +456,9 @@ split calculations to divide work optimally across a set of worker processes.
 
 Although there is no defined minimum value for this result, as it
 is used to partition work during job submission, a block size
-that is too small will result in badly partitioned workload.
+that is too small will result in badly partitioned workload,
+or even the `JobSubmissionClient` and equivalent
+running out of memory as it calculates the partitions.
 
 Any FileSystem that does not actually break files into blocks SHOULD
 return a number for this that results in efficient processing.

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -78,6 +78,7 @@ Get the status of a path
         if isFile(FS, p) :
             stat.length = len(FS.Files[p])
             stat.isdir = False
+            stat.blockSize > 0
         elif isDir(FS, p) :
             stat.length = 0
             stat.isdir = True
@@ -451,13 +452,11 @@ split calculations to divide work optimally across a set of worker processes.
 
 #### Postconditions
 
-    result = integer >= 0
+    result = integer > 0
 
 Although there is no defined minimum value for this result, as it
 is used to partition work during job submission, a block size
-that is too small will result in either too many jobs being submitted
-for efficient work, or the `JobSubmissionClient` running out of memory.
-
+that is too small will result in badly partitioned workload.
 
 Any FileSystem that does not actually break files into blocks SHOULD
 return a number for this that results in efficient processing.
@@ -503,12 +502,12 @@ on the filesystem.
 
 #### Postconditions
 
-
+    if len(FS, P) > 0: getFileStatus(P).getBlockSize() > 0
     result == getFileStatus(P).getBlockSize()
 
-The outcome of this operation MUST be identical to that contained in
-the `FileStatus` returned from `getFileStatus(P)`.
-
+1. The outcome of this operation MUST be identical to the value of
+   `getFileStatus(P).getBlockSize()`.
+1. By inference, it MUST be > 0 for any file of length > 0.
 
 ## State Changing Operations
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCreateTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCreateTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractContractCreateTest extends
                              e);
     } catch (IOException e) {
       handleRelaxedException("overwriting a dir with a file ",
-                             "IOException",
+                             "FileAlreadyExistsException",
                              e);
     }
     assertIsDirectory(path);
@@ -154,11 +154,11 @@ public abstract class AbstractContractCreateTest extends
       handleExpectedException(expected);
     } catch (FileNotFoundException e) {
       handleRelaxedException("overwriting a dir with a file ",
-          "FileAlreadyExistsException",
-          e);
+                             "FileAlreadyExistsException",
+                             e);
     } catch (IOException e) {
       handleRelaxedException("overwriting a dir with a file ",
-                             "IOException",
+                             "FileAlreadyExistsException",
                              e);
     }
     assertIsDirectory(path);
@@ -182,7 +182,7 @@ public abstract class AbstractContractCreateTest extends
           skip("This Filesystem delays visibility of newly created files");
         }
         assertPathExists("expected path to be visible before anything written",
-            path);
+                         path);
       }
     }
   }
@@ -252,17 +252,14 @@ public abstract class AbstractContractCreateTest extends
         status.getBlockSize() > 0);
     
     long defaultBlockSize = fs.getDefaultBlockSize(path);
-    assertTrue("fs.getDefaultBlockSize(path) size is invalid "+ defaultBlockSize,
+    assertTrue("fs.getDefaultBlockSize(path) size is invalid " + defaultBlockSize,
         defaultBlockSize > 0);
   }
-
   
   @Test
   public void testFileStatusBlocksizeEmptyFile() throws Throwable {
     describe("check that an empty file may return a 0-byte blocksize");
     FileSystem fs = getFileSystem();
-
-
     Path path = path("testFileStatusBlocksizeEmptyFile");
     ContractTestUtils.touch(fs, path);
 
@@ -275,7 +272,5 @@ public abstract class AbstractContractCreateTest extends
     assertTrue("fs.getDefaultBlockSize(path) size is invalid "+ defaultBlockSize,
         defaultBlockSize >= 0);
   }
-
-  
   
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -1109,7 +1109,7 @@ public class ContractTestUtils extends Assert {
    *    <i>other than file not found</i>
    */
   public static FileStatus getFileStatusEventually(FileSystem fs, Path path,
-      int timeout) throws IOException {
+      int timeout) throws IOException, InterruptedException {
     long endTime = System.currentTimeMillis() + timeout;
     FileStatus stat = null;
     do {
@@ -1119,6 +1119,8 @@ public class ContractTestUtils extends Assert {
         if (System.currentTimeMillis() > endTime) {
           // timeout, raise an assert with more diagnostics
           assertPathExists(fs, "Path not found after " + timeout + " mS", path);
+        } else {
+          Thread.sleep(50);
         }
       }
     } while (stat == null);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.hadoop.util.StopWatch;
 import org.junit.Assert;
 import org.junit.internal.AssumptionViolatedException;
 import org.slf4j.Logger;


### PR DESCRIPTION
Enhance FS spec & tests to mandate FileStatus.getBlocksize() >0 for non-empty files
