### PR TITLE
MAPREDUCE-6475 cleanup 

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
@@ -2862,35 +2862,38 @@ public class TestRMContainerAllocator {
 
     Configuration conf = new Configuration();
     MyResourceManager rm = new MyResourceManager(conf);
-    rm.start();
-    DrainDispatcher dispatcher = (DrainDispatcher) rm.getRMContext()
+    try {
+      DrainDispatcher dispatcher = (DrainDispatcher) rm.getRMContext()
         .getDispatcher();
 
-    // Submit the application
-    RMApp app = rm.submitApp(1024);
-    dispatcher.await();
+      // Submit the application
+      RMApp app = rm.submitApp(1024);
+      dispatcher.await();
 
-    MockNM amNodeManager = rm.registerNode("amNM:1234", 2048);
-    amNodeManager.nodeHeartbeat(true);
-    dispatcher.await();
+      MockNM amNodeManager = rm.registerNode("amNM:1234", 2048);
+      amNodeManager.nodeHeartbeat(true);
+      dispatcher.await();
 
-    ApplicationAttemptId appAttemptId = app.getCurrentAppAttempt()
+      ApplicationAttemptId appAttemptId = app.getCurrentAppAttempt()
         .getAppAttemptId();
-    rm.sendAMLaunched(appAttemptId);
-    dispatcher.await();
+      rm.sendAMLaunched(appAttemptId);
+      dispatcher.await();
 
-    JobId jobId = MRBuilderUtils.newJobId(appAttemptId.getApplicationId(), 0);
-    Job mockJob = mock(Job.class);
-    when(mockJob.getReport()).thenReturn(
+      JobId jobId = MRBuilderUtils.newJobId(appAttemptId.getApplicationId(), 0);
+      Job mockJob = mock(Job.class);
+      when(mockJob.getReport()).thenReturn(
         MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
-            0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
-    MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
+          0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
+      MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
         appAttemptId, mockJob);
 
-    // Now kill the application
-    rm.killApp(app.getApplicationId());
-    rm.waitForState(app.getApplicationId(), RMAppState.KILLED);
-    allocator.schedule();
+      // Now kill the application
+      rm.killApp(app.getApplicationId());
+      rm.waitForState(app.getApplicationId(), RMAppState.KILLED);
+      allocator.schedule();
+    } finally {
+      rm.stop();
+    }
   }
 
   private static class MockScheduler implements ApplicationMasterProtocol {


### PR DESCRIPTION
This rebase on trunk cleans up `TestRMContainerAllocator.testAttemptNotFoundCausesRMCommunicatorException`

MAPREDUCE-6439 has probably fixed the underlying problem; all that's left of this patch is a stop of the mock rm; minor