### PR TITLE
HDFS-9459. hadoop-hdfs-native-client fails test build on Windows afte…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml
@@ -162,15 +162,13 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
                   <target>
                     <property name="compile_classpath" refid="maven.compile.classpath"/>
                     <property name="test_classpath" refid="maven.test.classpath"/>
-                    <target>
-                      <property name="compile_classpath" refid="maven.compile.classpath"/>
-                      <property name="test_classpath" refid="maven.test.classpath"/>
-                      <exec executable="ctest" failonerror="true" dir="${project.build.directory}/">
-                        <env key="CLASSPATH" value="${test_classpath}:${compile_classpath}"/>
-                        <!-- Make sure libhadoop.so is on LD_LIBRARY_PATH. -->
-                        <env key="LD_LIBRARY_PATH" value="${env.LD_LIBRARY_PATH}:${project.build.directory}/target/usr/local/lib:${hadoop.common.build.dir}/native/target/usr/local/lib"/>
-                      </exec>
-                    </target>
+                    <exec executable="ctest" failonerror="true" dir="${project.build.directory}/native">
+                      <env key="CLASSPATH" value="${test_classpath}:${compile_classpath}"/>
+                      <!-- HADOOP_HOME required to find winutils. -->
+                      <env key="HADOOP_HOME" value="${hadoop.common.build.dir}"/>
+                      <!-- Make sure hadoop.dll and jvm.dll are on PATH. -->
+                      <env key="PATH" value="${env.PATH};${hadoop.common.build.dir}/bin;${java.home}/jre/bin/server;${java.home}/bin/server"/>
+                    </exec>
                   </target>
                 </configuration>
               </execution>


### PR DESCRIPTION
…r transition to ctest.

I verified that the hadoop-hdfs-native-client tests build correctly and run successfully after applying this patch.