### PR TITLE
NNStorage does not synchronize iteration on a synchronized list

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NNStorage.java
@@ -836,8 +836,10 @@ public class NNStorage extends Storage implements Closeable,
    * @param sds A list of storage directories to mark as errored.
    */
   void reportErrorsOnDirectories(List<StorageDirectory> sds) {
-    for (StorageDirectory sd : sds) {
-      reportErrorsOnDirectory(sd);
+    synchronized(sds) {
+      for (StorageDirectory sd : sds) {
+        reportErrorsOnDirectory(sd);
+      }
     }
   }
 


### PR DESCRIPTION
In line 839 of NNStroage.java#reportErrorsOnDirectories, the synchronized list, `sds`
is iterated in an unsynchronized manner, but according to [Oracle Java 7 API specification]
(http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedList(java.util.List)),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration on `sds`. The synchronized list is passed to method `reportErrorsnODirectories` from [here](https://github.com/facebookarchive/hadoop-20/blob/2a29bc6ecf30edb1ad8dbde32aa49a317b4d44f4/src/hdfs/org/apache/hadoop/hdfs/server/namenode/FSImage.java#L508)