### PR TITLE
Shell.java: fix absolute path `/bin/ls`

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -160,7 +160,7 @@ abstract public class Shell {
   /** Return a command to get permission information. */
   public static String[] getGetPermissionCommand() {
     return (WINDOWS) ? new String[] { WINUTILS, "ls", "-F" }
-                     : new String[] { "/bin/ls", "-ld" };
+                     : new String[] { "ls", "-ld" };
   }
 
   /** Return a command to set permission */


### PR DESCRIPTION
This commit uses `ls` from PATH instead of relying on `ls` being stored in `/bin/`. The only file according to the POSIX standard which must be stored in `/bin/` is `sh`.
This fixes issues plaguing distributions like NixOS which dynamically stitch together a PATH.

This fix is loosly related to https://issues.apache.org/jira/browse/HADOOP-11935 and more specifically related to https://mail-archives.apache.org/mod_mbox/hadoop-user/201512.mbox/%3CCAH2nEUgsSeoJTJkD4T8z=D18ECnRgQ3Qvz861gU5+NPSsNgT=A@mail.gmail.com%3E