### PR TITLE
HADOOP-9991. Update netty to 3.7.1.Final to sync with zookeper

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -571,7 +571,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
-        <version>3.6.2.Final</version>
+        <version>3.7.1.Final</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Update netty to 3.7.1.Final because hadoop-client 2.7.2 depends on zookeeper 3.4.6 which depends on netty 3.7.x. Related to https://github.com/apache/hadoop/pull/84
