### PR TITLE
HADOOP-12984. Add GenericTestUtils.getTestDir method and use it for emporary directory in tests

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
@@ -49,6 +49,8 @@ import org.apache.hadoop.conf.Configuration.IntegerRanges;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.test.GenericTestUtils;
+
 import static org.apache.hadoop.util.PlatformName.IBM_JAVA;
 
 import org.codehaus.jackson.map.ObjectMapper;
@@ -427,8 +429,7 @@ public class TestConfiguration extends TestCase {
     Configuration conf = new Configuration();
     String[] dirs = new String[]{"a", "b", "c"};
     for (int i = 0; i < dirs.length; i++) {
-      dirs[i] = new Path(System.getProperty("test.build.data"), dirs[i])
-          .toString();
+      dirs[i] = new Path(GenericTestUtils.getTempPath(dirs[i])).toString();
     }
     conf.set("dirs", StringUtils.join(dirs, ","));
     for (int i = 0; i < 1000; i++) {
@@ -444,8 +445,7 @@ public class TestConfiguration extends TestCase {
     Configuration conf = new Configuration();
     String[] dirs = new String[]{"a", "b", "c"};
     for (int i = 0; i < dirs.length; i++) {
-      dirs[i] = new Path(System.getProperty("test.build.data"), dirs[i])
-          .toString();
+      dirs[i] = new Path(GenericTestUtils.getTempPath(dirs[i])).toString();
     }
     conf.set("dirs", StringUtils.join(dirs, ","));
     for (int i = 0; i < 1000; i++) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/TestCryptoStreamsForLocalFS.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/TestCryptoStreamsForLocalFS.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -38,8 +39,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestCryptoStreamsForLocalFS extends CryptoStreamsTestBase {
-  private static final String TEST_ROOT_DIR
-    = System.getProperty("test.build.data","build/test/data") + "/work-dir/localfs";
+  private static final String TEST_ROOT_DIR =
+      GenericTestUtils.getTempPath("work-dir/testcryptostreamsforlocalfs");
 
   private final File base = new File(TEST_ROOT_DIR);
   private final Path file = new Path(TEST_ROOT_DIR, "test-file");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyShell.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,8 +48,8 @@ public class TestKeyShell {
   public void setup() throws Exception {
     outContent.reset();
     errContent.reset();
-    final File tmpDir = new File(System.getProperty("test.build.data", "target"),
-        UUID.randomUUID().toString());
+    final File tmpDir = GenericTestUtils.getTestDir(UUID.randomUUID()
+        .toString());
     if (!tmpDir.mkdirs()) {
       throw new IOException("Unable to create " + tmpDir);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FSTestWrapper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FSTestWrapper.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.fs.Options.CreateOpts;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /**
  * Abstraction of filesystem functionality with additional helper methods
@@ -43,7 +44,7 @@ public abstract class FSTestWrapper implements FSWrapper {
   public FSTestWrapper(String testRootDir) {
     // Use default test dir if not provided
     if (testRootDir == null || testRootDir.isEmpty()) {
-      testRootDir = System.getProperty("test.build.data", "build/test/data");
+      testRootDir = GenericTestUtils.getTestDir().getAbsolutePath();
     }
     // salt test dir with some random digits for safe parallel runs
     this.testRootDir = testRootDir + "/"

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextMainOperationsBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextMainOperationsBaseTest.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.fs.Options.CreateOpts;
 import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import static org.junit.Assert.*;
@@ -99,8 +100,7 @@ public abstract class FileContextMainOperationsBaseTest  {
   
   @Before
   public void setUp() throws Exception {
-    File testBuildData = new File(System.getProperty("test.build.data",
-            "build/test/data"), RandomStringUtils.randomAlphanumeric(10));
+    File testBuildData = GenericTestUtils.getRandomizedTestDir();
     Path rootPath = new Path(testBuildData.getAbsolutePath(), 
             "root-uri");
     localFsRootPath = rootPath.makeQualified(LocalFileSystem.NAME, null);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextTestHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextTestHelper.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.fs.Options.CreateOpts;
 import org.apache.hadoop.fs.Options.CreateOpts.BlockSize;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 
 /**
@@ -39,11 +40,10 @@ public final class FileContextTestHelper {
   private String absTestRootDir = null;
 
   /**
-   * Create a context with test root relative to the <wd>/build/test/data
+   * Create a context with test root relative to the test directory
    */
   public FileContextTestHelper() {
-    this(System.getProperty("test.build.data", "target/test/data") + "/" +
-        RandomStringUtils.randomAlphanumeric(10));
+    this(GenericTestUtils.getRandomizedTestDir().getAbsolutePath());
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextURIBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextURIBase.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.fs;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
+
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -51,8 +53,8 @@ import static org.apache.hadoop.fs.FileContextTestHelper.*;
  * </p>
  */
 public abstract class FileContextURIBase {
-  private static final String basePath = System.getProperty("test.build.data",
-  "build/test/data") + "/testContextURI";
+  private static final String basePath =
+      GenericTestUtils.getTempPath("testContextURI");
   private static final Path BASE = new Path(basePath);
 
   // Matches anything containing <, >, :, ", |, ?, *, or anything that ends with

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemTestHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemTestHelper.java
@@ -22,9 +22,9 @@ import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.Random;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 
 import static org.junit.Assert.*;
@@ -45,7 +45,7 @@ public class FileSystemTestHelper {
    * Create helper with test root located at <wd>/build/test/data
    */
   public FileSystemTestHelper() {
-      this(System.getProperty("test.build.data", "target/test/data") + "/" + RandomStringUtils.randomAlphanumeric(10));
+    this(GenericTestUtils.getRandomizedTempPath());
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestAvroFSInput.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestAvroFSInput.java
@@ -22,6 +22,7 @@ import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 
 import junit.framework.TestCase;
 
@@ -30,14 +31,8 @@ public class TestAvroFSInput extends TestCase {
   private static final String INPUT_DIR = "AvroFSInput";
 
   private Path getInputPath() {
-    String dataDir = System.getProperty("test.build.data");
-    if (null == dataDir) {
-      return new Path(INPUT_DIR);
-    } else {
-      return new Path(new Path(dataDir), INPUT_DIR);
-    }
+    return new Path(GenericTestUtils.getTempPath(INPUT_DIR));
   }
-
 
   public void testAFSInput() throws Exception {
     Configuration conf = new Configuration();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestChecksumFileSystem.java
@@ -22,12 +22,13 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.*;
 import static org.junit.Assert.*;
 
 public class TestChecksumFileSystem {
-  static final String TEST_ROOT_DIR
-    = System.getProperty("test.build.data","build/test/data/work-dir/localfs");
+  static final String TEST_ROOT_DIR =
+      GenericTestUtils.getTempPath("work-dir/localfs");
 
   static LocalFileSystem localFs;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestDFVariations.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestDFVariations.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
 
 public class TestDFVariations {
   private static final String TEST_ROOT_DIR =
-      System.getProperty("test.build.data","build/test/data") + "/TestDFVariations";
+      GenericTestUtils.getTestDir("testdfvariations").getAbsolutePath();
   private static File test_root = null;
 
   @Before

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestDU.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestDU.java
@@ -26,11 +26,11 @@ import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /** This test makes sure that "DU" does not get to run on each call to getUsed */ 
 public class TestDU extends TestCase {
-  final static private File DU_DIR = new File(
-      System.getProperty("test.build.data","/tmp"), "dutmp");
+  final static private File DU_DIR = GenericTestUtils.getTestDir("dutmp");
 
   @Override
   public void setUp() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileContextResolveAfs.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileContextResolveAfs.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,9 +35,10 @@ public class TestFileContextResolveAfs {
   static {
     FileSystem.enableSymlinks();
   }
-  private static String TEST_ROOT_DIR_LOCAL
-    = System.getProperty("test.build.data","/tmp");
-  
+
+  private static String TEST_ROOT_DIR_LOCAL =
+      GenericTestUtils.getTestDir().getAbsolutePath();
+
   private FileContext fc;
   private FileSystem localFs;
   

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.*;
 
 import java.io.File;
@@ -55,9 +56,7 @@ import static org.mockito.Mockito.when;
 public class TestFileUtil {
   private static final Log LOG = LogFactory.getLog(TestFileUtil.class);
 
-  private static final String TEST_ROOT_DIR = System.getProperty(
-      "test.build.data", "/tmp") + "/fu";
-  private static final File TEST_DIR = new File(TEST_ROOT_DIR);
+  private static final File TEST_DIR = GenericTestUtils.getTestDir("fu");
   private static final String FILE = "x";
   private static final String LINK = "y";
   private static final String DIR = "dir";
@@ -962,10 +961,10 @@ public class TestFileUtil {
   @Test (timeout = 30000)
   public void testUntar() throws IOException {
     String tarGzFileName = System.getProperty("test.cache.data",
-        "build/test/cache") + "/test-untar.tgz";
+        "target/test/cache") + "/test-untar.tgz";
     String tarFileName = System.getProperty("test.cache.data",
         "build/test/cache") + "/test-untar.tar";
-    String dataDir = System.getProperty("test.build.data", "build/test/data");
+    File dataDir = GenericTestUtils.getTestDir();
     File untarDir = new File(dataDir, "untarDir");
 
     doUntarAndVerify(new File(tarGzFileName), untarDir);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -50,9 +51,8 @@ public class TestFsShellCopy {
     conf = new Configuration();
     shell = new FsShell(conf);
     lfs = FileSystem.getLocal(conf);
-    testRootDir = lfs.makeQualified(new Path(
-        System.getProperty("test.build.data","test/build/data"),
-        "testFsShellCopy"));
+    testRootDir = lfs.makeQualified(new Path(GenericTestUtils.getTempPath(
+        "testFsShellCopy")));
     
     lfs.mkdirs(testRootDir);
     lfs.setWorkingDirectory(testRootDir);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellReturnCode.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellReturnCode.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.fs.shell.FsCommand;
 import org.apache.hadoop.fs.shell.PathData;
 import org.apache.hadoop.io.IOUtils;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -63,9 +65,9 @@ public class TestFsShellReturnCode {
     fileSys = FileSystem.get(conf);
     fsShell = new FsShell(conf);
   }
-  
-  private static String TEST_ROOT_DIR = System.getProperty("test.build.data",
-      "build/test/data/testCHReturnCode");
+
+  private static String TEST_ROOT_DIR =
+      GenericTestUtils.getTempPath("testCHReturnCode");
 
   static void writeFile(FileSystem fs, Path name) throws Exception {
     FSDataOutputStream stm = fs.create(name);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellTouch.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellTouch.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -41,9 +42,8 @@ public class TestFsShellTouch {
     Configuration conf = new Configuration();
     shell = new FsShell(conf);
     lfs = FileSystem.getLocal(conf);
-    testRootDir = lfs.makeQualified(new Path(
-        System.getProperty("test.build.data","test/build/data"),
-        "testFsShell"));
+    testRootDir = lfs.makeQualified(
+        new Path(GenericTestUtils.getTempPath("testFsShell")));
 
     lfs.mkdirs(testRootDir);
     lfs.setWorkingDirectory(testRootDir);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestGetFileBlockLocations.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestGetFileBlockLocations.java
@@ -25,13 +25,14 @@ import java.util.Random;
 import junit.framework.TestCase;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /**
  * Testing the correctness of FileSystem.getFileBlockLocations.
  */
 public class TestGetFileBlockLocations extends TestCase {
-  private static String TEST_ROOT_DIR =
-      System.getProperty("test.build.data", "/tmp/testGetFileBlockLocations");
+  private static String TEST_ROOT_DIR = GenericTestUtils.getTempPath(
+      "testGetFileBlockLocations");
   private static final int FileLength = 4 * 1024 * 1024; // 4MB
   private Configuration conf;
   private Path path;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystemBasics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystemBasics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.junit.After;
 import org.junit.Assert;
@@ -45,8 +46,8 @@ import static org.junit.Assert.*;
  */
 public class TestHarFileSystemBasics {
 
-  private static final String ROOT_PATH = System.getProperty("test.build.data",
-      "build/test/data");
+  private static final String ROOT_PATH =
+      GenericTestUtils.getTempPath("testharfilesystembasics");
   private static final Path rootPath;
   static {
     String root = new Path(new File(ROOT_PATH).getAbsolutePath(), "localfs")

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHardLink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHardLink.java
@@ -24,6 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Before;
@@ -57,9 +58,7 @@ import static org.apache.hadoop.fs.HardLink.*;
  */
 public class TestHardLink {
   
-  public static final String TEST_ROOT_DIR = 
-    System.getProperty("test.build.data", "build/test/data") + "/test";
-  final static private File TEST_DIR = new File(TEST_ROOT_DIR, "hl");
+  final static private File TEST_DIR = GenericTestUtils.getTestDir("test/hl");
   private static String DIR = "dir_";
   //define source and target directories
   private static File src = new File(TEST_DIR, DIR + "src");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestListFiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestListFiles.java
@@ -22,11 +22,8 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.commons.logging.impl.Log4JLogger;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.log4j.Level;
 
 import static org.junit.Assert.*;
@@ -37,8 +34,8 @@ import org.junit.BeforeClass;
  * This class tests the FileStatus API.
  */
 public class TestListFiles {
-  {
-    ((Log4JLogger)FileSystem.LOG).getLogger().setLevel(Level.ALL);
+  static {
+    GenericTestUtils.setLogLevel(FileSystem.LOG, Level.ALL);
   }
 
   static final long seed = 0xDEADBEEFL;
@@ -53,9 +50,8 @@ public class TestListFiles {
   private static Path FILE3;
 
   static {
-    setTestPaths(new Path(
-      System.getProperty("test.build.data", "build/test/data/work-dir/localfs"),
-      "main_"));
+    setTestPaths(new Path(GenericTestUtils.getTempPath("testlistfiles"),
+        "main_"));
   }
 
   protected static Path getTestDir() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystem.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
 
@@ -45,10 +46,10 @@ import org.mockito.internal.util.reflection.Whitebox;
  * This class tests the local file system via the FileSystem abstraction.
  */
 public class TestLocalFileSystem {
-  private static final String TEST_ROOT_DIR
-    = System.getProperty("test.build.data","build/test/data") + "/work-dir/localfs";
+  private static final File base =
+      GenericTestUtils.getTestDir("work-dir/localfs");
 
-  private final File base = new File(TEST_ROOT_DIR);
+  private static final String TEST_ROOT_DIR = base.getAbsolutePath();
   private final Path TEST_PATH = new Path(TEST_ROOT_DIR, "test-file");
   private Configuration conf;
   private LocalFileSystem fileSys;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystemPermission.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFileSystemPermission.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.fs;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.*;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.log4j.Level;
 import org.apache.hadoop.util.Shell;
 
 import java.io.*;
@@ -31,19 +33,11 @@ import junit.framework.*;
  * This class tests the local file system via the FileSystem abstraction.
  */
 public class TestLocalFileSystemPermission extends TestCase {
-  static final String TEST_PATH_PREFIX = new Path(System.getProperty(
-      "test.build.data", "/tmp")).toString().replace(' ', '_')
-      + "/" + TestLocalFileSystemPermission.class.getSimpleName() + "_";
+  static final String TEST_PATH_PREFIX = GenericTestUtils.getTempPath(
+      TestLocalFileSystemPermission.class.getSimpleName());
 
-  {
-    try {
-      ((org.apache.commons.logging.impl.Log4JLogger)FileSystem.LOG).getLogger()
-      .setLevel(org.apache.log4j.Level.DEBUG);
-    }
-    catch(Exception e) {
-      System.out.println("Cannot change log level\n"
-          + StringUtils.stringifyException(e));
-    }
+  static {
+    GenericTestUtils.setLogLevel(FileSystem.LOG, Level.DEBUG);
   }
 
   private Path writeFile(FileSystem fs, String name) throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestPath.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestPath.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.AvroTestUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 
 import com.google.common.base.Joiner;
@@ -402,9 +403,8 @@ public class TestPath extends TestCase {
     // This test is not meaningful on Windows where * is disallowed in file name.
     if (Shell.WINDOWS) return;
     FileSystem lfs = FileSystem.getLocal(new Configuration());
-    Path testRoot = lfs.makeQualified(new Path(
-        System.getProperty("test.build.data","test/build/data"),
-        "testPathGlob"));
+    Path testRoot = lfs.makeQualified(
+        new Path(GenericTestUtils.getTempPath("testPathGlob")));
     lfs.delete(testRoot, true);
     lfs.mkdirs(testRoot);
     assertTrue(lfs.isDirectory(testRoot));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import junit.framework.TestCase;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 
 /**
@@ -41,9 +42,8 @@ import org.apache.hadoop.util.Time;
  */
 public class TestTrash extends TestCase {
 
-  private final static Path TEST_DIR =
-    new Path(new File(System.getProperty("test.build.data","/tmp")
-          ).toURI().toString().replace(' ', '+'), "testTrash");
+  private final static Path TEST_DIR = new Path(GenericTestUtils.getTempPath(
+      "testTrash"));
 
   protected static Path mkdir(FileSystem fs, Path p) throws IOException {
     assertTrue(fs.mkdirs(p));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTruncatedInputBug.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTruncatedInputBug.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import junit.framework.TestCase;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /**
  * test for the input truncation bug when mark/reset is used.
@@ -30,8 +31,7 @@ import org.apache.hadoop.conf.Configuration;
  */
 public class TestTruncatedInputBug extends TestCase {
   private static String TEST_ROOT_DIR =
-    new Path(System.getProperty("test.build.data","/tmp"))
-    .toString().replace(' ', '+');
+      GenericTestUtils.getTestDir().getAbsolutePath();
   
   private void writeFile(FileSystem fileSys, 
                          Path name, int nBytesToWrite) 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/sftp/TestSFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/sftp/TestSFTPFileSystem.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 
 import org.apache.sshd.SshServer;
@@ -54,7 +55,7 @@ public class TestSFTPFileSystem {
 
   private static final String TEST_SFTP_DIR = "testsftp";
   private static final String TEST_ROOT_DIR =
-    System.getProperty("test.build.data", "build/test/data");
+      GenericTestUtils.getTestDir().getAbsolutePath();
 
   @Rule public TestName name = new TestName();
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestPathData.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestPathData.java
@@ -29,14 +29,15 @@ import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestPathData {
-  private static final String TEST_ROOT_DIR = 
-      System.getProperty("test.build.data","build/test/data") + "/testPD";
+  private static final String TEST_ROOT_DIR =
+      GenericTestUtils.getTestDir("testPD").getAbsolutePath();
   protected Configuration conf;
   protected FileSystem fs;
   protected Path testDir;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestTextCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestTextCommand.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 
 /**
@@ -41,8 +42,7 @@ import org.junit.Test;
  */
 public class TestTextCommand {
   private static final File TEST_ROOT_DIR =
-    Paths.get(System.getProperty("test.build.data", "build/test/data"),
-        "testText").toFile();
+      GenericTestUtils.getTestDir("testText");
   private static final String AVRO_FILENAME =
     new File(TEST_ROOT_DIR, "weather.avro").toURI().getPath();
   private static final String TEXT_FILENAME =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewfsFileStatus.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewfsFileStatus.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.FsConstants;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
-
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -44,9 +44,8 @@ import static org.junit.Assert.*;
  */
 public class TestViewfsFileStatus {
 
-  private static final File TEST_DIR =
-    new File(System.getProperty("test.build.data", "/tmp"),
-          TestViewfsFileStatus.class.getSimpleName());
+  private static final File TEST_DIR = GenericTestUtils.getTestDir(
+      TestViewfsFileStatus.class.getSimpleName());
 
   @Test
   public void testFileStatusSerialziation()

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ClientBaseWithFixes.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ClientBaseWithFixes.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.net.ServerSocketUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.zookeeper.TestableZooKeeper;
 import org.apache.zookeeper.WatchedEvent;
@@ -62,8 +63,7 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
     protected static final Logger LOG = LoggerFactory.getLogger(ClientBaseWithFixes.class);
 
     public static int CONNECTION_TIMEOUT = 30000;
-    static final File BASETEST =
-        new File(System.getProperty("test.build.data", "build"));
+    static final File BASETEST = GenericTestUtils.getTestDir();
 
     protected final String hostPort = initHostPort();
     protected int maxCnxns = 0;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestAuthenticationSessionCookie.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestAuthenticationSessionCookie.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.mortbay.log.Log;
@@ -35,8 +36,8 @@ import java.net.HttpCookie;
 import java.util.List;
 
 public class TestAuthenticationSessionCookie {
-  private static final String BASEDIR = System.getProperty("test.build.dir",
-          "target/test-dir") + "/" + TestHttpCookieFlag.class.getSimpleName();
+  private static final String BASEDIR =
+      GenericTestUtils.getTempPath(TestHttpCookieFlag.class.getSimpleName());
   private static boolean isCookiePersistent;
   private static final long TOKEN_VALIDITY_SEC = 1000;
   private static long expires;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpCookieFlag.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpCookieFlag.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,8 +38,8 @@ import java.net.HttpCookie;
 import java.util.List;
 
 public class TestHttpCookieFlag {
-  private static final String BASEDIR = System.getProperty("test.build.dir",
-          "target/test-dir") + "/" + TestHttpCookieFlag.class.getSimpleName();
+  private static final String BASEDIR =
+      GenericTestUtils.getTempPath(TestHttpCookieFlag.class.getSimpleName());
   private static String keystoresDir;
   private static String sslConfDir;
   private static SSLFactory clientSslFactory;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLifecycle.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLifecycle.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.http;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 
@@ -76,8 +77,8 @@ public class TestHttpServerLifecycle extends HttpServerFunctionalTest {
   public void testStartedServerWithRequestLog() throws Throwable {
     HttpRequestLogAppender requestLogAppender = new HttpRequestLogAppender();
     requestLogAppender.setName("httprequestlog");
-    requestLogAppender.setFilename(System.getProperty("test.build.data", "/tmp/")
-        + "jetty-name-yyyy_mm_dd.log");
+    requestLogAppender.setFilename(
+        GenericTestUtils.getTempPath("jetty-name-yyyy_mm_dd.log"));
     Logger.getLogger(HttpServer2.class.getName() + ".test").addAppender(requestLogAppender);
     HttpServer2 server = null;
     server = createTestServer();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,8 +52,8 @@ import org.junit.Test;
  */
 public class TestSSLHttpServer extends HttpServerFunctionalTest {
 
-  private static final String BASEDIR = System.getProperty("test.build.dir",
-      "target/test-dir") + "/" + TestSSLHttpServer.class.getSimpleName();
+  private static final String BASEDIR =
+      GenericTestUtils.getTempPath(TestSSLHttpServer.class.getSimpleName());
 
   private static final Log LOG = LogFactory.getLog(TestSSLHttpServer.class);
   private static Configuration conf;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestArrayFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestArrayFile.java
@@ -24,6 +24,7 @@ import java.io.*;
 import org.apache.commons.logging.*;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.conf.*;
 import org.junit.Test;
@@ -38,9 +39,8 @@ import static org.junit.Assert.fail;
 public class TestArrayFile {
   private static final Log LOG = LogFactory.getLog(TestArrayFile.class);
   
-  private static final Path TEST_DIR = new Path(
-      System.getProperty("test.build.data", "/tmp"),
-      TestMapFile.class.getSimpleName());
+  private static final Path TEST_DIR = new Path(GenericTestUtils.getTempPath(
+      TestMapFile.class.getSimpleName()));
   private static String TEST_FILE = new Path(TEST_DIR, "test.array").toString();
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestBloomMapFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestBloomMapFile.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Progressable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -49,9 +50,8 @@ import org.junit.Test;
 
 public class TestBloomMapFile {
   private static Configuration conf = new Configuration();
-  private static final Path TEST_ROOT = new Path(
-      System.getProperty("test.build.data", "/tmp"),
-      TestMapFile.class.getSimpleName());
+  private static final Path TEST_ROOT = new Path(GenericTestUtils.getTempPath(
+      TestMapFile.class.getSimpleName()));
   private static final Path TEST_DIR = new Path(TEST_ROOT, "testfile");
   private static final Path TEST_FILE = new Path(TEST_ROOT, "testfile");
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestMapFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestMapFile.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Progressable;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,9 +49,8 @@ import static org.mockito.Mockito.*;
 
 public class TestMapFile {
   
-  private static final Path TEST_DIR = new Path(
-      System.getProperty("test.build.data", "/tmp"),
-      TestMapFile.class.getSimpleName());
+  private static final Path TEST_DIR = new Path(GenericTestUtils.getTempPath(
+      TestMapFile.class.getSimpleName()));
   
   private static Configuration conf = new Configuration();
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.io.SequenceFile.Metadata;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.io.serializer.avro.AvroReflectSerialization;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.conf.*;
 import org.junit.Test;
@@ -58,11 +59,11 @@ public class TestSequenceFile {
     int count = 1024 * 10;
     int megabytes = 1;
     int factor = 5;
-    Path file = new Path(System.getProperty("test.build.data",".")+"/test.seq");
-    Path recordCompressedFile = 
-      new Path(System.getProperty("test.build.data",".")+"/test.rc.seq");
-    Path blockCompressedFile = 
-      new Path(System.getProperty("test.build.data",".")+"/test.bc.seq");
+    Path file = new Path(GenericTestUtils.getTempPath("test.seq"));
+    Path recordCompressedFile = new Path(GenericTestUtils.getTempPath(
+        "test.rc.seq"));
+    Path blockCompressedFile = new Path(GenericTestUtils.getTempPath(
+        "test.bc.seq"));
  
     int seed = new Random().nextInt();
     LOG.info("Seed = " + seed);
@@ -320,13 +321,13 @@ public class TestSequenceFile {
     LOG.info("Testing SequenceFile with metadata");
     int count = 1024 * 10;
     CompressionCodec codec = new DefaultCodec();
-    Path file = new Path(System.getProperty("test.build.data",".")+"/test.seq.metadata");
-    Path sortedFile =
-      new Path(System.getProperty("test.build.data",".")+"/test.sorted.seq.metadata");
-    Path recordCompressedFile = 
-      new Path(System.getProperty("test.build.data",".")+"/test.rc.seq.metadata");
-    Path blockCompressedFile = 
-      new Path(System.getProperty("test.build.data",".")+"/test.bc.seq.metadata");
+    Path file = new Path(GenericTestUtils.getTempPath("test.seq.metadata"));
+    Path sortedFile = new Path(GenericTestUtils.getTempPath(
+        "test.sorted.seq.metadata"));
+    Path recordCompressedFile = new Path(GenericTestUtils.getTempPath(
+        "test.rc.seq.metadata"));
+    Path blockCompressedFile = new Path(GenericTestUtils.getTempPath(
+        "test.bc.seq.metadata"));
  
     FileSystem fs = FileSystem.getLocal(conf);
     SequenceFile.Metadata theMetadata = new SequenceFile.Metadata();
@@ -426,14 +427,14 @@ public class TestSequenceFile {
     LocalFileSystem fs = FileSystem.getLocal(conf);
   
     // create a sequence file 1
-    Path path1 = new Path(System.getProperty("test.build.data",".")+"/test1.seq");
+    Path path1 = new Path(GenericTestUtils.getTempPath("test1.seq"));
     SequenceFile.Writer writer = SequenceFile.createWriter(fs, conf, path1,
         Text.class, NullWritable.class, CompressionType.BLOCK);
     writer.append(new Text("file1-1"), NullWritable.get());
     writer.append(new Text("file1-2"), NullWritable.get());
     writer.close();
   
-    Path path2 = new Path(System.getProperty("test.build.data",".")+"/test2.seq");
+    Path path2 = new Path(GenericTestUtils.getTempPath("test2.seq"));
     writer = SequenceFile.createWriter(fs, conf, path2, Text.class,
         NullWritable.class, CompressionType.BLOCK);
     writer.append(new Text("file2-1"), NullWritable.get());
@@ -482,7 +483,7 @@ public class TestSequenceFile {
   public void testCreateUsesFsArg() throws Exception {
     FileSystem fs = FileSystem.getLocal(conf);
     FileSystem spyFs = Mockito.spy(fs);
-    Path p = new Path(System.getProperty("test.build.data", ".")+"/testCreateUsesFSArg.seq");
+    Path p = new Path(GenericTestUtils.getTempPath("testCreateUsesFSArg.seq"));
     SequenceFile.Writer writer = SequenceFile.createWriter(
         spyFs, conf, p, NullWritable.class, NullWritable.class);
     writer.close();
@@ -515,7 +516,7 @@ public class TestSequenceFile {
     LocalFileSystem fs = FileSystem.getLocal(conf);
 
     // create an empty file (which is not a valid sequence file)
-    Path path = new Path(System.getProperty("test.build.data",".")+"/broken.seq");
+    Path path = new Path(GenericTestUtils.getTempPath("broken.seq"));
     fs.create(path).close();
 
     // try to create SequenceFile.Reader
@@ -547,8 +548,7 @@ public class TestSequenceFile {
     LocalFileSystem fs = FileSystem.getLocal(conf);
 
     // create an empty file (which is not a valid sequence file)
-    Path path = new Path(System.getProperty("test.build.data", ".") +
-      "/zerolength.seq");
+    Path path = new Path(GenericTestUtils.getTempPath("zerolength.seq"));
     fs.create(path).close();
 
     try {
@@ -569,8 +569,8 @@ public class TestSequenceFile {
   public void testCreateWriterOnExistingFile() throws IOException {
     Configuration conf = new Configuration();
     FileSystem fs = FileSystem.getLocal(conf);
-    Path name = new Path(new Path(System.getProperty("test.build.data","."),
-        "createWriterOnExistingFile") , "file");
+    Path name = new Path(new Path(GenericTestUtils.getTempPath(
+        "createWriterOnExistingFile")), "file");
 
     fs.create(name);
     SequenceFile.createWriter(fs, conf, name, RandomDatum.class,
@@ -582,8 +582,8 @@ public class TestSequenceFile {
   @Test
   public void testRecursiveSeqFileCreate() throws IOException {
     FileSystem fs = FileSystem.getLocal(conf);
-    Path name = new Path(new Path(System.getProperty("test.build.data","."),
-        "recursiveCreateDir") , "file");
+    Path name = new Path(new Path(GenericTestUtils.getTempPath(
+        "recursiveCreateDir")), "file");
     boolean createParent = false;
 
     try {
@@ -605,8 +605,8 @@ public class TestSequenceFile {
   @Test
   public void testSerializationAvailability() throws IOException {
     Configuration conf = new Configuration();
-    Path path = new Path(System.getProperty("test.build.data", "."),
-        "serializationAvailability");
+    Path path = new Path(GenericTestUtils.getTempPath(
+        "serializationAvailability"));
     // Check if any serializers aren't found.
     try {
       SequenceFile.createWriter(

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFileAppend.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFileAppend.java
@@ -43,8 +43,8 @@ public class TestSequenceFileAppend {
 
   private static Configuration conf;
   private static FileSystem fs;
-  private static Path ROOT_PATH = new Path(System.getProperty(
-      "test.build.data", "build/test/data"));
+  private static Path ROOT_PATH =
+      new Path(GenericTestUtils.getTestDir().getAbsolutePath());
 
   @BeforeClass
   public static void setUp() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFileSerialization.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFileSerialization.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile.Reader;
 import org.apache.hadoop.io.SequenceFile.Writer;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,8 +51,7 @@ public class TestSequenceFileSerialization {
 
   @Test
   public void testJavaSerialization() throws Exception {
-    Path file = new Path(System.getProperty("test.build.data",".") +
-        "/testseqser.seq");
+    Path file = new Path(GenericTestUtils.getTempPath("testseqser.seq"));
     
     fs.delete(file, true);
     Writer writer = SequenceFile.createWriter(fs, conf, file, Long.class,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFileSync.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFileSync.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 
 public class TestSequenceFileSync {
@@ -52,8 +53,8 @@ public class TestSequenceFileSync {
   public void testLowSyncpoint() throws IOException {
     final Configuration conf = new Configuration();
     final FileSystem fs = FileSystem.getLocal(conf);
-    final Path path = new Path(System.getProperty("test.build.data", "/tmp"),
-      "sequencefile.sync.test");
+    final Path path = new Path(GenericTestUtils.getTempPath(
+        "sequencefile.sync.test"));
     final IntWritable input = new IntWritable();
     final Text val = new Text();
     SequenceFile.Writer writer = new SequenceFile.Writer(fs, conf, path,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSetFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSetFile.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.io;
 
 import java.io.*;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 
 import org.apache.commons.logging.*;
@@ -28,6 +27,7 @@ import org.apache.commons.logging.*;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.conf.*;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -38,8 +38,7 @@ import static org.junit.Assert.fail;
 /** Support for flat files of binary key/value pairs. */
 public class TestSetFile {
   private static final Log LOG = LogFactory.getLog(TestSetFile.class);
-  private static String FILE =
-    System.getProperty("test.build.data",".") + "/test.set";
+  private static String FILE = GenericTestUtils.getTempPath("test.set");
 
   private static Configuration conf = new Configuration();
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodec.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodec.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.io.compress.zlib.BuiltInZlibInflater;
 import org.apache.hadoop.io.compress.zlib.ZlibCompressor;
 import org.apache.hadoop.io.compress.zlib.ZlibCompressor.CompressionLevel;
 import org.apache.hadoop.io.compress.zlib.ZlibCompressor.CompressionStrategy;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.io.compress.zlib.ZlibFactory;
 import org.apache.hadoop.util.LineReader;
 import org.apache.hadoop.util.NativeCodeLoader;
@@ -338,9 +339,9 @@ public class TestCodec {
   private static Path writeSplitTestFile(FileSystem fs, Random rand,
       CompressionCodec codec, long infLen) throws IOException {
     final int REC_SIZE = 1024;
-    final Path wd = new Path(new Path(
-          System.getProperty("test.build.data", "/tmp")).makeQualified(fs),
-        codec.getClass().getSimpleName());
+    final Path wd = new Path(GenericTestUtils.getTempPath(
+        codec.getClass().getSimpleName())).makeQualified(
+            fs.getUri(), fs.getWorkingDirectory());
     final Path file = new Path(wd, "test" + codec.getDefaultExtension());
     final byte[] b = new byte[REC_SIZE];
     final Base64 b64 = new Base64(0, null);
@@ -596,9 +597,8 @@ public class TestCodec {
     FileSystem fs = FileSystem.get(conf);
     LOG.info("Creating MapFiles with " + records  + 
             " records using codec " + clazz.getSimpleName());
-    Path path = new Path(new Path(
-        System.getProperty("test.build.data", "/tmp")),
-      clazz.getSimpleName() + "-" + type + "-" + records);
+    Path path = new Path(GenericTestUtils.getTempPath(
+        clazz.getSimpleName() + "-" + type + "-" + records));
 
     LOG.info("Writing " + path);
     createMapFile(conf, fs, path, clazz.newInstance(), type, records);
@@ -750,8 +750,7 @@ public class TestCodec {
     CodecPool.returnDecompressor(zlibDecompressor);
 
     // Now create a GZip text file.
-    String tmpDir = System.getProperty("test.build.data", "/tmp/");
-    Path f = new Path(new Path(tmpDir), "testGzipCodecRead.txt.gz");
+    Path f = new Path(GenericTestUtils.getTempPath("testGzipCodecRead.txt.gz"));
     BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(
       new GZIPOutputStream(new FileOutputStream(f.toString()))));
     final String msg = "This is the message in the file!";
@@ -802,8 +801,7 @@ public class TestCodec {
     CodecPool.returnDecompressor(zlibDecompressor);
 
     // Now create a GZip text file.
-    String tmpDir = System.getProperty("test.build.data", "/tmp/");
-    Path f = new Path(new Path(tmpDir), "testGzipLongOverflow.bin.gz");
+    Path f = new Path(GenericTestUtils.getTempPath("testGzipLongOverflow.bin.gz"));
     BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(
       new GZIPOutputStream(new FileOutputStream(f.toString()))));
 
@@ -862,9 +860,8 @@ public class TestCodec {
                codec instanceof GzipCodec);
 
     final String msg = "This is the message we are going to compress.";
-    final String tmpDir = System.getProperty("test.build.data", "/tmp/");
-    final String fileName = new Path(new Path(tmpDir),
-        "testGzipCodecWrite.txt.gz").toString();
+    final String fileName = new Path(GenericTestUtils.getTempPath(
+        "testGzipCodecWrite.txt.gz")).toString();
 
     BufferedWriter w = null;
     Compressor gzipCompressor = CodecPool.getCompressor(codec);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFile.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.file.tfile.TFile.Reader;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
 import org.junit.After;
 import org.junit.Before;
@@ -43,8 +44,7 @@ import static org.junit.Assert.assertFalse;
  * 
  */
 public class TestTFile {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
+  private static String ROOT = GenericTestUtils.getTempPath("tfile-test");
   private FileSystem fs;
   private Configuration conf;
   private static final int minBlockSize = 512;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileByteArrays.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileByteArrays.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.io.file.tfile.TFile.Reader;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Location;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,8 +47,7 @@ import org.junit.Test;
  * 
  */
 public class TestTFileByteArrays {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
   private final static int BLOCK_SIZE = 512;
   private final static int BUF_SIZE = 64;
   private final static int K = 1024;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileComparator2.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileComparator2.java
@@ -27,13 +27,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class TestTFileComparator2 {
-  private static final String ROOT = System.getProperty("test.build.data",
-      "/tmp/tfile-test");
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
   private static final String name = "test-tfile-comparator2";
   private final static int BLOCK_SIZE = 512;
   private static final String VALUE = "value";

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileComparators.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileComparators.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /**
  * 
@@ -38,9 +39,7 @@ import org.apache.hadoop.io.file.tfile.TFile.Writer;
  * 
  */
 public class TestTFileComparators {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
-
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
   private final static int BLOCK_SIZE = 512;
   private FileSystem fs;
   private Configuration conf;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeek.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeek.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.io.file.tfile.RandomDistribution.DiscreteRNG;
 import org.apache.hadoop.io.file.tfile.TFile.Reader;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /**
  * test the performance for seek.
@@ -246,8 +247,7 @@ public class TestTFileSeek {
     int fsOutputBufferSizeLzo = 1;
     int fsOutputBufferSizeGz = 1;
    
-    String rootDir =
-        System.getProperty("test.build.data", "/tmp/tfile-test");
+    String rootDir = GenericTestUtils.getTestDir().getAbsolutePath();
     String file = "TestTFileSeek";
     String compress = "gz";
     int minKeyLen = 10;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeqFileComparison.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeqFileComparison.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner.Entry;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 
 public class TestTFileSeqFileComparison {
@@ -515,9 +516,7 @@ public class TestTFileSeqFileComparison {
   }
 
   private static class MyOptions {
-    String rootDir =
-        System
-            .getProperty("test.build.data", "/tmp/tfile-test");
+    String rootDir = GenericTestUtils.getTestDir().getAbsolutePath();;
     String compress = "gz";
     String format = "tfile";
     int dictSize = 1000;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSplit.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSplit.java
@@ -32,10 +32,10 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.file.tfile.TFile.Reader;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
+import org.apache.hadoop.test.GenericTestUtils;
 
 public class TestTFileSplit {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
 
   private final static int BLOCK_SIZE = 64 * 1024;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileStreams.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileStreams.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.io.file.tfile.TFile.Reader;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
+import org.apache.hadoop.test.GenericTestUtils;
 
 /**
  * 
@@ -46,8 +47,7 @@ import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
  */
 
 public class TestTFileStreams {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
 
   private final static int BLOCK_SIZE = 512;
   private final static int K = 1024;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileUnsortedByteArrays.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileUnsortedByteArrays.java
@@ -29,13 +29,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.file.tfile.TFile.Reader;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
 import org.apache.hadoop.io.file.tfile.TFile.Reader.Scanner;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestTFileUnsortedByteArrays {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
-
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
 
   private final static int BLOCK_SIZE = 512;
   private final static int BUF_SIZE = 64;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestVLong.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestVLong.java
@@ -29,12 +29,12 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestVLong {
-  private static String ROOT =
-      System.getProperty("test.build.data", "/tmp/tfile-test");
+  private static String ROOT = GenericTestUtils.getTestDir().getAbsolutePath();
   private Configuration conf;
   private FileSystem fs;
   private Path path;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestNativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestNativeIO.java
@@ -61,8 +61,7 @@ import static org.apache.hadoop.io.nativeio.NativeIO.POSIX.Stat.*;
 public class TestNativeIO {
   static final Log LOG = LogFactory.getLog(TestNativeIO.class);
 
-  static final File TEST_DIR = new File(
-    System.getProperty("test.build.data"), "testnativeio");
+  static final File TEST_DIR = GenericTestUtils.getTestDir("testnativeio");
 
   @Before
   public void checkLoaded() {
@@ -516,8 +515,7 @@ public class TestNativeIO {
 
   @Test (timeout = 30000)
   public void testRenameTo() throws Exception {
-    final File TEST_DIR = new File(new File(
-        System.getProperty("test.build.data","build/test/data")), "renameTest");
+    final File TEST_DIR = GenericTestUtils.getTestDir("renameTest") ;
     assumeTrue(TEST_DIR.mkdirs());
     File nonExistentFile = new File(TEST_DIR, "nonexistent");
     File targetFile = new File(TEST_DIR, "target");
@@ -566,9 +564,7 @@ public class TestNativeIO {
   @Test(timeout=10000)
   public void testMlock() throws Exception {
     assumeTrue(NativeIO.isAvailable());
-    final File TEST_FILE = new File(new File(
-        System.getProperty("test.build.data","build/test/data")),
-        "testMlockFile");
+    final File TEST_FILE = GenericTestUtils.getTestDir("testMlockFile");
     final int BUF_LEN = 12289;
     byte buf[] = new byte[BUF_LEN];
     int bufSum = 0;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestSharedFileDescriptorFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestSharedFileDescriptorFactory.java
@@ -31,12 +31,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 
 public class TestSharedFileDescriptorFactory {
   static final Log LOG = LogFactory.getLog(TestSharedFileDescriptorFactory.class);
 
-  private static final File TEST_BASE =
-      new File(System.getProperty("test.build.data", "/tmp"));
+  private static final File TEST_BASE = GenericTestUtils.getTestDir();
 
   @Before
   public void setup() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/RollingFileSystemSinkTestBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/RollingFileSystemSinkTestBase.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.impl.TestMetricsConfig;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -68,9 +69,8 @@ import static org.junit.Assert.assertTrue;
 public class RollingFileSystemSinkTestBase {
   protected static final String SINK_PRINCIPAL_KEY = "rfssink.principal";
   protected static final String SINK_KEYTAB_FILE_KEY = "rfssink.keytab";
-  protected static final File ROOT_TEST_DIR =
-      new File(System.getProperty("test.build.data", "target/test"),
-        "RollingFileSystemSinkTest");
+  protected static final File ROOT_TEST_DIR = GenericTestUtils.getTestDir(
+      "RollingFileSystemSinkTest");
   protected static final SimpleDateFormat DATE_FORMAT =
       new SimpleDateFormat("yyyyMMddHH");
   protected static File methodDir;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestCredentials.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestCredentials.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,8 +48,7 @@ import static org.junit.Assert.*;
 
 public class TestCredentials {
   private static final String DEFAULT_HMAC_ALGORITHM = "HmacSHA1";
-  private static final File tmpDir =
-    new File(System.getProperty("test.build.data", "/tmp"), "mapred");  
+  private static final File tmpDir = GenericTestUtils.getTestDir("mapred");
     
   @Before
   public void setUp() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.hadoop.security.alias.JavaKeyStoreProvider;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -108,8 +109,7 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
   
   @Test
   public void testExtractPassword() throws IOException {
-    File testDir = new File(System.getProperty("test.build.data", 
-                                               "target/test-dir"));
+    File testDir = GenericTestUtils.getTestDir();
     testDir.mkdirs();
     File secretFile = new File(testDir, "secret.txt");
     Writer writer = new FileWriter(secretFile);
@@ -123,8 +123,7 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
 
   @Test
   public void testConfGetPassword() throws Exception {
-    File testDir = new File(System.getProperty("test.build.data",
-                                               "target/test-dir"));
+    File testDir = GenericTestUtils.getTestDir();
     Configuration conf = new Configuration();
     final Path jksPath = new Path(testDir.toString(), "test.jks");
     final String ourUrl =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
@@ -30,14 +30,14 @@ import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestCredShell {
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-  private static final File tmpDir =
-      new File(System.getProperty("test.build.data", "/tmp"), "creds");
+  private static final File tmpDir = GenericTestUtils.getTestDir("creds");
 
   /* The default JCEKS provider - for testing purposes */
   private String jceksProvider;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredentialProviderFactory.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.ProviderUtils;
 import org.apache.hadoop.security.UserGroupInformation;
-
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,8 +61,7 @@ public class TestCredentialProviderFactory {
   'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
   '2', '3', '4', '5', '6', '7', '8', '9',};
 
-  private static final File tmpDir =
-      new File(System.getProperty("test.build.data", "/tmp"), "creds");
+  private static final File tmpDir = GenericTestUtils.getTestDir("creds");
 
   @Test
   public void testFactory() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/KeyStoreTestUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/KeyStoreTestUtil.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.hadoop.security.alias.JavaKeyStoreProvider;
+import org.apache.hadoop.test.GenericTestUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -470,8 +471,7 @@ public class KeyStoreTestUtil {
   }
 
   public static void provisionPasswordsToCredentialProvider() throws Exception {
-    File testDir = new File(System.getProperty("test.build.data",
-        "target/test-dir"));
+    File testDir = GenericTestUtils.getTestDir();
 
     Configuration conf = new Configuration();
     final Path jksPath = new Path(testDir.toString(), "test.jks");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestReloadingX509TrustManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestReloadingX509TrustManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.security.ssl;
 
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -37,9 +38,8 @@ import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.generateKeyPair;
 
 public class TestReloadingX509TrustManager {
 
-  private static final String BASEDIR =
-    System.getProperty("test.build.data", "target/test-dir") + "/" +
-    TestReloadingX509TrustManager.class.getSimpleName();
+  private static final String BASEDIR = GenericTestUtils.getTempPath(
+      TestReloadingX509TrustManager.class.getSimpleName());
 
   private X509Certificate cert1;
   private X509Certificate cert2;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestSSLFactory.java
@@ -52,8 +52,7 @@ public class TestSSLFactory {
   private static final Logger LOG = LoggerFactory
       .getLogger(TestSSLFactory.class);
   private static final String BASEDIR =
-    System.getProperty("test.build.dir", "target/test-dir") + "/" +
-    TestSSLFactory.class.getSimpleName();
+      GenericTestUtils.getTempPath(TestSSLFactory.class.getSimpleName());
   private static final String KEYSTORES_DIR =
     new File(BASEDIR).getAbsolutePath();
   private String sslConfsDir;
@@ -433,8 +432,7 @@ public class TestSSLFactory {
       sslConf = KeyStoreTestUtil.createServerSSLConfig(keystore, confPassword,
         confKeyPassword, truststore);
       if (useCredProvider) {
-        File testDir = new File(System.getProperty("test.build.data",
-            "target/test-dir"));
+        File testDir = GenericTestUtils.getTestDir();
         final Path jksPath = new Path(testDir.toString(), "test.jks");
         final String ourUrl =
             JavaKeyStoreProvider.SCHEME_NAME + "://file" + jksPath.toUri();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/JarFinder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/JarFinder.java
@@ -31,6 +31,8 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import org.apache.hadoop.test.GenericTestUtils;
+
 /**
  * Finds the Jar for a class. If the class is in a directory in the
  * classpath, it creates a Jar on the fly with the contents of the directory
@@ -152,7 +154,7 @@ public class JarFinder {
             klassName = klassName.replace(".", "/") + ".class";
             path = path.substring(0, path.length() - klassName.length());
             File baseDir = new File(path);
-            File testDir = new File(System.getProperty("test.build.dir", "target/test-dir"));
+            File testDir = GenericTestUtils.getTestDir();
             testDir = testDir.getAbsoluteFile();
             if (!testDir.exists()) {
               testDir.mkdirs();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestApplicationClassLoader.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestApplicationClassLoader.java
@@ -37,6 +37,7 @@ import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,8 +46,7 @@ import com.google.common.collect.Lists;
 
 public class TestApplicationClassLoader {
   
-  private static File testDir = new File(System.getProperty("test.build.data",
-          System.getProperty("java.io.tmpdir")), "appclassloader");
+  private static File testDir = GenericTestUtils.getTestDir("appclassloader");
   
   @Before
   public void setUp() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestClasspath.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestClasspath.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,8 +43,8 @@ import org.junit.Test;
 public class TestClasspath {
 
   private static final Log LOG = LogFactory.getLog(TestClasspath.class);
-  private static final File TEST_DIR = new File(
-    System.getProperty("test.build.data", "/tmp"), "TestClasspath");
+  private static final File TEST_DIR = GenericTestUtils.getTestDir(
+      "TestClasspath");
   private static final Charset UTF8 = Charset.forName("UTF-8");
 
   static {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestGenericOptionsParser.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestGenericOptionsParser.java
@@ -199,7 +199,7 @@ public class TestGenericOptionsParser extends TestCase {
     super.setUp();
     conf = new Configuration();
     localFs = FileSystem.getLocal(conf);
-    testDir = new File(System.getProperty("test.build.data", "/tmp"), "generic");
+    testDir = GenericTestUtils.getTestDir("generic");
     if(testDir.exists())
       localFs.delete(new Path(testDir.toString()), true);
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHostsFileReader.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestHostsFileReader.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.*;
 import static org.junit.Assert.*;
 
@@ -31,8 +32,7 @@ import static org.junit.Assert.*;
 public class TestHostsFileReader {
 
   // Using /test/build/data/tmp directory to store temprory files
-  final String HOSTS_TEST_DIR = new File(System.getProperty(
-          "test.build.data", "/tmp")).getAbsolutePath();
+  final String HOSTS_TEST_DIR = GenericTestUtils.getTestDir().getAbsolutePath();
   File EXCLUDES_FILE = new File(HOSTS_TEST_DIR, "dfs.exclude");
   File INCLUDES_FILE = new File(HOSTS_TEST_DIR, "dfs.include");
   String excludesFile = HOSTS_TEST_DIR + "/dfs.exclude";

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestJarFinder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestJarFinder.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.util;
 
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -79,8 +80,8 @@ public class TestJarFinder {
 
   @Test
   public void testExistingManifest() throws Exception {
-    File dir = new File(System.getProperty("test.build.dir", "target/test-dir"),
-                        TestJarFinder.class.getName() + "-testExistingManifest");
+    File dir = GenericTestUtils
+        .getTestDir(TestJarFinder.class.getName() + "-testExistingManifest");
     delete(dir);
     dir.mkdirs();
 
@@ -107,8 +108,8 @@ public class TestJarFinder {
 
   @Test
   public void testNoManifest() throws Exception {
-    File dir = new File(System.getProperty("test.build.dir", "target/test-dir"),
-                        TestJarFinder.class.getName() + "-testNoManifest");
+    File dir = GenericTestUtils
+        .getTestDir(TestJarFinder.class.getName() + "-testNoManifest");
     delete(dir);
     dir.mkdirs();
     File propsFile = new File(dir, "props.properties");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestRunJar.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestRunJar.java
@@ -32,6 +32,7 @@ import java.util.zip.ZipEntry;
 import junit.framework.TestCase;
 
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,11 +45,8 @@ public class TestRunJar extends TestCase {
 
   @Override
   @Before
-  protected void setUp()
-      throws Exception {
-    TEST_ROOT_DIR =
-        new File(System.getProperty("test.build.data", "/tmp"), getClass()
-            .getSimpleName());
+  protected void setUp() throws Exception {
+    TEST_ROOT_DIR = GenericTestUtils.getTestDir(getClass().getSimpleName());
     if (!TEST_ROOT_DIR.exists()) {
       TEST_ROOT_DIR.mkdirs();
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShell.java
@@ -31,6 +31,8 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.test.GenericTestUtils;
+
 import static org.apache.hadoop.util.Shell.*;
 import org.junit.Assume;
 import org.junit.Before;
@@ -49,7 +51,7 @@ public class TestShell extends Assert {
   @Rule
   public TestName methodName = new TestName();
 
-  private File rootTestDir = new File(System.getProperty("test.build.data", "target/"));
+  private File rootTestDir = GenericTestUtils.getTestDir();
 
   /**
    * A filename generated uniquely for each test method. The file

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -63,8 +64,8 @@ public class TestSysInfoLinux {
     }
   }
   private static final FakeLinuxResourceCalculatorPlugin plugin;
-  private static String TEST_ROOT_DIR = new Path(System.getProperty(
-         "test.build.data", "/tmp")).toString().replace(' ', '+');
+  private static String TEST_ROOT_DIR = GenericTestUtils.getTestDir()
+      .getAbsolutePath();
   private static final String FAKE_MEMFILE;
   private static final String FAKE_CPUFILE;
   private static final String FAKE_STATFILE;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestWinUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestWinUtils.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,8 +45,8 @@ import static org.hamcrest.CoreMatchers.*;
 public class TestWinUtils {
 
   private static final Log LOG = LogFactory.getLog(TestWinUtils.class);
-  private static File TEST_DIR = new File(System.getProperty("test.build.data",
-      "target"+File.pathSeparator + "tmp"), TestWinUtils.class.getSimpleName());
+  private static File TEST_DIR = GenericTestUtils.getTestDir(
+      TestWinUtils.class.getSimpleName());
 
   String winutils;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestZKUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestZKUtil.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ZKUtil.BadAclFormatException;
 import org.apache.hadoop.util.ZKUtil.ZKAuthInfo;
 import org.apache.zookeeper.ZooDefs.Perms;
@@ -34,8 +35,8 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestZKUtil {
-  private static final String TEST_ROOT_DIR = System.getProperty(
-      "test.build.data", "/tmp") + "/TestZKUtil";
+  private static final String TEST_ROOT_DIR = GenericTestUtils.getTempPath(
+      "TestZKUtil");
   private static final File TEST_FILE = new File(TEST_ROOT_DIR,
       "test-file");
   


### PR DESCRIPTION
Rebased.