### PR TITLE
HADOOP-12345,HADOOP-11823 fixes

### DIFF
--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/RpcDeniedReply.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/RpcDeniedReply.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.oncrpc;
 
 import org.apache.hadoop.oncrpc.security.Verifier;
+import org.apache.hadoop.oncrpc.security.VerifierNone;
 
 /** 
  * Represents RPC message MSG_DENIED reply body. See RFC 1831 for details.
@@ -47,7 +48,7 @@ public class RpcDeniedReply extends RpcReply {
   }
 
   public static RpcDeniedReply read(int xid, ReplyState replyState, XDR xdr) {
-    Verifier verifier = Verifier.readFlavorAndVerifier(xdr);
+    Verifier verifier = new VerifierNone();
     RejectState rejectState = RejectState.fromValue(xdr.readInt());
     return new RpcDeniedReply(xid, replyState, rejectState, verifier);
   }

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
@@ -63,6 +63,10 @@ public class CredentialsSys extends Credentials {
     return mAuxGIDs;
   }
 
+  public int getStamp() {
+    return mStamp;
+  }
+
   public void setGID(int gid) {
     this.mGID = gid;
   }
@@ -93,8 +97,15 @@ public class CredentialsSys extends Credentials {
 
   @Override
   public void write(XDR xdr) {
+    int padding = 0;
+    // we do not need compute padding if the hostname is already a multiple of 4
+    if (mHostName.getBytes(Charsets.UTF_8).length != 0) {
+      padding = 4 - (mHostName.getBytes(Charsets.UTF_8).length % 4);
+    }
     // mStamp + mHostName.length + mHostName + mUID + mGID + mAuxGIDs.count
     mCredentialsLength = 20 + mHostName.getBytes(Charsets.UTF_8).length;
+    // add the extra padding to the credential length where hostname is not a multiple of 4
+    mCredentialsLength = mCredentialsLength + padding;
     // mAuxGIDs
     if (mAuxGIDs != null && mAuxGIDs.length > 0) {
       mCredentialsLength += mAuxGIDs.length * 4;

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/oncrpc/security/TestCredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/oncrpc/security/TestCredentialsSys.java
@@ -33,6 +33,7 @@ public class TestCredentialsSys {
     CredentialsSys credential = new CredentialsSys();
     credential.setUID(0);
     credential.setGID(1);
+    credential.setStamp(1234);
     
     XDR xdr = new XDR();
     credential.write(xdr);
@@ -42,5 +43,6 @@ public class TestCredentialsSys {
     
     assertEquals(0, newCredential.getUID());
     assertEquals(1, newCredential.getGID());
+    assertEquals(1234, newCredential.getStamp());
   }
 }


### PR DESCRIPTION
I have already filed the HADOOP-12345 and HADOOP-11823 jira. 

The fix for HADOOP-12345 is to correctly compute the credential length which is passed as part of the NFS request. We need to round the XDR bytes to a multiple of 4 if the hostname in the credential is not a multiple of 4.

The fix for HADOOP-11823 is when RPC returns a denied reply, the code should not check for a verifier. It is a bug as it doesn't match the RPC protocol. (See Page 33 from NFS Illustrated book).
 

This is my first time contributing to Hadoop. 