### PR TITLE
HADOOP-12345: Compute the correct credential length

### DIFF
--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Credentials.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Credentials.java
@@ -66,4 +66,8 @@ public abstract class Credentials extends RpcAuthInfo {
   protected Credentials(AuthFlavor flavor) {
     super(flavor);
   }
+
+  public int getCredentialLength() {
+    return mCredentialsLength;
+  }
 }

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Credentials.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Credentials.java
@@ -67,6 +67,7 @@ public abstract class Credentials extends RpcAuthInfo {
   protected Credentials(AuthFlavor flavor) {
     super(flavor);
   }
+
   @VisibleForTesting
   int getCredentialLength() {
     return mCredentialsLength;

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Credentials.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Credentials.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.oncrpc.security;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.oncrpc.XDR;
@@ -66,8 +67,8 @@ public abstract class Credentials extends RpcAuthInfo {
   protected Credentials(AuthFlavor flavor) {
     super(flavor);
   }
-
-  public int getCredentialLength() {
+  @VisibleForTesting
+  int getCredentialLength() {
     return mCredentialsLength;
   }
 }

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
@@ -64,7 +64,8 @@ public class CredentialsSys extends Credentials {
     return mAuxGIDs;
   }
 
-  public int getStamp() {
+  @VisibleForTesting
+  int getStamp() {
     return mStamp;
   }
 

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.oncrpc.security;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.Charsets;
 import org.apache.hadoop.oncrpc.XDR;
 
@@ -79,7 +80,8 @@ public class CredentialsSys extends Credentials {
     this.mStamp = stamp;
   }
 
-  public void setHostName(String hostname) {
+  @VisibleForTesting
+  void setHostName(String hostname) {
     this.mHostName = hostname;
   }
 
@@ -102,8 +104,9 @@ public class CredentialsSys extends Credentials {
   @Override
   public void write(XDR xdr) {
     int padding = 0;
-    // we do not need to compute padding if the hostname is already a multiple of 4
+    // Ensure there are padding bytes if hostname is not a multiple of 4.
     padding = 4 - (mHostName.getBytes(Charsets.UTF_8).length % 4);
+    // padding bytes is zero if hostname is already a multiple of 4.
     padding = padding % 4;
     // mStamp + mHostName.length + mHostName + mUID + mGID + mAuxGIDs.count
     mCredentialsLength = 20 + mHostName.getBytes(Charsets.UTF_8).length;

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
@@ -63,6 +63,10 @@ public class CredentialsSys extends Credentials {
     return mAuxGIDs;
   }
 
+  public int getStamp() {
+    return mStamp;
+  }
+
   public void setGID(int gid) {
     this.mGID = gid;
   }
@@ -93,8 +97,15 @@ public class CredentialsSys extends Credentials {
 
   @Override
   public void write(XDR xdr) {
+    int padding = 0;
+    // we do not need compute padding if the hostname is already a multiple of 4
+    if (mHostName.getBytes(Charsets.UTF_8).length != 0) {
+      padding = 4 - (mHostName.getBytes(Charsets.UTF_8).length % 4);
+    }
     // mStamp + mHostName.length + mHostName + mUID + mGID + mAuxGIDs.count
     mCredentialsLength = 20 + mHostName.getBytes(Charsets.UTF_8).length;
+    // add the extra padding to the credential length where hostname is not a multiple of 4
+    mCredentialsLength = mCredentialsLength + padding;
     // mAuxGIDs
     if (mAuxGIDs != null && mAuxGIDs.length > 0) {
       mCredentialsLength += mAuxGIDs.length * 4;

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/CredentialsSys.java
@@ -79,6 +79,10 @@ public class CredentialsSys extends Credentials {
     this.mStamp = stamp;
   }
 
+  public void setHostName(String hostname) {
+    this.mHostName = hostname;
+  }
+
   @Override
   public void read(XDR xdr) {
     mCredentialsLength = xdr.readInt();
@@ -98,13 +102,11 @@ public class CredentialsSys extends Credentials {
   @Override
   public void write(XDR xdr) {
     int padding = 0;
-    // we do not need compute padding if the hostname is already a multiple of 4
-    if (mHostName.getBytes(Charsets.UTF_8).length != 0) {
-      padding = 4 - (mHostName.getBytes(Charsets.UTF_8).length % 4);
-    }
+    // we do not need to compute padding if the hostname is already a multiple of 4
+    padding = 4 - (mHostName.getBytes(Charsets.UTF_8).length % 4);
+    padding = padding % 4;
     // mStamp + mHostName.length + mHostName + mUID + mGID + mAuxGIDs.count
     mCredentialsLength = 20 + mHostName.getBytes(Charsets.UTF_8).length;
-    // add the extra padding to the credential length where hostname is not a multiple of 4
     mCredentialsLength = mCredentialsLength + padding;
     // mAuxGIDs
     if (mAuxGIDs != null && mAuxGIDs.length > 0) {

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/oncrpc/security/TestCredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/oncrpc/security/TestCredentialsSys.java
@@ -33,6 +33,7 @@ public class TestCredentialsSys {
     CredentialsSys credential = new CredentialsSys();
     credential.setUID(0);
     credential.setGID(1);
+    credential.setStamp(1234);
     
     XDR xdr = new XDR();
     credential.write(xdr);
@@ -42,5 +43,6 @@ public class TestCredentialsSys {
     
     assertEquals(0, newCredential.getUID());
     assertEquals(1, newCredential.getGID());
+    assertEquals(1234, newCredential.getStamp());
   }
 }

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/oncrpc/security/TestCredentialsSys.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/oncrpc/security/TestCredentialsSys.java
@@ -45,4 +45,44 @@ public class TestCredentialsSys {
     assertEquals(1, newCredential.getGID());
     assertEquals(1234, newCredential.getStamp());
   }
+  
+  @Test
+  public void testHostNameNotMultipleOf4() {
+    CredentialsSys credential = new CredentialsSys();
+    credential.setUID(0);
+    credential.setGID(1);
+    credential.setStamp(1234);
+    credential.setHostName("hadoop-nfs");
+    
+    XDR xdr = new XDR();
+    credential.write(xdr);
+    
+    CredentialsSys newCredential = new CredentialsSys();
+    newCredential.read(xdr.asReadOnlyWrap());
+    
+    assertEquals(0, newCredential.getUID());
+    assertEquals(1, newCredential.getGID());
+    assertEquals(1234, newCredential.getStamp());
+    assertEquals(32, newCredential.getCredentialLength());
+  }
+
+  @Test
+  public void testHostNameMultipleOf4() {
+    CredentialsSys credential = new CredentialsSys();
+    credential.setUID(0);
+    credential.setGID(1);
+    credential.setStamp(1234);
+    credential.setHostName("apachehadoop");
+    
+    XDR xdr = new XDR();
+    credential.write(xdr);
+    
+    CredentialsSys newCredential = new CredentialsSys();
+    newCredential.read(xdr.asReadOnlyWrap());
+    
+    assertEquals(0, newCredential.getUID());
+    assertEquals(1, newCredential.getGID());
+    assertEquals(1234, newCredential.getStamp());
+    assertEquals(32, newCredential.getCredentialLength());
+  }
 }


### PR DESCRIPTION
I had to discard my earlier pull request as that included fix for the jira HADOOP-11823, hence creating a separate one for each of them.

The fix here addresses the correct credential length to be computed. We need to round of the machine name length to the next multiple of 4, else using such a credential in the NFS RPC request will result in GARBAGE_ARGS from the NFS server. See RFC-5531, page 24 and page 8 