### PR TITLE
HADOOP-11823: dont check for verifier in RpcDeniedReply

### DIFF
--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/RpcDeniedReply.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/RpcDeniedReply.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.oncrpc;
 
 import org.apache.hadoop.oncrpc.security.Verifier;
+import org.apache.hadoop.oncrpc.security.VerifierNone;
 
 /** 
  * Represents RPC message MSG_DENIED reply body. See RFC 1831 for details.
@@ -47,7 +48,7 @@ public class RpcDeniedReply extends RpcReply {
   }
 
   public static RpcDeniedReply read(int xid, ReplyState replyState, XDR xdr) {
-    Verifier verifier = Verifier.readFlavorAndVerifier(xdr);
+    Verifier verifier = new VerifierNone();
     RejectState rejectState = RejectState.fromValue(xdr.readInt());
     return new RpcDeniedReply(xid, replyState, rejectState, verifier);
   }


### PR DESCRIPTION
When RPC returns a denied reply, the code should not check for a verifier. It is a bug as it doesn't match the RPC protocol. (See Page 33 from NFS Illustrated book).
