### PR TITLE
HADOOP-12774 use UGI.currentUser for user and group of s3a objects

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
@@ -312,7 +312,7 @@ public class Listing {
       for (String prefix : objects.getCommonPrefixes()) {
         Path keyPath = owner.keyToQualifiedPath(prefix);
         if (acceptor.accept(keyPath, prefix) && filter.accept(keyPath)) {
-          FileStatus status = new S3AFileStatus(true, false, keyPath,
+          FileStatus status = new S3AFileStatus(false, keyPath,
               owner.getUsername());
           LOG.debug("Adding directory: {}", status);
           added++;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
@@ -298,7 +298,7 @@ public class Listing {
         // Skip over keys that are ourselves and old S3N _$folder$ files
         if (acceptor.accept(keyPath, summary) && filter.accept(keyPath)) {
           FileStatus status = createFileStatus(keyPath, summary,
-              owner.getDefaultBlockSize(keyPath));
+              owner.getDefaultBlockSize(keyPath), owner.getUsername());
           LOG.debug("Adding: {}", status);
           stats.add(status);
           added++;
@@ -312,7 +312,8 @@ public class Listing {
       for (String prefix : objects.getCommonPrefixes()) {
         Path keyPath = owner.keyToQualifiedPath(prefix);
         if (acceptor.accept(keyPath, prefix) && filter.accept(keyPath)) {
-          FileStatus status = new S3AFileStatus(true, false, keyPath);
+          FileStatus status = new S3AFileStatus(true, false, keyPath,
+              owner.getUsername());
           LOG.debug("Adding directory: {}", status);
           added++;
           stats.add(status);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
@@ -32,18 +32,24 @@ import org.apache.hadoop.fs.Path;
 @InterfaceStability.Evolving
 public class S3AFileStatus extends FileStatus {
   private boolean isEmptyDirectory;
+  private final String owner;
 
   // Directories
-  public S3AFileStatus(boolean isdir, boolean isemptydir, Path path) {
+  public S3AFileStatus(boolean isdir,
+      boolean isemptydir,
+      Path path,
+      String owner) {
     super(0, isdir, 1, 0, 0, path);
     isEmptyDirectory = isemptydir;
+    this.owner = owner;
   }
 
   // Files
   public S3AFileStatus(long length, long modification_time, Path path,
-      long blockSize) {
+      long blockSize, String owner) {
     super(length, false, 1, blockSize, modification_time, path);
     isEmptyDirectory = false;
+    this.owner = owner;
   }
 
   public boolean isEmptyDirectory() {
@@ -52,7 +58,16 @@ public class S3AFileStatus extends FileStatus {
 
   @Override
   public String getOwner() {
-    return System.getProperty("user.name");
+    return owner;
+  }
+
+  /**
+   * The group of an S3A entry is the same as the owner
+   * @return the owner.
+   */
+  @Override
+  public String getGroup() {
+    return owner;
   }
 
   /** Compare if this object is equal to another object.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
@@ -32,42 +32,40 @@ import org.apache.hadoop.fs.Path;
 @InterfaceStability.Evolving
 public class S3AFileStatus extends FileStatus {
   private boolean isEmptyDirectory;
-  private final String owner;
 
-  // Directories
-  public S3AFileStatus(boolean isdir,
-      boolean isemptydir,
+  /**
+   * Create a directory status.
+   * @param isemptydir is this an empty directory?
+   * @param path the path
+   * @param owner the owner
+   */
+  public S3AFileStatus(boolean isemptydir,
       Path path,
       String owner) {
-    super(0, isdir, 1, 0, 0, path);
+    super(0, true, 1, 0, 0, path);
     isEmptyDirectory = isemptydir;
-    this.owner = owner;
+    setOwner(owner);
+    setGroup(owner);
   }
 
-  // Files
+  /**
+   * A simple file.
+   * @param length file length
+   * @param modification_time mod time
+   * @param path path
+   * @param blockSize block size
+   * @param owner owner
+   */
   public S3AFileStatus(long length, long modification_time, Path path,
       long blockSize, String owner) {
     super(length, false, 1, blockSize, modification_time, path);
     isEmptyDirectory = false;
-    this.owner = owner;
+    setOwner(owner);
+    setGroup(owner);
   }
 
   public boolean isEmptyDirectory() {
     return isEmptyDirectory;
-  }
-
-  @Override
-  public String getOwner() {
-    return owner;
-  }
-
-  /**
-   * The group of an S3A entry is the same as the owner
-   * @return the owner.
-   */
-  @Override
-  public String getGroup() {
-    return owner;
   }
 
   /** Compare if this object is equal to another object.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1489,7 +1489,7 @@ public class S3AFileSystem extends FileSystem {
 
         if (objectRepresentsDirectory(key, meta.getContentLength())) {
           LOG.debug("Found exact file: fake directory");
-          return new S3AFileStatus(true, true, path, username);
+          return new S3AFileStatus(true, path, username);
         } else {
           LOG.debug("Found exact file: normal file");
           return new S3AFileStatus(meta.getContentLength(),
@@ -1514,7 +1514,7 @@ public class S3AFileSystem extends FileSystem {
 
           if (objectRepresentsDirectory(newKey, meta.getContentLength())) {
             LOG.debug("Found file (with /): fake directory");
-            return new S3AFileStatus(true, true, path, username);
+            return new S3AFileStatus(true, path, username);
           } else {
             LOG.warn("Found file (with /): real file? should not happen: {}",
                 key);
@@ -1560,10 +1560,10 @@ public class S3AFileSystem extends FileSystem {
           }
         }
 
-        return new S3AFileStatus(true, false, path, username);
+        return new S3AFileStatus(false, path, username);
       } else if (key.isEmpty()) {
         LOG.debug("Found root directory");
-        return new S3AFileStatus(true, true, path, username);
+        return new S3AFileStatus(true, path, username);
       }
     } catch (AmazonServiceException e) {
       if (e.getStatusCode() != 404) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1391,7 +1391,7 @@ public class S3AFileSystem extends FileSystem {
   }
 
   /**
-   * Get the username of the FS
+   * Get the username of the FS.
    * @return the short name of the user who instantiated the FS
    */
   public String getUsername() {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -244,7 +244,7 @@ public final class S3AUtils {
       long blockSize,
       String owner) {
     if (objectRepresentsDirectory(summary.getKey(), summary.getSize())) {
-      return new S3AFileStatus(true, true, keyPath, owner);
+      return new S3AFileStatus(true, keyPath, owner);
     } else {
       return new S3AFileStatus(summary.getSize(),
           dateToLong(summary.getLastModified()), keyPath,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -236,17 +236,19 @@ public final class S3AUtils {
    * @param keyPath path to entry
    * @param summary summary from AWS
    * @param blockSize block size to declare.
+   * @param owner owner of the file
    * @return a status entry
    */
   public static S3AFileStatus createFileStatus(Path keyPath,
       S3ObjectSummary summary,
-      long blockSize) {
+      long blockSize,
+      String owner) {
     if (objectRepresentsDirectory(summary.getKey(), summary.getSize())) {
-      return new S3AFileStatus(true, true, keyPath);
+      return new S3AFileStatus(true, true, keyPath, owner);
     } else {
       return new S3AFileStatus(summary.getSize(),
           dateToLong(summary.getLastModified()), keyPath,
-          blockSize);
+          blockSize, owner);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -44,7 +44,6 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URI;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 
 import org.apache.hadoop.security.ProviderUtils;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -44,8 +44,11 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URI;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
 
 import org.apache.hadoop.security.ProviderUtils;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.hadoop.util.VersionInfo;
@@ -436,7 +439,7 @@ public class ITestS3AConfiguration {
     dir1.mkdirs();
     dir2.mkdirs();
     conf = new Configuration();
-    conf.set(Constants.BUFFER_DIR, dir1 +", " + dir2);
+    conf.set(Constants.BUFFER_DIR, dir1 + ", " + dir2);
     fs = S3ATestUtils.createTestFileSystem(conf);
     File tmp1 = fs.createTmpFileForWrite("out-", 1024, conf);
     tmp1.delete();
@@ -444,6 +447,25 @@ public class ITestS3AConfiguration {
     tmp2.delete();
     assertNotEquals("round robin not working",
         tmp1.getParent(), tmp2.getParent());
+  }
+
+  @Test
+  public void testUsernameFromUGI() throws Throwable {
+    final String alice = "alice";
+    UserGroupInformation fakeUser =
+        UserGroupInformation.createUserForTesting(alice,
+            new String[]{"users", "administrators"});
+    conf = new Configuration();
+    fs = fakeUser.doAs(new PrivilegedExceptionAction<S3AFileSystem>() {
+      @Override
+      public S3AFileSystem run() throws Exception{
+        return S3ATestUtils.createTestFileSystem(conf);
+      }
+    });
+    assertEquals("username", alice, fs.getUsername());
+    S3AFileStatus status = fs.getFileStatus(new Path("/"));
+    assertEquals("owner in " + status, alice, status.getOwner());
+    assertEquals("group in " + status, alice, status.getGroup());
   }
 
   /**


### PR DESCRIPTION
This patch grabs the UGI current user shortname in the FS initialize call, then uses that as the user and group for all filestatus instances generated.

```
$ ./hadoop fs -ls s3a://hwdev-steve-ireland/
Found 1 items
drwxrwxrwx   - stevel stevel          0 2016-10-07 17:29 s3a://hwdev-steve-ireland/tests
```
