### PR TITLE
YARN-5721. NPE at AMRMClientImpl.getMatchingRequests

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/AMRMClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/AMRMClientImpl.java
@@ -664,15 +664,17 @@ public class AMRMClientImpl<T extends ContainerRequest> extends AMRMClient<T> {
     List<LinkedHashSet<T>> list = new LinkedList<LinkedHashSet<T>>();
 
     RemoteRequestsTable remoteRequestsTable = getTable(0);
-    List<ResourceRequestInfo<T>> matchingRequests =
-        remoteRequestsTable.getMatchingRequests(priority, resourceName,
-            executionType, capability);
-    // If no exact match. Container may be larger than what was requested.
-    // get all resources <= capability. map is reverse sorted.
-    for (ResourceRequestInfo<T> resReqInfo : matchingRequests) {
-      if (canFit(resReqInfo.remoteRequest.getCapability(), capability) &&
-        !resReqInfo.containerRequests.isEmpty()) {
-        list.add(resReqInfo.containerRequests);
+    if (remoteRequestsTable != null) {
+      List<ResourceRequestInfo<T>> matchingRequests =
+          remoteRequestsTable.getMatchingRequests(priority, resourceName,
+              executionType, capability);
+      // If no exact match. Container may be larger than what was requested.
+      // get all resources <= capability. map is reverse sorted.
+      for (ResourceRequestInfo<T> resReqInfo : matchingRequests) {
+        if (canFit(resReqInfo.remoteRequest.getCapability(), capability) &&
+            !resReqInfo.containerRequests.isEmpty()) {
+          list.add(resReqInfo.containerRequests);
+        }
       }
     }
     // no match found


### PR DESCRIPTION
The following NPE was thrown using a Spark 2.1.0-SNAPSHOT (as client) by changing Hadoop dependency to the latest (by the time the ERROR has been generated).

{{2016-10-10 11:33:53,392 ERROR yarn.ApplicationMaster: Uncaught exception:
java.lang.NullPointerException
at org.apache.hadoop.yarn.client.api.impl.AMRMClientImpl.getMatchingRequests(AMRMClientImpl.java:668)
at org.apache.hadoop.yarn.client.api.impl.AMRMClientImpl.getMatchingRequests(AMRMClientImpl.java:651)
at org.apache.spark.deploy.yarn.YarnAllocator.getPendingAtLocation(YarnAllocator.scala:210)
at org.apache.spark.deploy.yarn.YarnAllocator.getPendingAllocate(YarnAllocator.scala:203)
at org.apache.spark.deploy.yarn.YarnAllocator.updateResourceRequests(YarnAllocator.scala:318)
at org.apache.spark.deploy.yarn.YarnAllocator.allocateResources(YarnAllocator.scala:278)
at org.apache.spark.deploy.yarn.ApplicationMaster.registerAM(ApplicationMaster.scala:350)
at org.apache.spark.deploy.yarn.ApplicationMaster.runExecutorLauncher(ApplicationMaster.scala:418)
at org.apache.spark.deploy.yarn.ApplicationMaster.run(ApplicationMaster.scala:250)}}

We've also pulled the latest code (1 hour ago) from the repository, and ran a test for getMatchingRequests. Same NPE has been encountered.

getMatchingRequests should never throw an NPE even if it has been called right after the client has been started.
