### PR TITLE
HDFS-11012. Unnecessary INFO logging on DFSClients for InvalidToken.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1261,8 +1261,9 @@ public class DFSInputStream extends FSInputStream
      */
     if (ex instanceof InvalidBlockTokenException ||
         ex instanceof InvalidToken) {
-      DFSClient.LOG.info("Access token was invalid when connecting to "
-          + targetAddr + " : " + ex);
+      DFSClient.LOG.debug(
+          "Access token was invalid when connecting to {}: {}",
+          targetAddr, ex);
       return true;
     }
     return false;


### PR DESCRIPTION
This is for JIRA: https://issues.apache.org/jira/browse/HDFS-11012

The change merely switches the log level while also changing the string to use the SLF4J formatter to reduce the string append cost when unnecessary.