### PR TITLE
YARN-5800: Deleted LinuxContainerExecutor comment from yarn-default.xml

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -965,7 +965,6 @@
     <description>who will execute(launch) the containers.</description>
     <name>yarn.nodemanager.container-executor.class</name>
     <value>org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor</value>
-<!--<value>org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor</value>-->
   </property>
 
   <property>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-5800
- Removed the comment about LinuxContainerExecutor from the yarn-default.xml file
