### PR TITLE
HADOOP-13600. S3a rename() to copy files in a directory in parallel

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -107,11 +107,15 @@ public final class Constants {
   public static final String MAX_PAGING_KEYS = "fs.s3a.paging.maximum";
   public static final int DEFAULT_MAX_PAGING_KEYS = 5000;
 
-  // the maximum number of threads to allow in the pool used by TransferManager
+  // the maximum number of threads to allow in the pool used by TransferManager for uploads
   public static final String MAX_THREADS = "fs.s3a.threads.max";
   public static final int DEFAULT_MAX_THREADS = 10;
 
-  // the time an idle thread waits before terminating
+  // the maximum number of threads to allow in the pool used by TransferManager for copies
+  public static final String COPY_MAX_THREADS = "fs.s3a.copy.threads.max";
+  public static final int DEFAULT_COPY_MAX_THREADS = 25;
+
+  // the time an idle thread waits before terminating for uploads and copies
   public static final String KEEPALIVE_TIME = "fs.s3a.threads.keepalivetime";
   public static final int DEFAULT_KEEPALIVE_TIME = 60;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/CopyContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/CopyContext.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import com.amazonaws.event.ProgressListener;
+import com.amazonaws.services.s3.transfer.Copy;
+
+
+/**
+ * A wrapper around a {@link Copy} object, the source key for the copy, the destination for the copy, the length of the
+ * key copied, and the {@link ProgressListener.ExceptionReporter} for the copy.
+ */
+class CopyContext {
+
+  private final Copy copy;
+  private final String srcKey;
+  private final String destKey;
+  private final long length;
+  private final ProgressListener.ExceptionReporter progressListener;
+
+  CopyContext(Copy copy, String srcKey, String destKey, long length,
+              ProgressListener.ExceptionReporter progressListener) {
+    this.copy = copy;
+    this.srcKey = srcKey;
+    this.destKey = destKey;
+    this.length = length;
+    this.progressListener = progressListener;
+  }
+
+  Copy getCopy() {
+    return copy;
+  }
+
+  String getSrcKey() {
+    return srcKey;
+  }
+
+  String getDestKey() {
+    return destKey;
+  }
+
+  long getLength() {
+    return length;
+  }
+
+  ProgressListener.ExceptionReporter getProgressListener() {
+    return progressListener;
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/LazyTransferManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/LazyTransferManager.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerConfiguration;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.apache.hadoop.fs.s3a.Constants.COPY_MAX_THREADS;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_COPY_MAX_THREADS;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_KEEPALIVE_TIME;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAX_THREADS;
+import static org.apache.hadoop.fs.s3a.Constants.KEEPALIVE_TIME;
+import static org.apache.hadoop.fs.s3a.Constants.MAX_THREADS;
+import static org.apache.hadoop.fs.s3a.S3AUtils.getMaxThreads;
+import static org.apache.hadoop.fs.s3a.S3AUtils.longOption;
+
+
+/**
+ * A wrapper around a {@link TransferManager} that lazily initializes the {@link TransferManager}.
+ */
+class LazyTransferManager {
+
+  private final AmazonS3 s3;
+  private final TransferManagerConfiguration transferConfiguration;
+  private final int maxThreads;
+  private final long keepAliveTime;
+  private final String threadPoolName;
+
+  private TransferManager transferManager;
+  private ExecutorService executorService;
+
+  private LazyTransferManager(AmazonS3 s3, TransferManagerConfiguration transferConfiguration, int maxThreads,
+                      long keepAliveTime, String threadPoolName) {
+    this.s3 = s3;
+    this.transferConfiguration = transferConfiguration;
+    this.maxThreads = maxThreads;
+    this.keepAliveTime = keepAliveTime;
+    this.threadPoolName = threadPoolName;
+  }
+
+  synchronized TransferManager get() {
+    if (transferManager == null) {
+      transferManager = createTransferManager();
+      return transferManager;
+    }
+    return transferManager;
+  }
+
+  boolean isInitialized() {
+    return transferManager == null;
+  }
+
+  ExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  private TransferManager createTransferManager() {
+    executorService = new ThreadPoolExecutor(
+            maxThreads, Integer.MAX_VALUE,
+            keepAliveTime, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            BlockingThreadPoolExecutorService.newDaemonThreadFactory(
+                    threadPoolName));
+
+    TransferManager transferManager = new TransferManager(s3, executorService);
+    transferManager.setConfiguration(transferConfiguration);
+    return transferManager;
+  }
+
+  static LazyTransferManager createLazyUploadTransferManager(AmazonS3 s3, Configuration conf, long partSize,
+                                                                     long multiPartThreshold) {
+    int maxThreads = getMaxThreads(conf, MAX_THREADS, DEFAULT_MAX_THREADS);
+    long keepAliveTime = longOption(conf, KEEPALIVE_TIME, DEFAULT_KEEPALIVE_TIME, 0);
+
+    TransferManagerConfiguration transferConfiguration = new TransferManagerConfiguration();
+    transferConfiguration.setMinimumUploadPartSize(partSize);
+    transferConfiguration.setMultipartUploadThreshold(multiPartThreshold);
+
+    return new LazyTransferManager(s3, transferConfiguration, maxThreads, keepAliveTime, "s3a-upload-unbounded");
+  }
+
+  static LazyTransferManager createLazyCopyTransferManager(AmazonS3 s3, Configuration conf, long partSize,
+                                                                   long multiPartThreshold) {
+    int maxThreads = getMaxThreads(conf, COPY_MAX_THREADS, DEFAULT_COPY_MAX_THREADS);
+    long keepAliveTime = longOption(conf, KEEPALIVE_TIME, DEFAULT_KEEPALIVE_TIME, 0);
+
+    TransferManagerConfiguration transferConfiguration = new TransferManagerConfiguration();
+    transferConfiguration.setMultipartCopyPartSize(partSize);
+    transferConfiguration.setMultipartCopyThreshold(multiPartThreshold);
+
+    return new LazyTransferManager(s3, transferConfiguration, maxThreads, keepAliveTime, "s3a-copy-unbounded");
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ParallelDirectoryRenamer.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ParallelDirectoryRenamer.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.amazonaws.event.ProgressEvent;
+import com.amazonaws.event.ProgressListener;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+
+/**
+ * Renames a S3 directory by issuing parallel COPY requests.
+ */
+class ParallelDirectoryRenamer {
+
+  private final S3AFileSystem fs;
+
+  private static final DeleteObjectsRequest.KeyVersion END_OF_KEYS_TO_DELETE = new DeleteObjectsRequest.KeyVersion(null,
+          null);
+
+  ParallelDirectoryRenamer(S3AFileSystem fs) {
+    this.fs = fs;
+  }
+
+  List<CopyContext> rename(String srcKey, String dstKey, S3AFileStatus dstStatus) throws IOException {
+
+    List<DeleteObjectsRequest.KeyVersion> dirKeysToDelete = new ArrayList<>();
+
+    List<CopyContext> copies = new ArrayList<>();
+
+    // A blocking queue that tracks all objects that need to be deleted
+    BlockingQueue<DeleteObjectsRequest.KeyVersion> deleteQueue = new LinkedBlockingQueue<>();
+
+    // Used to track if the delete thread was gracefully shutdown
+    boolean deleteFutureComplete = false;
+    FutureTask<Void> deleteFuture = null;
+
+    try {
+      // Launch a thread that will read from the deleteQueue and batch delete any files that have already been copied
+      deleteFuture = buildAndStartDeletionThread(deleteQueue);
+
+      if (dstStatus != null && dstStatus.isEmptyDirectory() == Tristate.TRUE) {
+        // delete unnecessary fake directory.
+        deleteQueue.add(new DeleteObjectsRequest.KeyVersion(dstKey));
+      }
+
+      // Used to abort future copy tasks as soon as one copy task fails
+      AtomicBoolean copyFailure = new AtomicBoolean(false);
+
+      Path parentPath = fs.keyToPath(srcKey);
+      RemoteIterator<LocatedFileStatus> iterator = fs.listFilesAndEmptyDirectories(parentPath, true);
+      while (iterator.hasNext()) {
+
+        LocatedFileStatus status = iterator.next();
+        String key = fs.pathToKey(status.getPath());
+        if (status.isDirectory() && !key.endsWith("/")) {
+          key += "/";
+        }
+        String newDstKey = dstKey + key.substring(srcKey.length());
+
+        DeleteObjectsRequest.KeyVersion deleteKeyVersion = null;
+        if (status.isDirectory()) {
+          dirKeysToDelete.add(new DeleteObjectsRequest.KeyVersion(key));
+        } else {
+          deleteKeyVersion = new DeleteObjectsRequest.KeyVersion(key);
+        }
+
+        // If no previous file hit a copy failure, copy this file
+        if (!copyFailure.get()) {
+
+          ProgressListener.ExceptionReporter progressListener = new ProgressListener.ExceptionReporter(
+                  new RenameProgressListener(deleteKeyVersion, deleteQueue, copyFailure));
+
+          copies.add(new CopyContext(fs.copyFileAsync(key, newDstKey, progressListener), key, newDstKey,
+                  status.getLen(), progressListener));
+        } else {
+          // We got a copy failure, so don't bother going through the rest of the files
+          break;
+        }
+      }
+
+      for (CopyContext copyContext : copies) {
+        try {
+          copyContext.getCopy().waitForCopyResult();
+          copyContext.getProgressListener().throwExceptionIfAny();
+          fs.incrementWriteOperations();
+          fs.getInstrumentation().filesCopied(1, copyContext.getLength());
+        } catch (InterruptedException e) {
+          throw new RenameFailedException(copyContext.getSrcKey(), copyContext.getDestKey(), e);
+        }
+      }
+
+      if (copyFailure.get()) {
+        throw new RenameFailedException(srcKey, dstKey,
+                new IllegalStateException("Progress listener indicated a copy failure, but no exception was thrown"));
+      }
+
+      deleteQueue.addAll(dirKeysToDelete);
+      deleteQueue.add(END_OF_KEYS_TO_DELETE);
+
+      try {
+        deleteFuture.get();
+      } catch (ExecutionException | InterruptedException e) {
+        throw new RenameFailedException(srcKey, dstKey, e);
+      }
+      deleteFutureComplete = true;
+    } finally {
+      if (!deleteFutureComplete) {
+        if (deleteFuture != null && !deleteFuture.isDone() && !deleteFuture.isCancelled()) {
+          deleteFuture.cancel(true);
+        }
+      }
+    }
+    return copies;
+  }
+
+  private FutureTask<Void> buildAndStartDeletionThread(BlockingQueue<DeleteObjectsRequest.KeyVersion> deleteQueue) {
+    List<DeleteObjectsRequest.KeyVersion> keysToDelete = new ArrayList<>();
+    FutureTask<Void> deleteFuture = new FutureTask<>(() -> {
+      while (true) {
+        while (keysToDelete.size() < fs.getMaxEntriesToDelete()) {
+          DeleteObjectsRequest.KeyVersion key = deleteQueue.take();
+
+          // The thread runs until it is given an a message that no more keys need to be deleted (END_OF_KEYS_TO_DELETE)
+          if (key == END_OF_KEYS_TO_DELETE) {
+            // Delete any remaining keys and exit
+            fs.removeKeys(keysToDelete, true, false);
+            return null;
+          } else {
+            keysToDelete.add(key);
+          }
+        }
+        fs.removeKeys(keysToDelete, true, false);
+      }
+    });
+
+    Thread deleteThread = new Thread(deleteFuture);
+    deleteThread.setName("s3a-rename-delete-thread");
+    deleteThread.start();
+    return deleteFuture;
+  }
+
+  /**
+   * A {@link ProgressListener} for renames. When the transfer completes, the listener will delete the source key and
+   * update any relevant statistics.
+   */
+  private static class RenameProgressListener implements ProgressListener {
+
+    private final DeleteObjectsRequest.KeyVersion keyVersion;
+    private final Queue<DeleteObjectsRequest.KeyVersion> deleteQueue;
+    private final AtomicBoolean copyFailure;
+
+    RenameProgressListener(DeleteObjectsRequest.KeyVersion keyVersion,
+                           Queue<DeleteObjectsRequest.KeyVersion> deleteQueue,
+                           AtomicBoolean copyFailure) {
+      this.keyVersion = keyVersion;
+      this.deleteQueue = deleteQueue;
+      this.copyFailure = copyFailure;
+    }
+
+    @Override
+    public void progressChanged(ProgressEvent progressEvent) {
+      switch (progressEvent.getEventType()) {
+        case CLIENT_REQUEST_SUCCESS_EVENT:
+          if (keyVersion != null) {
+            deleteQueue.add(keyVersion);
+          }
+          break;
+        case CLIENT_REQUEST_FAILED_EVENT:
+          copyFailure.set(true);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -881,4 +881,12 @@ public final class S3AUtils {
     }
   }
 
+  static int getMaxThreads(Configuration conf, String maxThreadsKey, int defaultMaxThreads) {
+    int maxThreads = conf.getInt(maxThreadsKey, defaultMaxThreads);
+    if (maxThreads < 2) {
+      LOG.warn(maxThreadsKey + " must be at least 2: forcing to 2.");
+      maxThreads = 2;
+    }
+    return maxThreads;
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AConcurrentOps.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AConcurrentOps.java
@@ -94,6 +94,7 @@ public class ITestS3AConcurrentOps extends S3AScaleTestBase {
   private S3AFileSystem getRestrictedFileSystem() throws Exception {
     Configuration conf = getConfiguration();
     conf.setInt(MAX_THREADS, 2);
+    conf.setInt(COPY_MAX_THREADS, 2);
     conf.setInt(MAX_TOTAL_TASKS, 1);
 
     conf.set(MIN_MULTIPART_THRESHOLD, "10M");


### PR DESCRIPTION
* Creates two separate `TransferManager`s - one for file uploads and one for file copies; this way they can be both configured separately; users may want to set the # of parallel uploads to a lower value than the # of parallel copies because uploads require actual I/O while copies do not
* Main modifications are to the `innerRename` method
* Instead of renaming a directory file by file, use the copy `TranferManager` to upload them in parallel
* Copies are submitted to the `TransferManager` and then tracked using the returned `Copy` object
* Deletes are handled via a `BlockingQueue` - once each copy is complete it adds a key to the queue, once `MAX_ENTRIES_TO_DELETE` keys need to be deleted, then the `removeKeys` method is invoked
* A separate thread is spawned to read from the delete queue and issue the delete requests
* A `ProgressListener` is used to track when a copy has been completed, once a copy finishes, the key to delete is added to the delete queue
* Some other re-factoring to make the above possible