### PR TITLE
YARN-5924 - Resource Manager fails to load state with InvalidProtocolBufferException

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/FileSystemRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/FileSystemRMStateStore.java
@@ -301,7 +301,8 @@ public class FileSystemRMStateStore extends RMStateStore {
         assert fileNodeStatus.isFile();
         try {
           String fileName = fileNodeStatus.getPath().getName();
-          if (checkAndRemovePartialRecordWithRetries(fileNodeStatus.getPath())) {
+          if (checkAndRemovePartialRecordWithRetries(
+                  fileNodeStatus.getPath())) {
             continue;
           }
           byte[] fileData = readFileWithRetries(fileNodeStatus.getPath(),
@@ -312,14 +313,17 @@ public class FileSystemRMStateStore extends RMStateStore {
           rmAppStateFileProcessor.processChildNode(dirName, fileName,
                     fileData);
         } catch (InvalidProtocolBufferException ex) {
-          LOG.warn("Removing broken " + dir.getPath() + " app's directory as its data is invalid, to prevent RM restart failure.", ex);
+          LOG.warn("Removing broken " + dir.getPath() + " app's directory " +
+                  "as its data is invalid, to prevent RM restart failure.", ex);
           // removing directory with broken data
           if (existsWithRetries(dir.getPath())) {
             deleteFileWithRetries(dir.getPath());
           }
           break;
         } catch (Exception ex) {
-          LOG.warn("Skipping state loading for " + dir.getPath() + " app's directory because of exception to prevent RM restart failure", ex);
+          LOG.warn("Skipping state loading for " + dir.getPath() + 
+                  " app's directory because of exception" +
+                  " to prevent RM restart failure", ex);
           break;
         }
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/FileSystemRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/FileSystemRMStateStore.java
@@ -321,7 +321,7 @@ public class FileSystemRMStateStore extends RMStateStore {
           }
           break;
         } catch (Exception ex) {
-          LOG.warn("Skipping state loading for " + dir.getPath() + 
+          LOG.warn("Skipping state loading for " + dir.getPath() +
                   " app's directory because of exception" +
                   " to prevent RM restart failure", ex);
           break;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestFSRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestFSRMStateStore.java
@@ -214,8 +214,10 @@ public class TestFSRMStateStore extends RMStateStoreTestBase {
             new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
     try {
       fsTester = new TestFSRMStateStoreTester(cluster, false);
-      // If the state store is FileSystemRMStateStore then add invalid application data.
-      // It should discard the entry and remove application with broken data from the file system.
+      // If the state store is FileSystemRMStateStore 
+      // then add invalid application data.
+      // It should discard the entry and remove application 
+      // with broken data from the file system.
       FileSystemRMStateStore fileSystemRMStateStore =
               (FileSystemRMStateStore) fsTester.getRMStateStore();
       String appIdStr = "application_1477986176766_0134";
@@ -226,8 +228,9 @@ public class TestFSRMStateStore extends RMStateStoreTestBase {
       Path tempAppFile =
               new Path(appDir, appId.toString());
       
-        // write invalid data
-      try (FSDataOutputStream fsOut = fileSystemRMStateStore.fs.create(tempAppFile, false)) {
+      // write invalid data
+      try (FSDataOutputStream fsOut = 
+                   fileSystemRMStateStore.fs.create(tempAppFile, false)) {
         fsOut.write("\\00\\00\\00\\00\\00".getBytes());
       }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestFSRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/TestFSRMStateStore.java
@@ -214,9 +214,9 @@ public class TestFSRMStateStore extends RMStateStoreTestBase {
             new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
     try {
       fsTester = new TestFSRMStateStoreTester(cluster, false);
-      // If the state store is FileSystemRMStateStore 
+      // If the state store is FileSystemRMStateStore
       // then add invalid application data.
-      // It should discard the entry and remove application 
+      // It should discard the entry and remove application
       // with broken data from the file system.
       FileSystemRMStateStore fileSystemRMStateStore =
               (FileSystemRMStateStore) fsTester.getRMStateStore();
@@ -227,9 +227,9 @@ public class TestFSRMStateStore extends RMStateStoreTestBase {
               fsTester.store.getAppDir(appId.toString());
       Path tempAppFile =
               new Path(appDir, appId.toString());
-      
+
       // write invalid data
-      try (FSDataOutputStream fsOut = 
+      try (FSDataOutputStream fsOut =
                    fileSystemRMStateStore.fs.create(tempAppFile, false)) {
         fsOut.write("\\00\\00\\00\\00\\00".getBytes());
       }


### PR DESCRIPTION
The solution is to catch "InvalidProtocolBufferException", show warning and remove application's folder that contains invalid data to prevent RM restart failure. 

Additionally, I've added catch for other exceptions that can appear during recovering of the specific application, to avoid RM failure even if the only one application's state can't be loaded.
