### PR TITLE
HDFS-11234: Made the socket buffer size configurable with the config …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -1507,7 +1507,10 @@ public class DFSOutputStream extends FSOutputSummer
     final int timeout = client.getDatanodeReadTimeout(length);
     NetUtils.connect(sock, isa, client.getRandomLocalInterfaceAddr(), client.getConf().socketTimeout);
     sock.setSoTimeout(timeout);
-    sock.setSendBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+    if (HdfsConstants.DEFAULT_DATA_SOCKET_SIZE > 0) {
+	DFSClient.LOG.info("Setting buf size to " + HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+	sock.setSendBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+    }
     if(DFSClient.LOG.isDebugEnabled()) {
       DFSClient.LOG.debug("Send buf size " + sock.getSendBufferSize());
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsConstants.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsConstants.java
@@ -70,9 +70,12 @@ public class HdfsConstants {
   // to 1k.
   public static final int MAX_PATH_LENGTH = 8000;
   public static final int MAX_PATH_DEPTH = 1000;
+  
+  // specify socket buffer size in bytes, useful to increase for high latency/high bandwidth systems.
+  // As a special case, values <=0 cause the setReceiveBufferSize/setSendBufferSize function call to be skipped;
+  // letting the kernel do the right thing. -1 is the default, old default was 128*1024 bytes
+  public static final int DEFAULT_DATA_SOCKET_SIZE = new HdfsConfiguration().getInt("fs.hdfs.data.socket.size", -1); 
 
-  // TODO should be conf injected?
-  public static final int DEFAULT_DATA_SOCKET_SIZE = 128 * 1024;
   public static final int IO_FILE_BUFFER_SIZE = new HdfsConfiguration().getInt(
       DFSConfigKeys.IO_FILE_BUFFER_SIZE_KEY,
       DFSConfigKeys.IO_FILE_BUFFER_SIZE_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -893,7 +893,10 @@ public class DataNode extends ReconfigurableBase
       tcpPeerServer = new TcpPeerServer(dnConf.socketWriteTimeout,
           DataNode.getStreamingAddr(conf));
     }
-    tcpPeerServer.setReceiveBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+    if(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE > 0) {
+	LOG.info("Setting buf size to " + HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+	tcpPeerServer.setReceiveBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+    }
     streamingAddr = tcpPeerServer.getStreamingAddr();
     LOG.info("Opened streaming server at " + streamingAddr);
     this.threadGroup = new ThreadGroup("dataXceiverServer");
@@ -941,8 +944,10 @@ public class DataNode extends ReconfigurableBase
     }
     DomainPeerServer domainPeerServer =
       new DomainPeerServer(domainSocketPath, port);
-    domainPeerServer.setReceiveBufferSize(
-        HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+    if( HdfsConstants.DEFAULT_DATA_SOCKET_SIZE > 0){
+	 LOG.info("Setting buf size to " + HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+	domainPeerServer.setReceiveBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+    }
     return domainPeerServer;
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -706,8 +706,11 @@ class DataXceiver extends Receiver implements Runnable {
                       (HdfsServerConstants.WRITE_TIMEOUT_EXTENSION * targets.length);
           NetUtils.connect(mirrorSock, mirrorTarget, timeoutValue);
           mirrorSock.setSoTimeout(timeoutValue);
-          mirrorSock.setSendBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
-          
+	  if (HdfsConstants.DEFAULT_DATA_SOCKET_SIZE > 0) {
+          	LOG.info("Setting buf size to " + HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+		mirrorSock.setSendBufferSize(HdfsConstants.DEFAULT_DATA_SOCKET_SIZE);
+          }
+
           OutputStream unbufMirrorOut = NetUtils.getOutputStream(mirrorSock,
               writeTimeout);
           InputStream unbufMirrorIn = NetUtils.getInputStream(mirrorSock);


### PR DESCRIPTION
…node fs.hdfs.data.socket.size to be set in core-site.xml. If the node is not found, the default value is -1, so socket buffer size would not be set.