### PR TITLE
MAPREDUCE-6827. Fixed bug: the second foreach-loop was not executed

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/ReduceContextImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/ReduceContextImpl.java
@@ -348,10 +348,9 @@ public class ReduceContextImpl<KEYIN,VALUEIN,KEYOUT,VALUEOUT>
   }
 
   protected class ValueIterable implements Iterable<VALUEIN> {
-    private ValueIterator iterator = new ValueIterator();
     @Override
     public Iterator<VALUEIN> iterator() {
-      return iterator;
+      return new ValueIterator();
     } 
   }
   


### PR DESCRIPTION
Failed to traverse `Iterable values` with `foreach` at the second time in reduce() method, because the second foreach-loop was not executed.

[JIRA MAPREDUCE-6827](https://issues.apache.org/jira/browse/MAPREDUCE-6827)

The following code is a reduce() method (of WordCount):


	public static class WcReducer extends Reducer<Text, IntWritable, Text, IntWritable> {

		@Override
		protected void reduce(Text key, Iterable<IntWritable> values, Context context)
				throws IOException, InterruptedException {

			// print some logs
			List<String> vals = new LinkedList<>();
			for(IntWritable i : values) {
				vals.add(i.toString());
			}
			System.out.println(String.format(">>>> reduce(%s, [%s])",
					key, String.join(", ", vals)));

			// sum of values
			int sum = 0;
			for(IntWritable i : values) {
				sum += i.get();
			}
			System.out.println(String.format(">>>> reduced(%s, %s)",
					key, sum));

			context.write(key, new IntWritable(sum));
		}
	}

After running it, we got the result that the value of the variable `sum` is always 0！

After debugging, it was found that the second foreach-loop was not executed, and the root cause was the returned value of `Iterable.iterator()`, it returned the same instance in the two calls called by foreach-loop. In general, **`Iterable.iterator()` should return a new instance in each call**, such as `ArrayList.iterator()`. This patch fixed the bug.

Signed-off-by: Javeme <javaloveme@gmail.com>