### PR TITLE
Total Throughput Calculation Error in TestDFSIO

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -1042,7 +1042,7 @@ public class TestDFSIO implements Tool {
         "        Number of files: " + tasks,
         " Total MBytes processed: " + df.format(toMB(size)),
         "      Throughput mb/sec: " + df.format(size * 1000.0 / (time * MEGA)),
-        "Total Throughput mb/sec: " + df.format(toMB(size) / ((float)execTime)),
+        "Total Throughput mb/sec: " + df.format(toMB(size) * 1000.0 / ((float)execTime)),
         " Average IO rate mb/sec: " + df.format(med),
         "  IO rate std deviation: " + df.format(stdDev),
         "     Test exec time sec: " + df.format((float)execTime / 1000),


### PR DESCRIPTION
Total throughput should be toMB(size) * 1000.0 / ((float) execTime)