### PR TITLE
HADOOP-13371. S3A globber to use bulk listObject call over recursive directory scan

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Globber.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Globber.java
@@ -231,7 +231,9 @@ class Globber {
         }
         for (FileStatus candidate : candidates) {
           if (globFilter.hasPattern()) {
-            FileStatus[] children = listStatus(candidate.getPath());
+            Path path = candidate.getPath();
+            path.filter = globFilter;
+            FileStatus[] children = listStatus(path);
             if (children.length == 1) {
               // If we get back only one result, this could be either a listing
               // of a directory with one entry, or it could reflect the fact

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Globber.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Globber.java
@@ -256,8 +256,8 @@ class Globber {
                 if (!child.isDirectory()) continue; 
               }
               // Set the child path based on the parent path.
-              child.setPath(new Path(candidate.getPath(),
-                      child.getPath().getName()));
+              child.setPath(new Path(candidate.getPath().toString() + Path.SEPARATOR
+                + child.getPath().getName()));
               if (globFilter.accept(child.getPath())) {
                 newCandidates.add(child);
               }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
@@ -63,6 +63,8 @@ public class Path implements Comparable, Serializable, ObjectInputValidation {
   public static final boolean WINDOWS =
       System.getProperty("os.name").startsWith("Windows");
 
+  public PathFilter filter = null;
+
   /**
    *  Pre-compiled regular expressions to detect path formats.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1432,7 +1432,7 @@ public class S3AFileSystem extends FileSystem {
       Listing.FileStatusListingIterator files =
           listing.createFileStatusListingIterator(path,
               request,
-              ACCEPT_ALL,
+              (f.filter == null) ? ACCEPT_ALL : f.filter,
               new Listing.AcceptAllButSelfAndS3nDirs(path));
       result = new ArrayList<>(files.getBatchSize());
       while (files.hasNext()) {


### PR DESCRIPTION
Hi @steveloughran 

This pull request is for fixing (mitigating) the issue of [HADOOP-13371](https://issues.apache.org/jira/browse/HADOOP-13371).

With this patch, it now passes the filter before glob happens.

I had an issue of getting OOM for globbing large s3 buckets before since it kept all possible paths and the filtering happened at the end. Now this patch prunes unnecessary paths with the filter first. I applied this patch to our production pipelines, things run flawlessly.
This should be applicable to branch-2.8 as well.

Thanks in advance for reviewing this.