### PR TITLE
Fix JobConf.getNumMapTasks() Java doc

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobConf.java
@@ -1334,7 +1334,7 @@ public class JobConf extends Configuration {
   public void setNumMapTasks(int n) { setInt(JobContext.NUM_MAPS, n); }
 
   /**
-   * Get the configured number of reduce tasks for this job. Defaults to 
+   * Get the configured number of reduce tasks for this job. Defaults to
    * <code>1</code>.
    * 
    * @return the number of reduce tasks for this job.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobConf.java
@@ -1286,10 +1286,10 @@ public class JobConf extends Configuration {
   }
 
   /**
-   * Get configured the number of reduce tasks for this job.
+   * Get the configured number of map tasks for this job.
    * Defaults to <code>1</code>.
    * 
-   * @return the number of reduce tasks for this job.
+   * @return the number of map tasks for this job.
    */
   public int getNumMapTasks() { return getInt(JobContext.NUM_MAPS, 1); }
   
@@ -1334,7 +1334,7 @@ public class JobConf extends Configuration {
   public void setNumMapTasks(int n) { setInt(JobContext.NUM_MAPS, n); }
 
   /**
-   * Get configured the number of reduce tasks for this job. Defaults to 
+   * Get the configured number of reduce tasks for this job. Defaults to 
    * <code>1</code>.
    * 
    * @return the number of reduce tasks for this job.


### PR DESCRIPTION
# Problem

The original description of the `getNumMapTasks()` method in JobConf was invalid, because it referenced to the number of reducer tasks instead of the map tasks.

from: Get configured the number of reduce tasks for this job.
to:     Get the configured number of map tasks for this job.

It was maybe the result of a tricky copy-paste  :-)

# Solution

Change the doc to refer to the number of map tasks.

The PR resolves the following [JIRA issue](https://issues.apache.org/jira/browse/HADOOP-14228)