### PR TITLE
HADOOP-14235. S3A Path does not understand colon (:) when globbing

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Globber.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Globber.java
@@ -254,8 +254,8 @@ class Globber {
                 if (!child.isDirectory()) continue; 
               }
               // Set the child path based on the parent path.
-              child.setPath(new Path(candidate.getPath(),
-                      child.getPath().getName()));
+              child.setPath(new Path(candidate.getPath().toString() + Path.SEPARATOR
+                + child.getPath().getName()));
               if (globFilter.accept(child.getPath())) {
                 newCandidates.add(child);
               }


### PR DESCRIPTION
Hi @steveloughran @liuml07 

I explained the issue at https://issues.apache.org/jira/browse/HADOOP-14235

This pull request fixes the issue and does not break other things as far as I know. (I also ran the unit tests).

Probably, #204 should also fix this issue. This pull request is for a short-term solution in case anyone is interested.