### PR TITLE
HADOOP-14239. S3A Retry Multiple S3 Key Deletion

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -59,6 +59,8 @@ import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException.DeleteError;
 import com.amazonaws.services.s3.transfer.Copy;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerConfiguration;
@@ -1006,10 +1008,25 @@ public class S3AFileSystem extends FileSystem {
    * operation statistics.
    * @param deleteRequest keys to delete on the s3-backend
    */
-  private void deleteObjects(DeleteObjectsRequest deleteRequest) {
+  private void deleteObjects(DeleteObjectsRequest deleteRequest) throws InvalidRequestException {
     incrementWriteOperations();
     incrementStatistic(OBJECT_DELETE_REQUESTS, 1);
-    s3.deleteObjects(deleteRequest);
+    try {
+      s3.deleteObjects(deleteRequest);
+    } catch (MultiObjectDeleteException ex) {
+      List<DeleteObjectsRequest.KeyVersion> errorKeys = new ArrayList<>();
+      for (DeleteError deleteError : ex.getErrors()) {
+        errorKeys.add(new DeleteObjectsRequest.KeyVersion(deleteError.getKey()));
+      }
+      if (errorKeys.size() == deleteRequest.getKeys().size()) {
+        // fallback to single key deletion if all of them failed
+        for (DeleteObjectsRequest.KeyVersion keyVersion : errorKeys) {
+          deleteObject(keyVersion.getKey());
+        }
+      } else {
+        deleteObjects(deleteRequest.withKeys(errorKeys));
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Hi @steveloughran @liuml07 

Sorry for sending may requests.

I explained the problem here https://issues.apache.org/jira/browse/HADOOP-14239

This pull requests recursively retries to delete only S3 keys that are previously failed to delete during the multiple object deletion because aws-java-sdk retry does not help. If it still fails, it will fall back to the single deletion.