### PR TITLE
YARN-6457  use existing conf object as a resource for sslConf object in WebApps for the builder to use in HttpServer2

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -375,16 +375,20 @@ public class WebAppUtils {
   /**
    * Load the SSL keystore / truststore into the HttpServer builder.
    * @param builder the HttpServer2.Builder to populate with ssl config
-   * @param sslConf the Configuration instance to use during loading of SSL conf
+   * @param conf the Configuration instance to use during loading of SSL conf
+   *
+   * @return HttpServer2.Builder instance (passed in as the first parameter) after loading SSL stores
    */
   public static HttpServer2.Builder loadSslConfiguration(
-      HttpServer2.Builder builder, Configuration sslConf) {
-    if (sslConf == null) {
-      sslConf = new Configuration(false);
+      HttpServer2.Builder builder, Configuration conf) {
+
+    Configuration sslConf = new Configuration(false);
+
+    sslConf.addResource(YarnConfiguration.YARN_SSL_SERVER_RESOURCE_DEFAULT);
+    if (conf != null) {
+      sslConf.addResource(conf);
     }
     boolean needsClientAuth = YarnConfiguration.YARN_SSL_CLIENT_HTTPS_NEED_AUTH_DEFAULT;
-    sslConf.addResource(YarnConfiguration.YARN_SSL_SERVER_RESOURCE_DEFAULT);
-
     return builder
         .needsClientAuth(needsClientAuth)
         .keyPassword(getPassword(sslConf, WEB_APP_KEY_PASSWORD_KEY))


### PR DESCRIPTION
use the passed conf object as a resource in local sslConf so it can be overridden