### PR TITLE
HADOOP-9320 Fix Hadoop native build failure on ARM hard-float

### DIFF
--- a/hadoop-common-project/hadoop-common/HadoopCommon.cmake
+++ b/hadoop-common-project/hadoop-common/HadoopCommon.cmake
@@ -153,35 +153,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         endif()
     endif()
 
-    # Determine float ABI of JVM on ARM.
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-        find_program(READELF readelf)
-        if(READELF MATCHES "NOTFOUND")
-            message(WARNING "readelf not found; JVM float ABI detection disabled")
-        else(READELF MATCHES "NOTFOUND")
-            execute_process(
-                COMMAND ${READELF} -A ${JAVA_JVM_LIBRARY}
-                OUTPUT_VARIABLE JVM_ELF_ARCH
-                ERROR_QUIET)
-            if(NOT JVM_ELF_ARCH MATCHES "Tag_ABI_VFP_args: VFP registers")
-                # Test compilation with -mfloat-abi=softfp using an arbitrary libc function
-                # (typically fails with "fatal error: bits/predefs.h: No such file or directory"
-                # if soft-float dev libraries are not installed)
-                message("Soft-float JVM detected")
-                include(CMakePushCheckState)
-                cmake_push_check_state()
-                set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mfloat-abi=softfp")
-                include(CheckSymbolExists)
-                check_symbol_exists(exit stdlib.h SOFTFP_AVAILABLE)
-                if(NOT SOFTFP_AVAILABLE)
-                    message(FATAL_ERROR "Soft-float dev libraries required (e.g. 'apt-get install libc6-dev-armel' on Debian/Ubuntu)")
-                endif()
-                cmake_pop_check_state()
-                hadoop_add_compiler_flags("-mfloat-abi=softfp")
-            endif()
-        endif()
-    endif()
-
 #
 # Solaris-specific configuration.
 #

--- a/hadoop-common-project/hadoop-common/HadoopJNI.cmake
+++ b/hadoop-common-project/hadoop-common/HadoopJNI.cmake
@@ -95,3 +95,38 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 else()
     find_package(JNI REQUIRED)
 endif()
+
+# Determine float ABI of JVM on ARM Linux
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_program(READELF readelf)
+    if (READELF MATCHES "NOTFOUND")
+        message(WARNING "readelf not found; JVM float ABI detection disabled")
+    else (READELF MATCHES "NOTFOUND")
+        message(STATUS "Checking float ABI of ${JAVA_JVM_LIBRARY}")
+        execute_process(
+            COMMAND ${READELF} -A ${JAVA_JVM_LIBRARY}
+            OUTPUT_VARIABLE JVM_ELF_ARCH
+            ERROR_QUIET)
+        if (JVM_ELF_ARCH MATCHES "Tag_ABI_VFP_args: VFP registers")
+           message(STATUS "Hard-float JVM detected")
+        else ()
+            message(STATUS "Soft-float JVM detected")
+
+            # Test compilation with -mfloat-abi=softfp using an arbitrary libc function
+            # (typically fails with "fatal error: bits/predefs.h: No such file or directory"
+            # if soft-float dev libraries are not installed)
+            include(CMakePushCheckState)
+            cmake_push_check_state()
+            set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mfloat-abi=softfp")
+            include(CheckSymbolExists)
+            check_symbol_exists(exit stdlib.h SOFTFP_AVAILABLE)
+            if (NOT SOFTFP_AVAILABLE)
+                message(FATAL_ERROR "Soft-float dev libraries required (e.g. 'apt-get install libc6-dev-armel' on Debian/Ubuntu)")
+            endif (NOT SOFTFP_AVAILABLE)
+            cmake_pop_check_state()
+
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=softfp")
+        endif ()
+    endif (READELF MATCHES "NOTFOUND")
+endif (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+


### PR DESCRIPTION
Moved the ARM JVM float ABI detection from `HadoopCommon.cmake` to `HadoopJNI.cmake`, because `${JAVA_JVM_LIBRARY}` is not available in `HadoopCommon.cmake` yet and therefore the build fails.

This commit fixes this issue.