### PR TITLE
 [ Indiscoverable bug in HDFS] FsDatasetSpi.isValidBlock() lacks null pointer check inside and neither do the callers

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
@@ -892,7 +892,11 @@ public class DiskBalancer {
       while (!iter.atEnd() && item.getErrorCount() < getMaxError(item)) {
         try {
           ExtendedBlock block = iter.nextBlock();
-
+          
+          //null pointer should not be passed to FsDatasetSpi.isValidBlock()
+          if(block == null){
+            return block;
+          }
           // A valid block is a finalized block, we iterate until we get
           // finalized blocks
           if (!this.dataset.isValidBlock(block)) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1816,7 +1816,10 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   @Override // FsDatasetSpi
   public void checkBlock(ExtendedBlock b, long minLength, ReplicaState state)
       throws ReplicaNotFoundException, UnexpectedReplicaStateException,
-      FileNotFoundException, EOFException, IOException {
+      FileNotFoundException, EOFException, IOException, NullPointerException {
+    if(b == null){
+      throw new NullPointerException("Input Block is null!");
+    }
     final ReplicaInfo replicaInfo = volumeMap.get(b.getBlockPoolId(), 
         b.getLocalBlock());
     if (replicaInfo == null) {


### PR DESCRIPTION
Dear Hadoop Developers,
I'm from Alibaba, China. Recently, I meet a scenario where user want to migrate all the data in the old volumes to newly added volumes. Although HDFS now has a DiskBalancer tool, but it doesn't meet the requirement of us. So, we develop a new tool DiskMigration, which can migrate all the data in the current volumes to the new volumes and keep balance of data distribution at the same time.
After introduce the work I'm doing, now we get to the point of the bug of the newest version hadoop3.0:
BlockIteratorImpl.nextBlock() will look for the blocks in the source volume, if there are no blocks any more, it will return null up to DiskBalancer.getBlockToCopy(). However, the DiskBalancer.getBlockToCopy() will check whether it's a valid block.
When I look into the FsDatasetSpi.isValidBlock(), I find that it doesn't check the null pointer! In fact, we firstly need to check whether it's null or not, or exception will occur.
This bug is hard to find, because the DiskBalancer hardly copy all the data of one volume to others. Even if some times we may copy all the data of one volume to other volumes, when the bug occurs, the copy process has already done.
However, when we try to copy all the data of two or more volumes to other volumes in more than one step, the thread will be shut down, which is caused by the bug above.
The bug can fixed by two ways:
1)Before the call of FsDatasetSpi.isValidBlock(), we check the null pointer
2)Check the null pointer inside the implementation of FsDatasetSpi.isValidBlock()