### PR TITLE
HDFS-12424 Fix sorting of the datatable on the Datanodes page in the NN UI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.js
@@ -331,12 +331,12 @@
             'columns': [
               { 'orderDataType': 'ng-value', 'searchable': true },
               { 'orderDataType': 'ng-value', 'searchable': true },
-              { 'orderDataType': 'ng-value', 'type': 'numeric' },
-              { 'orderDataType': 'ng-value', 'type': 'numeric' },
-              { 'orderDataType': 'ng-value', 'type': 'numeric' },
-              { 'orderData': 3, 'type': 'numeric' },
-              { 'orderDataType': 'ng-value', 'type': 'numeric'},
-              { 'orderData': 5 }
+              { 'orderDataType': 'ng-value', 'type': 'num' },
+              { 'orderDataType': 'ng-value', 'type': 'num' },
+              { 'orderDataType': 'ng-value', 'type': 'num' },
+              { 'type': 'num' },
+              { 'orderDataType': 'ng-value', 'type': 'num'},
+              { 'type': 'string' }
             ]});
           renderHistogram(data);
           $('#ui-tabs a[href="#tab-datanode"]').tab('show');


### PR DESCRIPTION
This fix basically comes down to three things:

- type: numeric isn't a thing -- it needs to be type num per the [datatable doc](https://datatables.net/reference/option/columns.type)
- orderData was wrong in both instances; we don't want those columns to sort by some other column
- version sorting by anything other than string is going to be even more confusing than it is if we sort it by string