### PR TITLE
YARN-6475: Refactor long methods in hadoop-yarn-server-nodemanager

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/LinuxContainerExecutor.java
@@ -61,7 +61,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.*;
@@ -423,24 +422,11 @@ public class LinuxContainerExecutor extends ContainerExecutor {
   public int launchContainer(ContainerStartContext ctx)
       throws IOException, ConfigurationException {
     Container container = ctx.getContainer();
-    Path nmPrivateContainerScriptPath = ctx.getNmPrivateContainerScriptPath();
-    Path nmPrivateTokensPath = ctx.getNmPrivateTokensPath();
     String user = ctx.getUser();
-    String appId = ctx.getAppId();
-    Path containerWorkDir = ctx.getContainerWorkDir();
-    List<String> localDirs = ctx.getLocalDirs();
-    List<String> logDirs = ctx.getLogDirs();
-    List<String> filecacheDirs = ctx.getFilecacheDirs();
-    List<String> userLocalDirs = ctx.getUserLocalDirs();
-    List<String> containerLocalDirs = ctx.getContainerLocalDirs();
-    List<String> containerLogDirs = ctx.getContainerLogDirs();
-    Map<Path, List<String>> localizedResources = ctx.getLocalizedResources();
 
     verifyUsernamePattern(user);
-    String runAsUser = getRunAsUser(user);
 
     ContainerId containerId = container.getContainerId();
-    String containerIdStr = containerId.toString();
 
     resourcesHandler.preExecute(containerId,
             container.getResource());
@@ -495,39 +481,10 @@ public class LinuxContainerExecutor extends ContainerExecutor {
     try {
       Path pidFilePath = getPidFilePath(containerId);
       if (pidFilePath != null) {
-        List<String> prefixCommands = new ArrayList<>();
-        ContainerRuntimeContext.Builder builder = new ContainerRuntimeContext
-            .Builder(container);
+        ContainerRuntimeContext runtimeContext = buildContainerRuntimeContext(
+            ctx, pidFilePath, resourcesOptions, tcCommandFile);
 
-        addSchedPriorityCommand(prefixCommands);
-        if (prefixCommands.size() > 0) {
-          builder.setExecutionAttribute(CONTAINER_LAUNCH_PREFIX_COMMANDS,
-              prefixCommands);
-        }
-
-        builder.setExecutionAttribute(LOCALIZED_RESOURCES, localizedResources)
-            .setExecutionAttribute(RUN_AS_USER, runAsUser)
-            .setExecutionAttribute(USER, user)
-            .setExecutionAttribute(APPID, appId)
-            .setExecutionAttribute(CONTAINER_ID_STR, containerIdStr)
-            .setExecutionAttribute(CONTAINER_WORK_DIR, containerWorkDir)
-            .setExecutionAttribute(NM_PRIVATE_CONTAINER_SCRIPT_PATH,
-                nmPrivateContainerScriptPath)
-            .setExecutionAttribute(NM_PRIVATE_TOKENS_PATH, nmPrivateTokensPath)
-            .setExecutionAttribute(PID_FILE_PATH, pidFilePath)
-            .setExecutionAttribute(LOCAL_DIRS, localDirs)
-            .setExecutionAttribute(LOG_DIRS, logDirs)
-            .setExecutionAttribute(FILECACHE_DIRS, filecacheDirs)
-            .setExecutionAttribute(USER_LOCAL_DIRS, userLocalDirs)
-            .setExecutionAttribute(CONTAINER_LOCAL_DIRS, containerLocalDirs)
-            .setExecutionAttribute(CONTAINER_LOG_DIRS, containerLogDirs)
-            .setExecutionAttribute(RESOURCES_OPTIONS, resourcesOptions);
-
-        if (tcCommandFile != null) {
-          builder.setExecutionAttribute(TC_COMMAND_FILE, tcCommandFile);
-        }
-
-        linuxContainerRuntime.launchContainer(builder.build());
+        linuxContainerRuntime.launchContainer(runtimeContext);
       } else {
         LOG.info(
             "Container was marked as inactive. Returning terminated error");
@@ -597,6 +554,50 @@ public class LinuxContainerExecutor extends ContainerExecutor {
     }
 
     return 0;
+  }
+
+  private ContainerRuntimeContext buildContainerRuntimeContext(
+      ContainerStartContext ctx, Path pidFilePath,
+      String resourcesOptions, String tcCommandFile) {
+
+    List<String> prefixCommands = new ArrayList<>();
+    addSchedPriorityCommand(prefixCommands);
+
+    Container container = ctx.getContainer();
+
+    ContainerRuntimeContext.Builder builder = new ContainerRuntimeContext
+              .Builder(container);
+    if (prefixCommands.size() > 0) {
+      builder.setExecutionAttribute(CONTAINER_LAUNCH_PREFIX_COMMANDS,
+              prefixCommands);
+    }
+
+    builder.setExecutionAttribute(LOCALIZED_RESOURCES,
+      ctx.getLocalizedResources())
+      .setExecutionAttribute(RUN_AS_USER, getRunAsUser(ctx.getUser()))
+      .setExecutionAttribute(USER, ctx.getUser())
+      .setExecutionAttribute(APPID, ctx.getAppId())
+      .setExecutionAttribute(CONTAINER_ID_STR,
+        container.getContainerId().toString())
+      .setExecutionAttribute(CONTAINER_WORK_DIR, ctx.getContainerWorkDir())
+      .setExecutionAttribute(NM_PRIVATE_CONTAINER_SCRIPT_PATH,
+        ctx.getNmPrivateContainerScriptPath())
+      .setExecutionAttribute(NM_PRIVATE_TOKENS_PATH,
+        ctx.getNmPrivateTokensPath())
+      .setExecutionAttribute(PID_FILE_PATH, pidFilePath)
+      .setExecutionAttribute(LOCAL_DIRS, ctx.getLocalDirs())
+      .setExecutionAttribute(LOG_DIRS, ctx.getLogDirs())
+      .setExecutionAttribute(FILECACHE_DIRS, ctx.getFilecacheDirs())
+      .setExecutionAttribute(USER_LOCAL_DIRS, ctx.getUserLocalDirs())
+      .setExecutionAttribute(CONTAINER_LOCAL_DIRS, ctx.getContainerLocalDirs())
+      .setExecutionAttribute(CONTAINER_LOG_DIRS, ctx.getContainerLogDirs())
+      .setExecutionAttribute(RESOURCES_OPTIONS, resourcesOptions);
+
+    if (tcCommandFile != null) {
+      builder.setExecutionAttribute(TC_COMMAND_FILE, tcCommandFile);
+    }
+
+    return builder.build();
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -217,12 +217,7 @@ public class ContainerLaunch implements Callable<Integer> {
       DataOutputStream tokensOutStream = null;
 
       // Select the working directory for the container
-      Path containerWorkDir =
-          dirsHandler.getLocalPathForWrite(ContainerLocalizer.USERCACHE
-                  + Path.SEPARATOR + user + Path.SEPARATOR
-                  + ContainerLocalizer.APPCACHE + Path.SEPARATOR + appIdStr
-                  + Path.SEPARATOR + containerIdStr,
-              LocalDirAllocator.SIZE_UNKNOWN, false);
+      Path containerWorkDir = deriveContainerWorkDir();
       recordContainerWorkDir(containerID, containerWorkDir.toString());
 
       String pidFileSubpath = getPidFileSubpath(appIdStr, containerIdStr);
@@ -246,32 +241,27 @@ public class ContainerLaunch implements Callable<Integer> {
       try {
         // /////////// Write out the container-script in the nmPrivate space.
         List<Path> appDirs = new ArrayList<Path>(localDirs.size());
-
         for (String localDir : localDirs) {
           Path usersdir = new Path(localDir, ContainerLocalizer.USERCACHE);
           Path userdir = new Path(usersdir, user);
           Path appsdir = new Path(userdir, ContainerLocalizer.APPCACHE);
           appDirs.add(new Path(appsdir, appIdStr));
         }
-        containerScriptOutStream =
-            lfs.create(nmPrivateContainerScriptPath,
-                EnumSet.of(CREATE, OVERWRITE));
+        containerScriptOutStream = lfs.create(nmPrivateContainerScriptPath,
+          EnumSet.of(CREATE, OVERWRITE));
 
         // Set the token location too.
-        environment.put(
-            ApplicationConstants.CONTAINER_TOKEN_FILE_ENV_NAME,
+        environment.put(ApplicationConstants.CONTAINER_TOKEN_FILE_ENV_NAME,
             new Path(containerWorkDir,
                 FINAL_CONTAINER_TOKENS_FILE).toUri().getPath());
         // Sanitize the container's environment
         sanitizeEnv(environment, containerWorkDir, appDirs, userLocalDirs,
-            containerLogDirs,
-          localResources, nmPrivateClasspathJarDir);
+            containerLogDirs, localResources, nmPrivateClasspathJarDir);
 
         // Write out the environment
         exec.writeLaunchEnv(containerScriptOutStream, environment,
             localResources, launchContext.getCommands(),
             new Path(containerLogDirs.get(0)), user);
-
         // /////////// End of writing out container-script
 
         // /////////// Write out the container-tokens in the nmPrivate space.
@@ -319,8 +309,28 @@ public class ContainerLaunch implements Callable<Integer> {
     }
 
     handleContainerExitCode(ret, containerLogDir);
-
     return ret;
+  }
+
+  private Path deriveContainerWorkDir() throws IOException {
+
+    final String containerWorkDirPath =
+        ContainerLocalizer.USERCACHE +
+        Path.SEPARATOR +
+        container.getUser() +
+        Path.SEPARATOR +
+        ContainerLocalizer.APPCACHE +
+        Path.SEPARATOR +
+        app.getAppId().toString() +
+        Path.SEPARATOR +
+        container.getContainerId().toString();
+
+    final Path containerWorkDir =
+        dirsHandler.getLocalPathForWrite(
+            containerWorkDirPath,
+            LocalDirAllocator.SIZE_UNKNOWN, false);
+
+    return containerWorkDir;
   }
 
   @SuppressWarnings("unchecked")
@@ -1254,103 +1264,111 @@ public class ContainerLaunch implements Callable<Integer> {
     // additional testing.  See YARN-358.
     if (Shell.WINDOWS) {
       
-      String inputClassPath = environment.get(Environment.CLASSPATH.name());
-
-      if (inputClassPath != null && !inputClassPath.isEmpty()) {
-
-        //On non-windows, localized resources
-        //from distcache are available via the classpath as they were placed
-        //there but on windows they are not available when the classpath
-        //jar is created and so they "are lost" and have to be explicitly
-        //added to the classpath instead.  This also means that their position
-        //is lost relative to other non-distcache classpath entries which will
-        //break things like mapreduce.job.user.classpath.first.  An environment
-        //variable can be set to indicate that distcache entries should come
-        //first
-
-        boolean preferLocalizedJars = Boolean.parseBoolean(
-          environment.get(Environment.CLASSPATH_PREPEND_DISTCACHE.name())
-          );
-
-        boolean needsSeparator = false;
-        StringBuilder newClassPath = new StringBuilder();
-        if (!preferLocalizedJars) {
-          newClassPath.append(inputClassPath);
-          needsSeparator = true;
-        }
-
-        // Localized resources do not exist at the desired paths yet, because the
-        // container launch script has not run to create symlinks yet.  This
-        // means that FileUtil.createJarWithClassPath can't automatically expand
-        // wildcards to separate classpath entries for each file in the manifest.
-        // To resolve this, append classpath entries explicitly for each
-        // resource.
-        for (Map.Entry<Path,List<String>> entry : resources.entrySet()) {
-          boolean targetIsDirectory = new File(entry.getKey().toUri().getPath())
-            .isDirectory();
-
-          for (String linkName : entry.getValue()) {
-            // Append resource.
-            if (needsSeparator) {
-              newClassPath.append(File.pathSeparator);
-            } else {
-              needsSeparator = true;
-            }
-            newClassPath.append(pwd.toString())
-              .append(Path.SEPARATOR).append(linkName);
-
-            // FileUtil.createJarWithClassPath must use File.toURI to convert
-            // each file to a URI to write into the manifest's classpath.  For
-            // directories, the classpath must have a trailing '/', but
-            // File.toURI only appends the trailing '/' if it is a directory that
-            // already exists.  To resolve this, add the classpath entries with
-            // explicit trailing '/' here for any localized resource that targets
-            // a directory.  Then, FileUtil.createJarWithClassPath will guarantee
-            // that the resulting entry in the manifest's classpath will have a
-            // trailing '/', and thus refer to a directory instead of a file.
-            if (targetIsDirectory) {
-              newClassPath.append(Path.SEPARATOR);
-            }
-          }
-        }
-        if (preferLocalizedJars) {
-          if (needsSeparator) {
-            newClassPath.append(File.pathSeparator);
-          }
-          newClassPath.append(inputClassPath);
-        }
-
-        // When the container launches, it takes the parent process's environment
-        // and then adds/overwrites with the entries from the container launch
-        // context.  Do the same thing here for correct substitution of
-        // environment variables in the classpath jar manifest.
-        Map<String, String> mergedEnv = new HashMap<String, String>(
-          System.getenv());
-        mergedEnv.putAll(environment);
-        
-        // this is hacky and temporary - it's to preserve the windows secure
-        // behavior but enable non-secure windows to properly build the class
-        // path for access to job.jar/lib/xyz and friends (see YARN-2803)
-        Path jarDir;
-        if (exec instanceof WindowsSecureContainerExecutor) {
-          jarDir = nmPrivateClasspathJarDir;
-        } else {
-          jarDir = pwd; 
-        }
-        String[] jarCp = FileUtil.createJarWithClassPath(
-          newClassPath.toString(), jarDir, pwd, mergedEnv);
-        // In a secure cluster the classpath jar must be localized to grant access
-        Path localizedClassPathJar = exec.localizeClasspathJar(
-            new Path(jarCp[0]), pwd, container.getUser());
-        String replacementClassPath = localizedClassPathJar.toString() + jarCp[1];
-        environment.put(Environment.CLASSPATH.name(), replacementClassPath);
-      }
+      sanitizeWindowsEnv(environment, pwd,
+          resources, nmPrivateClasspathJarDir);
     }
     // put AuxiliaryService data to environment
     for (Map.Entry<String, ByteBuffer> meta : containerManager
         .getAuxServiceMetaData().entrySet()) {
       AuxiliaryServiceHelper.setServiceDataIntoEnv(
           meta.getKey(), meta.getValue(), environment);
+    }
+  }
+
+  private void sanitizeWindowsEnv(Map<String, String> environment, Path pwd,
+      Map<Path, List<String>> resources, Path nmPrivateClasspathJarDir)
+      throws IOException {
+
+    String inputClassPath = environment.get(Environment.CLASSPATH.name());
+
+    if (inputClassPath != null && !inputClassPath.isEmpty()) {
+
+      //On non-windows, localized resources
+      //from distcache are available via the classpath as they were placed
+      //there but on windows they are not available when the classpath
+      //jar is created and so they "are lost" and have to be explicitly
+      //added to the classpath instead.  This also means that their position
+      //is lost relative to other non-distcache classpath entries which will
+      //break things like mapreduce.job.user.classpath.first.  An environment
+      //variable can be set to indicate that distcache entries should come
+      //first
+
+      boolean preferLocalizedJars = Boolean.parseBoolean(
+              environment.get(Environment.CLASSPATH_PREPEND_DISTCACHE.name())
+      );
+
+      boolean needsSeparator = false;
+      StringBuilder newClassPath = new StringBuilder();
+      if (!preferLocalizedJars) {
+        newClassPath.append(inputClassPath);
+        needsSeparator = true;
+      }
+
+      // Localized resources do not exist at the desired paths yet, because the
+      // container launch script has not run to create symlinks yet.  This
+      // means that FileUtil.createJarWithClassPath can't automatically expand
+      // wildcards to separate classpath entries for each file in the manifest.
+      // To resolve this, append classpath entries explicitly for each
+      // resource.
+      for (Map.Entry<Path,List<String>> entry : resources.entrySet()) {
+        boolean targetIsDirectory = new File(entry.getKey().toUri().getPath())
+                .isDirectory();
+
+        for (String linkName : entry.getValue()) {
+          // Append resource.
+          if (needsSeparator) {
+            newClassPath.append(File.pathSeparator);
+          } else {
+            needsSeparator = true;
+          }
+          newClassPath.append(pwd.toString())
+                  .append(Path.SEPARATOR).append(linkName);
+
+          // FileUtil.createJarWithClassPath must use File.toURI to convert
+          // each file to a URI to write into the manifest's classpath.  For
+          // directories, the classpath must have a trailing '/', but
+          // File.toURI only appends the trailing '/' if it is a directory that
+          // already exists.  To resolve this, add the classpath entries with
+          // explicit trailing '/' here for any localized resource that targets
+          // a directory.  Then, FileUtil.createJarWithClassPath will guarantee
+          // that the resulting entry in the manifest's classpath will have a
+          // trailing '/', and thus refer to a directory instead of a file.
+          if (targetIsDirectory) {
+            newClassPath.append(Path.SEPARATOR);
+          }
+        }
+      }
+      if (preferLocalizedJars) {
+        if (needsSeparator) {
+          newClassPath.append(File.pathSeparator);
+        }
+        newClassPath.append(inputClassPath);
+      }
+
+      // When the container launches, it takes the parent process's environment
+      // and then adds/overwrites with the entries from the container launch
+      // context.  Do the same thing here for correct substitution of
+      // environment variables in the classpath jar manifest.
+      Map<String, String> mergedEnv = new HashMap<String, String>(
+              System.getenv());
+      mergedEnv.putAll(environment);
+
+      // this is hacky and temporary - it's to preserve the windows secure
+      // behavior but enable non-secure windows to properly build the class
+      // path for access to job.jar/lib/xyz and friends (see YARN-2803)
+      Path jarDir;
+      if (exec instanceof WindowsSecureContainerExecutor) {
+        jarDir = nmPrivateClasspathJarDir;
+      } else {
+        jarDir = pwd;
+      }
+      String[] jarCp = FileUtil.createJarWithClassPath(
+              newClassPath.toString(), jarDir, pwd, mergedEnv);
+      // In a secure cluster the classpath jar must be localized to grant access
+      Path localizedClassPathJar = exec.localizeClasspathJar(
+              new Path(jarCp[0]), pwd, container.getUser());
+      String replacementClassPath = localizedClassPathJar.toString() + jarCp[1];
+      environment.put(Environment.CLASSPATH.name(), replacementClassPath);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java
@@ -462,10 +462,6 @@ public class DockerLinuxContainerRuntime implements LinuxContainerRuntime {
     //List<String> -> stored as List -> fetched/converted to List<String>
     //we can't do better here thanks to type-erasure
     @SuppressWarnings("unchecked")
-    List<String> localDirs = ctx.getExecutionAttribute(LOCAL_DIRS);
-    @SuppressWarnings("unchecked")
-    List<String> logDirs = ctx.getExecutionAttribute(LOG_DIRS);
-    @SuppressWarnings("unchecked")
     List<String> filecacheDirs = ctx.getExecutionAttribute(FILECACHE_DIRS);
     @SuppressWarnings("unchecked")
     List<String> containerLocalDirs = ctx.getExecutionAttribute(
@@ -528,9 +524,6 @@ public class DockerLinuxContainerRuntime implements LinuxContainerRuntime {
 
     addCGroupParentIfRequired(resourcesOpts, containerIdStr, runCommand);
 
-    Path nmPrivateContainerScriptPath = ctx.getExecutionAttribute(
-        NM_PRIVATE_CONTAINER_SCRIPT_PATH);
-
     String disableOverride = environment.get(
         ENV_DOCKER_CONTAINER_RUN_OVERRIDE_DISABLE);
 
@@ -548,33 +541,8 @@ public class DockerLinuxContainerRuntime implements LinuxContainerRuntime {
 
     String commandFile = dockerClient.writeCommandToTempFile(runCommand,
         containerIdStr);
-    PrivilegedOperation launchOp = new PrivilegedOperation(
-        PrivilegedOperation.OperationType.LAUNCH_DOCKER_CONTAINER);
-
-    launchOp.appendArgs(runAsUser, ctx.getExecutionAttribute(USER),
-        Integer.toString(PrivilegedOperation
-            .RunAsUserCommand.LAUNCH_DOCKER_CONTAINER.getValue()),
-        ctx.getExecutionAttribute(APPID),
-        containerIdStr, containerWorkDir.toString(),
-        nmPrivateContainerScriptPath.toUri().getPath(),
-        ctx.getExecutionAttribute(NM_PRIVATE_TOKENS_PATH).toUri().getPath(),
-        ctx.getExecutionAttribute(PID_FILE_PATH).toString(),
-        StringUtils.join(PrivilegedOperation.LINUX_FILE_PATH_SEPARATOR,
-            localDirs),
-        StringUtils.join(PrivilegedOperation.LINUX_FILE_PATH_SEPARATOR,
-            logDirs),
-        commandFile,
-        resourcesOpts);
-
-    String tcCommandFile = ctx.getExecutionAttribute(TC_COMMAND_FILE);
-
-    if (tcCommandFile != null) {
-      launchOp.appendArgs(tcCommandFile);
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Launching container with cmd: " + runCommand
-          .getCommandWithArguments());
-    }
+    PrivilegedOperation launchOp = buildLaunchOp(ctx,
+        commandFile, runCommand);
 
     try {
       privilegedOperationExecutor.executePrivilegedOperation(null,
@@ -587,6 +555,53 @@ public class DockerLinuxContainerRuntime implements LinuxContainerRuntime {
       throw new ContainerExecutionException("Launch container failed", e
           .getExitCode(), e.getOutput(), e.getErrorOutput());
     }
+  }
+
+  private PrivilegedOperation buildLaunchOp(ContainerRuntimeContext ctx,
+      String commandFile, DockerRunCommand runCommand) {
+
+    String runAsUser = ctx.getExecutionAttribute(RUN_AS_USER);
+    String containerIdStr = ctx.getContainer().getContainerId().toString();
+    Path nmPrivateContainerScriptPath = ctx.getExecutionAttribute(
+        NM_PRIVATE_CONTAINER_SCRIPT_PATH);
+    Path containerWorkDir = ctx.getExecutionAttribute(CONTAINER_WORK_DIR);
+
+    //we can't do better here thanks to type-erasure
+    @SuppressWarnings("unchecked")
+    List<String> localDirs = ctx.getExecutionAttribute(LOCAL_DIRS);
+    @SuppressWarnings("unchecked")
+    List<String> logDirs = ctx.getExecutionAttribute(LOG_DIRS);
+    String resourcesOpts = ctx.getExecutionAttribute(RESOURCES_OPTIONS);
+
+    PrivilegedOperation launchOp = new PrivilegedOperation(
+            PrivilegedOperation.OperationType.LAUNCH_DOCKER_CONTAINER);
+
+    launchOp.appendArgs(runAsUser, ctx.getExecutionAttribute(USER),
+            Integer.toString(PrivilegedOperation
+                    .RunAsUserCommand.LAUNCH_DOCKER_CONTAINER.getValue()),
+            ctx.getExecutionAttribute(APPID),
+            containerIdStr, containerWorkDir.toString(),
+            nmPrivateContainerScriptPath.toUri().getPath(),
+            ctx.getExecutionAttribute(NM_PRIVATE_TOKENS_PATH).toUri().getPath(),
+            ctx.getExecutionAttribute(PID_FILE_PATH).toString(),
+            StringUtils.join(PrivilegedOperation.LINUX_FILE_PATH_SEPARATOR,
+                    localDirs),
+            StringUtils.join(PrivilegedOperation.LINUX_FILE_PATH_SEPARATOR,
+                    logDirs),
+            commandFile,
+            resourcesOpts);
+
+    String tcCommandFile = ctx.getExecutionAttribute(TC_COMMAND_FILE);
+
+    if (tcCommandFile != null) {
+      launchOp.appendArgs(tcCommandFile);
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Launching container with cmd: " + runCommand
+              .getCommandWithArguments());
+    }
+
+    return launchOp;
   }
 
   @Override


### PR DESCRIPTION
Refactor all methods in hadoop-yarn-server-nodemanager that exceed 150 lines in length. Also fixes the method length related Checkstyle violations.