### PR TITLE
Update DiskBalancer.java

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
@@ -892,7 +892,9 @@ public class DiskBalancer {
       while (!iter.atEnd() && item.getErrorCount() < getMaxError(item)) {
         try {
           ExtendedBlock block = iter.nextBlock();
-
+          if(null == block){
+            return block;
+          }
           // A valid block is a finalized block, we iterate until we get
           // finalized blocks
           if (!this.dataset.isValidBlock(block)) {


### PR DESCRIPTION
BlockIteratorImpl.nextBlock() will look for the blocks in the source volume, if there are no blocks any more, it will return null up to DiskBalancer.getBlockToCopy(). However, the DiskBalancer.getBlockToCopy() will check whether it's a valid block.
When I look into the FsDatasetSpi.isValidBlock(), I find that it doesn't check the null pointer! In fact, we firstly need to check whether it's null or not, or exception will occur.
This bug is hard to find, because the DiskBalancer hardly copy all the data of one volume to others. Even if some times we may copy all the data of one volume to other volumes, when the bug occurs, the copy process has already done.
However, when we try to copy all the data of two or more volumes to other volumes in more than one step, the thread will be shut down, which is caused by the bug above.
The bug can fixed by two ways:
1)Before the call of FsDatasetSpi.isValidBlock(), we check the null pointer
2)Check the null pointer inside the implementation of FsDatasetSpi.isValidBlock()