### PR TITLE
add check compressor's byte size when finish compress

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BlockCompressorStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BlockCompressorStream.java
@@ -135,7 +135,7 @@ public class BlockCompressorStream extends CompressorStream {
 
   @Override
   public void finish() throws IOException {
-    if (!compressor.finished()) {
+    if (!compressor.finished() && compressor.getBytesRead() > 0) {
       rawWriteInt((int)compressor.getBytesRead());
       compressor.finish();
       while (!compressor.finished()) {


### PR DESCRIPTION
org.apache.hadoop.io.compress.BlockCompressorStream#finish is a public function,so other apps can call the method directly,such as `flume`,but when compressor.getBytesRead() == 0 then it will write a null data,and then the data after the null data will not be read as they lost. So,please add the check in the method.
Thank you.