### PR TITLE
MAPREDUCE-6752: Bad logging practices in mapreduce

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DefaultSpeculator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DefaultSpeculator.java
@@ -252,11 +252,9 @@ public class DefaultSpeculator extends AbstractService implements
 
   // This interface is intended to be used only for test cases.
   public void scanForSpeculations() {
-    LOG.info("We got asked to run a debug speculation scan.");
-    // debug
-    System.out.println("We got asked to run a debug speculation scan.");
-    System.out.println("There are " + scanControl.size()
-        + " events stacked already.");
+    LOG.debug("We got asked to run a debug speculation scan.");
+    LOG.debug("There are " + scanControl.size()
+            + " events stacked already.");
     scanControl.add(new Object());
     Thread.yield();
   }


### PR DESCRIPTION
Changed the log level of the method that is only used for debugging purpose as discussed here:

https://issues.apache.org/jira/browse/MAPREDUCE-6752
