### PR TITLE
HADOOP-14128. fix renameInternal in ChecksumFs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFs.java
@@ -455,17 +455,26 @@ public abstract class ChecksumFs extends FilterFs {
   @Override
   public void renameInternal(Path src, Path dst) 
     throws IOException, UnresolvedLinkException {
+    renameInternal(src, dst, false);
+  }
+
+  /**
+   * Rename files/dirs with overwrite flag.
+   */
+  @Override
+  public void renameInternal(Path src, Path dst, boolean overwrite)
+    throws IOException, UnresolvedLinkException {
     if (isDirectory(src)) {
-      getMyFs().rename(src, dst);
+      getMyFs().renameInternal(src, dst, overwrite);
     } else {
-      getMyFs().rename(src, dst);
+      getMyFs().renameInternal(src, dst, overwrite);
 
       Path checkFile = getChecksumFile(src);
       if (exists(checkFile)) { //try to rename checksum
         if (isDirectory(dst)) {
-          getMyFs().rename(checkFile, dst);
+          getMyFs().renameInternal(checkFile, dst, overwrite);
         } else {
-          getMyFs().rename(checkFile, getChecksumFile(dst));
+          getMyFs().renameInternal(checkFile, getChecksumFile(dst), overwrite);
         }
       }
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextMainOperationsBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextMainOperationsBaseTest.java
@@ -978,7 +978,8 @@ public abstract class FileContextMainOperationsBaseTest  {
     Path src = getTestRootPath(fc, "test/hadoop/file");
     createFile(src);
     Path dst = getTestRootPath(fc, "test/new/existingFile");
-    createFile(dst);
+    byte[] existingContent = "random existing content".getBytes();
+    createFile(dst, existingContent, 0, existingContent.length);
     
     // Fails without overwrite option
     try {
@@ -990,6 +991,10 @@ public abstract class FileContextMainOperationsBaseTest  {
     
     // Succeeds with overwrite option
     rename(src, dst, false, true, Rename.OVERWRITE);
+
+    // Should not throw an Exception
+    FSDataInputStream in = fc.open(dst);
+    in.close();
   }
 
   @Test
@@ -1213,9 +1218,13 @@ public abstract class FileContextMainOperationsBaseTest  {
   }
   
   protected void createFile(Path path) throws IOException {
+    createFile(path, data, 0, data.length);
+  }
+
+  protected void createFile(Path path, byte[] content, int offset, int length) throws IOException {
     FSDataOutputStream out = fc.create(path, EnumSet.of(CREATE),
         Options.CreateOpts.createParent());
-    out.write(data, 0, data.length);
+    out.write(content, offset, length);
     out.close();
   }
 


### PR DESCRIPTION
AbstractFs.rename(source, destination, options) calls
renameInternal(source, destination, overwrite)

This patch adds this method to ChecksumFs to rename the crc file in
addition to the file itself to avoid crc missmatch when use for example
in LocalFs.