### PR TITLE
Support Log4j 2 and Logback

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -150,6 +150,31 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -185,6 +210,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -452,6 +478,9 @@
               <value>org.apache.hadoop.test.TimedOutTestsListener</value>
             </property>
           </properties>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>ch.qos.logback:logback-classic</classpathDependencyExclude>
+          </classpathDependencyExcludes>
         </configuration>
       </plugin>
       <plugin>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/EventCount.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/EventCount.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.log.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Counter for log events at various levels.
+ */
+public enum EventCount {
+
+    FATAL, WARN, ERROR, INFO;
+
+    private final AtomicLong count = new AtomicLong();
+
+    public long incr() {
+        return count.incrementAndGet();
+    }
+
+    public long get() {
+        return count.get();
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/EventCounter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/EventCounter.java
@@ -31,43 +31,37 @@ import org.apache.log4j.spi.LoggingEvent;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public class EventCounter extends AppenderSkeleton {
-  private static final int FATAL = 0;
-  private static final int ERROR = 1;
-  private static final int WARN = 2;
-  private static final int INFO = 3;
 
-  private static class EventCounts {
-    private final long[] counts = {0, 0, 0, 0};
-
-    private synchronized void incr(int i) {
-      ++counts[i];
-    }
-
-    private synchronized long get(int i) {
-      return counts[i];
-    }
-  }
-
-  private static EventCounts counts = new EventCounts();
-
+  /**
+   * @deprecated Use EventCount.FATAL.get();
+   */
   @InterfaceAudience.Private
   public static long getFatal() {
-    return counts.get(FATAL);
+    return EventCount.FATAL.get();
   }
 
+  /**
+   * @deprecated Use EventCount.ERROR.get();
+   */
   @InterfaceAudience.Private
   public static long getError() {
-    return counts.get(ERROR);
+    return EventCount.ERROR.get();
   }
 
+  /**
+   * @deprecated Use EventCount.WARN.get();
+   */
   @InterfaceAudience.Private
   public static long getWarn() {
-    return counts.get(WARN);
+    return EventCount.WARN.get();
   }
 
+  /**
+   * @deprecated Use EventCount.INFO.get();
+   */
   @InterfaceAudience.Private
   public static long getInfo() {
-    return counts.get(INFO);
+    return EventCount.INFO.get();
   }
 
   @Override
@@ -76,16 +70,16 @@ public class EventCounter extends AppenderSkeleton {
     // depends on the api, == might not work
     // see HADOOP-7055 for details
     if (level.equals(Level.INFO)) {
-      counts.incr(INFO);
+      EventCount.INFO.incr();
     }
     else if (level.equals(Level.WARN)) {
-      counts.incr(WARN);
+      EventCount.WARN.incr();
     }
     else if (level.equals(Level.ERROR)) {
-      counts.incr(ERROR);
+      EventCount.ERROR.incr();
     }
     else if (level.equals(Level.FATAL)) {
-      counts.incr(FATAL);
+      EventCount.FATAL.incr();
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/Log4j2EventCounter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/Log4j2EventCounter.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.log.metrics;
+
+import java.io.Serializable;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+
+@Plugin(name = "HadoopEventCounter", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
+public class Log4j2EventCounter extends AbstractAppender {
+
+    public Log4j2EventCounter(String name, final Filter filter, final Layout<? extends Serializable> layout) {
+        super(name, filter, layout);
+    }
+
+    @Override
+    public void append(LogEvent logEvent) {
+        switch(logEvent.getLevel().getStandardLevel()) {
+            case FATAL:
+                EventCount.FATAL.incr();
+                break;
+            case ERROR:
+                EventCount.ERROR.incr();
+                break;
+            case WARN:
+                EventCount.WARN.incr();
+                break;
+            case INFO:
+                EventCount.INFO.incr();
+                break;
+        }
+    }
+
+    @PluginBuilderFactory
+    public static <B extends Log4j2EventCounter.Builder<B>> B newBuilder() {
+        return new Log4j2EventCounter.Builder<B>().asBuilder();
+    }
+
+    /**
+     * Builds Log4j2EventCounter instances.
+     * @param <B> The type to build
+     */
+    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+            implements org.apache.logging.log4j.core.util.Builder<Log4j2EventCounter> {
+
+        @Override
+        public Log4j2EventCounter build() {
+            return new Log4j2EventCounter(getName(), getFilter(), getLayout());
+        }
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/LogbackEventCounter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/metrics/LogbackEventCounter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.log.metrics;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+
+public class LogbackEventCounter extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        int level = eventObject.getLevel().levelInt;
+
+        switch (level) {
+            case Level.ERROR_INT:
+                EventCount.ERROR.incr();
+                break;
+            case Level.WARN_INT:
+                EventCount.WARN.incr();
+                break;
+            case Level.INFO_INT:
+                EventCount.INFO.incr();
+                break;
+            default:
+                if (level > Level.ERROR_INT) {
+                    EventCount.FATAL.incr();
+                }
+        }
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
@@ -31,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.log.metrics.EventCount;
 import org.apache.hadoop.log.metrics.EventCounter;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -236,9 +237,9 @@ public class JvmMetrics implements MetricsSource {
   }
 
   private void getEventCounters(MetricsRecordBuilder rb) {
-    rb.addCounter(LogFatal, EventCounter.getFatal())
-      .addCounter(LogError, EventCounter.getError())
-      .addCounter(LogWarn, EventCounter.getWarn())
-      .addCounter(LogInfo, EventCounter.getInfo());
+    rb.addCounter(LogFatal, EventCount.FATAL.get())
+      .addCounter(LogError, EventCount.ERROR.get())
+      .addCounter(LogWarn, EventCount.WARN.get())
+      .addCounter(LogInfo, EventCount.INFO.get());
   }
 }

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -836,6 +836,34 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.10.0</version>
+        <scope>compile</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>2.10.0</version>
+        <scope>compile</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>1.2.3</version>
+        <scope>compile</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
+        <scope>compile</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bundle</artifactId>
         <version>${aws-java-sdk.version}</version>


### PR DESCRIPTION
This patch relates to https://issues.apache.org/jira/browse/HADOOP-12956. It makes the logging implementation in hadoop common optional and provides support for event counters in Log4j 2 and Logback in addition to Log4j 1.