### PR TITLE
MAPREDUCE-7017:Too many times of meaningless invocation in TaskAttemptImpl#resolveHosts

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -1080,6 +1080,8 @@ public class MRAppMaster extends CompositeService {
     private TimelineV2Client timelineV2Client = null;
     private String historyUrl = null;
 
+    private Map<String, String> ipHostMaps = new HashMap<>();
+
     private final TaskAttemptFinishingMonitor taskAttemptFinishingMonitor;
 
     public RunningAppContext(Configuration config,
@@ -1100,6 +1102,14 @@ public class MRAppMaster extends CompositeService {
           timelineClient = TimelineClient.createTimelineClient();
         }
       }
+    }
+    
+    public String getHost(String ip) {
+      return ipHostMaps.get(ip);
+    }
+
+    public void putHost(String ip, String host) {
+      ipHostMaps.put(ip, host);
     }
 
     @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -81,6 +81,7 @@ import org.apache.hadoop.mapreduce.v2.api.records.TaskAttemptState;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskId;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskType;
 import org.apache.hadoop.mapreduce.v2.app.AppContext;
+import org.apache.hadoop.mapreduce.v2.app.MRAppMaster;
 import org.apache.hadoop.mapreduce.v2.app.TaskAttemptListener;
 import org.apache.hadoop.mapreduce.v2.app.commit.CommitterTaskAbortEvent;
 import org.apache.hadoop.mapreduce.v2.app.job.TaskAttemptStateInternal;
@@ -1818,7 +1819,14 @@ public abstract class TaskAttemptImpl implements
         if (src[i] == null) {
           continue;
         } else if (isIP(src[i])) {
-          result.add(resolveHost(src[i]));
+          String host = ((MRAppMaster.RunningAppContext) appContext).getHost(src[i]);
+          if (host == null) {
+            String resolveHost = resolveHost(src[i]);
+            result.add(resolveHost);
+            ((MRAppMaster.RunningAppContext) appContext).putHost(src[i], resolveHost);
+          } else {
+            result.add(host);
+          }
         } else {
           result.add(src[i]);
         }


### PR DESCRIPTION
MRAppMaster uses TaskAttemptImpl::resolveHosts to determine the dataLocalHosts for each task when the location of data split is IP, which will call a lot of times ( taskNum * dfsReplication) of function InetAddress::getByName and most of the funcition calls are redundant. When the job has a great number of tasks and the speed of DNS resolution is not fast enough, it will take a lot of time at this stage before the job running.