### PR TITLE
[HADOOP-15096] Don't create user with lastlog

### DIFF
--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -34,7 +34,7 @@ fi
 docker build -t "hadoop-build-${USER_ID}" - <<UserSpecificDocker
 FROM hadoop-build
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME}
-RUN useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+RUN useradd -g ${GROUP_ID} -u ${USER_ID} -l -k /root -m ${USER_NAME}
 RUN echo "${USER_NAME}\tALL=NOPASSWD: ALL" > "/etc/sudoers.d/hadoop-build-${USER_ID}"
 ENV HOME /home/${USER_NAME}
 


### PR DESCRIPTION
This fixes a problem where in certain cases, the useradd command can create a very large diff that can blow up the host disk size.

The reason for this is that lastlog is a sparse file, but AUFS under docker apparently doesn't deal with those well and creates a very large file.