### PR TITLE
POC: replace explicit method parameters null-checks by a declarative approach

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -324,6 +324,10 @@
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>tech.harmonysoft</groupId>
+      <artifactId>traute-javac</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStreamBuilder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStreamBuilder.java
@@ -120,8 +120,6 @@ public abstract class FSDataOutputStreamBuilder
    */
   protected FSDataOutputStreamBuilder(@Nonnull FileSystem fileSystem,
       @Nonnull Path p) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(p);
     fs = fileSystem;
     path = p;
     bufferSize = fs.getConf().getInt(IO_FILE_BUFFER_SIZE_KEY,
@@ -149,7 +147,6 @@ public abstract class FSDataOutputStreamBuilder
    * Set permission for the file.
    */
   public B permission(@Nonnull final FsPermission perm) {
-    Preconditions.checkNotNull(perm);
     permission = perm;
     return getThisBuilder();
   }
@@ -213,7 +210,6 @@ public abstract class FSDataOutputStreamBuilder
    * Set the facility of reporting progress.
    */
   public B progress(@Nonnull final Progressable prog) {
-    Preconditions.checkNotNull(prog);
     progress = prog;
     return getThisBuilder();
   }
@@ -260,7 +256,6 @@ public abstract class FSDataOutputStreamBuilder
    * Set checksum opt.
    */
   public B checksumOpt(@Nonnull final ChecksumOpt chksumOpt) {
-    Preconditions.checkNotNull(chksumOpt);
     checksumOpt = chksumOpt;
     return getThisBuilder();
   }

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -107,6 +107,7 @@
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>
+    <traute.version>1.0.10</traute.version>
 
     <!-- The java version enforced by the maven enforcer -->
     <!-- more complex patterns can be used here, such as
@@ -1353,6 +1354,13 @@
           <version>${snakeyaml.version}</version>
         </dependency>
 
+        <dependency>
+          <groupId>tech.harmonysoft</groupId>
+          <artifactId>traute-javac</artifactId>
+          <version>${traute.version}</version>
+          <scope>provided</scope> <!-- make the jar eligible for compilation only -->
+        </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -1405,6 +1413,9 @@
             <source>${javac.version}</source>
             <target>${javac.version}</target>
             <useIncrementalCompilation>false</useIncrementalCompilation>
+            <compilerArgs>
+              <arg>-Xplugin:Traute</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This *PR* shows an approach when explicit *null*-checks (*Preconditions.checkNotNull()*) are generated automatically by the [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin for method parameters marked by *Nonnull* annotation.  

Example: consider the [FSDataOutputStreamBuilder.permission()](https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStreamBuilder.java#L151) - its bytecode looks like if it's compiled from the source below:  

```java
public B permission(@Nonnull final FsPermission perm) {
    if (perm == null) {
        throw new NullPointerException("String Argument 'perm' of type FsPermission (#0 out of 1, zero-based) is marked by @javax.annotation.Nonnull but got null for it");
    }
    Preconditions.checkNotNull(perm);
    permission = perm;
    return getThisBuilder();
}
```  

Details:  

```
javap -c ./hadoop-common-project/hadoop-common/target/classes/org/apache/hadoop/fs/FSDataOutputStreamBuilder.class
...
  public B permission(org.apache.hadoop.fs.permission.FsPermission);
    Code:
       0: aload_1
       1: ifnonnull     14
       4: new           #16                 // class java/lang/NullPointerException
       7: dup
       8: ldc           #31                 // String Argument 'perm' of type FsPermission (#0 out of 1, zero-based) is marked by @javax.annotation.Nonnull but got null for it
      10: invokespecial #18                 // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
      14: aload_0
      15: aload_1
      16: putfield      #3                  // Field permission:Lorg/apache/hadoop/fs/permission/FsPermission;
      19: aload_0
      20: invokevirtual #32                 // Method getThisBuilder:()Lorg/apache/hadoop/fs/FSDataOutputStreamBuilder;
      23: areturn
```  

So, the idea is to do the following:  
1. Go through the project's codebase and find all places where *Preconditions.checkNotNull()* is called for method parameter
2. Ensure that target method parameter is marked by the *Nonnull* annotation (e.g. [ActiveStandbyElector.isStaleClient()](https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ActiveStandbyElector.java#L1124) is not marked by it, so, we need to add the annotation)
3. Remove *Preconditions.checkNotNull()* call  

Benefits:  
* the code becomes cleaner without that explicit checks
* the code is better documented as it's immediately clear what method parameters must be not-*null*
* IDEs highlight possible *NPE* for method parameters marked by *Nonnull* annotations

Please let me know if you like the idea, I'm fine with providing a *PR* which applies the solution to the whole project's codebase then.

TESTED: mvn clean package & ensured that resulting
        bytecode has the checks