### PR TITLE
YARN-7684. Fix The Total Memory and VCores display in the yarn UI is …

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
@@ -85,8 +85,8 @@ public class ClusterMetricsInfo {
     this.containersPending = metrics.getPendingContainers();
     this.containersReserved = metrics.getReservedContainers();
 
-    this.totalMB = availableMB + allocatedMB;
-    this.totalVirtualCores = availableVirtualCores + allocatedVirtualCores;
+    this.totalMB = rs.getClusterResource().getMemory();
+    this.totalVirtualCores = rs.getClusterResource().getVirtualCores();
     this.activeNodes = clusterMetrics.getNumActiveNMs();
     this.lostNodes = clusterMetrics.getNumLostNMs();
     this.unhealthyNodes = clusterMetrics.getUnhealthyNMs();


### PR DESCRIPTION
The Total Memory and VCores display in the yarn UI is not correct with labeled node

Use the cluster resource memory and Vcores info instead of the root queue metrics, availableMB + allocatedMB. and availableVirtualCores + allocatedVirtualCores.