### PR TITLE
Fix NullPointerException caused by null-builder

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/AllocateResponsePBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/AllocateResponsePBImpl.java
@@ -336,6 +336,7 @@ public class AllocateResponsePBImpl extends AllocateResponse {
 
   @Override
   public synchronized void setNMTokens(List<NMToken> nmTokens) {
+    maybeInitBuilder();
     if (nmTokens == null || nmTokens.isEmpty()) {
       if (this.nmTokens != null) {
         this.nmTokens.clear();


### PR DESCRIPTION
Sometimes occurs java.lang.NullPointerException leading to app failed.