### PR TITLE
YARN PROXYSERVER throw IOEXCEPTION

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -248,6 +248,10 @@ public class WebAppProxyServlet extends HttpServlet {
     }
     OutputStream out = resp.getOutputStream();
     try {
+      //too many request will throw Exception connection
+      client.setConnectionTimeout(100);
+      client.setTimeout(100);
+
       HttpResponse httpResp = client.execute(base);
       resp.setStatus(httpResp.getStatusLine().getStatusCode());
       for (Header header : httpResp.getAllHeaders()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/WebAppProxyServlet.java
@@ -248,7 +248,7 @@ public class WebAppProxyServlet extends HttpServlet {
     }
     OutputStream out = resp.getOutputStream();
     try {
-      //too many request will throw Exception connection
+      //wait too long . then have too many request will throw IOException 
       client.setConnectionTimeout(100);
       client.setTimeout(100);
 


### PR DESCRIPTION
When we more than ten users simultaneously submitted to view the proxyserver, there will be stuck, and then it will throw IO exception