### PR TITLE
[HADOOP-15261] Upgrade commons-io from 2.4 to 2.5

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -778,7 +778,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
move commons-io up to 2.5 which introduced by kerb-simplekdc.