### PR TITLE
YARN-8056. Fix possible NPE when start Application Master

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmFilterInitializer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/main/java/org/apache/hadoop/yarn/server/webproxy/amfilter/AmFilterInitializer.java
@@ -68,7 +68,9 @@ public class AmFilterInitializer extends FilterInitializer {
       List<String> urls = new ArrayList<>();
       for (String rmId : rmIds) {
         String url = getUrlByRmId(yarnConf, rmId);
-        urls.add(url);
+        if (url != null) {
+          urls.add(url);
+        }
       }
       if (!urls.isEmpty()) {
         params.put(RM_HA_URLS, StringUtils.join(",", urls));


### PR DESCRIPTION
Fix possible NPE when yarn.resourcemanager.webapp.address or yarn.resourcemanager.webapp.https.address is not set in yarn-site.xml (incomplete configuration of HA).