### PR TITLE
HDFS-13321: Inadequate information for handling catch clauses

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -230,9 +230,9 @@ class BPServiceActor implements Runnable {
         LOG.debug(this + " received versionRequest response: " + nsInfo);
         break;
       } catch(SocketTimeoutException e) {  // namenode is busy
-        LOG.warn("Problem connecting to server: " + nnAddr);
+        LOG.warn("Problem connecting to server: " + nnAddr, e);
       } catch(IOException e ) {  // namenode is not available
-        LOG.warn("Problem connecting to server: " + nnAddr);
+        LOG.warn("Problem connecting to server: " + nnAddr, e);
       }
       
       // try again in a second


### PR DESCRIPTION
The description of the problem:
https://issues.apache.org/jira/browse/HDFS-13321
I just added stack traces information to those two logging statements, so that the exception type can be generated to the logs.