### PR TITLE
YARN-8057 Inadequate information for handling catch clauses

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/NMClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/NMClientImpl.java
@@ -124,11 +124,11 @@ public class NMClientImpl extends NMClient {
       } catch (YarnException e) {
         LOG.error("Failed to stop Container " +
             startedContainer.getContainerId() +
-            "when stopping NMClientImpl");
+            "when stopping NMClientImpl", e);
       } catch (IOException e) {
         LOG.error("Failed to stop Container " +
             startedContainer.getContainerId() +
-            "when stopping NMClientImpl");
+            "when stopping NMClientImpl", e);
       }
     }
   }


### PR DESCRIPTION
The description of the problem:
https://issues.apache.org/jira/browse/YARN-8057
I added stack traces information to those two logging statements, so that the full exception information can be generated to the logs.