### PR TITLE
Minor spell mistake in comment : Line number 101

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
@@ -98,7 +98,7 @@ message INodeSection {
      * format. The bits can be divided in four segments:
      * [0:2) || [2:26) || [26:27) || [27:29) || [29:32)
      *
-     * [0:2) -- reserved for futute uses.
+     * [0:2) -- reserved for future uses.
      * [2:26) -- the name of the entry, which is an ID that points to a
      * string in the StringTableSection.
      * [26:27) -- the scope of the entry (AclEntryScopeProto)


### PR DESCRIPTION
There is a minor spell mistake on line number 100, where future is misspelled as "futute" under "message AclFeatureProto" section.
Here is code snippet:

message AclFeatureProto {
    /**
     * An ACL entry is represented by a 32-bit integer in Big Endian
     * format. The bits can be divided in four segments:
     * [0:2) || [2:26) || [26:27) || [27:29) || [29:32)
     *
     * [0:2) -- reserved for future uses.
     * [2:26) -- the name of the entry, which is an ID that points to a
     * string in the StringTableSection.
     * [26:27) -- the scope of the entry (AclEntryScopeProto)
     * [27:29) -- the type of the entry (AclEntryTypeProto)
     * [29:32) -- the permission of the entry (FsActionProto)
     *
     */
    repeated fixed32 entries = 2 [packed = true];
  }
message AclFeatureProto {
/**
* An ACL entry is represented by a 32-bit integer in Big Endian
* format. The bits can be divided in four segments:
* [0:2) || [2:26) || [26:27) || [27:29) || [29:32)
*
* [0:2) -- reserved for futute uses.
* [2:26) -- the name of the entry, which is an ID that points to a
* string in the StringTableSection.
* [26:27) -- the scope of the entry (AclEntryScopeProto)
* [27:29) -- the type of the entry (AclEntryTypeProto)
* [29:32) -- the permission of the entry (FsActionProto)
*
*/