### PR TITLE
classpath description is not full for hadoop cmd

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop
@@ -39,7 +39,7 @@ function print_usage(){
   echo "  checknative [-a|-h]  check native hadoop and compression libraries availability"
   echo "  distcp <srcurl> <desturl> copy file or directories recursively"
   echo "  archive -archiveName NAME -p <parent path> <src>* <dest> create a hadoop archive"
-  echo "  classpath            prints the class path needed to get the"
+  echo "  classpath            prints the class path needed to get the Hadoop jar and the required libraries"
   echo "                       Hadoop jar and the required libraries"
   echo "  credential           interact with credential providers"
   echo "  daemonlog            get/set the log level for each daemon"


### PR DESCRIPTION
 Changed line number 43 where classpath description is not full and changed it to the one provided in hadoopv3:  "prints the class path needed to get the Hadoop jar and the required libraries"