### PR TITLE
MAPREDUCE-7120. Make hadoop consider wildcard host as datalocal

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -162,6 +162,7 @@ public abstract class TaskAttemptImpl implements
   private static final Logger LOG =
       LoggerFactory.getLogger(TaskAttemptImpl.class);
   private static final long MEMORY_SPLITS_RESOLUTION = 1024; //TODO Make configurable?
+  private static final String ANY = "*";
   private final static RecordFactory recordFactory = RecordFactoryProvider.getRecordFactory(null);
 
   protected final JobConf conf;
@@ -683,7 +684,9 @@ public abstract class TaskAttemptImpl implements
     RackResolver.init(conf);
     this.dataLocalRacks = new HashSet<String>(); 
     for (String host : this.dataLocalHosts) {
-      this.dataLocalRacks.add(RackResolver.resolve(host).getNetworkLocation());
+      if (!ANY.equals(host)) {
+        this.dataLocalRacks.add(RackResolver.resolve(host).getNetworkLocation());
+      }
     }
 
     locality = Locality.OFF_SWITCH;
@@ -1586,7 +1589,7 @@ public abstract class TaskAttemptImpl implements
     locality = Locality.OFF_SWITCH;
     if (dataLocalHosts.size() > 0) {
       String cHost = resolveHost(containerNodeId.getHost());
-      if (dataLocalHosts.contains(cHost)) {
+      if (dataLocalHosts.contains(ANY) || dataLocalHosts.contains(cHost)) {
         locality = Locality.NODE_LOCAL;
       }
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
@@ -98,10 +98,11 @@ public class RMContainerAllocator extends RMContainerRequestor
     implements ContainerAllocator {
 
   static final Logger LOG = LoggerFactory.getLogger(RMContainerAllocator.class);
-  
+
+  static final String ANY = "*";
   public static final 
   float DEFAULT_COMPLETED_MAPS_PERCENT_FOR_REDUCE_SLOWSTART = 0.05f;
-  
+
   static final Priority PRIORITY_FAST_FAIL_MAP;
   static final Priority PRIORITY_REDUCE;
   static final Priority PRIORITY_MAP;
@@ -160,6 +161,8 @@ public class RMContainerAllocator extends RMContainerRequestor
   private int hostLocalAssigned = 0;
   private int rackLocalAssigned = 0;
   private int lastCompletedTasks = 0;
+
+  private boolean isLocationIrrelevant = false;
   
   private boolean recalculateReduceSchedule = false;
   private Resource mapResourceRequest = Resources.none();
@@ -1121,6 +1124,10 @@ public class RMContainerAllocator extends RMContainerRequestor
               new ContainerRequest(event, PRIORITY_MAP, mapNodeLabelExpression);
           for (String host : event.getHosts()) {
             LinkedList<TaskAttemptId> list = mapsHostMapping.get(host);
+            if (ANY.equals(host)) {
+              LOG.info("Location is irrelevant in map hosts");
+              isLocationIrrelevant = true;
+            }
             if (list == null) {
               list = new LinkedList<TaskAttemptId>();
               mapsHostMapping.put(host, list);
@@ -1339,8 +1346,13 @@ public class RMContainerAllocator extends RMContainerRequestor
           || PRIORITY_OPPORTUNISTIC_MAP.equals(priority)) {
         LOG.info("Replacing MAP container " + allocated.getId());
         // allocated container was for a map
-        String host = allocated.getNodeId().getHost();
-        LinkedList<TaskAttemptId> list = mapsHostMapping.get(host);
+        LinkedList<TaskAttemptId> list;
+        if (isLocationIrrelevant) {
+          list = mapsHostMapping.get(ANY);
+        } else {
+          String host = allocated.getNodeId().getHost();
+          list = mapsHostMapping.get(host);
+        }
         if (list != null && list.size() > 0) {
           TaskAttemptId tId = list.removeLast();
           if (maps.containsKey(tId)) {
@@ -1405,7 +1417,12 @@ public class RMContainerAllocator extends RMContainerRequestor
           // "if (maps.containsKey(tId))" below should be almost always true.
           // hence this while loop would almost always have O(1) complexity
           String host = allocated.getNodeId().getHost();
-          LinkedList<TaskAttemptId> list = mapsHostMapping.get(host);
+          LinkedList<TaskAttemptId> list;
+          if (isLocationIrrelevant){
+            list = mapsHostMapping.get(ANY);
+          } else {
+            list = mapsHostMapping.get(host);
+          }
           while (list != null && list.size() > 0) {
             if (LOG.isDebugEnabled()) {
               LOG.debug("Host matched to the request list " + host);


### PR DESCRIPTION
This allows hadoop to treat "*" as data local. This allows remote filesystems to increase performance by skipping retrys for data locality by returning "*" as the block host when the filesystem is asked for the block location.