### PR TITLE
HADOOP-15585. Fix passing options via $HADOOP_OPTS

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1772,7 +1772,7 @@ function hadoop_java_exec
 
   export CLASSPATH
   #shellcheck disable=SC2086
-  exec "${JAVA}" "-Dproc_${command}" ${HADOOP_OPTS} "${class}" "$@"
+  eval exec '"${JAVA}"' '"-Dproc_${command}"' ${HADOOP_OPTS} '"${class}"' '"$@"'
 }
 
 ## @description  Start a non-privileged daemon in the foreground.
@@ -1809,7 +1809,7 @@ function hadoop_start_daemon
 
   export CLASSPATH
   #shellcheck disable=SC2086
-  exec "${JAVA}" "-Dproc_${command}" ${HADOOP_OPTS} "${class}" "$@"
+  eval exec '"${JAVA}"' '"-Dproc_${command}"' ${HADOOP_OPTS} '"${class}"' '"$@"'
 }
 
 ## @description  Start a non-privileged daemon in the background.
@@ -1938,16 +1938,16 @@ function hadoop_start_secure_daemon
   fi
 
   # shellcheck disable=SC2086
-  exec "${jsvc}" \
-    "-Dproc_${daemonname}" \
-    -outfile "${daemonoutfile}" \
-    -errfile "${daemonerrfile}" \
-    -pidfile "${daemonpidfile}" \
+  eval exec '"${jsvc}"' \
+    '"-Dproc_${daemonname}"' \
+    -outfile '"${daemonoutfile}"' \
+    -errfile '"${daemonerrfile}"' \
+    -pidfile '"${daemonpidfile}"' \
     -nodetach \
-    -user "${HADOOP_SECURE_USER}" \
-    -cp "${CLASSPATH}" \
+    -user '"${HADOOP_SECURE_USER}"' \
+    -cp '"${CLASSPATH}"' \
     ${HADOOP_OPTS} \
-    "${class}" "$@"
+    '"${class}"' '"$@"'
 }
 
 ## @description  Start a privileged daemon in the background.


### PR DESCRIPTION
Prior to this change, if HADOOP_OPTS contains any arguments that include a space, the command is not parsed correctly. The only alternative appears to be to use 'eval'. Switching to use 'eval' *instead of* 'exec' also works, but it results in an intermediate bash process being left alive throughout the entire lifetime of the Java process being started. Using 'exec' prefixed by 'eval' as has been done in this commit gets the best of both worlds, in that options with spaces are parsed correctly, and you don't end up with an intermediate bash process as the parent of the Java process.