### PR TITLE
YARN-3929. Add uncleaning option for local app log file

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1367,6 +1367,13 @@ public class YarnConfiguration extends Configuration {
       = 10 * 60 * 1000;
 
   /**
+   * Whether to clean up after nodemanager logs when log aggregation is enabled
+   */
+  public static final String LOG_AGGREGATION_ENABLE_LOCAL_CLEANUP =
+      YARN_PREFIX + "log-aggregation.enable-local-cleanup";
+  public static final boolean DEFAULT_LOG_AGGREGATION_ENABLE_LOCAL_CLEANUP = true;
+
+  /**
    * Number of seconds to retain logs on the NodeManager. Only applicable if Log
    * aggregation is disabled
    */


### PR DESCRIPTION
Add uncleaning option for local app log file with log-aggregation enabled

Support new config to enable/disable local app log file cleanup when log-aggregation is enabled