### PR TITLE
MAPREDUCE-7127. Add aggregated webservice endpoints to fetch all tasks & their taskAttempts

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AMWebServices.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -40,6 +42,9 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.mapreduce.JobACL;
+import org.apache.hadoop.mapreduce.task.TaskAttemptDescription;
+import org.apache.hadoop.mapreduce.task.TaskDescription;
+import org.apache.hadoop.mapreduce.task.TaskDescriptions;
 import org.apache.hadoop.mapreduce.v2.api.protocolrecords.KillTaskAttemptRequest;
 import org.apache.hadoop.mapreduce.v2.api.protocolrecords.KillTaskAttemptResponse;
 import org.apache.hadoop.mapreduce.v2.api.protocolrecords.impl.pb.KillTaskAttemptRequestPBImpl;
@@ -537,5 +542,66 @@ public class AMWebServices {
     ret.setState(TaskAttemptState.KILLED.toString());
 
     return Response.status(Status.OK).entity(ret).build();
+  }
+
+  @GET
+  @Path("/jobs/{jobid}/taskDescriptions")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public TaskDescriptions getTaskDescriptions(@Context HttpServletRequest hsr,
+      @PathParam("jobid") String jid) {
+    init();
+    Job job = getJobFromJobIdString(jid, appCtx);
+    TaskDescriptions taskDescriptions = new TaskDescriptions();
+    taskDescriptions.setFound(job != null);
+    long startTime, finishTime;
+    if (job != null && job.getTasks() != null && !job.getTasks().isEmpty()) {
+      List<TaskDescription> taskDescriptionList = new ArrayList<TaskDescription>();
+      for (Task task : job.getTasks().values()) {
+        TaskDescription taskDescription = new TaskDescription();
+        taskDescription.setJobId(jid);
+        taskDescription.setTaskId(task.getID().toString());
+        taskDescription.setProgress(Float.toString(task.getProgress() * 100));
+        taskDescription.setTaskType(task.getType().name());
+
+        startTime = Long.MAX_VALUE;
+        finishTime = 0;
+
+        if (task.getAttempts() != null && !task.getAttempts().isEmpty()) {
+          List<TaskAttemptDescription> taskAttemptDescriptionList = new ArrayList<TaskAttemptDescription>();
+
+          for (TaskAttempt ta : task.getAttempts().values()) {
+            if (ta != null && ta.getAssignedContainerID() != null) {
+              TaskAttemptDescription taskAttemptDescription = new TaskAttemptDescription();
+              taskAttemptDescription.setTaskAttemptId(ta.getID().toString() + ":" + ta.getAssignedContainerID().toString());
+              taskAttemptDescription.setTaskAttemptState(ta.getState().name());
+              taskAttemptDescription.setStartTime(ta.getLaunchTime());
+              if (ta.getLaunchTime() < startTime) {
+                startTime = ta.getLaunchTime();
+              }
+              if (task.isFinished() && ta.isFinished() && ta.getFinishTime() > finishTime) {
+                finishTime = ta.getFinishTime();
+              }
+              taskAttemptDescription.setFinishTime(ta.getFinishTime());
+              taskAttemptDescription.setPhase(ta.getPhase().name());
+              taskAttemptDescription.setProgress(ta.getProgress() * 100);
+              taskAttemptDescription.setTaskAttemptState(ta.getState().name());
+              if (task.getType() == TaskType.REDUCE) {
+                taskAttemptDescription.setShuffleFinishTime(ta.getShuffleFinishTime());
+                taskAttemptDescription.setSortFinishTime(ta.getSortFinishTime());
+              }
+              taskAttemptDescriptionList.add(taskAttemptDescription);
+            }
+          }
+
+          taskDescription.setTaskAttempts(taskAttemptDescriptionList);
+          taskDescription.setStartTime(startTime);
+          taskDescription.setFinishTime(finishTime);
+        }
+        taskDescriptionList.add(taskDescription);
+      }
+      taskDescriptions.setTaskDescriptionList(taskDescriptionList);
+    }
+
+    return taskDescriptions;
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/JAXBContextResolver.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/JAXBContextResolver.java
@@ -29,6 +29,7 @@ import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 import javax.xml.bind.JAXBContext;
 
+import org.apache.hadoop.mapreduce.task.TaskDescriptions;
 import org.apache.hadoop.mapreduce.v2.app.webapp.dao.AMAttemptInfo;
 import org.apache.hadoop.mapreduce.v2.app.webapp.dao.AMAttemptsInfo;
 import org.apache.hadoop.mapreduce.v2.app.webapp.dao.AppInfo;
@@ -64,7 +65,8 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
     JobCounterInfo.class, TaskCounterInfo.class, CounterGroupInfo.class,
     JobInfo.class, JobsInfo.class, ReduceTaskAttemptInfo.class,
     TaskAttemptInfo.class, TaskInfo.class, TasksInfo.class,
-    TaskAttemptsInfo.class, ConfEntryInfo.class, RemoteExceptionData.class};
+    TaskAttemptsInfo.class, ConfEntryInfo.class, RemoteExceptionData.class,
+    TaskDescriptions.class};
 
   // these dao classes need root unwrapping
   private final Class[] rootUnwrappedTypes = {JobTaskAttemptState.class};

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -422,6 +422,24 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   }
 
+  @Test
+  public void testTaskDescriptions() throws Exception {
+    WebResource r = resource();
+    Map<JobId, Job> jobsMap = appContext.getAllJobs();
+    for (JobId id : jobsMap.keySet()) {
+      String jobId = MRApps.toString(id);
+      ClientResponse response = r.path("ws").path("v1").path("mapreduce")
+          .path("jobs").path(jobId).path("taskDescriptions").accept(MediaType.APPLICATION_JSON)
+          .get(ClientResponse.class);
+      assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
+      JSONObject json = response.getEntity(JSONObject.class);
+      assertEquals("incorrect number of elements", 1, json.length());
+      JSONObject jobs = json.getJSONObject("TaskDescriptions");
+      JSONArray arr = jobs.getJSONArray("taskDescriptionList");
+      assertNotNull(arr);
+    }
+  }
+
   public void verifyAMJob(JSONObject info, Job job) throws JSONException {
 
     assertEquals("incorrect number of elements", 31, info.length());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskAttemptDescription.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskAttemptDescription.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.task;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "TaskAttemptDescription")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TaskAttemptDescription {
+
+  public String taskAttemptId;
+
+  public String taskAttemptState;
+
+  public long   startTime;
+
+  public long   finishTime;
+
+  public String phase;
+
+  public float progress;
+
+  public long shuffleFinishTime;
+
+  public long sortFinishTime;
+
+  public TaskAttemptDescription() {
+  }
+
+  public String getTaskAttemptId() {
+    return taskAttemptId;
+  }
+
+  public void setTaskAttemptId(String taskAttemptId) {
+    this.taskAttemptId = taskAttemptId;
+  }
+
+  public String getTaskAttemptState() {
+    return taskAttemptState;
+  }
+
+  public void setTaskAttemptState(String taskAttemptState) {
+    this.taskAttemptState = taskAttemptState;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public void setStartTime(long startTime) {
+    this.startTime = startTime;
+  }
+
+  public long getFinishTime() {
+    return finishTime;
+  }
+
+  public void setFinishTime(long finishTime) {
+    this.finishTime = finishTime;
+  }
+
+  public String getPhase() {
+    return phase;
+  }
+
+  public void setPhase(String phase) {
+    this.phase = phase;
+  }
+
+  public float getProgress() {
+    return progress;
+  }
+
+  public void setProgress(float progress) {
+    this.progress = progress;
+  }
+
+  public long getShuffleFinishTime() {
+    return shuffleFinishTime;
+  }
+
+  public void setShuffleFinishTime(long shuffleFinishTime) {
+    this.shuffleFinishTime = shuffleFinishTime;
+  }
+
+  public long getSortFinishTime() {
+    return sortFinishTime;
+  }
+
+  public void setSortFinishTime(long sortFinishTime) {
+    this.sortFinishTime = sortFinishTime;
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskDescription.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskDescription.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.task;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "TaskDescription")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TaskDescription {
+
+  private List<TaskAttemptDescription> taskAttempts;
+
+  private String jobId;
+
+  private String taskId;
+
+  private String taskType;
+
+  private String progress;
+
+  private long startTime;
+
+  private long finishTime;
+
+  public TaskDescription() {
+  }
+
+  public List<TaskAttemptDescription> getTaskAttempts() {
+    return taskAttempts;
+  }
+
+  public void setTaskAttempts(List<TaskAttemptDescription> taskAttempts) {
+    this.taskAttempts = taskAttempts;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public String getTaskId() {
+    return taskId;
+  }
+
+  public void setTaskId(String taskId) {
+    this.taskId = taskId;
+  }
+
+  public String getTaskType() {
+    return taskType;
+  }
+
+  public void setTaskType(String taskType) {
+    this.taskType = taskType;
+  }
+
+  public String getProgress() {
+    return progress;
+  }
+
+  public void setProgress(String progress) {
+    this.progress = progress;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public void setStartTime(long startTime) {
+    this.startTime = startTime;
+  }
+
+  public long getFinishTime() {
+    return finishTime;
+  }
+
+  public void setFinishTime(long finishTime) {
+    this.finishTime = finishTime;
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskDescriptionComparator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskDescriptionComparator.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.task;
+
+import java.util.Comparator;
+
+public class TaskDescriptionComparator implements Comparator<TaskDescription> {
+  @Override
+  public int compare(TaskDescription t1, TaskDescription t2) {
+    if(t1.getTaskType().equalsIgnoreCase(t2.getTaskType())){
+      return t1.getTaskId().compareTo(t2.getTaskId());
+    } else if ("MAP".equalsIgnoreCase(t1.getTaskType())) {
+      return -1;
+    } else {
+      return 1;
+    }
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskDescriptions.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/TaskDescriptions.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.task;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+@JsonRootName(value = "TaskDescriptions")
+@XmlRootElement(name = "TaskDescriptions")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TaskDescriptions {
+
+  protected boolean found;
+
+  protected boolean successful;
+
+  protected String errorMsg;
+
+  protected List<TaskDescription> taskDescriptionList;
+
+  public boolean isFound() {
+    return found;
+  }
+
+  public void setFound(boolean found) {
+    this.found = found;
+  }
+
+  public boolean isSuccessful() {
+    return successful;
+  }
+
+  public void setSuccessful(boolean successful) {
+    this.successful = successful;
+  }
+
+  public String getErrorMsg() {
+    return errorMsg;
+  }
+
+  public void setErrorMsg(String errorMsg) {
+    this.errorMsg = errorMsg;
+  }
+
+  public List<TaskDescription> getTaskDescriptionList() {
+    return taskDescriptionList;
+  }
+
+  public void setTaskDescriptionList(List<TaskDescription> taskDescriptionList) {
+    this.taskDescriptionList = taskDescriptionList;
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/ConfigureAware.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/ConfigureAware.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs;
+
+import org.apache.hadoop.conf.Configuration;
+
+public interface ConfigureAware {
+  Configuration getConfig();
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Loads and manages the Job history cache.
  */
-public class JobHistory extends AbstractService implements HistoryContext {
+public class JobHistory extends AbstractService implements HistoryContext, ConfigureAware {
   private static final Logger LOG = LoggerFactory.getLogger(JobHistory.class);
 
   public static final Pattern CONF_FILENAME_REGEX = Pattern.compile("("

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.mapreduce.v2.hs.webapp;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -33,10 +36,17 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.mapreduce.JobACL;
+import org.apache.hadoop.mapreduce.task.TaskAttemptDescription;
+import org.apache.hadoop.mapreduce.task.TaskDescription;
+import org.apache.hadoop.mapreduce.task.TaskDescriptionComparator;
+import org.apache.hadoop.mapreduce.task.TaskDescriptions;
 import org.apache.hadoop.mapreduce.v2.api.records.AMInfo;
+import org.apache.hadoop.mapreduce.v2.api.records.JobId;
 import org.apache.hadoop.mapreduce.v2.api.records.JobState;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskId;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskType;
@@ -71,6 +81,8 @@ import com.google.inject.Inject;
 
 @Path("/ws/v1/history")
 public class HsWebServices {
+  private static final Log LOG = LogFactory.getLog(HsWebServices.class);
+
   private final HistoryContext ctx;
   private WebApp webapp;
 
@@ -78,11 +90,18 @@ public class HsWebServices {
   @Context
   UriInfo uriInfo;
 
+  private TaskDescriptionsFetcher taskDescriptionsFetcher;
+
+  private TaskDescriptionComparator taskDescriptionComparator;
+
   @Inject
   public HsWebServices(final HistoryContext ctx, final Configuration conf,
       final WebApp webapp) {
     this.ctx = ctx;
     this.webapp = webapp;
+    JerseyClient jerseyClient = new JerseyClient();
+    this.taskDescriptionsFetcher = new TaskDescriptionsFetcher(ctx, jerseyClient);
+    this.taskDescriptionComparator = new TaskDescriptionComparator();
   }
 
   private boolean hasAccess(Job job, HttpServletRequest request) {
@@ -406,6 +425,115 @@ public class HsWebServices {
     TaskAttempt ta = AMWebServices.getTaskAttemptFromTaskAttemptString(attId,
         task);
     return new JobTaskAttemptCounterInfo(ta);
+  }
+
+  @GET
+  @Path("/mapreduce/jobs/{jobid}/describeTasks")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public TaskDescriptions getTaskAttempts(@Context HttpServletRequest hsr, @PathParam("jobid") String jid) {
+
+    init();
+    TaskDescriptions taskDescriptions = null;
+    Job job = null;
+
+    try {
+      job = AMWebServices.getJobFromJobIdString(jid, ctx);
+      checkAccess(job, hsr);
+    } catch (Exception e) {
+      // Cannot find the job from local, which is normal if a job is still running. Ignore the exception
+    }
+
+    try {
+      if (job != null) {
+        // Found the job from local, i.e., JHS
+        taskDescriptions = getTaskDescriptionsFromJHS(job, jid);
+      } else {
+        JobId jobId = MRApps.toJobID(jid);
+        if (jobId != null) {
+          // Fetch the job from remote AM
+          taskDescriptions = taskDescriptionsFetcher.fetch(jobId);
+        }
+      }
+
+      if (taskDescriptions == null) {
+        taskDescriptions = new TaskDescriptions();
+        taskDescriptions.setFound(false);
+      } else {
+        List<TaskDescription> records = taskDescriptions.getTaskDescriptionList();
+        if (records != null && !records.isEmpty()) {
+          // sort output task attempts, map tasks first
+          Collections.sort(records, this.taskDescriptionComparator);
+          taskDescriptions.setTaskDescriptionList(records);
+        }
+      }
+
+      taskDescriptions.setSuccessful(true);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      if (taskDescriptions == null){
+        taskDescriptions = new TaskDescriptions();
+      }
+      taskDescriptions.setSuccessful(false);
+      taskDescriptions.setErrorMsg(e.getMessage());
+    }
+
+    return taskDescriptions;
+  }
+
+  private TaskDescriptions getTaskDescriptionsFromJHS(Job job, String jid) {
+    TaskDescriptions taskDescriptions = null;
+    taskDescriptions = new TaskDescriptions();
+    taskDescriptions.setFound(true);
+    long startTime, finishTime;
+    if (job.getTasks() != null && !job.getTasks().isEmpty()) {
+      List<TaskDescription> taskDescriptionList = new ArrayList<TaskDescription>();
+      for (Task task : job.getTasks().values()) {
+        TaskDescription taskDescription = new TaskDescription();
+        taskDescription.setJobId(jid);
+        taskDescription.setTaskId(task.getID().toString());
+        taskDescription.setProgress(Float.toString(task.getProgress() * 100));
+        taskDescription.setTaskType(task.getType().name());
+
+        startTime = Long.MAX_VALUE;
+        finishTime = 0;
+
+        if (task.getAttempts() != null && !task.getAttempts().isEmpty()) {
+          List<TaskAttemptDescription> taskAttemptDescriptionList = new ArrayList<TaskAttemptDescription>();
+
+          for (TaskAttempt ta : task.getAttempts().values()) {
+            if (ta != null) {
+              TaskAttemptDescription taskAttemptDescription = new TaskAttemptDescription();
+              taskAttemptDescription.setTaskAttemptId(ta.getID().toString() + ":" + ta.getAssignedContainerID().toString());
+              taskAttemptDescription.setTaskAttemptState(ta.getState().name());
+              taskAttemptDescription.setStartTime(ta.getLaunchTime());
+              if (ta.getLaunchTime() < startTime) {
+                startTime = ta.getLaunchTime();
+              }
+              if (task.isFinished() && ta.isFinished() && ta.getFinishTime() > finishTime) {
+                finishTime = ta.getFinishTime();
+              }
+              taskAttemptDescription.setFinishTime(ta.getFinishTime());
+              taskAttemptDescription.setPhase(ta.getPhase().name());
+              taskAttemptDescription.setProgress(ta.getProgress() * 100);
+              taskAttemptDescription.setTaskAttemptState(ta.getState().name());
+              if (task.getType() == TaskType.REDUCE) {
+                taskAttemptDescription.setShuffleFinishTime(ta.getShuffleFinishTime());
+                taskAttemptDescription.setSortFinishTime(ta.getSortFinishTime());
+              }
+              taskAttemptDescriptionList.add(taskAttemptDescription);
+            }
+          }
+
+          taskDescription.setTaskAttempts(taskAttemptDescriptionList);
+          taskDescription.setStartTime(startTime);
+          taskDescription.setFinishTime(finishTime);
+        }
+        taskDescriptionList.add(taskDescription);
+      }
+      taskDescriptions.setTaskDescriptionList(taskDescriptionList);
+    }
+
+    return taskDescriptions;
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/JAXBContextResolver.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/JAXBContextResolver.java
@@ -30,6 +30,7 @@ import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 import javax.xml.bind.JAXBContext;
 
+import org.apache.hadoop.mapreduce.task.TaskDescriptions;
 import org.apache.hadoop.mapreduce.v2.app.webapp.dao.ConfInfo;
 import org.apache.hadoop.mapreduce.v2.app.webapp.dao.CounterGroupInfo;
 import org.apache.hadoop.mapreduce.v2.app.webapp.dao.CounterInfo;
@@ -66,7 +67,7 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
       JobCounterInfo.class, ReduceTaskAttemptInfo.class, TaskAttemptInfo.class,
       TaskAttemptsInfo.class, CounterGroupInfo.class,
       TaskCounterGroupInfo.class, AMAttemptInfo.class, AMAttemptsInfo.class,
-      RemoteExceptionData.class };
+      RemoteExceptionData.class, TaskDescriptions.class};
 
   public JAXBContextResolver() throws Exception {
     this.types = new HashSet<Class>(Arrays.asList(cTypes));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/JerseyClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/JerseyClient.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
+import org.codehaus.jackson.map.DeserializationConfig;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.api.json.JSONConfiguration;
+
+public class JerseyClient implements RestClient {
+
+  private static final Log LOG = LogFactory.getLog(JerseyClient.class);
+
+  private final static String FORMAT = "application/json";
+
+  private Client client;
+
+  protected ObjectMapper mapper;
+  public JerseyClient() {
+    ClientConfig clientConfig = new DefaultClientConfig();
+    clientConfig.getFeatures().put(JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE);
+    clientConfig.getClasses().add(JacksonJsonProvider.class);
+    client = Client.create(clientConfig);
+    mapper = new ObjectMapper()
+        .configure(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+        .configure(DeserializationConfig.Feature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, true)
+        .configure(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true)
+        .configure(DeserializationConfig.Feature.AUTO_DETECT_CREATORS, true)
+        .configure(DeserializationConfig.Feature.AUTO_DETECT_SETTERS, true)
+        .configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(DeserializationConfig.Feature.USE_ANNOTATIONS, true);
+  }
+
+  public String fetchJson(String url) {
+    WebResource webResource = client.resource(url);
+
+    ClientResponse response = webResource.accept(FORMAT).get(ClientResponse.class);
+
+    if (response.getStatus() != 200) {
+      String msg = "Failed to fetch " + url + ", HTTP error code : " + response.getStatus();
+      LOG.error(msg);
+      if (response.getStatus() == 404) {
+        // Use special handling for 404 errors
+        throw new NotFoundException(msg);
+      }
+      throw new RuntimeException(msg);
+    }
+    String responseString = response.getEntity(String.class);
+    if (!response.getType().toString().contains(MediaType.APPLICATION_JSON)) {
+      LOG.error("Received non-json (" + response.getType() + ") response from "
+          + url + ", response: " + responseString);
+      return null;
+    }
+
+    return responseString;
+  }
+
+  public <T> T fetchAs(String url, Class<T> clazz){
+    String json = fetchJson(url);
+    if(json == null || json.trim().isEmpty()){
+      LOG.info("Fetched empty response from " + url);
+      return null;
+    }
+
+    try {
+      return mapper.readValue(json, clazz);
+    } catch (IOException e) {
+      LOG.error("Error deserializing class  " + clazz.getName() + " from json " + json, e);
+      return null;
+    }
+  }
+
+  @Override
+  public <T> T convert(String json, Class<T> clazz) {
+    if(json == null || json.isEmpty()){
+      return null;
+    }
+
+    try {
+      return mapper.readValue(json, clazz);
+    } catch (IOException e) {
+      LOG.error("Error deserializing class  " + clazz.getName() + " from json " + json, e);
+      return null;
+    }
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/NotFoundException.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/NotFoundException.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+public class NotFoundException extends RuntimeException {
+  public NotFoundException(String message) {
+    super(message);
+  }
+
+  public NotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public NotFoundException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/RestClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/RestClient.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+public interface RestClient {
+
+  String fetchJson(String url);
+
+  <T> T fetchAs(String url, Class<T> clazz);
+
+  <T> T convert(String json, Class<T> clazz);
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TaskDescriptionsFetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TaskDescriptionsFetcher.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.task.TaskDescriptions;
+import org.apache.hadoop.mapreduce.v2.api.records.JobId;
+import org.apache.hadoop.mapreduce.v2.hs.ConfigureAware;
+import org.apache.hadoop.mapreduce.v2.hs.HistoryContext;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.app.SimpleAppInfo;
+import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
+
+public class TaskDescriptionsFetcher {
+
+  private static final Log LOG = LogFactory.getLog(TaskDescriptionsFetcher.class);
+
+  private static final String RM_APPS_PATH = "/ws/v1/cluster/apps/";
+  private static final String AM_TASK_DESCRIPTIONS_PATH = "/ws/v1/mapreduce/jobs/";
+
+  private final HistoryContext ctx;
+
+  private Configuration config;
+
+  private final RestClient restClient;
+
+  public TaskDescriptionsFetcher(HistoryContext ctx, RestClient restClient) {
+    this.ctx = ctx;
+    config = ((ConfigureAware) ctx).getConfig();
+    this.restClient = restClient;
+  }
+
+  public TaskDescriptions fetch(JobId jobId) {
+    TaskDescriptions taskDescriptions = null;
+    // Query AM tracking URL from RM
+    String rmWebAppUrl = WebAppUtils.getRMWebAppURLWithScheme(config);
+    LOG.debug("RMWebAppURL: " + rmWebAppUrl);
+    ApplicationId appId = jobId.getAppId();
+    SimpleAppInfo app;
+    try {
+      app = restClient.fetchAs(rmWebAppUrl + RM_APPS_PATH + appId.toString() + "/info", SimpleAppInfo.class);
+
+      if (app != null && app.getTrackingUrl() != null) {
+        // Get TaskDescriptions from AM
+        String taskUrl = buildMRAppMasterWebServiceUrl(app.getTrackingUrl(), jobId.toString());
+        LOG.debug("AMTaskDescriptionURL: " + taskUrl);
+        taskDescriptions = restClient.fetchAs(taskUrl, TaskDescriptions.class);
+      } else {
+        LOG.debug("App for " + jobId + " is not ready");
+      }
+    } catch (NotFoundException e) {
+      taskDescriptions = new TaskDescriptions();
+      taskDescriptions.setSuccessful(true);
+      taskDescriptions.setFound(false);
+      LOG.info("App for " + jobId + " is not found");
+    }
+
+    return taskDescriptions;
+  }
+
+  protected String buildMRAppMasterWebServiceUrl(String trackUrl, String jobId) {
+    if (trackUrl.endsWith("/")) {
+      return trackUrl.substring(0, trackUrl.length() - 1) + AM_TASK_DESCRIPTIONS_PATH + jobId + "/taskDescriptions";
+    }
+    return trackUrl + AM_TASK_DESCRIPTIONS_PATH + jobId + "/taskDescriptions";
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/dao/JobsInfo.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/dao/JobsInfo.java
@@ -23,6 +23,9 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+@JsonRootName(value = "jobs")
 @XmlRootElement(name = "jobs")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class JobsInfo {
@@ -40,4 +43,11 @@ public class JobsInfo {
     return this.job;
   }
 
+  public ArrayList<JobInfo> getJob() {
+    return job;
+  }
+
+  public void setJob(ArrayList<JobInfo> job) {
+    this.job = job;
+  }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/MockHistoryContext.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/MockHistoryContext.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.mapreduce.v2.hs;
 import java.io.IOException;
 import java.util.Map;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.v2.api.records.JobId;
 import org.apache.hadoop.mapreduce.v2.api.records.JobState;
@@ -31,10 +32,11 @@ import org.apache.hadoop.mapreduce.v2.hs.webapp.dao.JobsInfo;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 
-public class MockHistoryContext extends MockAppContext implements HistoryContext {
+public class MockHistoryContext extends MockAppContext implements HistoryContext, ConfigureAware {
 
   private final Map<JobId, Job> partialJobs;
   private final Map<JobId, Job> fullJobs;
+  private Configuration config = new Configuration();
   
   public MockHistoryContext(int numJobs, int numTasks, int numAttempts) {
     super(0);
@@ -109,4 +111,8 @@ public class MockHistoryContext extends MockAppContext implements HistoryContext
         offset, count, user, queue, sBegin, sEnd, fBegin, fEnd, jobState);
   }
 
+  @Override
+  public Configuration getConfig() {
+    return config;
+  }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesJobs.java
@@ -777,6 +777,25 @@ public class TestHsWebServicesJobs extends JerseyTestBase {
     }
   }
 
+  @Test
+  public void testDescribeTasks() throws Exception {
+    WebResource r = resource();
+    Map<JobId, Job> jobsMap = appContext.getAllJobs();
+    for (JobId id : jobsMap.keySet()) {
+      String jobId = MRApps.toString(id);
+
+      ClientResponse response = r.path("ws").path("v1").path("history")
+          .path("mapreduce").path("jobs").path(jobId).path("describeTasks")
+          .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
+      assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
+      JSONObject json = response.getEntity(JSONObject.class);
+      assertEquals("incorrect number of elements", 1, json.length());
+      JSONObject jobs = json.getJSONObject("TaskDescriptions");
+      JSONArray arr = jobs.getJSONArray("taskDescriptionList");
+      assertNotNull(arr);
+    }
+  }
+
   public void verifyHsJobAttempts(JSONObject info, Job job)
       throws JSONException {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestJerseyClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestJerseyClient.java
@@ -1,0 +1,300 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.v2.api.records.JobId;
+import org.apache.hadoop.mapreduce.v2.api.records.JobState;
+import org.apache.hadoop.mapreduce.v2.app.AppContext;
+import org.apache.hadoop.mapreduce.v2.app.ClusterInfo;
+import org.apache.hadoop.mapreduce.v2.app.MockJobs;
+import org.apache.hadoop.mapreduce.v2.app.TaskAttemptFinishingMonitor;
+import org.apache.hadoop.mapreduce.v2.app.job.Job;
+import org.apache.hadoop.mapreduce.v2.app.webapp.dao.TasksInfo;
+import org.apache.hadoop.mapreduce.v2.hs.CachedHistoryStorage;
+import org.apache.hadoop.mapreduce.v2.hs.ConfigureAware;
+import org.apache.hadoop.mapreduce.v2.hs.HistoryContext;
+import org.apache.hadoop.mapreduce.v2.hs.MockHistoryJobs;
+import org.apache.hadoop.mapreduce.v2.hs.webapp.dao.JobsInfo;
+import org.apache.hadoop.service.AbstractService;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.app.AppState;
+import org.apache.hadoop.yarn.app.SimpleAppInfo;
+import org.apache.hadoop.yarn.event.EventHandler;
+import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
+import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
+import org.apache.hadoop.yarn.util.Clock;
+import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
+import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
+import org.apache.hadoop.yarn.webapp.WebApp;
+
+import com.google.inject.Guice;
+import com.google.inject.servlet.ServletModule;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestJerseyClient extends JerseyTest {
+
+  private static JerseyClient client;
+  private static Configuration conf = new Configuration();
+  private static TestAppContext appContext;
+  private static HsWebApp webApp;
+
+  static class TestAppContext extends AbstractService implements HistoryContext, ConfigureAware {
+    final ApplicationAttemptId appAttemptID;
+    final ApplicationId appID;
+    final String user = MockJobs.newUserName();
+    final Map<JobId, Job> partialJobs;
+    final Map<JobId, Job> fullJobs;
+    final long startTime = System.currentTimeMillis();
+
+    TestAppContext(int appid, int numJobs, int numTasks, int numAttempts,
+        boolean hasFailedTasks) {
+      super(TestAppContext.class.getName());
+      appID = MockJobs.newAppID(appid);
+      appAttemptID = ApplicationAttemptId.newInstance(appID, 0);
+      MockHistoryJobs.JobsPair jobs;
+      try {
+        jobs = MockHistoryJobs.newHistoryJobs(appID, numJobs, numTasks,
+            numAttempts, hasFailedTasks);
+      } catch (IOException e) {
+        throw new YarnRuntimeException(e);
+      }
+      partialJobs = jobs.partial;
+      fullJobs = jobs.full;
+    }
+
+    TestAppContext(int appid, int numJobs, int numTasks, int numAttempts) {
+      this(appid, numJobs, numTasks, numAttempts, false);
+    }
+
+    TestAppContext() {
+      this(0, 1, 2, 1);
+    }
+
+    @Override
+    public ApplicationAttemptId getApplicationAttemptId() {
+      return appAttemptID;
+    }
+
+    @Override
+    public ApplicationId getApplicationID() {
+      return appID;
+    }
+
+    @Override
+    public CharSequence getUser() {
+      return user;
+    }
+
+    @Override
+    public Job getJob(JobId jobID) {
+      return fullJobs.get(jobID);
+    }
+
+    public Job getPartialJob(JobId jobID) {
+      return partialJobs.get(jobID);
+    }
+
+    @Override
+    public Map<JobId, Job> getAllJobs() {
+      return partialJobs; // OK
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public EventHandler getEventHandler() {
+      return null;
+    }
+
+    @Override
+    public Clock getClock() {
+      return null;
+    }
+
+    @Override
+    public ClusterInfo getClusterInfo() {
+      return null;
+    }
+
+    @Override
+    public String getApplicationName() {
+      return "TestApp";
+    }
+
+    @Override
+    public long getStartTime() {
+      return startTime;
+    }
+
+
+    @Override
+    public Set<String> getBlacklistedNodes() {
+      return null;
+    }
+
+    @Override
+    public ClientToAMTokenSecretManager getClientToAMTokenSecretManager() {
+      return null;
+    }
+
+    @Override
+    public boolean isLastAMRetry() {
+      return false;
+    }
+
+    @Override
+    public boolean hasSuccessfullyUnregistered() {
+      return false;
+    }
+
+    @Override
+    public String getNMHostname() {
+      return null;
+    }
+
+    @Override
+    public Map<JobId, Job> getAllJobs(ApplicationId appID) {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    @Override
+    public JobsInfo getPartialJobs(Long offset, Long count, String user,
+        String queue, Long sBegin, Long sEnd, Long fBegin, Long fEnd,
+        JobState jobState) {
+      return CachedHistoryStorage.getPartialJobs(this.partialJobs.values(),
+          offset, count, user, queue, sBegin, sEnd, fBegin, fEnd, jobState);
+    }
+
+    @Override
+    public void setHistoryUrl(String historyUrl) {
+
+    }
+
+    @Override
+    public String getHistoryUrl() {
+      return null;
+    }
+
+    @Override
+    public TaskAttemptFinishingMonitor getTaskAttemptFinishingMonitor() {
+      return null;
+    }
+  }
+
+  private static class WebServletModule extends ServletModule {
+    @Override
+    protected void configureServlets() {
+      appContext = new TestAppContext();
+      webApp = mock(HsWebApp.class);
+      when(webApp.name()).thenReturn("hsmockwebapp");
+
+      bind(JAXBContextResolver.class);
+      bind(HsWebServices.class);
+      bind(GenericExceptionHandler.class);
+      bind(WebApp.class).toInstance(webApp);
+      bind(AppContext.class).toInstance(appContext);
+      bind(HistoryContext.class).toInstance(appContext);
+      bind(Configuration.class).toInstance(conf);
+
+      serve("/*").with(GuiceContainer.class);
+    }
+  }
+
+  static {
+    org.apache.hadoop.yarn.webapp.GuiceServletConfig.setInjector(
+        Guice.createInjector(new TestJerseyClient.WebServletModule()));
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    org.apache.hadoop.yarn.webapp.GuiceServletConfig.setInjector(
+        Guice.createInjector(new TestJerseyClient.WebServletModule()));
+    client = new JerseyClient();
+  }
+
+  @Override
+  protected AppDescriptor configure() {
+    return new WebAppDescriptor.Builder(
+        "org.apache.hadoop.mapreduce.v2.hs.webapp")
+        .contextListenerClass(GuiceServletConfig.class)
+        .filterClass(com.google.inject.servlet.GuiceFilter.class)
+        .contextPath("test").servletPath("/").build();
+  }
+
+  @Test
+  public void testFetch(){
+    String url = "http://localhost:9998/test/ws/v1/history/mapreduce/jobs";
+    try{
+      String str = client.fetchJson(url);
+      assertNotNull(str);
+      System.out.println(str);
+    } catch (Exception e){
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testFetchAs(){
+    String url = "http://localhost:9998/test/ws/v1/history/mapreduce/jobs";
+    try{
+      JobsInfo jobsInfo = client.fetchAs(url, JobsInfo.class);
+      assertNotNull(jobsInfo);
+      assertNotNull(jobsInfo.getJobs());
+      assertEquals(1, jobsInfo.getJobs().size());
+      for(org.apache.hadoop.mapreduce.v2.hs.webapp.dao.JobInfo info: jobsInfo.getJobs()){
+        System.out.println(info.getId());
+        String tasksUrl = url + "/" + info.getId() + "/tasks";
+        TasksInfo tasksInfo = client.fetchAs(tasksUrl, TasksInfo.class);
+        assertNotNull(tasksInfo);
+        assertNotNull(tasksInfo.getTask());
+        assertTrue(tasksInfo.getTask().size() > 0);
+      }
+    } catch (Exception e){
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testConvertJson() {
+    String json = "{\"SimpleAppInfo\":{\"id\":50,\"state\":\"COMPLETED\",\"trackingUrl\":\"http://ip-10-32-151-99.ec2.internal:9046/proxy/application_1426670112915_0050/jobhistory/job/job_1426670112915_0050\"}}";
+    SimpleAppInfo info = client.convert(json, SimpleAppInfo.class);
+    assertNotNull(info);
+    assertEquals(50, info.getId());
+    assertEquals(AppState.COMPLETED, info.getState());
+    assertEquals("http://ip-10-32-151-99.ec2.internal:9046/proxy/application_1426670112915_0050/jobhistory/job/job_1426670112915_0050",
+        info.getTrackingUrl());
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestTaskDescriptionsFetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestTaskDescriptionsFetcher.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.v2.hs.webapp;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.task.TaskDescriptions;
+import org.apache.hadoop.mapreduce.v2.hs.JobHistory;
+import org.apache.hadoop.mapreduce.v2.util.MRApps;
+import org.apache.hadoop.yarn.app.AppState;
+import org.apache.hadoop.yarn.app.SimpleAppInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestTaskDescriptionsFetcher {
+
+  @Test
+  public void testBuildMRAppMasterWebServiceUrl() {
+    String trackUrl = "http://ip-test.test:9046/proxy/application_1426670112915_0602/";
+    String jobId = "job_1426670112915_0602";
+    TaskDescriptionsFetcher fetcher = new TaskDescriptionsFetcher(mock(JobHistory.class), mock(RestClient.class));
+    String url = fetcher.buildMRAppMasterWebServiceUrl(trackUrl, jobId);
+    assertEquals("http://ip-test.test:9046/proxy/application_1426670112915_0602/ws/v1/mapreduce/jobs/job_1426670112915_0602/taskDescriptions", url);
+  }
+
+  @Test
+  public void testFetch() {
+    JobHistory ctx = mock(JobHistory.class);
+    when(ctx.getConfig()).thenReturn(new Configuration());
+    RestClient client = mock(RestClient.class);
+    SimpleAppInfo app = new SimpleAppInfo();
+    app.setId(0602);
+    app.setState(AppState.RUNNING);
+    app.setTrackingUrl("http://ip-test.test:9046/proxy/application_1426670112915_0602/");
+    when(client.fetchAs(anyString(), eq(SimpleAppInfo.class))).thenReturn(app);
+    TaskDescriptions expected = new TaskDescriptions();
+    expected.setFound(true);
+    expected.setSuccessful(true);
+    expected.setErrorMsg(null);
+    expected.setTaskDescriptionList(null);
+    when(client.fetchAs(anyString(), eq(TaskDescriptions.class))).thenReturn(expected);
+    TaskDescriptionsFetcher fetcher = new TaskDescriptionsFetcher(ctx, client);
+    TaskDescriptions fetched = fetcher.fetch(MRApps.toJobID("job_1426670112915_0602"));
+    assertNotNull(fetched);
+    assertTrue(fetched.isFound());
+    assertTrue(fetched.isSuccessful());
+    assertNull(fetched.getTaskDescriptionList());
+    assertNull(fetched.getErrorMsg());
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/app/AppState.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/app/AppState.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.app;
+
+public enum AppState {
+  NOT_STARTED, RUNNING, COMPLETED
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/app/SimpleAppInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/app/SimpleAppInfo.java
@@ -9,15 +9,14 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by tasklicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.mapreduce.v2.app.webapp.dao;
 
-import java.util.ArrayList;
+package org.apache.hadoop.yarn.app;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -25,30 +24,50 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.codehaus.jackson.map.annotate.JsonRootName;
 
-@JsonRootName(value = "tasks")
-@XmlRootElement(name = "tasks")
+@JsonRootName(value = "SimpleAppInfo")
+@XmlRootElement(name = "SimpleAppInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class TasksInfo {
+public class SimpleAppInfo {
 
-  protected ArrayList<TaskInfo> task = new ArrayList<TaskInfo>();
+  protected int id;
 
-  public TasksInfo() {
-  } // JAXB needs this
+  protected AppState state;
 
-  public void add(TaskInfo taskInfo) {
-    task.add(taskInfo);
+  protected String trackingUrl;
+
+  public SimpleAppInfo() {
   }
 
-  public ArrayList<TaskInfo> getTasks() {
-    return task;
+  public int getId() {
+    return id;
   }
 
-  public ArrayList<TaskInfo> getTask() {
-    return task;
+  public void setId(int id) {
+    this.id = id;
   }
 
-  public void setTask(ArrayList<TaskInfo> task) {
-    this.task = task;
+  public AppState getState() {
+    return state;
   }
 
+  public void setState(AppState state) {
+    this.state = state;
+  }
+
+  public String getTrackingUrl() {
+    return trackingUrl;
+  }
+
+  public void setTrackingUrl(String trackingUrl) {
+    this.trackingUrl = trackingUrl;
+  }
+
+  @Override
+  public String toString() {
+    return "SimpleAppInfo{" +
+        "id=" + id +
+        ", state=" + state +
+        ", trackingUrl='" + trackingUrl + '\'' +
+        '}';
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/JAXBContextResolver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/JAXBContextResolver.java
@@ -28,6 +28,7 @@ import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 import javax.xml.bind.JAXBContext;
 
+import org.apache.hadoop.yarn.app.SimpleAppInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.UserInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.*;
 import org.apache.hadoop.yarn.webapp.RemoteExceptionData;
@@ -55,7 +56,7 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
             UsersInfo.class, UserInfo.class, ApplicationStatisticsInfo.class,
             StatisticsItemInfo.class, CapacitySchedulerHealthInfo.class,
             FairSchedulerQueueInfoList.class, AppTimeoutsInfo.class,
-            AppTimeoutInfo.class, ResourceInformationsInfo.class };
+            AppTimeoutInfo.class, ResourceInformationsInfo.class, SimpleAppInfo.class};
     // these dao classes need root unwrapping
     final Class[] rootUnwrappedTypes =
         { NewApplication.class, ApplicationSubmissionContextInfo.class,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -119,6 +119,7 @@ import org.apache.hadoop.yarn.api.records.ReservationRequestInterpreter;
 import org.apache.hadoop.yarn.api.records.ReservationRequests;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.app.SimpleAppInfo;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
@@ -1564,6 +1565,56 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
           + "delegation token authentication.";
       throw new YarnException(msg);
     }
+  }
+
+  @GET
+  @Path("/apps/{appid}/info")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public SimpleAppInfo getSimpleAppInfo(@Context HttpServletRequest hsr,
+      @PathParam("appid") String appId) {
+    initForReadableEndpoints();
+    if (appId == null || appId.isEmpty()) {
+      throw new NotFoundException("appId, " + appId + ", is empty or null");
+    }
+    ApplicationId id;
+    id = ConverterUtils.toApplicationId(recordFactory, appId);
+    if (id == null) {
+      throw new NotFoundException("appId is null");
+    }
+    RMApp rmApp = rm.getRMContext().getRMApps().get(id);
+    if (rmApp == null) {
+      throw new NotFoundException("app with id: " + appId + " not found");
+    }
+
+    SimpleAppInfo app = new SimpleAppInfo();
+    app.setId(rmApp.getApplicationId().getId());
+
+    switch (rmApp.getState()) {
+      case NEW:
+      case SUBMITTED:
+      case ACCEPTED:
+        app.setState(org.apache.hadoop.yarn.app.AppState.NOT_STARTED);
+        break;
+      case RUNNING:
+      case FINISHING:
+        app.setState(org.apache.hadoop.yarn.app.AppState.RUNNING);
+        break;
+      case FINISHED:
+      case FAILED:
+      case KILLED:
+        app.setState(org.apache.hadoop.yarn.app.AppState.COMPLETED);
+        break;
+    }
+    // check if trackUrl is ready
+    String trackUrl = rmApp.getTrackingUrl();
+    if (trackUrl != null
+        && !trackUrl.isEmpty()
+        && app.getState() != null
+        && app.getState() != org.apache.hadoop.yarn.app.AppState.NOT_STARTED) {
+      app.setTrackingUrl(trackUrl);
+    }
+
+    return app;
   }
 
   @POST


### PR DESCRIPTION
There is a usecase to poll Hadoop for various running Tasks and display info on each individual task attempt to the user. To improve performance add additional endpoints to HS and AM webservices that will fetch aggregated data on hadoop tasks including their task attempts for a current job.