### PR TITLE
HADOOP-15652. Fix typos SPENGO into SPNEGO

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/MultiSchemeAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/MultiSchemeAuthenticationHandler.java
@@ -36,7 +36,7 @@ import com.google.common.base.Splitter;
 /**
  * The {@link MultiSchemeAuthenticationHandler} supports configuring multiple
  * authentication mechanisms simultaneously. e.g. server can support multiple
- * authentication mechanisms such as Kerberos (SPENGO) and LDAP. During the
+ * authentication mechanisms such as Kerberos (SPNEGO) and LDAP. During the
  * authentication phase, server will specify all possible authentication schemes
  * and let client choose the appropriate scheme. Please refer to RFC-2616 and
  * HADOOP-12082 for more details.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/log/LogLevel.java
@@ -282,7 +282,7 @@ public class LogLevel {
 
     /**
      * Configures the client to send HTTP/HTTPS request to the URL.
-     * Supports SPENGO for authentication.
+     * Supports SPNEGO for authentication.
      * @param urlString URL and query string to the daemon's web UI
      * @throws Exception if unable to connect
      */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/MultiSchemeDelegationTokenAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/web/MultiSchemeDelegationTokenAuthenticationHandler.java
@@ -42,7 +42,7 @@ import com.google.common.base.Splitter;
  * A {@link CompositeAuthenticationHandler} that supports multiple HTTP
  * authentication schemes along with Delegation Token functionality. e.g.
  * server can support multiple authentication mechanisms such as Kerberos
- * (SPENGO) and LDAP. During the authentication phase, server will specify
+ * (SPNEGO) and LDAP. During the authentication phase, server will specify
  * all possible authentication schemes and let client choose the appropriate
  * scheme. Please refer to RFC-2616 and HADOOP-12082 for more details.
  *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/WebHDFS.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/WebHDFS.md
@@ -134,7 +134,7 @@ Additionally, WebHDFS supports OAuth2 on the client side. The Namenode and Datan
 
 WebHDFS supports two type of OAuth2 code grants (user-provided refresh and access token or user provided credential) by default and provides a pluggable mechanism for implementing other OAuth2 authentications per the [OAuth2 RFC](https://tools.ietf.org/html/rfc6749), or custom authentications.  When using either of the provided code grant mechanisms, the WebHDFS client will refresh the access token as necessary.
 
-OAuth2 should only be enabled for clients not running with Kerberos SPENGO.
+OAuth2 should only be enabled for clients not running with Kerberos SPNEGO.
 
 | OAuth2 code grant mechanism | Description | Value of `dfs.webhdfs.oauth2.access.token.provider` that implements code grant |
 |:---- |:---- |:----|


### PR DESCRIPTION
There are some typo words `SPENGO` which should be `SPNEGO`.

Contributed by okumin