### PR TITLE
add non-empty folder when test cannot find HADOOP_CONF_DIR [https://i…

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.eclipse.jetty.util.StringUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,17 +61,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState
-    .HEALTHY;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
-import static org.apache.hadoop.ozone.OzoneConfigKeys
-    .DFS_CONTAINER_IPC_PORT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys
-    .DFS_CONTAINER_IPC_RANDOM_PORT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys
-    .DFS_CONTAINER_RATIS_IPC_PORT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys
-    .DFS_CONTAINER_RATIS_IPC_RANDOM_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_IPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_IPC_RANDOM_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_RANDOM_PORT;
+import static org.apache.hadoop.utils.db.DBConfigFromFile.CONFIG_DIR;
 
 /**
  * MiniOzoneCluster creates a complete in-process Ozone cluster suitable for
@@ -354,6 +351,12 @@ public final class MiniOzoneClusterImpl implements MiniOzoneCluster {
       omStore.setScmId(scmId.get());
       omStore.setOmId(omId.orElse(UUID.randomUUID().toString()));
       omStore.initialize();
+      
+      // when HADOOP_CONF_DIR is not set, createOm fails, set to a non-empty folder
+      if (StringUtil.isBlank(System.getProperty(CONFIG_DIR))) { 
+          System.setProperty(CONFIG_DIR, "/");
+      }
+      
       return OzoneManager.createOm(null, conf);
     }
 


### PR DESCRIPTION
…ssues.apache.org/jira/browse/HDDS-395] - Sree Vaddi

this is to avoid throwing exception that fails cluster from starting.