### PR TITLE
YARN-6636. Add basic fairscheduler nodelabel support.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3544,6 +3544,9 @@ public class YarnConfiguration extends Configuration {
 
   public static final int DEFAULT_CLUSTER_LEVEL_APPLICATION_PRIORITY = 0;
 
+  public static final String DEFAULT_AM_NODELABEL_EXPRESSION =
+      NODE_LABELS_PREFIX + "am.default-node-label-expression";
+
   public static final String APP_ATTEMPT_DIAGNOSTICS_LIMIT_KC =
       YARN_PREFIX + "app.attempt.diagnostics.limit.kc";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMAppManager.java
@@ -556,8 +556,8 @@ public class RMAppManager implements EventHandler<RMAppManagerEvent>,
 
         // set label expression for AM ANY request if not set
         if (null == anyReq.getNodeLabelExpression()) {
-          anyReq.setNodeLabelExpression(submissionContext
-              .getNodeLabelExpression());
+          anyReq.setNodeLabelExpression(determineAMNodeLabelExpression(
+              submissionContext.getNodeLabelExpression()));
         }
 
         // Put ANY request at the front
@@ -585,6 +585,14 @@ public class RMAppManager implements EventHandler<RMAppManagerEvent>,
     }
 
     return null;
+  }
+
+  private String determineAMNodeLabelExpression(String nodeLabelExpression) {
+    if (nodeLabelExpression == null) {
+      return conf.get(YarnConfiguration.DEFAULT_AM_NODELABEL_EXPRESSION, null);
+    } else {
+      return nodeLabelExpression;
+    }
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/RMNodeLabelsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/RMNodeLabelsManager.java
@@ -536,7 +536,7 @@ public class RMNodeLabelsManager extends CommonNodeLabelsManager {
 
   private boolean isNodeUsableByQueue(Set<String> nodeLabels, Queue q) {
     // node without any labels can be accessed by any queue
-    if (nodeLabels == null || nodeLabels.isEmpty()
+    if (q.accessibleNodeLabels.contains(ANY) || nodeLabels == null || nodeLabels.isEmpty()
         || (nodeLabels.size() == 1 && nodeLabels.contains(NO_LABEL))) {
       return true;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
@@ -178,6 +178,17 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
     }
   }
 
+  public void nodePartitionUpdated(RMContainer rmContainer, String oldPartition, String newPartition) {
+    Resource containerResource = rmContainer.getAllocatedResource();
+    this.attemptResourceUsage.decUsed(oldPartition, containerResource);
+    this.attemptResourceUsage.incUsed(newPartition, containerResource);
+
+    if (rmContainer.isAMContainer()) {
+      this.attemptResourceUsage.decAMUsed(oldPartition, containerResource);
+      this.attemptResourceUsage.incAMUsed(newPartition, containerResource);
+    }
+  }
+
   private void unreserveInternal(
       SchedulerRequestKey schedulerKey, FSSchedulerNode node) {
     try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueue.java
@@ -42,11 +42,13 @@ import org.apache.hadoop.yarn.security.AccessRequest;
 import org.apache.hadoop.yarn.security.PrivilegedEntity;
 import org.apache.hadoop.yarn.security.PrivilegedEntity.EntityType;
 import org.apache.hadoop.yarn.security.YarnAuthorizationProvider;
+import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Queue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerUtils;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 
 @Private
 @Unstable
@@ -256,6 +258,7 @@ public abstract class FSQueue implements Queue, Schedulable {
     queueInfo.setChildQueues(childQueueInfos);
     queueInfo.setQueueState(QueueState.RUNNING);
     queueInfo.setQueueStatistics(getQueueStatistics());
+    queueInfo.setAccessibleNodeLabels(getAccessibleNodeLabels());
     return queueInfo;
   }
 
@@ -461,14 +464,14 @@ public abstract class FSQueue implements Queue, Schedulable {
   
   @Override
   public Set<String> getAccessibleNodeLabels() {
-    // TODO, add implementation for FS
-    return null;
+    // Allow queue access to all node labels
+    return ImmutableSet.of(RMNodeLabelsManager.ANY);
   }
   
   @Override
   public String getDefaultNodeLabelExpression() {
-    // TODO, add implementation for FS
-    return null;
+    // Allow queue access to all node labels
+    return RMNodeLabelsManager.ANY;
   }
   
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSQueueMetrics.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Queue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
 
@@ -189,6 +190,23 @@ public class FSQueueMetrics extends QueueMetrics {
       boolean enableUserMetrics, Configuration conf) {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     return forQueue(ms, queueName, parent, enableUserMetrics, conf);
+  }
+
+  // All resource metrics should update the default partition
+  @Override
+  public void allocateResources(String partition, String user, int containers, Resource res,
+      boolean decrPending) {
+    super.allocateResources(RMNodeLabelsManager.NO_LABEL, user, containers, res, decrPending);
+  }
+
+  @Override
+  public void allocateResources(String partition, String user, Resource res) {
+    super.allocateResources(RMNodeLabelsManager.NO_LABEL, user, res);
+  }
+
+  @Override
+  public void releaseResources(String partition, String user, int containers, Resource res) {
+    super.releaseResources(RMNodeLabelsManager.NO_LABEL, user, containers, res);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerTestBase.java
@@ -116,12 +116,19 @@ public class FairSchedulerTestBase {
       int memory, String host, int priority, int numContainers,
       boolean relaxLocality) {
     return createResourceRequest(memory, 1, host, priority, numContainers,
-        relaxLocality);
+        relaxLocality, null);
   }
 
   protected ResourceRequest createResourceRequest(
       int memory, int vcores, String host, int priority, int numContainers,
       boolean relaxLocality) {
+    return createResourceRequest(memory, vcores, host, priority, numContainers,
+        relaxLocality, null);
+  }
+
+  protected ResourceRequest createResourceRequest(
+      int memory, int vcores, String host, int priority, int numContainers,
+      boolean relaxLocality, String label) {
     ResourceRequest request = recordFactory.newRecordInstance(ResourceRequest.class);
     request.setCapability(BuilderUtils.newResource(memory, vcores));
     request.setResourceName(host);
@@ -130,7 +137,7 @@ public class FairSchedulerTestBase {
     prio.setPriority(priority);
     request.setPriority(prio);
     request.setRelaxLocality(relaxLocality);
-    request.setNodeLabelExpression(RMNodeLabelsManager.NO_LABEL);
+    request.setNodeLabelExpression(label != null ? label : RMNodeLabelsManager.NO_LABEL);
     return request;
   }
 
@@ -155,20 +162,27 @@ public class FairSchedulerTestBase {
 
   protected ApplicationAttemptId createSchedulingRequest(
       int memory, int vcores, String queueId, String userId, int numContainers) {
-    return createSchedulingRequest(memory, vcores, queueId, userId, numContainers, 1);
+    return createSchedulingRequest(memory, vcores, queueId, userId, numContainers, 1, null);
   }
 
   protected ApplicationAttemptId createSchedulingRequest(
       int memory, String queueId, String userId, int numContainers, int priority) {
     return createSchedulingRequest(memory, 1, queueId, userId, numContainers,
-        priority);
+        priority, null);
   }
 
   protected ApplicationAttemptId createSchedulingRequest(
       int memory, int vcores, String queueId, String userId, int numContainers,
       int priority) {
+    return createSchedulingRequest(memory, vcores, queueId, userId, numContainers,
+        priority, null);
+  }
+
+  protected ApplicationAttemptId createSchedulingRequest(
+      int memory, int vcores, String queueId, String userId, int numContainers,
+      int priority, String label) {
     ResourceRequest request = createResourceRequest(memory, vcores,
-            ResourceRequest.ANY, priority, numContainers, true);
+            ResourceRequest.ANY, priority, numContainers, true, label);
     return createSchedulingRequest(Lists.newArrayList(request), queueId,
             userId);
   }
@@ -247,7 +261,7 @@ public class FairSchedulerTestBase {
   protected void createSchedulingRequestExistingApplication(
       int memory, int vcores, int priority, ApplicationAttemptId attId) {
     ResourceRequest request = createResourceRequest(memory, vcores, ResourceRequest.ANY,
-        priority, 1, true);
+        priority, 1, true, null);
     createSchedulingRequestExistingApplication(request, attId);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairSchedulerWithMultiResourceTypes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairSchedulerWithMultiResourceTypes.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.yarn.api.protocolrecords.ResourceTypes;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.RMContextImpl;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -91,6 +92,7 @@ public class TestFairSchedulerWithMultiResourceTypes
         YarnConfiguration.RESOURCE_TYPES + "."
             + ResourceInformation.MEMORY_MB.getName() + MAXIMUM_ALLOCATION,
         512);
+    scheduler.setRMContext(new RMContextImpl());
     scheduler.init(conf);
     scheduler.reinitialize(conf, null);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestSchedulingPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestSchedulingPolicy.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.server.resourcemanager.RMContextImpl;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.policies.DominantResourceFairnessPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.policies.FairSharePolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.policies.FifoPolicy;
@@ -51,6 +52,7 @@ public class TestSchedulingPolicy {
   @Before
   public void setUp() throws Exception {
     scheduler = new FairScheduler();
+    scheduler.setRMContext(new RMContextImpl());
     conf = new FairSchedulerConfiguration();
   }
 


### PR DESCRIPTION
Supports unfair label scheduling and non-exclusive node labels.