### PR TITLE
HDFS-13997. Add moment.js to the secondarynamenode web UI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/secondary/status.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/secondary/status.html
@@ -88,6 +88,7 @@
 
 <script type="text/javascript" src="/static/jquery-3.3.1.min.js">
 </script><script type="text/javascript" src="/static/bootstrap-3.3.7/js/bootstrap.min.js">
+</script><script type="text/javascript" src="/static/moment.min.js">
 </script><script type="text/javascript" src="/static/dust-full-2.0.0.min.js">
 </script><script type="text/javascript" src="/static/dust-helpers-1.1.1.min.js">
 </script><script type="text/javascript" src="/static/dfs-dust.js">


### PR DESCRIPTION
This pull request fix a problem on the web UI of secondarynamenode. As the UI won't show when dfs-dust.js try to call moment() and it is not included in the page.