### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/dev-support/bin/checkcompatibility.py
+++ b/dev-support/bin/checkcompatibility.py
@@ -192,7 +192,7 @@ def run_java_acc(src_name, src_jars, dst_name, dst_jars, annotations):
 
   if annotations is not None:
     annotations_path = os.path.join(get_scratch_dir(), "annotations.txt")
-    with file(annotations_path, "w") as f:
+    with open(annotations_path, "w") as f:
       for ann in annotations:
         print >>f, ann
     args += ["-annotations-list", annotations_path]

--- a/dev-support/determine-flaky-tests-hadoop.py
+++ b/dev-support/determine-flaky-tests-hadoop.py
@@ -111,6 +111,7 @@ def load_url_data(url):
  
 """ List all builds of the target project. """
 def list_builds(jenkins_url, job_name):
+  global error_count
   global summary_mode
   url = "%(jenkins)s/job/%(job_name)s/api/json?tree=builds[url,result,timestamp]" % dict(
       jenkins=jenkins_url,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/job_history_summary.py
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/job_history_summary.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import re
 import sys
 
@@ -41,19 +42,19 @@ for line in sys.stdin:
   event = words[0]
   attrs = parse(words[1])
   if event == 'MapAttempt':
-    if attrs.has_key("START_TIME"):
+    if "START_TIME" in attrs:
       mapStartTime[attrs["TASKID"]] = int(attrs["START_TIME"])/1000
-    elif attrs.has_key("FINISH_TIME"):
+    elif "FINISH_TIME" in attrs:
       mapEndTime[attrs["TASKID"]] = int(attrs["FINISH_TIME"])/1000
   elif event == 'ReduceAttempt':
-    if attrs.has_key("START_TIME"):
+    if "START_TIME" in attrs:
       reduceStartTime[attrs["TASKID"]] = int(attrs["START_TIME"]) / 1000
-    elif attrs.has_key("FINISH_TIME"):
+    elif "FINISH_TIME" in attrs:
       reduceShuffleTime[attrs["TASKID"]] = int(attrs["SHUFFLE_FINISHED"])/1000
       reduceSortTime[attrs["TASKID"]] = int(attrs["SORT_FINISHED"])/1000
       reduceEndTime[attrs["TASKID"]] = int(attrs["FINISH_TIME"])/1000
   elif event == 'Task':
-    if attrs["TASK_TYPE"] == "REDUCE" and attrs.has_key("COUNTERS"):
+    if attrs["TASK_TYPE"] == "REDUCE" and "COUNTERS" in attrs:
       for n,v in re.findall(counterPat, attrs["COUNTERS"]):
         if n == "File Systems.HDFS bytes written":
           reduceBytes[attrs["TASKID"]] = int(v)
@@ -67,15 +68,14 @@ startTime = min(reduce(min, mapStartTime.values()),
 endTime = max(reduce(max, mapEndTime.values()),
               reduce(max, reduceEndTime.values()))
 
-reduces = reduceBytes.keys()
-reduces.sort()
+reduces = sorted(reduceBytes.keys())
 
-print "Name reduce-output-bytes shuffle-finish reduce-finish"
+print("Name reduce-output-bytes shuffle-finish reduce-finish")
 for r in reduces:
-  print r, reduceBytes[r], reduceShuffleTime[r] - startTime,
-  print reduceEndTime[r] - startTime
+  print(r, reduceBytes[r], reduceShuffleTime[r] - startTime, end=' ')
+  print(reduceEndTime[r] - startTime)
 
-print
+print()
 
 for t in range(startTime, endTime):
   runningMaps[t] = 0
@@ -94,7 +94,7 @@ for reduce in reduceStartTime.keys():
   for t in range(reduceSortTime[reduce], reduceEndTime[reduce]):
     runningReduces[t] += 1
 
-print "time maps shuffle merge reduce"
+print("time maps shuffle merge reduce")
 for t in range(startTime, endTime):
-  print t - startTime, runningMaps[t], shufflingReduces[t], sortingReduces[t], 
-  print runningReduces[t]
+  print(t - startTime, runningMaps[t], shufflingReduces[t], sortingReduces[t], end=' ') 
+  print(runningReduces[t])


### PR DESCRIPTION
__print()__ is a function in Python 3.

Also, the builtin file() was removed in Python 3
* This PR recommends replacing it with __open()__ which works in both Python 2 and Python 3.

And,  Declare __global error_count__
* The global __error_count__ can not be incremented on line 126 unless it is declared as global beforehand.  Without this change, it is an _undefined name_ that has the potential to raise __NameError__ at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/apache/hadoop on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/job_history_summary.py:73:61: E999 SyntaxError: invalid syntax
print "Name reduce-output-bytes shuffle-finish reduce-finish"
                                                            ^
./dev-support/determine-flaky-tests-hadoop.py:125:5: F823 local variable 'error_count' (defined in enclosing scope on line 76) referenced before assignment
    error_count += 1
    ^
./dev-support/bin/checkcompatibility.py:195:10: F821 undefined name 'file'
    with file(annotations_path, "w") as f:
         ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'file'
1     F823 local variable 'error_count' (defined in enclosing scope on line 76) referenced before assignment
3
```