### PR TITLE
YARN-9009: Fix flaky test TestEntityGroupFSTimelineStore.testCleanLogs

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
@@ -70,7 +70,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
 
   private static final String SAMPLE_APP_PREFIX_CACHE_TEST = "1234_000";
   private static final int CACHE_TEST_CACHE_SIZE = 5;
-  
+
   private static final String TEST_SUMMARY_LOG_FILE_NAME
       = EntityGroupFSTimelineStore.SUMMARY_LOG_PREFIX + "test";
   private static final String TEST_DOMAIN_LOG_FILE_NAME
@@ -234,6 +234,8 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     Path pathAfter = appLogs.getAppDirPath();
     assertNotEquals(pathBefore, pathAfter);
     assertTrue(pathAfter.toString().contains(testDoneDirPath.toString()));
+
+    fs.delete(pathAfter, true);
   }
 
   @Test
@@ -483,7 +485,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
       AppState appstate) {
     // stop before creating new store to get the lock
     store.stop();
-    
+
     EntityGroupFSTimelineStore newStore = new EntityGroupFSTimelineStore() {
       @Override
       protected AppState getAppState(ApplicationId appId) throws IOException {


### PR DESCRIPTION
In TestEntityGroupFSTimelineStore, testCleanLogs fails when run after testMoveToDone.

This is because testMoveToDone moves a file into the same directory that testCleanLogs cleans, causing testCleanLogs to clean 3 files, instead of 2 as it expects.

To fix this, we can delete the file after it is moved by testMoveToDone.

Link to issue: [YARN-9009](https://issues.apache.org/jira/browse/YARN-9009)