### PR TITLE
YARN-9065.App's diags is too long,written zk error

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -720,6 +720,9 @@ public class YarnConfiguration extends Configuration {
   /** Zookeeper interaction configs */
   public static final String RM_ZK_PREFIX = RM_PREFIX + "zk-";
 
+  public static final String RM_ZK_MAX_BUFFER = RM_ZK_PREFIX + "jute-maxbuffer";
+  public static final int DEFAULT_ZK_MAX_BUFFER = 1000000;
+
   public static final String RM_ZK_ADDRESS = RM_ZK_PREFIX + "address";
 
   public static final String RM_ZK_NUM_RETRIES = RM_ZK_PREFIX + "num-retries";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -154,6 +154,7 @@ public class RMAppImpl implements RMApp, Recoverable {
   private final Set<String> applicationTags;
   private Map<String, String> applicationSchedulingEnvs = new HashMap<>();
 
+  private final int zkMaxBuffer;
   private final long attemptFailuresValidityInterval;
   private boolean amBlacklistingEnabled = false;
   private float blacklistDisableThreshold;
@@ -490,6 +491,8 @@ public class RMAppImpl implements RMApp, Recoverable {
           + this.applicationId + " is " + this.attemptFailuresValidityInterval
           + ".");
     }
+
+    zkMaxBuffer = conf.getInt(YarnConfiguration.RM_ZK_MAX_BUFFER, YarnConfiguration.DEFAULT_ZK_MAX_BUFFER);
 
     ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     this.readLock = lock.readLock();
@@ -1325,6 +1328,11 @@ public class RMAppImpl implements RMApp, Recoverable {
       break;
     default:
       break;
+    }
+
+    if (diags.length() > zkMaxBuffer) {
+      diags = diags.substring(0, zkMaxBuffer);
+      LOG.warn("The diags is too long, so it needs to be intercepted : " + diags);
     }
 
     ApplicationStateData appState =


### PR DESCRIPTION
When use ZKRMStateStore to store app info, App's diags is too long, written zk error.

The zk error log:

`2018-11-27 15:54:30,208 [myid:1] - WARN  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxn@373] - Exception causing close of session 0x36753e378030000 due to java.io.IOException: Len error 8603591`