### PR TITLE
recovery contaienr exit code not right

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/RecoverPausedContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/RecoverPausedContainerLaunch.java
@@ -103,6 +103,17 @@ public class RecoverPausedContainerLaunch extends ContainerLaunch {
       }
     }
 
+    if (retCode == ExitCode.FORCE_KILLED.getExitCode()
+        || retCode == ExitCode.TERMINATED.getExitCode()) {
+      // If the process was killed, Send container_cleanedup_after_kill and
+      // just break out of this method.
+      this.dispatcher.getEventHandler().handle(
+          new ContainerExitEvent(containerId,
+              ContainerEventType.CONTAINER_KILLED_ON_REQUEST, retCode,
+              "Container exited with a non-zero exit code " + retCode));
+      return retCode;
+    }
+
     if (retCode != 0) {
       LOG.warn("Recovered container exited with a non-zero exit code "
           + retCode);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/RecoveredContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/RecoveredContainerLaunch.java
@@ -107,6 +107,16 @@ public class RecoveredContainerLaunch extends ContainerLaunch {
         }
       }
     }
+    if (retCode == ExitCode.FORCE_KILLED.getExitCode()
+        || retCode == ExitCode.TERMINATED.getExitCode()) {
+      // If the process was killed, Send container_cleanedup_after_kill and
+      // just break out of this method.
+      this.dispatcher.getEventHandler().handle(
+          new ContainerExitEvent(containerId,
+              ContainerEventType.CONTAINER_KILLED_ON_REQUEST, retCode,
+              "Container exited with a non-zero exit code " + retCode));
+      return retCode;
+    }
 
     if (retCode != 0) {
       LOG.warn("Recovered container exited with a non-zero exit code "


### PR DESCRIPTION
It's correct exitCode when container launch nomally,but it is not correct if the container by recovery.
Out of memory exitCode is -104, the exitCode had to be lost when the container was recovered by restart NodeManager. 