### PR TITLE
HADOOP-16005: Add XAttr support to WASB and ABFS

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -3576,13 +3576,10 @@ public class NativeAzureFileSystem extends FileSystem {
   @Override
   public void setXAttr(Path path, String xAttrName, byte[] value, EnumSet<XAttrSetFlag> flag) throws IOException {
     Path absolutePath = makeAbsolute(path);
-
     performAuthCheck(absolutePath, WasbAuthorizationOperations.WRITE, "setXAttr", absolutePath);
 
     String key = pathToKey(absolutePath);
-
     FileMetadata metadata;
-
     try {
       metadata = store.retrieveMetadata(key);
     } catch (IOException ex) {
@@ -3590,7 +3587,6 @@ public class NativeAzureFileSystem extends FileSystem {
 
       if (innerException instanceof StorageException
           && NativeAzureFileSystemHelper.isFileNotFoundException((StorageException) innerException)) {
-
         throw new FileNotFoundException("File " + path + " doesn't exists.");
       }
 
@@ -3602,7 +3598,6 @@ public class NativeAzureFileSystem extends FileSystem {
     }
 
     boolean xAttrExists = store.retrieveAttribute(key, xAttrName) != null;
-
     XAttrSetFlag.validate(xAttrName, xAttrExists, flag);
 
     store.storeAttribute(key, xAttrName, value);
@@ -3620,13 +3615,10 @@ public class NativeAzureFileSystem extends FileSystem {
   @Override
   public byte[] getXAttr(Path path, String xAttrName) throws IOException {
     Path absolutePath = makeAbsolute(path);
-
     performAuthCheck(absolutePath, WasbAuthorizationOperations.READ, "getXAttr", absolutePath);
 
     String key = pathToKey(absolutePath);
-
     FileMetadata metadata;
-
     try {
       metadata = store.retrieveMetadata(key);
     } catch (IOException ex) {
@@ -3634,7 +3626,6 @@ public class NativeAzureFileSystem extends FileSystem {
 
       if (innerException instanceof StorageException
               && NativeAzureFileSystemHelper.isFileNotFoundException((StorageException) innerException)) {
-
         throw new FileNotFoundException("File " + path + " doesn't exists.");
       }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -3584,12 +3584,10 @@ public class NativeAzureFileSystem extends FileSystem {
       metadata = store.retrieveMetadata(key);
     } catch (IOException ex) {
       Throwable innerException = NativeAzureFileSystemHelper.checkForAzureStorageException(ex);
-
       if (innerException instanceof StorageException
           && NativeAzureFileSystemHelper.isFileNotFoundException((StorageException) innerException)) {
         throw new FileNotFoundException("File " + path + " doesn't exists.");
       }
-
       throw ex;
     }
 
@@ -3599,7 +3597,6 @@ public class NativeAzureFileSystem extends FileSystem {
 
     boolean xAttrExists = store.retrieveAttribute(key, xAttrName) != null;
     XAttrSetFlag.validate(xAttrName, xAttrExists, flag);
-
     store.storeAttribute(key, xAttrName, value);
   }
 
@@ -3623,12 +3620,10 @@ public class NativeAzureFileSystem extends FileSystem {
       metadata = store.retrieveMetadata(key);
     } catch (IOException ex) {
       Throwable innerException = NativeAzureFileSystemHelper.checkForAzureStorageException(ex);
-
       if (innerException instanceof StorageException
               && NativeAzureFileSystemHelper.isFileNotFoundException((StorageException) innerException)) {
         throw new FileNotFoundException("File " + path + " doesn't exists.");
       }
-
       throw ex;
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.azure.metrics.AzureFileSystemInstrumentation;
 import org.apache.hadoop.fs.azure.metrics.AzureFileSystemMetricsSystem;
 import org.apache.hadoop.fs.azure.security.Constants;
@@ -3561,6 +3562,90 @@ public class NativeAzureFileSystem extends FileSystem {
     } else {
       store.changePermissionStatus(key, newPermissionStatus);
     }
+  }
+
+  /**
+   * Set the value of an attribute for a path.
+   *
+   * @param path The path on which to set the attribute
+   * @param xAttrName The attribute to set
+   * @param value The byte value of the attribute to set (encoded in utf-8)
+   * @param flag The mode in which to set the attribute
+   * @throws IOException If there was an issue setting the attribute on Azure
+   */
+  @Override
+  public void setXAttr(Path path, String xAttrName, byte[] value, EnumSet<XAttrSetFlag> flag) throws IOException {
+    Path absolutePath = makeAbsolute(path);
+
+    performAuthCheck(absolutePath, WasbAuthorizationOperations.WRITE, "setXAttr", absolutePath);
+
+    String key = pathToKey(absolutePath);
+
+    FileMetadata metadata;
+
+    try {
+      metadata = store.retrieveMetadata(key);
+    } catch (IOException ex) {
+      Throwable innerException = NativeAzureFileSystemHelper.checkForAzureStorageException(ex);
+
+      if (innerException instanceof StorageException
+          && NativeAzureFileSystemHelper.isFileNotFoundException((StorageException) innerException)) {
+
+        throw new FileNotFoundException("File " + path + " doesn't exists.");
+      }
+
+      throw ex;
+    }
+
+    if (metadata == null) {
+      throw new FileNotFoundException("File doesn't exist: " + path);
+    }
+
+    boolean xAttrExists = store.retrieveAttribute(key, xAttrName) != null;
+
+    XAttrSetFlag.validate(xAttrName, xAttrExists, flag);
+
+    store.storeAttribute(key, xAttrName, value);
+  }
+
+  /**
+   * Get the value of an attribute for a path.
+   *
+   * @param path The path on which to get the attribute
+   * @param xAttrName The attribute to get
+   * @return The bytes of the attribute's value (encoded in utf-8)
+   *         or null if the attribute does not exist
+   * @throws IOException If there was an issue getting the attribute from Azure
+   */
+  @Override
+  public byte[] getXAttr(Path path, String xAttrName) throws IOException {
+    Path absolutePath = makeAbsolute(path);
+
+    performAuthCheck(absolutePath, WasbAuthorizationOperations.READ, "getXAttr", absolutePath);
+
+    String key = pathToKey(absolutePath);
+
+    FileMetadata metadata;
+
+    try {
+      metadata = store.retrieveMetadata(key);
+    } catch (IOException ex) {
+      Throwable innerException = NativeAzureFileSystemHelper.checkForAzureStorageException(ex);
+
+      if (innerException instanceof StorageException
+              && NativeAzureFileSystemHelper.isFileNotFoundException((StorageException) innerException)) {
+
+        throw new FileNotFoundException("File " + path + " doesn't exists.");
+      }
+
+      throw ex;
+    }
+
+    if (metadata == null) {
+      throw new FileNotFoundException("File doesn't exist: " + path);
+    }
+
+    return store.retrieveAttribute(key, xAttrName);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeFileSystemStore.java
@@ -76,6 +76,10 @@ interface NativeFileSystemStore {
   void changePermissionStatus(String key, PermissionStatus newPermission)
       throws AzureException;
 
+  byte[] retrieveAttribute(String key, String attribute) throws IOException;
+
+  void storeAttribute(String key, String attribute, byte[] value) throws IOException;
+
   /**
    * API to delete a blob in the back end azure storage.
    * @param key - key to the blob being deleted.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -666,7 +666,7 @@ public class AzureBlobFileSystem extends FileSystem {
       boolean xAttrExists = properties.containsKey(xAttrName);
       XAttrSetFlag.validate(name, xAttrExists, flag);
 
-      String xAttrValue = new String(value, AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING);
+      String xAttrValue = abfsStore.decodeAttribute(value);
       properties.put(xAttrName, xAttrValue);
       abfsStore.setPathProperties(path, properties);
     } catch (AzureBlobFileSystemException ex) {
@@ -702,7 +702,7 @@ public class AzureBlobFileSystem extends FileSystem {
       String xAttrName = ensureValidAttributeName(name);
       if (properties.containsKey(xAttrName)) {
         String xAttrValue = properties.get(xAttrName);
-        value = xAttrValue.getBytes(AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING);
+        value = abfsStore.encodeAttribute(xAttrValue);
       }
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,6 +57,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes;
@@ -634,6 +636,85 @@ public class AzureBlobFileSystem extends FileSystem {
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
+  }
+
+  /**
+   * Set the value of an attribute for a path.
+   *
+   * @param path The path on which to set the attribute
+   * @param name The attribute to set
+   * @param value The byte value of the attribute to set (encoded in latin-1)
+   * @param flag The mode in which to set the attribute
+   * @throws IOException If there was an issue setting the attribute on Azure
+   * @throws IllegalArgumentException If name is null or empty or if value is null
+   */
+  @Override
+  public void setXAttr(Path path, String name, byte[] value, EnumSet<XAttrSetFlag> flag)
+      throws IOException {
+    LOG.debug(
+        "AzureBlobFileSystem.setXAttr path: {}", path);
+
+    if (name == null || name.isEmpty() || value == null) {
+      throw new IllegalArgumentException("A valid name and value must be specified.");
+    }
+
+    Path qualifiedPath = makeQualified(path);
+    performAbfsAuthCheck(FsAction.READ_WRITE, qualifiedPath);
+
+    try {
+      Hashtable<String, String> properties = abfsStore.getPathStatus(path);
+      String xAttrName = ensureValidAttributeName(name);
+      boolean xAttrExists = properties.containsKey(xAttrName);
+      XAttrSetFlag.validate(name, xAttrExists, flag);
+
+      String xAttrValue = new String(value, AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING);
+      properties.put(xAttrName, xAttrValue);
+      abfsStore.setPathProperties(path, properties);
+    } catch (AzureBlobFileSystemException ex) {
+      checkException(path, ex);
+    }
+  }
+
+  /**
+   * Get the value of an attribute for a path.
+   *
+   * @param path The path on which to get the attribute
+   * @param name The attribute to get
+   * @return The bytes of the attribute's value (encoded in latin-1)
+   *         or null if the attribute does not exist
+   * @throws IOException If there was an issue getting the attribute from Azure
+   * @throws IllegalArgumentException If name is null or empty
+   */
+  @Override
+  public byte[] getXAttr(Path path, String name)
+      throws IOException {
+    LOG.debug(
+        "AzureBlobFileSystem.getXAttr path: {}", path);
+
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("A valid name must be specified.");
+    }
+
+    Path qualifiedPath = makeQualified(path);
+    performAbfsAuthCheck(FsAction.READ, qualifiedPath);
+
+    byte[] value = null;
+    try {
+      Hashtable<String, String> properties = abfsStore.getPathStatus(path);
+      String xAttrName = ensureValidAttributeName(name);
+      if (properties.containsKey(xAttrName)) {
+        String xAttrValue = properties.get(xAttrName);
+        value = xAttrValue.getBytes(AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING);
+      }
+    } catch (AzureBlobFileSystemException ex) {
+      checkException(path, ex);
+    }
+    return value;
+  }
+
+  private static String ensureValidAttributeName(String attribute) {
+    // to avoid HTTP 400 Bad Request, InvalidPropertyName
+    return attribute.replace('.', '_');
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -651,8 +651,7 @@ public class AzureBlobFileSystem extends FileSystem {
   @Override
   public void setXAttr(Path path, String name, byte[] value, EnumSet<XAttrSetFlag> flag)
       throws IOException {
-    LOG.debug(
-        "AzureBlobFileSystem.setXAttr path: {}", path);
+    LOG.debug("AzureBlobFileSystem.setXAttr path: {}", path);
 
     if (name == null || name.isEmpty() || value == null) {
       throw new IllegalArgumentException("A valid name and value must be specified.");
@@ -688,8 +687,7 @@ public class AzureBlobFileSystem extends FileSystem {
   @Override
   public byte[] getXAttr(Path path, String name)
       throws IOException {
-    LOG.debug(
-        "AzureBlobFileSystem.getXAttr path: {}", path);
+    LOG.debug("AzureBlobFileSystem.getXAttr path: {}", path);
 
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("A valid name must be specified.");

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -649,7 +649,7 @@ public class AzureBlobFileSystem extends FileSystem {
    * @throws IllegalArgumentException If name is null or empty or if value is null
    */
   @Override
-  public void setXAttr(Path path, String name, byte[] value, EnumSet<XAttrSetFlag> flag)
+  public void setXAttr(final Path path, final String name, final byte[] value, final EnumSet<XAttrSetFlag> flag)
       throws IOException {
     LOG.debug("AzureBlobFileSystem.setXAttr path: {}", path);
 
@@ -685,7 +685,7 @@ public class AzureBlobFileSystem extends FileSystem {
    * @throws IllegalArgumentException If name is null or empty
    */
   @Override
-  public byte[] getXAttr(Path path, String name)
+  public byte[] getXAttr(final Path path, final String name)
       throws IOException {
     LOG.debug("AzureBlobFileSystem.getXAttr path: {}", path);
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -123,7 +124,7 @@ public class AzureBlobFileSystemStore implements Closeable {
   private String primaryUserGroup;
   private static final String DATE_TIME_PATTERN = "E, dd MMM yyyy HH:mm:ss z";
   private static final String TOKEN_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'";
-  static final String XMS_PROPERTIES_ENCODING = "ISO-8859-1";
+  private static final String XMS_PROPERTIES_ENCODING = "ISO-8859-1";
   private static final int LIST_MAX_RESULTS = 500;
   private static final int GET_SET_AGGREGATE_COUNT = 2;
 
@@ -195,6 +196,14 @@ public class AzureBlobFileSystemStore implements Closeable {
   @Override
   public void close() throws IOException {
     IOUtils.cleanupWithLogger(LOG, client);
+  }
+
+  byte[] encodeAttribute(String value) throws UnsupportedEncodingException {
+    return value.getBytes(XMS_PROPERTIES_ENCODING);
+  }
+
+  String decodeAttribute(byte[] value) throws UnsupportedEncodingException {
+    return new String(value, XMS_PROPERTIES_ENCODING);
   }
 
   private String[] authorityParts(URI uri) throws InvalidUriAuthorityException, InvalidUriException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -123,7 +123,7 @@ public class AzureBlobFileSystemStore implements Closeable {
   private String primaryUserGroup;
   private static final String DATE_TIME_PATTERN = "E, dd MMM yyyy HH:mm:ss z";
   private static final String TOKEN_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'";
-  private static final String XMS_PROPERTIES_ENCODING = "ISO-8859-1";
+  static final String XMS_PROPERTIES_ENCODING = "ISO-8859-1";
   private static final int LIST_MAX_RESULTS = 500;
   private static final int GET_SET_AGGREGATE_COUNT = 2;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -22,10 +22,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.TimeZone;
 
 import org.apache.commons.logging.Log;
@@ -37,6 +39,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -64,6 +67,10 @@ public abstract class NativeAzureFileSystemBaseTest
     extends AbstractWasbTestBase {
 
   private final long modifiedTimeErrorMargin = 5 * 1000; // Give it +/-5 seconds
+
+  private static final short READ_WRITE_PERMISSIONS = 644;
+  private static final EnumSet<XAttrSetFlag> CREATE_FLAG = EnumSet.of(XAttrSetFlag.CREATE);
+  private static final EnumSet<XAttrSetFlag> REPLACE_FLAG = EnumSet.of(XAttrSetFlag.REPLACE);
 
   public static final Log LOG = LogFactory.getLog(NativeAzureFileSystemBaseTest.class);
   protected NativeAzureFileSystem fs;
@@ -115,6 +122,70 @@ public abstract class NativeAzureFileSystemBaseTest
     assertEquals(new FsPermission((short) 0644), status.getPermission());
     assertEquals("Testing", readString(testFile));
     fs.delete(testFile, true);
+  }
+
+  @Test
+  public void testSetGetXAttr() throws Exception {
+    byte[] attributeValue1 = "hi".getBytes(StandardCharsets.UTF_8);
+    byte[] attributeValue2 = "你好".getBytes(StandardCharsets.UTF_8);
+    String attributeName1 = "user.asciiAttribute";
+    String attributeName2 = "user.unicodeAttribute";
+    Path testFile = methodPath();
+
+    // after creating a file, the xAttr should not be present
+    createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
+    assertNull(fs.getXAttr(testFile, attributeName1));
+
+    // after setting the xAttr on the file, the value should be retrievable
+    fs.setXAttr(testFile, attributeName1, attributeValue1);
+    assertArrayEquals(attributeValue1, fs.getXAttr(testFile, attributeName1));
+
+    // after setting a second xAttr on the file, the first xAttr values should not be overwritten
+    fs.setXAttr(testFile, attributeName2, attributeValue2);
+    assertArrayEquals(attributeValue1, fs.getXAttr(testFile, attributeName1));
+    assertArrayEquals(attributeValue2, fs.getXAttr(testFile, attributeName2));
+  }
+
+  @Test
+  public void testSetGetXAttrCreateReplace() throws Exception {
+    byte[] attributeValue = "one".getBytes(StandardCharsets.UTF_8);
+    String attributeName = "user.someAttribute";
+    Path testFile = methodPath();
+
+    // after creating a file, it must be possible to create a new xAttr
+    createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
+    fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG);
+    assertArrayEquals(attributeValue, fs.getXAttr(testFile, attributeName));
+
+    // however after the xAttr is created, creating it again must fail
+    try {
+      fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG);
+      fail("Creating an existing xAttr should fail");
+    } catch (IOException ex) {
+      assertExceptionContains("XAttr: " + attributeName + " already exists.", ex);
+    }
+  }
+
+  @Test
+  public void testSetGetXAttrReplace() throws Exception {
+    byte[] attributeValue1 = "one".getBytes(StandardCharsets.UTF_8);
+    byte[] attributeValue2 = "two".getBytes(StandardCharsets.UTF_8);
+    String attributeName = "user.someAttribute";
+    Path testFile = methodPath();
+
+    // after creating a file, it must not be possible to replace an xAttr
+    createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
+    try {
+      fs.setXAttr(testFile, attributeName, attributeValue1, REPLACE_FLAG);
+      fail("Replacing a non-existing xAttr should fail");
+    } catch (IOException ex) {
+      assertExceptionContains("XAttr: " + attributeName + " does not exist.", ex);
+    }
+
+    // however after the xAttr is created, replacing it must succeed
+    fs.setXAttr(testFile, attributeName, attributeValue1, CREATE_FLAG);
+    fs.setXAttr(testFile, attributeName, attributeValue2, REPLACE_FLAG);
+    assertArrayEquals(attributeValue2, fs.getXAttr(testFile, attributeName));
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -54,6 +54,7 @@ import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.readStringFr
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.writeStringToFile;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.writeStringToStream;
 import static org.apache.hadoop.test.GenericTestUtils.*;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /*
  * Tests the Native Azure file system (WASB) against an actual blob store if
@@ -158,12 +159,7 @@ public abstract class NativeAzureFileSystemBaseTest
     assertArrayEquals(attributeValue, fs.getXAttr(testFile, attributeName));
 
     // however after the xAttr is created, creating it again must fail
-    try {
-      fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG);
-      fail("Creating an existing xAttr should fail");
-    } catch (IOException ex) {
-      assertExceptionContains("XAttr: " + attributeName + " already exists.", ex);
-    }
+    intercept(IOException.class, () -> fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG));
   }
 
   @Test
@@ -175,12 +171,7 @@ public abstract class NativeAzureFileSystemBaseTest
 
     // after creating a file, it must not be possible to replace an xAttr
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
-    try {
-      fs.setXAttr(testFile, attributeName, attributeValue1, REPLACE_FLAG);
-      fail("Replacing a non-existing xAttr should fail");
-    } catch (IOException ex) {
-      assertExceptionContains("XAttr: " + attributeName + " does not exist.", ex);
-    }
+    intercept(IOException.class, () -> fs.setXAttr(testFile, attributeName, attributeValue1, REPLACE_FLAG));
 
     // however after the xAttr is created, replacing it must succeed
     fs.setXAttr(testFile, attributeName, attributeValue1, CREATE_FLAG);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -18,16 +18,15 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
+import java.io.IOException;
+import java.util.EnumSet;
+
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.XAttrSetFlag;
 import org.junit.Assume;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.EnumSet;
-
 import static org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING;
-import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import static org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING;
+import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
+
+/**
+ * Test attribute operations.
+ */
+public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationTest {
+  private static final EnumSet<XAttrSetFlag> CREATE_FLAG = EnumSet.of(XAttrSetFlag.CREATE);
+  private static final EnumSet<XAttrSetFlag> REPLACE_FLAG = EnumSet.of(XAttrSetFlag.REPLACE);
+
+  public ITestAzureBlobFileSystemAttributes() throws Exception {
+    super();
+  }
+
+  @Test
+  public void testSetGetXAttr() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    Assume.assumeTrue(fs.getIsNamespaceEnabled());
+    byte[] attributeValue1 = "hi".getBytes(XMS_PROPERTIES_ENCODING);
+    byte[] attributeValue2 = "你好".getBytes(XMS_PROPERTIES_ENCODING);
+    String attributeName1 = "user.asciiAttribute";
+    String attributeName2 = "user.unicodeAttribute";
+    Path testFile = path("setGetXAttr");
+
+    // after creating a file, the xAttr should not be present
+    touch(testFile);
+    assertNull(fs.getXAttr(testFile, attributeName1));
+
+    // after setting the xAttr on the file, the value should be retrievable
+    fs.setXAttr(testFile, attributeName1, attributeValue1);
+    assertArrayEquals(attributeValue1, fs.getXAttr(testFile, attributeName1));
+
+    // after setting a second xAttr on the file, the first xAttr values should not be overwritten
+    fs.setXAttr(testFile, attributeName2, attributeValue2);
+    assertArrayEquals(attributeValue1, fs.getXAttr(testFile, attributeName1));
+    assertArrayEquals(attributeValue2, fs.getXAttr(testFile, attributeName2));
+  }
+
+  @Test
+  public void testSetGetXAttrCreateReplace() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    Assume.assumeTrue(fs.getIsNamespaceEnabled());
+    byte[] attributeValue = "one".getBytes(XMS_PROPERTIES_ENCODING);
+    String attributeName = "user.someAttribute";
+    Path testFile = path("createReplaceXAttr");
+
+    // after creating a file, it must be possible to create a new xAttr
+    touch(testFile);
+    fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG);
+    assertArrayEquals(attributeValue, fs.getXAttr(testFile, attributeName));
+
+    // however after the xAttr is created, creating it again must fail
+    try {
+      fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG);
+      fail("Creating an existing xAttr should fail");
+    } catch (IOException ex) {
+      assertExceptionContains("XAttr: " + attributeName + " already exists.", ex);
+    }
+  }
+
+  @Test
+  public void testSetGetXAttrReplace() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    Assume.assumeTrue(fs.getIsNamespaceEnabled());
+    byte[] attributeValue1 = "one".getBytes(XMS_PROPERTIES_ENCODING);
+    byte[] attributeValue2 = "two".getBytes(XMS_PROPERTIES_ENCODING);
+    String attributeName = "user.someAttribute";
+    Path testFile = path("replaceXAttr");
+
+    // after creating a file, it must not be possible to replace an xAttr
+    try {
+      touch(testFile);
+      fs.setXAttr(testFile, attributeName, attributeValue1, REPLACE_FLAG);
+      fail("Replacing a non-existing xAttr should fail");
+    } catch (IOException ex) {
+      assertExceptionContains("XAttr: " + attributeName + " does not exist.", ex);
+    }
+
+    // however after the xAttr is created, replacing it must succeed
+    fs.setXAttr(testFile, attributeName, attributeValue1, CREATE_FLAG);
+    fs.setXAttr(testFile, attributeName, attributeValue2, REPLACE_FLAG);
+    assertArrayEquals(attributeValue2, fs.getXAttr(testFile, attributeName));
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.XAttrSetFlag;
 import org.junit.Assume;
 import org.junit.Test;
 
-import static org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -44,8 +43,9 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
   public void testSetGetXAttr() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     Assume.assumeTrue(fs.getIsNamespaceEnabled());
-    byte[] attributeValue1 = "hi".getBytes(XMS_PROPERTIES_ENCODING);
-    byte[] attributeValue2 = "你好".getBytes(XMS_PROPERTIES_ENCODING);
+
+    byte[] attributeValue1 = fs.getAbfsStore().encodeAttribute("hi");
+    byte[] attributeValue2 = fs.getAbfsStore().encodeAttribute("你好");
     String attributeName1 = "user.asciiAttribute";
     String attributeName2 = "user.unicodeAttribute";
     Path testFile = path("setGetXAttr");
@@ -68,7 +68,7 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
   public void testSetGetXAttrCreateReplace() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     Assume.assumeTrue(fs.getIsNamespaceEnabled());
-    byte[] attributeValue = "one".getBytes(XMS_PROPERTIES_ENCODING);
+    byte[] attributeValue = fs.getAbfsStore().encodeAttribute("one");
     String attributeName = "user.someAttribute";
     Path testFile = path("createReplaceXAttr");
 
@@ -85,8 +85,8 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
   public void testSetGetXAttrReplace() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     Assume.assumeTrue(fs.getIsNamespaceEnabled());
-    byte[] attributeValue1 = "one".getBytes(XMS_PROPERTIES_ENCODING);
-    byte[] attributeValue2 = "two".getBytes(XMS_PROPERTIES_ENCODING);
+    byte[] attributeValue1 = fs.getAbfsStore().encodeAttribute("one");
+    byte[] attributeValue2 = fs.getAbfsStore().encodeAttribute("two");
     String attributeName = "user.someAttribute";
     Path testFile = path("replaceXAttr");
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -28,6 +28,7 @@ import java.util.EnumSet;
 
 import static org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.XMS_PROPERTIES_ENCODING;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
  * Test attribute operations.
@@ -78,12 +79,7 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
     assertArrayEquals(attributeValue, fs.getXAttr(testFile, attributeName));
 
     // however after the xAttr is created, creating it again must fail
-    try {
-      fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG);
-      fail("Creating an existing xAttr should fail");
-    } catch (IOException ex) {
-      assertExceptionContains("XAttr: " + attributeName + " already exists.", ex);
-    }
+    intercept(IOException.class, () -> fs.setXAttr(testFile, attributeName, attributeValue, CREATE_FLAG));
   }
 
   @Test
@@ -96,13 +92,10 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
     Path testFile = path("replaceXAttr");
 
     // after creating a file, it must not be possible to replace an xAttr
-    try {
+    intercept(IOException.class, () -> {
       touch(testFile);
       fs.setXAttr(testFile, attributeName, attributeValue1, REPLACE_FLAG);
-      fail("Replacing a non-existing xAttr should fail");
-    } catch (IOException ex) {
-      assertExceptionContains("XAttr: " + attributeName + " does not exist.", ex);
-    }
+    });
 
     // however after the xAttr is created, replacing it must succeed
     fs.setXAttr(testFile, attributeName, attributeValue1, CREATE_FLAG);


### PR DESCRIPTION
As discussed in [HADOOP-16005](https://issues.apache.org/jira/browse/HADOOP-16005), this pull request implements `getXAttr` and `setXAttr` on hadoop-azure's WASB and ABFS file-systems.

The changes were tested against the following Azure storage account configurations:

- WASB: StorageV2, RA-GRS replication in East US (primary) West US (secondary). [WASB test session screenshot](https://user-images.githubusercontent.com/1086421/50362109-699f5a00-0534-11e9-97c9-e8a7cee6e6c6.png). All tests pass and the ABFS tests are skipped as expected.

- ABFS: StorageV2 with Data Lake Storage Gen2 preview enabled, RA-GRS replication in East US (primary) West US (secondary). [ABFS test session screenshot](https://user-images.githubusercontent.com/1086421/50361278-fea05400-0530-11e9-9cb4-cc23dec87cfc.png). All ABFS tests pass but the WASB tests fail since the storage account hasn't implemented the blob endpoints yet.

The test-patch script passed: [test-patch output](https://user-images.githubusercontent.com/1086421/50377952-50aaad80-05f5-11e9-8ea2-b7bf99fc7509.png).