### PR TITLE
Fixing bug : https://issues.apache.org/jira/browse/MAPREDUCE-7089

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -547,6 +547,9 @@ public class TestDFSIO implements Tool {
                        String name, 
                        long totalSize // in bytes
                      ) throws IOException {
+      if (bufferSize <= 0) {
+        throw new IllegalArgumentException("Buffer size must be greater than 0");
+      }
       InputStream in = (InputStream)this.stream;
       long actualSize = 0;
       while (actualSize < totalSize) {


### PR DESCRIPTION
Bug: When a user configures the bufferSize to be 0, the while loop in TestDFSIO$ReadMapper.doIO function hangs endlessly.

solution : check if the bufferSize is greater than 0, if not throw IllegalArgument Exception