### PR TITLE
YARN-8246 winutils - fix failure to retrieve disk and network perf co…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/winutils/systeminfo.c
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/systeminfo.c
@@ -161,25 +161,25 @@ int GetDiskAndNetwork(LONGLONG* diskRead, LONGLONG* diskWrite, LONGLONG* netRead
   }
 
   // Add each one of the counters with wild cards
-  if(status = PdhAddCounter(hQuery, COUNTER_PATH_NET_READ_ALL, 0, &hCounterNetRead))
+  if(status = PdhAddEnglishCounter(hQuery, COUNTER_PATH_NET_READ_ALL, 0, &hCounterNetRead))
   {
     fwprintf_s(stderr, L"PdhAddCounter %s failed with 0x%x.\n", COUNTER_PATH_NET_READ_ALL, status);
     ret = EXIT_FAILURE;
     goto cleanup;
   }
-  if(status = PdhAddCounter(hQuery, COUNTER_PATH_NET_WRITE_ALL, 0, &hCounterNetWrite))
+  if(status = PdhAddEnglishCounter(hQuery, COUNTER_PATH_NET_WRITE_ALL, 0, &hCounterNetWrite))
   {
     fwprintf_s(stderr, L"PdhAddCounter %s failed with 0x%x.\n", COUNTER_PATH_NET_WRITE_ALL, status);
     ret = EXIT_FAILURE;
     goto cleanup;
   }
-  if(status = PdhAddCounter(hQuery, COUNTER_PATH_DISK_READ_ALL, 0, &hCounterDiskRead))
+  if(status = PdhAddEnglishCounter(hQuery, COUNTER_PATH_DISK_READ_ALL, 0, &hCounterDiskRead))
   {
     fwprintf_s(stderr, L"PdhAddCounter %s failed with 0x%x.\n", COUNTER_PATH_DISK_READ_ALL, status);
     ret = EXIT_FAILURE;
     goto cleanup;
   }
-  if(status = PdhAddCounter(hQuery, COUNTER_PATH_DISK_WRITE_ALL, 0, &hCounterDiskWrite))
+  if(status = PdhAddEnglishCounter(hQuery, COUNTER_PATH_DISK_WRITE_ALL, 0, &hCounterDiskWrite))
   {
     fwprintf_s(stderr, L"PdhAddCounter %s failed with 0x%x.\n", COUNTER_PATH_DISK_WRITE_ALL, status);
     ret = EXIT_FAILURE;


### PR DESCRIPTION
…unters on localized windows installlation.

PdhAddCounter expects performance counter path to be in the same language than the windows installation.
With current code, the calls to PdhAddCounter will fail with error 0xc0000bb8 (PDH_CSTATUS_NO_OBJECT)
on non-english windows installation.

The solution is to use PdhAddEnglishCounter function instead
https://docs.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhaddenglishcounterw

"This function provides a language-neutral way to add performance counters to the query"