### PR TITLE
[HDFS-14208]fix bug that there is some a large number missingblocks after failove to active

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2532,8 +2532,9 @@ public class BlockManager implements BlockStatsMXBean {
         return !node.hasStaleStorages();
       }
       if (context != null) {
-        if (!blockReportLeaseManager.checkLease(node, startTime,
-              context.getLeaseId())) {
+        if (!namesystem.isInStartupSafeMode()
+            && !blockReportLeaseManager.checkLease(node, startTime,
+                context.getLeaseId())) {
           return false;
         }
       }


### PR DESCRIPTION
when the cluster is very large, Standby startup takes about 1 hour.
Standby starts and exits the safe mode, and failover to active, a large number of missingblocks often appear. And it takes about 6 hours before missingblocks gradually disappear.

[HDFS-14208](https://issues.apache.org/jira/browse/HDFS-14208)