### PR TITLE
HDDS-1069. Temporarily disable the security acceptance tests in Ozone.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/test.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/test.sh
@@ -140,8 +140,6 @@ if [ "$RUN_ALL" = true ]; then
 #
 # We select the test suites and execute them on multiple type of clusters
 #
-   DEFAULT_TESTS=("security")
-   execute_tests ozonesecure "${DEFAULT_TESTS[@]}"
    DEFAULT_TESTS=("basic")
    execute_tests ozone "${DEFAULT_TESTS[@]}"
    TESTS=("ozonefs")


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/HDDS-1069