### PR TITLE
HDDS-1114. Fix findbugs/checkstyle/accepteance errors in Ozone

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -51,17 +51,14 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketA
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelDelegationTokenResponseProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CheckVolumeAccessRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CheckVolumeAccessResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateBucketRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateVolumeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteVolumeRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteVolumeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetDelegationTokenResponseProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetS3SecretRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetS3SecretResponse;
@@ -101,7 +98,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3ListB
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetVolumePropertyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
@@ -296,9 +292,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setCheckVolumeAccessRequest(req)
         .build();
 
-    OMResponse omResponse = submitRequest(omRequest);
-    CheckVolumeAccessResponse resp = omResponse
-        .getCheckVolumeAccessResponse();
+    OMResponse omResponse = handleError(submitRequest(omRequest));
 
     if (omResponse.getStatus() == ACCESS_DENIED) {
       return false;
@@ -348,8 +342,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDeleteVolumeRequest(req)
         .build();
 
-    DeleteVolumeResponse resp = handleError(submitRequest(omRequest))
-        .getDeleteVolumeResponse();
+    handleError(submitRequest(omRequest));
 
   }
 
@@ -440,8 +433,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setCreateBucketRequest(req)
         .build();
 
-    CreateBucketResponse resp = handleError(submitRequest(omRequest))
-        .getCreateBucketResponse();
+    handleError(submitRequest(omRequest));
 
   }
 
@@ -488,8 +480,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setSetBucketPropertyRequest(req)
         .build();
 
-    SetBucketPropertyResponse resp = handleError(submitRequest(omRequest))
-        .getSetBucketPropertyResponse();
+    handleError(submitRequest(omRequest));
 
   }
 
@@ -1108,9 +1099,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     final CancelDelegationTokenResponseProto resp;
     try {
-      resp = handleError(submitRequest(omRequest))
-          .getCancelDelegationTokenResponse();
-      return;
+      handleError(submitRequest(omRequest));
     } catch (IOException e) {
       if(e instanceof OMException) {
         throw (OMException)e;

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -109,4 +109,4 @@ Run ozoneFS tests
                         Execute               ls -l GET.txt
     ${rc}  ${result} =  Run And Return Rc And Output        ozone fs -ls o3fs://abcde.pqrs/
                         Should Be Equal As Integers     ${rc}                1
-                        Should contain    ${result}         VOLUME_NOT_FOUND
+                        Should contain    ${result}         not found

--- a/hadoop-ozone/dist/src/main/smoketest/test.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/test.sh
@@ -143,7 +143,7 @@ if [ "$RUN_ALL" = true ]; then
 #
    TESTS=("basic")
    execute_tests ozone "${TESTS[@]}"
-   TESTS=("audiparser")
+   TESTS=("auditparser")
    execute_tests ozone "${TESTS[@]}"
    TESTS=("ozonefs")
    execute_tests ozonefs "${TESTS[@]}"

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
@@ -173,7 +173,8 @@ public class VolumeManagerImpl implements VolumeManager {
       if (volumeArgs == null) {
         LOG.debug("Changing volume ownership failed for user:{} volume:{}",
             owner, volume);
-        throw  new OMException(ResultCodes.VOLUME_NOT_FOUND);
+        throw new OMException("Volume " + volume + " is not found",
+            ResultCodes.VOLUME_NOT_FOUND);
       }
 
       Preconditions.checkState(volume.equals(volumeArgs.getVolume()));
@@ -270,7 +271,8 @@ public class VolumeManagerImpl implements VolumeManager {
           metadataManager.getVolumeTable().get(dbVolumeKey);
       if (volumeArgs == null) {
         LOG.debug("volume:{} does not exist", volume);
-        throw new OMException(ResultCodes.VOLUME_NOT_FOUND);
+        throw new OMException("Volume " + volume + " is not found",
+            ResultCodes.VOLUME_NOT_FOUND);
       }
 
       return volumeArgs;
@@ -309,7 +311,8 @@ public class VolumeManagerImpl implements VolumeManager {
           metadataManager.getVolumeTable().get(dbVolumeKey);
       if (volumeArgs == null) {
         LOG.debug("volume:{} does not exist", volume);
-        throw new OMException(ResultCodes.VOLUME_NOT_FOUND);
+        throw new OMException("Volume " + volume + " is not found",
+            ResultCodes.VOLUME_NOT_FOUND);
       }
 
       if (!metadataManager.isVolumeEmpty(volume)) {
@@ -361,7 +364,8 @@ public class VolumeManagerImpl implements VolumeManager {
           metadataManager.getVolumeTable().get(dbVolumeKey);
       if (volumeArgs == null) {
         LOG.debug("volume:{} does not exist", volume);
-        throw  new OMException(ResultCodes.VOLUME_NOT_FOUND);
+        throw new OMException("Volume " + volume + " is not found",
+            ResultCodes.VOLUME_NOT_FOUND);
       }
 
       Preconditions.checkState(volume.equals(volumeArgs.getVolume()));

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -58,7 +58,8 @@ public class TestRootList {
   public void testListBucket() throws Exception {
 
     // List operation should succeed even there is no bucket.
-    ListBucketResponse response = (ListBucketResponse) rootEndpoint.get().getEntity();
+    ListBucketResponse response =
+        (ListBucketResponse) rootEndpoint.get().getEntity();
     assertEquals(0, response.getBucketsNum());
 
     String bucketBaseName = "bucket-" + getClass().getName();


### PR DESCRIPTION
Unfortunately as the previous two big commits (error handling HDDS-1068, checkstyle HDDS-1103) are committed in the same time a few new errors are introduced during the rebase.

This patch will fix the remaining 5 issues (+ a type in the acceptance test executor) 

See: https://issues.apache.org/jira/browse/HDDS-1114