### PR TITLE
HDDS-1117. Add async profiler to the hadoop-runner base container image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN chmod +x /usr/local/bin/dumb-init
 RUN mkdir -p /etc/security/keytabs && chmod -R a+wr /etc/security/keytabs 
 ADD https://repo.maven.apache.org/maven2/org/jboss/byteman/byteman/4.0.4/byteman-4.0.4.jar /opt/byteman.jar
 RUN chmod o+r /opt/byteman.jar
+RUN mkdir -p /opt/profiler && \
+    cd /opt/profiler && \
+    curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.5/async-profiler-1.5-linux-x64.tar.gz | tar xvz
 ENV JAVA_HOME=/usr/lib/jvm/jre/
 ENV PATH $PATH:/opt/hadoop/bin
 


### PR DESCRIPTION
HDDS-1116 provides a simple servlet to execute async profiler (https://github.com/jvm-profiling-tools/async-profiler) thanks to the Hive developers.

To run it in the docker-composed based example environments we should add it to the apache/hadoop-runner base image. 

Note: The size is not significant, the downloadable package is 102k.

See: https://issues.apache.org/jira/browse/HDDS-1117