### PR TITLE
HDDS-1129. Fix findbug/checkstyle errors in hadoop-hdds projects.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -109,7 +109,8 @@ public class BlockInputStream extends InputStream implements Seekable {
     int dataout = EOF;
 
     if (available == EOF) {
-      Preconditions.checkState (buffers == null); //should have released by now, see below
+      Preconditions
+          .checkState(buffers == null); //should have released by now, see below
     } else {
       dataout = Byte.toUnsignedInt(buffers.get(bufferIndex).get());
     }
@@ -149,7 +150,8 @@ public class BlockInputStream extends InputStream implements Seekable {
     while (len > 0) {
       int available = prepareRead(len);
       if (available == EOF) {
-        Preconditions.checkState(buffers == null); //should have been released by now
+        Preconditions
+            .checkState(buffers == null); //should have been released by now
         return total != 0 ? total : EOF;
       }
       buffers.get(bufferIndex).get(b, off + total, available);
@@ -167,7 +169,7 @@ public class BlockInputStream extends InputStream implements Seekable {
   }
 
   /**
-   * Determines if all data in the stream has been consumed
+   * Determines if all data in the stream has been consumed.
    *
    * @return true if EOF, false if more data is available
    */
@@ -176,8 +178,9 @@ public class BlockInputStream extends InputStream implements Seekable {
       return false;
     } else {
       // if there are any chunks, we better be at the last chunk for EOF
-      Preconditions.checkState (((chunks == null) || chunks.isEmpty() ||
-              chunkIndex == (chunks.size() - 1)), "EOF detected, but not at the last chunk");
+      Preconditions.checkState(((chunks == null) || chunks.isEmpty() ||
+              chunkIndex == (chunks.size() - 1)),
+          "EOF detected, but not at the last chunk");
       return true;
     }
   }
@@ -247,7 +250,7 @@ public class BlockInputStream extends InputStream implements Seekable {
         if (buffersRemaining()) {
           // move to next available buffer
           ++bufferIndex;
-          Preconditions.checkState (bufferIndex < buffers.size());
+          Preconditions.checkState(bufferIndex < buffers.size());
         } else {
           // no more buffers remaining
           break;

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -189,6 +189,13 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
         <version>${junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>findbugs</artifactId>
+        <version>3.0.1</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -100,6 +100,11 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import com.google.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
@@ -328,13 +329,13 @@ class PipelineStateMap {
     return updatedPipeline;
   }
 
-  private class PipelineQuery {
+  private static class PipelineQuery {
     private ReplicationType type;
     private ReplicationFactor factor;
 
     PipelineQuery(ReplicationType type, ReplicationFactor factor) {
-      this.type = type;
-      this.factor = factor;
+      this.type = Preconditions.checkNotNull(type);
+      this.factor = Preconditions.checkNotNull(factor);
     }
 
     PipelineQuery(Pipeline pipeline) {
@@ -343,6 +344,7 @@ class PipelineStateMap {
     }
 
     @Override
+    @SuppressFBWarnings("NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT")
     public boolean equals(Object other) {
       if (this == other) {
         return true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Implements Api for creating ratis pipelines.
  */
@@ -48,6 +50,8 @@ public class RatisPipelineProvider implements PipelineProvider {
   private final Configuration conf;
   private static Scheduler scheduler;
 
+  //TODO static Scheduler should be removed!!!! HDDS-1128
+  @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   RatisPipelineProvider(NodeManager nodeManager,
       PipelineStateManager stateManager, Configuration conf) {
     this.nodeManager = nodeManager;


### PR DESCRIPTION
HDDS-1114 fixed all the findbug/checkstyle problems but in the mean time new patches are committed with newer error.

Here I would like to cleanup the projects again.

(Except the static field in RatisPipelineProvider which will be ignored in this patch and tracked in HDDS-1128)

See: https://issues.apache.org/jira/browse/HDDS-1129