### PR TITLE
HDDS-1089. Disable OzoneFSStorageStatistics for hadoop versions older than 2.8

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
@@ -54,10 +54,33 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
   private ReplicationFactor replicationFactor;
   private OzoneFSStorageStatistics storageStatistics;
 
+  /**
+   * Create new OzoneClientAdapter implementation.
+   *
+   * @param volumeStr         Name of the volume to use.
+   * @param bucketStr         Name of the bucket to use
+   * @param storageStatistics Storage statistic (optional, can be null)
+   * @throws IOException In case of a problem.
+   */
   public OzoneClientAdapterImpl(String volumeStr, String bucketStr,
       OzoneFSStorageStatistics storageStatistics) throws IOException {
     this(createConf(), volumeStr, bucketStr, storageStatistics);
   }
+
+  /**
+   * Create new OzoneClientAdapter implementation.
+   *
+   * @param volumeStr         Name of the volume to use.
+   * @param bucketStr         Name of the bucket to use
+   * @param storageStatistics Storage statistic (optional, can be null)
+   * @throws IOException In case of a problem.
+   */
+  public OzoneClientAdapterImpl(String volumeStr, String bucketStr)
+      throws IOException {
+    this(createConf(), volumeStr, bucketStr, null);
+  }
+
+
 
   private static OzoneConfiguration createConf() {
     ClassLoader contextClassLoader =
@@ -102,13 +125,17 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
 
   @Override
   public InputStream createInputStream(String key) throws IOException {
-    storageStatistics.incrementCounter(Statistic.OBJECTS_READ, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.OBJECTS_READ, 1);
+    }
     return bucket.readKey(key).getInputStream();
   }
 
   @Override
   public OzoneFSOutputStream createKey(String key) throws IOException {
-    storageStatistics.incrementCounter(Statistic.OBJECTS_CREATED, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.OBJECTS_CREATED, 1);
+    }
     OzoneOutputStream ozoneOutputStream =
         bucket.createKey(key, 0, replicationType, replicationFactor,
             new HashMap<>());
@@ -117,7 +144,9 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
 
   @Override
   public void renameKey(String key, String newKeyName) throws IOException {
-    storageStatistics.incrementCounter(Statistic.OBJECTS_RENAMED, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.OBJECTS_RENAMED, 1);
+    }
     bucket.renameKey(key, newKeyName);
   }
 
@@ -130,7 +159,9 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public BasicKeyInfo getKeyInfo(String keyName) {
     try {
-      storageStatistics.incrementCounter(Statistic.OBJECTS_QUERY, 1);
+      if (storageStatistics != null) {
+        storageStatistics.incrementCounter(Statistic.OBJECTS_QUERY, 1);
+      }
       OzoneKey key = bucket.getKey(keyName);
       return new BasicKeyInfo(
           keyName,
@@ -167,7 +198,9 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
   public boolean createDirectory(String keyName) {
     try {
       LOG.trace("creating dir for key:{}", keyName);
-      storageStatistics.incrementCounter(Statistic.OBJECTS_CREATED, 1);
+      if (storageStatistics != null) {
+        storageStatistics.incrementCounter(Statistic.OBJECTS_CREATED, 1);
+      }
       bucket.createKey(keyName, 0, replicationType, replicationFactor,
           new HashMap<>()).close();
       return true;
@@ -187,7 +220,9 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
   public boolean deleteObject(String keyName) {
     LOG.trace("issuing delete for key" + keyName);
     try {
-      storageStatistics.incrementCounter(Statistic.OBJECTS_DELETED, 1);
+      if (storageStatistics != null) {
+        storageStatistics.incrementCounter(Statistic.OBJECTS_DELETED, 1);
+      }
       bucket.deleteKey(keyName);
       return true;
     } catch (IOException ioe) {
@@ -203,13 +238,17 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
 
   @Override
   public boolean hasNextKey(String key) {
-    storageStatistics.incrementCounter(Statistic.OBJECTS_LIST, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.OBJECTS_LIST, 1);
+    }
     return bucket.listKeys(key).hasNext();
   }
 
   @Override
   public Iterator<BasicKeyInfo> listKeys(String pathKey) {
-    storageStatistics.incrementCounter(Statistic.OBJECTS_LIST, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.OBJECTS_LIST, 1);
+    }
     return new IteratorAdapter(bucket.listKeys(pathKey));
   }
 

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
@@ -72,7 +72,6 @@ public class OzoneClientAdapterImpl implements OzoneClientAdapter {
    *
    * @param volumeStr         Name of the volume to use.
    * @param bucketStr         Name of the bucket to use
-   * @param storageStatistics Storage statistic (optional, can be null)
    * @throws IOException In case of a problem.
    */
   public OzoneClientAdapterImpl(String volumeStr, String bucketStr)

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -134,13 +134,21 @@ public class OzoneFileSystem extends FileSystem {
                 .put(OzoneFSStorageStatistics.NAME,
                     OzoneFSStorageStatistics::new);
       } catch (ClassNotFoundException e) {
-        storageStatistics = new OzoneFSStorageStatistics();
+        //we don't support storage statistics for hadoop2.7 and older
       }
 
       if (isolatedClassloader) {
-        this.adapter =
-            OzoneClientAdapterFactory.createAdapter(volumeStr, bucketStr,
-                storageStatistics);
+        try {
+          //register only to the GlobalStorageStatistics if the class exists.
+          //This is required to support hadoop versions <2.7
+          Class.forName("org.apache.hadoop.fs.GlobalStorageStatistics");
+          this.adapter =
+              OzoneClientAdapterFactory.createAdapter(volumeStr, bucketStr,
+                  storageStatistics);
+        } catch (ClassNotFoundException e) {
+          this.adapter =
+              OzoneClientAdapterFactory.createAdapter(volumeStr, bucketStr);
+        }
       } else {
         OzoneConfiguration ozoneConfiguration;
         if (conf instanceof OzoneConfiguration) {
@@ -196,7 +204,9 @@ public class OzoneFileSystem extends FileSystem {
 
   @Override
   public FSDataInputStream open(Path f, int bufferSize) throws IOException {
-    storageStatistics.incrementCounter(Statistic.INVOCATION_OPEN, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.INVOCATION_OPEN, 1);
+    }
     statistics.incrementWriteOps(1);
     LOG.trace("open() path:{}", f);
     final FileStatus fileStatus = getFileStatus(f);
@@ -215,7 +225,9 @@ public class OzoneFileSystem extends FileSystem {
                                    short replication, long blockSize,
                                    Progressable progress) throws IOException {
     LOG.trace("create() path:{}", f);
-    storageStatistics.incrementCounter(Statistic.INVOCATION_CREATE, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.INVOCATION_CREATE, 1);
+    }
     statistics.incrementWriteOps(1);
     final String key = pathToKey(f);
     final FileStatus status;
@@ -248,8 +260,10 @@ public class OzoneFileSystem extends FileSystem {
       short replication,
       long blockSize,
       Progressable progress) throws IOException {
-    storageStatistics.incrementCounter(
-        Statistic.INVOCATION_CREATE_NON_RECURSIVE, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(
+          Statistic.INVOCATION_CREATE_NON_RECURSIVE, 1);
+    }
     statistics.incrementWriteOps(1);
     final Path parent = path.getParent();
     if (parent != null) {
@@ -304,7 +318,9 @@ public class OzoneFileSystem extends FileSystem {
    */
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
-    storageStatistics.incrementCounter(Statistic.INVOCATION_RENAME, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.INVOCATION_RENAME, 1);
+    }
     statistics.incrementWriteOps(1);
     if (src.equals(dst)) {
       return true;
@@ -439,7 +455,9 @@ public class OzoneFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
-    storageStatistics.incrementCounter(Statistic.INVOCATION_DELETE, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.INVOCATION_DELETE, 1);
+    }
     statistics.incrementWriteOps(1);
     LOG.debug("Delete path {} - recursive {}", f, recursive);
     FileStatus status;
@@ -631,7 +649,9 @@ public class OzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f) throws IOException {
-    storageStatistics.incrementCounter(Statistic.INVOCATION_LIST_STATUS, 1);
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(Statistic.INVOCATION_LIST_STATUS, 1);
+    }
     statistics.incrementReadOps(1);
     LOG.trace("listStatus() path:{}", f);
     ListStatusIterator iterator = new ListStatusIterator(f);
@@ -718,7 +738,10 @@ public class OzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
-    storageStatistics.incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS, 1);
+    if (storageStatistics != null) {
+      storageStatistics
+          .incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS, 1);
+    }
     statistics.incrementReadOps(1);
     LOG.trace("getFileStatus() path:{}", f);
     Path qualifiedPath = f.makeQualified(uri, workingDir);


### PR DESCRIPTION
HDDS-1033 introduced OzoneFSStorageStatistics for OzoneFileSystem. It uses the StorageStatistics which is introduced in HADOOP-13065 (available from the hadoop2.8/3.0).

Using older hadoop (for example hadoop-2.7 which is included in the spark distributions) is not possible any more even with using the isolated class loader (introduced in HDDS-922).

Fortunately it can be fixed:
  *  We can support null in storageStatistics field with checking everywhere before call it.
  *  We can create a new constructor of OzoneClientAdapterImpl without using OzoneFSStorageStatistics): If OzoneFSStorageStatistics is not in the method/constructor signature we don't need to load it.
  * We can check the availability of HADOOP-13065 and if the classes are not in the classpath we can skip the initialization of the OzoneFSStorageStatistics

See: https://issues.apache.org/jira/browse/HDDS-1089