### PR TITLE
HDDS-1145. Add optional web server to the Ozone freon test tool

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -377,6 +377,26 @@ public final class OzoneConfigKeys {
       "ozone.fs.isolated-classloader";
 
 
+  public static final String OZONE_FREON_HTTP_ENABLED_KEY =
+      "ozone.freon.http.enabled";
+  public static final String OZONE_FREON_HTTP_BIND_HOST_KEY =
+      "ozone.freon.http-bind-host";
+  public static final String OZONE_FREON_HTTPS_BIND_HOST_KEY =
+      "ozone.freon.https-bind-host";
+  public static final String OZONE_FREON_HTTP_ADDRESS_KEY =
+      "ozone.freon.http-address";
+  public static final String OZONE_FREON_HTTPS_ADDRESS_KEY =
+      "ozone.freon.https-address";
+
+  public static final String OZONE_FREON_HTTP_BIND_HOST_DEFAULT = "0.0.0.0";
+  public static final int OZONE_FREON_HTTP_BIND_PORT_DEFAULT = 9884;
+  public static final int OZONE_FREON_HTTPS_BIND_PORT_DEFAULT = 9885;
+  public static final String
+      OZONE_FREON_HTTP_KERBEROS_PRINCIPAL_KEY =
+      "ozone.freon.http.kerberos.principal";
+  public static final String
+      OZONE_FREON_HTTP_KERBEROS_KEYTAB_FILE_KEY =
+      "ozone.freon.http.kerberos.keytab";
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1890,4 +1890,63 @@
       the servlet.
     </description>
   </property>
+
+  <property>
+    <name>ozone.freon.http-address</name>
+    <value>0.0.0.0:9884</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      The address and the base port where the FREON web ui will listen on.
+
+      If the port is 0 then the server will start on a free port.
+    </description>
+  </property>
+  <property>
+    <name>ozone.freon.http-bind-host</name>
+    <value>0.0.0.0</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      The actual address the Freon web server will bind to. If this
+      optional address is set, it overrides only the hostname portion of
+      ozone.freon.http-address.
+    </description>
+  </property>
+  <property>
+    <name>ozone.freon.http.enabled</name>
+    <value>true</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      Property to enable or disable FREON web ui.
+    </description>
+  </property>
+  <property>
+    <name>ozone.freon.https-address</name>
+    <value>0.0.0.0:9885</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      The address and the base port where the Freon web server will listen
+      on using HTTPS.
+
+      If the port is 0 then the server will start on a free port.
+    </description>
+  </property>
+  <property>
+    <name>ozone.freon.https-bind-host</name>
+    <value>0.0.0.0</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      The actual address the Freon web server will bind to using HTTPS.
+      If this optional address is set, it overrides only the hostname portion of
+      ozone.freon.http-address.
+    </description>
+  </property>
+  <property>
+    <name>ozone.freon.http.kerberos.principal</name>
+    <value>HTTP/_HOST@EXAMPLE.COM</value>
+  </property>
+  <property>
+    <name>ozone.freon.http.kerberos.keytab</name>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
+  </property>
+
 </configuration>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -47,6 +47,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-server-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -16,11 +16,16 @@
  */
 package org.apache.hadoop.ozone.freon;
 
+import java.io.IOException;
+
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 /**
  * Ozone data generator and performance test tool.
@@ -33,10 +38,41 @@ import picocli.CommandLine.Command;
     mixinStandardHelpOptions = true)
 public class Freon extends GenericCli {
 
+  public static final Logger LOG = LoggerFactory.getLogger(Freon.class);
+
+  @Option(names = "--server",
+      description = "Enable internal http server to provide metric "
+          + "and profile endpoint")
+  private boolean httpServer = false;
+
+  private FreonHttpServer freonHttpServer;
+
   @Override
   public void execute(String[] argv) {
     TracingUtil.initTracing("freon");
     super.execute(argv);
+  }
+
+  public void stopHttpServer() {
+    if (freonHttpServer != null) {
+      try {
+        freonHttpServer.stop();
+      } catch (Exception e) {
+        LOG.error("Freon http server can't be stopped", e);
+      }
+    }
+  }
+
+  public void startHttpServer() {
+    if (httpServer) {
+      try {
+        freonHttpServer = new FreonHttpServer(createOzoneConfiguration());
+        freonHttpServer.start();
+      } catch (IOException e) {
+        LOG.error("Freon http server can't be started", e);
+      }
+    }
+
   }
 
   public static void main(String[] args) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonHttpServer.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonHttpServer.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.server.BaseHttpServer;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+
+/**
+ * Http server to provide metrics + profile endpoint.
+ */
+public class FreonHttpServer extends BaseHttpServer {
+  public FreonHttpServer(Configuration conf) throws IOException {
+    super(conf, "freon");
+  }
+
+
+  @Override protected String getHttpAddressKey() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_ADDRESS_KEY;
+  }
+
+  @Override protected String getHttpBindHostKey() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_BIND_HOST_KEY;
+  }
+
+  @Override protected String getHttpsAddressKey() {
+    return OzoneConfigKeys.OZONE_FREON_HTTPS_ADDRESS_KEY;
+  }
+
+  @Override protected String getHttpsBindHostKey() {
+    return OzoneConfigKeys.OZONE_FREON_HTTPS_BIND_HOST_KEY;
+  }
+
+  @Override protected String getBindHostDefault() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_BIND_HOST_DEFAULT;
+  }
+
+  @Override protected int getHttpBindPortDefault() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_BIND_PORT_DEFAULT;
+  }
+
+  @Override protected int getHttpsBindPortDefault() {
+    return OzoneConfigKeys.OZONE_FREON_HTTPS_BIND_PORT_DEFAULT;
+  }
+
+  @Override protected String getKeytabFile() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_KERBEROS_KEYTAB_FILE_KEY;
+  }
+
+  @Override protected String getSpnegoPrincipal() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_KERBEROS_PRINCIPAL_KEY;
+  }
+
+  @Override protected String getEnabledKey() {
+    return OzoneConfigKeys.OZONE_FREON_HTTP_ENABLED_KEY;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -214,6 +214,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
     for (FreonOps ops : FreonOps.values()) {
       histograms.add(ops.ordinal(), new Histogram(new UniformReservoir()));
     }
+    freon.startHttpServer();
   }
 
   @Override
@@ -292,7 +293,10 @@ public final class RandomKeyGenerator implements Callable<Void> {
    */
   private void addShutdownHook() {
     Runtime.getRuntime().addShutdownHook(
-        new Thread(() -> printStats(System.out)));
+        new Thread(() -> {
+          printStats(System.out);
+          freon.stopHttpServer();
+        }));
   }
   /**
    * Prints stats of {@link Freon} run to the PrintStream.

--- a/hadoop-ozone/tools/src/main/resources/webapps/freon/.gitkeep
+++ b/hadoop-ozone/tools/src/main/resources/webapps/freon/.gitkeep
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
Recently we improved the default HttpServer to support prometheus monitoring and java profiling.

It would be very useful to enable the same options for freon testing:

 1. We need a simple way to profile freon and check the problems

 2. Long running freons should be monitored

We can create a new optional FreonHttpServer which includes all the required servlets by default.

See: https://issues.apache.org/jira/browse/HDDS-1145