### PR TITLE
HDDS-1152. Add trace information for the client side of the datanode writes

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -616,8 +616,8 @@ public final class RandomKeyGenerator implements Callable<Void> {
                     .startActive(true)) {
                   os.write(keyValue);
                   os.write(randomValue);
+                  os.close();
                 }
-                os.close();
 
                 long keyWriteDuration = System.nanoTime() - keyWriteStart;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -1,3 +1,4 @@
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
@@ -610,8 +611,12 @@ public final class RandomKeyGenerator implements Callable<Void> {
                     .update(keyCreationDuration);
                 keyCreationTime.getAndAdd(keyCreationDuration);
                 long keyWriteStart = System.nanoTime();
-                os.write(keyValue);
-                os.write(randomValue);
+                try (Scope writeScope = GlobalTracer.get()
+                    .buildSpan("writeKeyData")
+                    .startActive(true)) {
+                  os.write(keyValue);
+                  os.write(randomValue);
+                }
                 os.close();
 
                 long keyWriteDuration = System.nanoTime() - keyWriteStart;


### PR DESCRIPTION
The XCeiverClients can be traced on the client side to get some information about the time of chunk writes / block puts.

See: https://issues.apache.org/jira/browse/HDDS-1152