### PR TITLE
HDDS-1151. Propagate the tracing id in ScmBlockLocationProtocol

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
@@ -34,7 +35,7 @@ import java.util.List;
  * to read/write a block.
  */
 @KerberosInfo(serverPrincipal = ScmConfigKeys.HDDS_SCM_KERBEROS_PRINCIPAL_KEY)
-public interface ScmBlockLocationProtocol {
+public interface ScmBlockLocationProtocol extends Closeable {
 
   /**
    * Asks SCM where a block should be allocated. SCM responds with the

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ipc.ProtocolTranslator;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ozone.common.BlockGroup;
@@ -83,8 +84,13 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
     Preconditions.checkArgument(size > 0, "block size must be greater than 0");
 
     AllocateScmBlockRequestProto request =
-        AllocateScmBlockRequestProto.newBuilder().setSize(size).setType(type)
-            .setFactor(factor).setOwner(owner).build();
+        AllocateScmBlockRequestProto.newBuilder()
+            .setSize(size)
+            .setType(type)
+            .setFactor(factor)
+            .setOwner(owner)
+            .setTraceID(TracingUtil.exportCurrentSpan())
+            .build();
     final AllocateScmBlockResponseProto response;
     try {
       response = rpcProxy.allocateScmBlock(NULL_RPC_CONTROLLER, request);
@@ -117,7 +123,9 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
     List<KeyBlocks> keyBlocksProto = keyBlocksInfoList.stream()
         .map(BlockGroup::getProto).collect(Collectors.toList());
     DeleteScmKeyBlocksRequestProto request = DeleteScmKeyBlocksRequestProto
-        .newBuilder().addAllKeyBlocks(keyBlocksProto).build();
+        .newBuilder()
+        .addAllKeyBlocks(keyBlocksProto)
+        .build();
 
     final DeleteScmKeyBlocksResponseProto resp;
     try {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/protocolPB/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/protocolPB/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.protocolPB;
 
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
+import io.opentracing.Scope;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
@@ -37,6 +39,7 @@ import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos
     .DeleteScmKeyBlocksRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos
     .DeleteScmKeyBlocksResponseProto;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 
@@ -69,7 +72,9 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
   public AllocateScmBlockResponseProto allocateScmBlock(
       RpcController controller, AllocateScmBlockRequestProto request)
       throws ServiceException {
-    try {
+    try (Scope scope = TracingUtil
+        .importAndCreateScope("ScmBlockLocationProtocol.allocateBlock",
+            request.getTraceID())) {
       AllocatedBlock allocatedBlock =
           impl.allocateBlock(request.getSize(), request.getType(),
               request.getFactor(), request.getOwner());

--- a/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
+++ b/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
@@ -41,6 +41,7 @@ message AllocateScmBlockRequestProto {
   required ReplicationType type = 2;
   required hadoop.hdds.ReplicationFactor factor = 3;
   required string owner = 4;
+  optional string traceID = 5;
 
 }
 
@@ -71,6 +72,8 @@ message KeyBlocks {
  */
 message DeleteScmKeyBlocksResponseProto {
   repeated DeleteKeyBlocksResultProto results = 1;
+  optional string traceID = 2;
+
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.DeleteBlockResult;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.DeleteBlockResult;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -294,5 +295,10 @@ public class SCMBlockProtocolServer implements
         .withResult(AuditEventStatus.FAILURE.toString())
         .withException(throwable)
         .build();
+  }
+
+  @Override
+  public void close() throws IOException {
+    stop();
   }
 }

--- a/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
+++ b/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
@@ -112,8 +112,8 @@ public final class ObjectStoreHandler implements Closeable {
         TracingUtil.createProxy(
             new ScmBlockLocationProtocolClientSideTranslatorPB(
                 RPC.getProxy(ScmBlockLocationProtocolPB.class, scmVersion,
-                    scmBlockAddress, UserGroupInformation.getCurrentUser(), conf,
-                    NetUtils.getDefaultSocketFactory(conf),
+                    scmBlockAddress, UserGroupInformation.getCurrentUser(),
+                    conf, NetUtils.getDefaultSocketFactory(conf),
                     Client.getRpcTimeout(conf))),
             ScmBlockLocationProtocol.class);
 

--- a/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
+++ b/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
@@ -20,6 +20,7 @@ import com.sun.jersey.api.container.ContainerFactory;
 import com.sun.jersey.api.core.ApplicationAdapter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
@@ -72,7 +73,7 @@ public final class ObjectStoreHandler implements Closeable {
   private final OzoneManagerProtocol ozoneManagerClient;
   private final StorageContainerLocationProtocol
       storageContainerLocationClient;
-  private final ScmBlockLocationProtocolClientSideTranslatorPB
+  private final ScmBlockLocationProtocol
       scmBlockLocationClient;
   private final StorageHandler storageHandler;
   private ClientId clientId = ClientId.randomId();
@@ -108,11 +109,13 @@ public final class ObjectStoreHandler implements Closeable {
     InetSocketAddress scmBlockAddress =
         getScmAddressForBlockClients(conf);
     this.scmBlockLocationClient =
-        new ScmBlockLocationProtocolClientSideTranslatorPB(
-            RPC.getProxy(ScmBlockLocationProtocolPB.class, scmVersion,
-                scmBlockAddress, UserGroupInformation.getCurrentUser(), conf,
-                NetUtils.getDefaultSocketFactory(conf),
-                Client.getRpcTimeout(conf)));
+        TracingUtil.createProxy(
+            new ScmBlockLocationProtocolClientSideTranslatorPB(
+                RPC.getProxy(ScmBlockLocationProtocolPB.class, scmVersion,
+                    scmBlockAddress, UserGroupInformation.getCurrentUser(), conf,
+                    NetUtils.getDefaultSocketFactory(conf),
+                    Client.getRpcTimeout(conf))),
+            ScmBlockLocationProtocol.class);
 
     RPC.setProtocolEngine(conf, OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -724,7 +724,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
                 scmBlockAddress, UserGroupInformation.getCurrentUser(), conf,
                 NetUtils.getDefaultSocketFactory(conf),
                 Client.getRpcTimeout(conf)));
-    return scmBlockLocationClient;
+    return TracingUtil
+        .createProxy(scmBlockLocationClient, ScmBlockLocationProtocol.class);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestIngClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestIngClient.java
@@ -178,4 +178,9 @@ public class ScmBlockLocationTestIngClient implements ScmBlockLocationProtocol {
             .setScmId(scmId);
     return builder.build();
   }
+
+  @Override
+  public void close() throws IOException {
+
+  }
 }


### PR DESCRIPTION
The tracing propagation is not yet enabled for the ScmBlockLocationProtocol. We can't see the internal calls between OM and SCM. We need to propagate it at least for the allocateBlock call.

See: https://issues.apache.org/jira/browse/HDDS-1151