### PR TITLE
HDDS-1161. Disable failing test which are tracked by a separated jira

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/chillmode/TestSCMChillModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/chillmode/TestSCMChillModeManager.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Pipeline
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -128,6 +129,7 @@ public class TestSCMChillModeManager {
   }
 
   @Test
+  @Ignore("TODO:HDDS-1140")
   public void testDisableChillMode() {
     OzoneConfiguration conf = new OzoneConfiguration(config);
     conf.setBoolean(HddsConfigKeys.HDDS_SCM_CHILLMODE_ENABLED, false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
@@ -104,6 +105,7 @@ public class TestDeadNodeHandler {
   }
 
   @Test
+  @Ignore("TODO:HDDS-1155")
   public void testOnMessage() throws IOException, NodeNotFoundException {
     //GIVEN
     DatanodeDetails datanode1 = TestUtils.randomDatanodeDetails();
@@ -260,6 +262,7 @@ public class TestDeadNodeHandler {
   }
 
   @Test
+  @Ignore("TODO:HDDS-1155")
   public void testOnMessageReplicaFailure() throws Exception {
 
     DatanodeDetails datanode1 = TestUtils.randomDatanodeDetails();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,6 +196,7 @@ public class TestContainerStateManagerIntegration {
   }
 
   @Test
+  @Ignore("TODO:HDDS-1159")
   public void testGetMatchingContainerMultipleThreads()
       throws IOException, InterruptedException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKE
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_EXPIRED;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+import org.junit.Ignore;
 import static org.slf4j.event.Level.INFO;
 
 import java.io.File;
@@ -401,6 +402,7 @@ public final class TestSecureOzoneCluster {
    * @throws Exception
    */
   @Test
+  @Ignore("TODO:HDDS-1156")
   public void testDelegationToken() throws Exception {
 
     // Capture logs for assertions
@@ -546,6 +548,7 @@ public final class TestSecureOzoneCluster {
    * @throws Exception
    */
   @Test
+  @Ignore("TODO:HDDS-1156")
   public void testDelegationTokenRenewal() throws Exception {
     GenericTestUtils
         .setLogLevel(LoggerFactory.getLogger(Server.class.getName()), INFO);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -66,6 +67,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY
  * Tests ozone containers via secure grpc/netty.
  */
 @RunWith(Parameterized.class)
+@Ignore("TODO:HDDS-1157")
 public class TestOzoneContainerWithTLS {
   private final static Logger LOG = LoggerFactory.getLogger(
       TestOzoneContainerWithTLS.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManager.java
@@ -343,6 +343,7 @@ public class TestOzoneManager {
 
   // Create a volume and test Volume access for a different user
   @Test
+  @Ignore("TODO:HDDS-1147")
   public void testAccessVolume() throws IOException, OzoneException {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
     String adminName = "admin" + RandomStringUtils.randomNumeric(5);
@@ -673,6 +674,7 @@ public class TestOzoneManager {
    * @throws OzoneException
    */
   @Test
+  @Ignore("TODO:HDDS-1147")
   public void testRenameKey() throws IOException, OzoneException {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
     String adminName = "admin" + RandomStringUtils.randomNumeric(5);
@@ -1307,6 +1309,7 @@ public class TestOzoneManager {
    * @throws IOException
    */
   @Test
+  @Ignore("TODO:HDDS-1147")
   public void testOmInitializationFailure() throws Exception {
     OzoneConfiguration config = new OzoneConfiguration();
     final String path =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -130,6 +131,7 @@ public class TestOzoneManagerHA {
    * Test client request fails when 2 OMs are down.
    */
   @Test
+  @Ignore("TODO:HDDS-1158")
   public void testTwoOMNodesDown() throws Exception {
     cluster.stopOzoneManager(1);
     cluster.stopOzoneManager(2);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
@@ -36,6 +36,7 @@ import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -74,6 +75,7 @@ public class TestFreonWithDatanodeFastRestart {
   }
 
   @Test
+  @Ignore("TODO:HDDS-1160")
   public void testRestart() throws Exception {
     startFreon();
     StateMachine sm = getStateMachine();


### PR DESCRIPTION
As I wrote in the description of the parent Jira I propose to disable (@Ignore) the unit tests which are failing while we are fixing them to get clean Jira response from the PreCommit builds.

All the tests are tracked in a separated jira.

See: https://issues.apache.org/jira/browse/HDDS-1161