### PR TITLE
HADOOP-16134 001- initial design of a WriteOperationsContext

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AMultipartUploader.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AMultipartUploader.java
@@ -133,7 +133,7 @@ public class S3AMultipartUploader extends MultipartUploader {
     }
     AtomicInteger errorCount = new AtomicInteger(0);
     CompleteMultipartUploadResult result = writeHelper.completeMPUwithRetries(
-        key, uploadIdStr, eTags, totalLength, errorCount);
+        key, uploadIdStr, eTags, totalLength, errorCount, writeContext);
 
     byte[] eTag = result.getETag().getBytes(Charsets.UTF_8);
     return (PathHandle) () -> ByteBuffer.wrap(eTag);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AWriteOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AWriteOpContext.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.util.Progressable;
+
+/**
+ * Context for passing information down to S3 write operations.
+ */
+public class S3AWriteOpContext extends S3AOpContext {
+
+  private final DeleteParentPolicy deleteParentPolicy;
+
+  private final ExecutorService executorService;
+
+  private final Progressable progress;
+
+  private final S3AInstrumentation.OutputStreamStatistics statistics;
+
+  private final WriteOperationHelper writeOperationHelper;
+
+  /**
+   * Instantiate.
+   * @param isS3GuardEnabled
+   * @param invoker
+   * @param stats
+   * @param instrumentation
+   * @param dstFileStatus
+   * @param deleteParentPolicy policy about parent deletion.
+   * @param executorService the executor service to use to schedule work
+   * @param progress report progress in order to prevent timeouts. If
+   * this object implements {@code ProgressListener} then it will be
+   * directly wired up to the AWS client, so receive detailed progress
+   * information.
+   * @param statistics stats for this stream
+   * @param writeOperationHelper state of the write operation.
+   */
+  S3AWriteOpContext(
+      final boolean isS3GuardEnabled,
+      final Invoker invoker,
+      @Nullable final FileSystem.Statistics stats,
+      final S3AInstrumentation instrumentation,
+      final FileStatus dstFileStatus,
+      final DeleteParentPolicy deleteParentPolicy,
+      final ExecutorService executorService,
+      final Progressable progress,
+      final S3AInstrumentation.OutputStreamStatistics statistics,
+      final WriteOperationHelper writeOperationHelper) {
+    super(isS3GuardEnabled, invoker, stats, instrumentation, dstFileStatus);
+    this.deleteParentPolicy = deleteParentPolicy;
+    this.executorService = executorService;
+    this.progress = progress;
+    this.statistics = statistics;
+    this.writeOperationHelper = writeOperationHelper;
+  }
+
+  public DeleteParentPolicy getDeleteParentPolicy() {
+    return deleteParentPolicy;
+  }
+
+  public ExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  public Progressable getProgress() {
+    return progress;
+  }
+
+  public S3AInstrumentation.OutputStreamStatistics getStatistics() {
+    return statistics;
+  }
+
+  public WriteOperationHelper getWriteOperationHelper() {
+    return writeOperationHelper;
+  }
+
+  /**
+   * What is the delete policy here.
+   */
+  public enum DeleteParentPolicy {
+    /** Single large bulk delete. */
+    bulk,
+
+    /** Incremental GET / + delete; bail out on first found. */
+    incremental,
+
+    /** No attempt to delete. */
+    none
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AUtils;
+import org.apache.hadoop.fs.s3a.S3AWriteOpContext;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
 import org.apache.hadoop.fs.s3a.commit.files.PendingSet;
 import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
@@ -93,11 +94,24 @@ public class CommitOperations {
   public static final PathFilter PENDING_FILTER =
       path -> path.toString().endsWith(CommitConstants.PENDING_SUFFIX);
 
+  private final S3AWriteOpContext writeContext;
+
   /**
    * Instantiate.
    * @param fs FS to bind to
    */
-  public CommitOperations(S3AFileSystem fs) {
+  public CommitOperations(final S3AFileSystem fs) {
+    this(fs, fs.createWriteOpContext(null, null, S3AWriteOpContext.DeleteParentPolicy.bulk));
+  }
+
+  /**
+   * Instantiate.
+   * @param fs FS to bind to
+   * @param writeContext write context
+   */
+  public CommitOperations(final S3AFileSystem fs,
+      final S3AWriteOpContext writeContext) {
+    this.writeContext = writeContext;
     Preconditions.checkArgument(fs != null, "null fs");
     this.fs = fs;
     statistics = fs.newCommitterStatistics();
@@ -178,10 +192,11 @@ public class CommitOperations {
     // finalize the commit
     writeOperations.completeMPUwithRetries(
         commit.getDestinationKey(),
-              commit.getUploadId(),
-              toPartEtags(commit.getEtags()),
-              commit.getLength(),
-              new AtomicInteger(0));
+        commit.getUploadId(),
+        toPartEtags(commit.getEtags()),
+        commit.getLength(),
+        new AtomicInteger(0),
+        writeContext);
     return commit.getLength();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a;
 
 import org.apache.hadoop.fs.s3a.commit.PutTracker;
 import org.apache.hadoop.util.Progressable;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,9 +49,20 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     S3AInstrumentation.OutputStreamStatistics statistics = null;
     WriteOperationHelper oHelper = mock(WriteOperationHelper.class);
     PutTracker putTracker = mock(PutTracker.class);
-    stream = spy(new S3ABlockOutputStream(fs, "", executorService,
-      progressable, blockSize, blockFactory, statistics, oHelper,
-      putTracker));
+    S3AWriteOpContext writeContext = new S3AWriteOpContext(
+        false,
+        null,
+        null,
+        null,
+        null,
+        S3AWriteOpContext.DeleteParentPolicy.bulk,
+        executorService,
+        progressable,
+        null,
+        oHelper
+    );
+    stream = spy(new S3ABlockOutputStream(fs, "",
+        writeContext, blockSize, blockFactory, putTracker));
   }
 
   @Test


### PR DESCRIPTION
*Does not compile*

This adds
* a context which is passed round with writes
* a parent delete policy as part of this (unused)

This PoC shows that adding a new context everywhere is overcomplex as you now need to retrofit it through the stack, even though a  (single, shared) WriteOperationsHelper is already passed in

This doesn't compile: I put it together while half-listening to an online talk, and now I've done I've learned enough to say "not the right approach"

Better strategy:
* include the WriteOperationsContext in the WriteOperationsHelper;  instantiating a new one each time. This will automatically add it to all bits of the FS code which write data
* add a default/configurable delete policy to the FS, *but allow operations to explicitly overwrite this*. Example: completing all the committed work in a job commit, because we can rely on the write of the _SUCCESS file to do the work (so only do it for one file, not every file created)

We're also a bit constrained by how the MPU API of HADOOP-13186 tries to be independent of the FS instance -this is one of those cases where it complicates life even more. The FS/FC MUST be the factory for MPU instances.

Change-Id: I0de1d4b97fdf4c4f0ece1a27245ba9bb38a29559
