### PR TITLE
HADOOP-16149 hadoop-mapreduce-client-app build not converging

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -955,6 +955,16 @@
         <groupId>com.github.stefanbirkner</groupId>
         <artifactId>system-rules</artifactId>
         <version>1.18.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit-dep</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
Excludes the junit and hamcrest dependencies where they are out of date
Tested: locally

Change-Id: If95b12b223770b057041f99f0f8fd8ba370c377f