### PR TITLE
HDDS-623. On SCM UI, Node Manager info is empty

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -41,20 +41,8 @@
         <td>{{$ctrl.blockmanagermetrics.OpenContainersNo}}</td>
     </tr>
     <tr>
-        <td>Node Manager: Minimum chill mode nodes</td>
-        <td>{{$ctrl.nodemanagermetrics.MinimumChillModeNodes}}</td>
-    </tr>
-    <tr>
-        <td>Node Manager: Out-of-node chill mode</td>
-        <td>{{$ctrl.nodemanagermetrics.OutOfNodeChillMode}}</td>
-    </tr>
-    <tr>
         <td>Node Manager: Chill mode status</td>
         <td>{{$ctrl.scmmetrics.InChillMode}}</td>
-    </tr>
-    <tr>
-        <td>Node Manager: Manual chill mode</td>
-        <td>{{$ctrl.nodemanagermetrics.InManualChillMode}}</td>
     </tr>
     </tbody>
 </table>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -37,10 +37,6 @@
         <td>{{$ctrl.overview.jmx.DatanodeRpcPort}}</td>
     </tr>
     <tr>
-        <td>Block Manager: Open containers</td>
-        <td>{{$ctrl.blockmanagermetrics.OpenContainersNo}}</td>
-    </tr>
-    <tr>
         <td>Node Manager: Chill mode status</td>
         <td>{{$ctrl.scmmetrics.InChillMode}}</td>
     </tr>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -26,10 +26,6 @@
         },
         controller: function ($http) {
             var ctrl = this;
-            $http.get("jmx?qry=Hadoop:service=BlockManager,name=*")
-                .then(function (result) {
-                    ctrl.blockmanagermetrics = result.data.beans[0];
-                });
             $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
                 .then(function (result) {
                     ctrl.nodemanagermetrics = result.data.beans[0];


### PR DESCRIPTION
Fields like below are empty

Node Manager: Minimum chill mode nodes 
Node Manager: Out-of-node chill mode 
Node Manager: Chill mode status 
Node Manager: Manual chill mode

Please see attached screenshot !Screen Shot 2018-10-10 at 4.19.59 PM.png!

See: https://issues.apache.org/jira/browse/HDDS-623