### PR TITLE
HADOOP-16150. ChecksumFileSystem doesn't wrap concat()

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -372,6 +372,12 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
         + "by ChecksumFileSystem");
   }
 
+  @Override
+  public void concat(final Path f, final Path[] psrcs) throws IOException {
+    throw new UnsupportedOperationException("Concat is not supported "
+        + "by ChecksumFileSystem");
+  }
+
   /**
    * Calculated the length of the checksum file in bytes.
    * @param size the length of the data file in bytes

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractMultipartUploader.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractMultipartUploader.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.fs.contract.localfs;
 
+import org.junit.Assume;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractMultipartUploaderTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
@@ -26,6 +28,12 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
  */
 public class TestLocalFSContractMultipartUploader
     extends AbstractContractMultipartUploaderTest {
+
+  @Override
+  public void setup() throws Exception {
+    Assume.assumeTrue("Skipping until HDFS-13934", false);
+    super.setup();
+  }
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {


### PR DESCRIPTION
HADOOP-16150. ChecksumFileSystem doesn't wrap concat()

This intercepts concat() To throw an UnsupportedOperationException.
Without this the concat() call is passes straight down to the wrapped
FS, so, if the underlying FS does support concat(), concatenated files don't have checksums

It also disables the test TestLocalFSContractMultipartUploader, as the service-loader mechanism to create an MPU uploader needs to be replaced by an API call in the filesystems, as proposed by HDFS-13934

Contributed by Steve Loughran.

Change-Id: I85fc1fc9445ca0b7d325495d3bc55fe9f5e5ce52