### PR TITLE
HADOOP-14630  Contract Tests to verify create, mkdirs and rename under a file is forbidden

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -477,11 +477,11 @@ running out of memory as it calculates the partitions.
 
 Any FileSystem that does not actually break files into blocks SHOULD
 return a number for this that results in efficient processing.
-A FileSystem MAY make this user-configurable (the S3 and Swift filesystem clients do this).
+A FileSystem MAY make this user-configurable (the object store connectors usually do this).
 
 ###  `long getDefaultBlockSize(Path p)`
 
-Get the "default" block size for a path —that is, the block size to be used
+Get the "default" block size for a path --that is, the block size to be used
 when writing objects to a path in the filesystem.
 
 #### Preconditions
@@ -530,7 +530,7 @@ on the filesystem.
 
 ### `boolean mkdirs(Path p, FsPermission permission)`
 
-Create a directory and all its parents
+Create a directory and all its parents.
 
 #### Preconditions
 
@@ -545,7 +545,6 @@ No ancestor may be a file
     forall d = ancestors(FS, p) : 
         if exists(FS, d) and not isDir(FS, d) :
             raise [ParentNotDirectoryException, FileAlreadyExistsException, IOException]
-    
 
 #### Postconditions
 
@@ -590,7 +589,6 @@ No ancestor may be a file
     forall d = ancestors(FS, p) : 
         if exists(FS, d) and not isDir(FS, d) :
             raise [ParentNotDirectoryException, FileAlreadyExistsException, IOException]
-  
 
 FileSystems may reject the request for other
 reasons, such as the FS being read-only  (HDFS),
@@ -598,7 +596,8 @@ the block size being below the minimum permitted (HDFS),
 the replication count being out of range (HDFS),
 quotas on namespace or filesystem being exceeded, reserved
 names, etc. All rejections SHOULD be `IOException` or a subclass thereof
-and MAY be a `RuntimeException` or subclass. For instance, HDFS may raise a `InvalidPathException`.
+and MAY be a `RuntimeException` or subclass.
+For instance, HDFS may raise an `InvalidPathException`.
 
 #### Postconditions
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -535,9 +535,17 @@ Create a directory and all its parents
 #### Preconditions
 
 
+The path must either be a directory or not exist
+ 
      if exists(FS, p) and not isDir(FS, p) :
          raise [ParentNotDirectoryException, FileAlreadyExistsException, IOException]
 
+No ancestor may be a file
+
+    forall d = ancestors(FS, p) : 
+        if exists(FS, d) and not isDir(FS, d) :
+            raise [ParentNotDirectoryException, FileAlreadyExistsException, IOException]
+    
 
 #### Postconditions
 
@@ -577,6 +585,12 @@ Writing to or overwriting a directory must fail.
 
     if isDir(FS, p) : raise {FileAlreadyExistsException, FileNotFoundException, IOException}
 
+No ancestor may be a file
+
+    forall d = ancestors(FS, p) : 
+        if exists(FS, d) and not isDir(FS, d) :
+            raise [ParentNotDirectoryException, FileAlreadyExistsException, IOException]
+  
 
 FileSystems may reject the request for other
 reasons, such as the FS being read-only  (HDFS),

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -20,10 +20,7 @@ package org.apache.hadoop.fs.contract;
 
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.test.LambdaTestUtils;
-
 import org.junit.Test;
 
 import java.io.FileNotFoundException;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.fs.contract;
 
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.LambdaTestUtils;
+
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
@@ -29,10 +32,10 @@ import java.io.IOException;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 
 /**
- * Test creating files, overwrite options &c
+ * Test renaming files.
  */
 public abstract class AbstractContractRenameTest extends
-                                                 AbstractFSContractTestBase {
+    AbstractFSContractTestBase {
 
   @Test
   public void testRenameNewFileSameDir() throws Throwable {
@@ -83,7 +86,8 @@ public abstract class AbstractContractRenameTest extends
           "FileNotFoundException",
           e);
     }
-    assertPathDoesNotExist("rename nonexistent file created a destination file", target);
+    assertPathDoesNotExist("rename nonexistent file created a destination file",
+        target);
   }
 
   /**
@@ -112,7 +116,7 @@ public abstract class AbstractContractRenameTest extends
       // the filesystem supports rename(file, file2) by overwriting file2
 
       assertTrue("Rename returned false", renamed);
-        destUnchanged = false;
+      destUnchanged = false;
       } else {
         // rename is rejected by returning 'false' or throwing an exception
         if (renamed && !renameReturnsFalseOnRenameDestExists) {
@@ -129,12 +133,13 @@ public abstract class AbstractContractRenameTest extends
     // verify that the destination file is as expected based on the expected
     // outcome
     verifyFileContents(getFileSystem(), destFile,
-        destUnchanged? destData: srcData);
+        destUnchanged ? destData: srcData);
   }
 
   @Test
   public void testRenameDirIntoExistingDir() throws Throwable {
-    describe("Verify renaming a dir into an existing dir puts it underneath"
+    describe("Verify renaming a dir into an existing dir puts it"
+        + " underneath"
              +" and leaves existing files alone");
     FileSystem fs = getFileSystem();
     String sourceSubdir = "source";
@@ -145,15 +150,15 @@ public abstract class AbstractContractRenameTest extends
     Path destDir = path("dest");
 
     Path destFilePath = new Path(destDir, "dest-512.txt");
-    byte[] destDateset = dataset(512, 'A', 'Z');
-    writeDataset(fs, destFilePath, destDateset, destDateset.length, 1024, false);
+    byte[] destData = dataset(512, 'A', 'Z');
+    writeDataset(fs, destFilePath, destData, destData.length, 1024, false);
     assertIsFile(destFilePath);
 
     boolean rename = rename(srcDir, destDir);
     Path renamedSrc = new Path(destDir, sourceSubdir);
     assertIsFile(destFilePath);
     assertIsDirectory(renamedSrc);
-    verifyFileContents(fs, destFilePath, destDateset);
+    verifyFileContents(fs, destFilePath, destData);
     assertTrue("rename returned false though the contents were copied", rename);
   }
 
@@ -283,6 +288,48 @@ public abstract class AbstractContractRenameTest extends
       assertIsDirectory(parentDst);
       path = path.getParent();
     }
+  }
+
+  @Test
+  public void testRenameFileUnderFile() throws Throwable {
+    String action = "rename directly under file";
+    describe(action);
+    Path base = methodPath();
+    Path grandparent = new Path(base, "file");
+    expectRenameUnderFileFails(action,
+        grandparent,
+        new Path(base, "testRenameSrc"),
+        new Path(grandparent, "testRenameTarget"));
+  }
+
+  @Test
+  public void testRenameFileUnderFileSubdir() throws Throwable {
+    String action = "rename directly under file/subdir";
+    describe(action);
+    Path base = methodPath();
+    Path grandparent = new Path(base, "file");
+    Path parent = new Path(grandparent, "parent");
+    expectRenameUnderFileFails(action,
+        grandparent,
+        new Path(base, "testRenameSrc"),
+        new Path(parent, "testRenameTarget"));
+  }
+
+  protected void expectRenameUnderFileFails(String action,
+      Path file, Path renameSrc, Path renameTarget)
+      throws Exception {
+    byte[] data = dataset(256, 'a', 'z');
+    FileSystem fs = getFileSystem();
+    writeDataset(fs, file, data, data.length, 1024 * 1024,
+        true);
+    writeDataset(fs, renameSrc, data, data.length, 1024 * 1024,
+        true);
+    boolean renamed = rename(renameSrc, renameTarget);
+    String outcome = action + ": rename (" + renameSrc + ", " + renameTarget
+        + ")= " + renamed;
+    assertPathDoesNotExist("after " + outcome, renameTarget);
+    assertFalse(outcome, renamed);
+    assertPathExists(action, renameSrc);
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -324,9 +324,17 @@ public abstract class AbstractContractRenameTest extends
         true);
     writeDataset(fs, renameSrc, data, data.length, 1024 * 1024,
         true);
-    boolean renamed = rename(renameSrc, renameTarget);
-    String outcome = action + ": rename (" + renameSrc + ", " + renameTarget
-        + ")= " + renamed;
+    String outcome;
+    boolean renamed;
+    try {
+      renamed = rename(renameSrc, renameTarget);
+      outcome = action + ": rename (" + renameSrc + ", " + renameTarget
+          + ")= " + renamed;
+    } catch (IOException e) {
+      // raw local raises an exception here
+      renamed = false;
+      outcome = "rename raised an exception: " + e;
+    }
     assertPathDoesNotExist("after " + outcome, renameTarget);
     assertFalse(outcome, renamed);
     assertPathExists(action, renameSrc);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -291,7 +291,7 @@ public abstract class AbstractContractRenameTest extends
   }
 
   @Test
-  public void testRenameFileUnderFile() throws Throwable {
+  public void testRenameFileUnderFile() throws Exception {
     String action = "rename directly under file";
     describe(action);
     Path base = methodPath();
@@ -303,7 +303,7 @@ public abstract class AbstractContractRenameTest extends
   }
 
   @Test
-  public void testRenameFileUnderFileSubdir() throws Throwable {
+  public void testRenameFileUnderFileSubdir() throws Exception {
     String action = "rename directly under file/subdir";
     describe(action);
     Path base = methodPath();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContractTestBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractFSContractTestBase.java
@@ -226,6 +226,15 @@ public abstract class AbstractFSContractTestBase extends Assert
   }
 
   /**
+   * Get a path whose name ends with the name of this method.
+   * @return a path implicitly unique amongst all methods in this class
+   * @throws IOException IO problems
+   */
+  protected Path methodPath() throws IOException {
+    return path(methodName.getMethodName());
+  }
+
+  /**
    * Take a simple path like "/something" and turn it into
    * a qualified path against the test FS.
    * @param filepath path string in

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractOptions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractOptions.java
@@ -52,6 +52,15 @@ public interface ContractOptions {
   String CREATE_VISIBILITY_DELAYED = "create-visibility-delayed";
 
   /**
+   * Flag to indicate that it is possible to create a file under a file.
+   * This is a complete violation of the filesystem rules, but it is one
+   * which object stores have been known to do for performance
+   * <i>and because nobody has ever noticed.</i>
+   * {@value}
+   */
+  String CREATE_FILE_UNDER_FILE_ALLOWED = "create-file-under-file-allowed";
+
+  /**
    * Is a filesystem case sensitive.
    * Some of the filesystems that say "no" here may mean
    * that it varies from platform to platform -the localfs being the key

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -1543,7 +1543,8 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
           DSQuotaExceededException.class,
           QuotaByStorageTypeExceededException.class,
           UnresolvedPathException.class,
-          SnapshotAccessControlException.class);
+          SnapshotAccessControlException.class,
+          ParentNotDirectoryException.class);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/resources/contract/s3a.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/contract/s3a.xml
@@ -127,4 +127,9 @@
     <value>true</value>
   </property>
 
+  <property>
+    <name>fs.contract.create-file-under-file-allowed</name>
+    <value>true</value>
+  </property>
+
 </configuration>

--- a/hadoop-tools/hadoop-azure-datalake/src/test/java/org/apache/hadoop/fs/adl/live/TestAdlContractRenameLive.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/test/java/org/apache/hadoop/fs/adl/live/TestAdlContractRenameLive.java
@@ -19,9 +19,13 @@
 
 package org.apache.hadoop.fs.adl.live;
 
+import org.junit.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.security.AccessControlException;
+import org.apache.hadoop.test.LambdaTestUtils;
 
 /**
  * Test rename contract test cases on Adl file system.
@@ -31,5 +35,16 @@ public class TestAdlContractRenameLive extends AbstractContractRenameTest {
   @Override
   protected AbstractFSContract createContract(Configuration configuration) {
     return new AdlStorageContract(configuration);
+  }
+
+  /**
+   * ADL throws an Access Control Exception rather than return false.
+   * This is caught and its error text checked, to catch regressions.
+   */
+  @Test
+  public void testRenameFileUnderFile() throws Exception {
+    LambdaTestUtils.intercept(AccessControlException.class,
+        "Parent path is not a folder.",
+        super::testRenameFileUnderFile);
   }
 }

--- a/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystem.java
+++ b/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystem.java
@@ -596,14 +596,12 @@ public class SwiftNativeFileSystem extends FileSystem {
       store.rename(makeAbsolute(src), makeAbsolute(dst));
       //success
       return true;
-    } catch (SwiftOperationFailedException e) {
+    } catch (SwiftOperationFailedException
+        | FileAlreadyExistsException
+        | FileNotFoundException
+        | ParentNotDirectoryException e) {
       //downgrade to a failure
-      return false;
-    } catch (FileAlreadyExistsException e) {
-      //downgrade to a failure
-      return false;
-    } catch (FileNotFoundException e) {
-      //downgrade to a failure
+      LOG.debug("rename({}, {}) failed",src, dst, e);
       return false;
     }
   }

--- a/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystem.java
+++ b/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystem.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -46,6 +47,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -729,6 +731,31 @@ public class SwiftNativeFileSystem extends FileSystem {
   public static long getBytesUploaded(FSDataOutputStream outputStream) {
     SwiftNativeOutputStream snos = getSwiftNativeOutputStream(outputStream);
     return snos.getBytesUploaded();
+  }
+
+  /**
+   * {@inheritDoc}
+   * @throws FileNotFoundException if the parent directory is not present -or
+   * is not a directory.
+   */
+  @Override
+  public FSDataOutputStream createNonRecursive(Path path,
+      FsPermission permission,
+      EnumSet<CreateFlag> flags,
+      int bufferSize,
+      short replication,
+      long blockSize,
+      Progressable progress) throws IOException {
+    Path parent = path.getParent();
+    if (parent != null) {
+      // expect this to raise an exception if there is no parent
+      if (!getFileStatus(parent).isDirectory()) {
+        throw new FileAlreadyExistsException("Not a directory: " + parent);
+      }
+    }
+    return create(path, permission,
+        flags.contains(CreateFlag.OVERWRITE), bufferSize,
+        replication, blockSize, progress);
   }
 
 }

--- a/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystemStore.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.fs.swift.snative;
 
 import com.fasterxml.jackson.databind.type.CollectionType;
 
+import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.message.BasicHeader;
@@ -562,12 +563,16 @@ public class SwiftNativeFileSystemStore {
     //parent dir (in which case the dest dir exists), or the destination
     //directory is root, in which case it must also exist
     if (dstParent != null && !dstParent.equals(srcParent)) {
+      SwiftFileStatus fileStatus;
       try {
-        getObjectMetadata(dstParent);
+        fileStatus = getObjectMetadata(dstParent);
       } catch (FileNotFoundException e) {
         //destination parent doesn't exist; bail out
         LOG.debug("destination parent directory " + dstParent + " doesn't exist");
         throw e;
+      }
+      if (!fileStatus.isDir()) {
+        throw new ParentNotDirectoryException(dstParent.toString());
       }
     }
 

--- a/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-openstack/src/main/java/org/apache/hadoop/fs/swift/snative/SwiftNativeFileSystemStore.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.fs.swift.snative;
 
 import com.fasterxml.jackson.databind.type.CollectionType;
 
-import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.message.BasicHeader;
@@ -28,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.swift.exceptions.SwiftConfigurationException;
 import org.apache.hadoop.fs.swift.exceptions.SwiftException;


### PR DESCRIPTION
HADOOP-14630. Contract Tests to verify create, mkdirs and rename under a file is forbidden