### PR TITLE
HDDS-1214. Enable tracing for the datanode read/write path

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Proxy;
 import io.jaegertracing.Configuration;
 import io.jaegertracing.internal.JaegerTracer;
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
@@ -60,6 +61,19 @@ public final class TracingUtil {
     if (GlobalTracer.get().activeSpan() != null) {
       GlobalTracer.get().inject(GlobalTracer.get().activeSpan().context(),
           StringCodec.FORMAT, builder);
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Export the specific span as a string.
+   *
+   * @return encoded tracing context.
+   */
+  public static String exportSpan(Span span) {
+    StringBuilder builder = new StringBuilder();
+    if (span != null) {
+      GlobalTracer.get().inject(span.context(), StringCodec.FORMAT, builder);
     }
     return builder.toString();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.CloseContainerCommandProto;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.statemachine
     .SCMConnectionManager;
@@ -133,6 +134,7 @@ public class CloseContainerCommandHandler implements CommandHandler {
     final ContainerCommandRequestProto.Builder command =
         ContainerCommandRequestProto.newBuilder();
     command.setCmdType(ContainerProtos.Type.CloseContainer);
+    command.setTraceID(TracingUtil.exportCurrentSpan());
     command.setContainerID(containerId);
     command.setCloseContainer(
         ContainerProtos.CloseContainerRequestProto.getDefaultInstance());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -25,7 +25,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 
-import io.opentracing.Scope;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
@@ -51,7 +50,6 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ReadChunkRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ReadChunkResponseProto;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.hdds.security.token.TokenVerifier;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -271,51 +269,50 @@ public class ContainerStateMachine extends BaseStateMachine {
     final ContainerCommandRequestProto proto =
         getContainerCommandRequestProto(request.getMessage().getContent());
     Preconditions.checkArgument(request.getRaftGroupId().equals(gid));
-    try (Scope scope = TracingUtil
-        .importAndCreateScope(proto.getCmdType().name(), proto.getTraceID())) {
-      try {
-        dispatcher.validateContainerCommand(proto);
-      } catch (IOException ioe) {
-        TransactionContext ctxt = TransactionContext.newBuilder()
-            .setClientRequest(request)
-            .setStateMachine(this)
-            .setServerRole(RaftPeerRole.LEADER)
-            .build();
-        ctxt.setException(ioe);
-        return ctxt;
-      }
-      if (proto.getCmdType() == Type.WriteChunk) {
-        final WriteChunkRequestProto write = proto.getWriteChunk();
-        // create the log entry proto
-        final WriteChunkRequestProto commitWriteChunkProto =
-            WriteChunkRequestProto.newBuilder()
-                .setBlockID(write.getBlockID())
-                .setChunkData(write.getChunkData())
-                // skipping the data field as it is
-                // already set in statemachine data proto
-                .build();
-        ContainerCommandRequestProto commitContainerCommandProto =
-            ContainerCommandRequestProto
-                .newBuilder(proto)
-                .setWriteChunk(commitWriteChunkProto)
-                .build();
-
-        return TransactionContext.newBuilder()
-            .setClientRequest(request)
-            .setStateMachine(this)
-            .setServerRole(RaftPeerRole.LEADER)
-            .setStateMachineData(write.getData())
-            .setLogData(commitContainerCommandProto.toByteString())
-            .build();
-      } else {
-        return TransactionContext.newBuilder()
-            .setClientRequest(request)
-            .setStateMachine(this)
-            .setServerRole(RaftPeerRole.LEADER)
-            .setLogData(request.getMessage().getContent())
-            .build();
-      }
+    try {
+      dispatcher.validateContainerCommand(proto);
+    } catch (IOException ioe) {
+      TransactionContext ctxt = TransactionContext.newBuilder()
+          .setClientRequest(request)
+          .setStateMachine(this)
+          .setServerRole(RaftPeerRole.LEADER)
+          .build();
+      ctxt.setException(ioe);
+      return ctxt;
     }
+    if (proto.getCmdType() == Type.WriteChunk) {
+      final WriteChunkRequestProto write = proto.getWriteChunk();
+      // create the log entry proto
+      final WriteChunkRequestProto commitWriteChunkProto =
+          WriteChunkRequestProto.newBuilder()
+              .setBlockID(write.getBlockID())
+              .setChunkData(write.getChunkData())
+              // skipping the data field as it is
+              // already set in statemachine data proto
+              .build();
+      ContainerCommandRequestProto commitContainerCommandProto =
+          ContainerCommandRequestProto
+              .newBuilder(proto)
+              .setWriteChunk(commitWriteChunkProto)
+              .setTraceID(proto.getTraceID())
+              .build();
+
+      return TransactionContext.newBuilder()
+          .setClientRequest(request)
+          .setStateMachine(this)
+          .setServerRole(RaftPeerRole.LEADER)
+          .setStateMachineData(write.getData())
+          .setLogData(commitContainerCommandProto.toByteString())
+          .build();
+    } else {
+      return TransactionContext.newBuilder()
+          .setClientRequest(request)
+          .setStateMachine(this)
+          .setServerRole(RaftPeerRole.LEADER)
+          .setLogData(request.getMessage().getContent())
+          .build();
+    }
+
   }
 
   private ByteString getStateMachineData(StateMachineLogEntryProto entryProto) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -486,7 +486,8 @@ public final class XceiverServerRatis extends XceiverServer {
     super.submitRequest(request, pipelineID);
     RaftClientReply reply;
     try (Scope scope = TracingUtil
-        .importAndCreateScope(request.getCmdType().name(),
+        .importAndCreateScope(
+            "XceiverServerRatis." + request.getCmdType().name(),
             request.getTraceID())) {
 
       RaftClientRequest raftClientRequest =


### PR DESCRIPTION
HDDS-1150 introduced distributed for ozone components. But we have no trace context propagation between the clients and Ozone Datanodes.

As we use Grpc and Ratis on this RPC path the full tracing could be quite complex: we should propagate the trace id in Ratis and include it in all the log entries.

I propose a simplified solution here: to trace only the StateMachine operations.

As Ratis is a library we provide the implementation of the appropriate Raft elements especially the StateMachine and the raft messages. We can add the tracing information to the raft messages (in fact, we already have this field) and we can restore the tracing context during the StateMachine operations.

This approach is very simple (only a few lines of codes) and can show the time of the real write/read operations, but can't see the internals of the Ratis operations.

See: https://issues.apache.org/jira/browse/HDDS-1214