### PR TITLE
HADOOP-16162 Remove unused Job Summary Appender configurations from log4j.properties

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/conf/log4j.properties
+++ b/hadoop-common-project/hadoop-common/src/main/conf/log4j.properties
@@ -182,25 +182,6 @@ log4j.logger.com.amazonaws.http.AmazonHttpClient=ERROR
 #
 log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
 
-#
-# Job Summary Appender
-#
-# Use following logger to send summary to separate file defined by
-# hadoop.mapreduce.jobsummary.log.file :
-# hadoop.mapreduce.jobsummary.logger=INFO,JSA
-# 
-hadoop.mapreduce.jobsummary.logger=${hadoop.root.logger}
-hadoop.mapreduce.jobsummary.log.file=hadoop-mapreduce.jobsummary.log
-hadoop.mapreduce.jobsummary.log.maxfilesize=256MB
-hadoop.mapreduce.jobsummary.log.maxbackupindex=20
-log4j.appender.JSA=org.apache.log4j.RollingFileAppender
-log4j.appender.JSA.File=${hadoop.log.dir}/${hadoop.mapreduce.jobsummary.log.file}
-log4j.appender.JSA.MaxFileSize=${hadoop.mapreduce.jobsummary.log.maxfilesize}
-log4j.appender.JSA.MaxBackupIndex=${hadoop.mapreduce.jobsummary.log.maxbackupindex}
-log4j.appender.JSA.layout=org.apache.log4j.PatternLayout
-log4j.appender.JSA.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
-log4j.logger.org.apache.hadoop.mapred.JobInProgress$JobSummary=${hadoop.mapreduce.jobsummary.logger}
-log4j.additivity.org.apache.hadoop.mapred.JobInProgress$JobSummary=false
 
 #
 # shuffle connection log from shuffleHandler


### PR DESCRIPTION
HADOOP-16162 Remove unused Job Summary Appender configurations from log4j.properties

The Job Summary Appender (JSA) is introduced in MAPREDUCE-740 to provide the summary information of the job's runtime. And this appender is only referenced by the logger defined in `org.apache.hadoop.mapred.JobInProgress$JobSummary`. However, this class has been removed in MAPREDUCE-4266 together with other M/R1 files. This appender is no longer used and I guess we can remove it.