### PR TITLE
HDDS-1219. TestContainerActionsHandler.testCloseContainerAction has an intermittent failure

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerActionsHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerActionsHandler.java
@@ -59,7 +59,7 @@ public class TestContainerActionsHandler {
             TestUtils.randomDatanodeDetails(), cap);
 
     queue.fireEvent(SCMEvents.CONTAINER_ACTIONS, containerActions);
-
+    queue.processAll(1000L);
     verify(closeContainerEventHandler, times(1))
         .onMessage(ContainerID.valueof(1L), queue);
 


### PR DESCRIPTION
It's failed multiple times during the CI builds:

{code}
Error Message

Wanted but not invoked:
closeContainerEventHandler.onMessage(
    #1,
    org.apache.hadoop.hdds.server.events.EventQueue@3d3fcdb0
);
-> at org.apache.hadoop.hdds.scm.container.TestContainerActionsHandler.testCloseContainerAction(TestContainerActionsHandler.java:64)
Actually, there were zero interactions with this mock.
{code}

The fix is easy: we should call queue.processAll(1000L) to wait for the processing of all the events.


See: https://issues.apache.org/jira/browse/HDDS-1219