### PR TITLE
HADOOP-15691 Add PathCapabilities to FS and FC to complement StreamCapabilities

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
@@ -1362,4 +1362,16 @@ public abstract class AbstractFileSystem {
         new CompletableFuture<>(), () -> open(path, bufferSize));
   }
 
+  /**
+   * Return the base capabilities of the filesystems
+   * may override to declare different behavior.
+   * @param capability string to query the stream support for.
+   * @param path path to query the capability of.
+   * @return true if the capability is supported under that part of the FS.
+   * @throws IOException on failure
+   */
+  public boolean hasCapability(String capability, Path path)
+      throws IOException {
+    return false;
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
@@ -1379,10 +1379,10 @@ public abstract class AbstractFileSystem implements PathCapabilities {
     // qualify the path to make sure that it refers to the current FS.
     makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case FS_SYMLINKS:
+    case CommonPathCapabilities.FS_SYMLINKS:
       // delegate to the existing supportsSymlinks() call.
       return supportsSymlinks();
-    case FS_DELEGATION_TOKENS:
+    case CommonPathCapabilities.FS_DELEGATION_TOKENS:
       // this is less efficient than it should be.
       return getCanonicalServiceName() != null;
     default:

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.util.LambdaUtils;
 import org.apache.hadoop.util.Progressable;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1373,6 +1374,9 @@ public abstract class AbstractFileSystem implements PathCapabilities {
   public boolean hasPathCapability(final Path path,
       final String capability)
       throws IOException {
+    Preconditions.checkArgument(capability != null && !capability.isEmpty(),
+        "null/empty capability");
+    makeQualified(path);
     return false;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public abstract class AbstractFileSystem {
+public abstract class AbstractFileSystem implements PathCapabilities {
   static final Logger LOG = LoggerFactory.getLogger(AbstractFileSystem.class);
 
   /** Recording statistics per a file system class. */
@@ -1365,12 +1365,13 @@ public abstract class AbstractFileSystem {
   /**
    * Return the base capabilities of the filesystems
    * may override to declare different behavior.
-   * @param capability string to query the stream support for.
    * @param path path to query the capability of.
+   * @param capability string to query the stream support for.
    * @return true if the capability is supported under that part of the FS.
    * @throws IOException on failure
    */
-  public boolean hasCapability(String capability, Path path)
+  public boolean hasPathCapability(final Path path,
+      final String capability)
       throws IOException {
     return false;
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -866,4 +867,24 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
   public FSDataOutputStreamBuilder appendFile(Path path) {
     return createDataOutputStreamBuilder(this, path).append();
   }
+
+  /**
+   * Disable those operations which are disabled so as to guarantee
+   * checksumming of all created files.
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case PathCapabilities.FS_APPEND:
+    case PathCapabilities.FS_CONCAT:
+      return false;
+    default:
+      return superCapability;
+    }
+  }  
+  
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -879,12 +879,12 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
     // query the superclass, which triggers argument validation.
     boolean superCapability = super.hasPathCapability(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_APPEND:
-    case PathCapabilities.FS_CONCAT:
+    case CommonPathCapabilities.FS_APPEND:
+    case CommonPathCapabilities.FS_CONCAT:
       return false;
     default:
       return superCapability;
     }
-  }  
-  
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonPathCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonPathCapabilities.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs;
+
+import java.util.List;
+
+import org.apache.hadoop.fs.permission.FsPermission;
+
+/**
+ * Common path capabilities.
+ */
+public final class CommonPathCapabilities {
+
+  public CommonPathCapabilities() {
+  }
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#setAcl(Path, List)},
+   * {@link FileSystem#getAclStatus(Path)}
+   * and related methods?
+   * Value: {@value}.
+   */
+  public static final String FS_ACLS = "fs.paths.acls";
+
+  /**
+   * Does the Filesystem support {@link FileSystem#append(Path)}?
+   * Value: {@value}.
+   */
+  public static final String FS_APPEND = "fs.paths.append";
+
+  /**
+   * Does the FS support {@link FileSystem#getFileChecksum(Path)}?
+   * Value: {@value}.
+   */
+  public static final String FS_CHECKSUMS = "fs.paths.checksums";
+
+  /**
+   * Does the FS support {@link FileSystem#concat(Path, Path[])}?
+   * Value: {@value}.
+   */
+  public static final String FS_CONCAT = "fs.paths.concat";
+
+  /**
+   * Does the filesystem support Delegation Tokens?
+   * Value: {@value}.
+   */
+  public static final String FS_DELEGATION_TOKENS =
+      "fs.paths.delegation.tokens";
+
+  /**
+   * Does the FS support {@link FileSystem#listCorruptFileBlocks(Path)} ()}?
+   * Value: {@value}.
+   */
+  public static final String FS_LIST_CORRUPT_FILE_BLOCKS =
+      "fs.paths.list-corrupt-file-blocks";
+
+  /**
+   * Does the FS support
+   * {@link FileSystem#createPathHandle(FileStatus, Options.HandleOpt...)}
+   * and related methods?
+   * Value: {@value}.
+   */
+  public static final String FS_PATHHANDLES = "fs.paths.pathhandles";
+
+  /**
+   * Does the FS support {@link FileSystem#setPermission(Path, FsPermission)}
+   * and related methods?
+   * Value: {@value}.
+   */
+  public static final String FS_PERMISSIONS = "fs.paths.permissions";
+
+  /**
+   * Does this filesystem connector only support filesystem read operations?
+   * For example, the {@code HttpFileSystem} is always read-only.
+   * This is different from "is the specific instance and path read only?",
+   * which must be determined by checking permissions (where supported), or
+   * attempting write operations under a path.
+   * Value: {@value}.
+   */
+  public static final String FS_READ_ONLY_CONNECTOR =
+      "fs.paths.read-only-connector";
+
+  /**
+   * Does the FS support snapshots through
+   * {@link FileSystem#createSnapshot(Path)} and related methods??
+   * Value: {@value}.
+   */
+  public static final String FS_SNAPSHOTS = "fs.paths.snapshots";
+
+  /**
+   * Does the FS support {@link FileSystem#setStoragePolicy(Path, String)}
+   * and related methods?
+   * Value: {@value}.
+   */
+  public static final String FS_STORAGEPOLICY =
+      "fs.paths.storagepolicy";
+
+  /**
+   * Does the FS support symlinks through
+   * {@link FileSystem#createSymlink(Path, Path, boolean)} and related methods?
+   * Value: {@value}.
+   */
+  public static final String FS_SYMLINKS =
+      "fs.paths.symlinks";
+
+  /**
+   * Does the FS support {@link FileSystem#truncate(Path, long)} ?
+   * Value: {@value}.
+   */
+  public static final String FS_TRUNCATE =
+      "fs.paths.truncate";
+
+  /**
+   * Does the Filesystem support XAttributes through
+   * {@link FileSystem#setXAttr(Path, String, byte[])} and related methods?
+   * Value: {@value}.
+   */
+  public static final String FS_XATTRS = "fs.paths.xattrs";
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java
@@ -285,8 +285,9 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  public boolean hasCapability(final String capability, final Path path)
+  public boolean hasPathCapability(final Path path,
+      final String capability)
       throws IOException {
-    return fsImpl.hasCapability(capability, path);
+    return fsImpl.hasPathCapability(path, capability);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java
@@ -42,13 +42,15 @@ import org.apache.hadoop.util.Progressable;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public abstract class DelegateToFileSystem extends AbstractFileSystem {
+
   private static final int DELEGATE_TO_FS_DEFAULT_PORT = -1;
+
   protected final FileSystem fsImpl;
-  
+
   protected DelegateToFileSystem(URI theUri, FileSystem theFsImpl,
       Configuration conf, String supportedScheme, boolean authorityRequired)
       throws IOException, URISyntaxException {
-    super(theUri, supportedScheme, authorityRequired, 
+    super(theUri, supportedScheme, authorityRequired,
         getDefaultPortIfDefined(theFsImpl));
     fsImpl = theFsImpl;
     fsImpl.initialize(theUri, conf);
@@ -74,15 +76,15 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   public Path getInitialWorkingDirectory() {
     return fsImpl.getInitialWorkingDirectory();
   }
-  
+
   @Override
   @SuppressWarnings("deprecation") // call to primitiveCreate
-  public FSDataOutputStream createInternal (Path f,
+  public FSDataOutputStream createInternal(Path f,
       EnumSet<CreateFlag> flag, FsPermission absolutePermission, int bufferSize,
       short replication, long blockSize, Progressable progress,
       ChecksumOpt checksumOpt, boolean createParent) throws IOException {
     checkPath(f);
-    
+
     // Default impl assumes that permissions do not matter
     // calling the regular create is good enough.
     // FSs that implement permissions should override this.
@@ -95,7 +97,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
         throw new FileNotFoundException("Missing parent:" + f);
       }
       if (!stat.isDirectory()) {
-          throw new ParentNotDirectoryException("parent is not a dir:" + f);
+        throw new ParentNotDirectoryException("parent is not a dir:" + f);
       }
       // parent does exist - go ahead with create of file.
     }
@@ -155,7 +157,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   public FsServerDefaults getServerDefaults() throws IOException {
     return fsImpl.getServerDefaults();
   }
-  
+
   @Override
   public FsServerDefaults getServerDefaults(final Path f) throws IOException {
     return fsImpl.getServerDefaults(f);
@@ -183,7 +185,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
       throws IOException {
     checkPath(dir);
     fsImpl.primitiveMkdir(dir, permission, createParent);
-    
+
   }
 
   @Override
@@ -241,14 +243,14 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   @Override
   public boolean supportsSymlinks() {
     return fsImpl.supportsSymlinks();
-  }  
-  
+  }
+
   @Override
-  public void createSymlink(Path target, Path link, boolean createParent) 
-      throws IOException { 
+  public void createSymlink(Path target, Path link, boolean createParent)
+      throws IOException {
     fsImpl.createSymlink(target, link, createParent);
-  } 
-  
+  }
+
   @Override
   public Path getLinkTarget(final Path f) throws IOException {
     return fsImpl.getLinkTarget(f);
@@ -258,7 +260,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   public String getCanonicalServiceName() {
     return fsImpl.getCanonicalServiceName();
   }
-  
+
   @Override //AbstractFileSystem
   public List<Token<?>> getDelegationTokens(String renewer) throws IOException {
     return Arrays.asList(fsImpl.addDelegationTokens(renewer, null));
@@ -280,5 +282,11 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
       Configuration options,
       int bufferSize) throws IOException {
     return fsImpl.openFileWithOptions(path, mandatoryKeys, options, bufferSize);
+  }
+
+  @Override
+  public boolean hasCapability(final String capability, final Path path)
+      throws IOException {
+    return fsImpl.hasCapability(capability, path);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java
@@ -42,15 +42,13 @@ import org.apache.hadoop.util.Progressable;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public abstract class DelegateToFileSystem extends AbstractFileSystem {
-
   private static final int DELEGATE_TO_FS_DEFAULT_PORT = -1;
-
   protected final FileSystem fsImpl;
-
+  
   protected DelegateToFileSystem(URI theUri, FileSystem theFsImpl,
       Configuration conf, String supportedScheme, boolean authorityRequired)
       throws IOException, URISyntaxException {
-    super(theUri, supportedScheme, authorityRequired,
+    super(theUri, supportedScheme, authorityRequired, 
         getDefaultPortIfDefined(theFsImpl));
     fsImpl = theFsImpl;
     fsImpl.initialize(theUri, conf);
@@ -76,15 +74,15 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   public Path getInitialWorkingDirectory() {
     return fsImpl.getInitialWorkingDirectory();
   }
-
+  
   @Override
   @SuppressWarnings("deprecation") // call to primitiveCreate
-  public FSDataOutputStream createInternal(Path f,
+  public FSDataOutputStream createInternal (Path f,
       EnumSet<CreateFlag> flag, FsPermission absolutePermission, int bufferSize,
       short replication, long blockSize, Progressable progress,
       ChecksumOpt checksumOpt, boolean createParent) throws IOException {
     checkPath(f);
-
+    
     // Default impl assumes that permissions do not matter
     // calling the regular create is good enough.
     // FSs that implement permissions should override this.
@@ -97,7 +95,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
         throw new FileNotFoundException("Missing parent:" + f);
       }
       if (!stat.isDirectory()) {
-        throw new ParentNotDirectoryException("parent is not a dir:" + f);
+          throw new ParentNotDirectoryException("parent is not a dir:" + f);
       }
       // parent does exist - go ahead with create of file.
     }
@@ -157,7 +155,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   public FsServerDefaults getServerDefaults() throws IOException {
     return fsImpl.getServerDefaults();
   }
-
+  
   @Override
   public FsServerDefaults getServerDefaults(final Path f) throws IOException {
     return fsImpl.getServerDefaults(f);
@@ -185,7 +183,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
       throws IOException {
     checkPath(dir);
     fsImpl.primitiveMkdir(dir, permission, createParent);
-
+    
   }
 
   @Override
@@ -243,14 +241,14 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   @Override
   public boolean supportsSymlinks() {
     return fsImpl.supportsSymlinks();
-  }
-
+  }  
+  
   @Override
-  public void createSymlink(Path target, Path link, boolean createParent)
-      throws IOException {
+  public void createSymlink(Path target, Path link, boolean createParent) 
+      throws IOException { 
     fsImpl.createSymlink(target, link, createParent);
-  }
-
+  } 
+  
   @Override
   public Path getLinkTarget(final Path f) throws IOException {
     return fsImpl.getLinkTarget(f);
@@ -260,7 +258,7 @@ public abstract class DelegateToFileSystem extends AbstractFileSystem {
   public String getCanonicalServiceName() {
     return fsImpl.getCanonicalServiceName();
   }
-
+  
   @Override //AbstractFileSystem
   public List<Token<?>> getDelegationTokens(String renewer) throws IOException {
     return Arrays.asList(fsImpl.addDelegationTokens(renewer, null));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.Options.CreateOpts;
 import org.apache.hadoop.fs.impl.FutureDataInputStreamBuilderImpl;
+import org.apache.hadoop.fs.impl.FsLinkResolution;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -2941,9 +2943,11 @@ public class FileContext implements PathCapabilities {
    * @param capability string to query the stream support for.
    * @return true iff the capability is supported under that FS.
    * @throws IOException path resolution or other IO failure
+   * @throws IllegalArgumentException invalid arguments
    */
   public boolean hasPathCapability(Path path, String capability)
       throws IOException {
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
     return FsLinkResolution.resolve(this,
         fixRelativePart(path),
         (fs, p) -> fs.hasPathCapability(p, capability));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
@@ -171,7 +171,7 @@ import org.slf4j.LoggerFactory;
 
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public class FileContext {
+public class FileContext implements PathCapabilities {
   
   public static final Logger LOG = LoggerFactory.getLogger(FileContext.class);
   /**
@@ -836,7 +836,7 @@ public class FileContext {
     Path absF = fixRelativePart(f);
     return new FSLinkResolver<Boolean>() {
       @Override
-      public Boolean next(final AbstractFileSystem fs, final Path p) 
+      public Boolean next(final AbstractFileSystem fs, final Path p)
         throws IOException, UnresolvedLinkException {
         return fs.delete(p, recursive);
       }
@@ -2936,23 +2936,17 @@ public class FileContext {
   }
 
   /**
-   * Return the base capabilities of all filesystems; subclasses
-   * may override to declare different behavior.
-   * @param capability string to query the stream support for.
+   * Return the path capabilities of the bonded {@code AbstractFileSystem}.
    * @param path path to query the capability of.
-   * @return true if the capability is supported under that part of the FS.
-   * @throws IOException path resolution failure
+   * @param capability string to query the stream support for.
+   * @return true iff the capability is supported under that FS.
+   * @throws IOException path resolution or other IO failure
    */
-  public boolean hasCapability(String capability, Path path)
+  public boolean hasPathCapability(Path path, String capability)
       throws IOException {
-    return new FSLinkResolver<Boolean>() {
-      @Override
-      public Boolean next(final AbstractFileSystem fs,
-          final Path p)
-          throws IOException {
-        return fs.hasCapability(capability, p);
-      }
-    }.resolve(this, fixRelativePart(path));
+    return FsLinkResolution.resolve(this,
+        fixRelativePart(path),
+        (fs, p) -> fs.hasPathCapability(p, capability));
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
@@ -836,7 +836,7 @@ public class FileContext implements PathCapabilities {
     Path absF = fixRelativePart(f);
     return new FSLinkResolver<Boolean>() {
       @Override
-      public Boolean next(final AbstractFileSystem fs, final Path p)
+      public Boolean next(final AbstractFileSystem fs, final Path p) 
         throws IOException, UnresolvedLinkException {
         return fs.delete(p, recursive);
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
@@ -2934,4 +2934,25 @@ public class FileContext {
       }.resolve(FileContext.this, absF);
     }
   }
+
+  /**
+   * Return the base capabilities of all filesystems; subclasses
+   * may override to declare different behavior.
+   * @param capability string to query the stream support for.
+   * @param path path to query the capability of.
+   * @return true if the capability is supported under that part of the FS.
+   * @throws IOException path resolution failure
+   */
+  public boolean hasCapability(String capability, Path path)
+      throws IOException {
+    return new FSLinkResolver<Boolean>() {
+      @Override
+      public Boolean next(final AbstractFileSystem fs,
+          final Path p)
+          throws IOException {
+        return fs.hasCapability(capability, p);
+      }
+    }.resolve(this, fixRelativePart(path));
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3213,6 +3213,17 @@ public abstract class FileSystem extends Configured
     return ret;
   }
 
+  /**
+   * Return the base capabilities of all filesystems; subclasses
+   * may override to declare different behavior.
+   * @param capability string to query the stream support for.
+   * @param path path to query the capability of.
+   * @return true if the capability is supported under that part of the FS.
+   */
+  public boolean hasCapability(String capability, Path path) {
+    return false;
+  }
+
   // making it volatile to be able to do a double checked locking
   private volatile static boolean FILE_SYSTEMS_LOADED = false;
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3219,8 +3219,11 @@ public abstract class FileSystem extends Configured
    * @param capability string to query the stream support for.
    * @param path path to query the capability of.
    * @return true if the capability is supported under that part of the FS.
+   * @throws IOException this should not be raised, except on problems
+   * resolving paths or relaying the call.
    */
-  public boolean hasCapability(String capability, Path path) {
+  public boolean hasCapability(String capability, Path path)
+      throws IOException {
     return false;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -710,6 +710,7 @@ public abstract class FileSystem extends Configured
    *
    */
   protected void checkPath(Path path) {
+    Preconditions.checkArgument(path != null, "null path");
     URI uri = path.toUri();
     String thatScheme = uri.getScheme();
     if (thatScheme == null)                // fs is relative
@@ -3219,20 +3220,18 @@ public abstract class FileSystem extends Configured
    * of the capabilities of actual implementations.
    * Unless it has a way to explicitly determine the capabilities,
    * this method returns false.
-   * @param path path to query the capability of.
-   * @param capability string to query the stream support for.
-   * @return false
-   * @throws IOException this should not be raised, except on problems
-   * resolving paths or relaying the call.
+   * {@inheritDoc}
    */
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
+    Preconditions.checkArgument(capability != null && !capability.isEmpty(),
+        "null/empty capability");
     // qualify the path to make sure that it refers to the current FS.
     makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_SYMLINKS:
+    case PathCapabilities.FS_SYMLINKS:
       // delegate to the existing supportsSymlinks() call.
-      return supportsSymlinks();
+      return supportsSymlinks() && areSymlinksEnabled();
     default:
       // the feature is not implemented.
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.fs.Options.HandleOpt;
 import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.fs.impl.AbstractFSBuilderImpl;
 import org.apache.hadoop.fs.impl.FutureDataInputStreamBuilderImpl;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -3224,14 +3225,16 @@ public abstract class FileSystem extends Configured
    */
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    Preconditions.checkArgument(capability != null && !capability.isEmpty(),
-        "null/empty capability");
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
     // qualify the path to make sure that it refers to the current FS.
     makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_SYMLINKS:
+    case FS_SYMLINKS:
       // delegate to the existing supportsSymlinks() call.
       return supportsSymlinks() && areSymlinksEnabled();
+    case FS_DELEGATION_TOKENS:
+      // this is less efficient than it should be.
+      return getCanonicalServiceName() != null;
     default:
       // the feature is not implemented.
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3229,10 +3229,10 @@ public abstract class FileSystem extends Configured
     // qualify the path to make sure that it refers to the current FS.
     makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case FS_SYMLINKS:
+    case CommonPathCapabilities.FS_SYMLINKS:
       // delegate to the existing supportsSymlinks() call.
       return supportsSymlinks() && areSymlinksEnabled();
-    case FS_DELEGATION_TOKENS:
+    case CommonPathCapabilities.FS_DELEGATION_TOKENS:
       // this is less efficient than it should be.
       return getCanonicalServiceName() != null;
     default:

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFileSystem.java
@@ -725,4 +725,10 @@ public class FilterFileSystem extends FileSystem {
     return fs.openFileWithOptions(pathHandle, mandatoryKeys, options,
         bufferSize);
   }
+  
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    return fs.hasPathCapability(path, capability);
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFileSystem.java
@@ -725,7 +725,7 @@ public class FilterFileSystem extends FileSystem {
     return fs.openFileWithOptions(pathHandle, mandatoryKeys, options,
         bufferSize);
   }
-  
+
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
     return fs.hasPathCapability(path, capability);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFs.java
@@ -446,4 +446,8 @@ public abstract class FilterFs extends AbstractFileSystem {
     return myFs.openFileWithOptions(path, mandatoryKeys, options, bufferSize);
   }
 
+  public boolean hasCapability(final String capability, final Path path)
+      throws IOException {
+    return myFs.hasCapability(capability, path);
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FilterFs.java
@@ -446,8 +446,9 @@ public abstract class FilterFs extends AbstractFileSystem {
     return myFs.openFileWithOptions(path, mandatoryKeys, options, bufferSize);
   }
 
-  public boolean hasCapability(final String capability, final Path path)
+  public boolean hasPathCapability(final Path path,
+      final String capability)
       throws IOException {
-    return myFs.hasCapability(capability, path);
+    return myFs.hasPathCapability(path, capability);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FsLinkResolution.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FsLinkResolution.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs;
+
+import java.io.IOException;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Class to allow Java lambda expressions to be used in {@link FileContext}
+ * link resolution.
+ * @param <T> type of the returned value.
+ */
+public class FsLinkResolution<T> extends FSLinkResolver<T> {
+
+  /**
+   * The function to invoke in the {@link #next(AbstractFileSystem, Path)} call.
+   */
+  private final FsLinkResolutionFunction<T> fn;
+
+  /**
+   * Construct an instance with the given function.
+   * @param fn function to invoke.
+   */
+  public FsLinkResolution(final FsLinkResolutionFunction<T> fn) {
+    this.fn = Preconditions.checkNotNull(fn);
+  }
+
+  @Override
+  public T next(final AbstractFileSystem fs, final Path p)
+      throws IOException, UnresolvedLinkException {
+    return fn.apply(fs, p);
+  }
+
+  /**
+   * The signature of the function to invoke.
+   * @param <T> return type.
+   * @throws UnresolvedLinkException link resolution failure
+   * @throws IOException other IO failure.
+   */
+  @FunctionalInterface
+  public interface FsLinkResolutionFunction<T> {
+    T apply(final AbstractFileSystem fs, final Path p)
+        throws IOException, UnresolvedLinkException;
+  }
+
+  /**
+   * Apply the given function to the resolved path under the the supplied
+   * FileContext.
+   * @param fileContext file context to resolve under
+   * @param path path to resolve
+   * @param fn function to invoke
+   * @param <T> return type.
+   * @return the return value of the function as revoked against the resolved
+   * path.
+   * @throws UnresolvedLinkException link resolution failure
+   * @throws IOException other IO failure.
+   */
+  public static <T> T resolve(
+      final FileContext fileContext, final Path path,
+      final FsLinkResolutionFunction<T> fn)
+      throws UnresolvedLinkException, IOException {
+    return new FsLinkResolution<T>(fn).resolve(fileContext, path);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HarFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HarFileSystem.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.fs;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.Options.HandleOpt;
 import org.apache.hadoop.io.IOUtils;
@@ -907,11 +908,9 @@ public class HarFileSystem extends FileSystem {
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // query the superclass, which triggers argument validation.
-    super.hasPathCapability(path, capability);
-
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_READ_ONLY_CONNECTOR:
+    case CommonPathCapabilities.FS_READ_ONLY_CONNECTOR:
       return true;
     default:
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HarFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HarFileSystem.java
@@ -899,7 +899,25 @@ public class HarFileSystem extends FileSystem {
     throws IOException {
     throw new IOException("Har: setPermission not allowed");
   }
-  
+
+  /**
+   * Declare that this filesystem connector is always read only.
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // query the superclass, which triggers argument validation.
+    super.hasPathCapability(path, capability);
+
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case PathCapabilities.FS_READ_ONLY_CONNECTOR:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   /**
    * Hadoop archives input stream. This input stream fakes EOF 
    * since archive files are part of bigger part files.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
@@ -37,38 +37,38 @@ public interface PathCapabilities {
    * and related methods?
    * Value: {@value}.
    */
-  String FS_ACLS = "fs:acls";
+  String FS_ACLS = "fs.paths.acls";
 
   /**
    * Does the Filesystem support {@link FileSystem#append(Path)}?
    * Value: {@value}.
    */
-  String FS_APPEND = "fs:append";
+  String FS_APPEND = "fs.paths.append";
 
   /**
    * Does the FS support {@link FileSystem#getFileChecksum(Path)}?
    * Value: {@value}.
    */
-  String FS_CHECKSUMS = "fs:checksums";
+  String FS_CHECKSUMS = "fs.paths.checksums";
 
   /**
    * Does the FS support {@link FileSystem#concat(Path, Path[])}?
    * Value: {@value}.
    */
-  String FS_CONCAT = "fs:concat";
+  String FS_CONCAT = "fs.paths.concat";
 
   /**
    * Does the FS support {@link FileSystem#listCorruptFileBlocks(Path)} ()}?
    * Value: {@value}.
    */
-  String FS_LIST_CORRUPT_FILE_BLOCKS = "fs:list-corrupt-file-blocks";
+  String FS_LIST_CORRUPT_FILE_BLOCKS = "fs.paths.list-corrupt-file-blocks";
 
   /**
    * Does the FS support {@link FileSystem#setPermission(Path, FsPermission)}
    * and related methods?
    * Value: {@value}.
    */
-  String FS_PERMISSIONS = "fs:permissions";
+  String FS_PERMISSIONS = "fs.paths.permissions";
 
   /**
    * Does the FS support
@@ -76,7 +76,7 @@ public interface PathCapabilities {
    * and related methods?
    * Value: {@value}.
    */
-  String FS_PATHHANDLES = "fs:pathhandles";
+  String FS_PATHHANDLES = "fs.paths.pathhandles";
 
   /**
    * Does this filesystem connector only support filesystem read operations?
@@ -86,41 +86,47 @@ public interface PathCapabilities {
    * attempting write operations under a path.
    * Value: {@value}.
    */
-  String FS_READ_ONLY_CONNECTOR = "fs:read-only-connector";
+  String FS_READ_ONLY_CONNECTOR = "fs.paths.read-only-connector";
 
   /**
    * Does the FS support snapshots through
    * {@link FileSystem#createSnapshot(Path)} and related methods??
    * Value: {@value}.
    */
-  String FS_SNAPSHOTS = "fs:snapshots";
+  String FS_SNAPSHOTS = "fs.paths.snapshots";
 
   /**
    * Does the FS support {@link FileSystem#setStoragePolicy(Path, String)} 
    * and related methods?
    * Value: {@value}.
    */
-  String FS_STORAGEPOLICY = "fs:storagepolicy";
+  String FS_STORAGEPOLICY = "fs.paths.storagepolicy";
 
   /**
    * Does the FS support symlinks through
    * {@link FileSystem#createSymlink(Path, Path, boolean)} and related methods?
    * Value: {@value}.
    */
-  String FS_SYMLINKS = "fs:symlinks";
+  String FS_SYMLINKS = "fs.paths.symlinks";
 
   /**
    * Does the FS support {@link FileSystem#truncate(Path, long)} ?
    * Value: {@value}.
    */
-  String FS_TRUNCATE = "fs:truncate";
+  String FS_TRUNCATE = "fs.paths.truncate";
 
   /**
    * Does the Filesystem support XAttributes through
    * {@link FileSystem#setXAttr(Path, String, byte[])} and related methods?
    * Value: {@value}.
    */
-  String FS_XATTRS = "fs:xattrs";
+  String FS_XATTRS = "fs.paths.xattrs";
+
+  /**
+   * Does the filesystem support Delegation Tokens?
+   * Value: {@value}.
+   */
+  String FS_DELEGATION_TOKENS = "fs.paths.delegation.tokens";
 
   /**
    * Probe for a filesystem instance offering a specific capability under the

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
@@ -19,9 +19,6 @@
 package org.apache.hadoop.fs;
 
 import java.io.IOException;
-import java.util.List;
-
-import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
  * The Path counterpoint to {@link StreamCapabilities}; a query to see if,
@@ -29,104 +26,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
  * path.
  */
 public interface PathCapabilities {
-
-  /**
-   * Does the Filesystem support
-   * {@link FileSystem#setAcl(Path, List)},
-   * {@link FileSystem#getAclStatus(Path)} 
-   * and related methods?
-   * Value: {@value}.
-   */
-  String FS_ACLS = "fs.paths.acls";
-
-  /**
-   * Does the Filesystem support {@link FileSystem#append(Path)}?
-   * Value: {@value}.
-   */
-  String FS_APPEND = "fs.paths.append";
-
-  /**
-   * Does the FS support {@link FileSystem#getFileChecksum(Path)}?
-   * Value: {@value}.
-   */
-  String FS_CHECKSUMS = "fs.paths.checksums";
-
-  /**
-   * Does the FS support {@link FileSystem#concat(Path, Path[])}?
-   * Value: {@value}.
-   */
-  String FS_CONCAT = "fs.paths.concat";
-
-  /**
-   * Does the FS support {@link FileSystem#listCorruptFileBlocks(Path)} ()}?
-   * Value: {@value}.
-   */
-  String FS_LIST_CORRUPT_FILE_BLOCKS = "fs.paths.list-corrupt-file-blocks";
-
-  /**
-   * Does the FS support {@link FileSystem#setPermission(Path, FsPermission)}
-   * and related methods?
-   * Value: {@value}.
-   */
-  String FS_PERMISSIONS = "fs.paths.permissions";
-
-  /**
-   * Does the FS support
-   * {@link FileSystem#createPathHandle(FileStatus, Options.HandleOpt...)}
-   * and related methods?
-   * Value: {@value}.
-   */
-  String FS_PATHHANDLES = "fs.paths.pathhandles";
-
-  /**
-   * Does this filesystem connector only support filesystem read operations?
-   * For example, the {@code HttpFileSystem} is always read-only.
-   * This is different from "is the specific instance and path read only?", which
-   * must be determined by checking permissions (where supported), or
-   * attempting write operations under a path.
-   * Value: {@value}.
-   */
-  String FS_READ_ONLY_CONNECTOR = "fs.paths.read-only-connector";
-
-  /**
-   * Does the FS support snapshots through
-   * {@link FileSystem#createSnapshot(Path)} and related methods??
-   * Value: {@value}.
-   */
-  String FS_SNAPSHOTS = "fs.paths.snapshots";
-
-  /**
-   * Does the FS support {@link FileSystem#setStoragePolicy(Path, String)} 
-   * and related methods?
-   * Value: {@value}.
-   */
-  String FS_STORAGEPOLICY = "fs.paths.storagepolicy";
-
-  /**
-   * Does the FS support symlinks through
-   * {@link FileSystem#createSymlink(Path, Path, boolean)} and related methods?
-   * Value: {@value}.
-   */
-  String FS_SYMLINKS = "fs.paths.symlinks";
-
-  /**
-   * Does the FS support {@link FileSystem#truncate(Path, long)} ?
-   * Value: {@value}.
-   */
-  String FS_TRUNCATE = "fs.paths.truncate";
-
-  /**
-   * Does the Filesystem support XAttributes through
-   * {@link FileSystem#setXAttr(Path, String, byte[])} and related methods?
-   * Value: {@value}.
-   */
-  String FS_XATTRS = "fs.paths.xattrs";
-
-  /**
-   * Does the filesystem support Delegation Tokens?
-   * Value: {@value}.
-   */
-  String FS_DELEGATION_TOKENS = "fs.paths.delegation.tokens";
 
   /**
    * Probe for a filesystem instance offering a specific capability under the

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs;
+
+import java.io.IOException;
+
+/**
+ * The Path counterpoint to {@link StreamCapabilities}; a query to see if,
+ * a FileSystem/FileContext instance has a specific capability under the given
+ * path.
+ */
+public interface PathCapabilities {
+
+  /**
+   * Probe for a filesystem instance offering a specific capability under the
+   * given path.
+   * If the function returns {@code true}, the filesystem is explicitly
+   * declaring that the capability is available.
+   * If the function returns {@code false}, it can mean one of:
+   * <ul>
+   *   <li>The capability is not known.</li>
+   *   <li>The capability is known but it is not supported.</li>
+   *   <li>The capability is known but the filesystem does not know if it
+   *   is supported under the supplied path it.</li>
+   * </ul>
+   * The core guarantee which a caller can rely on is: if the predicate
+   * returns true, then the specific operation/behavior can be expected to be
+   * supported.
+   * @param path path to query the capability of.
+   * @param capability string to query the stream support for.
+   * @return true if the capability is supported under that part of the FS.
+   * @throws IOException this should not be raised, except on problems
+   * resolving paths or relaying the call.
+   */
+  boolean hasPathCapability(Path path, String capability)
+      throws IOException;
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/PathCapabilities.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.fs;
 
 import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
  * The Path counterpoint to {@link StreamCapabilities}; a query to see if,
@@ -26,6 +29,98 @@ import java.io.IOException;
  * path.
  */
 public interface PathCapabilities {
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#setAcl(Path, List)},
+   * {@link FileSystem#getAclStatus(Path)} 
+   * and related methods?
+   * Value: {@value}.
+   */
+  String FS_ACLS = "fs:acls";
+
+  /**
+   * Does the Filesystem support {@link FileSystem#append(Path)}?
+   * Value: {@value}.
+   */
+  String FS_APPEND = "fs:append";
+
+  /**
+   * Does the FS support {@link FileSystem#getFileChecksum(Path)}?
+   * Value: {@value}.
+   */
+  String FS_CHECKSUMS = "fs:checksums";
+
+  /**
+   * Does the FS support {@link FileSystem#concat(Path, Path[])}?
+   * Value: {@value}.
+   */
+  String FS_CONCAT = "fs:concat";
+
+  /**
+   * Does the FS support {@link FileSystem#listCorruptFileBlocks(Path)} ()}?
+   * Value: {@value}.
+   */
+  String FS_LIST_CORRUPT_FILE_BLOCKS = "fs:list-corrupt-file-blocks";
+
+  /**
+   * Does the FS support {@link FileSystem#setPermission(Path, FsPermission)}
+   * and related methods?
+   * Value: {@value}.
+   */
+  String FS_PERMISSIONS = "fs:permissions";
+
+  /**
+   * Does the FS support
+   * {@link FileSystem#createPathHandle(FileStatus, Options.HandleOpt...)}
+   * and related methods?
+   * Value: {@value}.
+   */
+  String FS_PATHHANDLES = "fs:pathhandles";
+
+  /**
+   * Does this filesystem connector only support filesystem read operations?
+   * For example, the {@code HttpFileSystem} is always read-only.
+   * This is different from "is the specific instance and path read only?", which
+   * must be determined by checking permissions (where supported), or
+   * attempting write operations under a path.
+   * Value: {@value}.
+   */
+  String FS_READ_ONLY_CONNECTOR = "fs:read-only-connector";
+
+  /**
+   * Does the FS support snapshots through
+   * {@link FileSystem#createSnapshot(Path)} and related methods??
+   * Value: {@value}.
+   */
+  String FS_SNAPSHOTS = "fs:snapshots";
+
+  /**
+   * Does the FS support {@link FileSystem#setStoragePolicy(Path, String)} 
+   * and related methods?
+   * Value: {@value}.
+   */
+  String FS_STORAGEPOLICY = "fs:storagepolicy";
+
+  /**
+   * Does the FS support symlinks through
+   * {@link FileSystem#createSymlink(Path, Path, boolean)} and related methods?
+   * Value: {@value}.
+   */
+  String FS_SYMLINKS = "fs:symlinks";
+
+  /**
+   * Does the FS support {@link FileSystem#truncate(Path, long)} ?
+   * Value: {@value}.
+   */
+  String FS_TRUNCATE = "fs:truncate";
+
+  /**
+   * Does the Filesystem support XAttributes through
+   * {@link FileSystem#setXAttr(Path, String, byte[])} and related methods?
+   * Value: {@value}.
+   */
+  String FS_XATTRS = "fs:xattrs";
 
   /**
    * Probe for a filesystem instance offering a specific capability under the
@@ -43,10 +138,11 @@ public interface PathCapabilities {
    * returns true, then the specific operation/behavior can be expected to be
    * supported.
    * @param path path to query the capability of.
-   * @param capability string to query the stream support for.
+   * @param capability non-null, non-empty string to query the path for support.
    * @return true if the capability is supported under that part of the FS.
    * @throws IOException this should not be raised, except on problems
    * resolving paths or relaying the call.
+   * @throws IllegalArgumentException invalid arguments
    */
   boolean hasPathCapability(Path path, String capability)
       throws IOException;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
@@ -41,6 +41,7 @@ import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Locale;
 import java.util.StringTokenizer;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -1059,5 +1060,17 @@ public class RawLocalFileSystem extends FileSystem {
     FileStatus fi = getFileLinkStatusInternal(f, false);
     // return an unqualified symlink target
     return fi.getSymlink();
+  }
+
+  @Override
+  public boolean hasCapability(String capability,
+      Path path) {
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case StreamCapabilities.FS_APPEND:
+    case StreamCapabilities.FS_PERMISSIONS:
+      return true;
+    default:
+      return super.hasCapability(capability, path);
+    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
@@ -1063,14 +1063,20 @@ public class RawLocalFileSystem extends FileSystem {
   }
 
   @Override
-  public boolean hasCapability(String capability,
-      Path path) {
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // qualify the path to make sure that it refers to the current FS.
+    Path p = makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
     case StreamCapabilities.FS_APPEND:
+    case StreamCapabilities.FS_CONCAT:
     case StreamCapabilities.FS_PERMISSIONS:
+    case StreamCapabilities.FS_PATHHANDLES:
+    case StreamCapabilities.FS_SYMLINKS:
+    case StreamCapabilities.FS_TRUNCATE:
       return true;
     default:
-      return super.hasCapability(capability, path);
+      return super.hasPathCapability(p, capability);
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
@@ -1065,18 +1065,19 @@ public class RawLocalFileSystem extends FileSystem {
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // qualify the path to make sure that it refers to the current FS.
-    Path p = makeQualified(path);
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_APPEND:
-    case StreamCapabilities.FS_CONCAT:
-    case StreamCapabilities.FS_PERMISSIONS:
-    case StreamCapabilities.FS_PATHHANDLES:
-    case StreamCapabilities.FS_SYMLINKS:
-    case StreamCapabilities.FS_TRUNCATE:
+    case PathCapabilities.FS_APPEND:
+    case PathCapabilities.FS_CONCAT:
+    case PathCapabilities.FS_PATHHANDLES:
+    case PathCapabilities.FS_PERMISSIONS:
+    case PathCapabilities.FS_TRUNCATE:
       return true;
+    case PathCapabilities.FS_SYMLINKS:
+      return FileSystem.areSymlinksEnabled();
     default:
-      return super.hasPathCapability(p, capability);
+      return superCapability;
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
@@ -47,6 +47,7 @@ import java.util.StringTokenizer;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.nativeio.NativeIO;
@@ -1065,19 +1066,18 @@ public class RawLocalFileSystem extends FileSystem {
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // query the superclass, which triggers argument validation.
-    boolean superCapability = super.hasPathCapability(path, capability);
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_APPEND:
-    case PathCapabilities.FS_CONCAT:
-    case PathCapabilities.FS_PATHHANDLES:
-    case PathCapabilities.FS_PERMISSIONS:
-    case PathCapabilities.FS_TRUNCATE:
+    case CommonPathCapabilities.FS_APPEND:
+    case CommonPathCapabilities.FS_CONCAT:
+    case CommonPathCapabilities.FS_PATHHANDLES:
+    case CommonPathCapabilities.FS_PERMISSIONS:
+    case CommonPathCapabilities.FS_TRUNCATE:
       return true;
-    case PathCapabilities.FS_SYMLINKS:
+    case CommonPathCapabilities.FS_SYMLINKS:
       return FileSystem.areSymlinksEnabled();
     default:
-      return superCapability;
+      return super.hasPathCapability(path, capability);
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
@@ -60,58 +60,6 @@ public interface StreamCapabilities {
   String UNBUFFER = "in:unbuffer";
 
   /**
-   * Does the Filesystem support get/set ACLs and related methods?
-   */
-  String FS_ACLS = "fs:acls";
-
-  /**
-   * Does the Filesystem support append operations?
-   */
-  String FS_APPEND = "fs:append";
-
-  /**
-   * Does the FS support {@code concat()}?
-   */
-  String FS_CONCAT = "fs:concat";
-
-  /**
-   * Does the FS support {@code setPermission(Path, FsPermission)}
-   * and related methods?
-   */
-  String FS_PERMISSIONS = "fs:permissions";
-
-  /**
-   * Does the FS support path handles??
-   */
-  String FS_PATHHANDLES = "fs:pathhandles";
-
-  /**
-   * Does the FS support snapshot?
-   */
-  String FS_SNAPSHOTS = "fs:snapshots";
-
-  /**
-   * Does the FS support storage policies?
-   */
-  String FS_STORAGEPOLICY = "fs:storagepolicy";
-
-  /**
-   * Does the FS support symlinks?
-   */
-  String FS_SYMLINKS = "fs:symlinks";
-
-  /**
-   * Does the FS support truncate()?
-   */
-  String FS_TRUNCATE = "fs:truncate";
-
-  /**
-   * Does the Filesystem support XAttributes
-   * {@code setXAttr(Path, String, byte[])} and related methods?
-   */
-  String FS_XATTRS = "fs:xattrs";
-
-  /**
    * Capabilities that a stream can support and be queried for.
    */
   @Deprecated

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
@@ -18,8 +18,11 @@
 
 package org.apache.hadoop.fs;
 
+import java.util.List;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
  * Interface to query streams for supported capabilities.
@@ -58,6 +61,36 @@ public interface StreamCapabilities {
    * Stream unbuffer capability implemented by {@link CanUnbuffer#unbuffer()}.
    */
   String UNBUFFER = "in:unbuffer";
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#setAcl(Path, List)} and related methods?
+   */
+  String FS_ACLS = "fs:acls";
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#append(Path)} and related methods?
+   */
+  String FS_APPEND = "fs:append";
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#concat(Path, Path[])}?
+   */
+  String FS_CONCAT = "fs:concat";
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#setPermission(Path, FsPermission)} and related methods?
+   */
+  String FS_PERMISSIONS = "fs:permissions";
+
+  /**
+   * Does the Filesystem support
+   * {@link FileSystem#setXAttr(Path, String, byte[])} and related methods?
+   */
+  String FS_XATTRS = "fs:xattrs";
 
   /**
    * Capabilities that a stream can support and be queried for.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
@@ -18,11 +18,8 @@
 
 package org.apache.hadoop.fs;
 
-import java.util.List;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
  * Interface to query streams for supported capabilities.
@@ -63,32 +60,54 @@ public interface StreamCapabilities {
   String UNBUFFER = "in:unbuffer";
 
   /**
-   * Does the Filesystem support
-   * {@link FileSystem#setAcl(Path, List)} and related methods?
+   * Does the Filesystem support get/set ACLs and related methods?
    */
   String FS_ACLS = "fs:acls";
 
   /**
-   * Does the Filesystem support
-   * {@link FileSystem#append(Path)} and related methods?
+   * Does the Filesystem support append operations?
    */
   String FS_APPEND = "fs:append";
 
   /**
-   * Does the Filesystem support
-   * {@link FileSystem#concat(Path, Path[])}?
+   * Does the FS support {@code concat()}?
    */
   String FS_CONCAT = "fs:concat";
 
   /**
-   * Does the Filesystem support
-   * {@link FileSystem#setPermission(Path, FsPermission)} and related methods?
+   * Does the FS support {@code setPermission(Path, FsPermission)}
+   * and related methods?
    */
   String FS_PERMISSIONS = "fs:permissions";
 
   /**
-   * Does the Filesystem support
-   * {@link FileSystem#setXAttr(Path, String, byte[])} and related methods?
+   * Does the FS support path handles??
+   */
+  String FS_PATHHANDLES = "fs:pathhandles";
+
+  /**
+   * Does the FS support snapshot?
+   */
+  String FS_SNAPSHOTS = "fs:snapshots";
+
+  /**
+   * Does the FS support storage policies?
+   */
+  String FS_STORAGEPOLICY = "fs:storagepolicy";
+
+  /**
+   * Does the FS support symlinks?
+   */
+  String FS_SYMLINKS = "fs:symlinks";
+
+  /**
+   * Does the FS support truncate()?
+   */
+  String FS_TRUNCATE = "fs:truncate";
+
+  /**
+   * Does the Filesystem support XAttributes
+   * {@code setXAttr(Path, String, byte[])} and related methods?
    */
   String FS_XATTRS = "fs:xattrs";
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/http/AbstractHttpFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/http/AbstractHttpFileSystem.java
@@ -20,14 +20,15 @@ package org.apache.hadoop.fs.http;
 
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
 
@@ -120,11 +121,10 @@ abstract class AbstractHttpFileSystem extends FileSystem {
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // query the superclass, which triggers argument validation.
-    super.hasPathCapability(path, capability);
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
 
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_READ_ONLY_CONNECTOR:
+    case CommonPathCapabilities.FS_READ_ONLY_CONNECTOR:
       return true;
     default:
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/http/AbstractHttpFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/http/AbstractHttpFileSystem.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLConnection;
+import java.util.Locale;
 
 abstract class AbstractHttpFileSystem extends FileSystem {
   private static final long DEFAULT_BLOCK_SIZE = 4096;
@@ -109,6 +111,24 @@ abstract class AbstractHttpFileSystem extends FileSystem {
   @Override
   public FileStatus getFileStatus(Path path) throws IOException {
     return new FileStatus(-1, false, 1, DEFAULT_BLOCK_SIZE, 0, path);
+  }
+
+  /**
+   * Declare that this filesystem connector is always read only.
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // query the superclass, which triggers argument validation.
+    super.hasPathCapability(path, capability);
+
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case PathCapabilities.FS_READ_ONLY_CONNECTOR:
+      return true;
+    default:
+      return false;
+    }
   }
 
   private static class HttpDataInputStream extends FilterInputStream

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/FsLinkResolution.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/FsLinkResolution.java
@@ -16,17 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs;
+package org.apache.hadoop.fs.impl;
 
 import java.io.IOException;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.AbstractFileSystem;
+import org.apache.hadoop.fs.FSLinkResolver;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.UnresolvedLinkException;
+
 /**
- * Class to allow Java lambda expressions to be used in {@link FileContext}
+ * Class to allow Lambda expressions to be used in {@link FileContext}
  * link resolution.
  * @param <T> type of the returned value.
  */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
 public class FsLinkResolution<T> extends FSLinkResolver<T> {
 
   /**
@@ -44,19 +54,26 @@ public class FsLinkResolution<T> extends FSLinkResolver<T> {
 
   @Override
   public T next(final AbstractFileSystem fs, final Path p)
-      throws IOException, UnresolvedLinkException {
+      throws UnresolvedLinkException, IOException {
     return fn.apply(fs, p);
   }
 
   /**
    * The signature of the function to invoke.
-   * @param <T> return type.
-   * @throws UnresolvedLinkException link resolution failure
-   * @throws IOException other IO failure.
+   * @param <T> type resolved to
    */
   @FunctionalInterface
   public interface FsLinkResolutionFunction<T> {
-    T apply(final AbstractFileSystem fs, final Path p)
+
+    /**
+     * 
+     * @param fs filesystem to resolve against.
+     * @param path path to resolve
+     * @return a result of type T
+     * @throws UnresolvedLinkException link resolution failure
+     * @throws IOException other IO failure.
+     */
+    T apply(final AbstractFileSystem fs, final Path path)
         throws IOException, UnresolvedLinkException;
   }
 
@@ -76,6 +93,6 @@ public class FsLinkResolution<T> extends FSLinkResolver<T> {
       final FileContext fileContext, final Path path,
       final FsLinkResolutionFunction<T> fn)
       throws UnresolvedLinkException, IOException {
-    return new FsLinkResolution<T>(fn).resolve(fileContext, path);
+    return new FsLinkResolution<>(fn).resolve(fileContext, path);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/PathCapabilitiesSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/PathCapabilitiesSupport.java
@@ -18,12 +18,11 @@
 
 package org.apache.hadoop.fs.impl;
 
-
-import com.google.common.base.Preconditions;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.Path;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
@@ -37,8 +36,8 @@ public class PathCapabilitiesSupport {
    */
   public static void validatehasPathCapabilityArgs(
       final Path path, final String capability) {
-    Preconditions.checkArgument(capability != null && !capability.isEmpty(),
+    checkArgument(path != null, "null path");
+    checkArgument(capability != null && !capability.isEmpty(),
         "null/empty capability");
-    Preconditions.checkArgument(path != null, "null path");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/PathCapabilitiesSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/PathCapabilitiesSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.impl;
+
+
+import com.google.common.base.Preconditions;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.Path;
+
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class PathCapabilitiesSupport {
+
+  /**
+   * Validate the arguments to {@code PathCapabilities.hadCapability()}.
+   * @param path path to query the capability of.
+   * @param capability non-null, non-empty string to query the path for support.
+   * @throws IllegalArgumentException if a an argument is invalid.
+   */
+  public static void validatehasPathCapabilityArgs(
+      final Path path, final String capability) {
+    Preconditions.checkArgument(capability != null && !capability.isEmpty(),
+        "null/empty capability");
+    Preconditions.checkArgument(path != null, "null path");
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -52,10 +52,10 @@ import org.apache.hadoop.fs.FsServerDefaults;
 import org.apache.hadoop.fs.FsStatus;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
@@ -948,7 +948,7 @@ public class ViewFileSystem extends FileSystem {
     Path p = makeQualified(path);
 
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_CONCAT:
+    case PathCapabilities.FS_CONCAT:
       // concat is not supported, as it may be invoked across filesystems.
       return false;
     default:

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -933,8 +933,17 @@ public class ViewFileSystem extends FileSystem {
     return res.targetFileSystem.getLinkTarget(res.remainingPath);
   }
 
+  /**
+   * Fail fast on known write capabilities (append, concat),
+   * forward the rest to the viewed FS.
+   * @param capability string to query the stream support for.
+   * @param path path to query the capability of.
+   * @return the capability
+   * @throws IOException if there is no resolved FS, or it raises an IOE.
+   */
   @Override
-  public boolean hasCapability(String capability, Path path) {
+  public boolean hasCapability(String capability, Path path)
+      throws IOException {
 
     // fail fast on capabilities whose operations are all write access
     // (so will always fail later on)
@@ -951,7 +960,7 @@ public class ViewFileSystem extends FileSystem {
       return res.targetFileSystem.hasCapability(capability, res.remainingPath);
     } catch (FileNotFoundException e) {
       // no mount point, nothing will work.
-      return false;
+      throw new NotInMountpointException(path, "hasCapability");
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.BlockStoragePolicySpi;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -57,6 +58,7 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.XAttrSetFlag;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.AclUtil;
@@ -944,11 +946,12 @@ public class ViewFileSystem extends FileSystem {
   @Override
   public boolean hasPathCapability(Path path, String capability)
       throws IOException {
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
     // qualify the path to make sure that it refers to the current FS.
     Path p = makeQualified(path);
 
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_CONCAT:
+    case CommonPathCapabilities.FS_CONCAT:
       // concat is not supported, as it may be invoked across filesystems.
       return false;
     default:

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -515,31 +515,6 @@ on the filesystem.
    `getFileStatus(P).getBlockSize()`.
 1. By inference, it MUST be > 0 for any file of length > 0.
 
-
-### `boolean hasCapability(String capability, Path path)`
-
-
-#### Preconditions
-
-`capability` is a string in the list defined in 
-<a href="#StreamCapability">StreamCapability</a>, for all filesystems,
-or a specific option which a filesystem may have enabled.
-For the latter, the URI scheme of the filesystem must be used as a prefix
-of the capability, such as "s3a:magic.committer". 
-
-#### Postconditions
-
-If and only if the filesystem at the specified path has the named
-capability, may the predicate return `true`. 
-
-If the capability is unknown, or the capability is not known to be supported,
-the predicate MUST return `false`.
-
-This is an extension of the <a href="#StreamCapability">StreamCapability</a>,
-extended to take a path, and so work with filesystems which can mount
-other filesystems too.
-
-
 ## <a name="state_changing_operations"></a> State Changing Operations
 
 ### `boolean mkdirs(Path p, FsPermission permission)`

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -515,7 +515,32 @@ on the filesystem.
    `getFileStatus(P).getBlockSize()`.
 1. By inference, it MUST be > 0 for any file of length > 0.
 
-## State Changing Operations
+
+### `boolean hasCapability(String capability, Path path)`
+
+
+#### Preconditions
+
+`capability` is a string in the list defined in 
+<a href="#StreamCapability">StreamCapability</a>, for all filesystems,
+or a specific option which a filesystem may have enabled.
+For the latter, the URI scheme of the filesystem must be used as a prefix
+of the capability, such as "s3a:magic.committer". 
+
+#### Postconditions
+
+If and only if the filesystem at the specified path has the named
+capability, may the predicate return `true`. 
+
+If the capability is unknown, or the capability is not known to be supported,
+the predicate MUST return `false`.
+
+This is an extension of the <a href="#StreamCapability">StreamCapability</a>,
+extended to take a path, and so work with filesystems which can mount
+other filesystems too.
+
+
+## <a name="state_changing_operations"></a> State Changing Operations
 
 ### `boolean mkdirs(Path p, FsPermission permission)`
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractAppendTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractAppendTest.java
@@ -20,10 +20,14 @@ package org.apache.hadoop.fs.contract;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.fs.PathCapabilities.FS_APPEND;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
@@ -149,4 +153,11 @@ public abstract class AbstractContractAppendTest extends AbstractFSContractTestB
                                                  dataset.length);
     ContractTestUtils.compareByteArrays(dataset, bytes, dataset.length);
   }
+
+  @Test
+  public void testFileSystemDeclaresCapability() throws Throwable {
+    assertHasPathCapabilities(getFileSystem(), target,
+        PathCapabilities.FS_APPEND);
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractConcatTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractConcatTest.java
@@ -24,7 +24,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.fs.PathCapabilities.FS_CONCAT;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertFileHasLength;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
@@ -91,6 +93,11 @@ public abstract class AbstractContractConcatTest extends AbstractFSContractTestB
     createFile(getFileSystem(), target, false, block);
     handleExpectedException(intercept(Exception.class,
         () -> getFileSystem().concat(target, new Path[]{target})));
+  }
+
+  @Test
+  public void testFileSystemDeclaresCapability() throws Throwable {
+    assertHasPathCapabilities(getFileSystem(), target, FS_CONCAT);
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.io.IOUtils;
@@ -1466,19 +1467,37 @@ public class ContractTestUtils extends Assert {
     assertTrue("Stream should be instanceof StreamCapabilities",
         stream instanceof StreamCapabilities);
 
-    if (shouldHaveCapabilities!=null) {
+    StreamCapabilities source = (StreamCapabilities) stream;
+    if (shouldHaveCapabilities != null) {
       for (String shouldHaveCapability : shouldHaveCapabilities) {
         assertTrue("Should have capability: " + shouldHaveCapability,
-            ((StreamCapabilities) stream).hasCapability(shouldHaveCapability));
+            source.hasCapability(shouldHaveCapability));
       }
     }
 
-    if (shouldNotHaveCapabilities!=null) {
+    if (shouldNotHaveCapabilities != null) {
       for (String shouldNotHaveCapability : shouldNotHaveCapabilities) {
         assertFalse("Should not have capability: " + shouldNotHaveCapability,
-            ((StreamCapabilities) stream)
-                .hasCapability(shouldNotHaveCapability));
+            source.hasCapability(shouldNotHaveCapability));
       }
+    }
+  }
+
+  /**
+   * Custom assert to test {@link PathCapabilities}.
+   *
+   * @param source source (FS, FC, etc)
+   * @param path path to check
+   * @param capabilities The array of unexpected capabilities
+   */
+  public static void assertHasPathCapabilities(
+      final PathCapabilities source,
+      final Path path,
+      final String...capabilities) throws IOException {
+
+    for (String shouldHaveCapability : capabilities) {
+      assertTrue("Should have capability: " + shouldHaveCapability,
+          source.hasPathCapability(path, shouldHaveCapability));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.fs.FsStatus;
 import org.apache.hadoop.fs.GlobalStorageStatistics;
 import org.apache.hadoop.fs.GlobalStorageStatistics.StorageStatisticsProvider;
 import org.apache.hadoop.fs.InvalidPathHandleException;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PathHandle;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Options;
@@ -59,7 +60,6 @@ import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.StorageType;
-import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.UnresolvedLinkException;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.hadoop.fs.XAttrSetFlag;
@@ -3408,28 +3408,30 @@ public class DistributedFileSystem extends FileSystem
   /**
    * HDFS client capabilities.
    * Keep {@code WebHdfsFileSystem} in sync.
-   * @param path
-   * @param capability string to query the stream support for.
-   * @return true if a capability is supported.
+   * {@inheritDoc}
    */
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // qualify the path to make sure that it refers to the current FS.
-    Path p = makeQualified(path);
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
+
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_ACLS:
-    case StreamCapabilities.FS_APPEND:
-    case StreamCapabilities.FS_CONCAT:
-    case StreamCapabilities.FS_PERMISSIONS:
-    case StreamCapabilities.FS_PATHHANDLES:
-    case StreamCapabilities.FS_SNAPSHOTS:
-    case StreamCapabilities.FS_STORAGEPOLICY:
-    case StreamCapabilities.FS_SYMLINKS:
-    case StreamCapabilities.FS_XATTRS:
+    case PathCapabilities.FS_ACLS:
+    case PathCapabilities.FS_APPEND:
+    case PathCapabilities.FS_CHECKSUMS:
+    case PathCapabilities.FS_CONCAT:
+    case PathCapabilities.FS_LIST_CORRUPT_FILE_BLOCKS:
+    case PathCapabilities.FS_PATHHANDLES:
+    case PathCapabilities.FS_PERMISSIONS:
+    case PathCapabilities.FS_SNAPSHOTS:
+    case PathCapabilities.FS_STORAGEPOLICY:
+    case PathCapabilities.FS_XATTRS:
       return true;
+    case PathCapabilities.FS_SYMLINKS:
+      return FileSystem.areSymlinksEnabled();
     default:
-      return super.hasPathCapability(p, capability);
+      return superCapability;
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.fs.UnresolvedLinkException;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.hadoop.fs.XAttrSetFlag;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -3413,8 +3414,9 @@ public class DistributedFileSystem extends FileSystem
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // query the superclass, which triggers argument validation.
-    boolean superCapability = super.hasPathCapability(path, capability);
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
+    // qualify the path to make sure that it refers to the current FS.
+    makeQualified(path);
 
     switch (capability.toLowerCase(Locale.ENGLISH)) {
     case PathCapabilities.FS_ACLS:
@@ -3431,7 +3433,7 @@ public class DistributedFileSystem extends FileSystem
     case PathCapabilities.FS_SYMLINKS:
       return FileSystem.areSymlinksEnabled();
     default:
-      return superCapability;
+      return super.hasPathCapability(path, capability);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -3407,23 +3407,29 @@ public class DistributedFileSystem extends FileSystem
 
   /**
    * HDFS client capabilities.
-   * Keep WebHdfsFileSystem in sync.
-   * @param capability string to query the stream support for.
+   * Keep {@code WebHdfsFileSystem} in sync.
    * @param path
+   * @param capability string to query the stream support for.
    * @return true if a capability is supported.
    */
   @Override
-  public boolean hasCapability(String capability,
-      Path path) {
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // qualify the path to make sure that it refers to the current FS.
+    Path p = makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
     case StreamCapabilities.FS_ACLS:
     case StreamCapabilities.FS_APPEND:
     case StreamCapabilities.FS_CONCAT:
     case StreamCapabilities.FS_PERMISSIONS:
+    case StreamCapabilities.FS_PATHHANDLES:
+    case StreamCapabilities.FS_SNAPSHOTS:
+    case StreamCapabilities.FS_STORAGEPOLICY:
+    case StreamCapabilities.FS_SYMLINKS:
     case StreamCapabilities.FS_XATTRS:
       return true;
     default:
-      return super.hasCapability(capability, path);
+      return super.hasPathCapability(p, capability);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.UnresolvedLinkException;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.hadoop.fs.XAttrSetFlag;
@@ -117,6 +118,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -3401,5 +3403,27 @@ public class DistributedFileSystem extends FileSystem
   @Override
   public HdfsDataOutputStreamBuilder appendFile(Path path) {
     return new HdfsDataOutputStreamBuilder(this, path).append();
+  }
+
+  /**
+   * HDFS client capabilities.
+   * Keep WebHdfsFileSystem in sync.
+   * @param capability string to query the stream support for.
+   * @param path
+   * @return true if a capability is supported.
+   */
+  @Override
+  public boolean hasCapability(String capability,
+      Path path) {
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case StreamCapabilities.FS_ACLS:
+    case StreamCapabilities.FS_APPEND:
+    case StreamCapabilities.FS_CONCAT:
+    case StreamCapabilities.FS_PERMISSIONS:
+    case StreamCapabilities.FS_XATTRS:
+      return true;
+    default:
+      return super.hasCapability(capability, path);
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -76,8 +76,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsServerDefaults;
 import org.apache.hadoop.fs.GlobalStorageStatistics;
 import org.apache.hadoop.fs.GlobalStorageStatistics.StorageStatisticsProvider;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.StorageStatistics;
-import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.permission.FsCreateModes;
 import org.apache.hadoop.hdfs.DFSOpsCountStatistics;
 import org.apache.hadoop.hdfs.DFSOpsCountStatistics.OpType;
@@ -1121,6 +1121,11 @@ public class WebHdfsFileSystem extends FileSystem
     ).run();
   }
 
+  @Override
+  public boolean supportsSymlinks() {
+    return true;
+  }
+
   /**
    * Create a symlink pointing to the destination path.
    */
@@ -2025,20 +2030,24 @@ public class WebHdfsFileSystem extends FileSystem
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // qualify the path to make sure that it refers to the current FS.
-    Path p = makeQualified(path);
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_ACLS:
-    case StreamCapabilities.FS_APPEND:
-    case StreamCapabilities.FS_CONCAT:
-    case StreamCapabilities.FS_PERMISSIONS:
-    case StreamCapabilities.FS_SNAPSHOTS:
-    case StreamCapabilities.FS_STORAGEPOLICY:
-    case StreamCapabilities.FS_SYMLINKS:
-    case StreamCapabilities.FS_XATTRS:
+    case PathCapabilities.FS_ACLS:
+    case PathCapabilities.FS_APPEND:
+    case PathCapabilities.FS_CHECKSUMS:
+    case PathCapabilities.FS_CONCAT:
+    case PathCapabilities.FS_PERMISSIONS:
+    case PathCapabilities.FS_SNAPSHOTS:
+    case PathCapabilities.FS_STORAGEPOLICY:
+    case PathCapabilities.FS_XATTRS:
+      return true;
+    case PathCapabilities.FS_SYMLINKS:
+      // there's no checking of the {symlinksEnabled} flag in this class,\
+      // so always return true.
       return true;
     default:
-      return super.hasPathCapability(p, capability);
+      return superCapability;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -2018,22 +2018,27 @@ public class WebHdfsFileSystem extends FileSystem
 
   /**
    * This filesystem's capabilities must be in sync with that of HDFS.
+   * @param path path to query the capability of.
    * @param capability string to query the stream support for.
-   * @param path
    * @return true if a capability is supported.
    */
   @Override
-  public boolean hasCapability(String capability,
-      Path path) {
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // qualify the path to make sure that it refers to the current FS.
+    Path p = makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
     case StreamCapabilities.FS_ACLS:
     case StreamCapabilities.FS_APPEND:
     case StreamCapabilities.FS_CONCAT:
     case StreamCapabilities.FS_PERMISSIONS:
+    case StreamCapabilities.FS_SNAPSHOTS:
+    case StreamCapabilities.FS_STORAGEPOLICY:
+    case StreamCapabilities.FS_SYMLINKS:
     case StreamCapabilities.FS_XATTRS:
       return true;
     default:
-      return super.hasCapability(capability, path);
+      return super.hasPathCapability(p, capability);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -48,6 +48,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -76,6 +77,7 @@ import org.apache.hadoop.fs.FsServerDefaults;
 import org.apache.hadoop.fs.GlobalStorageStatistics;
 import org.apache.hadoop.fs.GlobalStorageStatistics.StorageStatisticsProvider;
 import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.permission.FsCreateModes;
 import org.apache.hadoop.hdfs.DFSOpsCountStatistics;
 import org.apache.hadoop.hdfs.DFSOpsCountStatistics.OpType;
@@ -2012,6 +2014,27 @@ public class WebHdfsFileSystem extends FileSystem
   @VisibleForTesting
   public void setTestProvider(KeyProvider kp) {
     testProvider = kp;
+  }
+
+  /**
+   * This filesystem's capabilities must be in sync with that of HDFS.
+   * @param capability string to query the stream support for.
+   * @param path
+   * @return true if a capability is supported.
+   */
+  @Override
+  public boolean hasCapability(String capability,
+      Path path) {
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case StreamCapabilities.FS_ACLS:
+    case StreamCapabilities.FS_APPEND:
+    case StreamCapabilities.FS_CONCAT:
+    case StreamCapabilities.FS_PERMISSIONS:
+    case StreamCapabilities.FS_XATTRS:
+      return true;
+    default:
+      return super.hasCapability(capability, path);
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.XAttrCodec;
 import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.AclEntry;
@@ -84,6 +85,7 @@ import java.net.URL;
 import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -1496,4 +1498,29 @@ public class HttpFSFileSystem extends FileSystem
     return JsonUtilClient.toSnapshottableDirectoryList(json);
   }
 
+  /**
+   * This filesystem's capabilities must be in sync with that of HDFS.
+   * @param path path to query the capability of.
+   * @param capability string to query the stream support for.
+   * @return true if a capability is supported.
+   */
+  @Override
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // qualify the path to make sure that it refers to the current FS.
+    Path p = makeQualified(path);
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case StreamCapabilities.FS_ACLS:
+    case StreamCapabilities.FS_APPEND:
+    case StreamCapabilities.FS_CONCAT:
+    case StreamCapabilities.FS_PERMISSIONS:
+    case StreamCapabilities.FS_SNAPSHOTS:
+    case StreamCapabilities.FS_STORAGEPOLICY:
+    case StreamCapabilities.FS_SYMLINKS:
+    case StreamCapabilities.FS_XATTRS:
+      return true;
+    default:
+      return super.hasPathCapability(p, capability);
+    }
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -34,10 +34,10 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.StorageType;
-import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.XAttrCodec;
 import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.AclEntry;
@@ -1499,28 +1499,30 @@ public class HttpFSFileSystem extends FileSystem
   }
 
   /**
-   * This filesystem's capabilities must be in sync with that of HDFS.
-   * @param path path to query the capability of.
-   * @param capability string to query the stream support for.
-   * @return true if a capability is supported.
+   * This filesystem's capabilities must be in sync with that of 
+   * {@code DistributedFileSystem.hasPathCapability()} except
+   * where the feature is not exposed (e.g. symlinks).
+   * {@inheritDoc}
    */
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // qualify the path to make sure that it refers to the current FS.
-    Path p = makeQualified(path);
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
+    
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_ACLS:
-    case StreamCapabilities.FS_APPEND:
-    case StreamCapabilities.FS_CONCAT:
-    case StreamCapabilities.FS_PERMISSIONS:
-    case StreamCapabilities.FS_SNAPSHOTS:
-    case StreamCapabilities.FS_STORAGEPOLICY:
-    case StreamCapabilities.FS_SYMLINKS:
-    case StreamCapabilities.FS_XATTRS:
+    case PathCapabilities.FS_ACLS:
+    case PathCapabilities.FS_APPEND:
+    case PathCapabilities.FS_CONCAT:
+    case PathCapabilities.FS_PERMISSIONS:
+    case PathCapabilities.FS_SNAPSHOTS:
+    case PathCapabilities.FS_STORAGEPOLICY:
+    case PathCapabilities.FS_XATTRS:
       return true;
+    case PathCapabilities.FS_SYMLINKS:
+      return false;
     default:
-      return super.hasPathCapability(p, capability);
+      return superCapability;
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -26,6 +26,7 @@ import java.util.List;
 import com.google.common.base.Charsets;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.DelegationTokenRenewer;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -34,7 +35,6 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.StorageType;
@@ -1509,17 +1509,17 @@ public class HttpFSFileSystem extends FileSystem
       throws IOException {
     // query the superclass, which triggers argument validation.
     boolean superCapability = super.hasPathCapability(path, capability);
-    
+
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_ACLS:
-    case PathCapabilities.FS_APPEND:
-    case PathCapabilities.FS_CONCAT:
-    case PathCapabilities.FS_PERMISSIONS:
-    case PathCapabilities.FS_SNAPSHOTS:
-    case PathCapabilities.FS_STORAGEPOLICY:
-    case PathCapabilities.FS_XATTRS:
+    case CommonPathCapabilities.FS_ACLS:
+    case CommonPathCapabilities.FS_APPEND:
+    case CommonPathCapabilities.FS_CONCAT:
+    case CommonPathCapabilities.FS_PERMISSIONS:
+    case CommonPathCapabilities.FS_SNAPSHOTS:
+    case CommonPathCapabilities.FS_STORAGEPOLICY:
+    case CommonPathCapabilities.FS_XATTRS:
       return true;
-    case PathCapabilities.FS_SYMLINKS:
+    case CommonPathCapabilities.FS_SYMLINKS:
       return false;
     default:
       return superCapability;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -105,6 +105,7 @@ import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.fs.s3a.auth.delegation.AWSPolicyProvider;
@@ -3606,8 +3607,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // delegate to parent simply to validate arguments.
-    super.hasPathCapability(path, capability);
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
+    // qualify the path to make sure that it refers to the current FS.
+    makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
 
     case CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER:
@@ -3624,7 +3626,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           ETAG_CHECKSUM_ENABLED_DEFAULT);
       
     default:
-      return false;
+      return super.hasPathCapability(path, capability);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3603,7 +3603,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   }
 
   @Override
-  public boolean hasCapability(String capability, Path path) {
+  public boolean hasPathCapability(final Path path, final String capability) {
+    // qualify the path to make sure that it refers to the current FS.
+    makeQualified(path);
     return hasCapability(capability);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3602,6 +3602,11 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     return instrumentation.newCommitterStatistics();
   }
 
+  @Override
+  public boolean hasCapability(String capability, Path path) {
+    return hasCapability(capability);
+  }
+
   /**
    * Return the capabilities of this filesystem instance.
    * @param capability string to query the stream support for.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -85,6 +85,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -99,7 +100,6 @@ import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
@@ -3620,11 +3620,11 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       // select is only supported if enabled
       return selectBinding.isEnabled();
 
-    case PathCapabilities.FS_CHECKSUMS:
+    case CommonPathCapabilities.FS_CHECKSUMS:
       // capability depends on FS configuration
       return getConf().getBoolean(ETAG_CHECKSUM_ENABLED,
           ETAG_CHECKSUM_ENABLED_DEFAULT);
-      
+
     default:
       return super.hasPathCapability(path, capability);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitConstants.java
@@ -82,7 +82,7 @@ public final class CommitConstants {
 
   /**
    * Flag to indicate that a store supports magic committers.
-   * returned in {@code StreamCapabilities}
+   * returned in {@code PathCapabilities}
    * Value: {@value}.
    */
   public static final String STORE_CAPABILITY_MAGIC_COMMITTER

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -1157,7 +1157,8 @@ public abstract class S3GuardTool extends Configured implements Tool {
       } else {
         println(out, "Filesystem %s is not using S3Guard", fsUri);
       }
-      boolean magic = fs.hasCapability(
+      boolean magic = fs.hasPathCapability(
+          new Path(s3Path),
           CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER);
       println(out, "The \"magic\" committer %s supported",
           magic ? "is" : "is not");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
@@ -28,10 +28,10 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.junit.Assume;
 import org.junit.Test;
 
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.store.EtagChecksum;
 import org.apache.hadoop.test.LambdaTestUtils;
 
@@ -144,7 +144,7 @@ public class ITestS3AMiscOperations extends AbstractS3ATestBase {
     EtagChecksum checksum1 = fs.getFileChecksum(file1, 0);
     LOG.info("Checksum for {}: {}", file1, checksum1);
     assertTrue("FS checksum support disabled",
-        fs.hasPathCapability(file1, PathCapabilities.FS_CHECKSUMS));
+        fs.hasPathCapability(file1, CommonPathCapabilities.FS_CHECKSUMS));
     assertNotNull("Null file 1 checksum", checksum1);
     assertNotEquals("file 1 checksum", 0, checksum1.getLength());
     assertEquals("checksums", checksum1,
@@ -163,7 +163,7 @@ public class ITestS3AMiscOperations extends AbstractS3ATestBase {
     Path file1 = touchFile("file1");
     EtagChecksum checksum1 = fs.getFileChecksum(file1, 0);
     assertFalse("FS checksum support enabled",
-        fs.hasPathCapability(file1, PathCapabilities.FS_CHECKSUMS));
+        fs.hasPathCapability(file1, CommonPathCapabilities.FS_CHECKSUMS));
     assertNull("Checksums are being generated", checksum1);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMiscOperations.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.store.EtagChecksum;
 import org.apache.hadoop.test.LambdaTestUtils;
 
@@ -142,6 +143,8 @@ public class ITestS3AMiscOperations extends AbstractS3ATestBase {
     Path file1 = touchFile("file1");
     EtagChecksum checksum1 = fs.getFileChecksum(file1, 0);
     LOG.info("Checksum for {}: {}", file1, checksum1);
+    assertTrue("FS checksum support disabled",
+        fs.hasPathCapability(file1, PathCapabilities.FS_CHECKSUMS));
     assertNotNull("Null file 1 checksum", checksum1);
     assertNotEquals("file 1 checksum", 0, checksum1.getLength());
     assertEquals("checksums", checksum1,
@@ -159,6 +162,8 @@ public class ITestS3AMiscOperations extends AbstractS3ATestBase {
     final S3AFileSystem fs = getFileSystem();
     Path file1 = touchFile("file1");
     EtagChecksum checksum1 = fs.getFileChecksum(file1, 0);
+    assertFalse("FS checksum support enabled",
+        fs.hasPathCapability(file1, PathCapabilities.FS_CHECKSUMS));
     assertNull("Checksums are being generated", checksum1);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1168,9 +1168,12 @@ public final class S3ATestUtils {
    * Skip a test if the FS isn't marked as supporting magic commits.
    * @param fs filesystem
    */
-  public static void assumeMagicCommitEnabled(S3AFileSystem fs) {
+  public static void assumeMagicCommitEnabled(S3AFileSystem fs)
+      throws IOException {
     assume("Magic commit option disabled on " + fs,
-        fs.hasCapability(CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER));
+        fs.hasPathCapability(
+            fs.getWorkingDirectory(),
+            CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER));
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.PathCapabilities.FS_DELEGATION_TOKENS;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeSessionTestsEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.roundTrip;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.unsetHadoopCredentialProviders;
@@ -110,6 +112,12 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
     String service = fs.getCanonicalServiceName();
     assertEquals("canonical URI and service name mismatch",
         uri, new URI(service));
+  }
+
+  @Test
+  public void testFSDeclaresDTSupport() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    assertHasPathCapabilities(fs, fs.getHomeDirectory(), FS_DELEGATION_TOKENS);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
@@ -528,10 +528,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
   @Test
   public void testWriteNormalStream() throws Throwable {
     S3AFileSystem fs = getFileSystem();
-    Assume.assumeTrue(
-        "Filesystem does not have magic support enabled: " + fs,
-        fs.hasCapability(STORE_CAPABILITY_MAGIC_COMMITTER));
-
+    assumeMagicCommitEnabled(fs);
     Path destFile = path("normal");
     try (FSDataOutputStream out = fs.create(destFile, true)) {
       out.writeChars("data");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
@@ -446,7 +446,7 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
     String name = fs.getUri().toString();
     S3GuardTool.BucketInfo cmd = new S3GuardTool.BucketInfo(
         getConfiguration());
-    if (fs.hasCapability(
+    if (fs.hasPathCapability(fs.getWorkingDirectory(),
         CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER)) {
       // if the FS is magic, expect this to work
       exec(cmd, S3GuardTool.BucketInfo.MAGIC_FLAG, name);

--- a/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
@@ -1033,7 +1033,10 @@ public class AdlFileSystem extends FileSystem {
   }
 
   @Override
-  public boolean hasCapability(String capability, Path path) {
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // qualify the path to make sure that it refers to the current FS.
+    Path p = makeQualified(path);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
     case StreamCapabilities.FS_ACLS:
     case StreamCapabilities.FS_APPEND:
@@ -1041,7 +1044,7 @@ public class AdlFileSystem extends FileSystem {
     case StreamCapabilities.FS_PERMISSIONS:
       return true;
     default:
-      return super.hasCapability(capability, path);
+      return super.hasPathCapability(p, capability);
     }
   }
 }

--- a/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
@@ -47,6 +47,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.ContentSummary.Builder;
 import org.apache.hadoop.fs.CreateFlag;
@@ -58,7 +59,6 @@ import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.adl.oauth2.AzureADTokenProvider;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
@@ -1039,10 +1039,10 @@ public class AdlFileSystem extends FileSystem {
     // query the superclass, which triggers argument validation.
     boolean superCapability = super.hasPathCapability(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case PathCapabilities.FS_ACLS:
-    case PathCapabilities.FS_APPEND:
-    case PathCapabilities.FS_CONCAT:
-    case PathCapabilities.FS_PERMISSIONS:
+    case CommonPathCapabilities.FS_ACLS:
+    case CommonPathCapabilities.FS_APPEND:
+    case CommonPathCapabilities.FS_CONCAT:
+    case CommonPathCapabilities.FS_PERMISSIONS:
       return true;
     default:
       return superCapability;

--- a/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.adl.oauth2.AzureADTokenProvider;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
@@ -1036,15 +1036,16 @@ public class AdlFileSystem extends FileSystem {
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
     // qualify the path to make sure that it refers to the current FS.
-    Path p = makeQualified(path);
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
     switch (capability.toLowerCase(Locale.ENGLISH)) {
-    case StreamCapabilities.FS_ACLS:
-    case StreamCapabilities.FS_APPEND:
-    case StreamCapabilities.FS_CONCAT:
-    case StreamCapabilities.FS_PERMISSIONS:
+    case PathCapabilities.FS_ACLS:
+    case PathCapabilities.FS_APPEND:
+    case PathCapabilities.FS_CONCAT:
+    case PathCapabilities.FS_PERMISSIONS:
       return true;
     default:
-      return super.hasPathCapability(p, capability);
+      return superCapability;
     }
   }
 }

--- a/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -57,6 +58,7 @@ import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.adl.oauth2.AzureADTokenProvider;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
@@ -1028,5 +1030,18 @@ public class AdlFileSystem extends FileSystem {
       dest.set(generic, value, key + " via " + origin);
     }
     return dest;
+  }
+
+  @Override
+  public boolean hasCapability(String capability, Path path) {
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+    case StreamCapabilities.FS_ACLS:
+    case StreamCapabilities.FS_APPEND:
+    case StreamCapabilities.FS_CONCAT:
+    case StreamCapabilities.FS_PERMISSIONS:
+      return true;
+    default:
+      return super.hasCapability(capability, path);
+    }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -3866,4 +3866,15 @@ public class NativeAzureFileSystem extends FileSystem {
   void updateDaemonUsers(List<String> daemonUsers) {
     this.daemonUsers = daemonUsers;
   }
+
+  @Override
+  public boolean hasCapability(String capability,
+      Path path) {
+    switch (capability) {
+    case StreamCapabilities.FS_PERMISSIONS:
+      return true;
+    default:
+      return super.hasCapability(capability, path);
+    }
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -3868,13 +3868,15 @@ public class NativeAzureFileSystem extends FileSystem {
   }
 
   @Override
-  public boolean hasCapability(String capability,
-      Path path) {
+  public boolean hasPathCapability(final Path path, final String capability)
+      throws IOException {
+    // qualify the path to make sure that it refers to the current FS.
+    Path p = makeQualified(path);
     switch (capability) {
     case StreamCapabilities.FS_PERMISSIONS:
       return true;
     default:
-      return super.hasCapability(capability, path);
+      return super.hasPathCapability(p, capability);
     }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BufferedFSInputStream;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -60,7 +61,6 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
@@ -69,6 +69,7 @@ import org.apache.hadoop.fs.azure.metrics.AzureFileSystemMetricsSystem;
 import org.apache.hadoop.fs.azure.security.Constants;
 import org.apache.hadoop.fs.azure.security.RemoteWasbDelegationTokenManager;
 import org.apache.hadoop.fs.azure.security.WasbDelegationTokenManager;
+import org.apache.hadoop.fs.impl.PathCapabilitiesSupport;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.permission.PermissionStatus;
@@ -3871,17 +3872,16 @@ public class NativeAzureFileSystem extends FileSystem {
   @Override
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
-    // qualify the path to make sure that it refers to the current FS.
-    // query the superclass, which triggers argument validation.
-    boolean superCapability = super.hasPathCapability(path, capability);
+    PathCapabilitiesSupport.validatehasPathCapabilityArgs(path, capability);
+
     switch (capability) {
-    case PathCapabilities.FS_PERMISSIONS:
+    case CommonPathCapabilities.FS_PERMISSIONS:
       return true;
     // Append support is dynamic
-    case PathCapabilities.FS_APPEND:
+    case CommonPathCapabilities.FS_APPEND:
       return appendSupportEnabled;
     default:
-      return superCapability;
+      return super.hasPathCapability(path, capability);
     }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
@@ -3871,12 +3872,16 @@ public class NativeAzureFileSystem extends FileSystem {
   public boolean hasPathCapability(final Path path, final String capability)
       throws IOException {
     // qualify the path to make sure that it refers to the current FS.
-    Path p = makeQualified(path);
+    // query the superclass, which triggers argument validation.
+    boolean superCapability = super.hasPathCapability(path, capability);
     switch (capability) {
-    case StreamCapabilities.FS_PERMISSIONS:
+    case PathCapabilities.FS_PERMISSIONS:
       return true;
+    // Append support is dynamic
+    case PathCapabilities.FS_APPEND:
+      return appendSupportEnabled;
     default:
-      return super.hasPathCapability(p, capability);
+      return superCapability;
     }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Future;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import org.apache.hadoop.fs.PathCapabilities;
+import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClientThrottlingIntercept;
 import org.slf4j.Logger;
@@ -1122,12 +1122,12 @@ public class AzureBlobFileSystem extends FileSystem {
     makeQualified(path);
 
     switch (capability) {
-    case PathCapabilities.FS_PERMISSIONS:
-    case PathCapabilities.FS_APPEND:
+    case CommonPathCapabilities.FS_PERMISSIONS:
+    case CommonPathCapabilities.FS_APPEND:
       return true;
-    case PathCapabilities.FS_ACLS:
+    case CommonPathCapabilities.FS_ACLS:
       return getIsNamespaceEnabled();
-    case PathCapabilities.FS_DELEGATION_TOKENS:
+    case CommonPathCapabilities.FS_DELEGATION_TOKENS:
       return delegationTokenEnabled;
     default:
       return super.hasPathCapability(path, capability);

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
@@ -35,8 +35,6 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Counter;
-import org.apache.hadoop.fs.permission.FsAction;
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.tools.CopyListingFileStatus;
@@ -464,25 +462,6 @@ public abstract class AbstractContractDistCpTest
   public void testLargeFilesFromRemote() throws Exception {
     describe("copy multiple large files from remote to local");
     largeFiles(remoteFS, remoteDir, localFS, localDir);
-  }
-
-  @Test
-  public void testFilePermissionsToRemote() throws Throwable {
-    describe("Try to preserve file permissions from local to remote");
-    Path text700 = new Path(localDir, "text700");
-    Path text400 = new Path(localDir, "text400");
-    ContractTestUtils.touch(localFS, text700);
-    FsPermission o700 = new FsPermission(FsAction.ALL, null, null);
-    FsPermission o400 = new FsPermission(FsAction.READ, null, null);
-    localFS.setPermission(text700, o700);
-    localFS.setPermission(text400, o400);
-    Path target = new Path(remoteDir, "permissions");
-    DistCpOptions options = new DistCpOptions.Builder(
-        Collections.singletonList(localDir), target)
-        .preserve(DistCpOptions.FileAttribute.PERMISSION)
-        .preserve(DistCpOptions.FileAttribute.XATTR)
-        .build();
-    runDistCp(options);
   }
 
   /**


### PR DESCRIPTION
Add a PathCapabilities interface to both FileSystem and FileContext to declare the capabilities under the path of a filesystem through both the FileSystem and FileContext APIs