### PR TITLE
HDDS-1232 : Recon Container DB service definition.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/LevelDBStoreIterator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/LevelDBStoreIterator.java
@@ -61,4 +61,9 @@ public class LevelDBStoreIterator implements MetaStoreIterator<KeyValue> {
   public void seekToLast() {
     levelDBIterator.seekToLast();
   }
+
+  @Override
+  public void prefixSeek(byte[] prefix) {
+    levelDBIterator.seek(prefix);
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/MetaStoreIterator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/MetaStoreIterator.java
@@ -36,4 +36,9 @@ public interface MetaStoreIterator<T> extends Iterator<T> {
    */
   void seekToLast();
 
+  /**
+   * seek with prefix.
+   */
+  void prefixSeek(byte[] prefix);
+
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStoreIterator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStoreIterator.java
@@ -63,4 +63,9 @@ public class RocksDBStoreIterator implements MetaStoreIterator<KeyValue> {
     rocksDBIterator.seekToLast();
   }
 
+  @Override
+  public void prefixSeek(byte[] prefix) {
+    rocksDBIterator.seek(prefix);
+  }
+
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/utils/TestMetadataStore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/utils/TestMetadataStore.java
@@ -163,6 +163,58 @@ public class TestMetadataStore {
 
   }
 
+
+  @Test
+  public void testIteratorPrefixSeek() throws Exception {
+    Configuration conf = new OzoneConfiguration();
+    conf.set(OzoneConfigKeys.OZONE_METADATA_STORE_IMPL, storeImpl);
+    File dbDir = GenericTestUtils.getRandomizedTestDir();
+    MetadataStore dbStore = MetadataStoreBuilder.newBuilder()
+        .setConf(conf)
+        .setCreateIfMissing(true)
+        .setDbFile(dbDir)
+        .build();
+
+    for (int i = 0; i < 5; i++) {
+      dbStore.put(getBytes("a" + i), getBytes("a-value" + i));
+    }
+
+    for (int i = 0; i < 5; i++) {
+      dbStore.put(getBytes("b" + i), getBytes("b-value" + i));
+    }
+
+    for (int i = 0; i < 5; i++) {
+      dbStore.put(getBytes("c" + i), getBytes("c-value" + i));
+    }
+
+    for (int i = 5; i < 10; i++) {
+      dbStore.put(getBytes("b" + i), getBytes("b-value" + i));
+    }
+
+    for (int i = 5; i < 10; i++) {
+      dbStore.put(getBytes("a" + i), getBytes("a-value" + i));
+    }
+
+
+    MetaStoreIterator<KeyValue> metaStoreIterator = dbStore.iterator();
+    metaStoreIterator.prefixSeek(getBytes("b"));
+    int i = 0;
+    while (metaStoreIterator.hasNext()) {
+      KeyValue val = metaStoreIterator.next();
+      String key = getString(val.getKey());
+      if (key.startsWith("b")) {
+        assertEquals("b-value" + i, getString(val.getValue()));
+      } else {
+        break;
+      }
+      i++;
+    }
+    assertTrue(i == 10);
+    dbStore.close();
+    dbStore.destroy();
+    FileUtils.deleteDirectory(dbDir);
+  }
+
   @Test
   public void testMetaStoreConfigDifferentFromType() throws IOException {
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -125,13 +125,29 @@ public final class ServerUtils {
    * @return
    */
   public static File getScmDbDir(Configuration conf) {
-    final Collection<String> metadirs = conf.getTrimmedStringCollection(
-        ScmConfigKeys.OZONE_SCM_DB_DIRS);
+
+    File metadataDir = getDirWithFallBackToOzoneMetadata(conf, ScmConfigKeys
+        .OZONE_SCM_DB_DIRS, "SCM");
+    if (metadataDir != null) {
+      return metadataDir;
+    }
+
+    LOG.warn("{} is not configured. We recommend adding this setting. " +
+        "Falling back to {} instead.",
+        ScmConfigKeys.OZONE_SCM_DB_DIRS, HddsConfigKeys.OZONE_METADATA_DIRS);
+    return getOzoneMetaDirPath(conf);
+  }
+
+  public static File getDirWithFallBackToOzoneMetadata(Configuration conf,
+                                                       String key,
+                                                       String componentName) {
+    final Collection<String> metadirs = conf.getTrimmedStringCollection(key);
 
     if (metadirs.size() > 1) {
       throw new IllegalArgumentException(
-          "Bad config setting " + ScmConfigKeys.OZONE_SCM_DB_DIRS +
-          ". SCM does not support multiple metadata dirs currently");
+          "Bad config setting " + key +
+              ". " + componentName +
+              " does not support multiple metadata dirs currently");
     }
 
     if (metadirs.size() == 1) {
@@ -143,11 +159,7 @@ public final class ServerUtils {
       }
       return dbDirPath;
     }
-
-    LOG.warn("{} is not configured. We recommend adding this setting. " +
-        "Falling back to {} instead.",
-        ScmConfigKeys.OZONE_SCM_DB_DIRS, HddsConfigKeys.OZONE_METADATA_DIRS);
-    return getOzoneMetaDirPath(conf);
+    return null;
   }
 
   /**

--- a/hadoop-ozone/ozone-recon/pom.xml
+++ b/hadoop-ozone/ozone-recon/pom.xml
@@ -22,7 +22,7 @@
   </parent>
   <name>Apache Hadoop Ozone Recon</name>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>ozone-recon</artifactId>
+  <artifactId>hadoop-ozone-ozone-recon</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -49,6 +49,17 @@
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
       <version>4.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -18,6 +18,10 @@
 package org.apache.hadoop.ozone.recon;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.spi.MetadataStoreProvider;
+import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
+import org.apache.hadoop.ozone.recon.spi.impl.ContainerDBServiceProviderImpl;
+import org.apache.hadoop.utils.MetadataStore;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
@@ -30,6 +34,9 @@ public class ReconControllerModule extends AbstractModule {
   protected void configure() {
     bind(OzoneConfiguration.class).toProvider(OzoneConfigurationProvider.class);
     bind(ReconHttpServer.class).in(Singleton.class);
+    bind(MetadataStore.class).toProvider(MetadataStoreProvider.class);
+    bind(ContainerDBServiceProvider.class)
+        .to(ContainerDBServiceProviderImpl.class);
   }
 
 

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconHttpServer.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconHttpServer.java
@@ -37,52 +37,52 @@ public class ReconHttpServer extends BaseHttpServer {
 
   @Override
   protected String getHttpAddressKey() {
-    return ReconServerConfiguration.OZONE_RECON_HTTP_ADDRESS_KEY;
+    return ReconServerConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
   }
 
   @Override
   protected String getHttpsAddressKey() {
-    return ReconServerConfiguration.OZONE_RECON_HTTPS_ADDRESS_KEY;
+    return ReconServerConfigKeys.OZONE_RECON_HTTPS_ADDRESS_KEY;
   }
 
   @Override
   protected String getHttpBindHostKey() {
-    return ReconServerConfiguration.OZONE_RECON_HTTP_BIND_HOST_KEY;
+    return ReconServerConfigKeys.OZONE_RECON_HTTP_BIND_HOST_KEY;
   }
 
   @Override
   protected String getHttpsBindHostKey() {
-    return ReconServerConfiguration.OZONE_RECON_HTTPS_BIND_HOST_KEY;
+    return ReconServerConfigKeys.OZONE_RECON_HTTPS_BIND_HOST_KEY;
   }
 
   @Override
   protected String getBindHostDefault() {
-    return ReconServerConfiguration.OZONE_RECON_HTTP_BIND_HOST_DEFAULT;
+    return ReconServerConfigKeys.OZONE_RECON_HTTP_BIND_HOST_DEFAULT;
   }
 
   @Override
   protected int getHttpBindPortDefault() {
-    return ReconServerConfiguration.OZONE_RECON_HTTP_BIND_PORT_DEFAULT;
+    return ReconServerConfigKeys.OZONE_RECON_HTTP_BIND_PORT_DEFAULT;
   }
 
   @Override
   protected int getHttpsBindPortDefault() {
-    return ReconServerConfiguration.OZONE_RECON_HTTPS_BIND_PORT_DEFAULT;
+    return ReconServerConfigKeys.OZONE_RECON_HTTPS_BIND_PORT_DEFAULT;
   }
 
   @Override
   protected String getKeytabFile() {
-    return ReconServerConfiguration.OZONE_RECON_KEYTAB_FILE;
+    return ReconServerConfigKeys.OZONE_RECON_KEYTAB_FILE;
   }
 
   @Override
   protected String getSpnegoPrincipal() {
-    return ReconServerConfiguration
+    return ReconServerConfigKeys
         .OZONE_RECON_WEB_AUTHENTICATION_KERBEROS_PRINCIPAL;
   }
 
   @Override
   protected String getEnabledKey() {
-    return ReconServerConfiguration.OZONE_RECON_HTTP_ENABLED_KEY;
+    return ReconServerConfigKeys.OZONE_RECON_HTTP_ENABLED_KEY;
   }
 }

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.recon;
 
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_DB_SUFFIX;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -25,7 +27,7 @@ import org.apache.hadoop.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
-public final class ReconServerConfiguration {
+public final class ReconServerConfigKeys {
 
   public static final String OZONE_RECON_HTTP_ENABLED_KEY =
       "ozone.recon.http.enabled";
@@ -48,9 +50,17 @@ public final class ReconServerConfiguration {
   public static final String OZONE_RECON_DOMAIN_NAME =
       "ozone.recon.domain.name";
 
+  public static final String OZONE_RECON_CONTAINER_DB_CACHE_SIZE_MB =
+      "ozone.recon.container.db.cache.size.mb";
+  public static final int OZONE_RECON_CONTAINER_DB_CACHE_SIZE_DEFAULT = 128;
+
+  public static final String OZONE_RECON_DB_DIRS = "ozone.recon.db.dirs";
+  public static final String RECON_CONTAINER_DB = "recon-" +
+      CONTAINER_DB_SUFFIX;
+
   /**
    * Private constructor for utility class.
    */
-  private ReconServerConfiguration() {
+  private ReconServerConfigKeys() {
   }
 }

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerKeyPrefix.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerKeyPrefix.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.api.types;
+
+/**
+ * Class to encapsulate the Key information needed for the Recon container DB.
+ * Currently, it is containerId and key prefix.
+ */
+public class ContainerKeyPrefix {
+
+  private long containerId;
+  private String keyPrefix;
+
+  public ContainerKeyPrefix(long containerId, String keyPrefix) {
+    this.containerId = containerId;
+    this.keyPrefix = keyPrefix;
+  }
+
+  public long getContainerId() {
+    return containerId;
+  }
+
+  public void setContainerId(long containerId) {
+    this.containerId = containerId;
+  }
+
+  public String getKeyPrefix() {
+    return keyPrefix;
+  }
+
+  public void setKeyPrefix(String keyPrefix) {
+    this.keyPrefix = keyPrefix;
+  }
+}

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.spi;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
+
+/**
+ * The Recon Container DB Service interface.
+ */
+@InterfaceStability.Evolving
+public interface ContainerDBServiceProvider {
+
+  /**
+   * Store the container to Key prefix mapping into the Recon Container DB.
+   *
+   * @param containerKeyPrefix the containerId, key-prefix tuple.
+   * @param count              Count of Keys with that prefix.
+   */
+  void storeContainerKeyMapping(ContainerKeyPrefix containerKeyPrefix,
+                                Integer count) throws IOException;
+
+  /**
+   * Get the stored key prefix count for the given containerId, key prefix.
+   *
+   * @param containerKeyPrefix the containerId, key-prefix tuple.
+   * @return count of keys with that prefix.
+   */
+  Integer getCountForForContainerKeyPrefix(
+      ContainerKeyPrefix containerKeyPrefix) throws IOException;
+
+  /**
+   * Get the stored key prefixes for the given containerId.
+   *
+   * @param containerId the given containerId.
+   * @return Map of Key prefix -> count.
+   */
+  Map<String, Integer> getKeyPrefixesForContainer(long containerId);
+}

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/MetadataStoreProvider.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/MetadataStoreProvider.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.spi;
+
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.
+    OZONE_RECON_CONTAINER_DB_CACHE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.
+    OZONE_RECON_CONTAINER_DB_CACHE_SIZE_MB;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.
+    OZONE_RECON_DB_DIRS;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.
+    RECON_CONTAINER_DB;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.utils.MetadataStore;
+import org.apache.hadoop.utils.MetadataStoreBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+/**
+ * Provider for the Recon container DB (Metadata store).
+ */
+public class MetadataStoreProvider implements
+    Provider<MetadataStore> {
+
+  @VisibleForTesting
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MetadataStoreProvider.class);
+
+  @Inject
+  private OzoneConfiguration configuration;
+
+  @Override
+  public MetadataStore get() {
+    File metaDir = ServerUtils.getDirWithFallBackToOzoneMetadata(configuration,
+        OZONE_RECON_DB_DIRS, "Recon");
+    File containerDBPath = new File(metaDir, RECON_CONTAINER_DB);
+    int cacheSize = configuration.getInt(OZONE_RECON_CONTAINER_DB_CACHE_SIZE_MB,
+        OZONE_RECON_CONTAINER_DB_CACHE_SIZE_DEFAULT);
+
+    try {
+      return MetadataStoreBuilder.newBuilder()
+          .setConf(configuration)
+          .setDbFile(containerDBPath)
+          .setCacheSize(cacheSize * OzoneConsts.MB)
+          .build();
+    } catch (IOException ioEx) {
+      LOG.error("Unable to initialize Recon container metadata store.", ioEx);
+    }
+    return null;
+  }
+}

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.spi.impl;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
+import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
+import org.apache.hadoop.utils.MetaStoreIterator;
+import org.apache.hadoop.utils.MetadataStore;
+
+/**
+ * Implementation of the Recon Container DB Service.
+ */
+@Singleton
+public class ContainerDBServiceProviderImpl
+    implements ContainerDBServiceProvider {
+
+  private final static String KEY_DELIMITER = "_";
+
+  @Inject
+  private MetadataStore containerDBStore;
+
+  /**
+   * Concatenate the containerId and Key Prefix using a delimiter and store the
+   * count into the container DB store.
+   *
+   * @param containerKeyPrefix the containerId, key-prefix tuple.
+   * @param count              Count of Keys with that prefix.
+   * @throws IOException
+   */
+  @Override
+  public void storeContainerKeyMapping(ContainerKeyPrefix containerKeyPrefix,
+                                       Integer count)
+      throws IOException {
+    String dbKeyStr = String.valueOf(containerKeyPrefix.getContainerId()) +
+        KEY_DELIMITER + containerKeyPrefix.getKeyPrefix();
+    byte[] dbKey = dbKeyStr.getBytes();
+    byte[] dbValue = ByteBuffer.allocate(4).putInt(count).array();
+    containerDBStore.put(dbKey, dbValue);
+  }
+
+  /**
+   * Put together the key from the passed in object and get the count from
+   * the container DB store.
+   *
+   * @param containerKeyPrefix the containerId, key-prefix tuple.
+   * @return count of keys matching the containerId, key-prefix.
+   * @throws IOException
+   */
+  @Override
+  public Integer getCountForForContainerKeyPrefix(
+      ContainerKeyPrefix containerKeyPrefix) throws IOException {
+    String dbKeyStr = String.valueOf(containerKeyPrefix.getContainerId()) +
+        KEY_DELIMITER + containerKeyPrefix.getKeyPrefix();
+    byte[] dbKey = dbKeyStr.getBytes();
+    byte[] value = containerDBStore.get(dbKey);
+    return ByteBuffer.wrap(value).getInt();
+  }
+
+  /**
+   * Use the DB's prefix seek iterator to start the scan from the given
+   * container ID prefix.
+   *
+   * @param containerId the given containerId.
+   * @return Map of (Key-Prefix,Count of Keys).
+   */
+  @Override
+  public Map<String, Integer> getKeyPrefixesForContainer(long containerId) {
+
+    Map<String, Integer> prefixes = new HashMap<>();
+    MetaStoreIterator<MetadataStore.KeyValue> containerIterator =
+        containerDBStore.iterator();
+    byte[] containerIdPrefixBytes = String.valueOf(containerId).getBytes();
+    containerIterator.prefixSeek(containerIdPrefixBytes);
+    while (containerIterator.hasNext()) {
+      MetadataStore.KeyValue keyValue = containerIterator.next();
+      byte[] containerKey = keyValue.getKey();
+      String containerKeyString = new String(containerKey);
+      //The prefix seek only guarantees that the iterator's head will be
+      // positioned at the first prefix match. We still have to check the key
+      // prefix.
+      if (containerKeyString.startsWith(String.valueOf(containerId))) {
+        byte[] keyPrefix = ArrayUtils.subarray(containerKey,
+            containerIdPrefixBytes.length + 1,
+            containerKey.length);
+        prefixes.put(new String(keyPrefix), ByteBuffer.wrap(keyValue.getValue())
+            .getInt());
+      } else {
+        break; //Break when the first mismatch occurs.
+      }
+    }
+    return prefixes;
+  }
+
+}

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.hadoop.hdds.scm.server.SCMBlockProtocolServer;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
 import org.apache.hadoop.utils.MetaStoreIterator;

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -58,7 +58,7 @@ public class ContainerDBServiceProviderImpl
    * count into the container DB store.
    *
    * @param containerKeyPrefix the containerId, key-prefix tuple.
-   * @param count              Count of Keys with that prefix.
+   * @param count Count of the keys matching that prefix.
    * @throws IOException
    */
   @Override

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/package-info.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The classes in this package define the Service Provider implementations for
+ * Recon. This provides connectivity to underlying Ozone subsystems.
+ */
+package org.apache.hadoop.ozone.recon.spi.impl;

--- a/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImplTest.java
+++ b/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImplTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.spi.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
+import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
+import org.apache.hadoop.utils.MetaStoreIterator;
+import org.apache.hadoop.utils.MetadataStore;
+import org.apache.hadoop.utils.MetadataStoreBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+/**
+ * Test ContainerDBServiceProviderImpl.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerDBServiceProviderImplTest {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private MetadataStore containerDBStore;
+  private ContainerDBServiceProvider containerDbServiceProvider
+      = new ContainerDBServiceProviderImpl();
+  private Injector injector;
+
+  @Before
+  public void setUp() throws IOException {
+    tempFolder.create();
+    File dbDir = tempFolder.getRoot();
+    containerDBStore = MetadataStoreBuilder.newBuilder()
+        .setConf(new OzoneConfiguration())
+        .setCreateIfMissing(true)
+        .setDbFile(dbDir)
+        .build();
+    injector = Guice.createInjector(new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(MetadataStore.class).toInstance(containerDBStore);
+        bind(ContainerDBServiceProvider.class)
+            .toInstance(containerDbServiceProvider);
+      }
+    });
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    tempFolder.delete();
+  }
+
+  @Test
+  public void testStoreContainerKeyMapping() throws Exception {
+
+    long containerId = System.currentTimeMillis();
+    Map<String, Integer> prefixCounts = new HashMap<>();
+    prefixCounts.put("V1/B1/K1", 1);
+    prefixCounts.put("V1/B1/K2", 2);
+    prefixCounts.put("V1/B2/K3", 3);
+
+    for (String prefix : prefixCounts.keySet()) {
+      ContainerKeyPrefix containerKeyPrefix = new ContainerKeyPrefix(
+          containerId, prefix);
+      containerDbServiceProvider.storeContainerKeyMapping(
+          containerKeyPrefix, prefixCounts.get(prefix));
+    }
+
+    int count = 0;
+    MetaStoreIterator<MetadataStore.KeyValue> iterator =
+        containerDBStore.iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      count++;
+    }
+    assertTrue(count == 3);
+  }
+
+  @Test
+  public void testGetCountForForContainerKeyPrefix() throws Exception {
+    long containerId = System.currentTimeMillis();
+
+    containerDbServiceProvider.storeContainerKeyMapping(new
+        ContainerKeyPrefix(containerId, "V1/B1/K1"), 2);
+
+    Integer count = containerDbServiceProvider.
+        getCountForForContainerKeyPrefix(new ContainerKeyPrefix(containerId,
+            "V1/B1/K1"));
+    assertTrue(count == 2);
+  }
+
+  @Test
+  public void testGetKeyPrefixesForContainer() throws Exception {
+    long containerId = System.currentTimeMillis();
+
+    containerDbServiceProvider.storeContainerKeyMapping(new
+        ContainerKeyPrefix(containerId, "V1/B1/K1"), 1);
+
+    containerDbServiceProvider.storeContainerKeyMapping(new
+        ContainerKeyPrefix(containerId, "V1/B1/K2"), 2);
+
+    long nextContainerId = System.currentTimeMillis();
+    containerDbServiceProvider.storeContainerKeyMapping(new
+        ContainerKeyPrefix(nextContainerId, "V1/B2/K1"), 3);
+
+    Map<String, Integer> keyPrefixMap = containerDbServiceProvider
+        .getKeyPrefixesForContainer(containerId);
+    assertTrue(keyPrefixMap.size() == 2);
+    assertTrue(keyPrefixMap.get("V1/B1/K1") == 1);
+    assertTrue(keyPrefixMap.get("V1/B1/K2") == 2);
+
+    keyPrefixMap = containerDbServiceProvider
+        .getKeyPrefixesForContainer(nextContainerId);
+    assertTrue(keyPrefixMap.size() == 1);
+    assertTrue(keyPrefixMap.get("V1/B2/K1") == 3);
+  }
+}

--- a/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/package-info.java
+++ b/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Package for recon server impl tests.
+ */
+package org.apache.hadoop.ozone.recon.spi.impl;


### PR DESCRIPTION
The attached patch contains the Recon container DB service definition (Interface + Impl). It uses a RocksDB instance to store the container-Key information. The interface is still evolving at this point of time, and maybe updated when the end to end work is done to read the OM DB snapshot and write the container-key data into this DB.

Unit testing done. Manual testing will be done along with HDDS-1233 and HDDS-1234.