### PR TITLE
HADOOP-16183. Use latest Yetus to support ozone specific build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile"
         YETUS='yetus'
         // Branch or tag name.  Yetus release tags are 'rel/X.Y.Z'
-        YETUS_VERSION='rel/0.9.0'
+        YETUS_VERSION='rel/0.10.0'
     }
 
     parameters {


### PR DESCRIPTION
In YETUS-816 the hadoop personality is improved to better support ozone specific changes.

Unfortunately the hadoop personality is part of the Yetus project and not the Hadoop project: we need a new yetus release or switch to an unreleased version.

In this patch I propose to use the latest commit from yetus (but use that fixed commit instead updating all the time). 

See: https://issues.apache.org/jira/browse/HADOOP-16183