### PR TITLE
HDFS-14348: Fix JNI exception handling issues in libhdfs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -2531,6 +2531,7 @@ int hadoopRzOptionsSetByteBufferPool(
         // If the specified className is NULL, delete any previous
         // ByteBufferPool we had.
         (*env)->DeleteGlobalRef(env, opts->byteBufferPool);
+        opts->byteBufferPool = NULL;
     }
     ret = 0;
 done:

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -2720,6 +2720,7 @@ static int translateZCRException(JNIEnv *env, jthrowable exc)
     }
     if (!strcmp(className, "java.lang.UnsupportedOperationException")) {
         ret = EPROTONOSUPPORT;
+        destroyLocalReference(env, exc);
         goto done;
     }
     ret = printExceptionAndFree(env, exc, PRINT_EXC_ALL,

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
@@ -328,6 +328,11 @@ jthrowable classNameOfObject(jobject jobj, JNIEnv *env, char **name)
         goto done;
     }
     str = (*env)->CallObjectMethod(env, cls, mid);
+    jthr = (*env)->ExceptionOccurred(env);
+    if (jthr) {
+        (*env)->ExceptionClear(env);
+        goto done;
+    }
     if (str == NULL) {
         jthr = getPendingExceptionAndClear(env);
         goto done;
@@ -644,8 +649,7 @@ jthrowable fetchEnumInstance(JNIEnv *env, const char *className,
 
     clazz = (*env)->FindClass(env, className);
     if (!clazz) {
-        return newRuntimeError(env, "fetchEnum(%s, %s): failed to find class.",
-                className, valueName);
+        return getPendingExceptionAndClear(env);
     }
     if (snprintf(prettyClass, sizeof(prettyClass), "L%s;", className)
           >= sizeof(prettyClass)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
@@ -23,6 +23,9 @@
 #include <pthread.h>
 #include <stdio.h>
 
+#include "exception.h"
+#include "jni_helper.h"
+
 #define UNKNOWN "UNKNOWN"
 #define MAXTHRID 256
 
@@ -55,12 +58,18 @@ void hdfsThreadDestructor(void *v)
     if (ret != 0) {
       fprintf(stderr, "hdfsThreadDestructor: GetJavaVM failed with error %d\n",
         ret);
-      (*env)->ExceptionDescribe(env);
+      if ((*env)->ExceptionOccurred) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+      }
     } else {
       ret = (*vm)->DetachCurrentThread(vm);
 
       if (ret != JNI_OK) {
-        (*env)->ExceptionDescribe(env);
+        if ((*env)->ExceptionOccurred) {
+          (*env)->ExceptionDescribe(env);
+          (*env)->ExceptionClear(env);
+        }
         get_current_thread_id(env, thr_name, MAXTHRID);
 
         fprintf(stderr, "hdfsThreadDestructor: Unable to detach thread %s "
@@ -78,44 +87,60 @@ void hdfsThreadDestructor(void *v)
 }
 
 static void get_current_thread_id(JNIEnv* env, char* id, int max) {
-  jclass cls;
-  jmethodID mth;
-  jobject thr;
-  jstring thr_name;
+  jvalue jVal;
+  jobject thr = NULL;
+  jstring thr_name = NULL;
   jlong thr_id = 0;
+  jthrowable jthr = NULL;
   const char *thr_name_str;
 
-  cls = (*env)->FindClass(env, "java/lang/Thread");
-  mth = (*env)->GetStaticMethodID(env, cls, "currentThread",
-      "()Ljava/lang/Thread;");
-  thr = (*env)->CallStaticObjectMethod(env, cls, mth);
-
-  if (thr != NULL) {
-    mth = (*env)->GetMethodID(env, cls, "getId", "()J");
-    thr_id = (*env)->CallLongMethod(env, thr, mth);
-    (*env)->ExceptionDescribe(env);
-
-    mth = (*env)->GetMethodID(env, cls, "toString", "()Ljava/lang/String;");
-    thr_name = (jstring)(*env)->CallObjectMethod(env, thr, mth);
-
-    if (thr_name != NULL) {
-      thr_name_str = (*env)->GetStringUTFChars(env, thr_name, NULL);
-
-      // Treating the jlong as a long *should* be safe
-      snprintf(id, max, "%s:%ld", thr_name_str, thr_id);
-
-      // Release the char*
-      (*env)->ReleaseStringUTFChars(env, thr_name, thr_name_str);
-    } else {
-      (*env)->ExceptionDescribe(env);
-
-      // Treating the jlong as a long *should* be safe
-      snprintf(id, max, "%s:%ld", UNKNOWN, thr_id);
-    }
-  } else {
-    (*env)->ExceptionDescribe(env);
+  jthr = invokeMethod(env, &jVal, STATIC, NULL, "java/lang/Thread",
+          "currentThread", "()Ljava/lang/Thread;");
+  if (jthr) {
     snprintf(id, max, "%s", UNKNOWN);
+    printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "get_current_thread_id: Thread#currentThread failed: ");
+    goto done;
   }
+  thr = jVal.l;
+
+  jthr = invokeMethod(env, &jVal, INSTANCE, thr, "java/lang/Thread",
+                      "getId", "()J");
+  if (jthr) {
+    snprintf(id, max, "%s", UNKNOWN);
+    printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "get_current_thread_id: Thread#getId failed: ");
+    goto done;
+  }
+  thr_id = jVal.j;
+
+  jthr = invokeMethod(env, &jVal, INSTANCE, thr, "java/lang/Thread",
+                      "toString", "()Ljava/lang/String;");
+  if (jthr) {
+    snprintf(id, max, "%s:%ld", UNKNOWN, thr_id);
+    printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "get_current_thread_id: Thread#toString failed: ");
+    goto done;
+  }
+  thr_name = jVal.l;
+
+  thr_name_str = (*env)->GetStringUTFChars(env, thr_name, NULL);
+  if (!thr_name_str) {
+    printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "get_current_thread_id: GetStringUTFChars failed: ");
+    snprintf(id, max, "%s:%ld", UNKNOWN, thr_id);
+    goto done;
+  }
+
+  // Treating the jlong as a long *should* be safe
+  snprintf(id, max, "%s:%ld", thr_name_str, thr_id);
+
+  // Release the char*
+  (*env)->ReleaseStringUTFChars(env, thr_name, thr_name_str);
+
+done:
+  destroyLocalReference(env, thr);
+  destroyLocalReference(env, thr_name);
 
   // Make sure the id is null terminated in case we overflow the max length
   id[max - 1] = '\0';

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/os/posix/thread_local_storage.c
@@ -49,6 +49,7 @@ void hdfsThreadDestructor(void *v)
   struct ThreadLocalState *state = (struct ThreadLocalState*)v;
   JNIEnv *env = state->env;;
   jint ret;
+  jthrowable jthr;
   char thr_name[MAXTHRID];
 
   /* Detach the current thread from the JVM */
@@ -58,7 +59,8 @@ void hdfsThreadDestructor(void *v)
     if (ret != 0) {
       fprintf(stderr, "hdfsThreadDestructor: GetJavaVM failed with error %d\n",
         ret);
-      if ((*env)->ExceptionOccurred) {
+      jthr = (*env)->ExceptionOccurred(env);
+      if (jthr) {
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
       }
@@ -66,7 +68,8 @@ void hdfsThreadDestructor(void *v)
       ret = (*vm)->DetachCurrentThread(vm);
 
       if (ret != JNI_OK) {
-        if ((*env)->ExceptionOccurred) {
+        jthr = (*env)->ExceptionOccurred(env);
+        if (jthr) {
           (*env)->ExceptionDescribe(env);
           (*env)->ExceptionClear(env);
         }


### PR DESCRIPTION
[HDFS-14348](https://issues.apache.org/jira/browse/HDFS-14348) contains a list of all the JNI issues this patch fixes. All of the changes are related to proper exception handling when using the JNI library.

Some highlights:

* `hadoopRzOptionsSetByteBufferPool` was changed to add proper exception handling for `NewGlobalRef` and to cleanup some of the logic that was missed in HDFS-14321
* `get_current_thread_id` was re-written to use methods from `jni_helper.h` rather than using the JNI library directly; this fixes several issues with exception handling that were present in the code