### PR TITLE
HDDS-1259. OzoneFS classpath separation is broken by the token validation

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -48,8 +48,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.GlobalStorageStatistics;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
@@ -87,7 +85,6 @@ public class OzoneFileSystem extends FileSystem {
   private Path workingDir;
 
   private OzoneClientAdapter adapter;
-  private boolean securityEnabled;
 
   private OzoneFSStorageStatistics storageStatistics;
 
@@ -174,19 +171,9 @@ public class OzoneFileSystem extends FileSystem {
               OzoneClientAdapterFactory.createAdapter(volumeStr, bucketStr);
         }
       } else {
-        OzoneConfiguration ozoneConfiguration;
-        if (conf instanceof OzoneConfiguration) {
-          ozoneConfiguration = (OzoneConfiguration) conf;
-        } else {
-          ozoneConfiguration = new OzoneConfiguration(conf);
-        }
 
-        SecurityConfig secConfig = new SecurityConfig(ozoneConfiguration);
-        if (secConfig.isSecurityEnabled()) {
-          this.securityEnabled = true;
-        }
         this.adapter = new OzoneClientAdapterImpl(omHost,
-            Integer.parseInt(omPort), ozoneConfiguration,
+            Integer.parseInt(omPort), conf,
             volumeStr, bucketStr, storageStatistics);
       }
 
@@ -701,8 +688,7 @@ public class OzoneFileSystem extends FileSystem {
 
   @Override
   public Token<?> getDelegationToken(String renewer) throws IOException {
-    return securityEnabled? adapter.getDelegationToken(renewer) :
-        super.getDelegationToken(renewer);
+    return adapter.getDelegationToken(renewer);
   }
 
   /**


### PR DESCRIPTION
hadoop-ozone-filesystem-lib-legacy-0.4.0-SNAPSHOT.jar can't work any more together with older hadoop version, after the change of HDDS-1183.

{code}
2019-03-13 13:48:51 WARN  FileSystem:3170 - Cannot load filesystem: java.util.ServiceConfigurationError: org.apache.hadoop.fs.FileSystem: Provider org.apache.hadoop.fs.ozone.OzoneFileSystem could not be instantiated
2019-03-13 13:48:51 WARN  FileSystem:3174 - java.lang.NoClassDefFoundError: org/apache/hadoop/hdds/conf/OzoneConfiguration
2019-03-13 13:48:51 WARN  FileSystem:3174 - java.lang.ClassNotFoundException: org.apache.hadoop.hdds.conf.OzoneConfiguration
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/hadoop/hdds/conf/OzoneConfiguration
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at org.apache.hadoop.conf.Configuration.getClassByNameOrNull(Configuration.java:2332)
	at org.apache.hadoop.conf.Configuration.getClassByName(Configuration.java:2297)
	at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2393)
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:3208)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3240)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:121)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3291)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3259)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:470)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:356)
	at org.apache.hadoop.fs.shell.PathData.expandAsGlob(PathData.java:325)
	at org.apache.hadoop.fs.shell.Command.expandArgument(Command.java:245)
	at org.apache.hadoop.fs.shell.Command.expandArguments(Command.java:228)
	at org.apache.hadoop.fs.shell.FsCommand.processRawArguments(FsCommand.java:103)
	at org.apache.hadoop.fs.shell.Command.run(Command.java:175)
	at org.apache.hadoop.fs.FsShell.run(FsShell.java:315)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:76)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:90)
	at org.apache.hadoop.fs.FsShell.main(FsShell.java:378)
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.hdds.conf.OzoneConfiguration
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 21 more
{code}

And Ozone file system current jar is compatible only with hadoop 3.2 after the latest HA change. It means that ozonefs is broken everywhere where the hadoop version is older than 3.2.

See: https://issues.apache.org/jira/browse/HDDS-1259