### PR TITLE
HDDS-1283. Fix the dynamic documentation of basic s3 client usage

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
@@ -68,7 +68,7 @@
 
     <p>For example with aws-cli:</p>
 
-    <pre>aws s3api --endpoint <script>document.write(window.location.href).replace("static/", "")</script> create-bucket --bucket=wordcount</pre>
+    <pre>aws s3api --endpoint <script>document.write(window.location.href.replace("static/", ""))</script> create-bucket --bucket=wordcount</pre>
 
     <p>For more information, please check the <a href="docs">documentation.</a>
     </p>


### PR DESCRIPTION
S3 gateway has a default web page to display a generic message if you open the endpoint in the browser:

http://localhost:9878/static/

It also contains a simple example to use the endpoint:

{code}
This is an endpoint of Apache Hadoop Ozone S3 gateway. Use it with any AWS S3 compatible tool with setting this url as an endpoint

For example with aws-cli:

aws s3api --endpoint http://localhost:9878/static/ create-bucket --bucket=wordcount

For more information, please check the documentation. 
{code}

Unfortunately the endpoint is wrong here, the static should be removed from the url.

The trivial fix is to move the ) in the js code>  



See: https://issues.apache.org/jira/browse/HDDS-1283