### PR TITLE
HDDS-1265. "ozone sh s3 getsecret" throws Null Pointer Exception for unsecured clusters

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShell.java
@@ -81,13 +81,14 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLU
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+
+import static org.apache.hadoop.ozone.web.ozShell.s3.GetS3SecretHandler.OZONE_GETS3SECRET_ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -1214,36 +1215,18 @@ public class TestOzoneShell {
   }
 
   @Test
-  @Ignore("Can't run without secure cluster.")
   public void testS3Secret() throws Exception {
     String setOmAddress =
         "--set=" + OZONE_OM_ADDRESS_KEY + "=" + getOmAddress();
 
-    err.reset();
-    String outputFirstAttempt;
-    String outputSecondAttempt;
+    String output;
 
-    //First attempt: If secrets are not found in database, they will be created
     String[] args = new String[] {setOmAddress, "s3", "getsecret"};
     execute(shell, args);
-    outputFirstAttempt = out.toString();
-    //Extracting awsAccessKey & awsSecret value from output
-    String[] output = outputFirstAttempt.split("\n");
-    String awsAccessKey = output[0].split("=")[1];
-    String awsSecret = output[1].split("=")[1];
-    assertTrue((awsAccessKey != null && awsAccessKey.length() > 0) &&
-            (awsSecret != null && awsSecret.length() > 0));
+    // Get the first line of output
+    output = out.toString().split("\n")[0];
 
-    out.reset();
-
-    //Second attempt: Since secrets were created in previous attempt, it
-    // should return the same value
-    args = new String[] {setOmAddress, "s3", "getsecret"};
-    execute(shell, args);
-    outputSecondAttempt = out.toString();
-
-    //verifying if secrets from both attempts are same
-    assertTrue(outputFirstAttempt.equals(outputSecondAttempt));
+    assertTrue(output.equals(OZONE_GETS3SECRET_ERROR));
   }
 
   private void createS3Bucket(String userName, String s3Bucket) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
@@ -17,11 +17,14 @@
  */
 package org.apache.hadoop.ozone.web.ozShell.s3;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.security.UserGroupInformation;
 import picocli.CommandLine.Command;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 
 /**
  * Executes getsecret calls.
@@ -30,19 +33,28 @@ import picocli.CommandLine.Command;
     description = "returns s3 secret for current user")
 public class GetS3SecretHandler extends Handler {
 
+  private static final String OZONE_GETS3SECRET_ERROR = "This command is not" +
+      " supported in unsecure clusters.";
   /**
    * Executes getS3Secret.
    */
   @Override
   public Void call() throws Exception {
+    OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
     OzoneClient client =
-        new OzoneAddress().createClient(createOzoneConfiguration());
+        new OzoneAddress().createClient(ozoneConfiguration);
 
-    System.out.println(
-        client.getObjectStore().getS3Secret(
-        UserGroupInformation.getCurrentUser().getUserName()
-        ).toString()
-    );
+    // getS3Secret works only with secured clusters
+    if (ozoneConfiguration.getBoolean(OZONE_SECURITY_ENABLED_KEY, false)) {
+      System.out.println(
+          client.getObjectStore().getS3Secret(
+              UserGroupInformation.getCurrentUser().getUserName()
+          ).toString()
+      );
+    } else {
+      // Throw an error message for unsecured cluster
+      System.out.println(OZONE_GETS3SECRET_ERROR);
+    }
 
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
@@ -52,7 +52,7 @@ public class GetS3SecretHandler extends Handler {
           ).toString()
       );
     } else {
-      // Throw an error message for unsecured cluster
+      // log a warning message for unsecured cluster
       System.out.println(OZONE_GETS3SECRET_ERROR);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
@@ -33,7 +33,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY
     description = "returns s3 secret for current user")
 public class GetS3SecretHandler extends Handler {
 
-  private static final String OZONE_GETS3SECRET_ERROR = "This command is not" +
+  public static final String OZONE_GETS3SECRET_ERROR = "This command is not" +
       " supported in unsecure clusters.";
   /**
    * Executes getS3Secret.


### PR DESCRIPTION
"ozone sh s3 getsecret" command throws a Null Pointer Exception.

This patch fixes it by showing the following message:

```
hadoop@fa14f2633ba4:~$ ozone sh s3 getsecret
This command is not supported in unsecure clusters.
```