### PR TITLE
HDDS-1263. SCM CLI does not list container with id 1

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -190,7 +190,7 @@ public class SCMContainerManager implements ContainerManager {
       Collections.sort(containersIds);
 
       return containersIds.stream()
-          .filter(id -> id.getId() > startId)
+          .filter(id -> id.getId() >= startId)
           .limit(count)
           .map(id -> {
             try {


### PR DESCRIPTION
"ozone scmcli list --start=1" lists containers starting from container ID 2.
There is no way to list the container with containerID 1.

This PR fixes this behavior.