### PR TITLE
HADOOP-16195 MarshalledCredentials toString

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentials.java
@@ -227,7 +227,7 @@ public final class MarshalledCredentials implements Writable, Serializable {
       // session/role credentials may have an expiry and role ARN.
       return String.format("session credentials, expiry %s; %s(%s)",
           getExpirationDateTime()
-              .map(x -> x.format(DateTimeFormatter.ISO_DATE))
+              .map(x -> x.format(DateTimeFormatter.ISO_DATE_TIME))
               .orElse("unknown"),
           (isNotEmpty(roleARN)
               ? ("role \"" + roleARN + "\" ")


### PR DESCRIPTION
S3A MarshalledCredentials.toString() doesn't print full date/time of expiry

Change-Id: I4f1bdd2be0d5760c5501dce6edb6122499108b53