### PR TITLE
HADOOP-16090 S3A Client to add explicit support for versioned stores.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1916,6 +1916,15 @@
   </description>
 </property>
 
+<property>
+  <name>fs.s3a.versioned.store</name>
+  <value>false</value>
+  <description>
+    Is the S3 Bucket "versioned"? If so, the S3A connector
+    will optimize its behavior for versioned data.
+  </description>
+</property>
+
 <!-- Azure file system properties -->
 <property>
   <name>fs.AbstractFileSystem.wasb.impl</name>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -721,4 +721,17 @@ public final class Constants {
    * Default change detection require version: true.
    */
   public static final boolean CHANGE_DETECT_REQUIRE_VERSION_DEFAULT = true;
+
+  /**
+   * Is the store versioned?
+   * value: {@value}.
+   */
+  public static final String VERSIONED_STORE
+      = "fs.s3a.versioned.store";
+
+  /**
+   * Default versioned store option: {@value}.
+   */
+  public static final boolean VERSIONED_STORE_DEFAULT = false;
+
 }

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1270,6 +1270,46 @@ will be thrown.  When `false` and and eTag or version ID is not returned,
 the stream can be read, but without any version checking.
 
 
+
+### <a name="versioned-store"></a> Working with Versioned Stores
+
+Amazon S3 supports [versioned storage](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html),
+where the previous versions of files are retained, even after deletion.
+
+To make the S3A connector work better with versioned stores, set
+the configuration option `fs.s3a.versioned.store` to `true`.
+
+```xml
+<property>
+  <name>fs.s3a.versioned.store</name>
+  <value>false</value>
+  <description>
+    Is the S3 Bucket "versioned"? If so, the S3A connector
+    will optimize its behavior for versioned data.
+  </description>
+</property>
+```
+
+Setting this option for non-versioned stores is not dangerous, but likely
+to make some operations slower. 
+
+With a versioned store, the change detection source can be set to use
+the version ID:
+
+```xml
+<property>
+  <name>fs.s3a.change.detection.source</name>
+  <value>versionid</value>
+</property>
+```
+
+Note: the specific optimizations which the S3A client does for versioned
+object stores may change across versions: the goals are
+
+* Reduce the number of needless key deletion requests made, even at the expense of more
+HEAD operations [HADOOP-16090](https://issues.apache.org/jira/browse/HADOOP-16090).
+* Use version IDs where possible. 
+
 ## <a name="per_bucket_configuration"></a>Configuring different S3 buckets with Per-Bucket Configuration
 
 Different S3 buckets can be accessed with different S3A client configurations.


### PR DESCRIPTION
Adds the option fs.s3a.versioned.store to enable all policy changes for efficiently working with versioned object stores.

This (initial?) patch reverts to the original probe-then-delete mechanism of cleaning up fake empty directories; the test ITestS3AFileOperationCost.testFakeDirectoryDeletion() verifies that this
reduces the number of paths queued for deletion.

Change-Id: I9708ffc3784e8f7e742b5885b48cbaf9600f6232