### PR TITLE
HDDS-1302. Fix SCM CLI does not list container with id 1

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -190,7 +190,7 @@ public class SCMContainerManager implements ContainerManager {
       Collections.sort(containersIds);
 
       return containersIds.stream()
-          .filter(id -> id.getId() >= startId)
+          .filter(id -> id.getId() > startId)
           .limit(count)
           .map(id -> {
             try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -294,8 +294,13 @@ public class SCMClientProtocolServer implements
     auditMap.put("startContainerID", String.valueOf(startContainerID));
     auditMap.put("count", String.valueOf(count));
     try {
+      // To allow startcontainerId to take the value "0",
+      // "null" is assigned, so that its handled in the
+      // scm.getContainerManager().listContainer method
+      final ContainerID containerId = startContainerID != 0 ? ContainerID
+          .valueof(startContainerID) : null;
       return scm.getContainerManager().
-          listContainer(ContainerID.valueof(startContainerID), count);
+          listContainer(containerId, count);
     } catch (Exception ex) {
       auditSuccess = false;
       AUDIT.logReadFailure(


### PR DESCRIPTION
This PR aims to avoid the contradiction with JavaDoc after the fix in HDDS-1263.

https://issues.apache.org/jira/browse/HDDS-1302

