### PR TITLE
HDDS-1332. Add some logging for flaky test testStartStopDatanodeState…

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -397,7 +397,6 @@ public class DatanodeStateMachine implements Closeable {
   @VisibleForTesting
   public boolean isDaemonStopped() {
     return this.executorService.isShutdown()
-        && this.getContext().getExecutionCount() == 0
         && this.getContext().getState() == DatanodeStates.SHUTDOWN;
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.container.common;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.conf.Configuration;
@@ -165,8 +166,12 @@ public class TestDatanodeStateMachine {
       stateMachine.startDaemon();
       SCMConnectionManager connectionManager =
           stateMachine.getConnectionManager();
-      GenericTestUtils.waitFor(() -> connectionManager.getValues().size() == 1,
-          1000, 30000);
+      GenericTestUtils.waitFor(
+          () -> {
+            LOG.info("connectionManager.getValues().size() is {}",
+                connectionManager.getValues().size());
+            return connectionManager.getValues().size() == 1;
+          }, 1000, 30000);
 
       stateMachine.stopDaemon();
       assertTrue(stateMachine.isDaemonStopped());


### PR DESCRIPTION
…Machine. Contributed by Arpit Agarwal.

Also remove an overaggressive clause in DatanodeStateMachine#isDaemonStopped,

Change-Id: I4f9dc6aeff7f4502956d160e35f2c4caadccb246