### PR TITLE
[HDDS-1351] NoClassDefFoundError when running ozone genconf

### DIFF
--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -60,6 +60,18 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>3.2.4</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `jaxb-core` and some `javax` artifacts to `hadoop-ozone-tools` dependencies to make `ozone genconf` work with JDK11, too.

https://issues.apache.org/jira/browse/HDDS-1351

## How was this patch tested?

```
$ mvn -Phdds -DskipTests -Dmaven.javadoc.skip=true -Pdist -Dtar -DskipShade -am -pl :hadoop-ozone-dist clean package
$ cd $(git rev-parse --show-toplevel)/hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone
$ docker-compose run datanode ozone genconf /tmp
ozone-site.xml has been generated at /tmp
```