### PR TITLE
HDDS-1357. ozone s3 shell command has confusing subcommands

### DIFF
--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -128,7 +128,7 @@ function ozonecmd_case
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"
     ;;
     sh | shell)
-      HADOOP_CLASSNAME=org.apache.hadoop.ozone.web.ozShell.Shell
+      HADOOP_CLASSNAME=org.apache.hadoop.ozone.web.ozShell.OzoneShell
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"
     ;;
     s3)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShell.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort;
+import org.apache.hadoop.ozone.web.ozShell.OzoneShell;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
 import org.apache.hadoop.ozone.web.request.OzoneQuota;
 import org.apache.hadoop.ozone.web.response.BucketInfo;
@@ -142,7 +143,7 @@ public class TestOzoneShell {
     baseDir = new File(path);
     baseDir.mkdirs();
 
-    shell = new Shell();
+    shell = new OzoneShell();
 
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneShell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneShell.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.web.ozShell;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.ozone.web.ozShell.Shell;
 import org.apache.hadoop.ozone.web.ozShell.bucket.BucketCommands;
 import org.apache.hadoop.ozone.web.ozShell.keys.KeyCommands;
 import org.apache.hadoop.ozone.web.ozShell.token.TokenCommands;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneShell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneShell.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.web.ozShell;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ozone.web.ozShell.Shell;
+import org.apache.hadoop.ozone.web.ozShell.bucket.BucketCommands;
+import org.apache.hadoop.ozone.web.ozShell.keys.KeyCommands;
+import org.apache.hadoop.ozone.web.ozShell.token.TokenCommands;
+import org.apache.hadoop.ozone.web.ozShell.volume.VolumeCommands;
+
+import io.opentracing.Scope;
+import io.opentracing.util.GlobalTracer;
+import picocli.CommandLine.Command;
+
+/**
+ * Shell commands for native rpc object manipulation.
+ */
+@Command(name = "ozone sh",
+    description = "Shell for Ozone object store",
+    subcommands = {
+        VolumeCommands.class,
+        BucketCommands.class,
+        KeyCommands.class,
+        TokenCommands.class
+    },
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true)
+public class OzoneShell extends Shell {
+
+  /**
+   * Main for the ozShell Command handling.
+   *
+   * @param argv - System Args Strings[]
+   * @throws Exception
+   */
+  public static void main(String[] argv) throws Exception {
+    new OzoneShell().run(argv);
+  }
+
+  @Override
+  public void execute(String[] argv) {
+    TracingUtil.initTracing("shell");
+    try (Scope scope = GlobalTracer.get().buildSpan("main").startActive(true)) {
+      super.execute(argv);
+    }
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/Shell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/Shell.java
@@ -19,19 +19,10 @@
 package org.apache.hadoop.ozone.web.ozShell;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
-import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.web.ozShell.bucket.BucketCommands;
-import org.apache.hadoop.ozone.web.ozShell.keys.KeyCommands;
-import org.apache.hadoop.ozone.web.ozShell.token.TokenCommands;
-import org.apache.hadoop.ozone.web.ozShell.volume.VolumeCommands;
 
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine.Command;
 
 /**
  * Ozone user interface commands.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/Shell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/Shell.java
@@ -39,17 +39,7 @@ import picocli.CommandLine.Command;
  * This class uses dispatch method to make calls
  * to appropriate handlers that execute the ozone functions.
  */
-@Command(name = "ozone sh",
-    description = "Shell for Ozone object store",
-    subcommands = {
-        VolumeCommands.class,
-        BucketCommands.class,
-        KeyCommands.class,
-        TokenCommands.class
-    },
-    versionProvider = HddsVersionProvider.class,
-    mixinStandardHelpOptions = true)
-public class Shell extends GenericCli {
+public abstract class Shell extends GenericCli {
 
   private static final Logger LOG = LoggerFactory.getLogger(Shell.class);
 
@@ -75,23 +65,7 @@ public class Shell extends GenericCli {
   // General options
   public static final int DEFAULT_OZONE_PORT = 50070;
 
-  @Override
-  public void execute(String[] argv) {
-    TracingUtil.initTracing("shell");
-    try (Scope scope = GlobalTracer.get().buildSpan("main").startActive(true)) {
-      super.execute(argv);
-    }
-  }
 
-  /**
-   * Main for the ozShell Command handling.
-   *
-   * @param argv - System Args Strings[]
-   * @throws Exception
-   */
-  public static void main(String[] argv) throws Exception {
-    new Shell().run(argv);
-  }
 
   @Override
   protected void printError(Throwable errorArg) {


### PR DESCRIPTION
Let's check the potential subcommands of ozone sh:

{code}
[hadoop@om-0 keytabs]$ ozone sh
Incomplete command
Usage: ozone sh [-hV] [--verbose] [-D=<String=String>]... [COMMAND]
Shell for Ozone object store
      --verbose   More verbose output. Show the stack trace of the errors.
  -D, --set=<String=String>

  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  volume, vol  Volume specific operations
  bucket       Bucket specific operations
  key          Key specific operations
  token        Token specific operations
{code}

This is fine, but for ozone s3:

{code}
[hadoop@om-0 keytabs]$ ozone s3
Incomplete command
Usage: ozone s3 [-hV] [--verbose] [-D=<String=String>]... [COMMAND]
Shell for S3 specific operations
      --verbose   More verbose output. Show the stack trace of the errors.
  -D, --set=<String=String>

  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  getsecret    Returns s3 secret for current user
  path         Returns the ozone path for S3Bucket
  volume, vol  Volume specific operations
  bucket       Bucket specific operations
  key          Key specific operations
  token        Token specific operations
{code}

This list should contain only the getsecret/path commands and not the volume/bucket/key subcommands.

See: https://issues.apache.org/jira/browse/HDDS-1357