### PR TITLE
HDDS-1322. Hugo errors when building Ozone

### DIFF
--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -49,8 +49,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
               <workingDirectory>${project.build.directory}</workingDirectory>
               <arguments>
                 <argument>${basedir}/dev-support/bin/generate-site.sh</argument>
-                <argument>${hdds.version}</argument>
-                <argument>${project.build.directory}</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Maven build fails to create HDDS docs due to the following hugo error in `hadoop-hdds-docs`:

```
$ mvn -Phdds -pl :hadoop-hdds-docs clean compile
...
[INFO] --- exec-maven-plugin:1.6.0:exec (default) @ hadoop-hdds-docs ---
Error: unknown command "0.5.0-SNAPSHOT" for "hugo"
Run 'hugo --help' for usage.
...
[INFO] BUILD SUCCESS
```

`generate-site.sh` passes all arguments to `hugo`, which expects commands, not HDDS version number and target directory.  I think these two parameters are unnecessary, hence the patch removes them.

https://issues.apache.org/jira/browse/HDDS-1322

## How was this patch tested?

With the fix docs can be generated using Maven:

```
$ mvn -Phdds -pl :hadoop-hdds-docs clean compile
...
[INFO] --- exec-maven-plugin:1.6.0:exec (default) @ hadoop-hdds-docs ---
Building sites …
...
                   | EN
+------------------+----+
  Pages            | 27
  Paginator pages  |  0
  Non-page files   |  0
  Static files     | 18
  Processed images |  0
  Aliases          |  0
  Sitemaps         |  1
  Cleaned          |  0

Total in 49 ms
```