### PR TITLE
[HDDS-1360] Invalid metric type due to fully qualified class name

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMContainerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMContainerMetrics.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.metrics2.lib.Interns;
 public class SCMContainerMetrics implements MetricsSource {
 
   private final SCMMXBean scmmxBean;
-  private static final String SOURCE = SCMContainerMetrics.class.getName();
+  private static final String SOURCE = SCMContainerMetrics.class.getSimpleName();
 
   public SCMContainerMetrics(SCMMXBean scmmxBean) {
     this.scmmxBean = scmmxBean;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use simple class name for metrics name to fix `invalid metric type` error in Prometheus.

https://issues.apache.org/jira/browse/HDDS-1360

## How was this patch tested?

Ran docker-compose in `ozoneperf` direcory (without `freon`).