### PR TITLE
HADOOP-16233. S3AFileStatus to declare that isEncrypted() is always true

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -96,6 +96,17 @@ can be queried to find if the path has an ACL. `getFileStatus(Path p).isEncrypte
 can be queried to find if the path is encrypted. `getFileStatus(Path p).isErasureCoded()`
 will tell if the path is erasure coded or not.
 
+YARN's distributed cache lets applications add paths to be cached across
+containers and applications via `Job.addCacheFile()` and `Job.addCacheArchive()`.
+The cache treats world-readable resources paths added as shareable across
+applications, and downloads them differently, unless they are declared as encrypted.
+
+To avoid failures during container launching, especially when delegation tokens
+are used, filesystems and object stores which not implement POSIX access permissions
+for both files and directories, MUST always return `true` to the `isEncrypted()`
+predicate. This can be done by setting the `encrypted` flag to true when creating
+the `FileStatus` instance.
+
 ### `Path getHomeDirectory()`
 
 The function `getHomeDirectory` returns the home directory for the FileSystem

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractOpenTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractOpenTest.java
@@ -80,8 +80,18 @@ public abstract class AbstractContractOpenTest
       final Path path = path("file");
       createFile(getFileSystem(), path, false, new byte[0]);
       final FileStatus stat = getFileSystem().getFileStatus(path);
-      assertFalse("Expecting false for stat.isEncrypted()",
+      assertEquals("Result wrong for for isEncrypted() in " + stat,
+          areZeroByteFilesEncrypted(),
           stat.isEncrypted());
+  }
+
+  /**
+   * Are zero byte files encrypted. This is implicitly
+   * false for filesystems which do not encrypt.
+   * @return true iff zero byte files are encrypted.
+   */
+  protected boolean areZeroByteFilesEncrypted() {
+    return false;
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
@@ -54,7 +54,9 @@ public class S3AFileStatus extends FileStatus {
   public S3AFileStatus(Tristate isemptydir,
       Path path,
       String owner) {
-    super(0, true, 1, 0, 0, path);
+    super(0, true, 1, 0, 0, 0,
+        null, null, null, null,
+        path, false, true, false);
     isEmptyDirectory = isemptydir;
     setOwner(owner);
     setGroup(owner);
@@ -70,7 +72,9 @@ public class S3AFileStatus extends FileStatus {
    */
   public S3AFileStatus(long length, long modification_time, Path path,
       long blockSize, String owner) {
-    super(length, false, 1, blockSize, modification_time, path);
+    super(length, false, 1, blockSize, modification_time, 0,
+        null, null, null, null,
+        path, false, true, false);
     isEmptyDirectory = Tristate.FALSE;
     setOwner(owner);
     setGroup(owner);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractOpen.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractOpen.java
@@ -45,4 +45,13 @@ public class ITestS3AContractOpen extends AbstractContractOpenTest {
   protected AbstractFSContract createContract(Configuration conf) {
     return new S3AContract(conf);
   }
+
+  /**
+   * S3A always declares zero byte files as encrypted.
+   * @return true, always.
+   */
+  @Override
+  protected boolean areZeroByteFilesEncrypted() {
+    return true;
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationIT.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationIT.java
@@ -70,7 +70,10 @@ public abstract class AbstractDelegationIT extends AbstractS3ATestBase {
     assertEquals("Kind of token " + token,
         kind,
         token.getKind());
-    return token.decodeIdentifier();
+    AbstractS3ATokenIdentifier tid
+        = token.decodeIdentifier();
+    LOG.info("Found for URI {}, token {}", uri, tid);
+    return tid;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/mapreduce/filecache/TestS3AResourceScope.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/mapreduce/filecache/TestS3AResourceScope.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.filecache;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
+import org.apache.hadoop.test.HadoopTestBase;
+
+/**
+ * Test how S3A resources are scoped in YARN caching.
+ * In this package to make use of package-private methods of
+ * {@link ClientDistributedCacheManager}.
+ */
+public class TestS3AResourceScope extends HadoopTestBase {
+
+  private static final Path PATH = new Path("s3a://example/path");
+
+  @Test
+  public void testS3AFilesArePrivate() throws Throwable {
+    S3AFileStatus status = new S3AFileStatus(false, PATH, "self");
+    assertTrue("Not encrypted: " + status, status.isEncrypted());
+    assertNotExecutable(status);
+  }
+
+  @Test
+  public void testS3AFilesArePrivateOtherContstructor() throws Throwable {
+    S3AFileStatus status = new S3AFileStatus(0, 0, PATH, 1, "self");
+    assertTrue("Not encrypted: " + status, status.isEncrypted());
+    assertNotExecutable(status);
+  }
+
+  private void assertNotExecutable(final S3AFileStatus status)
+      throws IOException {
+    Map<URI, FileStatus> cache = new HashMap<>();
+    cache.put(PATH.toUri(), status);
+    assertFalse("Should not have been executable " + status,
+        ClientDistributedCacheManager.ancestorsHaveExecutePermissions(
+            null, PATH, cache));
+  }
+}


### PR DESCRIPTION
This is needed to fix up some confusion about caching of job.addCache() handling of S3A paths; all parent dirs -the files are downloaded by the NM without  using the DTs of the user submitting the job. This means that when you submit jobs to an EC2 cluster with lower IAM permissions than the user, cached resources don't get downloaded and the job doesn't start.

Production code changes:
* S3AFileStatus Adds "true" to the superclass's encrypted flag during construction.

Tests
* Base AbstractContractOpenTest can control whether zero byte files created in tests are encrypted. Not done via an XML attribute, just a subclass point. Thoughts?
* Verify that the filecache considers paths to not have the permissions which trigger reduce-privilege downloads
* And extend ITestDelegatedMRJob to test a completely different bucket (open street map), to verify that cached resources do get their tokens picked up

Docs:
* Advise FS developers to say all files are encrypted. It's otherwise harmless and it'll stop other people seeing impossible to debug error messages on app launch.

Contributed by Steve Loughran.

Change-Id: Ifaae4c9d735ccc5eafeebd2584b65daf2d4e5da3