### PR TITLE
HDDS-1383. [Ozone Upgrade] Create the project skeleton with CLI interface

### DIFF
--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -52,6 +52,7 @@ function hadoop_usage
   hadoop_add_subcommand "s3" client "command line interface for s3 related operations"
   hadoop_add_subcommand "version" client "print the version"
   hadoop_add_subcommand "dtutil" client "operations related to delegation tokens"
+  hadoop_add_subcommand "upgrade" client "HDFS to Ozone in-place upgrade tool"
 
   hadoop_generate_usage "${HADOOP_SHELL_EXECNAME}" false
 }
@@ -173,6 +174,10 @@ function ozonecmd_case
     dtutil)
       HADOOP_CLASSNAME=org.apache.hadoop.security.token.DtUtilShell
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
+    ;;
+    upgrade)
+      HADOOP_CLASSNAME=org.apache.hadoop.ozone.upgrade.InPlaceUpgrade
+      OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-upgrade"
     ;;
     *)
       HADOOP_CLASSNAME="${subcmd}"

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -110,6 +110,13 @@
                   <classifier>classpath</classifier>
                   <destFileName>hadoop-ozone-recon.classpath</destFileName>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.hadoop</groupId>
+                  <artifactId>hadoop-ozone-upgrade</artifactId>
+                  <version>${ozone.version}</version>
+                  <classifier>classpath</classifier>
+                  <destFileName>hadoop-ozone-upgrade.classpath</destFileName>
+                </artifactItem>
               </artifactItems>
             </configuration>
           </execution>
@@ -254,6 +261,10 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-docs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-ozone-upgrade</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -50,6 +50,7 @@
     <module>dist</module>
     <module>ozone-recon</module>
     <module>ozone-recon-codegen</module>
+    <module>upgrade</module>
   </modules>
 
   <repositories>
@@ -163,6 +164,11 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-ozone-recon</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-ozone-upgrade</artifactId>
         <version>${ozone.version}</version>
       </dependency>
       <dependency>

--- a/hadoop-ozone/upgrade/pom.xml
+++ b/hadoop-ozone/upgrade/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hadoop</groupId>
+    <artifactId>hadoop-ozone</artifactId>
+    <version>0.5.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hadoop-ozone-upgrade</artifactId>
+  <version>0.5.0-SNAPSHOT</version>
+  <description>Apache Hadoop Ozone In-Place Upgrade</description>
+  <name>Apache Hadoop Ozone In-Place Upgrade</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.15.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Balance.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Balance.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.upgrade;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+
+/**
+ * Execute Ozone specific HDFS ballanced..
+ */
+@Command(name = "balance",
+    description = "Move the HDFS blocks for a better distribution "
+        + "usage.")
+public class Balance implements Callable<Void> {
+
+  @Override
+  public Void call() throws Exception {
+    System.err.println("[In-Place upgrade : balance] is not yet supported.");
+    return null;
+  }
+
+}

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Balance.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Balance.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 
 /**
- * Execute Ozone specific HDFS ballanced..
+ * Command to move blocks between HDFS datanodes.
  */
 @Command(name = "balance",
     description = "Move the HDFS blocks for a better distribution "

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Execute.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Execute.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.upgrade;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+
+/**
+ * Execute Ozone specific HDFS ballanced..
+ */
+@Command(name = "execute",
+    description = "Start/restart upgrade from HDFS to Ozone cluster.")
+public class Execute implements Callable<Void> {
+
+  @Override
+  public Void call() throws Exception {
+    System.err.println("In-Place upgrade : execute] is not yet supported.");
+    return null;
+  }
+
+}

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/InPlaceUpgrade.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/InPlaceUpgrade.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.upgrade;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "ozone upgrade",
+    description = "Convert raw HDFS data to Ozone data without data movement.",
+    subcommands = {
+        Plan.class,
+        Balance.class,
+        Execute.class,
+    },
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true)
+public class InPlaceUpgrade extends GenericCli {
+
+  public static void main(String[] args) {
+    new InPlaceUpgrade().run(args);
+  }
+}

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/InPlaceUpgrade.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/InPlaceUpgrade.java
@@ -22,6 +22,12 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
 import picocli.CommandLine.Command;
 
+/**
+ * Command  line interface for the In-Place upgrade utility.
+ * <p>
+ * In-Place upgrade can convert HDFS cluster data to Ozone data without
+ * (or minimal) data moving.
+ */
 @Command(name = "ozone upgrade",
     description = "Convert raw HDFS data to Ozone data without data movement.",
     subcommands = {

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Plan.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/Plan.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.upgrade;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+
+/**
+ * Command to calculate statistics and estimate the upgrade.
+ */
+@Command(name = "plan",
+    description = "Plan existing HDFS block distribution and give."
+        + "estimation.")
+public class Plan implements Callable<Void> {
+
+  @Override
+  public Void call() throws Exception {
+    System.err.println("[In-Place upgrade : plan] is not yet supported.");
+    return null;
+  }
+
+}

--- a/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/package-info.java
+++ b/hadoop-ozone/upgrade/src/main/java/org/apache/hadoop/ozone/upgrade/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.upgrade;
+
+/**
+ * In-Place upgrade utility to upgrade HDDS to Ozone cluster..
+ */


### PR DESCRIPTION
Ozone In-Place upgrade tool is a tool to upgrade hdfs data to ozone data without data movement.

In this jira I will create a skeleton project with the cli interface without any business logic.

See: https://issues.apache.org/jira/browse/HDDS-1383