### PR TITLE
HDDS-1398. Concurrency issue in SCMConnectionManager#getValues

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -35,13 +35,13 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static java.util.Collections.unmodifiableList;
 import static org.apache.hadoop.hdds.scm.HddsServerUtil
     .getScmRpcTimeOutInMilliseconds;
 
@@ -184,7 +184,12 @@ public class SCMConnectionManager
    * @return - List of RPC Endpoints.
    */
   public Collection<EndpointStateMachine> getValues() {
-    return scmMachines.values();
+    readLock();
+    try {
+      return unmodifiableList(new ArrayList<>(scmMachines.values()));
+    } finally {
+      readUnlock();
+    }
   }
 
   @Override
@@ -201,9 +206,7 @@ public class SCMConnectionManager
   public List<EndpointStateMachineMBean> getSCMServers() {
     readLock();
     try {
-      return Collections
-          .unmodifiableList(new ArrayList<>(scmMachines.values()));
-
+      return unmodifiableList(new ArrayList<>(scmMachines.values()));
     } finally {
       readUnlock();
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
@@ -154,8 +154,6 @@ public class TestDatanodeStateMachine {
 
   /**
    * Assert that starting statemachine executes the Init State.
-   *
-   * @throws InterruptedException
    */
   @Test
   public void testStartStopDatanodeStateMachine() throws IOException,
@@ -167,9 +165,9 @@ public class TestDatanodeStateMachine {
           stateMachine.getConnectionManager();
       GenericTestUtils.waitFor(
           () -> {
-            LOG.info("connectionManager.getValues().size() is {}",
-                connectionManager.getValues().size());
-            return connectionManager.getValues().size() == 1;
+            int size = connectionManager.getValues().size();
+            LOG.info("connectionManager.getValues().size() is {}", size);
+            return size == 1;
           }, 1000, 30000);
 
       stateMachine.stopDaemon();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testStartStopDatanodeStateMachine` is flaky, causing [occasional pre-commit build failures](https://builds.apache.org/job/hadoop-multibranch/job/PR-691/1/artifact/out/patch-unit-hadoop-hdds_container-service.txt).  [HDDS-1332](https://issues.apache.org/jira/browse/HDDS-1332) added some logging to find out more about the cause.

I think the problem is not test-specific, and is caused by the following: `SCMConnectionManager#scmMachines` is a plain `HashMap`, guarded by a `ReadWriteLock` in most places where it's used, except `getValues()`.  The method also returns the values collection without any write protection (though currently none of the callers modify it).

This is an attempt to fix the cause by acquiring the read lock and creating a read-only copy.

https://issues.apache.org/jira/browse/HDDS-1332

## How was this patch tested?

Ran affected unit tests several times, plus tried `ozone` docker-compose cluster.