### PR TITLE
HDDS-1397. Avoid the usage of signal handlers in datanodes of the MiniOzoneClusters

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -105,7 +105,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   @VisibleForTesting
   public static HddsDatanodeService createHddsDatanodeService(
       String[] args, Configuration conf) {
-    return createHddsDatanodeService(args, conf, true);
+    return createHddsDatanodeService(args, conf, false);
   }
 
   /**
@@ -124,11 +124,9 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     if (args.length == 0 && printBanner) {
       StringUtils
           .startupShutdownMessage(HddsDatanodeService.class, args, LOG);
-      return new HddsDatanodeService(conf);
-    } else {
-      new HddsDatanodeService().run(args);
-      return null;
+
     }
+    return new HddsDatanodeService(conf);
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
[~arpaga] showed me a problem that TestQueryNode.testHealthyNodesCount is failed in the CI check of HDDS-1339.

According to the logs the test is timed out because only 4 datanodes are started out of the 5.

The log also contained an exception from one datanode:

```
2019-04-04 00:26:33,583 WARN  ozone.HddsDatanodeService (LogAdapter.java:warn(59)) - failed to register any UNIX signal loggers: 
java.lang.IllegalStateException: Can't re-install the signal handlers.
    at org.apache.hadoop.util.SignalLogger.register(SignalLogger.java:77)
    at org.apache.hadoop.util.StringUtils.startupShutdownMessage(StringUtils.java:718)
    at org.apache.hadoop.util.StringUtils.startupShutdownMessage(StringUtils.java:707)
    at org.apache.hadoop.ozone.HddsDatanodeService.createHddsDatanodeService(HddsDatanodeService.java:126)
    at org.apache.hadoop.ozone.HddsDatanodeService.createHddsDatanodeService(HddsDatanodeService.java:108)
    at org.apache.hadoop.ozone.MiniOzoneClusterImpl$Builder.createHddsDatanodes(MiniOzoneClusterImpl.java:552)
```

The code which requires the signal handler is the following (signal handler is registered in the startupShutdownMessage)

```
/**
   * Create an Datanode instance based on the supplied command-line arguments.
   * <p>
   * This method is intended for unit tests only. It suppresses the
   * startup/shutdown message and skips registering Unix signal handlers.
   *
   * @param args        command line arguments.
   * @param conf        HDDS configuration
   * @param printBanner if true, then log a verbose startup message.
   * @return Datanode instance
   */
  private static HddsDatanodeService createHddsDatanodeService(
      String[] args, Configuration conf, boolean printBanner) {
    if (args.length == 0 && printBanner) {
      StringUtils
          .startupShutdownMessage(HddsDatanodeService.class, args, LOG);
      return new HddsDatanodeService(conf);
    } else {
      new HddsDatanodeService().run(args);
      return null;
   }
```

As you can read from the comment it's expected to be called with printBanner=false to avoid the creation of the signal handler. 

Note: In the startupShutdownMessage method a new signal handler is registered and signal handlers can be registered only once:

```
//SignalLogger
  void register(final LogAdapter LOG) {
   if (registered) {
      throw new IllegalStateException("Can't re-install the signal handlers.");
    }
 ....
```

We have a dedicated method to create datanode service for the unit tests. The only thing what we need is to turn OFF the signal handler registration here. (The following code fragment shows the original state where the signal handler creation is requested with the true parameter value)

```
  @VisibleForTesting
  public static HddsDatanodeService createHddsDatanodeService(
      String[] args, Configuration conf) {
    return createHddsDatanodeService(args, conf, true);
  }
```

See: https://issues.apache.org/jira/browse/HDDS-1397