### PR TITLE
HDDS-1402. Remove unused ScmBlockLocationProtocol from ObjectStoreHandler

### DIFF
--- a/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
+++ b/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
@@ -16,14 +16,15 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import com.sun.jersey.api.container.ContainerFactory;
-import com.sun.jersey.api.core.ApplicationAdapter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
-import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolClientSideTranslatorPB;
-import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
@@ -41,16 +42,9 @@ import org.apache.hadoop.ozone.web.interfaces.StorageHandler;
 import org.apache.hadoop.ozone.web.netty.ObjectStoreJerseyContainer;
 import org.apache.hadoop.ozone.web.storage.DistributedStorageHandler;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.ratis.protocol.ClientId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.sun.jersey.api.container.ContainerFactory;
+import com.sun.jersey.api.core.ApplicationAdapter;
 import static com.sun.jersey.api.core.ResourceConfig.FEATURE_TRACE;
 import static com.sun.jersey.api.core.ResourceConfig.PROPERTY_CONTAINER_REQUEST_FILTERS;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForBlockClients;
@@ -58,6 +52,9 @@ import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.ozone.OmUtils.getOmAddress;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_TRACE_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_TRACE_ENABLED_KEY;
+import org.apache.ratis.protocol.ClientId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implements object store handling within the DataNode process.  This class is
@@ -73,8 +70,7 @@ public final class ObjectStoreHandler implements Closeable {
   private final OzoneManagerProtocol ozoneManagerClient;
   private final StorageContainerLocationProtocol
       storageContainerLocationClient;
-  private final ScmBlockLocationProtocol
-      scmBlockLocationClient;
+
   private final StorageHandler storageHandler;
   private ClientId clientId = ClientId.randomId();
 
@@ -108,14 +104,6 @@ public final class ObjectStoreHandler implements Closeable {
 
     InetSocketAddress scmBlockAddress =
         getScmAddressForBlockClients(conf);
-    this.scmBlockLocationClient =
-        TracingUtil.createProxy(
-            new ScmBlockLocationProtocolClientSideTranslatorPB(
-                RPC.getProxy(ScmBlockLocationProtocolPB.class, scmVersion,
-                    scmBlockAddress, UserGroupInformation.getCurrentUser(),
-                    conf, NetUtils.getDefaultSocketFactory(conf),
-                    Client.getRpcTimeout(conf))),
-            ScmBlockLocationProtocol.class, conf);
 
     RPC.setProtocolEngine(conf, OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
@@ -171,7 +159,6 @@ public final class ObjectStoreHandler implements Closeable {
     LOG.info("Closing ObjectStoreHandler.");
     storageHandler.close();
     IOUtils.cleanupWithLogger(LOG, storageContainerLocationClient);
-    IOUtils.cleanupWithLogger(LOG, scmBlockLocationClient);
     IOUtils.cleanupWithLogger(LOG, ozoneManagerClient);
   }
 }

--- a/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
+++ b/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
@@ -102,9 +102,6 @@ public final class ObjectStoreHandler implements Closeable {
                     Client.getRpcTimeout(conf))),
             StorageContainerLocationProtocol.class, conf);
 
-    InetSocketAddress scmBlockAddress =
-        getScmAddressForBlockClients(conf);
-
     RPC.setProtocolEngine(conf, OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
     long omVersion =

--- a/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
+++ b/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/hdfs/server/datanode/ObjectStoreHandler.java
@@ -47,7 +47,6 @@ import com.sun.jersey.api.container.ContainerFactory;
 import com.sun.jersey.api.core.ApplicationAdapter;
 import static com.sun.jersey.api.core.ResourceConfig.FEATURE_TRACE;
 import static com.sun.jersey.api.core.ResourceConfig.PROPERTY_CONTAINER_REQUEST_FILTERS;
-import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForBlockClients;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.ozone.OmUtils.getOmAddress;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_TRACE_ENABLED_DEFAULT;


### PR DESCRIPTION
When I analyzed the usages of the available RPC protocols in Ozone I found that the ScmBlockLocationProtocol is not used in ObjectStore at all.

I would propose to remove it...

See: https://issues.apache.org/jira/browse/HDDS-1402