### PR TITLE
HDDS-1370. Command Execution in Datanode fails becaue of NPE

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
@@ -86,7 +86,16 @@ public class RunningDatanodeState implements DatanodeState {
     for (EndpointStateMachine endpoint : connectionManager.getValues()) {
       Callable<EndpointStateMachine.EndPointStates> endpointTask
           = getEndPointTask(endpoint);
-      ecs.submit(endpointTask);
+      if (endpointTask != null) {
+        ecs.submit(endpointTask);
+      } else {
+        // This can happen if a task is taking more time than the timeOut
+        // specified for the task in await, and when it is completed the task
+        // has set the state to Shutdown, we may see the state as shutdown
+        // here. So, we need to Shutdown DatanodeStateMachine.
+        LOG.error("State is Shutdown in RunningDatanodeState");
+        context.setState(DatanodeStateMachine.DatanodeStates.SHUTDOWN);
+      }
     }
   }
   //TODO : Cache some of these tasks instead of creating them


### PR DESCRIPTION
The reason for this can be if we take more time in executing a task, and in taskAwait we will return state as RUNNING and continue, and now when we execute task again internally endPoint state can be shutdown. Below code can return null. So, we need a null check over there.

Callable<EndpointStateMachine.EndPointStates> endpointTask
          = getEndPointTask(endpoint);