### PR TITLE
HDDS-1417. After successfully importing a container, datanode should delete the container tar.gz file from working directory.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -95,13 +95,12 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
       LOG.error(
           "Can't import the downloaded container data id=" + containerID,
           e);
+    } finally {
       try {
         Files.delete(tarFilePath);
       } catch (Exception ex) {
-        LOG.error(
-            "Container import is failed and the downloaded file can't be "
-                + "deleted: "
-                + tarFilePath.toAbsolutePath().toString());
+        LOG.error("Got exception while deleting downloaded container file: "
+            + tarFilePath.toAbsolutePath().toString(), ex);
       }
     }
   }


### PR DESCRIPTION
Whenever we want to replicate or copy a container from one datanode to another, we compress the container data and create a tar.gz file. This tar file is then copied from source datanode to destination datanode. In destination, we use a temporary working directory where this tar file is copied. Once the copying is complete we import the container. After importing the container we no longer need the tar file in the working directory of destination datanode, this has to be deleted.