### PR TITLE
HDDS-1424. Support multi-container robot test execution

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -122,3 +122,6 @@ run cp -p -r "${ROOT}/hadoop-ozone/dist/src/main/smoketest" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/src/main/blockade" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/k8s" kubernetes
 run cp -p -r "${ROOT}/hadoop-ozone/dist/src/main/Dockerfile" .
+
+#workaround for https://issues.apache.org/jira/browse/MRESOURCES-236
+find ./compose -name "*.sh" -exec chmod 755 {} \;

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -140,7 +140,7 @@
         <version>3.1.0</version>
         <executions>
           <execution>
-            <id>copy-compose</id>
+            <id>copy-compose-files</id>
             <phase>compile</phase>
             <goals>
               <goal>copy-resources</goal>

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -14,14 +14,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-RESULT_DIR=result
-#delete previous results
-rm -rf "${DIR:?}/$RESULT_DIR"
 
-REPLACEMENT="$DIR/../compose/test-all.sh"
-echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
 
-${REPLACEMENT}
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
 
-cp -r "$DIR/../compose/result" "$DIR"
+start_docker_env
+
+#Due to the limitation of the current auditparser test, it should be the
+#first test in a clean cluster.
+
+execute_robot_test scm auditparser
+
+execute_robot_test scm basic/basic.robot
+
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozonefs/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonefs/test.sh
@@ -14,14 +14,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-RESULT_DIR=result
-#delete previous results
-rm -rf "${DIR:?}/$RESULT_DIR"
 
-REPLACEMENT="$DIR/../compose/test-all.sh"
-echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
 
-${REPLACEMENT}
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
 
-cp -r "$DIR/../compose/result" "$DIR"
+start_docker_env
+
+execute_robot_test scm ozonefs/ozonefs.robot
+
+
+## TODO: As of the hhe o3fs tests are unstable.
+
+export OZONE_HOME=/opt/ozone
+
+#execute_robot_test hadoop32 ozonefs/hadoopo3fs.robot
+
+#execute_robot_test hadoop31 ozonefs/hadoopo3fs.robot
+
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozonefs/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonefs/test.sh
@@ -26,7 +26,7 @@ start_docker_env
 execute_robot_test scm ozonefs/ozonefs.robot
 
 
-## TODO: As of the hhe o3fs tests are unstable.
+## TODO: As of now the o3fs tests are unstable.
 
 export OZONE_HOME=/opt/ozone
 

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/test.sh
@@ -14,14 +14,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-RESULT_DIR=result
-#delete previous results
-rm -rf "${DIR:?}/$RESULT_DIR"
 
-REPLACEMENT="$DIR/../compose/test-all.sh"
-echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
 
-${REPLACEMENT}
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
 
-cp -r "$DIR/../compose/result" "$DIR"
+start_docker_env
+
+execute_robot_test scm basic/basic.robot
+
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozones3/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozones3/test.sh
@@ -14,14 +14,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-RESULT_DIR=result
-#delete previous results
-rm -rf "${DIR:?}/$RESULT_DIR"
 
-REPLACEMENT="$DIR/../compose/test-all.sh"
-echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
 
-${REPLACEMENT}
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
 
-cp -r "$DIR/../compose/result" "$DIR"
+start_docker_env
+
+execute_robot_test scm basic/basic.robot
+
+execute_robot_test scm s3
+
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -14,14 +14,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-RESULT_DIR=result
-#delete previous results
-rm -rf "${DIR:?}/$RESULT_DIR"
 
-REPLACEMENT="$DIR/../compose/test-all.sh"
-echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
 
-${REPLACEMENT}
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
 
-cp -r "$DIR/../compose/result" "$DIR"
+export SECURITY_ENABLED=true
+
+start_docker_env
+
+execute_robot_test scm kinit.robot
+
+execute_robot_test scm basic
+
+execute_robot_test scm security
+
+execute_robot_test scm ozonefs/ozonefs.robot
+
+execute_robot_test scm s3
+
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/test-single.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-single.sh
@@ -14,14 +14,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-RESULT_DIR=result
-#delete previous results
-rm -rf "${DIR:?}/$RESULT_DIR"
 
-REPLACEMENT="$DIR/../compose/test-all.sh"
-echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
+#
+# Single test executor, can start a single robot test in any running container.
+#
 
-${REPLACEMENT}
 
-cp -r "$DIR/../compose/result" "$DIR"
+COMPOSE_DIR="$PWD"
+export COMPOSE_DIR
+
+if [[ ! -f "$COMPOSE_DIR/docker-compose.yaml" ]]; then
+    echo "docker-compose.yaml is missing from the current dir. Please run this command from a docker-compose environment."
+    exit 1
+fi
+if (( $# != 2 )); then
+cat << EOF
+   Single test executor
+
+   Usage:
+
+     ../test-single.sh <container> <robot_test>
+
+        container: Name of the running docker-compose container (docker-compose.yaml is required in the current directory)
+
+        robot_test: name of the robot test or directory relative to the smoketest dir.
+
+
+
+EOF
+
+fi
+
+# shellcheck source=testlib.sh
+source "$COMPOSE_DIR/../testlib.sh"
+
+execute_robot_test "$1" "$2"
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+COMPOSE_ENV_NAME=$(basename "$COMPOSE_DIR")
+COMPOSE_FILE=$COMPOSE_DIR/docker-compose.yaml
+RESULT_DIR="$COMPOSE_DIR/result"
+RESULT_DIR_INSIDE="${OZONE_DIR:-/opt/hadoop}/compose/$(basename "$COMPOSE_ENV_NAME")/result"
+SMOKETEST_DIR_INSIDE="${OZONE_DIR:-/opt/hadoop}/smoketest"
+
+#delete previous results
+rm -rf "$RESULT_DIR"
+mkdir -p "$RESULT_DIR"
+#Should be writeable from the docker containers where user is different.
+chmod ogu+w "$RESULT_DIR"
+
+## @description wait until 3 datanodes are up (or 30 seconds)
+## @param the docker-compose file
+wait_for_datanodes(){
+
+  #Reset the timer
+  SECONDS=0
+
+  #Don't give it up until 30 seconds
+  while [[ $SECONDS -lt 90 ]]; do
+
+     #This line checks the number of HEALTHY datanodes registered in scm over the
+     # jmx HTTP servlet
+     datanodes=$(docker-compose -f "$1" exec -T scm curl -s 'http://localhost:9876/jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo' | jq -r '.beans[0].NodeCount[] | select(.key=="HEALTHY") | .value')
+      if [[ "$datanodes" == "3" ]]; then
+
+        #It's up and running. Let's return from the function.
+         echo "$datanodes datanodes are up and registered to the scm"
+         return
+      else
+
+         #Print it only if a number. Could be not a number if scm is not yet started
+         if [[ "$datanodes" ]]; then
+            echo "$datanodes datanode is up and healthy (until now)"
+         fi
+      fi
+
+      sleep 2
+   done
+   echo "WARNING! Datanodes are not started successfully. Please check the docker-compose files"
+}
+
+## @description  Starts a docker-compose based test environment
+start_docker_env(){
+  docker-compose -f "$COMPOSE_FILE" down
+  docker-compose -f "$COMPOSE_FILE" up -d --scale datanode=3
+  wait_for_datanodes "$COMPOSE_FILE"
+  sleep 10
+}
+
+## @description  Execute robot tests in a specific container.
+## @param        Name of the container in the docker-compose file
+## @param        robot test file or directory relative to the smoketest dir
+execute_robot_test(){
+  CONTAINER="$1"
+  TEST="$2"
+  TEST_NAME=$(basename "$TEST")
+  TEST_NAME=${TEST_NAME%.*}
+  set +e
+  TEST_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
+  docker-compose -f "$COMPOSE_FILE" exec -e  SECURITY_ENABLED="${SECURITY_ENABLED}" -T "$CONTAINER" python -m robot --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$RESULT_DIR_INSIDE/robot-$OUTPUT_NAME.xml" "$SMOKETEST_DIR_INSIDE/$TEST"
+  set -e
+
+}
+
+## @description  Stops a docker-compose based test environment (with saving the logs)
+stop_docker_env(){
+  docker-compose -f "$COMPOSE_FILE" logs > "$RESULT_DIR/docker-$OUTPUT_NAME.log"
+  if [ "${KEEP_RUNNING:-false}" = false ]; then
+     docker-compose -f "$COMPOSE_FILE" down
+  fi
+}
+
+## @description  Generate robot framework reports based on the saved results.
+generate_report(){
+  #Generate the combined output and return with the right exit code (note: robot = execute test, rebot = generate output)
+  docker run --rm -v "$DIR/..:${OZONE_DIR:-/opt/hadoop}" apache/hadoop-runner rebot -d "$RESULT_DIR_INSIDE" "$RESULT_DIR_INSIDE/robot-*.xml"
+}

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -77,7 +77,7 @@ execute_robot_test(){
   TEST_NAME=$(basename "$TEST")
   TEST_NAME=${TEST_NAME%.*}
   set +e
-  TEST_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
+  OUTPUT_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
   docker-compose -f "$COMPOSE_FILE" exec -e  SECURITY_ENABLED="${SECURITY_ENABLED}" -T "$CONTAINER" python -m robot --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$RESULT_DIR_INSIDE/robot-$OUTPUT_NAME.xml" "$SMOKETEST_DIR_INSIDE/$TEST"
   set -e
 

--- a/hadoop-ozone/dist/src/main/smoketest/README.md
+++ b/hadoop-ozone/dist/src/main/smoketest/README.md
@@ -27,4 +27,37 @@ The argument of the `robot` could be any robot file or directory.
 
 The current configuration in the robot files (hostnames, ports) are adjusted for the docker-based setup but you can easily modify it for any environment.
 
-The `./test.sh` in this directory can start multiple type of clusters (ozone standalone or ozone + hdfs) and execute the test framework with all of the clusters.
+# Run tests in docker environment
+
+In the ./compose folder there are additional test scripts to make it easy to run all tests or run a specific test in a docker environment.
+
+## Test one environment
+
+Go to the compose directory and execute the test.sh directly from there:
+
+```
+cd compose/ozone
+./test.sh
+```
+
+The results will be saved to the `compose/ozone/results`
+
+## Run all the tests
+
+```
+cd compose
+./test-all.sh
+```
+
+The results will be combined to the `compose/results` folder.
+
+## Run one specific test case
+
+Start the compose environment and execute test:
+
+```
+cd compose/ozone
+docker-compose up -d
+#wait....
+../test-single.sh scm basic/basic.robot
+```

--- a/hadoop-ozone/dist/src/main/smoketest/kinit.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/kinit.robot
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Kinit test user
+Library             OperatingSystem
+Resource            commonlib.robot
+Test Timeout        2 minute
+
+
+*** Test Cases ***
+Kinit
+   Kinit test user

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test ozone fs with hadoopfs
+Library             OperatingSystem
+Library             String
+Resource            ../commonlib.robot
+
+*** Variables ***
+${DATANODE_HOST}        datanode
+${PREFIX}               ozone
+
+*** Test cases ***
+
+Test hadoop dfs
+    ${random} =        Generate Random String  5  [NUMBERS]
+    ${result} =        Execute                    hdfs dfs -put /opt/hadoop/NOTICE.txt o3fs://bucket1.vol1/${PREFIX}-${random}
+    ${result} =        Execute                    hdfs dfs -ls o3fs://bucket1.vol1/
+                       Should contain             ${PREFIX}-${random}


### PR DESCRIPTION
The ./smoketest folder in the distribution package contains robotframework based test scripts to test the main behaviour of Ozone.

The tests have two layers:

1. robot test definitions to execute commands and assert the results (on a given host machine)
2. ./smoketest/test.sh which starts/stops the docker-compose based environments AND execute the selected robot tests inside the right hosts

The second one (test.sh) has some serious limitations:

1. all the tests are executed inside the same container (om):

https://github.com/apache/hadoop/blob/5f951ea2e39ae4dfe554942baeec05849cd7d3c2/hadoop-ozone/dist/src/main/smoketest/test.sh#L89

Some of the tests (ozonesecure-mr, ozonefs) may require the flexibility to execute different robot tests in different containers.

2. The definition of the global test set is complex and hard to understood. 

The current code is:
{code}
   TESTS=("basic")
   execute_tests ozone "${TESTS[@]}"
   TESTS=("auditparser")
   execute_tests ozone "${TESTS[@]}"
   TESTS=("ozonefs")
   execute_tests ozonefs "${TESTS[@]}"
   TESTS=("basic")
   execute_tests ozone-hdfs "${TESTS[@]}"
   TESTS=("s3")
   execute_tests ozones3 "${TESTS[@]}"
   TESTS=("security")
   execute_tests ozonesecure .
{code} 

For example for ozonesecure the TESTS is not used. And the usage of bash lists require additional complexity in the execute_tests function.

I propose here a very lightweight refactor. Instead of including both the test definitions AND the helper methods in test.sh I would separate them.

Let's put a test.sh to each of the compose directories. The separated test.sh can include common methods from a main shell script. For example:

{code}

source "$COMPOSE_DIR/../testlib.sh"

start_docker_env

execute_robot_test scm basic/basic.robot

execute_robot_test scm s3

stop_docker_env

generate_report

{code}

This is a more clean and more flexible definition. It's easy to execute just this test (as it's saved to the compose/ozones3 directory. And it's more flexible.

Other example, where multiple containers are used to execute tests:

{code}

source "$COMPOSE_DIR/../testlib.sh"

start_docker_env

execute_robot_test scm ozonefs/ozonefs.robot



export OZONE_HOME=/opt/ozone

execute_robot_test hadoop32 ozonefs/hadoopo3fs.robot

execute_robot_test hadoop31 ozonefs/hadoopo3fs.robot

stop_docker_env

generate_report
{code}

With this separation the definition of the helper methods (eg. execute_robot_test or stop_docker_env) would also be simplified.

See: https://issues.apache.org/jira/browse/HDDS-1424