### PR TITLE
HDDS-1419. Fix shellcheck errors in start-chaos.sh

### DIFF
--- a/hadoop-ozone/integration-test/src/test/bin/start-chaos.sh
+++ b/hadoop-ozone/integration-test/src/test/bin/start-chaos.sh
@@ -15,21 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-date=`date +"%m-%d-%y-%T"`
+date=$(date +"%m-%d-%y-%T")
 fileformat=".MiniOzoneChaosCluster.log"
 heapformat=".dump"
 current="/tmp/"
-filename=$current$date$fileformat
-heapdumpfile=$current$date$heapformat
+filename="${current}${date}${fileformat}"
+heapdumpfile="${current}${date}${heapformat}"
 
-export MAVEN_OPTS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={$heapdumpfile}"
+export MAVEN_OPTS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${heapdumpfile}"
 
-echo "logging to" ${filename}
-echo "heapdump to" ${heapdumpfile}
+echo "logging to ${filename}"
+echo "heapdump to ${heapdumpfile}"
 
 echo "Starting MiniOzoneChaosCluster"
-mvn clean install -DskipTests > ${filename} 2>&1
+mvn clean install -DskipTests > "${filename}" 2>&1
 mvn exec:java \
   -Dexec.mainClass="org.apache.hadoop.ozone.TestMiniChaosOzoneCluster" \
   -Dexec.classpathScope=test \
-  -Dexec.args="$*" >> ${filename} 2>&1
+  -Dexec.args="$*" >> "${filename}" 2>&1


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Fix shellcheck errors in `start-chaos.sh`
 * Enclose all remaining variables in `{}`
 * Fix typo in enclosure of variable: `{$heapdumpfile}` -> `${heapdumpfile}`

https://issues.apache.org/jira/browse/HDDS-1419

## How was this patch tested?

Verified that shellcheck no longer reports any problems about `start-chaos.sh`.

Also ran `start-chaos.sh`:

```
$ cd hadoop-ozone/integration-test
$ src/test/bin/start-chaos.sh
logging to /tmp/04-11-19-17:07:58.MiniOzoneChaosCluster.log
heapdump to /tmp/04-11-19-17:07:58.dump
Starting MiniOzoneChaosCluster
```

Verified that `HeapDumpPath` passed to the `java` process is the same as shown by `start-chaos.sh`.

```
$ ps x | grep -o '[H]eapDumpPath[^ ]*'
HeapDumpPath=/tmp/04-11-19-17:07:58.dump
```

