### PR TITLE
[YARN-9479] Use Objects.equals(String,String) to avoid possible NullPointerException

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/UserGroupMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/UserGroupMappingPlacementRule.java
@@ -196,9 +196,9 @@ public class UserGroupMappingPlacementRule extends PlacementRule {
         ApplicationPlacementContext mappedQueue = getPlacementForUser(user);
         if (mappedQueue != null) {
           // We have a mapping, should we use it?
-          if (queueName.equals(YarnConfiguration.DEFAULT_QUEUE_NAME)
+          if (Objects.equals(queueName,YarnConfiguration.DEFAULT_QUEUE_NAME)
               //queueName will be same as mapped queue name in case of recovery
-              || queueName.equals(mappedQueue.getQueue())
+              || Objects.equals(queueName,mappedQueue.getQueue())
               || overrideWithQueueMappings) {
             LOG.info("Application " + applicationId + " user " + user
                 + " mapping [" + queueName + "] to [" + mappedQueue


### PR DESCRIPTION
Hello,
I found that the String "queueName" may have potential risk of 
NullPointerException since they are immediately used after initialization and there is no null checker. One recommended API is Objects.equals(String,String) which can avoid this exception.