### PR TITLE
HDFS-14425:Native build fails on macos due to jlong in hdfs.c

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -3056,7 +3056,7 @@ tOffset hdfsGetDefaultBlockSizeAtPath(hdfsFS fs, const char *path)
             path);
         return -1;
     }
-    jthr = getDefaultBlockSize(env, jFS, jPath, &blockSize);
+    jthr = getDefaultBlockSize(env, jFS, jPath, (jlong *)&blockSize);
     (*env)->DeleteLocalRef(env, jPath);
     if (jthr) {
         errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,


### PR DESCRIPTION
[WARNING] /Users/xx/tmp/idea/hadoop-3.2.0-src/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c:3033:/Users/xx/tmp/idea/hadoop-3.2.0-src/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c:3033:4949::  warningwarning: : incompatible pointer types passing 'tOffset *' (aka 'long long *') to parameter of type 'jlong *' (aka 'long *') [-Wincompatible-pointer-types]incompatible pointer types passing 'tOffset *' (aka 'long long *') to parameter of type 'jlong *' (aka 'long *') [-Wincompatible-pointer-types]