### PR TITLE
HDDS-999. Make the DNS resolution in OzoneManager more resilient. (swagle)

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
@@ -44,7 +44,6 @@ services:
          - 9874:9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -49,7 +49,6 @@ services:
          - 9892:9872
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
          - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
@@ -63,7 +62,6 @@ services:
          - 9894:9872
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
          - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -36,7 +36,6 @@ services:
          - 9890:9872
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozone-recon/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-recon/docker-compose.yaml
@@ -36,7 +36,6 @@ services:
          - 9874:9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -36,7 +36,6 @@ services:
          - 9874:9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozonefs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonefs/docker-compose.yaml
@@ -34,7 +34,6 @@ services:
          - 9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
          - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
          - 9874:9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozones3/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozones3/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
          - 9874:9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["ozone","om"]

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -49,7 +49,6 @@ services:
     ports:
       - 9874:9874
     environment:
-      WAITFOR: scm:9876
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
     env_file:
       - docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -51,7 +51,6 @@ services:
     ports:
       - 9874:9874
     environment:
-      WAITFOR: scm:9876
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
     env_file:
       - docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozonetrace/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonetrace/docker-compose.yaml
@@ -39,7 +39,6 @@ services:
          - 9874:9874
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-         WAITFOR: scm:9876
       env_file:
           - ./docker-config
       command: ["ozone","om"]

--- a/hadoop-ozone/dist/src/main/k8s/ozone/om-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/ozone/om-statefulset.yaml
@@ -43,9 +43,6 @@ spec:
             - ozone
             - om
             - --init
-          env:
-            - name: "ENSURE_OM_INITIALIZED"
-              value: "/data/metadata/om/current/VERSION"
           volumeMounts:
             - name: "data"
               mountPath: "/data"
@@ -58,9 +55,6 @@ spec:
           args:
             - ozone
             - om
-          env:
-            - name: "ENSURE_OM_INITIALIZED"
-              value: "/data/metadata/om/current/VERSION"
           volumeMounts:
             - name: "data"
               mountPath: "/data"

--- a/hadoop-ozone/dist/src/main/k8s/ozone/om-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/ozone/om-statefulset.yaml
@@ -44,8 +44,8 @@ spec:
             - om
             - --init
           env:
-            - name: "WAITFOR"
-              value: "scm-0.scm:9876"
+            - name: "ENSURE_OM_INITIALIZED"
+              value: "/data/metadata/om/current/VERSION"
           volumeMounts:
             - name: "data"
               mountPath: "/data"
@@ -59,8 +59,8 @@ spec:
             - ozone
             - om
           env:
-            - name: "WAITFOR"
-              value: "scm-0.scm:9876"
+            - name: "ENSURE_OM_INITIALIZED"
+              value: "/data/metadata/om/current/VERSION"
           volumeMounts:
             - name: "data"
               mountPath: "/data"

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -302,7 +302,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // For testing purpose only, not hit scm from om as Hadoop UGI can't login
     // two principals in the same JVM.
     if (!testSecureOmFlag) {
-      ScmInfo scmInfo = scmBlockClient.getScmInfo();
+      ScmInfo scmInfo = getScmInfo(configuration);
       if (!(scmInfo.getClusterId().equals(omStorage.getClusterID()) && scmInfo
           .getScmId().equals(omStorage.getScmId()))) {
         throw new OMException("SCM version info mismatch.",


### PR DESCRIPTION
Brought back change from HDDS-776 with the retriable task, OM will now wait for at least 50 seconds before giving up.