### PR TITLE
HDFS-14456:HAState#prepareToEnterState neednt a lock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -958,9 +958,9 @@ public class NameNode extends ReconfigurableBase implements
     try {
       initializeGenericKeys(conf, nsId, namenodeId);
       initialize(getConf());
+      state.prepareToEnterState(haContext);
       try {
         haContext.writeLock();
-        state.prepareToEnterState(haContext);
         state.enterState(haContext);
       } finally {
         haContext.writeUnlock();


### PR DESCRIPTION
prepareToEnterState in HAState is called without the context being locked.

But in NameNode#NameNode, prepareToEnterState is after haContext.writeLock()

 
``` java
try {
  haContext.writeLock();
  state.prepareToEnterState(haContext);
  state.enterState(haContext);
} finally {
  haContext.writeUnlock();
}
```

Is it OK?

I move `state.prepareToEnterState(haContext);` out 