### PR TITLE
HDDS-1479. Update S3.md documentation

### DIFF
--- a/hadoop-hdds/docs/content/S3.md
+++ b/hadoop-hdds/docs/content/S3.md
@@ -82,8 +82,8 @@ Operation on Objects:
 Endpoint                            | Status          | Notes
 ------------------------------------|-----------------|---------------
 PUT Object                          | implemented     |
-GET Object                          | implemented     | Range headers are not supported
-Multipart Uplad                     | implemented |Except the listing of the current MultiPartUploads.
+GET Object                          | implemented     |
+Multipart Upload                     | implemented |Except the listing of the current MultiPartUploads.
 DELETE Object                       | implemented     |
 HEAD Object                         | implemented     |
 


### PR DESCRIPTION
HDDS-791 implemented range get operation.

But, S3.md documentation still has the below line: 

GET Object | implemented | Range headers are not supported

This PR deletes the "Range headers are not supported" from the doc.