### PR TITLE
HADOOP-16294: Enable access to input options by DistCp subclasses

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -417,7 +417,7 @@ public class DistCp extends Configured implements Tool {
   }
 
   /**
-   * Returns the input options
+   * Returns the input options.
    *
    * @return input options
    */

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -417,6 +417,15 @@ public class DistCp extends Configured implements Tool {
   }
 
   /**
+   * Returns the input options
+   *
+   * @return input options
+   */
+  protected DistCpOptions getInputOptions() {
+    return inputOptions;
+  }
+
+  /**
    * Main function of the DistCp program. Parses the input arguments (via OptionsParser),
    * and invokes the DistCp::run() method, via the ToolRunner.
    * @param argv Command-line arguments sent to DistCp.

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -417,12 +417,12 @@ public class DistCp extends Configured implements Tool {
   }
 
   /**
-   * Returns the input options.
+   * Returns the context.
    *
-   * @return input options
+   * @return the context
    */
-  protected DistCpOptions getInputOptions() {
-    return inputOptions;
+  protected DistCpContext getContext() {
+    return context;
   }
 
   /**


### PR DESCRIPTION
[HADOOP-16294](https://issues.apache.org/jira/browse/HADOOP-16294)

Adding a protected-scope getter for the DistCpOptions, so that a subclass does not need to save its own copy of the inputOptions supplied to its constructor, if it wishes to override the createInputFileListing method with logic similar to the original implementation, i.e. calling CopyListing#buildListing with a path and input options.