### PR TITLE
HDDS-1458. Create a maven profile to run fault injection tests

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -340,6 +340,39 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>blockade</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>blockade-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>python</executable>
+                  <workingDirectory>
+                    ${project.build.directory}/ozone-${project.version}
+                  </workingDirectory>
+                  <arguments>
+                    <argument>-m</argument>
+                    <argument>pytest</argument>
+                    <argument>-s</argument>
+                    <argument>${project.build.directory}/ozone-${project.version}/blockade</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 
 </project>


### PR DESCRIPTION
Some fault injection tests have been written using blockade.  It would be nice to have ability to start docker compose and exercise the blockade test cases against Ozone docker containers, and generate reports.  This is optional integration tests to catch race conditions and fault tolerance defects. 

We can introduce a profile with id: it (short for integration tests).  This will launch docker compose via maven-exec-plugin and run blockade to simulate container failures and timeout.

Usage command:
{code}
mvn clean verify -Pit
{code}

See: https://issues.apache.org/jira/browse/HDDS-1458