### PR TITLE
HADOOP-16085 S3Guard versioning (stevel patch 002)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1904,15 +1904,15 @@
   <name>fs.s3a.change.detection.mode</name>
   <value>server</value>
   <description>
-    Determines how change detection is applied to alert to S3 objects
-    rewritten while being read. Value 'server' indicates to apply the attribute
-    constraint directly on GetObject requests to S3. Value 'client' means to do a
-    client-side comparison of the attribute value returned in the response.  Value
-    'server' would not work with third-party S3 implementations that do not
-    support these constraints on GetObject. Values 'server' and 'client' generate
-    RemoteObjectChangedException when a mismatch is detected.  Value 'warn' works
-    like 'client' but generates only a warning.  Value 'none' will ignore change
-    detection completely.
+    Determines how change detection is applied to alert to inconsistent S3
+    objects read during or after an overwrite. Value 'server' indicates to apply
+    the attribute constraint directly on GetObject requests to S3. Value 'client'
+    means to do a client-side comparison of the attribute value returned in the
+    response.  Value 'server' would not work with third-party S3 implementations
+    that do not support these constraints on GetObject. Values 'server' and
+    'client' generate RemoteObjectChangedException when a mismatch is detected.
+    Value 'warn' works like 'client' but generates only a warning.  Value 'none'
+    will ignore change detection completely.
   </description>
 </property>
 

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -407,6 +407,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>test</scope>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/RemoteFileChangedException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/RemoteFileChangedException.java
@@ -32,6 +32,9 @@ import org.apache.hadoop.fs.PathIOException;
 @InterfaceStability.Unstable
 public class RemoteFileChangedException extends PathIOException {
 
+  public static final String PRECONDITIONS_FAILED =
+      "Constraints of request were unsatisfiable";
+
   /**
    * Constructs a RemoteFileChangedException.
    *
@@ -44,6 +47,23 @@ public class RemoteFileChangedException extends PathIOException {
       String operation,
       String message) {
     super(path, message);
+    setOperation(operation);
+  }
+
+  /**
+   * Constructs a RemoteFileChangedException.
+   *
+   * @param path the path accessed when the change was detected
+   * @param operation the operation (e.g. open, re-open) performed when the
+   * change was detected
+   * @param message a message providing more details about the condition
+   * @param cause inner cause.
+   */
+  public RemoteFileChangedException(String path,
+      String operation,
+      String message,
+      Throwable cause) {
+    super(path, message, cause);
     setOperation(operation);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileStatus.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
  * File status for an S3A "file".
@@ -32,6 +33,8 @@ import org.apache.hadoop.fs.Path;
 @InterfaceStability.Evolving
 public class S3AFileStatus extends FileStatus {
   private Tristate isEmptyDirectory;
+  private String eTag;
+  private String versionId;
 
   /**
    * Create a directory status.
@@ -69,15 +72,17 @@ public class S3AFileStatus extends FileStatus {
    * @param path path
    * @param blockSize block size
    * @param owner owner
+   * @param eTag eTag of the S3 object if available, else null
+   * @param versionId versionId of the S3 object if available, else null
    */
   public S3AFileStatus(long length, long modification_time, Path path,
-      long blockSize, String owner) {
-    super(length, false, 1, blockSize, modification_time, 0,
-        null, null, null, null,
+      long blockSize, String owner, String eTag, String versionId) {
+    super(length, false, 1, blockSize, modification_time,
+        0, null, owner, owner, null,
         path, false, true, false);
     isEmptyDirectory = Tristate.FALSE;
-    setOwner(owner);
-    setGroup(owner);
+    this.eTag = eTag;
+    this.versionId = versionId;
   }
 
   /**
@@ -86,16 +91,19 @@ public class S3AFileStatus extends FileStatus {
    * @param source FileStatus to convert to S3AFileStatus
    * @param isEmptyDirectory TRUE/FALSE if known to be / not be an empty
    *     directory, UNKNOWN if that information was not computed.
+   * @param eTag eTag of the S3 object if available, else null
+   * @param versionId versionId of the S3 object if available, else null
    * @return a new S3AFileStatus
    */
   public static S3AFileStatus fromFileStatus(FileStatus source,
-      Tristate isEmptyDirectory) {
+      Tristate isEmptyDirectory, String eTag, String versionId) {
     if (source.isDirectory()) {
       return new S3AFileStatus(isEmptyDirectory, source.getPath(),
           source.getOwner());
     } else {
       return new S3AFileStatus(source.getLen(), source.getModificationTime(),
-          source.getPath(), source.getBlockSize(), source.getOwner());
+          source.getPath(), source.getBlockSize(), source.getOwner(),
+          eTag, versionId);
     }
   }
 
@@ -107,6 +115,28 @@ public class S3AFileStatus extends FileStatus {
    */
   public Tristate isEmptyDirectory() {
     return isEmptyDirectory;
+  }
+
+  /**
+   * Update isEmptyDirectory attribute.
+   * @param isEmptyDirectory new isEmptyDirectory value
+   */
+  public void setIsEmptyDirectory(Tristate isEmptyDirectory) {
+    this.isEmptyDirectory = isEmptyDirectory;
+  }
+
+  /**
+   * @return the S3 object eTag when available, else null.
+   */
+  public String getETag() {
+    return eTag;
+  }
+
+  /**
+   * @return the S3 object versionId when available, else null.
+   */
+  public String getVersionId() {
+    return versionId;
   }
 
   /** Compare if this object is equal to another object.
@@ -150,8 +180,10 @@ public class S3AFileStatus extends FileStatus {
 
   @Override
   public String toString() {
-    return super.toString() +
-        String.format(" isEmptyDirectory=%s", isEmptyDirectory().name());
+    return super.toString()
+        + String.format(" isEmptyDirectory=%s", isEmptyDirectory().name()
+        + String.format(" eTag=%s", eTag)
+        + String.format(" versionId=%s", versionId));
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -74,6 +74,7 @@ import com.amazonaws.services.s3.transfer.Copy;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerConfiguration;
 import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.model.CopyResult;
 import com.amazonaws.services.s3.transfer.model.UploadResult;
 import com.amazonaws.event.ProgressListener;
 import com.google.common.annotations.VisibleForTesting;
@@ -115,6 +116,7 @@ import org.apache.hadoop.fs.s3a.auth.delegation.AbstractS3ATokenIdentifier;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 import org.apache.hadoop.fs.s3a.commit.PutTracker;
 import org.apache.hadoop.fs.s3a.commit.MagicCommitIntegration;
+import org.apache.hadoop.fs.s3a.impl.ChangeTracker;
 import org.apache.hadoop.fs.s3a.select.SelectBinding;
 import org.apache.hadoop.fs.s3a.select.SelectConstants;
 import org.apache.hadoop.fs.s3a.s3guard.DirListingMetadata;
@@ -696,11 +698,12 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   }
 
   /**
-   * Get the change detection policy for this FS instance.
+   * Get the change detection policy for this FS instance.  Only public to allow
+   * access in tests in other packages.
    * @return the change detection policy
    */
   @VisibleForTesting
-  ChangeDetectionPolicy getChangeDetectionPolicy() {
+  public ChangeDetectionPolicy getChangeDetectionPolicy() {
     return changeDetectionPolicy;
   }
 
@@ -877,7 +880,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       throws IOException {
 
     entryPoint(INVOCATION_OPEN);
-    final FileStatus fileStatus = getFileStatus(path);
+    final S3AFileStatus fileStatus = (S3AFileStatus) getFileStatus(path);
     if (fileStatus.isDirectory()) {
       throw new FileNotFoundException("Can't open " + path
           + " because it is a directory");
@@ -910,7 +913,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     return new FSDataInputStream(
         new S3AInputStream(
             readContext,
-            createObjectAttributes(path),
+            createObjectAttributes(
+                path,
+                fileStatus.getETag(),
+                fileStatus.getVersionId()),
             fileStatus.getLen(),
             s3));
   }
@@ -943,13 +949,20 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   /**
    * Create the attributes of an object for a get/select request.
    * @param f path path of the request.
+   * @param eTag the eTag of the S3 object
+   * @param versionId S3 object version ID
    * @return attributes to use when building the query.
    */
-  private S3ObjectAttributes createObjectAttributes(final Path f) {
+  private S3ObjectAttributes createObjectAttributes(
+      final Path f,
+      final String eTag,
+      final String versionId) {
     return new S3ObjectAttributes(bucket,
         pathToKey(f),
         getServerSideEncryptionAlgorithm(),
-        encryptionSecrets.getEncryptionKey());
+        encryptionSecrets.getEncryptionKey(),
+        eTag,
+        versionId);
   }
 
   /**
@@ -1213,19 +1226,27 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     if (srcStatus.isFile()) {
       LOG.debug("rename: renaming file {} to {}", src, dst);
       long length = srcStatus.getLen();
+      S3ObjectAttributes objectAttributes =
+          createObjectAttributes(srcStatus.getPath(),
+              srcStatus.getETag(), srcStatus.getVersionId());
+      S3AReadOpContext readContext = createReadContext(srcStatus, inputPolicy,
+          changeDetectionPolicy, readAhead);
       if (dstStatus != null && dstStatus.isDirectory()) {
         String newDstKey = maybeAddTrailingSlash(dstKey);
         String filename =
             srcKey.substring(pathToKey(src.getParent()).length()+1);
         newDstKey = newDstKey + filename;
-        copyFile(srcKey, newDstKey, length);
+        CopyResult copyResult = copyFile(srcKey, newDstKey, length,
+            objectAttributes, readContext);
         S3Guard.addMoveFile(metadataStore, srcPaths, dstMetas, src,
             keyToQualifiedPath(newDstKey), length, getDefaultBlockSize(dst),
-            username);
+            username, copyResult.getETag(), copyResult.getVersionId());
       } else {
-        copyFile(srcKey, dstKey, srcStatus.getLen());
+        CopyResult copyResult = copyFile(srcKey, dstKey, srcStatus.getLen(),
+            objectAttributes, readContext);
         S3Guard.addMoveFile(metadataStore, srcPaths, dstMetas, src, dst,
-            length, getDefaultBlockSize(dst), username);
+            length, getDefaultBlockSize(dst), username,
+            copyResult.getETag(), copyResult.getVersionId());
       }
       innerDelete(srcStatus, false);
     } else {
@@ -1248,10 +1269,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       }
 
       Path parentPath = keyToQualifiedPath(srcKey);
-      RemoteIterator<LocatedFileStatus> iterator = listFilesAndEmptyDirectories(
-          parentPath, true);
+      RemoteIterator<S3ALocatedFileStatus> iterator =
+          listFilesAndEmptyDirectories(parentPath, true);
       while (iterator.hasNext()) {
-        LocatedFileStatus status = iterator.next();
+        S3ALocatedFileStatus status = iterator.next();
         long length = status.getLen();
         String key = pathToKey(status.getPath());
         if (status.isDirectory() && !key.endsWith("/")) {
@@ -1261,7 +1282,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
             .add(new DeleteObjectsRequest.KeyVersion(key));
         String newDstKey =
             dstKey + key.substring(srcKey.length());
-        copyFile(key, newDstKey, length);
+        S3ObjectAttributes objectAttributes =
+            createObjectAttributes(status.getPath(),
+                status.getETag(), status.getVersionId());
+        S3AReadOpContext readContext = createReadContext(status, inputPolicy,
+            changeDetectionPolicy, readAhead);
+        CopyResult copyResult = copyFile(key, newDstKey, length,
+            objectAttributes, readContext);
 
         if (hasMetadataStore()) {
           // with a metadata store, the object entries need to be updated,
@@ -1273,7 +1300,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
                 childDst, username);
           } else {
             S3Guard.addMoveFile(metadataStore, srcPaths, dstMetas, childSrc,
-                childDst, length, getDefaultBlockSize(childDst), username);
+                childDst, length, getDefaultBlockSize(childDst), username,
+                copyResult.getETag(), copyResult.getVersionId());
           }
           // Ancestor directories may not be listed, so we explicitly add them
           S3Guard.addMoveAncestors(metadataStore, srcPaths, dstMetas,
@@ -1802,7 +1830,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       PutObjectResult result = s3.putObject(putObjectRequest);
       incrementPutCompletedStatistics(true, len);
       // update metadata
-      finishedWrite(putObjectRequest.getKey(), len);
+      finishedWrite(putObjectRequest.getKey(), len,
+          result.getETag(), result.getVersionId());
       return result;
     } catch (AmazonClientException e) {
       incrementPutCompletedStatistics(false, len);
@@ -2160,7 +2189,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     LOG.debug("List status for path: {}", path);
     entryPoint(INVOCATION_LIST_STATUS);
 
-    List<FileStatus> result;
+    List<S3AFileStatus> result;
     final FileStatus fileStatus =  getFileStatus(path);
 
     if (fileStatus.isDirectory()) {
@@ -2419,11 +2448,11 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         }
       }
 
-      FileStatus msStatus = pm.getFileStatus();
+      S3AFileStatus msStatus = pm.getFileStatus();
       if (needEmptyDirectoryFlag && msStatus.isDirectory()) {
         if (pm.isEmptyDirectory() != Tristate.UNKNOWN) {
           // We have a definitive true / false from MetadataStore, we are done.
-          return S3AFileStatus.fromFileStatus(msStatus, pm.isEmptyDirectory());
+          return msStatus;
         } else {
           DirListingMetadata children =
               S3Guard.listChildrenWithTtl(metadataStore, path, ttlTimeProvider);
@@ -2434,7 +2463,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         }
       } else {
         // Either this is not a directory, or we don't care if it is empty
-        return S3AFileStatus.fromFileStatus(msStatus, pm.isEmptyDirectory());
+        return msStatus;
       }
 
       // If the metadata store has no children for it and it's not listed in
@@ -2443,7 +2472,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       try {
         s3FileStatus = s3GetFileStatus(path, key, tombstones);
       } catch (FileNotFoundException e) {
-        return S3AFileStatus.fromFileStatus(msStatus, Tristate.TRUE);
+        return S3AFileStatus.fromFileStatus(msStatus, Tristate.TRUE,
+            null, null);
       }
       // entry was found, save in S3Guard
       return S3Guard.putAndReturn(metadataStore, s3FileStatus, instrumentation);
@@ -2482,7 +2512,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
               dateToLong(meta.getLastModified()),
               path,
               getDefaultBlockSize(path),
-              username);
+              username,
+              meta.getETag(),
+              meta.getVersionId());
         }
       } catch (AmazonServiceException e) {
         if (e.getStatusCode() != 404) {
@@ -2509,7 +2541,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
                     dateToLong(meta.getLastModified()),
                     path,
                     getDefaultBlockSize(path),
-                    username);
+                    username,
+                    meta.getETag(),
+                    meta.getVersionId());
           }
         } catch (AmazonServiceException e) {
           if (e.getStatusCode() != 404) {
@@ -2734,7 +2768,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     UploadResult result = waitForUploadCompletion(key, info);
     listener.uploadCompleted();
     // post-write actions
-    finishedWrite(key, info.getLength());
+    finishedWrite(key, info.getLength(),
+        result.getETag(), result.getVersionId());
     return result;
   }
 
@@ -2899,12 +2934,16 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @param srcKey source object path
    * @param dstKey destination object path
    * @param size object size
+   * @param srcAttributes S3 attributes of the source object
+   * @param readContext the read context
+   * @return the result of the copy
    * @throws AmazonClientException on failures inside the AWS SDK
    * @throws InterruptedIOException the operation was interrupted
    * @throws IOException Other IO problems
    */
   @Retries.RetryMixed
-  private void copyFile(String srcKey, String dstKey, long size)
+  private CopyResult copyFile(String srcKey, String dstKey, long size,
+      S3ObjectAttributes srcAttributes, S3AReadOpContext readContext)
       throws IOException, InterruptedIOException  {
     LOG.debug("copyFile {} -> {} ", srcKey, dstKey);
 
@@ -2918,27 +2957,90 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       }
     };
 
-    once("copyFile(" + srcKey + ", " + dstKey + ")", srcKey,
+    return once("copyFile(" + srcKey + ", " + dstKey + ")", srcKey,
         () -> {
           ObjectMetadata srcom = getObjectMetadata(srcKey);
           ObjectMetadata dstom = cloneObjectMetadata(srcom);
           setOptionalObjectMetadata(dstom);
+
+          ChangeTracker changeTracker = new ChangeTracker(
+              keyToQualifiedPath(srcKey).toString(),
+              changeDetectionPolicy,
+              readContext.instrumentation.newInputStreamStatistics()
+                  .getVersionMismatchCounter(),
+              srcAttributes);
+
+          changeTracker.processMetadata(srcom, "copy", 0);
+
           CopyObjectRequest copyObjectRequest =
               new CopyObjectRequest(bucket, srcKey, bucket, dstKey);
+          changeTracker.maybeApplyConstraint(copyObjectRequest);
+
           setOptionalCopyObjectRequestParameters(copyObjectRequest);
           copyObjectRequest.setCannedAccessControlList(cannedACL);
           copyObjectRequest.setNewObjectMetadata(dstom);
           Copy copy = transfers.copy(copyObjectRequest);
           copy.addProgressListener(progressListener);
           try {
-            copy.waitForCopyResult();
+            CopyOutcome copyOutcome = copyOutcome(copy);
+            InterruptedException interruptedException =
+                copyOutcome.getInterruptedException();
+            if (interruptedException != null) {
+              throw interruptedException;
+            }
+            RuntimeException runtimeException =
+                copyOutcome.getRuntimeException();
+            if (runtimeException != null) {
+              changeTracker.processException(runtimeException, "copy");
+              throw runtimeException;
+            }
+            CopyResult result = copyOutcome.getCopyResult();
+            changeTracker.processResponse(result);
             incrementWriteOperations();
             instrumentation.filesCopied(1, size);
+            return result;
           } catch (InterruptedException e) {
             throw new InterruptedIOException("Interrupted copying " + srcKey
                 + " to " + dstKey + ", cancelling");
           }
         });
+  }
+
+  private static CopyOutcome copyOutcome(Copy copy) {
+    try {
+      CopyResult result = copy.waitForCopyResult();
+      return new CopyOutcome(result, null, null);
+    } catch (RuntimeException e) {
+      return new CopyOutcome(null, null, e);
+    } catch (InterruptedException e) {
+      return new CopyOutcome(null, e, null);
+    }
+  }
+
+  private static final class CopyOutcome {
+    private final CopyResult copyResult;
+    private final InterruptedException interruptedException;
+    private final RuntimeException runtimeException;
+
+    private CopyOutcome(CopyResult copyResult,
+        InterruptedException interruptedException,
+        RuntimeException runtimeException) {
+      this.copyResult = copyResult;
+      this.interruptedException = interruptedException;
+      this.runtimeException = runtimeException;
+    }
+
+    public CopyResult getCopyResult() {
+      return copyResult;
+    }
+
+    public InterruptedException getInterruptedException() {
+      return interruptedException;
+    }
+
+    public RuntimeException getRuntimeException() {
+      return runtimeException;
+    }
   }
 
   /**
@@ -3044,6 +3146,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * </ol>
    * @param key key written to
    * @param length  total length of file written
+   * @param eTag eTag of the written object
+   * @param versionId S3 object versionId of the written object
    * @throws MetadataPersistenceException if metadata about the write could
    * not be saved to the metadata store and
    * fs.s3a.metadatastore.fail.on.write.error=true
@@ -3051,7 +3155,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @InterfaceAudience.Private
   @Retries.RetryTranslated("Except if failOnMetadataWriteError=false, in which"
       + " case RetryExceptionsSwallowed")
-  void finishedWrite(String key, long length)
+  void finishedWrite(String key, long length, String eTag, String versionId)
       throws MetadataPersistenceException {
     LOG.debug("Finished write to {}, len {}", key, length);
     Path p = keyToQualifiedPath(key);
@@ -3064,7 +3168,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         S3Guard.addAncestors(metadataStore, p, username);
         S3AFileStatus status = createUploadFileStatus(p,
             S3AUtils.objectRepresentsDirectory(key, length), length,
-            getDefaultBlockSize(p), username);
+            getDefaultBlockSize(p), username, eTag, versionId);
         S3Guard.putAndReturn(metadataStore, status, instrumentation);
       }
     } catch (IOException e) {
@@ -3436,26 +3540,41 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Retries.OnceTranslated
   public RemoteIterator<LocatedFileStatus> listFiles(Path f,
       boolean recursive) throws FileNotFoundException, IOException {
-    return innerListFiles(f, recursive,
-        new Listing.AcceptFilesOnly(qualify(f)));
+    return toLocatedFileStatusIterator(innerListFiles(f, recursive,
+        new Listing.AcceptFilesOnly(qualify(f))));
+  }
+
+  private static RemoteIterator<LocatedFileStatus> toLocatedFileStatusIterator(
+      RemoteIterator<? extends LocatedFileStatus> iterator) {
+    return new RemoteIterator<LocatedFileStatus>() {
+      @Override
+      public boolean hasNext() throws IOException {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public LocatedFileStatus next() throws IOException {
+        return iterator.next();
+      }
+    };
   }
 
   @Retries.OnceTranslated
-  public RemoteIterator<LocatedFileStatus> listFilesAndEmptyDirectories(Path f,
-      boolean recursive) throws IOException {
+  public RemoteIterator<S3ALocatedFileStatus> listFilesAndEmptyDirectories(
+      Path f, boolean recursive) throws IOException {
     return innerListFiles(f, recursive,
         new Listing.AcceptAllButS3nDirs());
   }
 
   @Retries.OnceTranslated
-  private RemoteIterator<LocatedFileStatus> innerListFiles(Path f, boolean
+  private RemoteIterator<S3ALocatedFileStatus> innerListFiles(Path f, boolean
       recursive, Listing.FileStatusAcceptor acceptor) throws IOException {
     entryPoint(INVOCATION_LIST_FILES);
     Path path = qualify(f);
     LOG.debug("listFiles({}, {})", path, recursive);
     try {
       // lookup dir triggers existence check
-      final FileStatus fileStatus = getFileStatus(path);
+      final S3AFileStatus fileStatus = (S3AFileStatus) getFileStatus(path);
       if (fileStatus.isFile()) {
         // simple case: File
         LOG.debug("Path is a file");
@@ -3467,7 +3586,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         String delimiter = recursive ? null : "/";
         LOG.debug("Requesting all entries under {} with delimiter '{}'",
             key, delimiter);
-        final RemoteIterator<FileStatus> cachedFilesIterator;
+        final RemoteIterator<S3AFileStatus> cachedFilesIterator;
         final Set<Path> tombstones;
         if (recursive) {
           final PathMetadata pm = metadataStore.get(path, true);
@@ -3539,52 +3658,55 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     entryPoint(INVOCATION_LIST_LOCATED_STATUS);
     Path path = qualify(f);
     LOG.debug("listLocatedStatus({}, {}", path, filter);
-    return once("listLocatedStatus", path.toString(),
-        () -> {
-          // lookup dir triggers existence check
-          final FileStatus fileStatus = getFileStatus(path);
-          if (fileStatus.isFile()) {
-            // simple case: File
-            LOG.debug("Path is a file");
-            return new Listing.SingleStatusRemoteIterator(
-                filter.accept(path) ? toLocatedFileStatus(fileStatus) : null);
-          } else {
-            // directory: trigger a lookup
-            final String key = maybeAddTrailingSlash(pathToKey(path));
-            final Listing.FileStatusAcceptor acceptor =
-                new Listing.AcceptAllButSelfAndS3nDirs(path);
-            DirListingMetadata meta =
-                S3Guard.listChildrenWithTtl(metadataStore, path,
-                    ttlTimeProvider);
-            final RemoteIterator<FileStatus> cachedFileStatusIterator =
-                listing.createProvidedFileStatusIterator(
-                    S3Guard.dirMetaToStatuses(meta), filter, acceptor);
-            return (allowAuthoritative && meta != null
-                && meta.isAuthoritative())
-                ? listing.createLocatedFileStatusIterator(
-                cachedFileStatusIterator)
-                : listing.createLocatedFileStatusIterator(
-                    listing.createFileStatusListingIterator(path,
-                        createListObjectsRequest(key, "/"),
-                        filter,
-                        acceptor,
-                        cachedFileStatusIterator));
-          }
-        });
+    RemoteIterator<? extends LocatedFileStatus> iterator =
+        once("listLocatedStatus", path.toString(),
+          () -> {
+            // lookup dir triggers existence check
+            final S3AFileStatus fileStatus =
+                (S3AFileStatus) getFileStatus(path);
+            if (fileStatus.isFile()) {
+              // simple case: File
+              LOG.debug("Path is a file");
+              return new Listing.SingleStatusRemoteIterator(
+                  filter.accept(path) ? toLocatedFileStatus(fileStatus) : null);
+            } else {
+              // directory: trigger a lookup
+              final String key = maybeAddTrailingSlash(pathToKey(path));
+              final Listing.FileStatusAcceptor acceptor =
+                  new Listing.AcceptAllButSelfAndS3nDirs(path);
+              DirListingMetadata meta =
+                  S3Guard.listChildrenWithTtl(metadataStore, path,
+                      ttlTimeProvider);
+              final RemoteIterator<S3AFileStatus> cachedFileStatusIterator =
+                  listing.createProvidedFileStatusIterator(
+                      S3Guard.dirMetaToStatuses(meta), filter, acceptor);
+              return (allowAuthoritative && meta != null
+                  && meta.isAuthoritative())
+                  ? listing.createLocatedFileStatusIterator(
+                  cachedFileStatusIterator)
+                  : listing.createLocatedFileStatusIterator(
+                      listing.createFileStatusListingIterator(path,
+                          createListObjectsRequest(key, "/"),
+                          filter,
+                          acceptor,
+                          cachedFileStatusIterator));
+            }
+          });
+    return toLocatedFileStatusIterator(iterator);
   }
 
   /**
-   * Build a {@link LocatedFileStatus} from a {@link FileStatus} instance.
+   * Build a {@link S3ALocatedFileStatus} from a {@link FileStatus} instance.
    * @param status file status
    * @return a located status with block locations set up from this FS.
    * @throws IOException IO Problems.
    */
-  LocatedFileStatus toLocatedFileStatus(FileStatus status)
+  S3ALocatedFileStatus toLocatedFileStatus(S3AFileStatus status)
       throws IOException {
-    return new LocatedFileStatus(status,
+    return new S3ALocatedFileStatus(status,
         status.isFile() ?
           getFileBlockLocations(status, 0, status.getLen())
-          : null);
+          : null, status.getETag(), status.getVersionId());
   }
 
   /**
@@ -3743,17 +3865,36 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // so the operation will fail if it is not there or S3Guard believes it has
     // been deleted.
     // validation of the file status are delegated to the binding.
-    final FileStatus fileStatus = getFileStatus(path);
+    final S3AFileStatus fileStatus = (S3AFileStatus) getFileStatus(path);
 
     // readahead range can be dynamically set
     long ra = options.getLong(READAHEAD_RANGE, readAhead);
+    S3ObjectAttributes objectAttributes = createObjectAttributes(
+        path, fileStatus.getETag(), fileStatus.getVersionId());
+    S3AReadOpContext readContext = createReadContext(fileStatus, inputPolicy,
+        changeDetectionPolicy, ra);
+
+    if (!fileStatus.isDirectory()) {
+      // check that the object metadata lines up with what is expected
+      // based on the object attributes (which may contain an eTag or versionId)
+      // from S3Guard
+      ChangeTracker changeTracker =
+          new ChangeTracker(uri.toString(),
+              changeDetectionPolicy,
+              readContext.instrumentation.newInputStreamStatistics()
+                  .getVersionMismatchCounter(),
+              objectAttributes);
+      ObjectMetadata objectMetadata = getObjectMetadata(path);
+      changeTracker.processMetadata(objectMetadata, "select", 0);
+    }
+
     // build and execute the request
     return selectBinding.select(
-        createReadContext(fileStatus, inputPolicy, changeDetectionPolicy, ra),
+        readContext,
         expression,
         options,
         generateSSECustomerKey(),
-        createObjectAttributes(path));
+        objectAttributes);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2968,6 +2968,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       }
     };
 
+    ChangeTracker changeTracker = new ChangeTracker(
+        keyToQualifiedPath(srcKey).toString(),
+        changeDetectionPolicy,
+        readContext.instrumentation.newInputStreamStatistics()
+            .getVersionMismatchCounter(),
+        srcAttributes);
+
     Invoker readInvoker = readContext.getReadInvoker();
     return readInvoker.retry(
         "\"copyFile(\" + srcKey + \", \" + dstKey + \")\", srcKey", null,
@@ -2976,13 +2983,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           ObjectMetadata srcom = getObjectMetadata(srcKey);
           ObjectMetadata dstom = cloneObjectMetadata(srcom);
           setOptionalObjectMetadata(dstom);
-
-          ChangeTracker changeTracker = new ChangeTracker(
-              keyToQualifiedPath(srcKey).toString(),
-              changeDetectionPolicy,
-              readContext.instrumentation.newInputStreamStatistics()
-                  .getVersionMismatchCounter(),
-              srcAttributes);
 
           changeTracker.processMetadata(srcom, "copy", 0);
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -153,7 +153,8 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     this.serverSideEncryptionKey = s3Attributes.getServerSideEncryptionKey();
     this.changeTracker = new ChangeTracker(uri,
         ctx.getChangeDetectionPolicy(),
-        streamStatistics.getVersionMismatchCounter());
+        streamStatistics.getVersionMismatchCounter(),
+        s3Attributes);
     setInputPolicy(ctx.getInputPolicy());
     setReadahead(ctx.getReadahead());
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ALocatedFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ALocatedFileStatus.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.LocatedFileStatus;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link LocatedFileStatus} extended to also carry ETag and object version ID.
+ */
+public class S3ALocatedFileStatus extends LocatedFileStatus {
+
+  private static final long serialVersionUID = 3597192103662929338L;
+
+  private final String eTag;
+  private final String versionId;
+
+  public S3ALocatedFileStatus(S3AFileStatus status, BlockLocation[] locations,
+      String eTag, String versionId) {
+    super(checkNotNull(status), locations);
+    this.eTag = eTag;
+    this.versionId = versionId;
+  }
+
+  public String getETag() {
+    return eTag;
+  }
+
+  public String getVersionId() {
+    return versionId;
+  }
+
+  // equals() and hashCode() overridden to avoid FindBugs warning.
+  // Base implementation is equality on Path only, which is still appropriate.
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -530,16 +530,20 @@ public final class S3AUtils {
    * @param summary summary from AWS
    * @param blockSize block size to declare.
    * @param owner owner of the file
+   * @param eTag S3 object eTag or null if unavailable
+   * @param versionId S3 object versionId or null if unavailable
    * @return a status entry
    */
   public static S3AFileStatus createFileStatus(Path keyPath,
       S3ObjectSummary summary,
       long blockSize,
-      String owner) {
+      String owner,
+      String eTag,
+      String versionId) {
     long size = summary.getSize();
     return createFileStatus(keyPath,
         objectRepresentsDirectory(summary.getKey(), size),
-        size, summary.getLastModified(), blockSize, owner);
+        size, summary.getLastModified(), blockSize, owner, eTag, versionId);
   }
 
   /**
@@ -552,22 +556,27 @@ public final class S3AUtils {
    * @param size file length
    * @param blockSize block size for file status
    * @param owner Hadoop username
+   * @param eTag S3 object eTag or null if unavailable
+   * @param versionId S3 object versionId or null if unavailable
    * @return a status entry
    */
   public static S3AFileStatus createUploadFileStatus(Path keyPath,
-      boolean isDir, long size, long blockSize, String owner) {
+      boolean isDir, long size, long blockSize, String owner,
+      String eTag, String versionId) {
     Date date = isDir ? null : new Date();
-    return createFileStatus(keyPath, isDir, size, date, blockSize, owner);
+    return createFileStatus(keyPath, isDir, size, date, blockSize, owner,
+        eTag, versionId);
   }
 
   /* Date 'modified' is ignored when isDir is true. */
   private static S3AFileStatus createFileStatus(Path keyPath, boolean isDir,
-      long size, Date modified, long blockSize, String owner) {
+      long size, Date modified, long blockSize, String owner,
+      String eTag, String versionId) {
     if (isDir) {
       return new S3AFileStatus(Tristate.UNKNOWN, keyPath, owner);
     } else {
       return new S3AFileStatus(size, dateToLong(modified), keyPath, blockSize,
-          owner);
+          owner, eTag, versionId);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3GuardExistsRetryPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3GuardExistsRetryPolicy.java
@@ -42,6 +42,7 @@ public class S3GuardExistsRetryPolicy extends S3ARetryPolicy {
   protected Map<Class<? extends Exception>, RetryPolicy> createExceptionMap() {
     Map<Class<? extends Exception>, RetryPolicy> b = super.createExceptionMap();
     b.put(FileNotFoundException.class, retryIdempotentCalls);
+    b.put(RemoteFileChangedException.class, retryIdempotentCalls);
     return b;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ObjectAttributes.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ObjectAttributes.java
@@ -34,16 +34,22 @@ public class S3ObjectAttributes {
   private final String key;
   private final S3AEncryptionMethods serverSideEncryptionAlgorithm;
   private final String serverSideEncryptionKey;
+  private final String eTag;
+  private final String versionId;
 
   public S3ObjectAttributes(
       String bucket,
       String key,
       S3AEncryptionMethods serverSideEncryptionAlgorithm,
-      String serverSideEncryptionKey) {
+      String serverSideEncryptionKey,
+      String eTag,
+      String versionId) {
     this.bucket = bucket;
     this.key = key;
     this.serverSideEncryptionAlgorithm = serverSideEncryptionAlgorithm;
     this.serverSideEncryptionKey = serverSideEncryptionKey;
+    this.eTag = eTag;
+    this.versionId = versionId;
   }
 
   public String getBucket() {
@@ -60,5 +66,13 @@ public class S3ObjectAttributes {
 
   public String getServerSideEncryptionKey() {
     return serverSideEncryptionKey;
+  }
+
+  public String getETag() {
+    return eTag;
+  }
+
+  public String getVersionId() {
+    return versionId;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeDetectionPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeDetectionPolicy.java
@@ -269,6 +269,7 @@ public abstract class ChangeDetectionPolicy {
       long position,
       String operation,
       long timesAlreadyDetected) {
+    String positionText = position >= 0 ? (" at " + position) : "";
     switch (mode) {
     case None:
       // something changed; we don't care.
@@ -278,8 +279,8 @@ public abstract class ChangeDetectionPolicy {
         // only warn on the first detection to avoid a noisy log
         LOG.warn(
             String.format(
-                "%s change detected on %s %s at %d. Expected %s got %s",
-                getSource(), operation, uri, position, revisionId,
+                "%s change detected on %s %s%s. Expected %s got %s",
+                getSource(), operation, uri, positionText, revisionId,
                 newRevisionId));
         return new ImmutablePair<>(true, null);
       }
@@ -293,9 +294,9 @@ public abstract class ChangeDetectionPolicy {
               operation,
               String.format("%s "
                       + CHANGE_DETECTED
-                      + " while reading at position %s."
+                      + " on %s%s."
                     + " Expected %s got %s",
-              getSource(), position, revisionId, newRevisionId)));
+              getSource(), operation, positionText, revisionId, newRevisionId)));
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeDetectionPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeDetectionPolicy.java
@@ -25,7 +25,6 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.transfer.model.CopyResult;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 import org.apache.hadoop.fs.s3a.RemoteFileChangedException;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeTracker.java
@@ -20,11 +20,13 @@ package org.apache.hadoop.fs.s3a.impl;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.transfer.model.CopyResult;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.fs.s3a.NoVersionAttributeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,14 +34,18 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.s3a.NoVersionAttributeException;
 import org.apache.hadoop.fs.s3a.RemoteFileChangedException;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.http.HttpStatus.SC_PRECONDITION_FAILED;
 
 /**
- * Change tracking for input streams: the revision ID/etag
- * the previous request is recorded and when the next request comes in,
- * it is compared.
+ * Change tracking for input streams: the version ID or etag of the object is
+ * tracked and compared on open/re-open.  An initial version ID or etag may or
+ * may not be available, depending on usage (e.g. if S3Guard is utilized).
+ *
  * Self-contained for testing and use in different streams.
  */
 @InterfaceAudience.Private
@@ -49,7 +55,7 @@ public class ChangeTracker {
   private static final Logger LOG =
       LoggerFactory.getLogger(ChangeTracker.class);
 
-  public static final String CHANGE_REPORTED_BY_S3 = "reported by S3";
+  public static final String CHANGE_REPORTED_BY_S3 = "Change reported by S3";
 
   /** Policy to use. */
   private final ChangeDetectionPolicy policy;
@@ -76,13 +82,20 @@ public class ChangeTracker {
    * @param uri URI of object being tracked
    * @param policy policy to track.
    * @param versionMismatches reference to the version mismatch counter
+   * @param s3ObjectAttributes attributes of the object, potentially including
+   * an eTag or versionId to match depending on {@code policy}
    */
   public ChangeTracker(final String uri,
       final ChangeDetectionPolicy policy,
-      final AtomicLong versionMismatches) {
+      final AtomicLong versionMismatches,
+      final S3ObjectAttributes s3ObjectAttributes) {
     this.policy = checkNotNull(policy);
     this.uri = uri;
     this.versionMismatches = versionMismatches;
+    this.revisionId = policy.getRevisionId(s3ObjectAttributes);
+    if (revisionId != null) {
+      LOG.debug("Revision ID for object at {}: {}", uri, revisionId);
+    }
   }
 
   public String getRevisionId() {
@@ -115,6 +128,23 @@ public class ChangeTracker {
     return false;
   }
 
+  /**
+   * Apply any revision control set by the policy if it is to be
+   * enforced on the server.
+   * @param request request to modify
+   * @return true iff a constraint was added.
+   */
+  public boolean maybeApplyConstraint(
+      final CopyObjectRequest request) {
+
+    if (policy.getMode() == ChangeDetectionPolicy.Mode.Server
+        && revisionId != null) {
+      policy.applyRevisionConstraint(request, revisionId);
+      return true;
+    }
+    return false;
+  }
+
 
   /**
    * Process the response from the server for validation against the
@@ -135,29 +165,97 @@ public class ChangeTracker {
         // object was not returned.
         versionMismatches.incrementAndGet();
         throw new RemoteFileChangedException(uri, operation,
-            String.format("%s change "
-                    + CHANGE_REPORTED_BY_S3
+            String.format(CHANGE_REPORTED_BY_S3
                     + " while reading"
                     + " at position %s."
-                    + " Version %s was unavailable",
-                getSource(),
+                    + " %s %s was unavailable",
                 pos,
+                getSource(),
                 getRevisionId()));
       } else {
         throw new PathIOException(uri, "No data returned from GET request");
       }
     }
 
-    final ObjectMetadata metadata = object.getObjectMetadata();
+    processMetadata(object.getObjectMetadata(), operation, pos);
+  }
+
+  /**
+   * Process the response from the server for validation against the
+   * change policy.
+   * @param copyResult result of a copy operation
+   * @throws PathIOException raised on failure
+   * @throws RemoteFileChangedException if the remote file has changed.
+   */
+  public void processResponse(final CopyResult copyResult)
+      throws PathIOException {
+    // ETag (sometimes, depending on encryption and/or multipart) is not the
+    // same on the copied object as the original.  Version Id seems to never
+    // be the same on the copy.  As such, there isn't really anything that
+    // can be verified on the response, except that a revision ID is present
+    // if required.
+    String newRevisionId = policy.getRevisionId(copyResult);
+    LOG.debug("Copy result {}: {}", policy.getSource(), newRevisionId);
+    if (newRevisionId == null && policy.isRequireVersion()) {
+      throw new NoVersionAttributeException(uri, String.format(
+          "Change detection policy requires %s",
+          policy.getSource()));
+    }
+  }
+
+  /**
+   * Process an exception generated against the change policy.
+   * If the exception indicates the file has changed, this method throws
+   * {@code RemoteFileChangedException} with the original exception as the
+   * cause.
+   * @param e the exception
+   * @param operation the operation performed when the exception was
+   * generated (e.g. "copy", "read", "select").
+   * @throws RemoteFileChangedException if the remote file has changed.
+   */
+  public void processException(Exception e, String operation) throws
+      RemoteFileChangedException {
+    if (e instanceof AmazonServiceException) {
+      AmazonServiceException serviceException = (AmazonServiceException) e;
+      if (serviceException.getStatusCode() == SC_PRECONDITION_FAILED) {
+        versionMismatches.incrementAndGet();
+        throw new RemoteFileChangedException(uri, operation, String.format(
+            RemoteFileChangedException.PRECONDITIONS_FAILED
+                + " on %s."
+                + " Version %s was unavailable",
+            getSource(),
+            getRevisionId()),
+            serviceException);
+      }
+    }
+  }
+
+  /**
+   * Process metadata response from server for validation against the change
+   * policy.
+   * @param metadata metadata returned from server
+   * @param operation operation in progress
+   * @param pos offset of read
+   * @throws PathIOException raised on failure
+   * @throws RemoteFileChangedException if the remote file has changed.
+   */
+  public void processMetadata(final ObjectMetadata metadata,
+      final String operation,
+      final long pos) throws PathIOException {
     final String newRevisionId = policy.getRevisionId(metadata, uri);
+    processNewRevision(newRevisionId, operation, pos);
+  }
+
+  private void processNewRevision(final String newRevisionId,
+      final String operation, final long pos) throws PathIOException {
     if (newRevisionId == null && policy.isRequireVersion()) {
       throw new NoVersionAttributeException(uri, String.format(
           "Change detection policy requires %s",
           policy.getSource()));
     }
     if (revisionId == null) {
-      // revisionId is null on first (re)open. Pin it so change can be detected
-      // if object has been updated
+      // revisionId may be null on first (re)open. Pin it so change can be
+      // detected if object has been updated
       LOG.debug("Setting revision ID for object at {}: {}",
           uri, newRevisionId);
       revisionId = newRevisionId;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyOutcome.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyOutcome.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import com.amazonaws.SdkBaseException;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.model.CopyResult;
+
+/**
+ * Extracts the outcome of a TransferManager-executed copy operation.
+ */
+public final class CopyOutcome {
+
+  /**
+   * Result of a successful copy.
+   */
+  private final CopyResult copyResult;
+
+  /** the copy was interrupted. */
+  private final InterruptedException interruptedException;
+
+  /**
+   * The copy raised an AWS Exception of some form.
+   */
+  private final SdkBaseException awsException;
+
+  public CopyOutcome(CopyResult copyResult,
+      InterruptedException interruptedException,
+      SdkBaseException awsException) {
+    this.copyResult = copyResult;
+    this.interruptedException = interruptedException;
+    this.awsException = awsException;
+  }
+
+  public CopyResult getCopyResult() {
+    return copyResult;
+  }
+
+  public InterruptedException getInterruptedException() {
+    return interruptedException;
+  }
+
+  public SdkBaseException getAwsException() {
+    return awsException;
+  }
+
+  /**
+   * Calls {@code Copy.waitForCopyResult()} to await the result, converts
+   * it to a copy outcome.
+   * Exceptions caught and
+   * @param copy the copy operation.
+   * @return the outcome.
+   */
+  public static CopyOutcome waitForCopy(Copy copy) {
+    try {
+      CopyResult result = copy.waitForCopyResult();
+      return new CopyOutcome(result, null, null);
+    } catch (SdkBaseException e) {
+      return new CopyOutcome(null, null, e);
+    } catch (InterruptedException e) {
+      return new CopyOutcome(null, e, null);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DDBPathMetadata.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DDBPathMetadata.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.s3a.s3guard;
 
-import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.Tristate;
 
 /**
@@ -36,18 +36,18 @@ public class DDBPathMetadata extends PathMetadata {
     this.setLastUpdated(pmd.getLastUpdated());
   }
 
-  public DDBPathMetadata(FileStatus fileStatus) {
+  public DDBPathMetadata(S3AFileStatus fileStatus) {
     super(fileStatus);
     this.isAuthoritativeDir = false;
   }
 
-  public DDBPathMetadata(FileStatus fileStatus, Tristate isEmptyDir,
+  public DDBPathMetadata(S3AFileStatus fileStatus, Tristate isEmptyDir,
       boolean isDeleted) {
     super(fileStatus, isEmptyDir, isDeleted);
     this.isAuthoritativeDir = false;
   }
 
-  public DDBPathMetadata(FileStatus fileStatus, Tristate isEmptyDir,
+  public DDBPathMetadata(S3AFileStatus fileStatus, Tristate isEmptyDir,
       boolean isDeleted, boolean isAuthoritativeDir, long lastUpdated) {
     super(fileStatus, isEmptyDir, isDeleted);
     this.isAuthoritativeDir = isAuthoritativeDir;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DescendantsIterator.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DescendantsIterator.java
@@ -28,9 +28,9 @@ import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 
 /**
  * {@code DescendantsIterator} is a {@link RemoteIterator} that implements
@@ -83,7 +83,7 @@ import org.apache.hadoop.fs.RemoteIterator;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
-public class DescendantsIterator implements RemoteIterator<FileStatus> {
+public class DescendantsIterator implements RemoteIterator<S3AFileStatus> {
 
   private final MetadataStore metadataStore;
   private final Queue<PathMetadata> queue = new LinkedList<>();
@@ -121,7 +121,7 @@ public class DescendantsIterator implements RemoteIterator<FileStatus> {
   }
 
   @Override
-  public FileStatus next() throws IOException {
+  public S3AFileStatus next() throws IOException {
     if (!hasNext()) {
       throw new NoSuchElementException("No more descendants.");
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DirListingMetadata.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DirListingMetadata.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.Tristate;
 
 /**
@@ -61,7 +62,7 @@ public class DirListingMetadata extends ExpirableMetadata {
    * Create a directory listing metadata container.
    *
    * @param path Path of the directory. If this path has a host component, then
-   *     all paths added later via {@link #put(FileStatus)} must also have
+   *     all paths added later via {@link #put(S3AFileStatus)} must also have
    *     the same host.
    * @param listing Entries in the directory.
    * @param isAuthoritative true iff listing is the full contents of the
@@ -225,7 +226,7 @@ public class DirListingMetadata extends ExpirableMetadata {
    * @return true if the status was added or replaced with a new value. False
    * if the same FileStatus value was already present.
    */
-  public boolean put(FileStatus childFileStatus) {
+  public boolean put(S3AFileStatus childFileStatus) {
     Preconditions.checkNotNull(childFileStatus,
         "childFileStatus must be non-null");
     Path childPath = childStatusToPathKey(childFileStatus);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
@@ -88,6 +88,7 @@ import org.apache.hadoop.fs.s3a.AWSServiceThrottledException;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.Retries;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AUtils;
@@ -129,6 +130,14 @@ import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.*;
  *      This attribute is meaningful only to file items.</li>
  * <li> optional long attribute revealing block size of the file.
  *      This attribute is meaningful only to file items.</li>
+ * <li> optional string attribute tracking the s3 eTag of the file.
+ *      May be absent if the metadata was entered with a version of S3Guard
+ *      before this was tracked.
+ *      This attribute is meaningful only to file items.</li>
+  * <li> optional string attribute tracking the s3 versionId of the file.
+ *      May be absent if the metadata was entered with a version of S3Guard
+ *      before this was tracked.
+ *      This attribute is meaningful only to file items.</li>
  * </ul>
  *
  * The DynamoDB partition key is the parent, and the range key is the child.
@@ -155,20 +164,20 @@ import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.*;
  * This is persisted to a single DynamoDB table as:
  *
  * <pre>
- * =========================================================================
- * | parent                 | child | is_dir | mod_time | len |     ...    |
- * =========================================================================
- * | /bucket                | dir1  | true   |          |     |            |
- * | /bucket/dir1           | dir2  | true   |          |     |            |
- * | /bucket/dir1           | dir3  | true   |          |     |            |
- * | /bucket/dir1/dir2      | file1 |        |   100    | 111 |            |
- * | /bucket/dir1/dir2      | file2 |        |   200    | 222 |            |
- * | /bucket/dir1/dir3      | dir4  | true   |          |     |            |
- * | /bucket/dir1/dir3      | dir5  | true   |          |     |            |
- * | /bucket/dir1/dir3/dir4 | file3 |        |   300    | 333 |            |
- * | /bucket/dir1/dir3/dir5 | file4 |        |   400    | 444 |            |
- * | /bucket/dir1/dir3      | dir6  | true   |          |     |            |
- * =========================================================================
+ * ====================================================================================
+ * | parent                 | child | is_dir | mod_time | len | etag | ver_id |  ...  |
+ * ====================================================================================
+ * | /bucket                | dir1  | true   |          |     |      |        |       |
+ * | /bucket/dir1           | dir2  | true   |          |     |      |        |       |
+ * | /bucket/dir1           | dir3  | true   |          |     |      |        |       |
+ * | /bucket/dir1/dir2      | file1 |        |   100    | 111 | abc  |  mno   |       |
+ * | /bucket/dir1/dir2      | file2 |        |   200    | 222 | def  |  pqr   |       |
+ * | /bucket/dir1/dir3      | dir4  | true   |          |     |      |        |       |
+ * | /bucket/dir1/dir3      | dir5  | true   |          |     |      |        |       |
+ * | /bucket/dir1/dir3/dir4 | file3 |        |   300    | 333 | ghi  |  stu   |       |
+ * | /bucket/dir1/dir3/dir5 | file4 |        |   400    | 444 | jkl  |  vwx   |       |
+ * | /bucket/dir1/dir3      | dir6  | true   |          |     |      |        |       |
+ * ====================================================================================
  * </pre>
  *
  * This choice of schema is efficient for read access patterns.
@@ -625,9 +634,8 @@ public class DynamoDBMetadataStore implements MetadataStore,
    * @param path   path to dir
    * @return new FileStatus
    */
-  private FileStatus makeDirStatus(String owner, Path path) {
-    return new FileStatus(0, true, 1, 0, 0, 0, null,
-            owner, null, path);
+  private S3AFileStatus makeDirStatus(String owner, Path path) {
+    return new S3AFileStatus(Tristate.UNKNOWN, path, owner);
   }
 
   @Override
@@ -710,7 +718,7 @@ public class DynamoDBMetadataStore implements MetadataStore,
       while (!parent.isRoot() && !ancestry.containsKey(parent)) {
         LOG.debug("auto-create ancestor path {} for child path {}",
             parent, path);
-        final FileStatus status = makeDirStatus(parent, username);
+        final S3AFileStatus status = makeDirStatus(parent, username);
         ancestry.put(parent, new DDBPathMetadata(status, Tristate.FALSE,
             false));
         parent = parent.getParent();
@@ -915,7 +923,7 @@ public class DynamoDBMetadataStore implements MetadataStore,
     while (path != null && !path.isRoot()) {
       final Item item = getConsistentItem(path);
       if (!itemExists(item)) {
-        final FileStatus status = makeDirStatus(path, username);
+        final S3AFileStatus status = makeDirStatus(path, username);
         metasToPut.add(new DDBPathMetadata(status, Tristate.FALSE, false,
             meta.isAuthoritativeDir(), meta.getLastUpdated()));
         path = path.getParent();
@@ -938,9 +946,8 @@ public class DynamoDBMetadataStore implements MetadataStore,
   }
 
   /** Create a directory FileStatus using current system time as mod time. */
-  static FileStatus makeDirStatus(Path f, String owner) {
-    return  new FileStatus(0, true, 1, 0, System.currentTimeMillis(), 0,
-        null, owner, owner, f);
+  static S3AFileStatus makeDirStatus(Path f, String owner) {
+    return new S3AFileStatus(Tristate.UNKNOWN, f, owner);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.Tristate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -231,7 +232,7 @@ public class LocalMetadataStore implements MetadataStore {
   public void put(PathMetadata meta) throws IOException {
 
     Preconditions.checkNotNull(meta);
-    FileStatus status = meta.getFileStatus();
+    S3AFileStatus status = meta.getFileStatus();
     Path path = standardize(status.getPath());
     synchronized (this) {
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreListFilesIterator.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreListFilesIterator.java
@@ -33,9 +33,9 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 
 /**
  * {@code MetadataStoreListFilesIterator} is a {@link RemoteIterator} that
@@ -85,14 +85,14 @@ import org.apache.hadoop.fs.RemoteIterator;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class MetadataStoreListFilesIterator implements
-    RemoteIterator<FileStatus> {
+    RemoteIterator<S3AFileStatus> {
   public static final Logger LOG = LoggerFactory.getLogger(
       MetadataStoreListFilesIterator.class);
 
   private final boolean allowAuthoritative;
   private final MetadataStore metadataStore;
   private final Set<Path> tombstones = new HashSet<>();
-  private Iterator<FileStatus> leafNodesIterator = null;
+  private Iterator<S3AFileStatus> leafNodesIterator = null;
 
   public MetadataStoreListFilesIterator(MetadataStore ms, PathMetadata meta,
       boolean allowAuthoritative) throws IOException {
@@ -104,7 +104,7 @@ public class MetadataStoreListFilesIterator implements
 
   private void prefetch(PathMetadata meta) throws IOException {
     final Queue<PathMetadata> queue = new LinkedList<>();
-    final Collection<FileStatus> leafNodes = new ArrayList<>();
+    final Collection<S3AFileStatus> leafNodes = new ArrayList<>();
 
     if (meta != null) {
       final Path path = meta.getFileStatus().getPath();
@@ -121,7 +121,7 @@ public class MetadataStoreListFilesIterator implements
 
     while(!queue.isEmpty()) {
       PathMetadata nextMetadata = queue.poll();
-      FileStatus nextStatus = nextMetadata.getFileStatus();
+      S3AFileStatus nextStatus = nextMetadata.getFileStatus();
       if (nextStatus.isFile()) {
         // All files are leaf nodes by definition
         leafNodes.add(nextStatus);
@@ -159,7 +159,7 @@ public class MetadataStoreListFilesIterator implements
   }
 
   @Override
-  public FileStatus next() {
+  public S3AFileStatus next() {
     return leafNodesIterator.next();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadata.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadata.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.Tristate;
 
 /**
@@ -33,7 +34,7 @@ import org.apache.hadoop.fs.s3a.Tristate;
 @InterfaceStability.Evolving
 public class PathMetadata extends ExpirableMetadata {
 
-  private final FileStatus fileStatus;
+  private S3AFileStatus fileStatus;
   private Tristate isEmptyDirectory;
   private boolean isDeleted;
 
@@ -43,24 +44,25 @@ public class PathMetadata extends ExpirableMetadata {
    * @return the entry.
    */
   public static PathMetadata tombstone(Path path) {
-    long now = System.currentTimeMillis();
-    FileStatus status = new FileStatus(0, false, 0, 0, now, path);
-    return new PathMetadata(status, Tristate.UNKNOWN, true);
+    S3AFileStatus s3aStatus = new S3AFileStatus(0,
+        System.currentTimeMillis(), path, 0, null,
+        null, null);
+    return new PathMetadata(s3aStatus, Tristate.UNKNOWN, true);
   }
 
   /**
    * Creates a new {@code PathMetadata} containing given {@code FileStatus}.
    * @param fileStatus file status containing an absolute path.
    */
-  public PathMetadata(FileStatus fileStatus) {
-    this(fileStatus, Tristate.UNKNOWN);
+  public PathMetadata(S3AFileStatus fileStatus) {
+    this(fileStatus, Tristate.UNKNOWN, false);
   }
 
-  public PathMetadata(FileStatus fileStatus, Tristate isEmptyDir) {
+  public PathMetadata(S3AFileStatus fileStatus, Tristate isEmptyDir) {
     this(fileStatus, isEmptyDir, false);
   }
 
-  public PathMetadata(FileStatus fileStatus, Tristate isEmptyDir, boolean
+  public PathMetadata(S3AFileStatus fileStatus, Tristate isEmptyDir, boolean
       isDeleted) {
     Preconditions.checkNotNull(fileStatus, "fileStatus must be non-null");
     Preconditions.checkNotNull(fileStatus.getPath(), "fileStatus path must be" +
@@ -75,7 +77,7 @@ public class PathMetadata extends ExpirableMetadata {
   /**
    * @return {@code FileStatus} contained in this {@code PathMetadata}.
    */
-  public final FileStatus getFileStatus() {
+  public final S3AFileStatus getFileStatus() {
     return fileStatus;
   }
 
@@ -91,6 +93,7 @@ public class PathMetadata extends ExpirableMetadata {
 
   void setIsEmptyDirectory(Tristate isEmptyDirectory) {
     this.isEmptyDirectory = isEmptyDirectory;
+    fileStatus.setIsEmptyDirectory(isEmptyDirectory);
   }
 
   public boolean isDeleted() {
@@ -128,10 +131,11 @@ public class PathMetadata extends ExpirableMetadata {
    * @param sb target StringBuilder
    */
   public void prettyPrint(StringBuilder sb) {
-    sb.append(String.format("%-5s %-20s %-7d %-8s %-6s",
+    sb.append(String.format("%-5s %-20s %-7d %-8s %-6s %-20s %-20s",
         fileStatus.isDirectory() ? "dir" : "file",
         fileStatus.getPath().toString(), fileStatus.getLen(),
-        isEmptyDirectory.name(), isDeleted));
+        isEmptyDirectory.name(), isDeleted,
+        fileStatus.getETag(), fileStatus.getVersionId()));
     sb.append(fileStatus);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadataDynamoDBTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadataDynamoDBTranslation.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.Tristate;
 
 /**
@@ -70,6 +71,8 @@ final class PathMetadataDynamoDBTranslation {
   static final String IS_DELETED = "is_deleted";
   static final String IS_AUTHORITATIVE = "is_authoritative";
   static final String LAST_UPDATED = "last_updated";
+  static final String ETAG = "etag";
+  static final String VERSION_ID = "version_id";
 
   /** Used while testing backward compatibility. */
   @VisibleForTesting
@@ -135,7 +138,7 @@ final class PathMetadataDynamoDBTranslation {
 
     boolean isDir = item.hasAttribute(IS_DIR) && item.getBoolean(IS_DIR);
     boolean isAuthoritativeDir = false;
-    final FileStatus fileStatus;
+    final S3AFileStatus fileStatus;
     long lastUpdated = 0;
     if (isDir) {
       isAuthoritativeDir = !IGNORED_FIELDS.contains(IS_AUTHORITATIVE)
@@ -146,8 +149,10 @@ final class PathMetadataDynamoDBTranslation {
       long len = item.hasAttribute(FILE_LENGTH) ? item.getLong(FILE_LENGTH) : 0;
       long modTime = item.hasAttribute(MOD_TIME) ? item.getLong(MOD_TIME) : 0;
       long block = item.hasAttribute(BLOCK_SIZE) ? item.getLong(BLOCK_SIZE) : 0;
-      fileStatus = new FileStatus(len, false, 1, block, modTime, 0, null,
-          username, username, path);
+      String eTag = item.getString(ETAG);
+      String versionId = item.getString(VERSION_ID);
+      fileStatus = new S3AFileStatus(
+          len, modTime, path, block, username, eTag, versionId);
     }
     lastUpdated =
         !IGNORED_FIELDS.contains(LAST_UPDATED)
@@ -172,7 +177,7 @@ final class PathMetadataDynamoDBTranslation {
    */
   static Item pathMetadataToItem(DDBPathMetadata meta) {
     Preconditions.checkNotNull(meta);
-    final FileStatus status = meta.getFileStatus();
+    final S3AFileStatus status = meta.getFileStatus();
     final Item item = new Item().withPrimaryKey(pathToKey(status.getPath()));
     if (status.isDirectory()) {
       item.withBoolean(IS_DIR, true);
@@ -183,6 +188,12 @@ final class PathMetadataDynamoDBTranslation {
       item.withLong(FILE_LENGTH, status.getLen())
           .withLong(MOD_TIME, status.getModificationTime())
           .withLong(BLOCK_SIZE, status.getBlockSize());
+      if (status.getETag() != null) {
+        item.withString(ETAG, status.getETag());
+      }
+      if (status.getVersionId() != null) {
+        item.withString(VERSION_ID, status.getVersionId());
+      }
     }
     item.withBoolean(IS_DELETED, meta.isDeleted());
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -68,7 +68,7 @@ public final class S3Guard {
   static final Class<? extends DynamoDBClientFactory>
       S3GUARD_DDB_CLIENT_FACTORY_IMPL_DEFAULT =
       DynamoDBClientFactory.DefaultDynamoDBClientFactory.class;
-  private static final FileStatus[] EMPTY_LISTING = new FileStatus[0];
+  private static final S3AFileStatus[] EMPTY_LISTING = new S3AFileStatus[0];
 
   // Utility class.  All static functions.
   private S3Guard() { }
@@ -164,7 +164,7 @@ public final class S3Guard {
    * @param dirMeta directory listing -may be null
    * @return a possibly-empty array of file status entries
    */
-  public static FileStatus[] dirMetaToStatuses(DirListingMetadata dirMeta)  {
+  public static S3AFileStatus[] dirMetaToStatuses(DirListingMetadata dirMeta)  {
     if (dirMeta == null) {
       return EMPTY_LISTING;
     }
@@ -178,7 +178,7 @@ public final class S3Guard {
       }
     }
 
-    return statuses.toArray(new FileStatus[0]);
+    return statuses.toArray(new S3AFileStatus[0]);
   }
 
   /**
@@ -201,7 +201,7 @@ public final class S3Guard {
    * @throws IOException if metadata store update failed
    */
   public static FileStatus[] dirListingUnion(MetadataStore ms, Path path,
-      List<FileStatus> backingStatuses, DirListingMetadata dirMeta,
+      List<S3AFileStatus> backingStatuses, DirListingMetadata dirMeta,
       boolean isAuthoritative, ITtlTimeProvider timeProvider)
       throws IOException {
 
@@ -232,7 +232,7 @@ public final class S3Guard {
             pm -> pm.getFileStatus().getPath(), PathMetadata::getFileStatus)
         );
 
-    for (FileStatus s : backingStatuses) {
+    for (S3AFileStatus s : backingStatuses) {
       if (deleted.contains(s.getPath())) {
         continue;
       }
@@ -323,7 +323,7 @@ public final class S3Guard {
      *    [/a/b/file0, /a/b/file1, /a/b/file2, /a/b/file3], isAuthoritative =
      *    true
      */
-    FileStatus prevStatus = null;
+    S3AFileStatus prevStatus = null;
 
     // Use new batched put to reduce round trips.
     List<PathMetadata> pathMetas = new ArrayList<>(dirs.size());
@@ -334,8 +334,8 @@ public final class S3Guard {
         boolean isLeaf = (prevStatus == null);
         Path f = dirs.get(i);
         assertQualified(f);
-        FileStatus status =
-            createUploadFileStatus(f, true, 0, 0, owner);
+        S3AFileStatus status =
+            createUploadFileStatus(f, true, 0, 0, owner, null, null);
 
         // We only need to put a DirListingMetadata if we are setting
         // authoritative bit
@@ -383,7 +383,8 @@ public final class S3Guard {
     }
     assertQualified(srcPath, dstPath);
 
-    FileStatus dstStatus = createUploadFileStatus(dstPath, true, 0, 0, owner);
+    S3AFileStatus dstStatus = createUploadFileStatus(dstPath, true, 0,
+        0, owner, null, null);
     addMoveStatus(srcPaths, dstMetas, srcPath, dstStatus);
   }
 
@@ -399,16 +400,18 @@ public final class S3Guard {
    * @param size length of file moved
    * @param blockSize  blocksize to associate with destination file
    * @param owner file owner to use in created records
+   * @param eTag the s3 object eTag of file moved
+   * @param versionId the s3 object versionId of file moved
    */
   public static void addMoveFile(MetadataStore ms, Collection<Path> srcPaths,
       Collection<PathMetadata> dstMetas, Path srcPath, Path dstPath,
-      long size, long blockSize, String owner) {
+      long size, long blockSize, String owner, String eTag, String versionId) {
     if (isNullMetadataStore(ms)) {
       return;
     }
     assertQualified(srcPath, dstPath);
-    FileStatus dstStatus = createUploadFileStatus(dstPath, false,
-        size, blockSize, owner);
+    S3AFileStatus dstStatus = createUploadFileStatus(dstPath, false,
+        size, blockSize, owner, eTag, versionId);
     addMoveStatus(srcPaths, dstMetas, srcPath, dstStatus);
   }
 
@@ -465,9 +468,8 @@ public final class S3Guard {
     while (!parent.isRoot()) {
       PathMetadata directory = metadataStore.get(parent);
       if (directory == null || directory.isDeleted()) {
-        FileStatus status = new FileStatus(0, true, 1, 0, 0, 0, null, username,
-            null, parent);
-        PathMetadata meta = new PathMetadata(status, Tristate.FALSE, false);
+        S3AFileStatus s3aStatus = new S3AFileStatus(Tristate.FALSE, parent, username);
+        PathMetadata meta = new PathMetadata(s3aStatus, Tristate.FALSE, false);
         newDirs.add(meta);
       } else {
         break;
@@ -480,7 +482,7 @@ public final class S3Guard {
   private static void addMoveStatus(Collection<Path> srcPaths,
       Collection<PathMetadata> dstMetas,
       Path srcPath,
-      FileStatus dstStatus) {
+      S3AFileStatus dstStatus) {
     srcPaths.add(srcPath);
     dstMetas.add(new PathMetadata(dstStatus));
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -44,12 +44,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.s3a.MultipartUtils;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.auth.delegation.S3ADelegationTokens;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
@@ -703,7 +703,7 @@ public abstract class S3GuardTool extends Configured implements Tool {
         if (dirCache.contains(parent)) {
           return;
         }
-        FileStatus dir = DynamoDBMetadataStore.makeDirStatus(parent,
+        S3AFileStatus dir = DynamoDBMetadataStore.makeDirStatus(parent,
             f.getOwner());
         getStore().put(new PathMetadata(dir));
         dirCache.add(parent);
@@ -718,13 +718,13 @@ public abstract class S3GuardTool extends Configured implements Tool {
      */
     private long importDir(FileStatus status) throws IOException {
       Preconditions.checkArgument(status.isDirectory());
-      RemoteIterator<LocatedFileStatus> it = getFilesystem()
+      RemoteIterator<S3ALocatedFileStatus> it = getFilesystem()
           .listFilesAndEmptyDirectories(status.getPath(), true);
       long items = 0;
 
       while (it.hasNext()) {
-        LocatedFileStatus located = it.next();
-        FileStatus child;
+        S3ALocatedFileStatus located = it.next();
+        S3AFileStatus child;
         if (located.isDirectory()) {
           child = DynamoDBMetadataStore.makeDirStatus(located.getPath(),
               located.getOwner());
@@ -734,7 +734,9 @@ public abstract class S3GuardTool extends Configured implements Tool {
               located.getModificationTime(),
               located.getPath(),
               located.getBlockSize(),
-              located.getOwner());
+              located.getOwner(),
+              located.getETag(),
+              located.getVersionId());
         }
         putParentsIfNotPresent(child);
         getStore().put(new PathMetadata(child));
@@ -761,7 +763,8 @@ public abstract class S3GuardTool extends Configured implements Tool {
         filePath = "/";
       }
       Path path = new Path(filePath);
-      FileStatus status = getFilesystem().getFileStatus(path);
+      S3AFileStatus status = (S3AFileStatus) getFilesystem()
+          .getFileStatus(path);
 
       try {
         initMetadataStore(false);

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
@@ -1097,6 +1097,111 @@ based on usage information collected from previous days, and choosing a
 combination of retry counts and an interval which allow for the clients to cope with
 some throttling, but not to time-out other applications.
 
+## Read-After-Overwrite Consistency
+
+S3Guard provides read-after-overwrite consistency through ETags (default) or
+object versioning checked either on the server (default) or client. This works
+such that a reader reading a file after an overwrite either sees the new version
+of the file or an error. Without S3Guard, new readers may see the original
+version. Once S3 reaches eventual consistency, new readers will see the new
+version.
+
+Readers using S3Guard will usually see the new file version, but may
+in rare cases see `RemoteFileChangedException` instead. This would occur if
+an S3 object read cannot provide the version tracked in S3Guard metadata.
+
+S3Guard achieves this behavior by storing ETags and object version IDs in the
+S3Guard metadata store (e.g. DynamoDB). On opening a file, S3AFileSystem
+will look in S3 for the version of the file indicated by the ETag or object
+version ID stored in the metadata store. If that version is unavailable,
+`RemoteFileChangedException` is thrown. Whether ETag or version ID and
+server or client mode is used is determed by the
+[fs.s3a.change.detection configuration options](./index.html#Handling_Read-During-Overwrite).
+
+### No Versioning Metadata Available
+
+When the first S3AFileSystem clients are upgraded to the version of
+S3AFileSystem that contains these change tracking features, any existing
+S3Guard metadata will not contain ETags or object version IDs.  Reads of files
+tracked in such S3Guard metadata will access whatever version of the file is
+available in S3 at the time of read.  Only if the file is subsequently updated
+will S3Guard start tracking ETag and object version ID and as such generating
+`RemoteFileChangedException` if an inconsistency is detected.
+
+Similarly, when S3Guard metadata is pruned, S3Guard will no longer be able to
+detect an inconsistent read.  S3Guard metadata should be retained for at least
+as long as the perceived possible read-after-overwrite temporary inconsistency
+window. That window is expected to be short, but there are no guarantees so it
+is at the administrator's discretion to weigh the risk.
+
+### Known Limitations
+
+#### S3 Select
+
+S3 Select does not provide a capability for server-side ETag or object
+version ID qualification. Whether fs.s3a.change.detection.mode is client or
+server, S3Guard will cause a client-side check of the file version before
+opening the file with S3 Select.  If the current version does not match the
+version tracked in S3Guard, `RemoteFileChangedException` is thrown.
+
+It is still possible that the S3 Select read will access a different version of
+the file, if the visible file version changes between the version check and
+the opening of the file.  This can happen due to eventual consistency or
+an overwrite of the file between the version check and the open of the file.
+
+#### Rename
+
+Rename is implemented via copy in S3.  With fs.s3a.change.detection.mode=client,
+a fully reliable mechansim for ensuring the copied content is the expected
+content is not possible. This is the case since there isn't necessarily a way
+to know the expected ETag or version ID to appear on the object resulting from
+the copy.
+
+Furthermore, if fs.s3a.change.detection.mode=server and a third-party S3
+implemntation is used that doesn't honor the provided ETag or version ID,
+S3AFileSystem and S3Guard cannot detect it.
+
+In either fs.s3.change.detection.mode=server or client, a client-side check
+will be performed before the copy to ensure the current version of the file
+matches S3Guard metadata.  If not, `RemoteFileChangedException` is thrown.
+Similar to as discussed with regard to S3 Select, this is not sufficient to
+guarantee that same version is the version copied.
+
+When fs.s3.change.detection.mode=server, the expected version is also specified
+in the underlying S3 CopyObjectRequest.  As long as the server honors it, the
+copied object will be correct.
+
+All this said, with the defaults of fs.s3.change.detection.mode=server and
+fs.s3.change.detection.source=etag against Amazon's S3, copy should in fact
+either copy the expected file version or, in the case of an eventual consistency
+anomaly, generate `RemoteFileChangedException`.  The same should be true with
+fs.s3.change.detection.source=versionid.
+
+#### Out of Sync Metadata
+
+The S3Guard version tracking metadata (ETag or object version ID) could become
+out of sync with the true current object metadata in S3.  For example, S3Guard
+is still tracking v1 of some file after v2 has been written.  This could occur
+for reasons such as a writer writing without utilizing S3Guard and/or
+S3AFileSystem or simply due to a write with S3AFileSystem and S3Guard that wrote
+successfully to S3, but failed in communication with S3Guard's metadata store
+(e.g. DynamoDB).
+
+If this happens, reads of the affected file(s) will result in
+`RemoteFileChangedException` until one of:
+
+* the S3Guard metadata is corrected out-of-band
+* the file is overwritten (causing an S3Guard metadata update)
+* the S3Guard metadata is pruned
+
+The S3Guard metadata for a file can be corrected with the `s3guard import`
+command as discussed above.  The command can take a file URI instead of a
+bucket URI to correct the metadata for a single file.  For example:
+
+```bash
+hadoop s3guard import [-meta URI] s3a://my-bucket/file-with-bad-metadata
+```
+
 ## Troubleshooting
 
 ### Error: `S3Guard table lacks version marker.`
@@ -1214,6 +1319,41 @@ successfully written to S3 and now the S3Guard metadata is likely to be out of
 sync.
 
 See [Fail on Error](#fail-on-error) for more detail.
+
+### Error `RemoteFileChangedException`
+
+An exception like the following could occur for a couple of reasons:
+
+* the S3Guard metadata is out of sync with the true S3 metadata.  For
+example, the S3Guard DynamoDB table is tracking a different ETag than the ETag
+shown in the exception.  This may suggest the object was updated in S3 without
+involvement from S3Guard or there was a transient failure when S3Guard tried to
+write to DynamoDB.
+
+* S3 is exhibiting read-after-overwrite temporary inconsistency.  The S3Guard
+metadata was updated with a new ETag during a recent write, but the current read
+is not seeing that ETag due to S3 eventual consistency.  This exception prevents
+the reader from an inconsistent read where the reader sees an older version of
+the file.
+
+```
+org.apache.hadoop.fs.s3a.RemoteFileChangedException: open 's3a://my-bucket/test/file.txt':
+  Change reported by S3 while reading at position 0.
+  ETag 4e886e26c072fef250cfaf8037675405 was unavailable
+  at org.apache.hadoop.fs.s3a.impl.ChangeTracker.processResponse(ChangeTracker.java:167)
+  at org.apache.hadoop.fs.s3a.S3AInputStream.reopen(S3AInputStream.java:207)
+  at org.apache.hadoop.fs.s3a.S3AInputStream.lambda$lazySeek$1(S3AInputStream.java:355)
+  at org.apache.hadoop.fs.s3a.Invoker.lambda$retry$2(Invoker.java:195)
+  at org.apache.hadoop.fs.s3a.Invoker.once(Invoker.java:109)
+  at org.apache.hadoop.fs.s3a.Invoker.lambda$retry$3(Invoker.java:265)
+  at org.apache.hadoop.fs.s3a.Invoker.retryUntranslated(Invoker.java:322)
+  at org.apache.hadoop.fs.s3a.Invoker.retry(Invoker.java:261)
+  at org.apache.hadoop.fs.s3a.Invoker.retry(Invoker.java:193)
+  at org.apache.hadoop.fs.s3a.Invoker.retry(Invoker.java:215)
+  at org.apache.hadoop.fs.s3a.S3AInputStream.lazySeek(S3AInputStream.java:348)
+  at org.apache.hadoop.fs.s3a.S3AInputStream.read(S3AInputStream.java:381)
+  at java.io.FilterInputStream.read(FilterInputStream.java:83)
+```
 
 ## Other Topics
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
@@ -1120,16 +1120,16 @@ server or client mode is used is determed by the
 
 ### No Versioning Metadata Available
 
-When the first S3AFileSystem clients are upgraded to the version of
-S3AFileSystem that contains these change tracking features, any existing
-S3Guard metadata will not contain ETags or object version IDs.  Reads of files
+When the first S3AFileSystem clients are upgraded to a version of
+`S3AFileSystem` that contains these change tracking features, any existing
+S3Guard metadata will not contain ETags or object version IDs. Reads of files
 tracked in such S3Guard metadata will access whatever version of the file is
-available in S3 at the time of read.  Only if the file is subsequently updated
+available in S3 at the time of read. Only if the file is subsequently updated
 will S3Guard start tracking ETag and object version ID and as such generating
 `RemoteFileChangedException` if an inconsistency is detected.
 
 Similarly, when S3Guard metadata is pruned, S3Guard will no longer be able to
-detect an inconsistent read.  S3Guard metadata should be retained for at least
+detect an inconsistent read. S3Guard metadata should be retained for at least
 as long as the perceived possible read-after-overwrite temporary inconsistency
 window. That window is expected to be short, but there are no guarantees so it
 is at the administrator's discretion to weigh the risk.
@@ -1139,43 +1139,43 @@ is at the administrator's discretion to weigh the risk.
 #### S3 Select
 
 S3 Select does not provide a capability for server-side ETag or object
-version ID qualification. Whether fs.s3a.change.detection.mode is client or
-server, S3Guard will cause a client-side check of the file version before
-opening the file with S3 Select.  If the current version does not match the
+version ID qualification. Whether `fs.s3a.change.detection.mode` is "client" or
+"server", S3Guard will cause a client-side check of the file version before
+opening the file with S3 Select. If the current version does not match the
 version tracked in S3Guard, `RemoteFileChangedException` is thrown.
 
 It is still possible that the S3 Select read will access a different version of
 the file, if the visible file version changes between the version check and
-the opening of the file.  This can happen due to eventual consistency or
+the opening of the file. This can happen due to eventual consistency or
 an overwrite of the file between the version check and the open of the file.
 
 #### Rename
 
-Rename is implemented via copy in S3.  With fs.s3a.change.detection.mode=client,
-a fully reliable mechansim for ensuring the copied content is the expected
+Rename is implemented via copy in S3. With `fs.s3a.change.detection.mode` set
+to "client", a fully reliable mechansim for ensuring the copied content is the expected
 content is not possible. This is the case since there isn't necessarily a way
 to know the expected ETag or version ID to appear on the object resulting from
 the copy.
 
-Furthermore, if fs.s3a.change.detection.mode=server and a third-party S3
-implemntation is used that doesn't honor the provided ETag or version ID,
+Furthermore, if `fs.s3a.change.detection.mode` is "server" and a third-party S3
+implementation is used that doesn't honor the provided ETag or version ID,
 S3AFileSystem and S3Guard cannot detect it.
 
-In either fs.s3.change.detection.mode=server or client, a client-side check
+When `fs.s3.change.detection.mode` is "client", a client-side check
 will be performed before the copy to ensure the current version of the file
-matches S3Guard metadata.  If not, `RemoteFileChangedException` is thrown.
+matches S3Guard metadata. If not, `RemoteFileChangedException` is thrown.
 Similar to as discussed with regard to S3 Select, this is not sufficient to
 guarantee that same version is the version copied.
 
-When fs.s3.change.detection.mode=server, the expected version is also specified
-in the underlying S3 CopyObjectRequest.  As long as the server honors it, the
+When `fs.s3.change.detection.mode` server, the expected version is also specified
+in the underlying S3 `CopyObjectRequest`. As long as the server honors it, the
 copied object will be correct.
 
-All this said, with the defaults of fs.s3.change.detection.mode=server and
-fs.s3.change.detection.source=etag against Amazon's S3, copy should in fact
+All this said, with the defaults of `fs.s3.change.detection.mode` of "server" and
+`fs.s3.change.detection.source` of "etag", when working with Amazon's S3, copy should in fact
 either copy the expected file version or, in the case of an eventual consistency
-anomaly, generate `RemoteFileChangedException`.  The same should be true with
-fs.s3.change.detection.source=versionid.
+anomaly, generate `RemoteFileChangedException`. The same should be true when
+`fs.s3.change.detection.source` = "versionid".
 
 #### Out of Sync Metadata
 
@@ -1195,8 +1195,8 @@ If this happens, reads of the affected file(s) will result in
 * the S3Guard metadata is pruned
 
 The S3Guard metadata for a file can be corrected with the `s3guard import`
-command as discussed above.  The command can take a file URI instead of a
-bucket URI to correct the metadata for a single file.  For example:
+command as discussed above. The command can take a file URI instead of a
+bucket URI to correct the metadata for a single file. For example:
 
 ```bash
 hadoop s3guard import [-meta URI] s3a://my-bucket/file-with-bad-metadata

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -970,8 +970,8 @@ and the like. The standard strategy here is to save to HDFS and then copy to S3.
 
 ```
 org.apache.hadoop.fs.s3a.RemoteFileChangedException: re-open `s3a://my-bucket/test/file.txt':
-  ETag change reported by S3 while reading at position 1949.
-  Version f9c186d787d4de9657e99f280ba26555 was unavailable
+  Change reported by S3 while reading at position 1949.
+  ETag f9c186d787d4de9657e99f280ba26555 was unavailable
   at org.apache.hadoop.fs.s3a.impl.ChangeTracker.processResponse(ChangeTracker.java:137)
   at org.apache.hadoop.fs.s3a.S3AInputStream.reopen(S3AInputStream.java:200)
   at org.apache.hadoop.fs.s3a.S3AInputStream.lambda$lazySeek$1(S3AInputStream.java:346)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
@@ -22,7 +22,10 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
@@ -43,6 +46,12 @@ public class ITestS3ADelayedFNF extends AbstractS3ATestBase {
   @Test
   public void testNotFoundFirstRead() throws Exception {
     FileSystem fs = getFileSystem();
+    ChangeDetectionPolicy changeDetectionPolicy =
+        ((S3AFileSystem) fs).getChangeDetectionPolicy();
+    Assume.assumeFalse("FNF not expected when using a bucket with"
+            + " object versioning",
+        changeDetectionPolicy.getSource() == Source.VersionId);
+
     Path p = path("some-file");
     ContractTestUtils.createFile(fs, p, false, new byte[] {20, 21, 22});
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.test.LambdaTestUtils;
+
 import org.junit.Assume;
 import org.junit.Test;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AInconsistency.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AInconsistency.java
@@ -24,9 +24,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.NullMetadataStore;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
@@ -106,6 +109,12 @@ public class ITestS3AInconsistency extends AbstractS3ATestBase {
   @Test
   public void testOpenDeleteRead() throws Exception {
     S3AFileSystem fs = getFileSystem();
+    ChangeDetectionPolicy changeDetectionPolicy =
+        ((S3AFileSystem) fs).getChangeDetectionPolicy();
+    Assume.assumeFalse("FNF not expected when using a bucket with"
+            + " object versioning",
+        changeDetectionPolicy.getSource() == Source.VersionId);
+
     Path p = path("testOpenDeleteRead.txt");
     writeTextFile(fs, p, "1337c0d3z", true);
     try (InputStream s = fs.open(p)) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AInconsistency.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AInconsistency.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.NullMetadataStore;
 import org.apache.hadoop.test.LambdaTestUtils;
+
 import org.junit.Assume;
 import org.junit.Test;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
@@ -18,11 +18,17 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -33,63 +39,112 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
+import org.apache.hadoop.fs.s3a.s3guard.LocalMetadataStore;
+import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
+import org.apache.hadoop.fs.s3a.s3guard.NullMetadataStore;
+import org.apache.hadoop.fs.s3a.s3guard.PathMetadata;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBucketOverrides;
+import static org.apache.hadoop.fs.s3a.select.SelectConstants.SELECT_SQL;
 import static org.apache.hadoop.test.LambdaTestUtils.eventually;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.apache.hadoop.test.LambdaTestUtils.interceptFuture;
 
 /**
  * Test S3A remote file change detection.
  */
 @RunWith(Parameterized.class)
 public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
+
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3ARemoteFileChanged.class);
 
+  private static final String TEST_DATA = "Some test data";
+  private static final String QUOTED_TEST_DATA =
+      "\"" + TEST_DATA + "\"";
+
+  private enum InteractionType {
+    READ, READ_AFTER_DELETE, COPY, SELECT
+  }
+
   private final String changeDetectionSource;
   private final String changeDetectionMode;
-  private final boolean expectChangeException;
-  private final boolean expectFileNotFoundException;
+  private final Collection<InteractionType> expectedExceptionInteractions;
+  private S3AFileSystem fs;
 
   @Parameterized.Parameters
   public static Collection<Object[]> params() {
     return Arrays.asList(new Object[][]{
         // make sure it works with invalid config
-        {"bogus", "bogus", true, true},
+        {"bogus", "bogus",
+            Arrays.asList(
+                InteractionType.READ,
+                InteractionType.READ_AFTER_DELETE,
+                InteractionType.COPY,
+                InteractionType.SELECT)},
 
         // test with etag
-        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_SERVER, true, true},
-        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_CLIENT, true, true},
-        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_WARN, false, true},
-        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_NONE, false, true},
+        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_SERVER,
+            Arrays.asList(
+                InteractionType.READ,
+                InteractionType.READ_AFTER_DELETE,
+                InteractionType.COPY,
+                InteractionType.SELECT)},
+        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_CLIENT,
+            Arrays.asList(
+                InteractionType.READ,
+                InteractionType.READ_AFTER_DELETE,
+                InteractionType.COPY,
+                InteractionType.SELECT)},
+        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_WARN,
+            Arrays.asList(
+                InteractionType.READ_AFTER_DELETE)},
+        {CHANGE_DETECT_SOURCE_ETAG, CHANGE_DETECT_MODE_NONE,
+            Arrays.asList(
+                InteractionType.READ_AFTER_DELETE)},
 
         // test with versionId
-        // when using server-side versionId, the exceptions shouldn't happen
-        // since the previous version will still be available
-        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_SERVER, false,
-            false},
+        // when using server-side versionId, the read exceptions shouldn't
+        // happen since the previous version will still be available, but
+        // they will still happen on rename and select since we always do a
+        // client-side check against the current version
+        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_SERVER,
+            Arrays.asList(
+                InteractionType.COPY,
+                InteractionType.SELECT)},
 
         // with client-side versionId it will behave similar to client-side eTag
-        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_CLIENT, true,
-            true},
+        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_CLIENT,
+            Arrays.asList(
+                InteractionType.READ,
+                InteractionType.READ_AFTER_DELETE,
+                InteractionType.COPY,
+                InteractionType.SELECT)},
 
-        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_WARN, false, true},
-        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_NONE, false, true}
+        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_WARN,
+            Arrays.asList(
+                InteractionType.READ_AFTER_DELETE)},
+        {CHANGE_DETECT_SOURCE_VERSION_ID, CHANGE_DETECT_MODE_NONE,
+            Arrays.asList(
+                InteractionType.READ_AFTER_DELETE)}
     });
   }
 
   public ITestS3ARemoteFileChanged(String changeDetectionSource,
       String changeDetectionMode,
-      boolean expectException,
-      boolean expectFileNotFoundException) {
+      Collection<InteractionType> expectedExceptionInteractions) {
     this.changeDetectionSource = changeDetectionSource;
     this.changeDetectionMode = changeDetectionMode;
-    this.expectChangeException = expectException;
-    this.expectFileNotFoundException = expectFileNotFoundException;
+    this.expectedExceptionInteractions = expectedExceptionInteractions;
+  }
+
+  @Before
+  public void setUp() {
+    fs = getFileSystem();
   }
 
   @Override
@@ -101,29 +156,37 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
         CHANGE_DETECT_MODE);
     conf.set(CHANGE_DETECT_SOURCE, changeDetectionSource);
     conf.set(CHANGE_DETECT_MODE, changeDetectionMode);
+
+    // reduce retry limit so FileNotFoundException cases timeout faster,
+    // speeding up the tests
+    conf.set(RETRY_LIMIT, "5");
+
+    if (conf.getClass(S3_METADATA_STORE_IMPL, MetadataStore.class) ==
+        NullMetadataStore.class) {
+      // favor LocalMetadataStore over NullMetadataStore
+      conf.setClass(S3_METADATA_STORE_IMPL,
+          LocalMetadataStore.class, MetadataStore.class);
+    }
     S3ATestUtils.disableFilesystemCaching(conf);
     return conf;
   }
 
+  /**
+   * Tests reading a file that is changed while the reader's InputStream is
+   * open.
+   */
   @Test
-  public void testReadFileChanged() throws Throwable {
+  public void testReadFileChangedStreamOpen() throws Throwable {
     final int originalLength = 8192;
     final byte[] originalDataset = dataset(originalLength, 'a', 32);
     final int newLength = originalLength + 1;
     final byte[] newDataset = dataset(newLength, 'A', 32);
-    final S3AFileSystem fs = getFileSystem();
     final Path testpath = path("readFileToChange.txt");
     // initial write
     writeDataset(fs, testpath, originalDataset, originalDataset.length,
         1024, false);
 
-    if (fs.getChangeDetectionPolicy().getSource() == Source.VersionId) {
-      // skip versionId tests if the bucket doesn't have object versioning
-      // enabled
-      Assume.assumeTrue(
-          "Target filesystem does not support versioning",
-          fs.getObjectMetadata(fs.pathToKey(testpath)).getVersionId() != null);
-    }
+    skipIfVersionPolicyAndNoVersionId(testpath);
 
     try(FSDataInputStream instream = fs.open(testpath)) {
       // seek forward and read successfully
@@ -152,7 +215,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
       // now check seek backward
       instream.seek(instream.getPos() - 100);
 
-      if (expectChangeException) {
+      if (expectedExceptionInteractions.contains(InteractionType.READ)) {
         intercept(RemoteFileChangedException.class, "", "read",
             () -> instream.read());
       } else {
@@ -164,7 +227,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
       // seek backward
       instream.seek(0);
 
-      if (expectChangeException) {
+      if (expectedExceptionInteractions.contains(InteractionType.READ)) {
         intercept(RemoteFileChangedException.class, "", "read",
             () -> instream.read(buf));
         intercept(RemoteFileChangedException.class, "", "read",
@@ -183,7 +246,8 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
       // seek backward
       instream.seek(0);
 
-      if (expectFileNotFoundException) {
+      if (expectedExceptionInteractions.contains(
+          InteractionType.READ_AFTER_DELETE)) {
         intercept(FileNotFoundException.class, "", "read()",
             () -> instream.read());
         intercept(FileNotFoundException.class, "", "readfully",
@@ -192,6 +256,189 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
         instream.read();
         instream.readFully(2048, buf);
       }
+    }
+  }
+
+  /**
+   * Tests reading a file where the version visible in S3 does not match the
+   * version tracked in the metadata store.
+   */
+  @Test
+  public void testReadFileChangedOutOfSyncMetadata() throws Throwable {
+    final Path testpath = writeOutOfSyncFileVersion("read.dat");
+
+    skipIfVersionPolicyAndNoVersionId(testpath);
+
+    final FSDataInputStream instream = fs.open(testpath);
+    if (expectedExceptionInteractions.contains(InteractionType.READ)) {
+      intercept(RemoteFileChangedException.class, "", "read()",
+          () -> {
+            instream.read();
+          });
+    } else {
+      instream.read();
+    }
+  }
+
+  /**
+   * Ensures a file can be read when there is no version metadata
+   * (ETag, versionId).
+   */
+  @Test
+  public void testReadWithNoVersionMetadata() throws Throwable {
+    final Path testpath = writeFileWithNoVersionMetadata("readnoversion.dat");
+
+    skipIfVersionPolicyAndNoVersionId(testpath);
+
+    final FSDataInputStream instream = fs.open(testpath);
+    assertEquals(TEST_DATA,
+        IOUtils.toString(instream, Charset.forName("UTF-8")).trim());
+  }
+
+  /**
+   * Tests using S3 Select on a file where the version visible in S3 does not
+   * match the version tracked in the metadata store.
+   */
+  @Test
+  public void testSelectChangedFile() throws Throwable {
+    final Path testpath = writeOutOfSyncFileVersion("select.dat");
+
+    skipIfVersionPolicyAndNoVersionId(testpath);
+
+    if (expectedExceptionInteractions.contains(InteractionType.SELECT)) {
+      interceptFuture(RemoteFileChangedException.class, "select",
+          fs.openFile(testpath)
+              .must(SELECT_SQL, "SELECT * FROM S3OBJECT").build());
+    } else {
+      fs.openFile(testpath)
+          .must(SELECT_SQL, "SELECT * FROM S3OBJECT").build().get();
+    }
+  }
+
+  /**
+   * Ensures a file can be read via S3 Select when there is no version metadata
+   * (ETag, versionId).
+   */
+  @Test
+  public void testSelectWithNoVersionMetadata() throws Throwable {
+    final Path testpath =
+        writeFileWithNoVersionMetadata("selectnoversion.dat");
+
+    skipIfVersionPolicyAndNoVersionId(testpath);
+
+    FSDataInputStream instream = fs.openFile(testpath)
+        .must(SELECT_SQL, "SELECT * FROM S3OBJECT").build().get();
+    assertEquals(QUOTED_TEST_DATA,
+        IOUtils.toString(instream, Charset.forName("UTF-8")).trim());
+  }
+
+  /**
+   * Tests doing a rename() on a file where the version visible in S3 does not
+   * match the version tracked in the metadata store.
+   * @throws Throwable
+   */
+  @Test
+  public void testRenameChangedFile() throws Throwable {
+    final Path testpath = writeOutOfSyncFileVersion("rename.dat");
+
+    skipIfVersionPolicyAndNoVersionId(testpath);
+
+    final Path dest = path("dest.dat");
+    if (expectedExceptionInteractions.contains(InteractionType.COPY)) {
+      intercept(RemoteFileChangedException.class, "", "copy()",
+          () -> {
+            fs.rename(testpath, dest);
+          });
+    } else {
+      fs.rename(testpath, dest);
+    }
+  }
+
+  /**
+   * Ensures a file can be renamed when there is no version metadata
+   * (ETag, versionId).
+   */
+  @Test
+  public void testRenameWithNoVersionMetadata() throws Throwable {
+    final Path testpath =
+        writeFileWithNoVersionMetadata("renamenoversion.dat");
+
+    skipIfVersionPolicyAndNoVersionId(testpath);
+
+    final Path dest = path("noversiondest.dat");
+    fs.rename(testpath, dest);
+    FSDataInputStream inputStream = fs.open(dest);
+    assertEquals(TEST_DATA,
+        IOUtils.toString(inputStream, Charset.forName("UTF-8")).trim());
+  }
+
+  /**
+   * Writes a file with old ETag and versionId in the metadata store such
+   * that the metadata is out of sync with S3.  Attempts to read such a file
+   * should result in {@link RemoteFileChangedException}.
+   */
+  private Path writeOutOfSyncFileVersion(String filename) throws IOException {
+    final Path testpath = path(filename);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrintWriter printWriter = new PrintWriter(out);
+    printWriter.println(TEST_DATA);
+    printWriter.close();
+    final byte[] dataset = out.toByteArray();
+    writeDataset(fs, testpath, dataset, dataset.length,
+        1024, false);
+    S3AFileStatus originalStatus = (S3AFileStatus) fs.getFileStatus(testpath);
+
+    // overwrite with half the content
+    writeDataset(fs, testpath, dataset, dataset.length / 2,
+        1024, true);
+
+    S3AFileStatus newStatus = (S3AFileStatus) fs.getFileStatus(testpath);
+
+    // put back the original etag, versionId
+    S3AFileStatus forgedStatus =
+        S3AFileStatus.fromFileStatus(newStatus, Tristate.FALSE,
+            originalStatus.getETag(), originalStatus.getVersionId());
+    fs.getMetadataStore().put(
+        new PathMetadata(forgedStatus, Tristate.FALSE, false));
+
+    return testpath;
+  }
+
+  /**
+   * Writes a file with null ETag and versionId in the metadata store.
+   */
+  private Path writeFileWithNoVersionMetadata(String filename)
+      throws IOException {
+    final Path testpath = path(filename);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrintWriter printWriter = new PrintWriter(out);
+    printWriter.println(TEST_DATA);
+    printWriter.close();
+    final byte[] dataset = out.toByteArray();
+    writeDataset(fs, testpath, dataset, dataset.length,
+        1024, false);
+    S3AFileStatus originalStatus = (S3AFileStatus) fs.getFileStatus(testpath);
+
+    // remove ETag and versionId
+    S3AFileStatus newStatus = S3AFileStatus.fromFileStatus(originalStatus,
+        Tristate.FALSE, null, null);
+    fs.getMetadataStore().put(new PathMetadata(newStatus, Tristate.FALSE,
+        false));
+
+    return testpath;
+  }
+
+  /**
+   * The test is invalid if the policy uses versionId but the bucket doesn't
+   * have versioning enabled.
+   */
+  private void skipIfVersionPolicyAndNoVersionId(Path testpath) throws IOException {
+    if (fs.getChangeDetectionPolicy().getSource() == Source.VersionId) {
+      // skip versionId tests if the bucket doesn't have object versioning
+      // enabled
+      Assume.assumeTrue(
+          "Target filesystem does not support versioning",
+          fs.getObjectMetadata(fs.pathToKey(testpath)).getVersionId() != null);
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardListConsistency.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardListConsistency.java
@@ -253,7 +253,7 @@ public class ITestS3GuardListConsistency extends AbstractS3ATestBase {
         DEFAULT_DELAY_KEY_SUBSTRING)));
 
     try {
-      RemoteIterator<LocatedFileStatus> old = fs.listFilesAndEmptyDirectories(
+      RemoteIterator<S3ALocatedFileStatus> old = fs.listFilesAndEmptyDirectories(
           path("a"), true);
       fail("Recently renamed dir should not be visible");
     } catch(FileNotFoundException e) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardOutOfBandOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardOutOfBandOperations.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +38,8 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.fs.s3a.s3guard.DirListingMetadata;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 
@@ -243,6 +246,12 @@ public class ITestS3GuardOutOfBandOperations extends AbstractS3ATestBase {
 
   @Test
   public void testOutOfBandDeletes() throws Exception {
+    ChangeDetectionPolicy changeDetectionPolicy =
+        ((S3AFileSystem) getFileSystem()).getChangeDetectionPolicy();
+    Assume.assumeFalse("FNF not expected when using a bucket with"
+            + " object versioning",
+        changeDetectionPolicy.getSource() == Source.VersionId);
+
     Path testFileName = path("OutOfBandDelete-" + UUID.randomUUID());
     outOfBandDeletes(testFileName, authoritative);
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -177,7 +177,7 @@ public class MockS3AFileSystem extends S3AFileSystem {
   }
 
   @Override
-  void finishedWrite(String key, long length) {
+  void finishedWrite(String key, long length, String eTag, String versionId) {
 
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1042,30 +1042,25 @@ public final class S3ATestUtils {
    * Verify the status entry of a directory matches that expected.
    * @param status status entry to check
    * @param replication replication factor
-   * @param modTime modified time
-   * @param accessTime access time
    * @param owner owner
-   * @param group user group
-   * @param permission permission.
    */
-  public static void verifyDirStatus(FileStatus status,
+  public static void verifyDirStatus(S3AFileStatus status,
       int replication,
-      long modTime,
-      long accessTime,
-      String owner,
-      String group,
-      FsPermission permission) {
+      String owner) {
     String details = status.toString();
     assertTrue("Is a dir: " + details, status.isDirectory());
     assertEquals("zero length: " + details, 0, status.getLen());
-
-    assertEquals("Mod time: " + details, modTime, status.getModificationTime());
+    // S3AFileStatus always assigns modTime = System.currentTimeMillis()
+    assertTrue("Mod time: " + details, status.getModificationTime() > 0);
     assertEquals("Replication value: " + details, replication,
         status.getReplication());
-    assertEquals("Access time: " + details, accessTime, status.getAccessTime());
+    assertEquals("Access time: " + details, 0, status.getAccessTime());
     assertEquals("Owner: " + details, owner, status.getOwner());
-    assertEquals("Group: " + details, group, status.getGroup());
-    assertEquals("Permission: " + details, permission, status.getPermission());
+    // S3AFileStatus always assigns group=owner
+    assertEquals("Group: " + details, owner, status.getGroup());
+    // S3AFileStatus always assigns permission = default
+    assertEquals("Permission: " + details,
+        FsPermission.getDefault(), status.getPermission());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestStreamChangeTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestStreamChangeTracker.java
@@ -20,18 +20,22 @@ package org.apache.hadoop.fs.s3a;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
-import org.apache.hadoop.fs.PathIOException;
+import com.amazonaws.services.s3.transfer.model.CopyResult;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeTracker;
 import org.apache.hadoop.test.HadoopTestBase;
+import org.apache.http.HttpStatus;
 
 import static org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.CHANGE_DETECTED;
 import static org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.createPolicy;
@@ -49,6 +53,8 @@ public class TestStreamChangeTracker extends HadoopTestBase {
   public static final String BUCKET = "bucket";
 
   public static final String OBJECT = "object";
+
+  public static final String DEST_OBJECT = "new_object";
 
   public static final String URI = "s3a://" + BUCKET + "/" + OBJECT;
 
@@ -161,8 +167,102 @@ public class TestStreamChangeTracker extends HadoopTestBase {
         CHANGE_DETECTED);
   }
 
+  @Test
+  public void testVersionCheckingUpfrontETag() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Server,
+        ChangeDetectionPolicy.Source.ETag,
+        false,
+        objectAttributes("etag1", "versionid1"));
+
+    assertEquals("etag1", tracker.getRevisionId());
+  }
+
+  @Test
+  public void testVersionCheckingUpfrontVersionId() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Server,
+        ChangeDetectionPolicy.Source.VersionId,
+        false,
+        objectAttributes("etag1", "versionid1"));
+
+    assertEquals("versionid1", tracker.getRevisionId());
+  }
+
+  @Test
+  public void testVersionCheckingETagCopyServer() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Server,
+        ChangeDetectionPolicy.Source.VersionId,
+        false,
+        objectAttributes("etag1", "versionid1"));
+    assertConstraintApplied(tracker, newCopyObjectRequest());
+  }
+
+  @Test
+  public void testVersionCheckingETagCopyClient() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Client,
+        ChangeDetectionPolicy.Source.VersionId,
+        false,
+        objectAttributes("etag1", "versionid1"));
+    assertFalse("Tracker should not have applied contraints " + tracker,
+        tracker.maybeApplyConstraint(newCopyObjectRequest()));
+  }
+
+  @Test
+  public void testCopyVersionIdRequired() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Client,
+        ChangeDetectionPolicy.Source.VersionId,
+        true,
+        objectAttributes("etag1", "versionId"));
+
+    expectNoVersionAttributeException(tracker, newCopyResult("etag1",
+        null),
+        "policy requires VersionId");
+  }
+
+  @Test
+  public void testCopyETagRequired() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Client,
+        ChangeDetectionPolicy.Source.ETag,
+        true,
+        objectAttributes("etag1", "versionId"));
+
+    expectNoVersionAttributeException(tracker, newCopyResult(null,
+        "versionId"),
+        "policy requires ETag");
+  }
+
+  @Test
+  public void testCopyVersionMismatch() throws Throwable {
+    ChangeTracker tracker = newTracker(
+        ChangeDetectionPolicy.Mode.Server,
+        ChangeDetectionPolicy.Source.ETag,
+        true,
+        objectAttributes("etag", "versionId"));
+
+    // 412 is translated to RemoteFileChangedException
+    AmazonServiceException awsException =
+        new AmazonServiceException("aws exception");
+    awsException.setStatusCode(HttpStatus.SC_PRECONDITION_FAILED);
+    expectChangeException(tracker, awsException, "copy",
+        RemoteFileChangedException.PRECONDITIONS_FAILED);
+
+    // processing another type of exception does nothing
+    tracker.processException(new RuntimeException(), "copy");
+  }
+
   protected void assertConstraintApplied(final ChangeTracker tracker,
       final GetObjectRequest request) {
+    assertTrue("Tracker should have applied contraints " + tracker,
+        tracker.maybeApplyConstraint(request));
+  }
+
+  protected void assertConstraintApplied(final ChangeTracker tracker,
+      final CopyObjectRequest request) throws PathIOException {
     assertTrue("Tracker should have applied contraints " + tracker,
         tracker.maybeApplyConstraint(request));
   }
@@ -175,9 +275,26 @@ public class TestStreamChangeTracker extends HadoopTestBase {
         RemoteFileChangedException.class);
   }
 
+  protected RemoteFileChangedException expectChangeException(
+      final ChangeTracker tracker,
+      final Exception exception,
+      final String operation,
+      final String message) throws Exception {
+    return expectException(tracker, exception, operation, message,
+        RemoteFileChangedException.class);
+  }
+
   protected PathIOException expectNoVersionAttributeException(
       final ChangeTracker tracker,
       final S3Object response,
+      final String message) throws Exception {
+    return expectException(tracker, response, message,
+        NoVersionAttributeException.class);
+  }
+
+  protected PathIOException expectNoVersionAttributeException(
+      final ChangeTracker tracker,
+      final CopyResult response,
       final String message) throws Exception {
     return expectException(tracker, response, message,
         NoVersionAttributeException.class);
@@ -193,6 +310,35 @@ public class TestStreamChangeTracker extends HadoopTestBase {
         message,
         () -> {
           tracker.processResponse(response, "", 0);
+          return tracker;
+        });
+  }
+
+  protected <T extends Exception> T expectException(
+      final ChangeTracker tracker,
+      final CopyResult response,
+      final String message,
+      final Class<T> clazz) throws Exception {
+    return intercept(
+        clazz,
+        message,
+        () -> {
+          tracker.processResponse(response);
+          return tracker;
+        });
+  }
+
+  protected <T extends Exception> T expectException(
+      final ChangeTracker tracker,
+      final Exception exception,
+      final String operation,
+      final String message,
+      final Class<T> clazz) throws Exception {
+    return intercept(
+        clazz,
+        message,
+        () -> {
+          tracker.processException(exception, operation);
           return tracker;
         });
   }
@@ -218,19 +364,49 @@ public class TestStreamChangeTracker extends HadoopTestBase {
    */
   protected ChangeTracker newTracker(final ChangeDetectionPolicy.Mode mode,
       final ChangeDetectionPolicy.Source source, boolean requireVersion) {
+    return newTracker(mode, source, requireVersion,
+        objectAttributes(null, null));
+  }
+
+  /**
+   * Create tracker.
+   * Contains standard assertions(s).
+   * @return the tracker.
+   */
+  protected ChangeTracker newTracker(final ChangeDetectionPolicy.Mode mode,
+      final ChangeDetectionPolicy.Source source, boolean requireVersion,
+      S3ObjectAttributes objectAttributes) {
     ChangeDetectionPolicy policy = createPolicy(
         mode,
         source,
         requireVersion);
     ChangeTracker tracker = new ChangeTracker(URI, policy,
-        new AtomicLong(0));
-    assertFalse("Tracker should not have applied constraints " + tracker,
-        tracker.maybeApplyConstraint(newGetObjectRequest()));
+        new AtomicLong(0), objectAttributes);
+    if (objectAttributes.getVersionId() == null
+        && objectAttributes.getETag() == null) {
+      assertFalse("Tracker should not have applied constraints " + tracker,
+          tracker.maybeApplyConstraint(newGetObjectRequest()));
+    }
     return tracker;
   }
 
   private GetObjectRequest newGetObjectRequest() {
     return new GetObjectRequest(BUCKET, OBJECT);
+  }
+
+  private CopyObjectRequest newCopyObjectRequest() {
+    return new CopyObjectRequest(BUCKET, OBJECT, BUCKET, DEST_OBJECT);
+  }
+
+  private CopyResult newCopyResult(String eTag, String versionId) {
+    CopyResult copyResult = new CopyResult();
+    copyResult.setSourceBucketName(BUCKET);
+    copyResult.setSourceKey(OBJECT);
+    copyResult.setDestinationBucketName(BUCKET);
+    copyResult.setDestinationKey(DEST_OBJECT);
+    copyResult.setETag(eTag);
+    copyResult.setVersionId(versionId);
+    return copyResult;
   }
 
   private S3Object newResponse(String etag, String versionId) {
@@ -251,5 +427,15 @@ public class TestStreamChangeTracker extends HadoopTestBase {
     response.setBucketName(BUCKET);
     response.setKey(OBJECT);
     return response;
+  }
+
+  private S3ObjectAttributes objectAttributes(
+      String etag, String versionId) {
+    return new S3ObjectAttributes(BUCKET,
+        OBJECT,
+        null,
+        null,
+        etag,
+        versionId);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
@@ -221,7 +221,7 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
       ContractTestUtils.touch(fs, path);
     } else if (onMetadataStore) {
       S3AFileStatus status = new S3AFileStatus(100L, System.currentTimeMillis(),
-          fs.qualify(path), 512L, "hdfs");
+          fs.qualify(path), 512L, "hdfs", null, null);
       putFile(ms, status);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStore.java
@@ -246,12 +246,13 @@ public class ITestDynamoDBMetadataStore extends MetadataStoreTestBase {
   }
 
   @Override
-  FileStatus basicFileStatus(Path path, int size, boolean isDir)
+  S3AFileStatus basicFileStatus(Path path, int size, boolean isDir)
       throws IOException {
     String owner = UserGroupInformation.getCurrentUser().getShortUserName();
     return isDir
         ? new S3AFileStatus(true, path, owner)
-        : new S3AFileStatus(size, getModTime(), path, BLOCK_SIZE, owner);
+        : new S3AFileStatus(size, getModTime(), path, BLOCK_SIZE, owner,
+            null, null);
   }
 
   private DynamoDBMetadataStore getDynamoMetadataStore() throws IOException {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
@@ -231,7 +230,7 @@ public class ITestDynamoDBMetadataStoreScale
             long pruneItems = 0;
             for (long i = 0; i < iterations; i++) {
               Path longPath = pathOfDepth(BATCH_SIZE, String.valueOf(i));
-              FileStatus status = basicFileStatus(longPath, 0, false, 12345,
+              S3AFileStatus status = basicFileStatus(longPath, 0, false,
                   12345);
               PathMetadata pm = new PathMetadata(status);
               synchronized (toCleanup) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolLocal.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolLocal.java
@@ -37,7 +37,9 @@ import org.junit.Test;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.Tristate;
 
 import static org.apache.hadoop.fs.s3a.MultipartTestUtils.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getLandsatCSVFile;
@@ -93,6 +95,41 @@ public class ITestS3GuardToolLocal extends AbstractS3GuardToolTestBase {
     assertEquals("Expected 2 items: empty directory and a parent directory", 2,
         ms.listChildren(parent).getListing().size());
     // assertTrue(children.isAuthoritative());
+  }
+
+  @Test
+  public void testImportCommandRepairsETagAndVersionId() throws Exception {
+    S3AFileSystem fs = getFileSystem();
+    MetadataStore ms = getMetadataStore();
+    Path path = path("test-version-metadata");
+    try (FSDataOutputStream out = fs.create(path)) {
+      out.write(1);
+    }
+    S3AFileStatus originalStatus = (S3AFileStatus) fs.getFileStatus(path);
+
+    // put in bogus ETag and versionId
+    S3AFileStatus bogusStatus = S3AFileStatus.fromFileStatus(originalStatus,
+        Tristate.FALSE, "bogusETag", "bogusVersionId");
+    ms.put(new PathMetadata(bogusStatus));
+
+    // sanity check that bogus status is actually persisted
+    S3AFileStatus retrievedBogusStatus = (S3AFileStatus) fs.getFileStatus(path);
+    assertEquals("bogus ETag was not persisted",
+        "bogusETag", retrievedBogusStatus.getETag());
+    assertEquals("bogus versionId was not persisted",
+        "bogusVersionId", retrievedBogusStatus.getVersionId());
+
+    // execute the import
+    S3GuardTool.Import cmd = new S3GuardTool.Import(fs.getConf());
+    cmd.setStore(ms);
+    exec(cmd, "import", path.toString());
+
+    // make sure ETag and versionId were corrected
+    S3AFileStatus updatedStatus = (S3AFileStatus) fs.getFileStatus(path);
+    assertEquals("ETag was not corrected",
+        originalStatus.getETag(), updatedStatus.getETag());
+    assertEquals("VersionId was not corrected",
+        originalStatus.getVersionId(), updatedStatus.getVersionId());
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Tristate;
 import org.apache.hadoop.io.IOUtils;
@@ -61,11 +62,13 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   /** Some dummy values for sanity-checking FileStatus contents. */
   static final long BLOCK_SIZE = 32 * 1024 * 1024;
   static final int REPLICATION = 1;
-  static final FsPermission PERMISSION = new FsPermission((short)0755);
   static final String OWNER = "bob";
-  static final String GROUP = "uncles";
-  private final long accessTime = System.currentTimeMillis();
-  private final long modTime = accessTime - 5000;
+  private final long modTime = System.currentTimeMillis() - 5000;
+
+  // attributes not supported by S3AFileStatus
+  static final FsPermission PERMISSION = null;
+  static final String GROUP = null;
+  private final long accessTime = 0;
 
   /**
    * Each test should override this.  Will use a new Configuration instance.
@@ -148,14 +151,14 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
       String[] checkNodes) throws Exception {
     // we set up the example file system tree in metadata store
     for (String pathStr : createNodes) {
-      final FileStatus status = pathStr.contains("file")
+      final S3AFileStatus status = pathStr.contains("file")
           ? basicFileStatus(strToPath(pathStr), 100, false)
           : basicFileStatus(strToPath(pathStr), 0, true);
       ms.put(new PathMetadata(status));
     }
 
     final PathMetadata rootMeta = new PathMetadata(makeDirStatus("/"));
-    RemoteIterator<FileStatus> iterator;
+    RemoteIterator<S3AFileStatus> iterator;
     if (implementation == DescendantsIterator.class) {
       iterator = new DescendantsIterator(ms, rootMeta);
     } else if (implementation == MetadataStoreListFilesIterator.class) {
@@ -647,8 +650,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     createNewDirs("/pruneFiles");
 
     long oldTime = getTime();
-    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/old", 1, oldTime,
-        oldTime)));
+    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/old", 1, oldTime)));
     DirListingMetadata ls2 = ms.listChildren(strToPath("/pruneFiles"));
     if (!allowMissing()) {
       assertListingsEqual(ls2.getListing(), "/pruneFiles/old");
@@ -659,8 +661,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     Thread.sleep(1);
     long cutoff = System.currentTimeMillis();
     long newTime = getTime();
-    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/new", 1, newTime,
-        newTime)));
+    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/new", 1, newTime)));
 
     DirListingMetadata ls;
     ls = ms.listChildren(strToPath("/pruneFiles"));
@@ -691,7 +692,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
 
     long oldTime = getTime();
     ms.put(new PathMetadata(makeFileStatus("/pruneDirs/dir/file",
-        1, oldTime, oldTime)));
+        1, oldTime)));
 
     // It's possible for the Local implementation to get from the old
     // modification time to here in under 1ms, causing it to not get pruned
@@ -715,10 +716,10 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     createNewDirs(rootDir, grandparentDir, parentDir);
     long time = System.currentTimeMillis();
     ms.put(new PathMetadata(
-        new FileStatus(0, false, 0, 0, time - 1, strToPath(staleFile)),
+        basicFileStatus(0, false, 0, time - 1, strToPath(staleFile)),
         Tristate.FALSE, false));
     ms.put(new PathMetadata(
-        new FileStatus(0, false, 0, 0, time + 1, strToPath(freshFile)),
+        basicFileStatus(0, false, 0, time + 1, strToPath(freshFile)),
         Tristate.FALSE, false));
 
     // set parent dir as authoritative
@@ -752,10 +753,10 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     createNewDirs(rootDir, grandparentDir, parentDir);
     long time = System.currentTimeMillis();
     ms.put(new PathMetadata(
-        new FileStatus(0, false, 0, 0, time + 1, strToPath(staleFile)),
+        basicFileStatus(0, false, 0, time + 1, strToPath(staleFile)),
         Tristate.FALSE, false));
     ms.put(new PathMetadata(
-        new FileStatus(0, false, 0, 0, time + 1, strToPath(freshFile)),
+        basicFileStatus(0, false, 0, time + 1, strToPath(freshFile)),
         Tristate.FALSE, false));
 
     if (!allowMissing()) {
@@ -811,7 +812,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   @Test
   public void testPutRetainsIsDeletedInParentListing() throws Exception {
     final Path path = strToPath("/a/b");
-    final FileStatus fileStatus = basicFileStatus(path, 0, false);
+    final S3AFileStatus fileStatus = basicFileStatus(path, 0, false);
     PathMetadata pm = new PathMetadata(fileStatus);
     pm.setIsDeleted(true);
     ms.put(pm);
@@ -948,40 +949,56 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     }
   }
 
-  FileStatus basicFileStatus(Path path, int size, boolean isDir) throws
+  S3AFileStatus basicFileStatus(Path path, int size, boolean isDir) throws
       IOException {
-    return basicFileStatus(path, size, isDir, modTime, accessTime);
+    return basicFileStatus(path, size, isDir, modTime);
   }
 
-  public static FileStatus basicFileStatus(Path path, int size, boolean isDir,
-      long newModTime, long newAccessTime) throws IOException {
-    return new FileStatus(size, isDir, REPLICATION, BLOCK_SIZE, newModTime,
-        newAccessTime, PERMISSION, OWNER, GROUP, path);
+  S3AFileStatus basicFileStatus(int size, boolean isDir,
+      long blockSize, long modificationTime, Path path) {
+    if (isDir) {
+      return new S3AFileStatus(Tristate.UNKNOWN, path, null);
+    }
+    else {
+      return new S3AFileStatus(size, modificationTime, path, blockSize, null,
+          null, null);
+    }
   }
 
-  private FileStatus makeFileStatus(String pathStr, int size) throws
+  public static S3AFileStatus basicFileStatus(Path path, int size,
+      boolean isDir, long newModTime) throws IOException {
+    if (isDir) {
+      return new S3AFileStatus(Tristate.UNKNOWN, path, OWNER);
+    }
+    else {
+      return new S3AFileStatus(size, newModTime, path, BLOCK_SIZE, OWNER,
+          null, null);
+    }
+  }
+
+  private S3AFileStatus makeFileStatus(String pathStr, int size) throws
       IOException {
-    return makeFileStatus(pathStr, size, modTime, accessTime);
+    return makeFileStatus(pathStr, size, modTime);
   }
 
-  private FileStatus makeFileStatus(String pathStr, int size, long newModTime,
-      long newAccessTime) throws IOException {
+  private S3AFileStatus makeFileStatus(String pathStr, int size,
+      long newModTime) throws IOException {
     return basicFileStatus(strToPath(pathStr), size, false,
-        newModTime, newAccessTime);
+        newModTime);
   }
 
   void verifyFileStatus(FileStatus status, long size) {
     S3ATestUtils.verifyFileStatus(status, size, BLOCK_SIZE, modTime);
   }
 
-  private FileStatus makeDirStatus(String pathStr) throws IOException {
-    return basicFileStatus(strToPath(pathStr), 0, true, modTime, accessTime);
+  private S3AFileStatus makeDirStatus(String pathStr) throws IOException {
+    return basicFileStatus(strToPath(pathStr), 0, true, modTime);
   }
 
   /**
    * Verify the directory file status. Subclass may verify additional fields.
    */
-  void verifyDirStatus(FileStatus status) {
+  void verifyDirStatus(S3AFileStatus status) {
     assertTrue("Is a dir", status.isDirectory());
     assertEquals("zero length", 0, status.getLen());
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDirListingMetadata.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDirListingMetadata.java
@@ -38,6 +38,8 @@ import static org.junit.Assert.*;
 public class TestDirListingMetadata {
 
   private static final String TEST_OWNER = "hadoop";
+  public static final String TEST_ETAG = "abc";
+  public static final String TEST_VERSION_ID = "def";
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -79,7 +81,8 @@ public class TestDirListingMetadata {
     PathMetadata pathMeta2 = new PathMetadata(
         new S3AFileStatus(true, new Path(path, "dir2"), TEST_OWNER));
     PathMetadata pathMeta3 = new PathMetadata(
-        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER));
+        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER,
+            TEST_ETAG, TEST_VERSION_ID));
     List<PathMetadata> listing = Arrays.asList(pathMeta1, pathMeta2, pathMeta3);
     DirListingMetadata meta = new DirListingMetadata(path, listing, false);
     assertEquals(path, meta.getPath());
@@ -130,7 +133,8 @@ public class TestDirListingMetadata {
     PathMetadata pathMeta2 = new PathMetadata(
         new S3AFileStatus(true, new Path(path, "dir2"), TEST_OWNER));
     PathMetadata pathMeta3 = new PathMetadata(
-        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER));
+        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER,
+            TEST_ETAG, TEST_VERSION_ID));
     List<PathMetadata> listing = Arrays.asList(pathMeta1, pathMeta2, pathMeta3);
     DirListingMetadata meta = new DirListingMetadata(path, listing, false);
     assertEquals(path, meta.getPath());
@@ -181,7 +185,8 @@ public class TestDirListingMetadata {
     PathMetadata pathMeta2 = new PathMetadata(
         new S3AFileStatus(true, new Path(path, "dir2"), TEST_OWNER));
     PathMetadata pathMeta3 = new PathMetadata(
-        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER));
+        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER,
+            TEST_ETAG, TEST_VERSION_ID));
     List<PathMetadata> listing = Arrays.asList(pathMeta1, pathMeta2, pathMeta3);
     DirListingMetadata meta = new DirListingMetadata(path, listing, false);
     assertEquals(path, meta.getPath());
@@ -243,7 +248,8 @@ public class TestDirListingMetadata {
     PathMetadata pathMeta2 = new PathMetadata(
         new S3AFileStatus(true, new Path(path, "dir2"), TEST_OWNER));
     PathMetadata pathMeta3 = new PathMetadata(
-        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER));
+        new S3AFileStatus(123, 456, new Path(path, "file1"), 8192, TEST_OWNER,
+            TEST_ETAG, TEST_VERSION_ID));
     List<PathMetadata> listing = Arrays.asList(pathMeta1, pathMeta2, pathMeta3);
     DirListingMetadata meta = new DirListingMetadata(path, listing, false);
     assertEquals(path, meta.getPath());
@@ -296,7 +302,7 @@ public class TestDirListingMetadata {
         new S3AFileStatus(true, new Path(parent, "dir2"), TEST_OWNER));
     PathMetadata pathMeta3 = new PathMetadata(
         new S3AFileStatus(123, 456, new Path(parent, "file1"), 8192,
-            TEST_OWNER));
+            TEST_OWNER, TEST_ETAG, TEST_VERSION_ID));
     List<PathMetadata> listing = Arrays.asList(pathMeta1, pathMeta2, pathMeta3);
     return new DirListingMetadata(parent, listing, false);
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestLocalMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestLocalMetadataStore.java
@@ -30,7 +30,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.fs.s3a.Tristate;
 
 /**
  * MetadataStore unit test for {@link LocalMetadataStore}.
@@ -168,8 +170,8 @@ public class TestLocalMetadataStore extends MetadataStoreTestBase {
 
   private static void populateEntry(Cache<Path, LocalMetadataEntry> cache,
       Path path) {
-    FileStatus fileStatus = new FileStatus(0, true, 0, 0, 0, path);
-    cache.put(path, new LocalMetadataEntry(new PathMetadata(fileStatus)));
+    S3AFileStatus s3aStatus = new S3AFileStatus(Tristate.UNKNOWN, path, null);
+    cache.put(path, new LocalMetadataEntry(new PathMetadata(s3aStatus)));
   }
 
   private static long sizeOfMap(Cache<Path, LocalMetadataEntry> cache) {
@@ -196,9 +198,8 @@ public class TestLocalMetadataStore extends MetadataStoreTestBase {
   }
 
   @Override
-  protected void verifyDirStatus(FileStatus status) {
-    S3ATestUtils.verifyDirStatus(status, REPLICATION, getModTime(),
-        getAccessTime(), OWNER, GROUP, PERMISSION);
+  protected void verifyDirStatus(S3AFileStatus status) {
+    S3ATestUtils.verifyDirStatus(status, REPLICATION, OWNER);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestObjectChangeDetectionAttributes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestObjectChangeDetectionAttributes.java
@@ -68,7 +68,8 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /**
  * Unit tests to ensure object eTag and versionId are captured on S3 PUT and
- * used on GET.  Further (integration) testing is performed in
+ * used on GET.
+ * Further (integration) testing is performed in
  * {@link org.apache.hadoop.fs.s3a.ITestS3ARemoteFileChanged}.
  */
 @RunWith(Parameterized.class)
@@ -79,17 +80,12 @@ public class TestObjectChangeDetectionAttributes extends AbstractS3AMockTest {
     this.changeDetectionSource = changeDetectionSource;
   }
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name = "change={0}")
   public static Collection<Object[]> params() {
     return Arrays.asList(new Object[][]{
         {CHANGE_DETECT_SOURCE_ETAG},
         {CHANGE_DETECT_SOURCE_VERSION_ID}
     });
-  }
-
-  @Override
-  public void setup() throws Exception {
-    super.setup();
   }
 
   @Override
@@ -159,14 +155,14 @@ public class TestObjectChangeDetectionAttributes extends AbstractS3AMockTest {
     assertContent(file, path, content, eTag, versionId);
 
     // test overwrite
-    byte[] newConent = new byte[Constants.MULTIPART_MIN_SIZE + 1];
-    Arrays.fill(newConent, (byte) 1);
+    byte[] newContent = new byte[Constants.MULTIPART_MIN_SIZE + 1];
+    Arrays.fill(newContent, (byte) 1);
     String newETag = "newETag";
     String newVersionId = "newVersionId";
 
-    multipartUpload(file, path, newConent, newETag, newVersionId);
+    multipartUpload(file, path, newContent, newETag, newVersionId);
     assertVersionAttributes(path, newETag, newVersionId);
-    assertContent(file, path, newConent, newETag, newVersionId);
+    assertContent(file, path, newContent, newETag, newVersionId);
   }
 
   private void putObject(String file, Path path, byte[] content,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestObjectChangeDetectionAttributes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestObjectChangeDetectionAttributes.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.AbstractS3AMockTest;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
+
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_MODE;
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_MODE_SERVER;
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_SOURCE;
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_SOURCE_ETAG;
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_SOURCE_VERSION_ID;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+
+/**
+ * Unit tests to ensure object eTag and versionId are captured on S3 PUT and
+ * used on GET.  Further (integration) testing is performed in
+ * {@link org.apache.hadoop.fs.s3a.ITestS3ARemoteFileChanged}.
+ */
+@RunWith(Parameterized.class)
+public class TestObjectChangeDetectionAttributes extends AbstractS3AMockTest {
+  private final String changeDetectionSource;
+
+  public TestObjectChangeDetectionAttributes(String changeDetectionSource) {
+    this.changeDetectionSource = changeDetectionSource;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {CHANGE_DETECT_SOURCE_ETAG},
+        {CHANGE_DETECT_SOURCE_VERSION_ID}
+    });
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+  }
+
+  @Override
+  public Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    conf.setClass(Constants.S3_METADATA_STORE_IMPL,
+        LocalMetadataStore.class, MetadataStore.class);
+    conf.set(CHANGE_DETECT_SOURCE, changeDetectionSource);
+    conf.set(CHANGE_DETECT_MODE, CHANGE_DETECT_MODE_SERVER);
+    return conf;
+  }
+
+  /**
+   * Tests a file uploaded with a single PUT to ensure eTag is captured and used
+   * on file read.
+   */
+  @Test
+  public void testCreateAndReadFileSinglePart() throws Exception {
+    String bucket = "s3a://mock-bucket/";
+    String file = "single-part-file";
+    Path path = new Path(bucket, file);
+    byte[] content = "content".getBytes();
+    String eTag = "abc";
+    String versionId = "def";
+
+    putObject(file, path, content, eTag, versionId);
+
+    // make sure the eTag and versionId were put into the metadataStore
+    assertVersionAttributes(path, eTag, versionId);
+
+    // Ensure underlying S3 getObject call uses the stored eTag or versionId
+    // when reading data back.  If it doesn't, the read won't work and the
+    // assert will fail.
+    assertContent(file, path, content, eTag, versionId);
+
+    // test overwrite
+    byte[] newConent = "newcontent".getBytes();
+    String newETag = "newETag";
+    String newVersionId = "newVersionId";
+
+    putObject(file, path, newConent, newETag, newVersionId);
+    assertVersionAttributes(path, newETag, newVersionId);
+    assertContent(file, path, newConent, newETag, newVersionId);
+  }
+
+  /**
+   * Tests a file uploaded with multi-part upload to ensure eTag is captured
+   * and used on file read.
+   */
+  @Test
+  public void testCreateAndReadFileMultiPart() throws Exception {
+    String bucket = "s3a://mock-bucket/";
+    String file = "multi-part-file";
+    Path path = new Path(bucket, file);
+    byte[] content = new byte[Constants.MULTIPART_MIN_SIZE + 1];
+    String eTag = "abc";
+    String versionId = "def";
+
+    multipartUpload(file, path, content, eTag, versionId);
+
+    // make sure the eTag and versionId were put into the metadataStore
+    assertVersionAttributes(path, eTag, versionId);
+
+    // Ensure underlying S3 getObject call uses the stored eTag or versionId
+    // when reading data back.  If it doesn't, the read won't work and the
+    // assert will fail.
+    assertContent(file, path, content, eTag, versionId);
+
+    // test overwrite
+    byte[] newConent = new byte[Constants.MULTIPART_MIN_SIZE + 1];
+    Arrays.fill(newConent, (byte) 1);
+    String newETag = "newETag";
+    String newVersionId = "newVersionId";
+
+    multipartUpload(file, path, newConent, newETag, newVersionId);
+    assertVersionAttributes(path, newETag, newVersionId);
+    assertContent(file, path, newConent, newETag, newVersionId);
+  }
+
+  private void putObject(String file, Path path, byte[] content,
+      String eTag, String versionId) throws IOException {
+    PutObjectResult putObjectResult = new PutObjectResult();
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(content.length);
+    putObjectResult.setMetadata(objectMetadata);
+    putObjectResult.setETag(eTag);
+    putObjectResult.setVersionId(versionId);
+
+    when(s3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
+        .thenThrow(NOT_FOUND);
+    when(s3.putObject(argThat(correctPutObjectRequest(file))))
+        .thenReturn(putObjectResult);
+    ListObjectsV2Result emptyListing = new ListObjectsV2Result();
+    when(s3.listObjectsV2(argThat(correctListObjectsRequest(file + "/"))))
+        .thenReturn(emptyListing);
+
+    FSDataOutputStream outputStream = fs.create(path);
+    outputStream.write(content);
+    outputStream.close();
+  }
+
+  private void multipartUpload(String file, Path path, byte[] content,
+      String eTag, String versionId) throws IOException {
+    CompleteMultipartUploadResult uploadResult =
+        new CompleteMultipartUploadResult();
+    uploadResult.setVersionId(versionId);
+
+    when(s3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
+        .thenThrow(NOT_FOUND);
+
+    InitiateMultipartUploadResult initiateMultipartUploadResult =
+        new InitiateMultipartUploadResult();
+    initiateMultipartUploadResult.setUploadId("uploadId");
+    when(s3.initiateMultipartUpload(
+        argThat(correctInitiateMultipartUploadRequest(file))))
+        .thenReturn(initiateMultipartUploadResult);
+
+    UploadPartResult uploadPartResult = new UploadPartResult();
+    uploadPartResult.setETag("partETag");
+    when(s3.uploadPart(argThat(correctUploadPartRequest(file))))
+        .thenReturn(uploadPartResult);
+
+    CompleteMultipartUploadResult multipartUploadResult =
+        new CompleteMultipartUploadResult();
+    multipartUploadResult.setETag(eTag);
+    multipartUploadResult.setVersionId(versionId);
+    when(s3.completeMultipartUpload(
+        argThat(correctMultipartUploadRequest(file))))
+        .thenReturn(multipartUploadResult);
+
+    ListObjectsV2Result emptyListing = new ListObjectsV2Result();
+    when(s3.listObjectsV2(argThat(correctListObjectsRequest(file + "/"))))
+        .thenReturn(emptyListing);
+
+    FSDataOutputStream outputStream = fs.create(path);
+    outputStream.write(content);
+    outputStream.close();
+  }
+
+  private void assertContent(String file, Path path, byte[] content,
+      String eTag, String versionId) throws IOException {
+    S3Object s3Object = new S3Object();
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setHeader(Headers.S3_VERSION_ID, versionId);
+    metadata.setHeader(Headers.ETAG, eTag);
+    s3Object.setObjectMetadata(metadata);
+    s3Object.setObjectContent(new ByteArrayInputStream(content));
+    when(s3.getObject(argThat(correctGetObjectRequest(file, eTag, versionId))))
+        .thenReturn(s3Object);
+    FSDataInputStream inputStream = fs.open(path);
+    byte[] readContent = IOUtils.toByteArray(inputStream);
+    assertArrayEquals(content, readContent);
+  }
+
+  private void assertVersionAttributes(Path path, String eTag, String versionId)
+      throws IOException {
+    MetadataStore metadataStore = fs.getMetadataStore();
+    PathMetadata pathMetadata = metadataStore.get(path);
+    assertNotNull(pathMetadata);
+    S3AFileStatus fileStatus = pathMetadata.getFileStatus();
+    assertEquals(eTag, fileStatus.getETag());
+    assertEquals(versionId, fileStatus.getVersionId());
+  }
+
+  private Matcher<GetObjectRequest> correctGetObjectRequest(final String key,
+      final String eTag, final String versionId) {
+    return new BaseMatcher<GetObjectRequest>() {
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof GetObjectRequest) {
+          GetObjectRequest getObjectRequest = (GetObjectRequest) item;
+          if (getObjectRequest.getKey().equals(key)) {
+            if (changeDetectionSource.equals(
+                CHANGE_DETECT_SOURCE_ETAG)) {
+              return getObjectRequest.getMatchingETagConstraints()
+                  .contains(eTag);
+            } else if (changeDetectionSource.equals(
+                CHANGE_DETECT_SOURCE_VERSION_ID)) {
+              return getObjectRequest.getVersionId().equals(versionId);
+            }
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("key and "
+            + changeDetectionSource
+            + " matches");
+      }
+    };
+  }
+
+  private Matcher<UploadPartRequest> correctUploadPartRequest(
+      final String key) {
+    return new BaseMatcher<UploadPartRequest>() {
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof UploadPartRequest) {
+          UploadPartRequest request = (UploadPartRequest) item;
+          return request.getKey().equals(key);
+        }
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("key matches");
+      }
+    };
+  }
+
+  private Matcher<InitiateMultipartUploadRequest>
+  correctInitiateMultipartUploadRequest(final String key) {
+    return new BaseMatcher<InitiateMultipartUploadRequest>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("key matches");
+      }
+
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof InitiateMultipartUploadRequest) {
+          InitiateMultipartUploadRequest request =
+              (InitiateMultipartUploadRequest) item;
+          return request.getKey().equals(key);
+        }
+        return false;
+      }
+    };
+  }
+
+  private Matcher<CompleteMultipartUploadRequest>
+  correctMultipartUploadRequest(final String key) {
+    return new BaseMatcher<CompleteMultipartUploadRequest>() {
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof CompleteMultipartUploadRequest) {
+          CompleteMultipartUploadRequest request =
+              (CompleteMultipartUploadRequest) item;
+          return request.getKey().equals(key);
+        }
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("key matches");
+      }
+    };
+  }
+
+  private Matcher<ListObjectsV2Request> correctListObjectsRequest(
+      final String key) {
+    return new BaseMatcher<ListObjectsV2Request>() {
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof ListObjectsV2Request) {
+          ListObjectsV2Request listObjectsRequest =
+              (ListObjectsV2Request) item;
+          return listObjectsRequest.getPrefix().equals(key);
+        }
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("key matches");
+      }
+    };
+  }
+
+  private Matcher<PutObjectRequest> correctPutObjectRequest(
+      final String key) {
+    return new BaseMatcher<PutObjectRequest>() {
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof PutObjectRequest) {
+          PutObjectRequest putObjectRequest = (PutObjectRequest) item;
+          return putObjectRequest.getKey().equals(key);
+        }
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("key matches");
+      }
+    };
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
+import org.apache.hadoop.fs.s3a.Tristate;
 
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_METADATASTORE_AUTHORITATIVE_DIR_TTL;
 
@@ -51,7 +53,7 @@ public class TestS3Guard extends Assert {
         Arrays.asList(m1, m2), false);
 
     // Two other files in s3
-    List<FileStatus> s3Listing = Arrays.asList(
+    List<S3AFileStatus> s3Listing = Arrays.asList(
         makeFileStatus("s3a://bucket/dir/s3-file3", false),
         makeFileStatus("s3a://bucket/dir/s3-file4", false)
     );
@@ -86,12 +88,15 @@ public class TestS3Guard extends Assert {
     return new PathMetadata(makeFileStatus(pathStr, isDir));
   }
 
-  private FileStatus makeFileStatus(String pathStr, boolean isDir) {
+  private S3AFileStatus makeFileStatus(String pathStr, boolean isDir) {
     Path p = new Path(pathStr);
+    S3AFileStatus fileStatus;
     if (isDir) {
-      return new FileStatus(0, true, 1, 1, System.currentTimeMillis(), p);
+      fileStatus = new S3AFileStatus(Tristate.UNKNOWN, p, null);
     } else {
-      return new FileStatus(100, false, 1, 1, System.currentTimeMillis(), p);
+      fileStatus = new S3AFileStatus(
+          100, System.currentTimeMillis(), p, 1, null, null, null);
     }
+    return fileStatus;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
@@ -170,7 +170,8 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
           status.getOwner());
     } else {
       return new S3AFileStatus(status.getLen(), status.getModificationTime(),
-          status.getPath(), status.getBlockSize(), status.getOwner());
+          status.getPath(), status.getBlockSize(), status.getOwner(),
+          status.getETag(), status.getVersionId());
     }
   }
 
@@ -207,7 +208,8 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
   }
 
   protected static S3AFileStatus makeFileStatus(Path path) throws IOException {
-    return new S3AFileStatus(SIZE, ACCESS_TIME, path, BLOCK_SIZE, OWNER);
+    return new S3AFileStatus(SIZE, ACCESS_TIME, path, BLOCK_SIZE, OWNER,
+        null, null);
   }
 
   protected static S3AFileStatus makeDirStatus(Path p) throws IOException {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectCLI.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectCLI.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.commons.io.IOUtils;
@@ -34,6 +35,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.fs.s3a.s3guard.S3GuardTool;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.OperationDuration;
@@ -80,6 +83,11 @@ public class ITestS3SelectCLI extends AbstractS3SelectTest {
     selectConf = new Configuration(getConfiguration());
     localFile = getTempFilename();
     landsatSrc = getLandsatGZ().toString();
+    ChangeDetectionPolicy changeDetectionPolicy =
+        getLandsatFS().getChangeDetectionPolicy();
+    Assume.assumeFalse("the standard landsat bucket doesn't have versioning",
+        changeDetectionPolicy.getSource() == Source.VersionId
+            && changeDetectionPolicy.isRequireVersion());
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.fs.s3a.select;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,6 +193,11 @@ public class ITestS3SelectLandsat extends AbstractS3SelectTest {
     // disable the gzip codec, so that the record readers do not
     // get confused
     enablePassthroughCodec(selectConf, ".gz");
+    ChangeDetectionPolicy changeDetectionPolicy =
+        getLandsatFS().getChangeDetectionPolicy();
+    Assume.assumeFalse("the standard landsat bucket doesn't have versioning",
+        changeDetectionPolicy.getSource() == Source.VersionId
+            && changeDetectionPolicy.isRequireVersion());
   }
 
   protected int getMaxLines() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.fs.s3a.select;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
-import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -35,6 +33,8 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectMRJob.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.fs.s3a.select;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -90,6 +93,13 @@ public class ITestS3SelectMRJob extends AbstractS3SelectTest {
   public void setup() throws Exception {
     super.setup();
     fs = S3ATestUtils.createTestFileSystem(conf);
+
+    ChangeDetectionPolicy changeDetectionPolicy =
+        getLandsatFS().getChangeDetectionPolicy();
+    Assume.assumeFalse("the standard landsat bucket doesn't have versioning",
+        changeDetectionPolicy.getSource() == Source.VersionId
+            && changeDetectionPolicy.isRequireVersion());
+
     rootPath = path("ITestS3SelectMRJob");
     Path workingDir = path("working");
     fs.setWorkingDirectory(workingDir);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/mapreduce/filecache/TestS3AResourceScope.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/mapreduce/filecache/TestS3AResourceScope.java
@@ -48,7 +48,7 @@ public class TestS3AResourceScope extends HadoopTestBase {
 
   @Test
   public void testS3AFilesArePrivateOtherContstructor() throws Throwable {
-    S3AFileStatus status = new S3AFileStatus(0, 0, PATH, 1, "self");
+    S3AFileStatus status = new S3AFileStatus(0, 0, PATH, 1, "self", null, null);
     assertTrue("Not encrypted: " + status, status.isEncrypted());
     assertNotExecutable(status);
   }


### PR DESCRIPTION
-move CopyOutcome into fs.s3a.impl package
-add new (failing) test for directory renaming where one of the files underneath is eventually consistent.
-pull out commonanity from test methods (spyOnFilesystem(), expectReadFailure())
-intercept() calls provide details on failure, primarily just by returning the result of the operation expected to fail.
-ChangeDetectionPolicy-raised exceptions on copy failures don't include position any more
-cache/restore metastore so even on test failures mockito is involved on teardown