### PR TITLE
HDFS-14482: Crash when using libhdfs with bad classpath

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
@@ -551,15 +551,15 @@ JNIEnv* getJNIEnv(void)
     state->env = getGlobalJNIEnv();
     mutexUnlock(&jvmMutex);
 
+    if (!state->env) {
+        goto fail;
+    }
+
     jthrowable jthr = NULL;
     jthr = initCachedClasses(state->env);
     if (jthr) {
       printExceptionAndFree(state->env, jthr, PRINT_EXC_ALL,
                             "initCachedClasses failed");
-      goto fail;
-    }
-
-    if (!state->env) {
       goto fail;
     }
     return state->env;


### PR DESCRIPTION
Fixes a bug in `jni_helper.c` `getJNIEnv` introduced by HDFS-14304. After HDFS-14304, the `getJNIEnv` would call `getGlobalJNIEnv` and pass the result to `jclasses.c` without first checking if the result of `getGlobalJNIEnv` is `NULL`.

Testing:
* Ran all libhdfs tests locally, they all pass.