### PR TITLE
HDFS-14303: branch-2 scan only meta file produce block dir structure check warn fix

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DirectoryScanner.java
@@ -881,7 +881,7 @@ public class DirectoryScanner implements Runnable {
         if (!Block.isBlockFilename(file)) {
           if (isBlockMetaFile(Block.BLOCK_FILE_PREFIX, file.getName())) {
             long blockId = Block.getBlockId(file.getName());
-            verifyFileLocation(file.getParentFile(), bpFinalizedDir,
+            verifyFileLocation(file, bpFinalizedDir,
                 blockId);
             report.add(new ScanInfo(blockId, null, file, vol));
           }


### PR DESCRIPTION
when scan a only meta file but no block file block, will produce a block structure warn eg:

WARN DirectoryScanner:? - Block: 1101939874 has to be upgraded to block ID-based layout. Actual block file path: /data14/hadoop/data/current/BP-1461038173-10.8.48.152-1481686842620/current/finalized/subdir174/subdir68, expected block file path: /data14/hadoop/data/current/BP-1461038173-10.8.48.152-1481686842620/current/finalized/subdir174/subdir68/subdir68

the cause is added a .getParentFile() call mistakenly