### PR TITLE
HADOOP-16321: ITestS3ASSL+TestOpenSSLSocketFactory failing with java.lang.UnsatisfiedLinkErrors

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestOpenSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestOpenSSLSocketFactory.java
@@ -35,7 +35,10 @@ public class TestOpenSSLSocketFactory {
 
   @Test
   public void testOpenSSL() throws IOException {
-    assumeTrue(NativeCodeLoader.buildSupportsOpenssl());
+    assumeTrue("Unable to load native libraries",
+            NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue("Build was not compiled with support for OpenSSL",
+            NativeCodeLoader.buildSupportsOpenssl());
     OpenSSLSocketFactory.initializeDefaultFactory(
             OpenSSLSocketFactory.SSLChannelMode.OpenSSL);
     assertThat(OpenSSLSocketFactory.getDefaultFactory()
@@ -44,7 +47,8 @@ public class TestOpenSSLSocketFactory {
 
   @Test
   public void testJSEEJava8() throws IOException {
-    assumeTrue(System.getProperty("java.version").startsWith("1.8"));
+    assumeTrue("Not running on Java 8",
+            System.getProperty("java.version").startsWith("1.8"));
     OpenSSLSocketFactory.initializeDefaultFactory(
             OpenSSLSocketFactory.SSLChannelMode.Default_JSSE);
     assertThat(Arrays.stream(OpenSSLSocketFactory.getDefaultFactory()

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ASSL.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ASSL.java
@@ -40,7 +40,10 @@ public class ITestS3ASSL extends AbstractS3ATestBase {
 
   @Test
   public void testOpenSSL() throws IOException {
-    assumeTrue(NativeCodeLoader.buildSupportsOpenssl());
+    assumeTrue("Unable to load native libraries",
+            NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue("Build was not compiled with support for OpenSSL",
+            NativeCodeLoader.buildSupportsOpenssl());
     Configuration conf = new Configuration(getConfiguration());
     conf.setEnum(Constants.SSL_CHANNEL_MODE,
             OpenSSLSocketFactory.SSLChannelMode.OpenSSL);


### PR DESCRIPTION
Added a `NativeCodeLoader.isNativeCodeLoaded())` check before these tests so they get skipped if native libraries can't be loaded or are not present.

Tested on OSX after a `mvn clean install -DskipTests` and `mvn clean install -DskipTests -Pnative`. The test gets skipped in both cases. 

Tested on the Hadoop dev Docker env; with `-Pnative` the test passes, without `-Pnative` the test is skipped.

`ITestS3ASSL` was tested against `us-east-1`.