### PR TITLE
HDDS-1565. Rename k8s-dev and k8s-dev-push profiles to docker and docker-push

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -286,7 +286,7 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>k8s-dev</id>
+      <id>docker-build</id>
       <properties>
         <docker.image>${user.name}/ozone:${project.version}</docker.image>
       </properties>
@@ -321,7 +321,7 @@
       </build>
     </profile>
     <profile>
-      <id>k8s-dev-push</id>
+      <id>docker-push</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Based on the feedback from [~eyang] I realized that the names of the k8s-dev and k8s-dev-push profile are not expressive enough as the created containers can be used not only for kubernetes but to use them in any other environments.

I propose to rename to docker/docker-push.

See: https://issues.apache.org/jira/browse/HDDS-1565