### PR TITLE
HADOOP-15183 S3Guard store becomes inconsistent after partial failure of rename

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/FutureIOSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/impl/FutureIOSupport.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.impl;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -108,20 +109,55 @@ public final class FutureIOSupport {
    */
   public static <T> T raiseInnerCause(final ExecutionException e)
       throws IOException {
+    throw unwrapInnerException(e);
+  }
+
+  /**
+   * Extract the cause of a completion failure and rethrow it if an IOE
+   * or RTE.
+   * @param e exception.
+   * @param <T> type of return value.
+   * @return nothing, ever.
+   * @throws IOException either the inner IOException, or a wrapper around
+   * any non-Runtime-Exception
+   * @throws RuntimeException if that is the inner cause.
+   */
+  public static <T> T raiseInnerCause(final CompletionException e)
+      throws IOException {
+    throw unwrapInnerException(e);
+  }
+
+  /**
+   * From the inner cause of an execution exception, extract the inner cause.
+   * If it is an RTE: throw immediately.
+   * If it is an IOE: Return.
+   * If it is a WrappedIOException: Unwrap and return
+   * Else: create a new IOException.
+   *
+   * Recursively handles wrapped Execution and Completion Exceptions in
+   * case something very complicated has happened.
+   * @param e exception.
+   * @return an IOException extracted or built from the cause.
+   * @throws RuntimeException if that is the inner cause.
+   */
+  private static IOException unwrapInnerException(final Throwable e) {
     Throwable cause = e.getCause();
     if (cause instanceof IOException) {
-      throw (IOException) cause;
+      return (IOException) cause;
     } else if (cause instanceof WrappedIOException){
-      throw ((WrappedIOException) cause).getCause();
+      return ((WrappedIOException) cause).getCause();
+    } else if (cause instanceof CompletionException){
+      return unwrapInnerException(cause);
+    } else if (cause instanceof ExecutionException){
+      return unwrapInnerException(cause);
     } else if (cause instanceof RuntimeException){
       throw (RuntimeException) cause;
     } else if (cause != null) {
       // other type: wrap with a new IOE
-      throw new IOException(cause);
+      return new IOException(cause);
     } else {
-      // this only happens if somebody deliberately raises
-      // an ExecutionException
-      throw new IOException(e);
+      // this only happens if there was no cause.
+      return new IOException(e);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1213,8 +1213,12 @@
 
 <property>
   <name>fs.s3a.connection.maximum</name>
-  <value>15</value>
-  <description>Controls the maximum number of simultaneous connections to S3.</description>
+  <value>72</value>
+  <description>Controls the maximum number of simultaneous connections to S3.
+    This must be bigger than the value of fs.s3a.threads.max so as to stop
+    threads being blocked waiting for new HTTPS connections.
+    Why not equal? The AWS SDK transfer manager also uses these connections.
+  </description>
 </property>
 
 <property>
@@ -1312,7 +1316,7 @@
 
 <property>
   <name>fs.s3a.threads.max</name>
-  <value>10</value>
+  <value>64</value>
   <description>The total number of threads available in the filesystem for data
     uploads *or any other queued filesystem operation*.</description>
 </property>
@@ -1326,8 +1330,25 @@
 
 <property>
   <name>fs.s3a.max.total.tasks</name>
-  <value>5</value>
-  <description>The number of operations which can be queued for execution</description>
+  <value>32</value>
+  <description>The number of operations which can be queued for execution.
+  This is in addition to the number of active threads in fs.s3a.threads.max.
+  </description>
+</property>
+
+<property>
+  <name>fs.s3a.executor.capacity</name>
+  <value>16</value>
+  <description>The maximum number of submitted tasks which is a single
+    operation (e.g. rename(), delete()) may submit simultaneously for
+    execution -excluding the IO-heavy block uploads, whose capacity
+    is set in "fs.s3a.fast.upload.active.blocks"
+
+    All tasks are submitted to the shared thread pool whose size is
+    set in "fs.s3a.threads.max"; the value of capacity should be less than that
+    of the thread pool itself, as the goal is to stop a single operation
+    from overloading that thread pool.
+  </description>
 </property>
 
 <property>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRenameTest.java
@@ -268,7 +268,7 @@ public abstract class AbstractContractRenameTest extends
    * @param dst the destination root to move
    * @param nestedPath the nested path to move
    */
-  private void validateAncestorsMoved(Path src, Path dst, String nestedPath)
+  protected void validateAncestorsMoved(Path src, Path dst, String nestedPath)
       throws IOException {
     assertIsDirectory(dst);
     assertPathDoesNotExist("src path should not exist", path(src + nestedPath));

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -418,6 +418,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -138,9 +138,15 @@ public final class Constants {
   public static final String ASSUMED_ROLE_CREDENTIALS_DEFAULT =
       SimpleAWSCredentialsProvider.NAME;
 
+
+  // the maximum number of tasks cached if all threads are already uploading
+  public static final String MAX_TOTAL_TASKS = "fs.s3a.max.total.tasks";
+
+  public static final int DEFAULT_MAX_TOTAL_TASKS = 32;
+
   // number of simultaneous connections to s3
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
-  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 15;
+  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 48;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =
@@ -193,10 +199,6 @@ public final class Constants {
   // the time an idle thread waits before terminating
   public static final String KEEPALIVE_TIME = "fs.s3a.threads.keepalivetime";
   public static final int DEFAULT_KEEPALIVE_TIME = 60;
-
-  // the maximum number of tasks cached if all threads are already uploading
-  public static final String MAX_TOTAL_TASKS = "fs.s3a.max.total.tasks";
-  public static final int DEFAULT_MAX_TOTAL_TASKS = 5;
 
   // size of each of or multipart pieces in bytes
   public static final String MULTIPART_SIZE = "fs.s3a.multipart.size";
@@ -282,6 +284,22 @@ public final class Constants {
    */
   @InterfaceStability.Unstable
   public static final int DEFAULT_FAST_UPLOAD_ACTIVE_BLOCKS = 4;
+
+  /**
+   * The capacity of executor queues for operations other than block
+   * upload, where {@link #FAST_UPLOAD_ACTIVE_BLOCKS} is used instead.
+   * This should be less than {@link #MAX_THREADS} for fair
+   * submission.
+   * Value: {@value}.
+   */
+  public static final String EXECUTOR_CAPACITY = "fs.s3a.executor.capacity";
+
+  /**
+   * The capacity of executor queues for operations other than block
+   * upload, where {@link #FAST_UPLOAD_ACTIVE_BLOCKS} is used instead.
+   * Value: {@value}
+   */
+  public static final int DEFAULT_EXECUTOR_CAPACITY = 16;
 
   // Private | PublicRead | PublicReadWrite | AuthenticatedRead |
   // LogDeliveryWrite | BucketOwnerRead | BucketOwnerFullControl

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2358,10 +2358,14 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       LOG.debug("Partial delete failure");
       // what to do if an IOE was raised? Given an exception was being
       // raised anyway, and the failures are logged, do nothing.
-      Triple<List<Path>, List<Path>, List<Pair<Path, IOException>>> results =
-          new MultiObjectDeleteSupport(createStoreContext())
-              .processDeleteFailure(ex, keysToDelete);
-      undeletedObjectsOnFailure.addAll(results.getMiddle());
+      if (!deleteFakeDir) {
+        // when deleting fake directories we don't want to delete metastore
+        // entries so we only process these failures on "real" deletes.
+        Triple<List<Path>, List<Path>, List<Pair<Path, IOException>>> results =
+            new MultiObjectDeleteSupport(createStoreContext())
+                .processDeleteFailure(ex, keysToDelete);
+        undeletedObjectsOnFailure.addAll(results.getMiddle());
+      }
       throw ex;
     } catch (AmazonClientException | IOException ex) {
       List<Path> paths = new MultiObjectDeleteSupport(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1392,14 +1392,17 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
             completeActiveCopiesAndDeleteSources =
                 (String reason) -> {
                   completeActiveCopies.apply(reason);
-                  removeSourceObjects(renameTracker, keysToDelete, pathsToDelete);
+                  removeSourceObjects(renameTracker,
+                      keysToDelete,
+                      pathsToDelete);
                   // now reset the lists.
                   keysToDelete.clear();
                   pathsToDelete.clear();
                   return null;
                 };
 
-        if (dstStatus != null && dstStatus.isEmptyDirectory() == Tristate.TRUE) {
+        if (dstStatus != null
+            && dstStatus.isEmptyDirectory() == Tristate.TRUE) {
           // delete unnecessary fake directory at the destination.
           // this MUST be done before anything else so that
           // rollback code doesn't get confused and insert a tombstone

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2302,10 +2302,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
   /**
    * Invoke {@link #removeKeysS3(List, boolean)} with handling of
-   * {@code MultiObjectDeleteException} in which S3Guard is updated with all
-   * deleted entries, before the exception is rethrown.
+   * {@code MultiObjectDeleteException}.
    *
-   * If an exception is not raised. the metastore is not updated.
    * @param keysToDelete collection of keys to delete on the s3-backend.
    *        if empty, no request is made of the object store.
    * @param deleteFakeDir indicates whether this is for deleting fake dirs
@@ -2328,12 +2326,17 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
   /**
    * Invoke {@link #removeKeysS3(List, boolean)} with handling of
-   * {@code MultiObjectDeleteException} in which S3Guard is updated with all
-   * deleted entries, before the exception is rethrown.
-   *
+   * {@code MultiObjectDeleteException} before the exception is rethrown.
+   * Specifically:
+   * <ol>
+   *   <li>Failure and !deleteFakeDir: S3Guard is updated with all
+   *    deleted entries</li>
+   *   <li>Failure where deleteFakeDir == true: do nothing with S3Guard</li>
+   *   <li>Success: do nothing with S3Guard</li>
+   * </ol>
    * @param keysToDelete collection of keys to delete on the s3-backend.
    *        if empty, no request is made of the object store.
-   * @param deleteFakeDir indicates whether this is for deleting fake dirs
+   * @param deleteFakeDir indicates whether this is for deleting fake dirs.
    * @param undeletedObjectsOnFailure List which will be built up of all
    * files that were not deleted. This happens even as an exception
    * is raised.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3532,7 +3532,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   /**
    * Perform post-write actions.
    * Calls {@link #deleteUnnecessaryFakeDirectories(Path)} and then
-   * {@link S3Guard#addAncestors(MetadataStore, Path, String, BulkOperationState)}}.
+   * updates any metastore.
    * This operation MUST be called after any PUT/multipart PUT completes
    * successfully.
    *
@@ -3565,7 +3565,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // See note about failure semantics in S3Guard documentation
     try {
       if (hasMetadataStore()) {
-        S3Guard.addAncestors(metadataStore, p, username, operationState);
+        S3Guard.addAncestors(metadataStore, p, operationState);
         S3AFileStatus status = createUploadFileStatus(p,
             S3AUtils.objectRepresentsDirectory(key, length), length,
             getDefaultBlockSize(p), username, eTag, versionId);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1368,7 +1368,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         dstKey = maybeAddTrailingSlash(dstKey);
         srcKey = maybeAddTrailingSlash(srcKey);
 
-        //Verify dest is not a child of the source directory
+        // Verify dest is not a child of the source directory
         if (dstKey.startsWith(srcKey)) {
           throw new RenameFailedException(srcKey, dstKey,
               "cannot rename a directory to a subdirectory of itself ");
@@ -1520,7 +1520,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     List<Path> undeletedObjects = new ArrayList<>();
     try {
       // remove the keys
-      // this does will update the metastore on a failure, but on
+      // this will update the metastore on a failure, but on
       // a successful operation leaves the store as is.
       removeKeys(keysToDelete, false, undeletedObjects);
       // and clear the list.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2621,6 +2621,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       while (files.hasNext()) {
         result.add(files.next());
       }
+      // merge the results. This will update the store as needed
       return S3Guard.dirListingUnion(metadataStore, path, result, dirMeta,
           allowAuthoritative, ttlTimeProvider);
     } else {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2399,7 +2399,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       }
       return outcome;
     } catch (FileNotFoundException e) {
-      LOG.debug("Couldn't delete {} - does not exist", f);
+      LOG.debug("Couldn't delete {} - does not exist: {}", f, e.toString());
       instrumentation.errorIgnored();
       return false;
     } catch (AmazonClientException e) {
@@ -3557,7 +3557,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   void finishedWrite(String key, long length, String eTag, String versionId,
       @Nullable final BulkOperationState operationState)
       throws MetadataPersistenceException {
-    LOG.debug("Finished write to {}, len {}", key, length);
+    LOG.debug("Finished write to {}, len {}. etag {}, version {}",
+        key, length, eTag, versionId);
     Path p = keyToQualifiedPath(key);
     Preconditions.checkArgument(length >= 0, "content length is negative");
     deleteUnnecessaryFakeDirectories(p.getParent());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2829,6 +2829,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   S3AFileStatus innerGetFileStatus(final Path f,
       boolean needEmptyDirectoryFlag) throws IOException {
     entryPoint(INVOCATION_GET_FILE_STATUS);
+    checkNotClosed();
     final Path path = qualify(f);
     String key = pathToKey(path);
     LOG.debug("Getting path status for {}  ({})", path, key);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -128,17 +128,16 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
    * This does not attempt to open it; that is only done on the first
    * actual read() operation.
    * @param ctx operation context
-   * @param s3Attributes object attributes from a HEAD request
-   * @param contentLength length of content
+   * @param s3Attributes object attributes
    * @param client S3 client to use
    */
   public S3AInputStream(S3AReadOpContext ctx,
       S3ObjectAttributes s3Attributes,
-      long contentLength,
       AmazonS3 client) {
     Preconditions.checkArgument(isNotEmpty(s3Attributes.getBucket()),
         "No Bucket");
     Preconditions.checkArgument(isNotEmpty(s3Attributes.getKey()), "No Key");
+    long contentLength = s3Attributes.getLen();
     Preconditions.checkArgument(contentLength >= 0, "Negative content length");
     this.context = ctx;
     this.bucket = s3Attributes.getBucket();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -137,13 +137,13 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     Preconditions.checkArgument(isNotEmpty(s3Attributes.getBucket()),
         "No Bucket");
     Preconditions.checkArgument(isNotEmpty(s3Attributes.getKey()), "No Key");
-    long contentLength = s3Attributes.getLen();
-    Preconditions.checkArgument(contentLength >= 0, "Negative content length");
+    long l = s3Attributes.getLen();
+    Preconditions.checkArgument(l >= 0, "Negative content length");
     this.context = ctx;
     this.bucket = s3Attributes.getBucket();
     this.key = s3Attributes.getKey();
     this.pathStr = ctx.dstFileStatus.getPath().toString();
-    this.contentLength = contentLength;
+    this.contentLength = l;
     this.client = client;
     this.uri = "s3a://" + this.bucket + "/" + this.key;
     this.streamStatistics = ctx.instrumentation.newInputStreamStatistics();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -183,6 +183,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       COMMITTER_MAGIC_FILES_CREATED,
       S3GUARD_METADATASTORE_PUT_PATH_REQUEST,
       S3GUARD_METADATASTORE_INITIALIZATION,
+      S3GUARD_METADATASTORE_RECORD_DELETES,
       S3GUARD_METADATASTORE_RECORD_READS,
       S3GUARD_METADATASTORE_RECORD_WRITES,
       S3GUARD_METADATASTORE_RETRY,
@@ -1063,6 +1064,14 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      */
     public void retrying() {
       // counters are incremented by owner.
+    }
+
+    /**
+     * Records have been read.
+     * @param count the number of records read
+     */
+    public void recordsDeleted(int count) {
+      incrementCounter(S3GUARD_METADATASTORE_RECORD_DELETES, count);
     }
 
     /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -183,10 +183,13 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       COMMITTER_MAGIC_FILES_CREATED,
       S3GUARD_METADATASTORE_PUT_PATH_REQUEST,
       S3GUARD_METADATASTORE_INITIALIZATION,
+      S3GUARD_METADATASTORE_RECORD_READS,
+      S3GUARD_METADATASTORE_RECORD_WRITES,
       S3GUARD_METADATASTORE_RETRY,
       S3GUARD_METADATASTORE_THROTTLED,
       STORE_IO_THROTTLED,
-      DELEGATION_TOKENS_ISSUED
+      DELEGATION_TOKENS_ISSUED,
+      FILES_DELETE_REJECTED
   };
 
   private static final Statistic[] GAUGES_TO_CREATE = {
@@ -1061,6 +1064,23 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     public void retrying() {
       // counters are incremented by owner.
     }
+
+    /**
+     * Records have been read.
+     * @param count the number of records read
+     */
+    public void recordsRead(int count) {
+      incrementCounter(S3GUARD_METADATASTORE_RECORD_READS, count);
+    }
+
+    /**
+     * records have been written (including deleted).
+     * @param count number of records written.
+     */
+    public void recordsWritten(int count) {
+      incrementCounter(S3GUARD_METADATASTORE_RECORD_WRITES, count);
+    }
+
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -84,6 +84,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.hadoop.fs.s3a.Constants.*;
+import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.translateDeleteException;
 
 /**
  * Utility methods for S3A code.
@@ -284,7 +285,7 @@ public final class S3AUtils {
       case 200:
         if (exception instanceof MultiObjectDeleteException) {
           // failure during a bulk delete
-          return translateMultiObjectDeleteException(message,
+          return translateDeleteException(message,
               (MultiObjectDeleteException) exception);
         }
         // other 200: FALL THROUGH
@@ -446,40 +447,6 @@ public final class S3AUtils {
       result = new AWSServiceIOException(message, ddbException);
     }
     return result;
-  }
-
-  /**
-   * A MultiObjectDeleteException is raised if one or more delete objects
-   * listed in a bulk DELETE operation failed.
-   * The top-level exception is therefore just "something wasn't deleted",
-   * but doesn't include the what or the why.
-   * This translation will extract an AccessDeniedException if that's one of
-   * the causes, otherwise grabs the status code and uses it in the
-   * returned exception.
-   * @param message text for the exception
-   * @param ex exception to translate
-   * @return an IOE with more detail.
-   */
-  public static IOException translateMultiObjectDeleteException(String message,
-      MultiObjectDeleteException ex) {
-    List<String> keys;
-    StringBuffer result = new StringBuffer(ex.getErrors().size() * 100);
-    result.append(message).append(": ");
-    String exitCode = "";
-    for (MultiObjectDeleteException.DeleteError error : ex.getErrors()) {
-      String code = error.getCode();
-      result.append(String.format("%s: %s: %s%n", code, error.getKey(),
-          error.getMessage()));
-      if (exitCode.isEmpty() ||  "AccessDenied".equals(code)) {
-        exitCode = code;
-      }
-    }
-    if ("AccessDenied".equals(exitCode)) {
-      return (IOException) new AccessDeniedException(result.toString())
-          .initCause(ex);
-    } else {
-      return new AWSS3IOException(result.toString(), ex);
-    }
   }
 
   /**
@@ -1004,7 +971,7 @@ public final class S3AUtils {
    * @return the value
    * @throws IllegalArgumentException if the value is below the minimum
    */
-  static int intOption(Configuration conf, String key, int defVal, int min) {
+  public static int intOption(Configuration conf, String key, int defVal, int min) {
     int v = conf.getInt(key, defVal);
     Preconditions.checkArgument(v >= min,
         String.format("Value of %s: %d is below the minimum value %d",
@@ -1022,7 +989,7 @@ public final class S3AUtils {
    * @return the value
    * @throws IllegalArgumentException if the value is below the minimum
    */
-  static long longOption(Configuration conf,
+  public static long longOption(Configuration conf,
       String key,
       long defVal,
       long min) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1351,7 +1351,7 @@ public final class S3AUtils {
    * @throws IOException anything in the closure, or iteration logic.
    */
   public static long applyLocatedFiles(
-      RemoteIterator<LocatedFileStatus> iterator,
+      RemoteIterator<? extends LocatedFileStatus> iterator,
       CallOnLocatedFileStatus eval) throws IOException {
     long count = 0;
     while (iterator.hasNext()) {
@@ -1371,7 +1371,7 @@ public final class S3AUtils {
    * @throws IOException anything in the closure, or iteration logic.
    */
   public static <T> List<T> mapLocatedFiles(
-      RemoteIterator<LocatedFileStatus> iterator,
+      RemoteIterator<? extends LocatedFileStatus> iterator,
       LocatedFileStatusMap<T> eval) throws IOException {
     final List<T> results = new ArrayList<>();
     applyLocatedFiles(iterator,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ObjectAttributes.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ObjectAttributes.java
@@ -18,38 +18,73 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import com.amazonaws.services.s3.transfer.model.CopyResult;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.Path;
 
 /**
- * This class is only a holder for bucket, key, SSE Algorithm and SSE key
- * attributes. It is used in {@link S3AInputStream} and the select equivalent.
+ * This class holds attributed of an object independent of the
+ * file status type.
+ * It is used in {@link S3AInputStream} and the select equivalent.
  * as a way to reduce parameters being passed
- * to the constructor of such class.
+ * to the constructor of such class,
+ * and elsewhere to be a source-neutral representation of a file status.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class S3ObjectAttributes {
   private final String bucket;
+  private final Path path;
   private final String key;
   private final S3AEncryptionMethods serverSideEncryptionAlgorithm;
   private final String serverSideEncryptionKey;
   private final String eTag;
   private final String versionId;
+  private final long len;
 
   public S3ObjectAttributes(
       String bucket,
+      Path path,
       String key,
       S3AEncryptionMethods serverSideEncryptionAlgorithm,
       String serverSideEncryptionKey,
       String eTag,
-      String versionId) {
+      String versionId, final long len) {
     this.bucket = bucket;
+    this.path = path;
     this.key = key;
     this.serverSideEncryptionAlgorithm = serverSideEncryptionAlgorithm;
     this.serverSideEncryptionKey = serverSideEncryptionKey;
     this.eTag = eTag;
     this.versionId = versionId;
+    this.len = len;
+  }
+
+  /**
+   * Construct from the result of a copy and those parameters
+   * which aren't included in an AWS SDK response.
+   * @param path
+   * @param copyResult copy result.
+   * @param serverSideEncryptionAlgorithm current encryption algorithm
+   * @param serverSideEncryptionKey any server side encryption key?
+   * @param len
+   */
+  public S3ObjectAttributes(
+      final Path path,
+      final CopyResult copyResult,
+      final S3AEncryptionMethods serverSideEncryptionAlgorithm,
+      final String serverSideEncryptionKey,
+      final long len) {
+    this.bucket = copyResult.getDestinationBucketName();
+    this.key = copyResult.getDestinationKey();
+    this.path = path;
+    this.serverSideEncryptionAlgorithm = serverSideEncryptionAlgorithm;
+    this.serverSideEncryptionKey = serverSideEncryptionKey;
+    this.eTag = copyResult.getETag();
+    this.versionId = copyResult.getVersionId();
+    this.len = len;
   }
 
   public String getBucket() {
@@ -74,5 +109,13 @@ public class S3ObjectAttributes {
 
   public String getVersionId() {
     return versionId;
+  }
+
+  public long getLen() {
+    return len;
+  }
+
+  public Path getPath() {
+    return path;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -42,6 +42,8 @@ public enum Statistic {
       "Total number of files created through the object store."),
   FILES_DELETED("files_deleted",
       "Total number of files deleted from the object store."),
+  FILES_DELETE_REJECTED("files_delete_rejected",
+      "Total number of files whose delete request was rejected"),
   FAKE_DIRECTORIES_CREATED("fake_directories_created",
       "Total number of fake directory entries created in the object store."),
   FAKE_DIRECTORIES_DELETED("fake_directories_deleted",
@@ -207,6 +209,12 @@ public enum Statistic {
       "S3Guard metadata store put one metadata path latency"),
   S3GUARD_METADATASTORE_INITIALIZATION("s3guard_metadatastore_initialization",
       "S3Guard metadata store initialization times"),
+  S3GUARD_METADATASTORE_RECORD_READS(
+      "s3guard_metadatastore_record_reads",
+      "S3Guard metadata store records read"),
+  S3GUARD_METADATASTORE_RECORD_WRITES(
+      "s3guard_metadatastore_record_writes",
+      "S3Guard metadata store records written"),
   S3GUARD_METADATASTORE_RETRY("s3guard_metadatastore_retry",
       "S3Guard metadata store retry events"),
   S3GUARD_METADATASTORE_THROTTLED("s3guard_metadatastore_throttled",

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -209,6 +209,9 @@ public enum Statistic {
       "S3Guard metadata store put one metadata path latency"),
   S3GUARD_METADATASTORE_INITIALIZATION("s3guard_metadatastore_initialization",
       "S3Guard metadata store initialization times"),
+  S3GUARD_METADATASTORE_RECORD_DELETES(
+      "s3guard_metadatastore_record_deletes",
+      "S3Guard metadata store records deleted"),
   S3GUARD_METADATASTORE_RECORD_READS(
       "s3guard_metadatastore_record_reads",
       "S3Guard metadata store records read"),

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
@@ -537,7 +537,8 @@ public class WriteOperationHelper {
    */
   public BulkOperationState initiateCommitOperation(
       Path path) throws IOException {
-    return S3Guard.initiateBulkWrite(owner.getMetadataStore(), path);
+    return S3Guard.initiateBulkWrite(owner.getMetadataStore(),
+        BulkOperationState.OperationType.Put, path);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -41,13 +42,15 @@ import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.amazonaws.services.s3.transfer.model.UploadResult;
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
+import org.apache.hadoop.fs.s3a.s3guard.S3Guard;
 import org.apache.hadoop.fs.s3a.select.SelectBinding;
 import org.apache.hadoop.util.DurationInfo;
 
@@ -226,7 +229,7 @@ public class WriteOperationHelper {
   /**
    * Finalize a multipart PUT operation.
    * This completes the upload, and, if that works, calls
-   * {@link S3AFileSystem#finishedWrite(String, long, String, String)}
+   * {@link S3AFileSystem#finishedWrite(String, long, String, String, BulkOperationState)}
    * to update the filesystem.
    * Retry policy: retrying, translated.
    * @param destKey destination of the commit
@@ -234,6 +237,7 @@ public class WriteOperationHelper {
    * @param partETags list of partial uploads
    * @param length length of the upload
    * @param retrying retrying callback
+   * @param operationState (nullable) operational state for a bulk update
    * @return the result of the operation.
    * @throws IOException on problems.
    */
@@ -243,7 +247,8 @@ public class WriteOperationHelper {
       String uploadId,
       List<PartETag> partETags,
       long length,
-      Retried retrying) throws IOException {
+      Retried retrying,
+      @Nullable BulkOperationState operationState) throws IOException {
     if (partETags.isEmpty()) {
       throw new IOException(
           "No upload parts in multipart upload to " + destKey);
@@ -263,7 +268,7 @@ public class WriteOperationHelper {
             }
     );
     owner.finishedWrite(destKey, length, uploadResult.getETag(),
-        uploadResult.getVersionId());
+        uploadResult.getVersionId(), operationState);
     return uploadResult;
   }
 
@@ -298,7 +303,8 @@ public class WriteOperationHelper {
         uploadId,
         partETags,
         length,
-        (text, e, r, i) -> errorCount.incrementAndGet());
+        (text, e, r, i) -> errorCount.incrementAndGet(),
+        null);
   }
 
   /**
@@ -487,6 +493,51 @@ public class WriteOperationHelper {
           owner.maybeCreateFakeParentDirectory(destPath);
         }
     );
+  }
+
+  /**
+   * This completes a multipart upload to the destination key via
+   * {@code finalizeMultipartUpload()}.
+   * Retry policy: retrying, translated.
+   * Retries increment the {@code errorCount} counter.
+   * @param destKey destination
+   * @param uploadId multipart operation Id
+   * @param partETags list of partial uploads
+   * @param length length of the upload
+   * @param operationState operational state for a bulk update
+   * @return the result of the operation.
+   * @throws IOException if problems arose which could not be retried, or
+   * the retry count was exceeded
+   */
+  @Retries.RetryTranslated
+  public CompleteMultipartUploadResult commitUpload(
+      String destKey,
+      String uploadId,
+      List<PartETag> partETags,
+      long length,
+      @Nullable BulkOperationState operationState)
+      throws IOException {
+    checkNotNull(uploadId);
+    checkNotNull(partETags);
+    LOG.debug("Completing multipart upload {} with {} parts",
+        uploadId, partETags.size());
+    return finalizeMultipartUpload(destKey,
+        uploadId,
+        partETags,
+        length,
+        Invoker.NO_OP,
+        operationState);
+  }
+
+  /**
+   * Initiate a commit operation through any metastore.
+   * @param path path under which the writes will all take place.
+   * @return an possibly null operation state from the metastore.
+   * @throws IOException failure to instantiate.
+   */
+  public BulkOperationState initiateCommitOperation(
+      Path path) throws IOException {
+    return S3Guard.initiateBulkWrite(owner.getMetadataStore(), path);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.fs.s3a.commit;
 
+import javax.annotation.Nullable;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -49,6 +50,8 @@ import org.apache.hadoop.fs.s3a.WriteOperationHelper;
 import org.apache.hadoop.fs.s3a.commit.files.PendingSet;
 import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
 import org.apache.hadoop.fs.s3a.commit.files.SuccessData;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
+import org.apache.hadoop.io.IOUtils;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.*;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.*;
@@ -128,10 +131,12 @@ public class CommitOperations {
   /**
    * Commit the operation, throwing an exception on any failure.
    * @param commit commit to execute
+   * @param operationState S3Guard state of ongoing operation.
    * @throws IOException on a failure
    */
-  public void commitOrFail(SinglePendingCommit commit) throws IOException {
-    commit(commit, commit.getFilename()).maybeRethrow();
+  private void commitOrFail(SinglePendingCommit commit,
+      final BulkOperationState operationState) throws IOException {
+    commit(commit, commit.getFilename(), operationState).maybeRethrow();
   }
 
   /**
@@ -139,16 +144,20 @@ public class CommitOperations {
    * and converted to an outcome.
    * @param commit entry to commit
    * @param origin origin path/string for outcome text
+   * @param operationState S3Guard state of ongoing operation.
    * @return the outcome
    */
-  public MaybeIOE commit(SinglePendingCommit commit, String origin) {
+  private MaybeIOE commit(
+      final SinglePendingCommit commit,
+      final String origin,
+      final BulkOperationState operationState) {
     LOG.debug("Committing single commit {}", commit);
     MaybeIOE outcome;
     String destKey = "unknown destination";
     try {
       commit.validate();
       destKey = commit.getDestinationKey();
-      long l = innerCommit(commit);
+      long l = innerCommit(commit, operationState);
       LOG.debug("Successful commit of file length {}", l);
       outcome = MaybeIOE.NONE;
       statistics.commitCompleted(commit.getLength());
@@ -171,17 +180,20 @@ public class CommitOperations {
   /**
    * Inner commit operation.
    * @param commit entry to commit
+   * @param operationState S3Guard state of ongoing operation.
    * @return bytes committed.
    * @throws IOException failure
    */
-  private long innerCommit(SinglePendingCommit commit) throws IOException {
+  private long innerCommit(
+      final SinglePendingCommit commit,
+      final BulkOperationState operationState) throws IOException {
     // finalize the commit
-    writeOperations.completeMPUwithRetries(
+    writeOperations.commitUpload(
         commit.getDestinationKey(),
               commit.getUploadId(),
               toPartEtags(commit.getEtags()),
               commit.getLength(),
-              new AtomicInteger(0));
+              operationState);
     return commit.getLength();
   }
 
@@ -249,7 +261,7 @@ public class CommitOperations {
    * @throws FileNotFoundException if the abort ID is unknown
    * @throws IOException on any failure
    */
-  public void abortSingleCommit(SinglePendingCommit commit)
+  private void abortSingleCommit(SinglePendingCommit commit)
       throws IOException {
     String destKey = commit.getDestinationKey();
     String origin = commit.getFilename() != null
@@ -268,7 +280,7 @@ public class CommitOperations {
    * @throws FileNotFoundException if the abort ID is unknown
    * @throws IOException on any failure
    */
-  public void abortMultipartCommit(String destKey, String uploadId)
+  private void abortMultipartCommit(String destKey, String uploadId)
       throws IOException {
     try {
       writeOperations.abortMultipartCommit(destKey, uploadId);
@@ -518,6 +530,116 @@ public class CommitOperations {
    */
   public void jobCompleted(boolean success) {
     statistics.jobCompleted(success);
+  }
+
+  /**
+   * Begin the final commit.
+   * @param path path for all work.
+   * @return the commit context to pass in.
+   * @throws IOException failure.
+   */
+  public CommitContext initiateCommitOperation(Path path) throws IOException {
+    return new CommitContext(writeOperations.initiateCommitOperation(path));
+  }
+
+  /**
+   * Commit context.
+   *
+   * It is used to manage the final commit sequence where files become
+   * visible. It contains a {@link BulkOperationState} field, which, if
+   * there is a metastore, will be requested from the store so that it
+   * can track multiple creation operations within the same overall operation.
+   * This will be null if there is no metastore, or the store chooses not
+   * to provide one.
+   *
+   * This can only be created through {@link #initiateCommitOperation(Path)}.
+   *
+   * Once the commit operation has completed, it must be closed.
+   * It must not be reused.
+   */
+  public final class CommitContext implements Closeable {
+
+    /**
+     * State of any metastore.
+     */
+    private final BulkOperationState operationState;
+
+    private CommitContext(@Nullable final BulkOperationState operationState) {
+      this.operationState = operationState;
+    }
+
+    /**
+     * Commit the operation, throwing an exception on any failure.
+     * See {@link CommitOperations#commitOrFail(SinglePendingCommit, BulkOperationState)}.
+     * @param commit commit to execute
+     * @throws IOException on a failure
+     */
+    public void commitOrFail(SinglePendingCommit commit) throws IOException {
+      CommitOperations.this.commitOrFail(commit, operationState);
+    }
+
+    /**
+     * Commit a single pending commit; exceptions are caught
+     * and converted to an outcome.
+     * See {@link CommitOperations#commit(SinglePendingCommit, String, BulkOperationState)}.
+     * @param commit entry to commit
+     * @param origin origin path/string for outcome text
+     * @return the outcome
+     */
+    public MaybeIOE commit(SinglePendingCommit commit,
+        String origin) {
+      return CommitOperations.this.commit(commit, origin, operationState);
+    }
+
+    /**
+     * See {@link CommitOperations#abortSingleCommit(SinglePendingCommit)}.
+     * @param commit pending commit to abort
+     * @throws FileNotFoundException if the abort ID is unknown
+     * @throws IOException on any failure
+     */
+    public void abortSingleCommit(final SinglePendingCommit commit)
+        throws IOException {
+      CommitOperations.this.abortSingleCommit(commit);
+    }
+
+    /**
+     * See {@link CommitOperations#revertCommit(SinglePendingCommit)}.
+     * @param commit pending commit
+     * @throws IOException failure
+     */
+    public void revertCommit(final SinglePendingCommit commit)
+        throws IOException {
+      CommitOperations.this.revertCommit(commit);
+    }
+
+    /**
+     * See {@link CommitOperations#abortMultipartCommit(String, String)}..
+     * @param destKey destination key
+     * @param uploadId upload to cancel
+     * @throws FileNotFoundException if the abort ID is unknown
+     * @throws IOException on any failure
+     */
+    public void abortMultipartCommit(
+        final String destKey,
+        final String uploadId)
+        throws IOException {
+      CommitOperations.this.abortMultipartCommit(destKey, uploadId);
+    }
+
+    @Override
+    public void close() throws IOException {
+      IOUtils.cleanupWithLogger(LOG, operationState);
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder(
+          "CommitContext{");
+      sb.append("operationState=").append(operationState);
+      sb.append('}');
+      return sb.toString();
+    }
+
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
@@ -414,7 +414,7 @@ public class CommitOperations {
    * @throws IOException failure
    */
   public void revertCommit(SinglePendingCommit commit) throws IOException {
-    LOG.warn("Revert {}", commit);
+    LOG.info("Revert {}", commit);
     try {
       writeOperations.revertCommit(commit.getDestinationKey());
     } finally {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
@@ -134,7 +134,8 @@ public class CommitOperations {
    * @param operationState S3Guard state of ongoing operation.
    * @throws IOException on a failure
    */
-  private void commitOrFail(SinglePendingCommit commit,
+  private void commitOrFail(
+      final SinglePendingCommit commit,
       final BulkOperationState operationState) throws IOException {
     commit(commit, commit.getFilename(), operationState).maybeRethrow();
   }
@@ -564,6 +565,10 @@ public class CommitOperations {
      */
     private final BulkOperationState operationState;
 
+    /**
+     * Create.
+     * @param operationState any S3Guard bulk state.
+     */
     private CommitContext(@Nullable final BulkOperationState operationState) {
       this.operationState = operationState;
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
@@ -123,8 +123,11 @@ public class MagicS3GuardCommitter extends AbstractS3ACommitter {
    */
   public void cleanupStagingDirs() {
     Path path = magicSubdir(getOutputPath());
-    Invoker.ignoreIOExceptions(LOG, "cleanup magic directory", path.toString(),
-        () -> deleteWithWarning(getDestFS(), path, true));
+    try(DurationInfo ignored = new DurationInfo(LOG, true,
+        "Deleting magic directory %s", path)) {
+      Invoker.ignoreIOExceptions(LOG, "cleanup magic directory", path.toString(),
+          () -> deleteWithWarning(getDestFS(), path, true));
+    }
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AbstractStoreOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AbstractStoreOperation.java
@@ -19,12 +19,12 @@
 package org.apache.hadoop.fs.s3a.impl;
 
 /**
- * Base class of operation in the store.
+ * Base class of operations in the store.
  * An operation is something which executes against the context to
  * perform a single function.
  * It is expected to have a limited lifespan.
  */
-public abstract class StoreOperation {
+public abstract class AbstractStoreOperation {
 
   private final StoreContext storeContext;
 
@@ -32,7 +32,7 @@ public abstract class StoreOperation {
    * constructor.
    * @param storeContext store context.
    */
-  public StoreOperation(final StoreContext storeContext) {
+  protected AbstractStoreOperation(final StoreContext storeContext) {
     this.storeContext = storeContext;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CallableSupplier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CallableSupplier.java
@@ -47,7 +47,11 @@ public final class CallableSupplier<T> implements Supplier {
 
   private final Callable<T> call;
 
-  CallableSupplier(final Callable<T> call) {
+  /**
+   * Create.
+   * @param call call to invoke.
+   */
+  public CallableSupplier(final Callable<T> call) {
     this.call = call;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CallableSupplier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CallableSupplier.java
@@ -87,7 +87,8 @@ public final class CallableSupplier<T> implements Supplier {
   }
 
   /**
-   * Wait for a list of futures to complete.
+   * Wait for a list of futures to complete. If the list is empty,
+   * return immediately.
    * @param futures list of futures.
    * @throws IOException if one of the called futures raised an IOE.
    * @throws RuntimeException if one of the futures raised one.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CallableSupplier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CallableSupplier.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.impl.WrappedIOException;
+import org.apache.hadoop.util.DurationInfo;
+
+import static org.apache.hadoop.fs.impl.FutureIOSupport.raiseInnerCause;
+
+/**
+ * A bridge from Callable to Supplier; catching exceptions
+ * raised by the callable and wrapping them as appropriate.
+ * @param <T> return type.
+ */
+public final class CallableSupplier<T> implements Supplier {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CallableSupplier.class);
+
+  private final Callable<T> call;
+
+  CallableSupplier(final Callable<T> call) {
+    this.call = call;
+  }
+
+  @Override
+  public Object get() {
+    try {
+      return call.call();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (IOException e) {
+      throw new WrappedIOException(e);
+    } catch (Exception e) {
+      throw new WrappedIOException(new IOException(e));
+    }
+  }
+
+  /**
+   * Submit a callable into a completable future.
+   * RTEs are rethrown.
+   * Non RTEs are caught and wrapped; IOExceptions to
+   * {@link WrappedIOException} instances.
+   * @param executor executor.
+   * @param call call to invoke
+   * @param <T> type
+   * @return the future to wait for
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> CompletableFuture<T> submit(
+      final Executor executor,
+      final Callable<T> call) {
+    return CompletableFuture.supplyAsync(
+        new CallableSupplier<T>(call), executor);
+  }
+
+  /**
+   * Wait for a list of futures to complete.
+   * @param futures list of futures.
+   * @throws IOException if one of the called futures raised an IOE.
+   * @throws RuntimeException if one of the futures raised one.
+   */
+  public static <T> void waitForCompletion(
+      final List<CompletableFuture<T>> futures)
+      throws IOException {
+    if (futures.isEmpty()) {
+      return;
+    }
+    // await completion
+    waitForCompletion(CompletableFuture.allOf(
+        futures.toArray(new CompletableFuture[0])));
+  }
+
+  /**
+   * Wait for a single of future to complete, extracting IOEs afterwards.
+   * @param future future to wait for.
+   * @throws IOException if one of the called futures raised an IOE.
+   * @throws RuntimeException if one of the futures raised one.
+   */
+  public static <T> void waitForCompletion(
+      final CompletableFuture<T> future)
+      throws IOException {
+    try(DurationInfo ignore =
+            new DurationInfo(LOG, false, "Waiting for task completion")) {
+      future.join();
+    } catch (CancellationException e) {
+      throw new IOException(e);
+    } catch (CompletionException e) {
+      raiseInnerCause(e);
+    }
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/FunctionsRaisingIOE.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/FunctionsRaisingIOE.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+
+/**
+ * Evolving support for functional programming/lambda-expressions.
+ * Currently in the s3a module for experimentation and evolution; at
+ * some point it could be pulled into hadoop-common.
+ */
+public final class FunctionsRaisingIOE {
+
+  private FunctionsRaisingIOE() {
+  }
+
+  /**
+   * Function of arity 1 which may raise an IOException.
+   * @param <T> type of arg1
+   * @param <R> type of return value.
+   */
+  @FunctionalInterface
+  public interface FunctionRaisingIOE<T, R> {
+
+    R apply(T t) throws IOException;
+  }
+
+  /**
+   * Function of arity 2 which may raise an IOException.
+   * @param <T> type of arg1
+   * @param <U> type of arg2
+   * @param <R> type of return value.
+   */
+  @FunctionalInterface
+  public interface BiFunctionRaisingIOE<T, U, R> {
+
+    R apply(T t, U u) throws IOException;
+  }
+
+  /**
+   * This is a callable which only raises an IOException.
+   * @param <R> return type
+   */
+  @FunctionalInterface
+  public interface CallableRaisingIOE<R> {
+    R apply() throws IOException;
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/FunctionsRaisingIOE.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/FunctionsRaisingIOE.java
@@ -59,6 +59,7 @@ public final class FunctionsRaisingIOE {
    */
   @FunctionalInterface
   public interface CallableRaisingIOE<R> {
+
     R apply() throws IOException;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.AWSS3IOException;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Support for Multi Object Deletion.
+ */
+public final class MultiObjectDeleteSupport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      MultiObjectDeleteSupport.class);
+
+  private final StoreContext context;
+
+  /**
+   * Initiate with a store context.
+   * @param context store context.
+   */
+  public MultiObjectDeleteSupport(final StoreContext context) {
+    this.context = context;
+  }
+
+  /**
+   * This is the exception exit code if access was denied on a delete.
+   * {@value}.
+   */
+  public static final String ACCESS_DENIED = "AccessDenied";
+
+  /**
+   * A {@code MultiObjectDeleteException} is raised if one or more
+   * paths listed in a bulk DELETE operation failed.
+   * The top-level exception is therefore just "something wasn't deleted",
+   * but doesn't include the what or the why.
+   * This translation will extract an AccessDeniedException if that's one of
+   * the causes, otherwise grabs the status code and uses it in the
+   * returned exception.
+   * @param message text for the exception
+   * @param deleteException the delete exception. to translate
+   * @return an IOE with more detail.
+   */
+  public static IOException translateDeleteException(
+      final String message,
+      final MultiObjectDeleteException deleteException) {
+    final StringBuilder result = new StringBuilder(
+        deleteException.getErrors().size() * 256);
+    result.append(message).append(": ");
+    String exitCode = "";
+    for (MultiObjectDeleteException.DeleteError error :
+        deleteException.getErrors()) {
+      String code = error.getCode();
+      result.append(String.format("%s: %s: %s%n", code, error.getKey(),
+          error.getMessage()));
+      if (exitCode.isEmpty() || ACCESS_DENIED.equals(code)) {
+        exitCode = code;
+      }
+    }
+    if (ACCESS_DENIED.equals(exitCode)) {
+      return (IOException) new AccessDeniedException(result.toString())
+          .initCause(deleteException);
+    } else {
+      return new AWSS3IOException(result.toString(), deleteException);
+    }
+  }
+
+  /**
+   * Process a multi object delete exception by building two paths from
+   * the delete request: one of all deleted files, one of all undeleted values.
+   * The latter are those rejected in the delete call.
+   * @param deleteException the delete exception.
+   * @param keysToDelete the keys in the delete request
+   * @return tuple of (undeleted, deleted) paths.
+   */
+  public Pair<List<Path>, List<Path>> splitUndeletedKeys(
+      final MultiObjectDeleteException deleteException,
+      final Collection<DeleteObjectsRequest.KeyVersion> keysToDelete) {
+    LOG.debug("Processing delete failure; keys to delete count = {};"
+            + " errors in exception {}; successful deletions = {}",
+        keysToDelete.size(),
+        deleteException.getErrors().size(),
+        deleteException.getDeletedObjects().size());
+    // convert the collection of keys being deleted into paths
+    final List<Path> pathsBeingDeleted = keysToPaths(keysToDelete);
+    // Take this is list of paths
+    // extract all undeleted entries contained in the exception and
+    // then removes them from the original list.
+    List<Path> undeleted = removeUndeletedPaths(deleteException, pathsBeingDeleted,
+        context.getKeyToPathQualifier());
+    return Pair.of(undeleted, pathsBeingDeleted);
+  }
+
+  /**
+   * Given a list of delete requests, convert them all to paths.
+   * @param keysToDelete list of keys for the delete operation.
+   * @return the paths.
+   */
+  public List<Path> keysToPaths(
+      final Collection<DeleteObjectsRequest.KeyVersion> keysToDelete) {
+    Function<String, Path> qualifier
+        = context.getKeyToPathQualifier();
+    return convertToPaths(keysToDelete, qualifier);
+  }
+
+  /**
+   * Given a list of delete requests, convert them all to paths.
+   * @param keysToDelete list of keys for the delete operation.
+   * @param qualifier path qualifier
+   * @return the paths.
+   */
+  public static List<Path> convertToPaths(
+      final Collection<DeleteObjectsRequest.KeyVersion> keysToDelete,
+      final Function<String, Path> qualifier) {
+    return keysToDelete.stream()
+        .map((keyVersion) ->
+          qualifier.apply(keyVersion.getKey()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Process a delete failure by removing from the metastore all entries
+   * which where deleted, as inferred from the delete failures exception
+   * and the original list of files to delete declares to have been deleted.
+   * @param deleteException the delete exception.
+   * @param keysToDelete collection of keys which had been requested.
+   * @return a tuple of (undeleted, deleted, failures)
+   */
+  public Triple<List<Path>, List<Path>, List<Pair<Path, IOException>>>
+      processDeleteFailure(
+
+      final MultiObjectDeleteException deleteException,
+      final List<DeleteObjectsRequest.KeyVersion> keysToDelete) {
+    final MetadataStore metadataStore =
+        checkNotNull(context.getMetadataStore(), "context metadatastore");
+    final List<Pair<Path, IOException>> failures = new ArrayList<>();
+    final Pair<List<Path>, List<Path>> outcome =
+        splitUndeletedKeys(deleteException, keysToDelete);
+    List<Path> deleted = outcome.getRight();
+    List<Path> undeleted = outcome.getLeft();
+    // delete the paths but recover
+    deleted.forEach(path -> {
+      try {
+        metadataStore.delete(path);
+      } catch (IOException e) {
+        // trouble: we failed to delete the far end entry
+        // try with the next one.
+        // if this is a big network failure, this is going to be noisy.
+        LOG.warn("Failed to update S3Guard store with deletion of {}", path);
+        failures.add(Pair.of(path, e));
+      }
+    });
+    if (LOG.isDebugEnabled()) {
+      undeleted.forEach(p -> LOG.debug("Deleted {}", p));
+    }
+    return Triple.of(undeleted, deleted, failures);
+  }
+
+  /**
+   * Build a list of undeleted paths from a {@code MultiObjectDeleteException}.
+   * Outside of unit tests, the qualifier function should be
+   * {@link S3AFileSystem#keyToQualifiedPath(String)}.
+   * @param deleteException the delete exception.
+   * @param qualifierFn function to qualify paths
+   * @return the possibly empty list of paths.
+   */
+  @VisibleForTesting
+  public static List<Path> extractUndeletedPaths(
+      final MultiObjectDeleteException deleteException,
+      final Function<String, Path> qualifierFn) {
+    return deleteException.getErrors().stream()
+        .map((e) -> qualifierFn.apply(e.getKey()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Process a {@code MultiObjectDeleteException} by
+   * removing all undeleted paths from the list of paths being deleted.
+   * The original list is updated, and so becomes the list of successfully
+   * deleted paths.
+   * @param deleteException the delete exception.
+   * @param pathsBeingDeleted list of paths which were being deleted.
+   * This has all undeleted paths removed, leaving only those deleted.
+   * @return the list of undeleted entries
+   */
+  @VisibleForTesting
+  static List<Path> removeUndeletedPaths(
+      final MultiObjectDeleteException deleteException,
+      final Collection<Path> pathsBeingDeleted,
+      final Function<String, Path> qualifier) {
+    List<Path> undeleted = extractUndeletedPaths(deleteException, qualifier);
+    pathsBeingDeleted.removeAll(undeleted);
+    return undeleted;
+  }
+
+  /**
+   * A delete operation failed.
+   * Currently just returns the list of all paths.
+   * @param ex exception.
+   * @param keysToDelete the keys which were being deleted.
+   * @return all paths which were not deleted.
+   */
+  public List<Path> processDeleteFailureGenericException(Exception ex,
+      final List<DeleteObjectsRequest.KeyVersion> keysToDelete) {
+    return keysToPaths(keysToDelete);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
@@ -176,6 +176,8 @@ public final class MultiObjectDeleteSupport {
     List<Path> deleted = outcome.getRight();
     List<Path> undeleted = outcome.getLeft();
     // delete the paths but recover
+    // TODO: handle the case where a parent path is deleted but not a child.
+    // TODO: in a fake object delete, we don't actually want to delete metastore entries
     deleted.forEach(path -> {
       try {
         metadataStore.delete(path);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
@@ -122,7 +122,8 @@ public final class MultiObjectDeleteSupport {
     // Take this is list of paths
     // extract all undeleted entries contained in the exception and
     // then removes them from the original list.
-    List<Path> undeleted = removeUndeletedPaths(deleteException, pathsBeingDeleted,
+    List<Path> undeleted = removeUndeletedPaths(deleteException,
+        pathsBeingDeleted,
         context.getKeyToPathQualifier());
     return Pair.of(undeleted, pathsBeingDeleted);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
@@ -114,6 +114,9 @@ public class StoreContext {
   private final FunctionsRaisingIOE.BiFunctionRaisingIOE<String, Long, File>
       tempFileFactory;
 
+  private final FunctionsRaisingIOE.CallableRaisingIOE<String>
+      getBucketLocation;
+
   /**
    * Instantiate.
    * No attempt to use a builder here as outside tests
@@ -138,7 +141,8 @@ public class StoreContext {
       final boolean useListV1,
       final boolean versioned,
       final FunctionsRaisingIOE.BiFunctionRaisingIOE<String, Long, File>
-          tempFileFactory) {
+          tempFileFactory,
+      final FunctionsRaisingIOE.CallableRaisingIOE<String> getBucketLocation) {
     this.fsURI = fsURI;
     this.bucket = bucket;
     this.configuration = configuration;
@@ -157,6 +161,7 @@ public class StoreContext {
     this.useListV1 = useListV1;
     this.versioned = versioned;
     this.tempFileFactory = tempFileFactory;
+    this.getBucketLocation = getBucketLocation;
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a.impl;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Optional;
 import java.util.function.Function;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -112,7 +111,7 @@ public class StoreContext {
   private final Function<String, Path> keyToPathQualifier;
 
   /** Factory for temporary files. */
-  private final FunctionsRaisingIOE.BiFunctionRaisingIOE<String, Long , File>
+  private final FunctionsRaisingIOE.BiFunctionRaisingIOE<String, Long, File>
       tempFileFactory;
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
@@ -316,4 +316,13 @@ public class StoreContext {
     return tempFileFactory.apply(prefix, size);
   }
 
+  /**
+   * Get the location of the bucket.
+   * @return the bucket location.
+   * @throws IOException failure.
+   */
+  public String getBucketLocation() throws IOException {
+    return getBucketLocation.apply();
+  }
+
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Invoker;
+import org.apache.hadoop.fs.s3a.S3AInputPolicy;
+import org.apache.hadoop.fs.s3a.S3AInstrumentation;
+import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
+import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.SemaphoredDelegatingExecutor;
+
+/**
+ * This class provides the core context of the S3A filesystem to subsidiary
+ * components, without exposing the entire parent class.
+ * This is eliminate explicit recursive coupling.
+ *
+ * Where methods on the FS are to be invoked, they are all passed in
+ * via functional interfaces, so test setups can pass in mock callbacks
+ * instead.
+ *
+ * <i>Warning:</i> this really is private and unstable. Do not use
+ * outside the org.apache.hadoop.fs.s3a package.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class StoreContext {
+
+  /** Filesystem URI. */
+  private final URI fsURI;
+
+  /** Bucket name. */
+  private final String bucket;
+
+  /** FS configuration after all per-bucket overrides applied. */
+  private final Configuration configuration;
+
+  /** Username. */
+  private final String username;
+
+  /** Principal who created the FS. */
+  private final UserGroupInformation owner;
+
+  /**
+   * Bounded thread pool for async operations.
+   */
+  private final ListeningExecutorService executor;
+
+  /**
+   * Capacity of new executors created.
+   */
+  private final int executorCapacity;
+
+  /** Invoker of operations. */
+  private final Invoker invoker;
+
+  /** Instrumentation and statistics. */
+  private final S3AInstrumentation instrumentation;
+  private final S3AStorageStatistics storageStatistics;
+
+  /** Seek policy. */
+  private final S3AInputPolicy inputPolicy;
+
+  /** How to react to changes in etags and versions. */
+  private final ChangeDetectionPolicy changeDetectionPolicy;
+
+  /** Evaluated options. */
+  private final boolean multiObjectDeleteEnabled;
+
+  /** List algorithm. */
+  private final boolean useListV1;
+
+  /** Is the store versioned? */
+  private final boolean versioned;
+
+  /**
+   * To allow this context to be passed down to the metastore, this field
+   * wll be null until initialized.
+   */
+  private final MetadataStore metadataStore;
+
+  /** Function to take a key and return a path. */
+  private final Function<String, Path> keyToPathQualifier;
+
+  /** Factory for temporary files. */
+  private final FunctionsRaisingIOE.BiFunctionRaisingIOE<String, Long , File>
+      tempFileFactory;
+
+  /**
+   * Instantiate.
+   * No attempt to use a builder here as outside tests
+   * this should only be created in the S3AFileSystem.
+   */
+  public StoreContext(
+      final URI fsURI,
+      final String bucket,
+      final Configuration configuration,
+      final String username,
+      final UserGroupInformation owner,
+      final ListeningExecutorService executor,
+      final int executorCapacity,
+      final Invoker invoker,
+      final S3AInstrumentation instrumentation,
+      final S3AStorageStatistics storageStatistics,
+      final S3AInputPolicy inputPolicy,
+      final ChangeDetectionPolicy changeDetectionPolicy,
+      final boolean multiObjectDeleteEnabled,
+      final MetadataStore metadataStore,
+      final Function<String, Path> keyToPathQualifier,
+      final boolean useListV1,
+      final boolean versioned,
+      final FunctionsRaisingIOE.BiFunctionRaisingIOE<String, Long, File>
+          tempFileFactory) {
+    this.fsURI = fsURI;
+    this.bucket = bucket;
+    this.configuration = configuration;
+    this.username = username;
+    this.owner = owner;
+    this.executor = executor;
+    this.executorCapacity = executorCapacity;
+    this.invoker = invoker;
+    this.instrumentation = instrumentation;
+    this.storageStatistics = storageStatistics;
+    this.inputPolicy = inputPolicy;
+    this.changeDetectionPolicy = changeDetectionPolicy;
+    this.multiObjectDeleteEnabled = multiObjectDeleteEnabled;
+    this.metadataStore = metadataStore;
+    this.keyToPathQualifier = keyToPathQualifier;
+    this.useListV1 = useListV1;
+    this.versioned = versioned;
+    this.tempFileFactory = tempFileFactory;
+  }
+
+  @Override
+  protected Object clone() throws CloneNotSupportedException {
+    return super.clone();
+  }
+
+  public URI getFsURI() {
+    return fsURI;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public Configuration getConfiguration() {
+    return configuration;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public ListeningExecutorService getExecutor() {
+    return executor;
+  }
+
+  public Invoker getInvoker() {
+    return invoker;
+  }
+
+  public S3AInstrumentation getInstrumentation() {
+    return instrumentation;
+  }
+
+  public S3AInputPolicy getInputPolicy() {
+    return inputPolicy;
+  }
+
+  public ChangeDetectionPolicy getChangeDetectionPolicy() {
+    return changeDetectionPolicy;
+  }
+
+  public boolean isMultiObjectDeleteEnabled() {
+    return multiObjectDeleteEnabled;
+  }
+
+  public MetadataStore getMetadataStore() {
+    return metadataStore;
+  }
+
+  public boolean isUseListV1() {
+    return useListV1;
+  }
+
+  public boolean isVersioned() {
+    return versioned;
+  }
+
+  public Function<String, Path> getKeyToPathQualifier() {
+    return keyToPathQualifier;
+  }
+
+  /**
+   * Get the storage statistics of this filesystem.
+   * @return the storage statistics
+   */
+  public S3AStorageStatistics getStorageStatistics() {
+    return storageStatistics;
+  }
+
+  /**
+   * Increment a statistic by 1.
+   * This increments both the instrumentation and storage statistics.
+   * @param statistic The operation to increment
+   */
+  public void incrementStatistic(Statistic statistic) {
+    incrementStatistic(statistic, 1);
+  }
+
+  /**
+   * Increment a statistic by a specific value.
+   * This increments both the instrumentation and storage statistics.
+   * @param statistic The operation to increment
+   * @param count the count to increment
+   */
+  public void incrementStatistic(Statistic statistic, long count) {
+    instrumentation.incrementCounter(statistic, count);
+    storageStatistics.incrementCounter(statistic, count);
+  }
+
+  /**
+   * Decrement a gauge by a specific value.
+   * @param statistic The operation to decrement
+   * @param count the count to decrement
+   */
+  public void decrementGauge(Statistic statistic, long count) {
+    instrumentation.decrementGauge(statistic, count);
+  }
+
+  /**
+   * Increment a gauge by a specific value.
+   * @param statistic The operation to increment
+   * @param count the count to increment
+   */
+  public void incrementGauge(Statistic statistic, long count) {
+    instrumentation.incrementGauge(statistic, count);
+  }
+
+  /**
+   * Create a new executor service with a given capacity.
+   * This executor submits works to the {@link #executor}, using a
+   * {@link SemaphoredDelegatingExecutor} to limit the number
+   * of requests coming in from a specific client.
+   *
+   * Because this delegates to an existing thread pool, the cost of
+   * creating a new instance here is low.
+   * As the throttling is per instance, separate instances
+   * should be created for each operation which wishes to execute work in
+   * parallel <i>without</i> saturating the base executor.
+   * This is important if either the duration of each operation is long
+   * or the submission rate of work is high.
+   * @param capacity maximum capacity of this executor.
+   * @return an executor for submitting work.
+   */
+  public ListeningExecutorService createThrottledExecutor(int capacity) {
+    return new SemaphoredDelegatingExecutor(executor,
+        capacity, true);
+  }
+
+  /**
+   * Create a new executor with the capacity defined in
+   * {@link #executorCapacity}.
+   * @return a new executor for exclusive use by the caller.
+   */
+  public ListeningExecutorService createThrottledExecutor() {
+    return createThrottledExecutor(executorCapacity);
+  }
+
+  public UserGroupInformation getOwner() {
+    return owner;
+  }
+
+  /**
+   * Create a temporary file somewhere.
+   * @param prefix prefix for the temporary file
+   * @param size expected size.
+   * @return a file reference.
+   * @throws IOException failure.
+   */
+  public File createTempFile(String prefix, long size) throws IOException {
+    return tempFileFactory.apply(prefix, size);
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreOperation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+/**
+ * Base class of operation in the store.
+ * An operation is something which executes against the context to
+ * perform a single function.
+ * It is expected to have a limited lifespan.
+ */
+public abstract class StoreOperation {
+
+  private final StoreContext storeContext;
+
+  /**
+   * constructor.
+   * @param storeContext store context.
+   */
+  public StoreOperation(final StoreContext storeContext) {
+    this.storeContext = storeContext;
+  }
+
+  public StoreContext getStoreContext() {
+    return storeContext;
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/BulkOperationState.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/BulkOperationState.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * This represents state which may be passed to bulk IO operations
+ * to enable them to store information about the state of the ongoing
+ * operation across invocations.
+ *
+ * A bulk operation state <i>MUST</i> only be be used for the single store
+ * from which it was created, and <i>MUST</i>only for the duration of a single
+ * bulk update operation.
+ *
+ * After the operation has completed, it <i>MUST</i> be closed so
+ * as to guarantee that all state is released.
+ */
+public class BulkOperationState implements Closeable {
+
+  @Override
+  public void close() throws IOException {
+
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/BulkOperationState.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/BulkOperationState.java
@@ -35,8 +35,42 @@ import java.io.IOException;
  */
 public class BulkOperationState implements Closeable {
 
+  private final OperationType operation;
+
+  /**
+   * Constructor.
+   * @param operation the type of the operation.
+   */
+  public BulkOperationState(final OperationType operation) {
+    this.operation = operation;
+  }
+
+  /**
+   * Get the operation type.
+   * @return the operation type.
+   */
+  public OperationType getOperation() {
+    return operation;
+  }
+
   @Override
   public void close() throws IOException {
 
+  }
+
+  /**
+   * Enumeration of operations which can be performed in bulk.
+   * This can be used by the stores however they want.
+   * One special aspect: renames are to be done through a {@link RenameTracker}.
+   * Callers will be blocked from initiating a rename through
+   * {@code S3Guard#initiateBulkWrite()}
+   */
+  public enum OperationType {
+    /** Writing data. */
+    Put,
+    /** Rename: add and delete. */
+    Rename,
+    /** Pruning: deleting entries and updating parents. */
+    Prune,
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DelayedUpdateRenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DelayedUpdateRenameTracker.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.amazonaws.SdkBaseException;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.Tristate;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+
+import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.addMoveAncestors;
+import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.addMoveDir;
+import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.addMoveFile;
+
+/**
+ * This is the rename updating strategy originally used:
+ * a collection of source paths and a list of destinations are created,
+ * then updated at the end (possibly slow).
+ */
+public class DelayedUpdateRenameTracker extends RenameTracker {
+
+  private final MetadataStore metadataStore;
+
+  private final Collection<Path> sourcePaths = new HashSet<>();
+
+  private final List<PathMetadata> destMetas = new ArrayList<>();
+
+  private final List<Path> deletedPaths = new ArrayList<>();
+
+  public DelayedUpdateRenameTracker(
+      final StoreContext storeContext,
+      final MetadataStore metadataStore,
+      final Path sourceRoot,
+      final Path dest,
+      final BulkOperationState operationState) {
+    super("DelayedUpdateRenameTracker", storeContext, metadataStore,
+        sourceRoot, dest, operationState);
+    this.metadataStore = storeContext.getMetadataStore();
+  }
+
+  @Override
+  public synchronized void fileCopied(
+      final Path sourcePath,
+      final S3ObjectAttributes sourceAttributes,
+      final S3ObjectAttributes destAttributes,
+      final Path destPath,
+      final long blockSize,
+      final boolean addAncestors) throws IOException {
+
+    addMoveFile(metadataStore,
+        sourcePaths,
+        destMetas,
+        sourcePath,
+        destPath,
+        sourceAttributes.getLen(),
+        blockSize,
+        getOwner(),
+        destAttributes.getETag(),
+        destAttributes.getVersionId());
+    // Ancestor directories may not be listed, so we explicitly add them
+    if (addAncestors) {
+      addMoveAncestors(metadataStore,
+          sourcePaths,
+          destMetas,
+          getSourceRoot(),
+          sourcePath,
+          destPath,
+          getOwner());
+    }
+  }
+
+  @Override
+  public synchronized void directoryMarkerCopied(final Path sourcePath,
+      final Path destPath,
+      final boolean addAncestors) throws IOException {
+    addMoveDir(metadataStore, sourcePaths, destMetas,
+        sourcePath,
+        destPath, getOwner());
+    // Ancestor directories may not be listed, so we explicitly add them
+    if (addAncestors) {
+      addMoveAncestors(metadataStore,
+          sourcePaths,
+          destMetas,
+          getSourceRoot(),
+          sourcePath,
+          destPath,
+          getOwner());
+    }
+  }
+
+  @Override
+  public synchronized void moveSourceDirectory() throws IOException {
+    if (!sourcePaths.contains(getSourceRoot())) {
+      addMoveDir(metadataStore, sourcePaths, destMetas,
+          getSourceRoot(),
+          getDest(), getOwner());
+    }
+  }
+
+  @Override
+  public synchronized void sourceObjectsDeleted(
+      final List<Path> paths) throws IOException {
+    // convert to paths.
+    deletedPaths.addAll(paths);
+  }
+
+  @Override
+  public void completeRename() throws IOException {
+    metadataStore.move(sourcePaths, destMetas, getOperationState());
+    super.completeRename();
+  }
+
+  @Override
+  public IOException renameFailed(final Exception ex) {
+    LOG.warn("Rename has failed; updating s3guard with destination state");
+    try {
+      // the destination paths are updated; the source is left alone.
+      // either the delete operation didn't begin, or the
+      metadataStore.move(new ArrayList<>(0), destMetas, getOperationState());
+      for (Path deletedPath : deletedPaths) {
+        // this is not ideal in that it may leave parent stuff around.
+        metadataStore.delete(deletedPath);
+      }
+      deleteParentPaths();
+    } catch (IOException | SdkBaseException e) {
+      LOG.warn("Ignoring error raised in AWS SDK ", e);
+    }
+
+    return super.renameFailed(ex);
+  }
+
+  /**
+   * Delete all the parent paths we know to be empty (by walking up the tree
+   * deleting as appropriate).
+   * @throws IOException failure
+   */
+  private void deleteParentPaths() throws IOException {
+    Set<Path> parentPaths = new HashSet<>();
+    for (Path deletedPath : deletedPaths) {
+      Path parent = deletedPath.getParent();
+      if (!parent.equals(getSourceRoot())) {
+        parentPaths.add(parent);
+      }
+    }
+    // now there's a set of parent paths. We now want to
+    // get them ordered by depth, so that deeper entries come first
+    // that way: when we check for a parent path existing we can
+    // see if it really is empty.
+    List<Path> parents = new ArrayList<>(parentPaths);
+    parents.sort(PathOrderComparators.TOPMOST_PATH_LAST);
+    for (Path parent : parents) {
+      PathMetadata md = metadataStore.get(parent, true);
+      if (md != null && md.isEmptyDirectory().equals(Tristate.TRUE)) {
+        // if were confident that this is empty: delete it.
+        metadataStore.delete(parent);
+      }
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DelayedUpdateRenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DelayedUpdateRenameTracker.java
@@ -40,6 +40,10 @@ import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.addMoveFile;
  * This is the rename updating strategy originally used:
  * a collection of source paths and a list of destinations are created,
  * then updated at the end (possibly slow).
+ * <p>
+ * It is not currently instantiated by any of the active trackers,
+ * but is preserved to show that the original rename strategy
+ * can be implemented via the tracker model.
  */
 public class DelayedUpdateRenameTracker extends RenameTracker {
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
@@ -1991,8 +1991,8 @@ public class DynamoDBMetadataStore implements MetadataStore,
   }
 
   /**
-   * Initiate the rename operation by creating the tracker and the associated
-   * {@link AncestorState}.
+   * Initiate the rename operation by creating the tracker for the filesystem
+   * to keep up to date with state changes in the S3A bucket.
    * @param storeContext store context.
    * @param source source path
    * @param sourceStatus status of the source file/dir

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
@@ -318,7 +318,8 @@ public class LocalMetadataStore implements MetadataStore {
   }
 
   @Override
-  public synchronized void put(DirListingMetadata meta) throws IOException {
+  public synchronized void put(DirListingMetadata meta,
+      final BulkOperationState operationState) throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("put dirMeta {}", meta.prettyPrint());
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
@@ -555,7 +555,7 @@ public class LocalMetadataStore implements MetadataStore {
   @Override
   public RenameTracker initiateRenameOperation(final StoreContext storeContext,
       final Path source,
-      final FileStatus sourceStatus, final Path dest) throws IOException {
+      final S3AFileStatus sourceStatus, final Path dest) throws IOException {
     return new ProgressiveRenameTracker(storeContext, this, source, dest,
         null);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
@@ -200,7 +200,7 @@ public interface MetadataStore extends Closeable {
    */
   @RetryTranslated
   void put(PathMetadata meta,
-      @Nullable BulkOperationState operationState) throws IOException;
+      @Nullable BulkOperationState BulkOperationState) throws IOException;
 
   /**
    * Saves metadata for any number of paths.
@@ -229,9 +229,11 @@ public interface MetadataStore extends Closeable {
    * another process.
    *
    * @param meta Directory listing metadata.
+   * @param operationState operational state for a bulk update
    * @throws IOException if there is an error
    */
-  void put(DirListingMetadata meta) throws IOException;
+  void put(final DirListingMetadata meta,
+      @Nullable final BulkOperationState operationState) throws IOException;
 
   /**
    * Destroy all resources associated with the metadata store.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
@@ -200,7 +200,7 @@ public interface MetadataStore extends Closeable {
    */
   @RetryTranslated
   void put(PathMetadata meta,
-      @Nullable BulkOperationState BulkOperationState) throws IOException;
+      @Nullable BulkOperationState operationState) throws IOException;
 
   /**
    * Saves metadata for any number of paths.
@@ -233,7 +233,7 @@ public interface MetadataStore extends Closeable {
    * @throws IOException if there is an error
    */
   void put(final DirListingMetadata meta,
-      @Nullable final BulkOperationState operationState) throws IOException;
+      @Nullable BulkOperationState operationState) throws IOException;
 
   /**
    * Destroy all resources associated with the metadata store.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
@@ -253,7 +253,7 @@ public interface MetadataStore extends Closeable {
    * Implementations MUST clear file metadata, and MAY clear directory metadata
    * (s3a itself does not track modification time for directories).
    * Implementations may also choose to throw UnsupportedOperationException
-   * istead. Note that modification times should be in UTC, as returned by
+   * instead. Note that modification times should be in UTC, as returned by
    * System.currentTimeMillis at the time of modification.
    *
    * @param modTime Oldest modification time to allow
@@ -310,11 +310,13 @@ public interface MetadataStore extends Closeable {
   /**
    * Initiate a bulk update and create an operation state for it.
    * This may then be passed into put operations.
+   * @param operation the type of the operation.
    * @param dest path under which updates will be explicitly put.
    * @return null or a store-specific state to pass into the put operations.
    * @throws IOException failure
    */
-  default BulkOperationState initiateBulkWrite(Path dest) throws IOException {
+  default BulkOperationState initiateBulkWrite(final BulkOperationState.OperationType operation,
+      Path dest) throws IOException {
     return null;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
@@ -28,11 +28,10 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.Retries.RetryTranslated;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 /**
@@ -134,9 +133,7 @@ public interface MetadataStore extends Closeable {
 
   /**
    * This adds all new ancestors of a path as directories.
-   * @param metadataStore store
    * @param qualifiedPath path to update
-   * @param username username to use in all new FileStatus entries.
    * @param operationState (nullable) operational state for a bulk update
    * @throws IOException failure
    */
@@ -304,7 +301,7 @@ public interface MetadataStore extends Closeable {
   RenameTracker initiateRenameOperation(
       StoreContext storeContext,
       Path source,
-      FileStatus sourceStatus,
+      S3AFileStatus sourceStatus,
       Path dest)
       throws IOException;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStore.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.Retries.RetryTranslated;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
@@ -130,6 +131,19 @@ public interface MetadataStore extends Closeable {
    * @throws IOException if there is an error
    */
   DirListingMetadata listChildren(Path path) throws IOException;
+
+  /**
+   * This adds all new ancestors of a path as directories.
+   * @param metadataStore store
+   * @param qualifiedPath path to update
+   * @param username username to use in all new FileStatus entries.
+   * @param operationState (nullable) operational state for a bulk update
+   * @throws IOException failure
+   */
+  @RetryTranslated
+  void addAncestors(
+      Path qualifiedPath,
+      @Nullable BulkOperationState operationState) throws IOException;
 
   /**
    * Record the effects of a {@link FileSystem#rename(Path, Path)} in the

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
@@ -100,7 +100,8 @@ public class NullMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void put(DirListingMetadata meta) throws IOException {
+  public void put(DirListingMetadata meta,
+      final BulkOperationState operationState) throws IOException {
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.fs.s3a.s3guard;
 import javax.annotation.Nullable;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
@@ -136,7 +136,7 @@ public class NullMetadataStore implements MetadataStore {
   @Override
   public RenameTracker initiateRenameOperation(final StoreContext storeContext,
       final Path source,
-      final FileStatus sourceStatus,
+      final S3AFileStatus sourceStatus,
       final Path dest)
       throws IOException {
     return new NullRenameTracker(storeContext, source, dest, this);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.s3a.s3guard;
 
+import javax.annotation.Nullable;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -138,6 +140,11 @@ public class NullMetadataStore implements MetadataStore {
       final Path dest)
       throws IOException {
     return new NullRenameTracker(storeContext, source, dest, this);
+  }
+
+  @Override
+  public void addAncestors(final Path qualifiedPath,
+      @Nullable final BulkOperationState operationState) throws IOException {
   }
 
   private static final class NullRenameTracker extends RenameTracker {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/NullMetadataStore.java
@@ -19,8 +19,11 @@
 package org.apache.hadoop.fs.s3a.s3guard;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -76,15 +79,22 @@ public class NullMetadataStore implements MetadataStore {
 
   @Override
   public void move(Collection<Path> pathsToDelete,
-      Collection<PathMetadata> pathsToCreate) throws IOException {
+      Collection<PathMetadata> pathsToCreate,
+      final BulkOperationState operationState) throws IOException {
   }
 
   @Override
-  public void put(PathMetadata meta) throws IOException {
+  public void put(final PathMetadata meta) throws IOException {
   }
 
   @Override
-  public void put(Collection<PathMetadata> meta) throws IOException {
+  public void put(PathMetadata meta,
+      final BulkOperationState operationState) throws IOException {
+  }
+
+  @Override
+  public void put(Collection<PathMetadata> meta,
+      final BulkOperationState operationState) throws IOException {
   }
 
   @Override
@@ -119,5 +129,35 @@ public class NullMetadataStore implements MetadataStore {
   @Override
   public void updateParameters(Map<String, String> parameters)
       throws IOException {
+  }
+
+  @Override
+  public RenameTracker initiateRenameOperation(final StoreContext storeContext,
+      final Path source,
+      final FileStatus sourceStatus,
+      final Path dest)
+      throws IOException {
+    return new NullRenameTracker(storeContext, source, dest, this);
+  }
+
+  private static final class NullRenameTracker extends RenameTracker {
+
+    private NullRenameTracker(
+        final StoreContext storeContext,
+        final Path source,
+        final Path dest, MetadataStore metadataStore) {
+      super("null tracker", storeContext, metadataStore, source, dest, null);
+    }
+
+    @Override
+    public void fileCopied(final Path childSource,
+        final S3ObjectAttributes sourceAttributes,
+        final S3ObjectAttributes destAttributes,
+        final Path destPath,
+        final long blockSize,
+        final boolean addAncestors) throws IOException {
+
+    }
+
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadataDynamoDBTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadataDynamoDBTranslation.java
@@ -51,7 +51,8 @@ import org.apache.hadoop.fs.s3a.Tristate;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
-final class PathMetadataDynamoDBTranslation {
+@VisibleForTesting
+public final class PathMetadataDynamoDBTranslation {
 
   /** The HASH key name of each item. */
   @VisibleForTesting
@@ -289,7 +290,8 @@ final class PathMetadataDynamoDBTranslation {
    * @param path path to convert
    * @return string for parent key
    */
-  static String pathToParentKey(Path path) {
+  @VisibleForTesting
+  public static String pathToParentKey(Path path) {
     Preconditions.checkNotNull(path);
     Preconditions.checkArgument(path.isUriPathAbsolute(), "Path not absolute");
     URI uri = path.toUri();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathOrderComparators.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathOrderComparators.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Comparator of path ordering for sorting collections.
+ *
+ * The definition of "topmost" is:
+ * <ol>
+ *   <li>The depth of a path is the primary comparator.</li>
+ *   <li>Root is topmost, "0"</li>
+ *   <li>If two paths are of equal depth, {@link Path#compareTo(Path)}</li>
+ *   is used. This delegates to URI compareTo.
+ *   <li>repeated sorts do not change the order</li>
+ * </ol>
+ */
+final class PathOrderComparators {
+
+  private PathOrderComparators() {
+  }
+
+  /**
+   * The shallowest paths come first.
+   * This is to be used when adding entries.
+   */
+  static final Comparator<Path> TOPMOST_PATH_FIRST
+      = new TopmostFirst();
+
+  /**
+   * The leaves come first.
+   * This is to be used when deleting entries.
+   */
+  static final Comparator<Path> TOPMOST_PATH_LAST
+      = new TopmostLast();
+
+  /**
+   * The shallowest paths come first.
+   * This is to be used when adding entries.
+   */
+  static final Comparator<PathMetadata> TOPMOST_PM_FIRST
+      = new PathMetadataComparator(TOPMOST_PATH_FIRST);
+
+  /**
+   * The leaves come first.
+   * This is to be used when deleting entries.
+   */
+  static final Comparator<PathMetadata> TOPMOST_PM_LAST
+      = new PathMetadataComparator(TOPMOST_PATH_LAST);
+
+  private static class TopmostFirst implements Comparator<Path>, Serializable {
+
+    @Override
+    public int compare(Path pathL, Path pathR) {
+      // exist fast on equal values.
+      if (pathL.equals(pathR)) {
+        return 0;
+      }
+      int depthL = pathL.depth();
+      int depthR = pathR.depth();
+      if (depthL < depthR) {
+        // left is higher up than the right.
+        return -1;
+      }
+      if (depthR < depthL) {
+        // right is higher up than the left
+        return 1;
+      }
+      // and if they are of equal depth, use the "classic" comparator
+      // of paths.
+      return pathL.compareTo(pathR);
+    }
+  }
+
+  /**
+   * Compare the topmost last.
+   * For some reason the .reverse() option wasn't giving the
+   * correct outcome.
+   */
+  private static final class TopmostLast extends TopmostFirst {
+
+    @Override
+    public int compare(final Path pathL, final Path pathR) {
+      int compare = super.compare(pathL, pathR);
+      if (compare < 0) {
+        return 1;
+      }
+      if (compare > 0) {
+        return -1;
+      }
+      return 0;
+    }
+  }
+
+  /**
+   * Compare on path status.
+   */
+  private static final class PathMetadataComparator implements
+      Comparator<PathMetadata>, Serializable {
+
+    private final Comparator<Path> inner;
+
+    private PathMetadataComparator(final Comparator<Path> inner) {
+      this.inner = inner;
+    }
+
+    @Override
+    public int compare(final PathMetadata o1, final PathMetadata o2) {
+      return inner.compare(o1.getFileStatus().getPath(),
+          o2.getFileStatus().getPath());
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/ProgressiveRenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/ProgressiveRenameTracker.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.util.DurationInfo;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.addMoveAncestors;
+import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.addMoveDir;
+
+/**
+ * This rename tracker progressively updates the metadata store
+ * as it proceeds, during the parallelized copy operation.
+ *
+ * Algorithm
+ * <ol>
+ *   <li>
+ *     As {@code RenameTracker.fileCopied()} callbacks
+ *     are raised, the metastore is updated with the new file entry.
+ *   </li>
+ *   <li>
+ *     Including parent entries, as appropriate.
+ *   </li>
+ *   <li>
+ *     All directories which have been created are tracked locally,
+ *     to avoid needing to read the store; this is a thread-safe structure.
+ *   </li>
+ *   <li>
+ *    The actual update is performed out of any synchronized block.
+ *   </li>
+ *   <li>
+ *     When deletes are executed, the store is also updated.
+ *   </li>
+ *   <li>
+ *     And at the completion of a successful rename, the source directory
+ *     is also removed.
+ *   </li>
+ * </ol>
+ * <pre>
+ *
+ * </pre>
+ */
+public class ProgressiveRenameTracker extends RenameTracker {
+
+  /**
+   * The collection of paths to delete; this is added as individual files
+   * are renamed.
+   * The metastore is only updated with these entries after the DELETE
+   * call succeeds.
+   */
+  private final Collection<Path> pathsToDelete = new HashSet<>();
+
+  private final List<PathMetadata> destMetas = new ArrayList<>();
+
+  public ProgressiveRenameTracker(
+      final StoreContext storeContext,
+      final MetadataStore metadataStore,
+      final Path sourceRoot,
+      final Path dest,
+      final BulkOperationState operationState) {
+    super("ProgressiveRenameTracker",
+        storeContext, metadataStore, sourceRoot, dest, operationState);
+  }
+
+  /**
+   * When a file is copied, any ancestors
+   * are calculated and then the store is updated with
+   * the destination entries.
+   *
+   * The source entries are added to the {@link #pathsToDelete} list.
+   * @param sourcePath path of source
+   * @param sourceAttributes status of source.
+   * @param destAttributes
+   * @param destPath destination path.
+   * @param blockSize block size.
+   * @param addAncestors should ancestors be added?
+   * @throws IOException failure
+   */
+  @Override
+  public void fileCopied(
+      final Path sourcePath,
+      final S3ObjectAttributes sourceAttributes,
+      final S3ObjectAttributes destAttributes,
+      final Path destPath,
+      final long blockSize,
+      final boolean addAncestors) throws IOException {
+
+    // build the list of entries to add in a synchronized block.
+    final List<PathMetadata> entriesToAdd = new ArrayList<>(1);
+    LOG.debug("Updating store with copied file {}", sourcePath);
+    MetadataStore store = getMetadataStore();
+    synchronized (this) {
+      checkArgument(!pathsToDelete.contains(sourcePath),
+          "File being renamed is already processed %s", destPath);
+      // create the file metadata and update the local structures.
+      S3Guard.addMoveFile(
+          store,
+          pathsToDelete,
+          entriesToAdd,
+          sourcePath,
+          destPath,
+          sourceAttributes.getLen(),
+          blockSize,
+          getOwner(),
+          destAttributes.getETag(),
+          destAttributes.getVersionId());
+      LOG.debug("New metastore entry : {}", entriesToAdd.get(0));
+      if (addAncestors) {
+        // add all new ancestors.
+        // TODO: include in bulk operation
+        addMoveAncestors(
+            store,
+            pathsToDelete,
+            entriesToAdd,
+            getSourceRoot(),
+            sourcePath,
+            destPath,
+            getOwner());
+      }
+    }
+
+    // outside the lock, the entriesToAdd list has all new files to create.
+    // ...so update the store.
+    store.move(null, entriesToAdd, getOperationState());
+  }
+
+  /**
+   * A directory marker has been added.
+   * Add the new entry and record the source path as another entry to delete.
+   * @param sourcePath status of source.
+   * @param destPath destination path.
+   * @param addAncestors should ancestors be added?
+   * @throws IOException failure.
+   */
+  @Override
+  public void directoryMarkerCopied(
+      final Path sourcePath,
+      final Path destPath,
+      final boolean addAncestors) throws IOException {
+    // this list is created on demand.
+    final List<PathMetadata> entriesToAdd = new ArrayList<>(1);
+    MetadataStore store = getMetadataStore();
+    synchronized (this) {
+      addMoveDir(store,
+          pathsToDelete,
+          entriesToAdd,
+          sourcePath,
+          destPath,
+          getOwner());
+      // Ancestor directories may not be listed, so we explicitly add them
+      if (addAncestors) {
+        addMoveAncestors(store,
+            pathsToDelete,
+            entriesToAdd,
+            getSourceRoot(),
+            sourcePath,
+            destPath,
+            getOwner());
+      }
+    }
+    // outside the lock, the entriesToAdd list has all new files to create.
+    // ...so update the store.
+    try (DurationInfo ignored = new DurationInfo(LOG, false,
+        "adding %s metastore entries", entriesToAdd.size())) {
+      store.move(null, entriesToAdd, getOperationState());
+    }
+  }
+
+  @Override
+  public synchronized void moveSourceDirectory() throws IOException {
+    if (!pathsToDelete.contains(getSourceRoot())) {
+      addMoveDir(getMetadataStore(), pathsToDelete, destMetas,
+          getSourceRoot(),
+          getDest(),
+          getOwner());
+    }
+  }
+
+  /**
+   * As source objects are deleted, so is the list of entries.
+   * @param paths keys of objects deleted.
+   * @throws IOException failure.
+   */
+  @Override
+  public void sourceObjectsDeleted(
+      final List<Path> paths) throws IOException {
+
+    // delete the paths from the metastore
+    try (DurationInfo ignored = new DurationInfo(LOG, false,
+        "delete %s metastore entries", paths.size())) {
+      getMetadataStore().move(paths, null, getOperationState());
+    }
+  }
+
+  @Override
+  public void completeRename() throws IOException {
+    // this should all have happened.
+    LOG.debug("Rename completed for {}", this);
+    getMetadataStore().move(pathsToDelete, destMetas, getOperationState());
+    super.completeRename();
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/ProgressiveRenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/ProgressiveRenameTracker.java
@@ -91,11 +91,11 @@ public class ProgressiveRenameTracker extends RenameTracker {
    * When a file is copied, any ancestors
    * are calculated and then the store is updated with
    * the destination entries.
-   *
+   * <p>
    * The source entries are added to the {@link #pathsToDelete} list.
    * @param sourcePath path of source
    * @param sourceAttributes status of source.
-   * @param destAttributes
+   * @param destAttributes destination attributes
    * @param destPath destination path.
    * @param blockSize block size.
    * @param addAncestors should ancestors be added?

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/RenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/RenameTracker.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.amazonaws.SdkBaseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.s3a.impl.StoreOperation;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.util.DurationInfo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.hadoop.fs.s3a.S3AUtils.translateException;
+
+/**
+ * A class which manages updating the metastore with the rename process
+ * as initiated in the S3AFilesystem rename.
+ * Subclasses must provide an implementation and return it in
+ * {@link MetadataStore#initiateRenameOperation(StoreContext, Path, FileStatus, Path)}.
+ * The {@link #operationState} field/constructor argument is an opaque state to
+ * be passed down to the metastore in its move operations; this allows the
+ * stores to manage ongoing state -while still being able to share
+ * rename tracker implementations.
+ * This is to avoid performance problems wherein the progressive rename
+ * tracker causes the store to repeatedly create and write duplicate
+ * ancestor entries for every file added.
+ */
+public abstract class RenameTracker extends StoreOperation {
+
+  public static final Logger LOG = LoggerFactory.getLogger(
+      RenameTracker.class);
+
+  /** source path. */
+  private final Path sourceRoot;
+
+  /** destination path. */
+  private final Path dest;
+
+  /**
+   * Track the duration of this operation.
+   */
+  private final DurationInfo durationInfo;
+
+  /**
+   * Generated name for strings.
+   */
+  private final String name;
+
+  /**
+   * Any ongoing state supplied to the rename tracker
+   * which is to be passed in with each move operation.
+   * This must be closed at the end of the tracker's life.
+   */
+  private final BulkOperationState operationState;
+
+  /**
+   * The metadata store for this tracker.
+   * Always non-null.
+   * This is passed in separate from the store context to guarantee
+   * that whichever store creates a tracker is explicitly bound to that
+   * instance.
+   */
+  private final MetadataStore metadataStore;
+
+  /**
+   * Constructor.
+   * @param name tracker name for logs.
+   * @param storeContext store context.
+   * @param metadataStore the stopre
+   * @param sourceRoot source path.
+   * @param dest destination path.
+   * @param operationState ongoing move state.
+   */
+  protected RenameTracker(
+      final String name,
+      final StoreContext storeContext,
+      final MetadataStore metadataStore,
+      final Path sourceRoot,
+      final Path dest,
+      final BulkOperationState operationState) {
+    super(checkNotNull(storeContext));
+    checkNotNull(storeContext.getUsername(), "No username");
+    this.metadataStore = checkNotNull(metadataStore);
+    this.sourceRoot = checkNotNull(sourceRoot);
+    this.dest = checkNotNull(dest);
+    this.operationState = operationState;
+    this.name = String.format("%s (%s, %s)", name, sourceRoot, dest);
+    durationInfo = new DurationInfo(LOG, false,
+        name +" (%s, %s)", sourceRoot, dest);
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  public Path getSourceRoot() {
+    return sourceRoot;
+  }
+
+  public Path getDest() {
+    return dest;
+  }
+
+  public String getOwner() {
+    return getStoreContext().getUsername();
+  }
+
+  public BulkOperationState getOperationState() {
+    return operationState;
+  }
+
+  /**
+   * Get the metadata store.
+   * @return a non-null store.
+   */
+  protected MetadataStore getMetadataStore() {
+    return metadataStore;
+  }
+
+  /**
+   * A file has been copied.
+   *
+   * @param childSource source of the file. This may actually be different
+   * from the path of the sourceAttributes. (HOW?)
+   * @param sourceAttributes status of source.
+   * @param destAttributes destination attributes
+   * @param destPath destination path.
+   * @param blockSize block size.
+   * @param addAncestors should ancestors be added?
+   * @throws IOException failure.
+   */
+  public abstract void fileCopied(
+      Path childSource,
+      S3ObjectAttributes sourceAttributes,
+      S3ObjectAttributes destAttributes,
+      Path destPath,
+      long blockSize,
+      boolean addAncestors) throws IOException;
+
+  /**
+   * A directory marker has been copied.
+   * @param sourcePath source path.
+   * @param destPath destination path.
+   * @param addAncestors should ancestors be added?
+   * @throws IOException failure.
+   */
+  public void directoryMarkerCopied(
+      Path sourcePath,
+      Path destPath,
+      boolean addAncestors) throws IOException {
+
+  }
+
+  /**
+   * The delete failed.
+   * By the time this is called, the metastore will already have
+   * been updated with the results of any partial delete failure,
+   * such that all files known to have been deleted will have been
+   * removed.
+   * @param e exception
+   * @param pathsToDelete paths which were to be deleted.
+   * @param undeletedObjects list of objects which were not deleted.
+   */
+  public IOException deleteFailed(
+      final Exception e,
+      final List<Path> pathsToDelete,
+      final List<Path> undeletedObjects) {
+
+    return convertToIOException(e);
+  }
+
+  /**
+   * Top level directory move.
+   * @throws IOException on failure
+   */
+  public void moveSourceDirectory() throws IOException {
+
+  }
+
+  /**
+   * Note that source objects have been deleted.
+   * The metastore will already have been updated.
+   * @param paths keys of objects deleted.
+   */
+  public void sourceObjectsDeleted(
+      final List<Path> paths) throws IOException {
+  }
+
+  /**
+   * Complete the operation.
+   * @throws IOException failure.
+   */
+  public void completeRename() throws IOException {
+    IOUtils.cleanupWithLogger(LOG, operationState);
+    noteRenameFinished();
+  }
+
+  /**
+   * Note that the rename has finished by closing the duration info;
+   * this will log the duration of the operation at debug.
+   */
+  protected void noteRenameFinished() {
+    durationInfo.close();
+  }
+
+  /**
+   * Rename has failed.
+   * The metastore now needs to be updated with its current state
+   * even though the operation is incomplete.
+   * Implementations MUST NOT throw exceptions here, as this is going to
+   * be invoked in an exception handler.
+   * catch and log or catch and return/wrap.
+   *
+   * The base implementation returns the IOE passed in and translates
+   * any AWS exception into an IOE.
+   * @param ex the exception which caused the failure.
+   * This is either an IOException or and AWS exception
+   * @return an IOException to throw in an exception.
+   */
+  public IOException renameFailed(Exception ex) {
+    LOG.debug("Rename has failed", ex);
+    IOUtils.cleanupWithLogger(LOG, operationState);
+    noteRenameFinished();
+    return convertToIOException(ex);
+  }
+
+  /**
+   * Convert a passed in exception (expected to be an IOE or AWS exception
+   * into an IOException.
+   * @param ex exception caught
+   * @return the exception to throw in the failure handler.
+   */
+  protected IOException convertToIOException(final Exception ex) {
+    if (ex instanceof IOException) {
+      return (IOException) ex;
+    } else if (ex instanceof SdkBaseException) {
+      return translateException("rename " + sourceRoot + " to " + dest,
+          sourceRoot.toString(),
+          (SdkBaseException) ex);
+    } else {
+      // should never happen, but for strictness
+      return new IOException(ex);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/RenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/RenameTracker.java
@@ -176,7 +176,6 @@ public abstract class RenameTracker extends AbstractStoreOperation {
       Path sourcePath,
       Path destPath,
       boolean addAncestors) throws IOException {
-
   }
 
   /**
@@ -200,10 +199,10 @@ public abstract class RenameTracker extends AbstractStoreOperation {
 
   /**
    * Top level directory move.
+   * This is invoked after all child entries have been copied
    * @throws IOException on failure
    */
   public void moveSourceDirectory() throws IOException {
-
   }
 
   /**
@@ -268,7 +267,7 @@ public abstract class RenameTracker extends AbstractStoreOperation {
           sourceRoot.toString(),
           (SdkBaseException) ex);
     } else {
-      // should never happen, but for strictness
+      // should never happen, but for completeness
       return new IOException(ex);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -182,20 +182,25 @@ public final class S3Guard {
   }
 
   /**
-   * Initiate a bulk update and create an operation state for it.
+   * Initiate a bulk write and create an operation state for it.
    * This may then be passed into put operations.
    * @param metastore store
+   * @param operation the type of the operation.
    * @param path path under which updates will be explicitly put.
    * @return a store-specific state to pass into the put operations, or null
    * @throws IOException failure
    */
   public static BulkOperationState initiateBulkWrite(
       @Nullable final MetadataStore metastore,
+      final BulkOperationState.OperationType operation,
       final Path path) throws IOException {
+    Preconditions.checkArgument(
+        operation != BulkOperationState.OperationType.Rename,
+        "Rename operations cannot be started through initiateBulkWrite");
     if (metastore == null || isNullMetadataStore(metastore)) {
       return null;
     } else {
-      return metastore.initiateBulkWrite(path);
+      return metastore.initiateBulkWrite(operation, path);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -511,7 +511,8 @@ public final class S3Guard {
 
   /**
    * This adds all new ancestors of a path as directories.
-   * This forwards to {@link MetadataStore#addAncestors(Path, BulkOperationState)}.
+   * This forwards to
+   * {@link MetadataStore#addAncestors(Path, BulkOperationState)}.
    * <p>
    * Originally it implemented the logic to probe for an add ancestors,
    * but with the addition of a store-specific bulk operation state

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.Retries.RetryTranslated;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
-import org.apache.hadoop.fs.s3a.Tristate;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import static org.apache.hadoop.fs.s3a.Constants.S3_METADATA_STORE_IMPL;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -594,7 +594,7 @@ public final class S3Guard {
       ITtlTimeProvider timeProvider)
       throws IOException {
     dirMeta.setLastUpdated(timeProvider.getNow());
-    ms.put(dirMeta);
+    ms.put(dirMeta, null);
   }
 
   public static DirListingMetadata listChildrenWithTtl(MetadataStore ms,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -725,6 +725,7 @@ public abstract class S3GuardTool extends Configured implements Tool {
     private long importDir(FileStatus status) throws IOException {
       Preconditions.checkArgument(status.isDirectory());
       BulkOperationState operationState = getStore().initiateBulkWrite(
+          BulkOperationState.OperationType.Put,
           status.getPath());
       RemoteIterator<S3ALocatedFileStatus> it = getFilesystem()
           .listFilesAndEmptyDirectories(status.getPath(), true);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/TableDeleteTimeoutException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/TableDeleteTimeoutException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import org.apache.hadoop.fs.PathIOException;
+
+/**
+ * An exception raised when a table being deleted is still present after
+ * the wait time is exceeded.
+ */
+public class TableDeleteTimeoutException extends PathIOException {
+
+  TableDeleteTimeoutException(final String path,
+      final String error,
+      final Throwable cause) {
+    super(path, error, cause);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
@@ -1474,6 +1474,18 @@ Caused by: java.lang.NullPointerException
   ... 1 more
 ```
 
+### Error `Attempt to change a resource which is still in use: Table is being deleted`
+
+```
+com.amazonaws.services.dynamodbv2.model.ResourceInUseException:
+  Attempt to change a resource which is still in use: Table is being deleted:
+   s3guard.test.testDynamoDBInitDestroy351245027
+    (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ResourceInUseException;)
+```
+
+You have attempted to call `hadoop s3guard destroy` on a table which is already
+being destroyed.
+
 ## Other Topics
 
 For details on how to test S3Guard, see [Testing S3Guard](./testing.html#s3guard)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRename.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRename.java
@@ -18,20 +18,38 @@
 
 package org.apache.hadoop.fs.contract.s3a;
 
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.fs.s3a.Statistic;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.verifyFileContents;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.S3A_TEST_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeEnableS3Guard;
 
 /**
  * S3A contract tests covering rename.
  */
 public class ITestS3AContractRename extends AbstractContractRenameTest {
+
+  public static final Logger LOG = LoggerFactory.getLogger(
+      ITestS3AContractRename.class);
+
+
+  @Override
+  protected int getTestTimeoutMillis() {
+    return S3A_TEST_TIMEOUT;
+  }
 
   /**
    * Create a configuration, possibly patching in S3Guard options.
@@ -51,6 +69,12 @@ public class ITestS3AContractRename extends AbstractContractRenameTest {
   }
 
   @Override
+  public void teardown() throws Exception {
+    describe("\nTeardown\n");
+    super.teardown();
+  }
+
+  @Override
   public void testRenameDirIntoExistingDir() throws Throwable {
     describe("Verify renaming a dir into an existing dir puts the files"
              +" from the source dir into the existing dir"
@@ -64,12 +88,55 @@ public class ITestS3AContractRename extends AbstractContractRenameTest {
     Path destDir = path("dest");
 
     Path destFilePath = new Path(destDir, "dest-512.txt");
-    byte[] destDateset = dataset(512, 'A', 'Z');
-    writeDataset(fs, destFilePath, destDateset, destDateset.length, 1024,
+    byte[] destDataset = dataset(512, 'A', 'Z');
+    writeDataset(fs, destFilePath, destDataset, destDataset.length, 1024,
         false);
     assertIsFile(destFilePath);
 
     boolean rename = fs.rename(srcDir, destDir);
     assertFalse("s3a doesn't support rename to non-empty directory", rename);
+  }
+
+  /**
+   * Test that after renaming, the nested file is moved along with all its
+   * ancestors. It is similar to {@link #testRenamePopulatesDirectoryAncestors}.
+   *
+   * This is an extension testRenamePopulatesFileAncestors
+   * of the superclass version which does better
+   * logging of the state of the store before the assertions.
+   */
+  @Test
+  public void testRenamePopulatesFileAncestors2() throws Exception {
+    final S3AFileSystem fs = (S3AFileSystem)getFileSystem();
+    Path base = path("testRenamePopulatesFileAncestors2");
+    final Path src = new Path(base, "src");
+    Path dest = new Path(base, "dest");
+    fs.mkdirs(src);
+    final String nestedFile = "/dir1/dir2/dir3/fileA";
+    // size of file to create
+    int filesize = 16 * 1024;
+    byte[] srcDataset = dataset(filesize, 'a', 'z');
+    Path srcFile = path(src + nestedFile);
+    Path destFile = path(dest + nestedFile);
+    writeDataset(fs, srcFile, srcDataset, srcDataset.length,
+        1024, false);
+
+    S3ATestUtils.MetricDiff fileCopyDiff = new S3ATestUtils.MetricDiff(fs,
+        Statistic.FILES_COPIED);
+    S3ATestUtils.MetricDiff fileCopyBytes = new S3ATestUtils.MetricDiff(fs,
+        Statistic.FILES_COPIED_BYTES);
+
+    fs.rename(src, dest);
+
+    describe("Rename has completed, examining data under " + base);
+    fileCopyDiff.assertDiffEquals("Number of files copied", 1);
+    fileCopyBytes.assertDiffEquals("Number of bytes copied", filesize);
+    // log everything in the base directory.
+    S3ATestUtils.lsR(fs, base, true);
+    // look at the data.
+    verifyFileContents(fs, destFile, srcDataset);
+    describe("validating results");
+    validateAncestorsMoved(src, dest, nestedFile);
+
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
@@ -20,9 +20,14 @@ package org.apache.hadoop.fs.s3a;
 
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.google.common.collect.Lists;
+import org.junit.Assume;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -31,13 +36,16 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.file.AccessDeniedException;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.getLandsatCSVPath;
+import static org.apache.hadoop.fs.s3a.test.ExtraAssertions.failIf;
+import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.*;
+import static org.apache.hadoop.fs.s3a.impl.TestPartialDeleteFailures.keysToDelete;
 import static org.apache.hadoop.test.LambdaTestUtils.*;
 
 /**
- * Test S3A Failure translation.
+ * ITest for failure handling, primarily multipart deletion.
  */
 public class ITestS3AFailureHandling extends AbstractS3ATestBase {
   private static final Logger LOG =
@@ -69,12 +77,17 @@ public class ITestS3AFailureHandling extends AbstractS3ATestBase {
 
   private void removeKeys(S3AFileSystem fileSystem, String... keys)
       throws IOException {
+    fileSystem.removeKeys(buildDeleteRequest(keys), false);
+  }
+
+  private List<DeleteObjectsRequest.KeyVersion> buildDeleteRequest(
+      final String[] keys) {
     List<DeleteObjectsRequest.KeyVersion> request = new ArrayList<>(
         keys.length);
     for (String key : keys) {
       request.add(new DeleteObjectsRequest.KeyVersion(key));
     }
-    fileSystem.removeKeys(request, false, false);
+    return request;
   }
 
   @Test
@@ -87,12 +100,86 @@ public class ITestS3AFailureHandling extends AbstractS3ATestBase {
     timer.end("removeKeys");
   }
 
+
+  private Path maybeGetCsvPath() {
+    Configuration conf = getConfiguration();
+    String csvFile = conf.getTrimmed(KEY_CSVTEST_FILE, DEFAULT_CSVTEST_FILE);
+    Assume.assumeTrue("CSV test file is not the default",
+        DEFAULT_CSVTEST_FILE.equals(csvFile));
+    return new Path(csvFile);
+  }
+
+  /**
+   * Test low-level failure handling with low level delete request.
+   */
   @Test
   public void testMultiObjectDeleteNoPermissions() throws Throwable {
-    Path testFile = getLandsatCSVPath(getConfiguration());
-    S3AFileSystem fs = (S3AFileSystem)testFile.getFileSystem(
+    describe("Delete the landsat CSV file and expect it to fail");
+    Path csvPath = maybeGetCsvPath();
+    S3AFileSystem fs = (S3AFileSystem)csvPath.getFileSystem(getConfiguration());
+    List<DeleteObjectsRequest.KeyVersion> keys
+        = buildDeleteRequest(
+            new String[]{
+                fs.pathToKey(csvPath),
+                "missing-key.csv"
+            });
+    MultiObjectDeleteException ex = intercept(
+        MultiObjectDeleteException.class,
+        () -> fs.removeKeys(keys, false));
+
+    final List<Path> undeleted
+        = extractUndeletedPaths(ex, fs::keyToQualifiedPath);
+    String undeletedFiles = join(undeleted);
+    failIf(undeleted.size() != 2,
+        "undeleted list size wrong: " + undeletedFiles,
+        ex);
+    assertTrue("no CSV in " +undeletedFiles, undeleted.contains(csvPath));
+
+    // and a full split, after adding a new key
+    String marker = "/marker";
+    Path markerPath = fs.keyToQualifiedPath(marker);
+    keys.add(new DeleteObjectsRequest.KeyVersion(marker));
+
+    Pair<List<Path>, List<Path>> pair =
+        new MultiObjectDeleteSupport(fs.createStoreContext())
+        .splitUndeletedKeys(ex, keys);
+    assertEquals(undeleted, pair.getLeft());
+    List<Path> right = pair.getRight();
+    assertEquals("Wrong size for " + join(right), 1, right.size());
+    assertEquals(markerPath, right.get(0));
+  }
+
+  /**
+   * See what happens when you delete two entries which do not exist.
+   * It must not raise an exception.
+   */
+  @Test
+  public void testMultiObjectDeleteMissingEntriesSucceeds() throws Throwable {
+    describe("Delete keys which don't exist");
+    Path base = path("missing");
+    S3AFileSystem fs = getFileSystem();
+    List<DeleteObjectsRequest.KeyVersion> keys = keysToDelete(
+        Lists.newArrayList(new Path(base, "1"), new Path(base, "2")));
+    fs.removeKeys(keys, false);
+  }
+
+  private String join(final Iterable iterable) {
+    return "[" + StringUtils.join(iterable, ",") + "]";
+  }
+
+  /**
+   * Test low-level failure handling with a single-entry file.
+   * This is deleted as a single call, so isn't that useful.
+   */
+  @Test
+  public void testSingleObjectDeleteNoPermissionsTranslated() throws Throwable {
+    describe("Delete the landsat CSV file and expect it to fail");
+    Path csvPath = maybeGetCsvPath();
+    S3AFileSystem fs = (S3AFileSystem) csvPath.getFileSystem(
         getConfiguration());
-    intercept(MultiObjectDeleteException.class,
-        () -> removeKeys(fs, fs.pathToKey(testFile)));
+    AccessDeniedException aex = intercept(AccessDeniedException.class,
+        () -> fs.delete(csvPath, false));
+    Throwable cause = aex.getCause();
+    failIf(cause == null, "no nested exception", aex);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
@@ -116,7 +116,8 @@ public class ITestS3AFailureHandling extends AbstractS3ATestBase {
   public void testMultiObjectDeleteNoPermissions() throws Throwable {
     describe("Delete the landsat CSV file and expect it to fail");
     Path csvPath = maybeGetCsvPath();
-    S3AFileSystem fs = (S3AFileSystem)csvPath.getFileSystem(getConfiguration());
+    S3AFileSystem fs = (S3AFileSystem) csvPath.getFileSystem(
+        getConfiguration());
     List<DeleteObjectsRequest.KeyVersion> keys
         = buildDeleteRequest(
             new String[]{

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetadataPersistenceException.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetadataPersistenceException.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3ATestUtils.MetricDiff;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.fs.s3a.s3guard.LocalMetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.NullMetadataStore;
@@ -129,8 +130,15 @@ public class ITestS3AMetadataPersistenceException extends AbstractS3ATestBase {
     }
 
     @Override
-    public void put(PathMetadata meta) throws IOException {
+    public void put(PathMetadata meta,
+        final BulkOperationState operationState) throws IOException {
       throw ioException;
     }
+
+    @Override
+    public void put(final PathMetadata meta) throws IOException {
+      put(meta, null);
+    }
+
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardListConsistency.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardListConsistency.java
@@ -47,6 +47,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.writeTextFile;
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.FailureInjectionPolicy.*;
 import static org.apache.hadoop.fs.s3a.InconsistentAmazonS3Client.*;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
  * Test S3Guard list consistency feature by injecting delayed listObjects()
@@ -253,13 +254,11 @@ public class ITestS3GuardListConsistency extends AbstractS3ATestBase {
     assertFalse(list.contains(path("a3/b/dir3-" +
         DEFAULT_DELAY_KEY_SUBSTRING)));
 
-    try {
-      RemoteIterator<S3ALocatedFileStatus> old = fs.listFilesAndEmptyDirectories(
-          path("a"), true);
-      fail("Recently renamed dir should not be visible");
-    } catch(FileNotFoundException e) {
-      // expected
-    }
+    intercept(FileNotFoundException.class, "",
+        "Recently renamed dir should not be visible",
+        () -> S3AUtils.mapLocatedFiles(
+            fs.listFilesAndEmptyDirectories(path("a"), true),
+            FileStatus::getPath));
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.commit.staging.StagingTestBase;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.util.Progressable;
 
 /**
@@ -177,7 +178,8 @@ public class MockS3AFileSystem extends S3AFileSystem {
   }
 
   @Override
-  void finishedWrite(String key, long length, String eTag, String versionId) {
+  void finishedWrite(String key, long length, String eTag, String versionId,
+          BulkOperationState operationState) {
 
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestStreamChangeTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestStreamChangeTracker.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeTracker;
@@ -57,6 +58,8 @@ public class TestStreamChangeTracker extends HadoopTestBase {
   public static final String DEST_OBJECT = "new_object";
 
   public static final String URI = "s3a://" + BUCKET + "/" + OBJECT;
+
+  public static final Path PATH = new Path(URI);
 
   @Test
   public void testVersionCheckingHandlingNoVersions() throws Throwable {
@@ -434,10 +437,12 @@ public class TestStreamChangeTracker extends HadoopTestBase {
   private S3ObjectAttributes objectAttributes(
       String etag, String versionId) {
     return new S3ObjectAttributes(BUCKET,
+        PATH,
         OBJECT,
         null,
         null,
         etag,
-        versionId);
+        versionId,
+        0);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -23,9 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.AccessDeniedException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.amazonaws.auth.AWSCredentials;
@@ -53,7 +51,6 @@ import org.apache.hadoop.fs.s3a.commit.CommitOperations;
 import org.apache.hadoop.fs.s3a.commit.files.PendingSet;
 import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
 
-import static org.apache.hadoop.fs.contract.ContractTestUtils.assertRenameOutcome;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
@@ -524,78 +521,6 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     return path(getMethodName());
   }
 
-  @Test
-  public void testRestrictedRename() throws Throwable {
-    describe("rename with parent paths not writeable");
-    executeRestrictedRename(createAssumedRoleConfig());
-  }
-
-  @Test
-  public void testRestrictedSingleDeleteRename() throws Throwable {
-    describe("rename with parent paths not writeable"
-        + " and multi-object delete disabled");
-    Configuration conf = createAssumedRoleConfig();
-    conf.setBoolean(ENABLE_MULTI_DELETE, false);
-    executeRestrictedRename(conf);
-  }
-
-  /**
-   * Execute a sequence of rename operations with access locked down.
-   * @param conf FS configuration
-   */
-  public void executeRestrictedRename(final Configuration conf)
-      throws IOException {
-    Path basePath = methodPath();
-    Path restrictedDir = new Path(basePath, "renameSrc");
-    Path destPath = new Path(basePath, "renameDest");
-    Path child = new Path(restrictedDir, "child");
-    // the full FS
-    S3AFileSystem fs = getFileSystem();
-    fs.delete(basePath, true);
-
-    bindRolePolicyStatements(conf,
-        STATEMENT_S3GUARD_CLIENT,
-        STATEMENT_ALLOW_SSE_KMS_RW,
-        STATEMENT_ALL_BUCKET_READ_ACCESS,
-        new Statement(Effects.Allow)
-          .addActions(S3_PATH_RW_OPERATIONS)
-          .addResources(directory(restrictedDir))
-          .addResources(directory(destPath))
-    );
-    roleFS = (S3AFileSystem) restrictedDir.getFileSystem(conf);
-
-    roleFS.getFileStatus(ROOT);
-    roleFS.mkdirs(restrictedDir);
-    // you can create an adjacent child
-    touch(roleFS, child);
-
-    roleFS.delete(destPath, true);
-    // as dest doesn't exist, this will map child -> dest
-    assertRenameOutcome(roleFS, child, destPath, true);
-
-    assertIsFile(destPath);
-    assertIsDirectory(restrictedDir);
-    Path renamedDestPath = new Path(restrictedDir, destPath.getName());
-    assertRenameOutcome(roleFS, destPath, restrictedDir, true);
-    assertIsFile(renamedDestPath);
-    roleFS.delete(restrictedDir, true);
-    roleFS.delete(destPath, true);
-  }
-
-  @Test
-  public void testRestrictedRenameReadOnlyData() throws Throwable {
-    describe("rename with source read only, multidelete");
-    executeRenameReadOnlyData(createAssumedRoleConfig());
-  }
-
-  @Test
-  public void testRestrictedRenameReadOnlySingleDelete() throws Throwable {
-    describe("rename with source read only single delete");
-    Configuration conf = createAssumedRoleConfig();
-    conf.setBoolean(ENABLE_MULTI_DELETE, false);
-    executeRenameReadOnlyData(conf);
-  }
-
   /**
    * Without simulation of STS failures, and with STS overload likely to
    * be very rare, there'll be no implicit test coverage of
@@ -613,102 +538,6 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
       provider.operationRetried("retry", new IOException("failure"), 0, true);
       provider.operationRetried("retry", new IOException("failure"), 1, true);
     }
-  }
-
-  /**
-   * Execute a sequence of rename operations where the source
-   * data is read only to the client calling rename().
-   * This will cause the inner delete() operations to fail, whose outcomes
-   * are explored.
-   * Multiple files are created (in parallel) for some renames, so exploring
-   * the outcome on bulk delete calls, including verifying that a
-   * MultiObjectDeleteException is translated to an AccessDeniedException.
-   * <ol>
-   *   <li>The exception raised is AccessDeniedException,
-   *   from single and multi DELETE calls.</li>
-   *   <li>It happens after the COPY. Not ideal, but, well, we can't pretend
-   *   it's a filesystem forever.</li>
-   * </ol>
-   * @param conf FS configuration
-   */
-  public void executeRenameReadOnlyData(final Configuration conf)
-      throws Exception {
-    assume("Does not work with S3Guard", !getFileSystem().hasMetadataStore());
-    Path basePath = methodPath();
-    Path destDir = new Path(basePath, "renameDest");
-    Path readOnlyDir = new Path(basePath, "readonlyDir");
-    Path readOnlyFile = new Path(readOnlyDir, "readonlyChild");
-
-    // the full FS
-    S3AFileSystem fs = getFileSystem();
-    fs.delete(basePath, true);
-
-    // this file is readable by the roleFS, but cannot be deleted
-    touch(fs, readOnlyFile);
-
-    bindRolePolicyStatements(conf,
-        STATEMENT_S3GUARD_CLIENT,
-        STATEMENT_ALL_BUCKET_READ_ACCESS,
-        new Statement(Effects.Allow)
-            .addActions(S3_PATH_RW_OPERATIONS)
-            .addResources(directory(destDir))
-    );
-    roleFS = (S3AFileSystem) destDir.getFileSystem(conf);
-
-    roleFS.delete(destDir, true);
-    roleFS.mkdirs(destDir);
-    // rename will fail in the delete phase
-    forbidden(readOnlyFile.toString(),
-        () -> roleFS.rename(readOnlyFile, destDir));
-
-    // and the source file is still there
-    assertIsFile(readOnlyFile);
-
-    // but so is the copied version, because there's no attempt
-    // at rollback, or preflight checking on the delete permissions
-    Path renamedFile = new Path(destDir, readOnlyFile.getName());
-
-    assertIsFile(renamedFile);
-
-    ContractTestUtils.assertDeleted(roleFS, renamedFile, true);
-    assertFileCount("Empty Dest Dir", roleFS,
-        destDir, 0);
-    // create a set of files
-    // this is done in parallel as it is 10x faster on a long-haul test run.
-    int range = 10;
-    touchFiles(fs, readOnlyDir, range);
-    // don't forget about that original file!
-    final long createdFiles = range + 1;
-    // are they all there?
-    assertFileCount("files ready to rename", roleFS,
-        readOnlyDir, createdFiles);
-
-    // try to rename the directory
-    LOG.info("Renaming readonly files {} to {}", readOnlyDir, destDir);
-    AccessDeniedException ex = forbidden("",
-        () -> roleFS.rename(readOnlyDir, destDir));
-    LOG.info("Result of renaming read-only files is AccessDeniedException", ex);
-    assertFileCount("files copied to the destination", roleFS,
-        destDir, createdFiles);
-    assertFileCount("files in the source directory", roleFS,
-        readOnlyDir, createdFiles);
-
-    // and finally (so as to avoid the delay of POSTing some more objects,
-    // delete that r/o source
-    forbidden("", () -> roleFS.delete(readOnlyDir, true));
-  }
-
-  /**
-   * Parallel-touch a set of files in the destination directory.
-   * @param fs filesystem
-   * @param destDir destination
-   * @param range range 1..range inclusive of files to create.
-   */
-  public void touchFiles(final S3AFileSystem fs,
-      final Path destDir,
-      final int range) {
-    IntStream.rangeClosed(1, range).parallel().forEach(
-        (i) -> eval(() -> touch(fs, new Path(destDir, "file-" + i))));
   }
 
   @Test
@@ -779,12 +608,16 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
       // all those commits must fail
       List<SinglePendingCommit> commits = pendingCommits.getLeft().getCommits();
       assertEquals(range, commits.size());
-      commits.parallelStream().forEach(
-          (c) -> {
-            CommitOperations.MaybeIOE maybeIOE = operations.commit(c, "origin");
-            Path path = c.destinationPath();
-            assertCommitAccessDenied(path, maybeIOE);
-          });
+      try(CommitOperations.CommitContext commitContext
+              = operations.initiateCommitOperation(uploadDest)) {
+        commits.parallelStream().forEach(
+            (c) -> {
+              CommitOperations.MaybeIOE maybeIOE =
+                  commitContext.commit(c, "origin");
+              Path path = c.destinationPath();
+              assertCommitAccessDenied(path, maybeIOE);
+            });
+      }
 
       // fail of all list and abort of .pending files.
       LOG.info("abortAllSinglePendingCommits({})", readOnlyDir);
@@ -840,24 +673,25 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
   @Test
   public void testPartialDelete() throws Throwable {
     describe("delete with part of the child tree read only; multidelete");
-    executePartialDelete(createAssumedRoleConfig());
+    executePartialDelete(createAssumedRoleConfig(), false);
   }
 
   @Test
   public void testPartialDeleteSingleDelete() throws Throwable {
     describe("delete with part of the child tree read only");
-    Configuration conf = createAssumedRoleConfig();
-    conf.setBoolean(ENABLE_MULTI_DELETE, false);
-    executePartialDelete(conf);
+    executePartialDelete(createAssumedRoleConfig(), true);
   }
 
   /**
    * Have a directory with full R/W permissions, but then remove
    * write access underneath, and try to delete it.
    * @param conf FS configuration
+   * @param singleDelete flag to indicate this is a single delete operation
    */
-  public void executePartialDelete(final Configuration conf)
+  public void executePartialDelete(final Configuration conf,
+      final boolean singleDelete)
       throws Exception {
+    conf.setBoolean(ENABLE_MULTI_DELETE, !singleDelete);
     Path destDir = methodPath();
     Path readOnlyDir = new Path(destDir, "readonlyDir");
 
@@ -888,25 +722,4 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
         roleFS.delete(pathWhichDoesntExist, true));
   }
 
-  /**
-   * Assert that the number of files in a destination matches that expected.
-   * @param text text to use in the message
-   * @param fs filesystem
-   * @param path path to list (recursively)
-   * @param expected expected count
-   * @throws IOException IO problem
-   */
-  private static void assertFileCount(String text, FileSystem fs,
-      Path path, long expected)
-      throws IOException {
-    List<String> files = new ArrayList<>();
-    applyLocatedFiles(fs.listFiles(path, true),
-        (status) -> files.add(status.getPath().toString()));
-    long actual = files.size();
-    if (actual != expected) {
-      String ls = files.stream().collect(Collectors.joining("\n"));
-      fail(text + ": expected " + expected + " files in " + path
-          + " but got " + actual + "\n" + ls);
-    }
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitMRJob.java
@@ -119,6 +119,7 @@ public abstract class AbstractITCommitMRJob extends AbstractYarnClusterITest {
       String sysprops = String.format("-Xmx256m -Dlog4j.configuration=%s",
           log4j);
       jobConf.set(JobConf.MAPRED_MAP_TASK_JAVA_OPTS, sysprops);
+      jobConf.set(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS, sysprops);
       jobConf.set("yarn.app.mapreduce.am.command-opts", sysprops);
     }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitMRJob.java
@@ -71,6 +71,9 @@ public abstract class AbstractITCommitMRJob extends AbstractYarnClusterITest {
     S3AFileSystem fs = getFileSystem();
     // final dest is in S3A
     Path outputPath = path(getMethodName());
+    // create and delete to force in a tombstone marker -see HADOOP-16207
+    fs.mkdirs(outputPath);
+    fs.delete(outputPath, true);
 
     String commitUUID = UUID.randomUUID().toString();
     String suffix = isUniqueFilenames() ? ("-" + commitUUID) : "";

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractYarnClusterITest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractYarnClusterITest.java
@@ -138,6 +138,12 @@ public abstract class AbstractYarnClusterITest extends AbstractCommitITest {
     return new ClusterBinding(miniDFSClusterService, yarnCluster);
   }
 
+  protected static void terminateCluster(ClusterBinding clusterBinding) {
+    if (clusterBinding != null) {
+      clusterBinding.terminate();
+    }
+  }
+
   /**
    * Get the cluster binding for this subclass
    * @return

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractYarnClusterITest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractYarnClusterITest.java
@@ -71,7 +71,7 @@ public abstract class AbstractYarnClusterITest extends AbstractCommitITest {
       LoggerFactory.getLogger(AbstractYarnClusterITest.class);
 
   private static final int TEST_FILE_COUNT = 2;
-  private static final int SCALE_TEST_FILE_COUNT = 20;
+  private static final int SCALE_TEST_FILE_COUNT = 50;
 
   public static final int SCALE_TEST_KEYS = 1000;
   public static final int BASE_TEST_KEYS = 10;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
@@ -278,7 +278,8 @@ public class ITestCommitOperations extends AbstractCommitITest {
     String child = "subdir/child.txt";
     Path pendingChildPath = new Path(pendingBaseDir, child);
     Path expectedDestPath = new Path(destDir, child);
-    assertPathDoesNotExist("dest file was found before upload", expectedDestPath);
+    assertPathDoesNotExist("dest file was found before upload",
+        expectedDestPath);
 
     createFile(fs, pendingChildPath, true, DATASET);
     commit("child.txt", pendingChildPath, expectedDestPath, 0, 0);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
@@ -617,6 +617,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
       assertPathExists("subdirectory", subdir);
       assertPathExists("destFile2", destFile2);
       if (writesOnFirstCommit != 0) {
+        LOG.info("DynamoDB Metastore is in use: checking write count");
         // S3Guard is in use against DDB, so the metrics can be checked
         // to see how many records were updated.
         // there should only be two new entries: one for the file and

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitMRJob.java
@@ -26,9 +26,7 @@ import org.junit.BeforeClass;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.commit.AbstractITCommitMRJob;
 import org.apache.hadoop.fs.s3a.commit.files.SuccessData;
 import org.apache.hadoop.mapred.JobConf;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitMRJob.java
@@ -58,7 +58,7 @@ public final class ITestMagicCommitMRJob extends AbstractITCommitMRJob {
 
   @AfterClass
   public static void teardownClusters() throws IOException {
-    clusterBinding.terminate();
+    terminateCluster(clusterBinding);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestS3AHugeMagicCommits.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestS3AHugeMagicCommits.java
@@ -143,9 +143,12 @@ public class ITestS3AHugeMagicCommits extends AbstractSTestS3AHugeFiles {
     assertNotNull("jobDir", jobDir);
     Pair<PendingSet, List<Pair<LocatedFileStatus, IOException>>>
         results = operations.loadSinglePendingCommits(jobDir, false);
-    for (SinglePendingCommit singlePendingCommit :
-        results.getKey().getCommits()) {
-      operations.commitOrFail(singlePendingCommit);
+    try(CommitOperations.CommitContext commitContext
+            = operations.initiateCommitOperation(jobDir)) {
+      for (SinglePendingCommit singlePendingCommit :
+          results.getKey().getCommits()) {
+        commitContext.commitOrFail(singlePendingCommit);
+      }
     }
     timer.end("time to commit %s", pendingDataFile);
     // upload is no longer pending

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestDirectoryCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestDirectoryCommitMRJob.java
@@ -46,7 +46,7 @@ public final class ITestDirectoryCommitMRJob extends AbstractITCommitMRJob {
 
   @AfterClass
   public static void teardownClusters() throws IOException {
-    clusterBinding.terminate();
+    terminateCluster(clusterBinding);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestPartitionCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestPartitionCommitMRJob.java
@@ -47,7 +47,7 @@ public final class ITestPartitionCommitMRJob extends AbstractITCommitMRJob {
 
   @AfterClass
   public static void teardownClusters() throws IOException {
-    clusterBinding.terminate();
+    terminateCluster(clusterBinding);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestStagingCommitMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestStagingCommitMRJob.java
@@ -58,7 +58,7 @@ public final class ITestStagingCommitMRJob extends AbstractITCommitMRJob {
 
   @AfterClass
   public static void teardownClusters() throws IOException {
-    clusterBinding.terminate();
+    terminateCluster(clusterBinding);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestStagingCommitMRJobBadDest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/integration/ITestStagingCommitMRJobBadDest.java
@@ -53,7 +53,7 @@ public final class ITestStagingCommitMRJobBadDest extends AbstractITCommitMRJob 
 
   @AfterClass
   public static void teardownClusters() throws IOException {
-    clusterBinding.terminate();
+    terminateCluster(clusterBinding);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
@@ -695,8 +695,8 @@ public class ITestPartialRenamesDeletes extends AbstractS3ATestBase {
         .as("ReadOnly directory " + directoryList)
         .containsAll(readOnlyFiles);
 
-    // do this prune in the test as well as teardown, so that the test reporting includes
-    // it in the runtime of a successful run.
+    // do this prune in the test as well as teardown, so that the test
+    // reporting includes it in the runtime of a successful run.
     prune(basePath);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
@@ -1,0 +1,809 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.google.common.base.Charsets;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.AbstractS3ATestBase;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3AUtils;
+import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
+import org.apache.hadoop.fs.s3a.s3guard.PathMetadataDynamoDBTranslation;
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+import org.apache.hadoop.util.DurationInfo;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
+import static org.apache.hadoop.fs.s3a.Constants.*;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.MetricDiff;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
+import static org.apache.hadoop.fs.s3a.S3AUtils.applyLocatedFiles;
+import static org.apache.hadoop.fs.s3a.Statistic.FILES_DELETE_REJECTED;
+import static org.apache.hadoop.fs.s3a.Statistic.OBJECT_DELETE_REQUESTS;
+import static org.apache.hadoop.fs.s3a.auth.RoleModel.Effects;
+import static org.apache.hadoop.fs.s3a.auth.RoleModel.Statement;
+import static org.apache.hadoop.fs.s3a.auth.RoleModel.directory;
+import static org.apache.hadoop.fs.s3a.auth.RoleModel.statement;
+import static org.apache.hadoop.fs.s3a.auth.RolePolicies.*;
+import static org.apache.hadoop.fs.s3a.auth.RoleTestUtils.bindRolePolicyStatements;
+import static org.apache.hadoop.fs.s3a.auth.RoleTestUtils.forbidden;
+import static org.apache.hadoop.fs.s3a.auth.RoleTestUtils.newAssumedRoleConfig;
+import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.submit;
+import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.waitForCompletion;
+import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.extractUndeletedPaths;
+import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.removeUndeletedPaths;
+import static org.apache.hadoop.fs.s3a.test.ExtraAssertions.assertFileCount;
+import static org.apache.hadoop.fs.s3a.test.ExtraAssertions.extractCause;
+import static org.apache.hadoop.test.LambdaTestUtils.eval;
+
+/**
+ * Test partial failures of delete and rename operations, especially
+ * that the S3Guard tables are consistent with the state of
+ * the filesystem.
+ *
+ * All these test have a unique path for each run, with a roleFS having
+ * full RW access to part of it, and R/O access to a restricted subdirectory
+ *
+ * The tests are parameterized to single/multi delete, which control which
+ * of the two delete mechanisms are used.
+ * In multi delete, in a scale test run, a significantly larger set of files
+ * is created and then deleted.
+ * This isn't done in the single delete as it is much slower and it is not
+ * the situation we are trying to create.
+ *
+ * This test manages to create lots of load on the s3guard prune command
+ * when that is tested in a separate test suite;
+ * too many tombstone files for the test to complete.
+ * An attempt is made in {@link #deleteTestDirInTeardown()} to prune these test
+ * files.
+ */
+@SuppressWarnings("ThrowableNotThrown")
+@RunWith(Parameterized.class)
+public class ITestPartialRenamesDeletes extends AbstractS3ATestBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ITestPartialRenamesDeletes.class);
+
+  private static final Path ROOT = new Path("/");
+
+  private static final Statement STATEMENT_ALL_BUCKET_READ_ACCESS
+      = statement(true, S3_ALL_BUCKETS, S3_BUCKET_READ_OPERATIONS);
+
+  /** Many threads for scale performance: {@value}. */
+  public static final int EXECUTOR_THREAD_COUNT = 64;
+
+  /**
+   * For submitting work.
+   */
+  private static final ListeningExecutorService EXECUTOR =
+      BlockingThreadPoolExecutorService.newInstance(
+          EXECUTOR_THREAD_COUNT,
+          EXECUTOR_THREAD_COUNT * 2,
+          30, TimeUnit.SECONDS,
+          "test-operations");
+
+  public static final int FILE_COUNT_NON_SCALED = 2;
+
+  /**
+   * The number of files for a scaled test. This is still
+   * less than half the amount which can be fitted into a delete
+   * request, so that even with this many R/W and R/O files,
+   * both can fit in the same request.
+   * Then, when a partial delete occurs, we can make assertions
+   * knowing that all R/W files should have been deleted and all
+   * R/O files rejected.
+   */
+  public static final int FILE_COUNT_SCALED = 10;
+
+  public static final int DIR_COUNT = 2;
+  public static final int DIR_COUNT_SCALED = 4;
+  public static final int DEPTH = 2;
+  public static final int DEPTH_SCALED = 2;
+
+  /**
+   * A role FS; if non-null it is closed in teardown.
+   */
+  private S3AFileSystem roleFS;
+
+  /**
+   * Base path for this test run.
+   */
+  private Path basePath;
+
+  private Path writableDir;
+
+  private Path readOnlyChild;
+
+  private Path readOnlyDir;
+
+  private Path noReadDir;
+
+  /** delete policy: single or multi? */
+  private final boolean multiDelete;
+
+  /**
+   * Configuration for the assume role FS.
+   */
+  private Configuration assumedRoleConfig;
+
+  private int fileCount;
+  private int dirCount;
+  private int dirDepth;
+
+  private boolean scaleTest;
+
+  /**
+   * Test array for parameterized test runs.
+   * <ul>
+   *   <li>Run 0: single deletes</li>
+   *   <li>Run 1: multi deletes</li>
+   * </ul>
+   *
+   * @return a list of parameter tuples.
+   */
+  @Parameterized.Parameters(name = "bulk delete={0}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {false},
+        {true},
+    });
+  }
+
+  /**
+   * Constructor.
+   * @param multiDelete single vs multi delete in the role FS?
+   */
+  public ITestPartialRenamesDeletes(final boolean multiDelete) {
+    this.multiDelete = multiDelete;
+  }
+
+  /**
+   * This sets up a unique path for every test run, so as to guarantee isolation
+   * from previous runs.
+   * It creates a role policy which has read access to everything except
+   * the contents of {@link #noReadDir}, and with write access to
+   * {@link #writableDir}.
+   * @throws Exception failure
+   */
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    assumeRoleTests();
+    basePath = uniquePath();
+    readOnlyDir = new Path(basePath, "readonlyDir");
+    writableDir = new Path(basePath, "writableDir");
+    readOnlyChild = new Path(readOnlyDir, "child");
+    noReadDir = new Path(basePath, "noReadDir");
+    // the full FS
+    S3AFileSystem fs = getFileSystem();
+    fs.delete(basePath, true);
+    fs.mkdirs(writableDir);
+
+    // create the baseline assumed role
+    assumedRoleConfig = createAssumedRoleConfig();
+    bindRolePolicyStatements(assumedRoleConfig,
+        STATEMENT_S3GUARD_CLIENT,
+        STATEMENT_ALL_BUCKET_READ_ACCESS,  // root:     r-x
+        new Statement(Effects.Allow)       // dest:     rwx
+            .addActions(S3_PATH_RW_OPERATIONS)
+            .addResources(directory(writableDir)),
+        new Statement(Effects.Deny)       // noReadDir: --x
+            .addActions(S3_ALL_GET)
+            .addActions(S3_ALL_PUT)
+            .addActions(S3_ALL_DELETE)
+            .addResources(directory(noReadDir)));
+    // the role configured to that set of restrictions
+    roleFS = (S3AFileSystem) readOnlyDir.getFileSystem(assumedRoleConfig);
+
+    // switch to the big set of files iff this is a multidelete run
+    // with -Dscale set.
+    // without that the DELETE calls become a key part of the bottleneck
+    scaleTest = multiDelete && getTestPropertyBool(
+        getConfiguration(),
+        KEY_SCALE_TESTS_ENABLED,
+        DEFAULT_SCALE_TESTS_ENABLED);
+    fileCount = scaleTest ? FILE_COUNT_SCALED : FILE_COUNT_NON_SCALED;
+    dirCount = scaleTest ? DIR_COUNT_SCALED : DIR_COUNT;
+    dirDepth = scaleTest ? DEPTH_SCALED : DEPTH;
+  }
+
+  @Override
+  public void teardown() throws Exception {
+    S3AUtils.closeAll(LOG, roleFS);
+    super.teardown();
+  }
+
+  /**
+   * Directory cleanup includes pruning everything under the path.
+   * This ensures that any in the tree from failed tests don't fill up
+   * the store with many, many, deleted entries.
+   * @throws IOException failure.
+   */
+  @Override
+  protected void deleteTestDirInTeardown() throws IOException {
+    super.deleteTestDirInTeardown();
+    Path path = getContract().getTestPath();
+    try {
+      prune(path);
+    } catch (IOException e) {
+      LOG.warn("When pruning the test directory {}", path, e);
+    }
+  }
+
+  private void assumeRoleTests() {
+    assume("No ARN for role tests", !getAssumedRoleARN().isEmpty());
+  }
+
+  private String getAssumedRoleARN() {
+    return getContract().getConf().getTrimmed(ASSUMED_ROLE_ARN, "");
+  }
+
+  /**
+   * Create the assumed role configuration.
+   * @return a config bonded to the ARN of the assumed role
+   */
+  public Configuration createAssumedRoleConfig() {
+    return createAssumedRoleConfig(getAssumedRoleARN());
+  }
+
+  /**
+   * Create a config for an assumed role; it also disables FS caching
+   * and sets the multi delete option to that of the current mode.
+   * @param roleARN ARN of role
+   * @return the new configuration
+   */
+  private Configuration createAssumedRoleConfig(String roleARN) {
+    Configuration conf = newAssumedRoleConfig(getContract().getConf(),
+        roleARN);
+    String bucketName = getTestBucketName(conf);
+
+    removeBucketOverrides(bucketName, conf, ENABLE_MULTI_DELETE);
+    conf.setBoolean(ENABLE_MULTI_DELETE, multiDelete);
+    return conf;
+  }
+
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    String bucketName = getTestBucketName(conf);
+
+    // ramp up the number of connections we can have for maximum PUT
+    // performance
+    removeBucketOverrides(bucketName, conf,
+        MAX_THREADS,
+        MAXIMUM_CONNECTIONS,
+        S3GUARD_DDB_BACKGROUND_SLEEP_MSEC_KEY);
+    conf.setInt(MAX_THREADS, EXECUTOR_THREAD_COUNT);
+    conf.setInt(MAXIMUM_CONNECTIONS, EXECUTOR_THREAD_COUNT * 2);
+    // turn off prune delays, so as to stop scale tests creating
+    // so much cruft that future CLI prune commands take forever
+    conf.setInt(S3GUARD_DDB_BACKGROUND_SLEEP_MSEC_KEY, 0);
+    return conf;
+  }
+
+  /**
+   * Create a unique path, which includes method name,
+   * multidelete flag and a random UUID.
+   * @return a string to use for paths.
+   * @throws IOException path creation failure.
+   */
+  private Path uniquePath() throws IOException {
+    return path(
+        String.format("%s-%s-%04d",
+            getMethodName(),
+            multiDelete ? "multi" : "single",
+            System.currentTimeMillis() % 10000));
+  }
+
+  /**
+   * This is here to verify role and path setup.
+   */
+  @Test
+  public void testCannotTouchUnderRODir() throws Throwable {
+    forbidden("touching the empty child " + readOnlyChild,
+        "",
+        () -> {
+          touch(roleFS, readOnlyChild);
+          return readOnlyChild;
+        });
+  }
+  @Test
+  public void testCannotReadUnderNoReadDir() throws Throwable {
+    Path path = new Path(noReadDir, "unreadable.txt");
+    createFile(getFileSystem(), path, true, "readonly".getBytes());
+    forbidden("trying to read " + path,
+        "",
+        () -> readUTF8(roleFS, path, -1));
+  }
+
+  @Test
+  public void testMultiDeleteOptionPropagated() throws Throwable {
+    describe("Verify the test parameter propagates to the store context");
+    StoreContext ctx = roleFS.createStoreContext();
+    Assertions.assertThat(ctx.isMultiObjectDeleteEnabled())
+        .as(ctx.toString())
+        .isEqualTo(multiDelete);
+  }
+
+  /**
+   * Execute a sequence of rename operations with access locked down.
+   */
+  @Test
+  public void testRenameParentPathNotWriteable() throws Throwable {
+    describe("rename with parent paths not writeable; multi=%s", multiDelete);
+    final Configuration conf = createAssumedRoleConfig();
+    bindRolePolicyStatements(conf,
+        STATEMENT_S3GUARD_CLIENT,
+        STATEMENT_ALLOW_SSE_KMS_RW,
+        STATEMENT_ALL_BUCKET_READ_ACCESS,
+        new Statement(Effects.Allow)
+            .addActions(S3_PATH_RW_OPERATIONS)
+            .addResources(directory(readOnlyDir))
+            .addResources(directory(writableDir)));
+    roleFS = (S3AFileSystem) readOnlyDir.getFileSystem(conf);
+
+    S3AFileSystem fs = getFileSystem();
+    roleFS.getFileStatus(ROOT);
+    fs.mkdirs(readOnlyDir);
+    // you can create an adjacent child
+    touch(fs, readOnlyChild);
+
+    fs.delete(writableDir, true);
+    // as dest doesn't exist, this will map child -> dest
+    assertRenameOutcome(roleFS, readOnlyChild, writableDir, true);
+
+    assertIsFile(writableDir);
+    assertIsDirectory(readOnlyDir);
+    Path renamedDestPath = new Path(readOnlyDir, writableDir.getName());
+    assertRenameOutcome(roleFS, writableDir, readOnlyDir, true);
+    assertIsFile(renamedDestPath);
+    roleFS.delete(readOnlyDir, true);
+    roleFS.delete(writableDir, true);
+  }
+
+  @Test
+  public void testRenameSingleFileFailsInDelete() throws Throwable {
+    describe("rename with source read only; multi=%s", multiDelete);
+    Path readOnlyFile = readOnlyChild;
+
+    // the full FS
+    S3AFileSystem fs = getFileSystem();
+    fs.delete(basePath, true);
+
+    // this file is readable by the roleFS, but cannot be deleted
+    touch(fs, readOnlyFile);
+
+    roleFS.delete(writableDir, true);
+    roleFS.mkdirs(writableDir);
+    // rename will fail in the delete phase
+    expectRenameForbidden(readOnlyFile, writableDir);
+
+    // and the source file is still there
+    assertIsFile(readOnlyFile);
+
+    // and so is the copied version, because there's no attempt
+    // at rollback, or preflight checking on the delete permissions
+    Path renamedFile = new Path(writableDir, readOnlyFile.getName());
+
+    assertIsFile(renamedFile);
+
+    ContractTestUtils.assertDeleted(roleFS, renamedFile, true);
+    assertFileCount("Empty Dest Dir", roleFS,
+        writableDir, 0);
+  }
+
+  /**
+   * Execute a sequence of rename operations where the source
+   * data is read only to the client calling rename().
+   * This will cause the inner delete() operations to fail, whose outcomes
+   * are explored.
+   * Multiple files are created (in parallel) for some renames, so the test
+   * explores the outcome on bulk delete calls, including verifying that a
+   * MultiObjectDeleteException is translated to an AccessDeniedException.
+   * <ol>
+   *   <li>The exception raised is AccessDeniedException,
+   *   from single and multi DELETE calls.</li>
+   *   <li>It happens after the COPY. Not ideal, but, well, we can't pretend
+   *   it's a filesystem forever.</li>
+   * </ol>
+   */
+  @Test
+  public void testRenameDirFailsInDelete() throws Throwable {
+    describe("rename with source read only; multi=%s", multiDelete);
+
+    // the full FS
+    S3AFileSystem fs = getFileSystem();
+
+    roleFS.mkdirs(writableDir);
+
+    // create a set of files
+    // this is done in parallel as it is 10x faster on a long-haul test run.
+    List<Path> createdFiles = createFiles(fs, readOnlyDir, dirDepth, fileCount,
+        dirCount);
+    // are they all there?
+    int expectedFileCount = createdFiles.size();
+    assertFileCount("files ready to rename", roleFS,
+        readOnlyDir, expectedFileCount);
+
+    // try to rename the directory
+    LOG.info("Renaming readonly files {} to {}", readOnlyDir, writableDir);
+
+    AccessDeniedException deniedException = expectRenameForbidden(readOnlyDir,
+        writableDir);
+    if (multiDelete) {
+      // look in that exception for a multidelete
+      MultiObjectDeleteException mde = extractCause(
+          MultiObjectDeleteException.class, deniedException);
+      final List<Path> undeleted
+          = extractUndeletedPaths(mde, fs::keyToQualifiedPath);
+      Assertions.assertThat(undeleted)
+          .as("files which could not be deleted")
+          .hasSize(expectedFileCount)
+          .containsAll(createdFiles)
+          .containsExactlyInAnyOrderElementsOf(createdFiles);
+    }
+    LOG.info("Result of renaming read-only files is as expected",
+        deniedException);
+    assertFileCount("files in the source directory", roleFS,
+        readOnlyDir, expectedFileCount);
+    // now lets look at the destination.
+    // even with S3Guard on, we expect the destination to match that of our
+    // the remote state.
+    // the test will exist
+    describe("Verify destination directory exists");
+    FileStatus st = roleFS.getFileStatus(writableDir);
+    assertTrue("Not a directory: " + st,
+        st.isDirectory());
+    assertFileCount("files in the dest directory", roleFS,
+        writableDir, expectedFileCount);
+  }
+
+  @Test
+  public void testRenameFileFailsNoWrite() throws Throwable {
+    describe("Try to rename to a write-only destination fails with src"
+        + " & dest unchanged.");
+    roleFS.mkdirs(writableDir);
+    S3AFileSystem fs = getFileSystem();
+    Path source = new Path(writableDir, "source");
+    touch(fs, source);
+    fs.mkdirs(readOnlyDir);
+    Path dest = new Path(readOnlyDir, "dest");
+    describe("Renaming files {} to {}", writableDir, dest);
+    // rename fails but doesn't raise an exception. Good or bad?
+    expectRenameForbidden(source, dest);
+    assertIsFile(source);
+    assertPathDoesNotExist("rename destination", dest);
+  }
+
+  @Test
+  public void testCopyDirFailsToReadOnlyDir() throws Throwable {
+    describe("Try to copy to a read-only destination");
+    roleFS.mkdirs(writableDir);
+    S3AFileSystem fs = getFileSystem();
+    List<Path> files = createFiles(fs, writableDir, dirDepth, fileCount,
+        dirCount);
+
+    fs.mkdirs(readOnlyDir);
+    Path dest = new Path(readOnlyDir, "dest");
+    expectRenameForbidden(writableDir, dest);
+    assertPathDoesNotExist("rename destination", dest);
+    assertFileCount("files in the source directory", roleFS,
+        writableDir, files.size());
+  }
+
+  @Test
+  public void testCopyFileFailsOnSourceRead() throws Throwable {
+    describe("The source file isn't readable, so the COPY fails");
+    Path source = new Path(noReadDir, "source");
+    S3AFileSystem fs = getFileSystem();
+    touch(fs, source);
+    fs.mkdirs(writableDir);
+    Path dest = new Path(writableDir, "dest");
+    expectRenameForbidden(source, dest);
+    assertIsFile(source);
+    assertPathDoesNotExist("rename destination", dest);
+  }
+
+  @Test
+  public void testCopyDirFailsOnSourceRead() throws Throwable {
+    describe("The source file isn't readable, so the COPY fails");
+    S3AFileSystem fs = getFileSystem();
+    List<Path> files = createFiles(fs, noReadDir, dirDepth, fileCount,
+        dirCount);
+    fs.mkdirs(writableDir);
+    Path dest = new Path(writableDir, "dest");
+    expectRenameForbidden(noReadDir, dest);
+    assertFileCount("files in the source directory", fs,
+        noReadDir, files.size());
+  }
+
+  /**
+   * Have a directory with full R/W permissions, but then remove
+   * write access underneath, and try to delete it.
+   */
+  @Test
+  public void testPartialDirDelete() throws Throwable {
+    describe("delete with part of the child tree read only;"
+            + " multidelete=%s", multiDelete);
+
+    // the full FS
+    S3AFileSystem fs = getFileSystem();
+
+    List<Path> readOnlyFiles = createFiles(fs, readOnlyDir,
+        dirDepth, fileCount, dirCount);
+    List<Path> deletableFiles = createFiles(fs,
+        writableDir, dirDepth, fileCount, dirCount);
+
+    // as a safety check, verify that one of the deletable files can be deleted
+    Path head = deletableFiles.remove(0);
+    assertTrue("delete " + head + " failed",
+        roleFS.delete(head, false));
+    List<Path> allFiles = Stream.concat(
+        readOnlyFiles.stream(),
+        deletableFiles.stream())
+        .collect(Collectors.toList());
+
+    // this set can be deleted by the role FS
+    MetricDiff rejectionCount = new MetricDiff(roleFS, FILES_DELETE_REJECTED);
+    MetricDiff deleteVerbCount = new MetricDiff(roleFS, OBJECT_DELETE_REQUESTS);
+
+    describe("Trying to delete read only directory");
+    AccessDeniedException ex = expectDeleteForbidden(readOnlyDir);
+    if (multiDelete) {
+      // multi-delete status checks
+      extractCause(MultiObjectDeleteException.class, ex);
+      rejectionCount.assertDiffEquals("Wrong rejection count",
+          readOnlyFiles.size());
+      deleteVerbCount.assertDiffEquals("Wrong delete count", 1);
+      reset(rejectionCount, deleteVerbCount);
+    }
+    // all the files are still there? (avoid in scale test due to cost)
+    if (!scaleTest) {
+      readOnlyFiles.forEach(this::pathMustExist);
+    }
+
+    describe("Trying to delete upper-level directory");
+    ex = expectDeleteForbidden(basePath);
+    if (multiDelete) {
+      // multi-delete status checks
+      extractCause(MultiObjectDeleteException.class, ex);
+      deleteVerbCount.assertDiffEquals("Wrong delete count", 1);
+      MultiObjectDeleteException mde = extractCause(
+          MultiObjectDeleteException.class, ex);
+      final List<Path> undeleted
+          = removeUndeletedPaths(mde, allFiles, fs::keyToQualifiedPath);
+      Assertions.assertThat(undeleted)
+          .as("files which could not be deleted")
+          .containsExactlyInAnyOrderElementsOf(readOnlyFiles);
+      Assertions.assertThat(allFiles)
+          .as("files which were deleted")
+          .containsExactlyInAnyOrderElementsOf(deletableFiles);
+      rejectionCount.assertDiffEquals("Wrong rejection count",
+          readOnlyFiles.size());
+    }
+    reset(rejectionCount, deleteVerbCount);
+
+    // build the set of all paths under the directory tree through
+    // a directory listing (i.e. not getFileStatus()).
+    // small risk of observed inconsistency here on unguarded stores.
+    final Set<Path> readOnlyListing = listFilesUnderPath(readOnlyDir, true);
+
+    String directoryList = readOnlyListing.stream()
+        .map(Path::toString)
+        .collect(Collectors.joining(", ", "[", "]"));
+
+    Assertions.assertThat(readOnlyListing)
+        .as("ReadOnly directory " + directoryList)
+        .containsAll(readOnlyFiles);
+  }
+
+  /**
+   * Expect the delete() call to fail.
+   * @param path path to delete.
+   * @return the expected exception.
+   * @throws Exception any other failure.
+   */
+  private AccessDeniedException expectDeleteForbidden(Path path)
+      throws Exception {
+    try(DurationInfo ignored =
+            new DurationInfo(LOG, true, "delete %s", path)) {
+      return forbidden("Expected an error deleting "  + path,
+          "",
+          () -> {
+            boolean r = roleFS.delete(path, true);
+            return " delete=" + r + " " + ls(path.getParent());
+          });
+    }
+  }
+
+  /**
+   * Expect that a rename will fail with an exception using the roleFS.
+   * @param src source
+   * @param dest dest
+   * @return the exception raised.
+   * @throws Exception any other failure
+   */
+  private AccessDeniedException expectRenameForbidden(Path src, Path dest)
+      throws Exception {
+    try(DurationInfo ignored =
+            new DurationInfo(LOG, true,
+                "rename(%s, %s)", src, dest)) {
+      return forbidden(
+          "Renaming " + src + " to " + dest,
+          "",
+          () -> {
+            boolean result = roleFS.rename(src, dest);
+            LOG.error("Rename should have been forbidden but returned {}",
+                result);
+            LOG.error("Source directory:\n{}",
+                ContractTestUtils.ls(getFileSystem(), src.getParent()));
+            LOG.error("Destination directory:\n{}",
+                ContractTestUtils.ls(getFileSystem(), src.getParent()));
+            return "Rename unexpectedly returned " + result;
+          });
+    }
+  }
+
+  /**
+   * Assert that a path must exist, map IOEs to RTEs for loops.
+   * @param p path.
+   */
+  private void pathMustExist(Path p) {
+    eval(() -> assertPathExists("Missing path", p));
+  }
+
+  /**
+   * Prune the store for everything under the test path.
+   * @param path path.
+   * @throws IOException on failure.
+   */
+  private void prune(Path path) throws IOException {
+    S3AFileSystem fs = getFileSystem();
+    if (fs.hasMetadataStore()) {
+      MetadataStore store = fs.getMetadataStore();
+      try(DurationInfo ignored =
+              new DurationInfo(LOG, true, "prune %s", path)) {
+        store.prune(System.currentTimeMillis(),
+            PathMetadataDynamoDBTranslation.pathToParentKey(fs.qualify(path)));
+      }
+    }
+  }
+
+  /**
+   * List all files under a path.
+   * @param path path to list
+   * @param recursive recursive listing?
+   * @return an unordered set of the paths.
+   * @throws IOException failure
+   */
+  private Set<Path> listFilesUnderPath(Path path, boolean recursive)
+      throws IOException {
+    Set<Path> files = new TreeSet<>();
+    try (DurationInfo ignore =
+             new DurationInfo(LOG, "ls -R %s", path)) {
+      applyLocatedFiles(getFileSystem().listFiles(path, recursive),
+          (status) -> files.add(status.getPath()));
+    }
+    return files;
+  }
+
+  /**
+   * Write the text to a file asynchronously. Logs the operation duration.
+   * @param fs filesystem
+   * @param path path
+   * @return future to the patch created.
+   */
+  private static CompletableFuture<Path> put(FileSystem fs,
+      Path path, String text) {
+    return submit(EXECUTOR, () -> {
+      try (DurationInfo ignore =
+               new DurationInfo(LOG, false, "Creating %s", path)) {
+        createFile(fs, path, true, text.getBytes(Charsets.UTF_8));
+        return path;
+      }
+    });
+  }
+
+  /**
+   * Parallel-touch a set of files in the destination directory.
+   * @param fs filesystem
+   * @param destDir destination
+   * @param depth file depth
+   * @param fileCount number of files to create.
+   * @param dirCount number of dirs to create at each level
+   * @return the list of files created.
+   */
+  public static List<Path> createFiles(final FileSystem fs,
+      final Path destDir,
+      final int depth,
+      final int fileCount,
+      final int dirCount) throws IOException {
+    List<CompletableFuture<Path>> futures = new ArrayList<>(fileCount);
+    List<Path> paths = new ArrayList<>(fileCount);
+    List<Path> dirs = new ArrayList<>(fileCount);
+    buildPaths(paths, dirs, destDir, depth, fileCount, dirCount);
+    try(DurationInfo ignore =
+            new DurationInfo(LOG, "Creating %d files", fileCount)) {
+      for (Path path : paths) {
+        futures.add(put(fs, path, path.getName()));
+      }
+      waitForCompletion(futures);
+      return paths;
+    }
+  }
+
+  /**
+   * Recursive method to build up lists of files and directories.
+   * @param filePaths list of file paths to add entries to.
+   * @param dirPaths list of directory paths to add entries to.
+   * @param destDir destination directory.
+   * @param depth depth of directories
+   * @param fileCount number of files.
+   * @param dirCount number of directories.
+   */
+  private static void buildPaths(
+      final List<Path> filePaths,
+      final List<Path> dirPaths,
+      final Path destDir,
+      final int depth,
+      final int fileCount,
+      final int dirCount) {
+    if (depth<=0) {
+      return;
+    }
+    // create the file paths
+    for (int i = 0; i < fileCount; i++) {
+      String name = "file-" + i;
+      Path p = new Path(destDir, name);
+      filePaths.add(p);
+    }
+    for (int i = 0; i < dirCount; i++) {
+      String name = "dir-" + i;
+      Path p = new Path(destDir, name);
+      dirPaths.add(p);
+      buildPaths(filePaths, dirPaths, p, depth - 1, fileCount, dirCount);
+    }
+
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
@@ -182,7 +182,7 @@ public class ITestPartialRenamesDeletes extends AbstractS3ATestBase {
    *
    * @return a list of parameter tuples.
    */
-  @Parameterized.Parameters(name = "bulk delete={0}")
+  @Parameterized.Parameters(name = "bulk-delete={0}")
   public static Collection<Object[]> params() {
     return Arrays.asList(new Object[][]{
         {false},

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -344,6 +344,12 @@ public class TestPartialDeleteFailures {
         final Path dest) throws IOException {
       throw new UnsupportedOperationException("unsupported");
     }
+
+    @Override
+    public void addAncestors(final Path qualifiedPath,
+        @Nullable final BulkOperationState operationState) throws IOException {
+
+    }
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -218,7 +218,8 @@ public class TestPartialDeleteFailures {
         TestPartialDeleteFailures::qualify,
         false,
         false,
-        null);
+        null,
+        () -> "us-west-1");
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -250,7 +250,6 @@ public class TestPartialDeleteFailures {
 
     @Override
     public void deleteSubtree(final Path path) {
-
     }
 
     @Override
@@ -274,11 +273,10 @@ public class TestPartialDeleteFailures {
         @Nullable final Collection<Path> pathsToDelete,
         @Nullable final Collection<PathMetadata> pathsToCreate,
         @Nullable final BulkOperationState moveState) {
-
     }
 
     @Override
-    public void put(final PathMetadata meta) throws IOException {
+    public void put(final PathMetadata meta) {
       put(meta, null);
     }
 
@@ -301,18 +299,14 @@ public class TestPartialDeleteFailures {
 
     @Override
     public void destroy() {
-
     }
 
     @Override
-    public void prune(final long modTime)
-        throws IOException, UnsupportedOperationException {
-
+    public void prune(final long modTime) {
     }
 
     @Override
-    public void prune(final long modTime, final String keyPrefix)
-        throws IOException, UnsupportedOperationException {
+    public void prune(final long modTime, final String keyPrefix) {
     }
 
     @Override
@@ -341,13 +335,13 @@ public class TestPartialDeleteFailures {
         final StoreContext storeContext,
         final Path source,
         final S3AFileStatus sourceStatus,
-        final Path dest) throws IOException {
+        final Path dest) {
       throw new UnsupportedOperationException("unsupported");
     }
 
     @Override
     public void addAncestors(final Path qualifiedPath,
-        @Nullable final BulkOperationState operationState) throws IOException {
+        @Nullable final BulkOperationState operationState) {
 
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -76,7 +76,7 @@ public class TestPartialDeleteFailures {
 
   @Before
   public void setUp() throws Exception {
-    context = craateMockStoreContext(true,
+    context = createMockStoreContext(true,
         new OperationTrackingStore());
   }
 
@@ -171,7 +171,7 @@ public class TestPartialDeleteFailures {
         deleteForbidden);
     OperationTrackingStore store
         = new OperationTrackingStore();
-    StoreContext storeContext = craateMockStoreContext(true, store);
+    StoreContext storeContext = createMockStoreContext(true, store);
     MultiObjectDeleteSupport deleteSupport
         = new MultiObjectDeleteSupport(storeContext);
     Triple<List<Path>, List<Path>, List<Pair<Path, IOException>>>
@@ -192,7 +192,7 @@ public class TestPartialDeleteFailures {
   }
 
 
-  StoreContext craateMockStoreContext(boolean multiDelete,
+  private StoreContext createMockStoreContext(boolean multiDelete,
       OperationTrackingStore store) throws URISyntaxException, IOException {
     URI name = new URI("s3a://bucket");
     return new StoreContext(

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.Invoker;
+import org.apache.hadoop.fs.s3a.S3AInputPolicy;
+import org.apache.hadoop.fs.s3a.S3AInstrumentation;
+import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
+import org.apache.hadoop.fs.s3a.s3guard.DirListingMetadata;
+import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
+import org.apache.hadoop.fs.s3a.s3guard.PathMetadata;
+import org.apache.hadoop.fs.s3a.s3guard.RenameTracker;
+import org.apache.hadoop.io.retry.RetryPolicies;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+
+import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.ACCESS_DENIED;
+import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.removeUndeletedPaths;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test suite covering translation of AWS SDK exceptions to S3A exceptions,
+ * and retry/recovery policies.
+ */
+public class TestPartialDeleteFailures {
+
+  private StoreContext context;
+
+  private static Path qualify(String k) {
+    return new Path("s3a://bucket/" + k);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    context = craateMockStoreContext(true,
+        new OperationTrackingStore());
+  }
+
+  @Test
+  public void testDeleteExtraction() {
+    List<Path> src = pathList("a", "a/b", "a/c");
+    List<Path> rejected = pathList("a/b");
+    MultiObjectDeleteException ex = createDeleteException(ACCESS_DENIED,
+        rejected);
+    List<Path> undeleted = removeUndeletedPaths(ex, src,
+        TestPartialDeleteFailures::qualify);
+    assertEquals(rejected, undeleted);
+  }
+
+  @Test
+  public void testSplitKeysFromResults() throws Throwable {
+    List<Path> src = pathList("a", "a/b", "a/c");
+    List<Path> rejected = pathList("a/b");
+    List<DeleteObjectsRequest.KeyVersion> keys = keysToDelete(src);
+    MultiObjectDeleteException ex = createDeleteException(ACCESS_DENIED,
+        rejected);
+    Pair<List<Path>, List<Path>> pair =
+        new MultiObjectDeleteSupport(context)
+          .splitUndeletedKeys(ex, keys);
+    List<Path> undeleted = pair.getLeft();
+    List<Path> deleted = pair.getRight();
+    assertEquals(rejected, undeleted);
+    // now check the deleted list to verify that it is valid
+    src.remove(rejected.get(0));
+    assertEquals(src, deleted);
+  }
+
+  /**
+   * Build a list of qualified paths from vararg parameters.
+   * @param paths paths to qualify and then convert to a lst.
+   * @return same paths as a list.
+   */
+  private List<Path> pathList(String... paths) {
+    return Arrays.stream(paths)
+        .map(TestPartialDeleteFailures::qualify)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Build a delete exception containing all the rejected paths.
+   * The list of successful entries is empty.
+   * @param rejected the rejected paths.
+   * @return a new exception
+   */
+  private MultiObjectDeleteException createDeleteException(
+      final String code,
+      final List<Path> rejected) {
+    List<MultiObjectDeleteException.DeleteError> errors = rejected.stream()
+        .map((p) -> {
+          MultiObjectDeleteException.DeleteError e
+              = new MultiObjectDeleteException.DeleteError();
+          e.setKey(p.toUri().getPath());
+          e.setCode(code);
+          e.setMessage("forbidden");
+          return e;
+        }).collect(Collectors.toList());
+    return new MultiObjectDeleteException(errors, Collections.emptyList());
+  }
+
+  /**
+   * From a list of paths, build up the list of keys for a delete request.
+   * @param paths path list
+   * @return a key list suitable for a delete request.
+   */
+  public static List<DeleteObjectsRequest.KeyVersion> keysToDelete(
+      List<Path> paths) {
+    return paths.stream()
+        .map((p) -> p.toUri().getPath())
+        .map(DeleteObjectsRequest.KeyVersion::new)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Verify that on a partial delete, the S3Guard tables are updated
+   * with deleted items. And only them.
+   */
+  @Test
+  public void testProcessDeleteFailure() throws Throwable {
+    Path pathA = qualify("/a");
+    Path pathAB = qualify("/a/b");
+    Path pathAC = qualify("/a/c");
+    List<Path> src = Lists.newArrayList(pathA, pathAB, pathAC);
+    List<DeleteObjectsRequest.KeyVersion> keyList = keysToDelete(src);
+    List<Path> deleteForbidden = Lists.newArrayList(pathAB);
+    final List<Path> deleteAllowed = Lists.newArrayList(pathA, pathAC);
+    MultiObjectDeleteException ex = createDeleteException(ACCESS_DENIED,
+        deleteForbidden);
+    OperationTrackingStore store
+        = new OperationTrackingStore();
+    StoreContext storeContext = craateMockStoreContext(true, store);
+    MultiObjectDeleteSupport deleteSupport
+        = new MultiObjectDeleteSupport(storeContext);
+    Triple<List<Path>, List<Path>, List<Pair<Path, IOException>>>
+        triple = deleteSupport.processDeleteFailure(ex, keyList);
+    Assertions.assertThat(triple.getRight())
+        .as("failure list")
+        .isEmpty();
+    List<Path> undeleted = triple.getLeft();
+    List<Path> deleted = triple.getMiddle();
+    Assertions.assertThat(deleted).
+        as("deleted files")
+        .containsAll(deleteAllowed)
+        .doesNotContainAnyElementsOf(deleteForbidden);
+    Assertions.assertThat(undeleted).
+        as("undeleted store entries")
+        .containsAll(deleteForbidden)
+        .doesNotContainAnyElementsOf(deleteAllowed);
+  }
+
+
+  StoreContext craateMockStoreContext(boolean multiDelete,
+      OperationTrackingStore store) throws URISyntaxException, IOException {
+    URI name = new URI("s3a://bucket");
+    return new StoreContext(
+        name,
+        "bucket",
+        new Configuration(),
+        "alice",
+        UserGroupInformation.getCurrentUser(),
+        BlockingThreadPoolExecutorService.newInstance(
+            4,
+            4,
+            10, TimeUnit.SECONDS,
+            "s3a-transfer-shared"),
+        Constants.DEFAULT_EXECUTOR_CAPACITY,
+        new Invoker(RetryPolicies.TRY_ONCE_THEN_FAIL, Invoker.LOG_EVENT),
+        new S3AInstrumentation(name),
+        new S3AStorageStatistics(),
+        S3AInputPolicy.Normal,
+        ChangeDetectionPolicy.createPolicy(ChangeDetectionPolicy.Mode.None,
+            ChangeDetectionPolicy.Source.ETag, false),
+        multiDelete,
+        store,
+        TestPartialDeleteFailures::qualify,
+        false,
+        false,
+        null);
+  }
+
+  /**
+   * MetadataStore which tracks what is deleted and added.
+   */
+  private static class OperationTrackingStore implements MetadataStore {
+
+    private final List<Path> deleted = new ArrayList<>();
+
+    private final List<Path> created = new ArrayList<>();
+
+    @Override
+    public void initialize(final FileSystem fs) {
+    }
+
+    @Override
+    public void initialize(final Configuration conf) {
+    }
+
+    @Override
+    public void delete(final Path path) {
+      deleted.add(path);
+    }
+
+    @Override
+    public void forgetMetadata(final Path path) {
+
+    }
+
+    @Override
+    public void deleteSubtree(final Path path) {
+
+    }
+
+    @Override
+    public PathMetadata get(final Path path) {
+      return null;
+    }
+
+    @Override
+    public PathMetadata get(final Path path,
+        final boolean wantEmptyDirectoryFlag) {
+      return null;
+    }
+
+    @Override
+    public DirListingMetadata listChildren(final Path path) {
+      return null;
+    }
+
+    @Override
+    public void move(
+        @Nullable final Collection<Path> pathsToDelete,
+        @Nullable final Collection<PathMetadata> pathsToCreate,
+        @Nullable final BulkOperationState moveState) {
+
+    }
+
+    @Override
+    public void put(final PathMetadata meta) throws IOException {
+      put(meta, null);
+    }
+
+    @Override
+    public void put(final PathMetadata meta,
+        final BulkOperationState operationState) {
+      created.add(meta.getFileStatus().getPath());
+    }
+
+    @Override
+    public void put(final Collection<PathMetadata> metas,
+        final BulkOperationState operationState) {
+      metas.stream().forEach(meta -> put(meta, null));
+    }
+
+    @Override
+    public void put(final DirListingMetadata meta) {
+      created.add(meta.getPath());
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void prune(final long modTime)
+        throws IOException, UnsupportedOperationException {
+
+    }
+
+    @Override
+    public void prune(final long modTime, final String keyPrefix)
+        throws IOException, UnsupportedOperationException {
+    }
+
+    @Override
+    public Map<String, String> getDiagnostics() {
+      return null;
+    }
+
+    @Override
+    public void updateParameters(final Map<String, String> parameters) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public List<Path> getDeleted() {
+      return deleted;
+    }
+
+    public List<Path> getCreated() {
+      return created;
+    }
+
+    @Override
+    public RenameTracker initiateRenameOperation(
+        final StoreContext storeContext,
+        final Path source,
+        final FileStatus sourceStatus,
+        final Path dest) throws IOException {
+      throw new UnsupportedOperationException("unsupported");
+    }
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -294,7 +294,8 @@ public class TestPartialDeleteFailures {
     }
 
     @Override
-    public void put(final DirListingMetadata meta) {
+    public void put(final DirListingMetadata meta,
+        final BulkOperationState operationState) {
       created.add(meta.getPath());
     }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -41,11 +41,11 @@ import org.junit.Test;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.Invoker;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AInputPolicy;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
@@ -340,7 +340,7 @@ public class TestPartialDeleteFailures {
     public RenameTracker initiateRenameOperation(
         final StoreContext storeContext,
         final Path source,
-        final FileStatus sourceStatus,
+        final S3AFileStatus sourceStatus,
         final Path dest) throws IOException {
       throw new UnsupportedOperationException("unsupported");
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
@@ -264,12 +264,13 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
       String...args) throws Exception {
     Path keepParent = path("prune-cli-keep");
     StopWatch timer = new StopWatch();
+    final S3AFileSystem fs = getFileSystem();
     try {
       S3GuardTool.Prune cmd = new S3GuardTool.Prune(cmdConf);
       cmd.setMetadataStore(ms);
 
-      getFileSystem().mkdirs(parent);
-      getFileSystem().mkdirs(keepParent);
+      fs.mkdirs(parent);
+      fs.mkdirs(keepParent);
       createFile(new Path(parent, "stale"), true, true);
       createFile(new Path(keepParent, "stale-to-keep"), true, true);
 
@@ -291,8 +292,10 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
       assertMetastoreListingCount(keepParent,
           "This child should have been kept (prefix restriction).", 1);
     } finally {
-      getFileSystem().delete(parent, true);
-      ms.prune(Long.MAX_VALUE);
+      fs.delete(parent, true);
+      fs.delete(keepParent, true);
+      ms.prune(Long.MAX_VALUE, fs.pathToKey(parent));
+      ms.prune(Long.MAX_VALUE, fs.pathToKey(keepParent));
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
@@ -204,7 +204,10 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
   protected static void putFile(MetadataStore ms, S3AFileStatus f)
       throws IOException {
     assertNotNull(f);
-    try(BulkOperationState bulkWrite = ms.initiateBulkWrite(f.getPath())) {
+    try (BulkOperationState bulkWrite =
+             ms.initiateBulkWrite(
+                 BulkOperationState.OperationType.Put,
+                 f.getPath())) {
       ms.put(new PathMetadata(f), bulkWrite);
       Path parent = f.getPath().getParent();
       while (parent != null) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStore.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -51,8 +52,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +68,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.hadoop.fs.s3a.Constants.*;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_TEST_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.SCALE_TEST_TIMEOUT_SECONDS;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
 import static org.apache.hadoop.fs.s3a.S3AUtils.clearBucketOption;
 import static org.apache.hadoop.fs.s3a.s3guard.PathMetadataDynamoDBTranslation.*;
@@ -113,6 +118,25 @@ public class ITestDynamoDBMetadataStore extends MetadataStoreTestBase {
   private static DynamoDBMetadataStore ddbmsStatic;
 
   private static String testDynamoDBTableName;
+
+
+  /**
+   * Test timeout.
+   * Uses the scale timeout option as some thing (including teardown) can be slow.
+   */
+  @Rule
+  public Timeout timeout = new Timeout(getTestTimeoutSeconds(), TimeUnit.SECONDS);
+
+  /**
+   * Get the test timeout in seconds.
+   * @return the test timeout as set in system properties or the default.
+   */
+  protected int getTestTimeoutSeconds() {
+    return getTestPropertyInt(new Configuration(),
+        KEY_TEST_TIMEOUT,
+        SCALE_TEST_TIMEOUT_SECONDS);
+  }
+
 
   /**
    * Create a path under the test path provided by
@@ -473,6 +497,7 @@ public class ITestDynamoDBMetadataStore extends MetadataStoreTestBase {
             .isGreaterThan(newMetas.size());
       }
     }
+    //
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStore.java
@@ -303,7 +303,7 @@ public class ITestDynamoDBMetadataStore extends MetadataStoreTestBase {
       if (meta != null) {
         for (DescendantsIterator desc = new DescendantsIterator(ms,
             meta);
-            desc.hasNext(); ) {
+            desc.hasNext();) {
           forgotten++;
           ms.forgetMetadata(desc.next().getPath());
         }
@@ -1006,7 +1006,8 @@ public class ITestDynamoDBMetadataStore extends MetadataStoreTestBase {
   protected List<Tag> listTagsOfStore(final DynamoDBMetadataStore store) {
     ListTagsOfResourceRequest listTagsOfResourceRequest =
         new ListTagsOfResourceRequest()
-            .withResourceArn(store.getTable().getDescription().getTableArn());
+            .withResourceArn(store.getTable().getDescription()
+                .getTableArn());
     return store.getAmazonDynamoDB()
         .listTagsOfResource(listTagsOfResourceRequest).getTags();
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
@@ -68,8 +68,8 @@ import static org.junit.Assume.*;
  * to overload the system and them have them back of until they finally complete.
  * <p>
  * With DDB on demand, throttling is very unlikely.
- * Here the tests simply run to completion, so act as regression tests on parallel
- * invocations on the metastore APIs
+ * Here the tests simply run to completion, so act as regression tests of
+ * parallel invocations on the metastore APIs
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ITestDynamoDBMetadataStoreScale
@@ -176,7 +176,7 @@ public class ITestDynamoDBMetadataStoreScale
   }
 
   private boolean expectThrottling() {
-      return !isOverProvisionedForTest && !isOnDemandTable;
+    return !isOverProvisionedForTest && !isOnDemandTable;
   }
 
   /**
@@ -351,14 +351,14 @@ public class ITestDynamoDBMetadataStoreScale
     PathMetadata metadata = new PathMetadata(status);
     ddbms.put(metadata, null);
     DirListingMetadata children = ddbms.listChildren(path.getParent());
-    try(DynamoDBMetadataStore.AncestorState state = ddbms.initiateBulkWrite(
-        BulkOperationState.OperationType.Put,
-        path)) {
+    try (DynamoDBMetadataStore.AncestorState state =
+             ddbms.initiateBulkWrite(
+                 BulkOperationState.OperationType.Put,
+                 path)) {
       execute("list",
           OPERATIONS_PER_THREAD,
           expectThrottling(),
-          () -> ddbms.put(children, state)
-      );
+          () -> ddbms.put(children, state));
     } finally {
       retryingDelete(path);
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
@@ -351,7 +351,9 @@ public class ITestDynamoDBMetadataStoreScale
     PathMetadata metadata = new PathMetadata(status);
     ddbms.put(metadata, null);
     DirListingMetadata children = ddbms.listChildren(path.getParent());
-    try(DynamoDBMetadataStore.AncestorState state = ddbms.initiateBulkWrite(path)) {
+    try(DynamoDBMetadataStore.AncestorState state = ddbms.initiateBulkWrite(
+        BulkOperationState.OperationType.Put,
+        path)) {
       execute("list",
           OPERATIONS_PER_THREAD,
           expectThrottling(),
@@ -370,7 +372,8 @@ public class ITestDynamoDBMetadataStoreScale
     List<PathMetadata> pms = new ArrayList<>();
     try {
       try (BulkOperationState bulkUpdate
-              = ddbms.initiateBulkWrite(child)) {
+              = ddbms.initiateBulkWrite(
+                  BulkOperationState.OperationType.Put, child)) {
         ddbms.put(new PathMetadata(makeDirStatus(base)), bulkUpdate);
         ddbms.put(new PathMetadata(makeDirStatus(child)), bulkUpdate);
         ddbms.getInvoker().retry("set up directory tree",
@@ -379,7 +382,8 @@ public class ITestDynamoDBMetadataStoreScale
             () -> ddbms.put(pms, bulkUpdate));
       }
       try (BulkOperationState bulkUpdate
-              = ddbms.initiateBulkWrite(child)) {
+              = ddbms.initiateBulkWrite(
+                  BulkOperationState.OperationType.Put, child)) {
         DDBPathMetadata dirData = ddbms.get(child, true);
         execute("put",
             OPERATIONS_PER_THREAD,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
@@ -363,6 +363,7 @@ public class ITestDynamoDBMetadataStoreScale
         base.toString(),
         true,
         () -> ddbms.put(pms, bulkUpdate));
+    bulkUpdate.close();
     try {
       DDBPathMetadata dirData = ddbms.get(child, true);
       execute("list",

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
+import org.junit.Assume;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.internal.AssumptionViolatedException;
@@ -53,6 +54,7 @@ import org.apache.hadoop.fs.s3a.scale.AbstractITestS3AMetadataStoreScale;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.DurationInfo;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.s3guard.MetadataStoreTestBase.basicFileStatus;
@@ -64,7 +66,10 @@ import static org.junit.Assume.*;
  * The throttle tests aren't quite trying to verify that throttling can
  * be recovered from, because that makes for very slow tests: you have
  * to overload the system and them have them back of until they finally complete.
- * Instead
+ * <p>
+ * With DDB on demand, throttling is very unlikely.
+ * Here the tests simply run to completion, so act as regression tests on parallel
+ * invocations on the metastore APIs
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ITestDynamoDBMetadataStoreScale
@@ -99,6 +104,8 @@ public class ITestDynamoDBMetadataStoreScale
 
   private static final int OPERATIONS_PER_THREAD = 50;
 
+  private boolean isOnDemandTable;
+
   /**
    * Create the metadata store. The table and region are determined from
    * the attributes of the FS used in the tests.
@@ -117,8 +124,7 @@ public class ITestDynamoDBMetadataStoreScale
         store instanceof DynamoDBMetadataStore);
     DDBCapacities capacities = DDBCapacities.extractCapacities(
         store.getDiagnostics());
-    assumeTrue("DBB table is on-demand",
-        !capacities.isOnDemandTable());
+    isOnDemandTable = capacities.isOnDemandTable();
 
     DynamoDBMetadataStore fsStore = (DynamoDBMetadataStore) store;
     Configuration conf = new Configuration(fs.getConf());
@@ -161,8 +167,6 @@ public class ITestDynamoDBMetadataStoreScale
     isOverProvisionedForTest = (
         originalCapacity.getReadCapacityUnits() > MAXIMUM_READ_CAPACITY
             || originalCapacity.getWriteCapacityUnits() > MAXIMUM_WRITE_CAPACITY);
-    assumeFalse("Table has too much capacity: " + originalCapacity.toString(),
-        isOverProvisionedForTest);
   }
 
   @Override
@@ -171,18 +175,22 @@ public class ITestDynamoDBMetadataStoreScale
     super.teardown();
   }
 
+  private boolean expectThrottling() {
+      return !isOverProvisionedForTest && !isOnDemandTable;
+  }
+
   /**
    * The subclass expects the superclass to be throttled; sometimes it is.
    */
   @Test
   @Override
   public void test_020_Moves() throws Throwable {
-    ThrottleTracker tracker = new ThrottleTracker();
+    ThrottleTracker tracker = new ThrottleTracker(ddbms);
     try {
       // if this doesn't throttle, all is well.
       super.test_020_Moves();
     } catch (AWSServiceThrottledException ex) {
-      // if the service was throttled, we ex;ect the exception text
+      // if the service was throttled, we expect the exception text
       GenericTestUtils.assertExceptionContains(
           DynamoDBMetadataStore.HINT_DDB_IOPS_TOO_LOW,
           ex,
@@ -224,9 +232,9 @@ public class ITestDynamoDBMetadataStoreScale
 
       ThrottleTracker result = execute("prune",
           1,
-          true,
+          expectThrottling(),
           () -> {
-            ThrottleTracker tracker = new ThrottleTracker();
+            ThrottleTracker tracker = new ThrottleTracker(ddbms);
             long pruneItems = 0;
             for (long i = 0; i < iterations; i++) {
               Path longPath = pathOfDepth(BATCH_SIZE, String.valueOf(i));
@@ -252,8 +260,10 @@ public class ITestDynamoDBMetadataStoreScale
               }
             }
           });
-      assertNotEquals("No batch retries in " + result,
-          0, result.batchThrottles);
+      if (expectThrottling()) {
+        assertNotEquals("No batch retries in " + result,
+            0, result.getBatchThrottles());
+      }
     } finally {
       describe("Cleaning up table %s", tableName);
       for (PathMetadata pm : toCleanup) {
@@ -277,7 +287,7 @@ public class ITestDynamoDBMetadataStoreScale
     try {
       execute("get",
           OPERATIONS_PER_THREAD,
-          true,
+          expectThrottling(),
           () -> ddbms.get(path, true)
       );
     } finally {
@@ -292,7 +302,7 @@ public class ITestDynamoDBMetadataStoreScale
   public void test_050_getVersionMarkerItem() throws Throwable {
     execute("get",
         OPERATIONS_PER_THREAD * 2,
-        true,
+        expectThrottling(),
         () -> ddbms.getVersionMarkerItem()
     );
   }
@@ -322,7 +332,7 @@ public class ITestDynamoDBMetadataStoreScale
       Path parent = path.getParent();
       execute("list",
           OPERATIONS_PER_THREAD,
-          true,
+          expectThrottling(),
           () -> ddbms.listChildren(parent)
       );
     } finally {
@@ -338,11 +348,11 @@ public class ITestDynamoDBMetadataStoreScale
     PathMetadata metadata = new PathMetadata(status);
     ddbms.put(metadata, null);
     DirListingMetadata children = ddbms.listChildren(path.getParent());
-    try {
+    try(DynamoDBMetadataStore.AncestorState state = ddbms.initiateBulkWrite(path)) {
       execute("list",
           OPERATIONS_PER_THREAD,
-          true,
-          () -> ddbms.put(children)
+          expectThrottling(),
+          () -> ddbms.put(children, state)
       );
     } finally {
       retryingDelete(path);
@@ -355,30 +365,63 @@ public class ITestDynamoDBMetadataStoreScale
     Path base = new Path("s3a://example.org/test_080_fullPathsToPut");
     Path child = new Path(base, "child");
     List<PathMetadata> pms = new ArrayList<>();
-    BulkOperationState bulkUpdate
-        = ddbms.initiateBulkWrite(child);
-    ddbms.put(new PathMetadata(makeDirStatus(base)), bulkUpdate);
-    ddbms.put(new PathMetadata(makeDirStatus(child)), bulkUpdate);
-    ddbms.getInvoker().retry("set up directory tree",
-        base.toString(),
-        true,
-        () -> ddbms.put(pms, bulkUpdate));
-    bulkUpdate.close();
-    try {
-      DDBPathMetadata dirData = ddbms.get(child, true);
-      execute("list",
-          OPERATIONS_PER_THREAD,
+    try(BulkOperationState bulkUpdate
+            = ddbms.initiateBulkWrite(child)) {
+      ddbms.put(new PathMetadata(makeDirStatus(base)), bulkUpdate);
+      ddbms.put(new PathMetadata(makeDirStatus(child)), bulkUpdate);
+      ddbms.getInvoker().retry("set up directory tree",
+          base.toString(),
           true,
-          () -> ddbms.fullPathsToPut(dirData)
+          () -> ddbms.put(pms, bulkUpdate));
+    }
+    try(BulkOperationState bulkUpdate
+            = ddbms.initiateBulkWrite(child)) {
+      DDBPathMetadata dirData = ddbms.get(child, true);
+      execute("put",
+          OPERATIONS_PER_THREAD,
+          expectThrottling(),
+          () -> ddbms.fullPathsToPut(dirData, bulkUpdate)
       );
-    } finally {
-      retryingDelete(base);
+    }
+  }
+
+  /**
+   * Try many deletes in parallel; this will create tombstones.
+   */
+  @Test
+  public void test_090_delete() throws Throwable {
+    Path path = new Path("s3a://example.org/delete");
+    S3AFileStatus status = new S3AFileStatus(true, path, "alice");
+    PathMetadata metadata = new PathMetadata(status);
+    ddbms.put(metadata, null);
+    try (DurationInfo ignored = new DurationInfo(LOG, true, "delete")) {
+      execute("delete",
+          OPERATIONS_PER_THREAD,
+          expectThrottling(),
+          () -> ddbms.delete(path)
+      );
+    }
+  }
+
+  /**
+   * Forget Metadata: delete entries without tombstones.
+   */
+  @Test
+  public void test_100_forgetMetadata() throws Throwable {
+    Path path = new Path("s3a://example.org/delete");
+    try (DurationInfo ignored = new DurationInfo(LOG, true, "delete")) {
+      execute("delete",
+          OPERATIONS_PER_THREAD,
+          expectThrottling(),
+          () -> ddbms.forgetMetadata(path)
+      );
     }
   }
 
   @Test
   public void test_900_instrumentation() throws Throwable {
     describe("verify the owner FS gets updated after throttling events");
+    Assume.assumeTrue("No throttling expected", expectThrottling());
     // we rely on the FS being shared
     S3AFileSystem fs = getFileSystem();
     String fsSummary = fs.toString();
@@ -413,7 +456,7 @@ public class ITestDynamoDBMetadataStoreScale
       throws Exception {
 
     final ContractTestUtils.NanoTimer timer = new ContractTestUtils.NanoTimer();
-    final ThrottleTracker tracker = new ThrottleTracker();
+    final ThrottleTracker tracker = new ThrottleTracker(ddbms);
     final ExecutorService executorService = Executors.newFixedThreadPool(
         THREADS);
     final List<Callable<ExecutionOutcome>> tasks = new ArrayList<>(THREADS);
@@ -512,86 +555,6 @@ public class ITestDynamoDBMetadataStoreScale
       sb.append("/");
     }
     return new Path(getFileSystem().getUri().toString(), sb.toString());
-  }
-
-  /**
-   * Something to track throttles.
-   * The constructor sets the counters to the current count in the
-   * DDB table; a call to {@link #reset()} will set it to the latest values.
-   * The {@link #probe()} will pick up the latest values to compare them with
-   * the original counts.
-   */
-  private class ThrottleTracker {
-
-    private long writeThrottleEventOrig = ddbms.getWriteThrottleEventCount();
-
-    private long readThrottleEventOrig = ddbms.getReadThrottleEventCount();
-
-    private long batchWriteThrottleCountOrig =
-        ddbms.getBatchWriteCapacityExceededCount();
-
-    private long readThrottles;
-
-    private long writeThrottles;
-
-    private long batchThrottles;
-
-    ThrottleTracker() {
-      reset();
-    }
-
-    /**
-     * Reset the counters.
-     */
-    private synchronized void reset() {
-      writeThrottleEventOrig
-          = ddbms.getWriteThrottleEventCount();
-
-      readThrottleEventOrig
-          = ddbms.getReadThrottleEventCount();
-
-      batchWriteThrottleCountOrig
-          = ddbms.getBatchWriteCapacityExceededCount();
-    }
-
-    /**
-     * Update the latest throttle count; synchronized.
-     * @return true if throttling has been detected.
-     */
-    private synchronized boolean probe() {
-      readThrottles = ddbms.getReadThrottleEventCount() - readThrottleEventOrig;
-      writeThrottles = ddbms.getWriteThrottleEventCount()
-          - writeThrottleEventOrig;
-      batchThrottles = ddbms.getBatchWriteCapacityExceededCount()
-          - batchWriteThrottleCountOrig;
-      return isThrottlingDetected();
-    }
-
-    @Override
-    public String toString() {
-      return String.format(
-          "Tracker with read throttle events = %d;"
-              + " write events = %d;"
-              + " batch throttles = %d",
-          readThrottles, writeThrottles, batchThrottles);
-    }
-
-    /**
-     * Assert that throttling has been detected.
-     */
-    void assertThrottlingDetected() {
-      assertTrue("No throttling detected in " + this +
-              " against " + ddbms.toString(),
-          isThrottlingDetected());
-    }
-
-    /**
-     * Has there been any throttling on an operation?
-     * @return true iff read, write or batch operations were throttled.
-     */
-    private boolean isThrottlingDetected() {
-      return readThrottles > 0 || writeThrottles > 0 || batchThrottles > 0;
-    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolDynamoDB.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolDynamoDB.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Callable;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.model.ListTagsOfResourceRequest;
+import com.amazonaws.services.dynamodbv2.model.ResourceInUseException;
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.amazonaws.services.dynamodbv2.model.Tag;
 import org.junit.Assert;
@@ -251,7 +252,9 @@ public class ITestS3GuardToolDynamoDB extends AbstractS3GuardToolTestBase {
           try {
             table.delete();
             table.waitForDelete();
-          } catch (ResourceNotFoundException e) { /* Ignore */ }
+          } catch (ResourceNotFoundException | ResourceInUseException e) {
+            /* Ignore */
+          }
         }
       }
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolLocal.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolLocal.java
@@ -417,7 +417,8 @@ public class ITestS3GuardToolLocal extends AbstractS3GuardToolTestBase {
         String[] fields = line.split("\\s");
         if (fields.length == 4 && fields[0].equals(Uploads.TOTAL)) {
           int parsedUploads = Integer.valueOf(fields[1]);
-          LOG.debug("Matched CLI output: {} {} {} {}", fields);
+          LOG.debug("Matched CLI output: {} {} {} {}",
+              fields[0], fields[1], fields[2], fields[3]);
           assertEquals("Unexpected number of uploads", numUploads,
               parsedUploads);
           return;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
@@ -153,7 +153,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
       final S3AFileStatus status = pathStr.contains("file")
           ? basicFileStatus(strToPath(pathStr), 100, false)
           : basicFileStatus(strToPath(pathStr), 0, true);
-      ms.put(new PathMetadata(status));
+      ms.put(new PathMetadata(status), null);
     }
 
     final PathMetadata rootMeta = new PathMetadata(makeDirStatus("/"));
@@ -240,7 +240,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
      * containing directory.  We only track direct children of the directory.
      * Thus this will not affect entry for /da1.
      */
-    ms.put(new PathMetadata(makeFileStatus("/da1/db1/fc1", 100)));
+    ms.put(new PathMetadata(makeFileStatus("/da1/db1/fc1", 100)), null);
 
     assertEmptyDirs("/da2", "/da3");
     assertDirectorySize("/da1/db1", 1);
@@ -252,7 +252,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     }
 
     /* This already exists, and should silently replace it. */
-    ms.put(new PathMetadata(makeDirStatus("/da1/db1")));
+    ms.put(new PathMetadata(makeDirStatus("/da1/db1")), null);
 
     /* If we had putNew(), and used it above, this would be empty again. */
     assertDirectorySize("/da1", 1);
@@ -260,8 +260,8 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     assertEmptyDirs("/da2", "/da3");
 
     /* Ensure new files update correct parent dirs. */
-    ms.put(new PathMetadata(makeFileStatus("/da1/db1/fc1", 100)));
-    ms.put(new PathMetadata(makeFileStatus("/da1/db1/fc2", 200)));
+    ms.put(new PathMetadata(makeFileStatus("/da1/db1/fc1", 100)), null);
+    ms.put(new PathMetadata(makeFileStatus("/da1/db1/fc2", 200)), null);
     assertDirectorySize("/da1", 1);
     assertDirectorySize("/da1/db1", 2);
     assertEmptyDirs("/da2", "/da3");
@@ -276,14 +276,15 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   public void testPutOverwrite() throws Exception {
     final String filePath = "/a1/b1/c1/some_file";
     final String dirPath = "/a1/b1/c1/d1";
-    ms.put(new PathMetadata(makeFileStatus(filePath, 100)));
-    ms.put(new PathMetadata(makeDirStatus(dirPath)));
+    ms.put(new PathMetadata(makeFileStatus(filePath, 100)), null);
+    ms.put(new PathMetadata(makeDirStatus(dirPath)), null);
     PathMetadata meta = ms.get(strToPath(filePath));
     if (!allowMissing() || meta != null) {
       verifyFileStatus(meta.getFileStatus(), 100);
     }
 
-    ms.put(new PathMetadata(basicFileStatus(strToPath(filePath), 9999, false)));
+    ms.put(new PathMetadata(basicFileStatus(strToPath(filePath), 9999, false)),
+        null);
     meta = ms.get(strToPath(filePath));
     if (!allowMissing() || meta != null) {
       verifyFileStatus(meta.getFileStatus(), 9999);
@@ -294,7 +295,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   public void testRootDirPutNew() throws Exception {
     Path rootPath = strToPath("/");
 
-    ms.put(new PathMetadata(makeFileStatus("/file1", 100)));
+    ms.put(new PathMetadata(makeFileStatus("/file1", 100)), null);
     DirListingMetadata dir = ms.listChildren(rootPath);
     if (!allowMissing() || dir != null) {
       assertNotNull("Root dir cached", dir);
@@ -334,7 +335,8 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     setUpDeleteTest(p);
     createNewDirs(p + "/ADirectory1/db1/dc1", p + "/ADirectory1/db1/dc1/dd1");
     ms.put(new PathMetadata(
-        makeFileStatus(p + "/ADirectory1/db1/dc1/dd1/deepFile", 100)));
+        makeFileStatus(p + "/ADirectory1/db1/dc1/dd1/deepFile", 100)),
+        null);
     if (!allowMissing()) {
       assertCached(p + "/ADirectory1/db1");
     }
@@ -384,9 +386,11 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     createNewDirs(prefix + "/ADirectory1", prefix + "/ADirectory2",
         prefix + "/ADirectory1/db1");
     ms.put(new PathMetadata(makeFileStatus(prefix + "/ADirectory1/db1/file1",
-        100)));
+        100)),
+        null);
     ms.put(new PathMetadata(makeFileStatus(prefix + "/ADirectory1/db1/file2",
-        100)));
+        100)),
+        null);
 
     PathMetadata meta = ms.get(strToPath(prefix + "/ADirectory1/db1/file2"));
     if (!allowMissing() || meta != null) {
@@ -399,8 +403,8 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   public void testGet() throws Exception {
     final String filePath = "/a1/b1/c1/some_file";
     final String dirPath = "/a1/b1/c1/d1";
-    ms.put(new PathMetadata(makeFileStatus(filePath, 100)));
-    ms.put(new PathMetadata(makeDirStatus(dirPath)));
+    ms.put(new PathMetadata(makeFileStatus(filePath, 100)), null);
+    ms.put(new PathMetadata(makeDirStatus(dirPath)), null);
     PathMetadata meta = ms.get(strToPath(filePath));
     if (!allowMissing() || meta != null) {
       assertNotNull("Get found file", meta);
@@ -586,7 +590,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     destMetas.add(new PathMetadata(makeDirStatus("/b1")));
     destMetas.add(new PathMetadata(makeFileStatus("/b1/file1", 100)));
     destMetas.add(new PathMetadata(makeFileStatus("/b1/file2", 100)));
-    ms.move(srcPaths, destMetas);
+    ms.move(srcPaths, destMetas, null);
 
     // Assert src is no longer there
     dirMeta = ms.listChildren(strToPath("/a1"));
@@ -630,7 +634,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     assertNull("Path2 should not be present yet.", meta);
 
     // Put p1, assert p2 doesn't match
-    ms.put(new PathMetadata(makeFileStatus(p1, 100)));
+    ms.put(new PathMetadata(makeFileStatus(p1, 100)), null);
     meta = ms.get(new Path(p2));
     assertNull("Path 2 should not match path 1.", meta);
 
@@ -649,7 +653,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     createNewDirs("/pruneFiles");
 
     long oldTime = getTime();
-    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/old", 1, oldTime)));
+    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/old", 1, oldTime)), null);
     DirListingMetadata ls2 = ms.listChildren(strToPath("/pruneFiles"));
     if (!allowMissing()) {
       assertListingsEqual(ls2.getListing(), "/pruneFiles/old");
@@ -660,7 +664,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     Thread.sleep(1);
     long cutoff = System.currentTimeMillis();
     long newTime = getTime();
-    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/new", 1, newTime)));
+    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/new", 1, newTime)), null);
 
     DirListingMetadata ls;
     ls = ms.listChildren(strToPath("/pruneFiles"));
@@ -691,7 +695,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
 
     long oldTime = getTime();
     ms.put(new PathMetadata(makeFileStatus("/pruneDirs/dir/file",
-        1, oldTime)));
+        1, oldTime)), null);
 
     // It's possible for the Local implementation to get from the old
     // modification time to here in under 1ms, causing it to not get pruned
@@ -716,10 +720,12 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     long time = System.currentTimeMillis();
     ms.put(new PathMetadata(
         basicFileStatus(0, false, 0, time - 1, strToPath(staleFile)),
-        Tristate.FALSE, false));
+        Tristate.FALSE, false),
+        null);
     ms.put(new PathMetadata(
         basicFileStatus(0, false, 0, time + 1, strToPath(freshFile)),
-        Tristate.FALSE, false));
+        Tristate.FALSE, false),
+        null);
 
     // set parent dir as authoritative
     if (!allowMissing()) {
@@ -753,10 +759,12 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     long time = System.currentTimeMillis();
     ms.put(new PathMetadata(
         basicFileStatus(0, false, 0, time + 1, strToPath(staleFile)),
-        Tristate.FALSE, false));
+        Tristate.FALSE, false),
+        null);
     ms.put(new PathMetadata(
         basicFileStatus(0, false, 0, time + 1, strToPath(freshFile)),
-        Tristate.FALSE, false));
+        Tristate.FALSE, false),
+        null);
 
     if (!allowMissing()) {
       // set parent dir as authoritative
@@ -814,7 +822,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     final S3AFileStatus fileStatus = basicFileStatus(path, 0, false);
     PathMetadata pm = new PathMetadata(fileStatus);
     pm.setIsDeleted(true);
-    ms.put(pm);
+    ms.put(pm, null);
     if(!allowMissing()) {
       final PathMetadata pathMetadata =
           ms.listChildren(path.getParent()).get(path);
@@ -854,8 +862,8 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   private void setupListStatus() throws IOException {
     createNewDirs("/a1", "/a2", "/a1/b1", "/a1/b2", "/a1/b1/c1",
         "/a1/b1/c1/d1");
-    ms.put(new PathMetadata(makeFileStatus("/a1/b1/file1", 100)));
-    ms.put(new PathMetadata(makeFileStatus("/a1/b1/file2", 100)));
+    ms.put(new PathMetadata(makeFileStatus("/a1/b1/file1", 100)), null);
+    ms.put(new PathMetadata(makeFileStatus("/a1/b1/file2", 100)), null);
   }
 
   private void assertListingsEqual(Collection<PathMetadata> listing,
@@ -886,7 +894,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
   private void createNewDirs(String... dirs)
       throws IOException {
     for (String pathStr : dirs) {
-      ms.put(new PathMetadata(makeDirStatus(pathStr)));
+      ms.put(new PathMetadata(makeDirStatus(pathStr)), null);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
@@ -532,7 +532,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     DirListingMetadata dirMeta = ms.listChildren(strToPath("/a1/b1"));
     dirMeta.setAuthoritative(true);
     dirMeta.put(makeFileStatus("/a1/b1/file_new", 100));
-    ms.put(dirMeta);
+    ms.put(dirMeta, null);
 
     dirMeta = ms.listChildren(strToPath("/a1/b1"));
     assertListingsEqual(dirMeta.getListing(), "/a1/b1/file1", "/a1/b1/file2",
@@ -733,7 +733,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     if (!allowMissing()) {
       DirListingMetadata parentDirMd = ms.listChildren(strToPath(parentDir));
       parentDirMd.setAuthoritative(true);
-      ms.put(parentDirMd);
+      ms.put(parentDirMd, null);
     }
 
     ms.prune(time);
@@ -772,7 +772,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
       // set parent dir as authoritative
       DirListingMetadata parentDirMd = ms.listChildren(strToPath(parentDir));
       parentDirMd.setAuthoritative(true);
-      ms.put(parentDirMd);
+      ms.put(parentDirMd, null);
 
       // prune the ms
       ms.prune(time);
@@ -804,7 +804,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     }
     DirListingMetadata dirMeta =
         new DirListingMetadata(strToPath(dirPath), metas, authoritative);
-    ms.put(dirMeta);
+    ms.put(dirMeta, null);
 
     if (!allowMissing()) {
       assertDirectorySize(dirPath, filenames.length);
@@ -890,7 +890,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     }
     DirListingMetadata dirMeta =
         new DirListingMetadata(strToPath(dirPath), metas, authoritative);
-    ms.put(dirMeta);
+    ms.put(dirMeta, null);
   }
 
   private void createNewDirs(String... dirs)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
@@ -653,7 +653,8 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     createNewDirs("/pruneFiles");
 
     long oldTime = getTime();
-    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/old", 1, oldTime)), null);
+    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/old", 1, oldTime)),
+        null);
     DirListingMetadata ls2 = ms.listChildren(strToPath("/pruneFiles"));
     if (!allowMissing()) {
       assertListingsEqual(ls2.getListing(), "/pruneFiles/old");
@@ -664,7 +665,8 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     Thread.sleep(1);
     long cutoff = System.currentTimeMillis();
     long newTime = getTime();
-    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/new", 1, newTime)), null);
+    ms.put(new PathMetadata(makeFileStatus("/pruneFiles/new", 1, newTime)),
+        null);
 
     DirListingMetadata ls;
     ls = ms.listChildren(strToPath("/pruneFiles"));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/MetadataStoreTestBase.java
@@ -888,7 +888,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
         .containsExactlyInAnyOrderElementsOf(b);
   }
 
-  private void putListStatusFiles(String dirPath, boolean authoritative,
+  protected void putListStatusFiles(String dirPath, boolean authoritative,
       String... filenames) throws IOException {
     ArrayList<PathMetadata> metas = new ArrayList<>(filenames .length);
     for (String filename : filenames) {
@@ -899,7 +899,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
     ms.put(dirMeta, null);
   }
 
-  private void createNewDirs(String... dirs)
+  protected void createNewDirs(String... dirs)
       throws IOException {
     for (String pathStr : dirs) {
       ms.put(new PathMetadata(makeDirStatus(pathStr)), null);
@@ -951,7 +951,7 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
    */
   Path strToPath(String p) throws IOException {
     final Path path = new Path(p);
-    assert path.isAbsolute();
+    assertTrue("Non-absolute path: " + path,  path.isAbsolute());
     return path.makeQualified(contract.getFileSystem().getUri(), null);
   }
 
@@ -986,16 +986,16 @@ public abstract class MetadataStoreTestBase extends HadoopTestBase {
       return new S3AFileStatus(Tristate.UNKNOWN, path, OWNER);
     } else {
       return new S3AFileStatus(size, newModTime, path, BLOCK_SIZE, OWNER,
-          null, null);
+          "etag", "version");
     }
   }
 
-  private S3AFileStatus makeFileStatus(String pathStr, int size) throws
+  protected S3AFileStatus makeFileStatus(String pathStr, int size) throws
       IOException {
     return makeFileStatus(pathStr, size, modTime);
   }
 
-  private S3AFileStatus makeFileStatus(String pathStr, int size,
+  protected S3AFileStatus makeFileStatus(String pathStr, int size,
       long newModTime) throws IOException {
     return basicFileStatus(strToPath(pathStr), size, false,
         newModTime);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDynamoDBMiscOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDynamoDBMiscOperations.java
@@ -26,7 +26,10 @@ import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.amazonaws.waiters.WaiterTimedOutException;
 import org.junit.Test;
 
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.AWSClientIOException;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.test.HadoopTestBase;
 import org.apache.hadoop.fs.Path;
 
@@ -107,6 +110,58 @@ public class TestDynamoDBMiscOperations extends HadoopTestBase {
 
     assertNull("The return value should be null.",
         ddbms.getDirListingMetadataFromDirMetaAndList(p, metas, dirPathMeta));
+  }
+
+  @Test
+  public void testAncestorStateForDir() throws Throwable {
+    final DynamoDBMetadataStore.AncestorState ancestorState
+        = new DynamoDBMetadataStore.AncestorState(null);
+
+    // path 1 is a directory
+    final Path path1 = new Path("s3a://bucket/1");
+    final S3AFileStatus status1 = new S3AFileStatus(true,
+        path1, "hadoop");
+    final DDBPathMetadata md1 = new DDBPathMetadata(
+        status1);
+    ancestorState.put(md1);
+    assertTrue("Status not found in ancestors",
+        ancestorState.contains(path1));
+    final DDBPathMetadata result = ancestorState.get(path1);
+    assertEquals(status1, result.getFileStatus());
+    assertTrue("Lookup failed",
+        ancestorState.findEntry(path1, true));
+    final Path path2 = new Path("s3a://bucket/2");
+    assertFalse("Lookup didn't fail",
+        ancestorState.findEntry(path2, true));
+    assertFalse("Lookup didn't fail",
+        ancestorState.contains(path2));
+    assertNull("Lookup didn't fail",
+        ancestorState.get(path2));
+  }
+
+  @Test
+  public void testAncestorStateForFile() throws Throwable {
+    final DynamoDBMetadataStore.AncestorState ancestorState
+        = new DynamoDBMetadataStore.AncestorState(null);
+
+    // path 1 is a file
+    final Path path1 = new Path("s3a://bucket/1");
+    final S3AFileStatus status1 = new S3AFileStatus(
+        1024_1024_1024L,
+        0,
+        path1,
+        32_000_000,
+        "hadoop",
+        "e4",
+        "f5");
+    final DDBPathMetadata md1 = new DDBPathMetadata(
+        status1);
+    ancestorState.put(md1);
+    assertTrue("Lookup failed",
+        ancestorState.findEntry(path1, false));
+    intercept(PathIOException.class,
+        DynamoDBMetadataStore.E_INCONSISTENT_UPDATE,
+        () -> ancestorState.findEntry(path1, true));
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDynamoDBMiscOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDynamoDBMiscOperations.java
@@ -26,7 +26,6 @@ import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.amazonaws.waiters.WaiterTimedOutException;
 import org.junit.Test;
 
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.AWSClientIOException;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
@@ -115,7 +114,8 @@ public class TestDynamoDBMiscOperations extends HadoopTestBase {
   @Test
   public void testAncestorStateForDir() throws Throwable {
     final DynamoDBMetadataStore.AncestorState ancestorState
-        = new DynamoDBMetadataStore.AncestorState(null);
+        = new DynamoDBMetadataStore.AncestorState(
+            BulkOperationState.OperationType.Rename, null);
 
     // path 1 is a directory
     final Path path1 = new Path("s3a://bucket/1");
@@ -142,7 +142,8 @@ public class TestDynamoDBMiscOperations extends HadoopTestBase {
   @Test
   public void testAncestorStateForFile() throws Throwable {
     final DynamoDBMetadataStore.AncestorState ancestorState
-        = new DynamoDBMetadataStore.AncestorState(null);
+        = new DynamoDBMetadataStore.AncestorState(
+        BulkOperationState.OperationType.Rename, null);
 
     // path 1 is a file
     final Path path1 = new Path("s3a://bucket/1");
@@ -162,6 +163,19 @@ public class TestDynamoDBMiscOperations extends HadoopTestBase {
     intercept(PathIOException.class,
         DynamoDBMetadataStore.E_INCONSISTENT_UPDATE,
         () -> ancestorState.findEntry(path1, true));
+  }
+
+  @Test
+  public void testNoBulkRenameThroughInitiateBulkWrite() throws Throwable {
+    intercept(IllegalArgumentException.class,
+        () -> S3Guard.initiateBulkWrite(null,
+            BulkOperationState.OperationType.Rename, null));
+  }
+  @Test
+  public void testInitiateBulkWrite() throws Throwable {
+    assertNull(
+        S3Guard.initiateBulkWrite(null,
+            BulkOperationState.OperationType.Put, null));
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestPathOrderComparators.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestPathOrderComparators.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.Path;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.hadoop.fs.s3a.s3guard.PathOrderComparators.TOPMOST_PATH_FIRST;
+import static org.apache.hadoop.fs.s3a.s3guard.PathOrderComparators.TOPMOST_PATH_LAST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test ordering of paths with the comparator matches requirements.
+ */
+public class TestPathOrderComparators {
+
+  private static final Path ROOT = new Path("s3a://bucket/");
+
+  public static final Path DIR_A = new Path(ROOT, "dirA");
+
+  public static final Path DIR_B = new Path(ROOT, "dirB");
+
+  public static final Path DIR_A_FILE_1 = new Path(DIR_A, "file1");
+
+  public static final Path DIR_A_FILE_2 = new Path(DIR_A, "file2");
+
+  public static final Path DIR_B_FILE_3 = new Path(DIR_B, "file3");
+
+  public static final Path DIR_B_FILE_4 = new Path(DIR_B, "file4");
+
+  @Test
+  public void testRootEqual() throws Throwable {
+    assertComparesEqual(ROOT, ROOT);
+  }
+
+  @Test
+  public void testRootFirst() throws Throwable {
+    assertComparesTopmost(ROOT, DIR_A_FILE_1);
+  }
+
+  @Test
+  public void testDirOrdering() throws Throwable {
+    assertComparesTopmost(DIR_A, DIR_B);
+  }
+
+  @Test
+  public void testFilesEqual() throws Throwable {
+    assertComparesEqual(DIR_A_FILE_1, DIR_A_FILE_1);
+  }
+
+  @Test
+  public void testFilesInSameDir() throws Throwable {
+    assertComparesTopmost(ROOT, DIR_A_FILE_1);
+    assertComparesTopmost(DIR_A, DIR_A_FILE_1);
+    assertComparesTopmost(DIR_A, DIR_A_FILE_2);
+    assertComparesTopmost(DIR_A_FILE_1, DIR_A_FILE_2);
+  }
+
+  @Test
+  public void testReversedFiles() throws Throwable {
+    assertReverseOrder(DIR_A_FILE_1, ROOT);
+    assertReverseOrder(DIR_A_FILE_1, DIR_A);
+    assertReverseOrder(DIR_A_FILE_2, DIR_A);
+    assertReverseOrder(DIR_A_FILE_2, DIR_A_FILE_1);
+  }
+
+  @Test
+  public void testFilesAndDifferentShallowDir() throws Throwable {
+    assertComparesTopmost(DIR_B, DIR_A_FILE_1);
+    assertComparesTopmost(DIR_A, DIR_B_FILE_3);
+  }
+
+  @Test
+  public void testOrderRoot() throws Throwable {
+    verifySorted(ROOT);
+  }
+
+  @Test
+  public void testOrderRootDirs() throws Throwable {
+    verifySorted(ROOT, DIR_A, DIR_B);
+  }
+
+  @Test
+  public void testOrderRootDirsAndFiles() throws Throwable {
+    verifySorted(ROOT, DIR_A, DIR_B, DIR_A_FILE_1, DIR_A_FILE_2);
+  }
+
+  @Test
+  public void testOrderRootDirsAndAllFiles() throws Throwable {
+    verifySorted(ROOT, DIR_A, DIR_B,
+        DIR_A_FILE_1, DIR_A_FILE_2,
+        DIR_B_FILE_3, DIR_B_FILE_4);
+  }
+
+  @Test
+  public void testSortOrderConstant() throws Throwable {
+    List<Path> sort1 = verifySorted(ROOT, DIR_A, DIR_B,
+        DIR_A_FILE_1, DIR_A_FILE_2,
+        DIR_B_FILE_3, DIR_B_FILE_4);
+    List<Path> sort2 = newArrayList(sort1);
+    assertSortsTo(sort2, sort1, true);
+  }
+
+  @Test
+  public void testSortReverse() throws Throwable {
+    List<Path> sort1 = newArrayList(
+        ROOT,
+        DIR_A,
+        DIR_B,
+        DIR_A_FILE_1,
+        DIR_A_FILE_2,
+        DIR_B_FILE_3,
+        DIR_B_FILE_4);
+    List<Path> expected = newArrayList(
+        DIR_B_FILE_4,
+        DIR_B_FILE_3,
+        DIR_A_FILE_2,
+        DIR_A_FILE_1,
+        DIR_B,
+        DIR_A,
+        ROOT);
+    assertSortsTo(expected, sort1, false);
+  }
+
+
+  private List<Path> verifySorted(Path... paths) {
+    List<Path> original = newArrayList(paths);
+    List<Path> sorted = newArrayList(paths);
+    assertSortsTo(original, sorted, true);
+    return sorted;
+  }
+
+  private void assertSortsTo(
+      final List<Path> original,
+      final List<Path> sorted,
+      boolean topmost) {
+    sorted.sort(topmost ? TOPMOST_PATH_FIRST : TOPMOST_PATH_LAST);
+    assertThat(sorted)
+        .as("Sorted paths")
+        .containsExactlyElementsOf(original);
+  }
+
+  private void assertComparesEqual(Path l, Path r) {
+    assertOrder(0, l, r);
+  }
+
+  private void assertComparesTopmost(Path l, Path r) {
+    assertOrder(-1, l, r);
+    assertOrder(1, r, l);
+  }
+
+  private void assertReverseOrder(Path l, Path r) {
+    assertComparesTo(-1, TOPMOST_PATH_LAST, l, r);
+    assertComparesTo(1, TOPMOST_PATH_LAST, r, l);
+  }
+
+  private void assertOrder(int res,
+      Path l, Path r) {
+    assertComparesTo(res, TOPMOST_PATH_FIRST, l, r);
+  }
+
+  private void assertComparesTo(final int expected,
+      final Comparator<Path> comparator,
+      final Path l, final Path r) {
+    int actual = comparator.compare(l, r);
+    if (actual < -1) {
+      actual = -1;
+    }
+    if (actual > 1) {
+      actual = 1;
+    }
+    assertEquals("Comparing " + l + " to " + r,
+        expected, actual);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestProgressiveRenameTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestProgressiveRenameTracker.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+/**
+ * Unit tests for {@link ProgressiveRenameTracker}.
+ */
+public class TestProgressiveRenameTracker {
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ThrottleTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ThrottleTracker.java
@@ -45,7 +45,7 @@ class ThrottleTracker {
 
   private long batchThrottles;
 
-  public ThrottleTracker(final DynamoDBMetadataStore ddbms) {
+  ThrottleTracker(final DynamoDBMetadataStore ddbms) {
     this.ddbms = ddbms;
     reset();
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ThrottleTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ThrottleTracker.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.s3guard;
+
+import org.junit.Assert;
+
+/**
+ * Something to track throttles in DynamoDB metastores.
+ * The constructor sets the counters to the current count in the
+ * DDB table; a call to {@link #reset()} will set it to the latest values.
+ * The {@link #probe()} will pick up the latest values to compare them with
+ * the original counts.
+ * <p>
+ * The toString value logs the state.
+ */
+class ThrottleTracker {
+
+  private final DynamoDBMetadataStore ddbms;
+
+  private long writeThrottleEventOrig = 0;
+
+  private long readThrottleEventOrig = 0;
+
+  private long batchWriteThrottleCountOrig = 0;
+
+  private long readThrottles;
+
+  private long writeThrottles;
+
+  private long batchThrottles;
+
+  public ThrottleTracker(final DynamoDBMetadataStore ddbms) {
+    this.ddbms = ddbms;
+    reset();
+  }
+
+  /**
+   * Reset the counters.
+   */
+  public synchronized void reset() {
+    writeThrottleEventOrig
+        = ddbms.getWriteThrottleEventCount();
+
+    readThrottleEventOrig
+        = ddbms.getReadThrottleEventCount();
+
+    batchWriteThrottleCountOrig
+        = ddbms.getBatchWriteCapacityExceededCount();
+  }
+
+  /**
+   * Update the latest throttle count; synchronized.
+   * @return true if throttling has been detected.
+   */
+  public synchronized boolean probe() {
+    setReadThrottles(
+        ddbms.getReadThrottleEventCount() - readThrottleEventOrig);
+    setWriteThrottles(ddbms.getWriteThrottleEventCount()
+        - writeThrottleEventOrig);
+    setBatchThrottles(ddbms.getBatchWriteCapacityExceededCount()
+        - batchWriteThrottleCountOrig);
+    return isThrottlingDetected();
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "Tracker with read throttle events = %d;"
+            + " write events = %d;"
+            + " batch throttles = %d",
+        getReadThrottles(), getWriteThrottles(), getBatchThrottles());
+  }
+
+  /**
+   * Assert that throttling has been detected.
+   */
+  public void assertThrottlingDetected() {
+    Assert.assertTrue("No throttling detected in " + this +
+            " against " + ddbms.toString(),
+        isThrottlingDetected());
+  }
+
+  /**
+   * Has there been any throttling on an operation?
+   * @return true iff read, write or batch operations were throttled.
+   */
+  public boolean isThrottlingDetected() {
+    return getReadThrottles() > 0 || getWriteThrottles()
+        > 0 || getBatchThrottles() > 0;
+  }
+
+  public long getReadThrottles() {
+    return readThrottles;
+  }
+
+  public void setReadThrottles(long readThrottles) {
+    this.readThrottles = readThrottles;
+  }
+
+  public long getWriteThrottles() {
+    return writeThrottles;
+  }
+
+  public void setWriteThrottles(long writeThrottles) {
+    this.writeThrottles = writeThrottles;
+  }
+
+  public long getBatchThrottles() {
+    return batchThrottles;
+  }
+
+  public void setBatchThrottles(long batchThrottles) {
+    this.batchThrottles = batchThrottles;
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
@@ -111,7 +111,8 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
     long count = 1; // Some value in case we throw an exception below
     try (MetadataStore ms = createMetadataStore()) {
 
-      try {
+      try (BulkOperationState bulkUpdate
+              = ms.initiateBulkWrite(null)) {
         // Setup
         count = populateMetadataStore(origMetas, ms);
 
@@ -130,7 +131,7 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
             toDelete = movedPaths;
             toCreate = origMetas;
           }
-          ms.move(toDelete, toCreate, null);
+          ms.move(toDelete, toCreate, bulkUpdate);
         }
         moveTimer.end();
         printTiming(LOG, "move", moveTimer, operations);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
@@ -184,7 +184,9 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
     long count = 0;
     NanoTimer putTimer = new NanoTimer();
     describe("Inserting into MetadataStore");
-    try(BulkOperationState operationState = ms.initiateBulkWrite(BUCKET_ROOT)) {
+    try (BulkOperationState operationState =
+            ms.initiateBulkWrite(BulkOperationState.OperationType.Put,
+                BUCKET_ROOT)) {
       for (PathMetadata p : paths) {
         ms.put(p, operationState);
         count++;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
@@ -111,8 +111,7 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
     long count = 1; // Some value in case we throw an exception below
     try (MetadataStore ms = createMetadataStore()) {
 
-      try (BulkOperationState bulkUpdate
-              = ms.initiateBulkWrite(null)) {
+      try {
         // Setup
         count = populateMetadataStore(origMetas, ms);
 
@@ -131,13 +130,15 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
             toDelete = movedPaths;
             toCreate = origMetas;
           }
-          ms.move(toDelete, toCreate, bulkUpdate);
+          ms.move(toDelete, toCreate, null);
         }
         moveTimer.end();
         printTiming(LOG, "move", moveTimer, operations);
       } finally {
         // Cleanup
         clearMetadataStore(ms, count);
+        ms.move(origPaths, null, null);
+        ms.move(movedPaths, null, null);
       }
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/ExtraAssertions.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/ExtraAssertions.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.util.DurationInfo;
+
+import static org.apache.hadoop.fs.s3a.S3AUtils.applyLocatedFiles;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Some extra assertions for tests.
+ */
+@InterfaceAudience.Private
+public final class ExtraAssertions {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      ExtraAssertions.class);
+
+  private ExtraAssertions() {
+  }
+
+  /**
+   * Assert that the number of files in a destination matches that expected.
+   * @param message text to use in the message
+   * @param fs filesystem
+   * @param path path to list (recursively)
+   * @param expected expected count
+   * @throws IOException IO problem
+   */
+  public static void assertFileCount(final String message,
+      final FileSystem fs,
+      final Path path,
+      final long expected)
+      throws IOException {
+    List<String> files = new ArrayList<>();
+    try (DurationInfo ignored = new DurationInfo(LOG, false,
+        "Counting files in %s", path)) {
+      applyLocatedFiles(fs.listFiles(path, true),
+          (status) -> files.add(status.getPath().toString()));
+    }
+    long actual = files.size();
+    if (actual != expected) {
+      String ls = files.stream().collect(Collectors.joining("\n"));
+      Assert.fail(message + ": expected " + expected + " files in " + path
+          + " but got " + actual + "\n" + ls);
+    }
+  }
+
+  /**
+   * Assert that a string contains a piece of text.
+   * @param text text to can.
+   * @param contained text to look for.
+   */
+  public static void assertTextContains(String text, String contained) {
+    assertTrue("string \"" + contained + "\" not found in \"" + text + "\"",
+        text != null && text.contains(contained));
+  }
+
+  /**
+   * If the condition is met, throw an AssertionError with the message
+   * and any nested exception.
+   * @param condition condition
+   * @param message text to use in the exception
+   * @param cause a (possibly null) throwable to init the cause with
+   * @throws AssertionError with the text and throwable if condition == true.
+   */
+  public static void failIf(boolean condition,
+      String message,
+      Throwable cause) {
+    if (condition) {
+      ContractTestUtils.fail(message, cause);
+    }
+  }
+
+  /**
+   * If the condition is met, throw an AssertionError with the message
+   * and any nested exception.
+   * @param condition condition
+   * @param message text to use in the exception
+   * @param cause a (possibly null) throwable to init the cause with
+   * @throws AssertionError with the text and throwable if condition == true.
+   */
+  public static void failUnless(boolean condition,
+      String message,
+      Throwable cause) {
+    failIf(!condition, message, cause);
+  }
+
+  /**
+   * Extract the inner cause of an exception.
+   * @param expected  expected class of the cause
+   * @param thrown thrown exception.
+   * @param <T> type of the cause
+   * @return the extracted exception.
+   * @throws AssertionError with the text and throwable if the cause is not as
+   * expected
+   */
+  public static <T extends Throwable> T extractCause(Class<T> expected,
+      Throwable thrown) {
+    Throwable cause = thrown.getCause();
+    failIf(cause == null,
+        "No inner cause",
+        thrown);
+    failUnless(cause.getClass().equals(expected),
+        "Inner cause is of wrong type : expected " + expected,
+        thrown);
+    return (T)cause;
+  }
+}


### PR DESCRIPTION
This is a major patch which has grown to become a "fix up the final issues with Auth mode" patch, built according to my proposed [refactoring S3A](https://github.com/steveloughran/engineering-proposals/blob/master/refactoring-s3a.md) design.

* new stuff goes into an o.a.h.fs.s3a.impl class to make clear its for implementation

## Multi-object delete:
*  `o.a.h.fs.s3a.impl.MultiObjectDeleteSupport` handles partial delete failures by parsing the response and updating the metastore with those deleted entries

## rename (i.e. copy + delete), plus scale and perf of commits

Each metastore has the notion of
* `BulkOperationState`; this can be used by a store to track entries which have been added/found during a set of operations (sequential or in parallel)
* and a `RenameTracker` which implements the algorithm for updating the store on rename. The `DelayedUpdateTracker` implements the classic "do it at the end" algorithm, while the `ProgressiveRenameTracker` does it incrementally. 
* and their own `addAncestors()` call which can update the bulk state based on examining the store and the current state of the `BulkOperationState`. This has been pushed down from `S3Guard.addAncestors()` to allow them to do their own thing with the bulk state.

`S3AFilesystem.innerRename` now copies in parallel; hard coded at 10 for now (having it a factor of the delete page size makes sense). each parallel copy operation notifies the current `RenameTracker` of its completion, so letting them choose what to do (`DelayedUpdate`: saves the change; `ProgressiveRenameTracker`: updates the store immediately). 

The RenameTracker also has the homework of updating the store state on the case of a partial rename failure. `DelayedUpdateTracker`: update the metastore; ProgressiveUpdate: no-op.

Local and DDB metastores now only use the `ProgressiveRenameTracker`; this was done after I'd move the classic design into its own tracker (i.e out of S3AFileSystem). Oh, and theres a `NullRenameTracker` for the null metastore.

The BulkOperationState ends up being passed all the way to the committers; to avoid them explicitly having to understand this, the `CommitOperations` class now has an inner (non-static) `CommitContext` class which contains this and exports the commit/abort/revert operations for the committers to call. Internally it then invokes WriteOperationHelper calls with the context, which then gets all the way through to `S3AFileSystem.finishedWrite()` for the updates there to decide what entries to put into the store.

With this design
* Renames are progressive and parallelized. So faster as well as keeping the the metastore consistent.
* Bulk delete failures are handled
* Commit operations don't generate excessive load on the store: if you are committing 500 files, then each parent dir will be checked ~once. (I say ~once as the get() is done out of a sync block, so multiple parallel entries may duplicate the work, but I'd rather that than lock during a remote RPC call).

Note that for both the parallelized commit and copy ops, we can also shuffle the source data so that we aren't doing it on the same lowest-level directory (what I'd expect today). That should reduce load on the S3 Store. With a move to parallel copy operations that will make a difference: the list comes in sequentially so the initial set of 10 renames will be adjacent. Actually I could be even cleverer there and sort by size. Why so? ensures that a large file doesn't become the straggler in the copy.
