### PR TITLE
YARN-9579:the property of sharedcache in mapred-default.xml

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -714,6 +714,8 @@
     The valid categories are: jobjar, libjars, files, archives.
     If "disabled" is specified then the job submission code will not use
     the shared cache.
+    If "enable" is specified then the job submission code will use the shared cache
+    with all resouce, include jobjar, libjars, files and archives.
   </description>
 </property>
 


### PR DESCRIPTION
add "enabled" category in mapred-default.xml.

Add the following content

`If "enable" is specified then the job submission code will use the shared cache with all resouce, include jobjar, libjars, files and archives.`