### PR TITLE
HDDS-1602. Fix TestContainerPersistence#testDeleteBlockTwice.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -229,12 +229,13 @@ public class BlockManagerImpl implements BlockManager {
       // to delete a Block which might have just gotten inserted after
       // the get check.
       byte[] kKey = Longs.toByteArray(blockID.getLocalID());
-      try {
-        db.getStore().delete(kKey);
-      } catch (IOException e) {
+
+      byte[] kData = db.getStore().get(kKey);
+      if (kData == null) {
         throw new StorageContainerException("Unable to find the block.",
             NO_SUCH_BLOCK);
       }
+      db.getStore().delete(kKey);
       // Decrement blockcount here
       container.getContainerData().decrKeyCount();
     }


### PR DESCRIPTION
As rocksdb - db.delete(key) when the key does not exist does nothing, it does not throw an exception.
First we should get and then call delete. 

As now for every block delete, we do two 2 db operations. get and then delete. If we want to avoid get(), we can directly call delete, and remove this test. But with this approach, deleteBlock can be called with some randomBlockId's and the user will not know whether this block exists, and we deleted it. (As we don't throw an exception.) So, not taken this approach. 
