### PR TITLE
HDDS-1533. JVM exit on TestHddsDatanodeService. Contributed by Mukul Kumar Singh.

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -65,13 +65,13 @@ public class TestHddsDatanodeService {
   public void testStartup() throws IOException {
     service = HddsDatanodeService.createHddsDatanodeService(args);
     service.start(conf);
-    service.join();
 
     assertNotNull(service.getDatanodeDetails());
     assertNotNull(service.getDatanodeDetails().getHostName());
     assertFalse(service.getDatanodeStateMachine().isDaemonStopped());
 
     service.stop();
+    service.join();
     service.close();
   }
 


### PR DESCRIPTION
Fix TestHddsDatanodeService exiting because of JVM exit.