### PR TITLE
HDDS-1568 : Add RocksDB metrics to OM.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStore.java
@@ -75,7 +75,8 @@ public class RocksDBStore implements MetadataStore {
         jmxProperties.put("dbName", dbFile.getName());
         statMBeanName = HddsUtils.registerWithJmxProperties(
             "Ozone", "RocksDbStore", jmxProperties,
-            new RocksDBStoreMBean(dbOptions.statistics()));
+            RocksDBStoreMBean.create(dbOptions.statistics(),
+                dbFile.getName()));
         if (statMBeanName == null) {
           LOG.warn("jmx registration failed during RocksDB init, db path :{}",
               dbFile.getAbsolutePath());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStoreMBean.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStoreMBean.java
@@ -18,10 +18,18 @@
 
 package org.apache.hadoop.utils;
 
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
 import org.rocksdb.HistogramData;
 import org.rocksdb.HistogramType;
 import org.rocksdb.Statistics;
 import org.rocksdb.TickerType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -41,19 +49,38 @@ import java.util.Set;
 /**
  * Adapter JMX bean to publish all the Rocksdb metrics.
  */
-public class RocksDBStoreMBean implements DynamicMBean {
+public class RocksDBStoreMBean implements DynamicMBean, MetricsSource {
 
   private Statistics statistics;
 
   private Set<String> histogramAttributes = new HashSet<>();
 
-  public RocksDBStoreMBean(Statistics statistics) {
+  private String contextName;
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RocksDBStoreMBean.class);
+
+  public final static String ROCKSDB_CONTEXT_PREFIX = "Rocksdb_";
+
+  public RocksDBStoreMBean(Statistics statistics, String dbName) {
+    this.contextName = ROCKSDB_CONTEXT_PREFIX + dbName;
     this.statistics = statistics;
     histogramAttributes.add("Average");
     histogramAttributes.add("Median");
     histogramAttributes.add("Percentile95");
     histogramAttributes.add("Percentile99");
     histogramAttributes.add("StandardDeviation");
+  }
+
+  public static RocksDBStoreMBean create(Statistics statistics,
+                                         String contextName) {
+
+    RocksDBStoreMBean rocksDBStoreMBean = new RocksDBStoreMBean(
+        statistics, contextName);
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(rocksDBStoreMBean.contextName,
+        "RocksDB Metrics",
+        rocksDBStoreMBean);
   }
 
   @Override
@@ -141,4 +168,47 @@ public class RocksDBStoreMBean implements DynamicMBean {
         attributes.toArray(new MBeanAttributeInfo[0]), null, null, null);
 
   }
+
+  @Override
+  public void getMetrics(MetricsCollector metricsCollector, boolean b) {
+    MetricsRecordBuilder rb = metricsCollector.addRecord(contextName);
+    getHistogramData(rb);
+    getTickerTypeData(rb);
+  }
+
+  /**
+   * Collect all histogram metrics from RocksDB statistics.
+   * @param rb Metrics Record Builder.
+   */
+  private void getHistogramData(MetricsRecordBuilder rb) {
+    for (HistogramType histogramType : HistogramType.values()) {
+      HistogramData histogram =
+          statistics.getHistogramData(
+              HistogramType.valueOf(histogramType.name()));
+      for (String histogramAttribute : histogramAttributes) {
+        try {
+          Method method =
+              HistogramData.class.getMethod("get" + histogramAttribute);
+          double metricValue =  (double) method.invoke(histogram);
+          rb.addGauge(Interns.info(histogramType.name() + "_" +
+                  histogramAttribute.toUpperCase(), "RocksDBStat"),
+              metricValue);
+        } catch (Exception e) {
+          LOG.error("Error reading histogram data {} ", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Collect all Counter metrics from RocksDB statistics.
+   * @param rb Metrics Record Builder.
+   */
+  private void getTickerTypeData(MetricsRecordBuilder rb) {
+    for (TickerType tickerType : TickerType.values()) {
+      rb.addCounter(Interns.info(tickerType.name(), "RocksDBStat"),
+          statistics.getTickerCount(tickerType));
+    }
+  }
+
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStoreMBean.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/RocksDBStoreMBean.java
@@ -78,9 +78,14 @@ public class RocksDBStoreMBean implements DynamicMBean, MetricsSource {
     RocksDBStoreMBean rocksDBStoreMBean = new RocksDBStoreMBean(
         statistics, contextName);
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(rocksDBStoreMBean.contextName,
-        "RocksDB Metrics",
-        rocksDBStoreMBean);
+    MetricsSource metricsSource = ms.getSource(rocksDBStoreMBean.contextName);
+    if (metricsSource != null) {
+      return (RocksDBStoreMBean)metricsSource;
+    } else {
+      return ms.register(rocksDBStoreMBean.contextName,
+          "RocksDB Metrics",
+          rocksDBStoreMBean);
+    }
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/db/DBStoreBuilder.java
@@ -28,6 +28,8 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
+import org.rocksdb.Statistics;
+import org.rocksdb.StatsLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +44,9 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_DB_PROFILE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS_OFF;
 
 /**
  * DBStore Builder.
@@ -57,12 +62,16 @@ public final class DBStoreBuilder {
   private List<String> tableNames;
   private Configuration configuration;
   private CodecRegistry registry;
+  private String rocksDbStat;
 
   private DBStoreBuilder(Configuration configuration) {
     tables = new HashSet<>();
     tableNames = new LinkedList<>();
     this.configuration = configuration;
     this.registry = new CodecRegistry();
+    this.rocksDbStat = configuration.getTrimmed(
+        OZONE_METADATA_STORE_ROCKSDB_STATISTICS,
+        OZONE_METADATA_STORE_ROCKSDB_STATISTICS_DEFAULT);
   }
 
   public static DBStoreBuilder newBuilder(Configuration configuration) {
@@ -187,7 +196,13 @@ public final class DBStoreBuilder {
 
     if (option == null) {
       LOG.info("Using default options. {}", dbProfile.toString());
-      return dbProfile.getDBOptions();
+      option = dbProfile.getDBOptions();
+    }
+
+    if (!rocksDbStat.equals(OZONE_METADATA_STORE_ROCKSDB_STATISTICS_OFF)) {
+      Statistics statistics = new Statistics();
+      statistics.setStatsLevel(StatsLevel.valueOf(rocksDbStat));
+      option = option.setStatistics(statistics);
     }
     return option;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/db/RDBStore.java
@@ -108,7 +108,8 @@ public class RDBStore implements DBStore {
         jmxProperties.put("dbName", dbFile.getName());
         statMBeanName = HddsUtils.registerWithJmxProperties(
             "Ozone", "RocksDbStore", jmxProperties,
-            new RocksDBStoreMBean(dbOptions.statistics()));
+            RocksDBStoreMBean.create(dbOptions.statistics(),
+                dbFile.getName()));
         if (statMBeanName == null) {
           LOG.warn("jmx registration failed during RocksDB init, db path :{}",
               dbFile.getAbsolutePath());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdds.server;
 
+import static org.apache.hadoop.utils.RocksDBStoreMBean.ROCKSDB_CONTEXT_PREFIX;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.HashMap;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricType;
 import org.apache.hadoop.metrics2.MetricsRecord;
@@ -90,6 +93,12 @@ public class PrometheusMetricsSink implements MetricsSink {
    */
   public String prometheusName(String recordName,
       String metricName) {
+
+    //RocksDB metric names already have underscores as delimiters.
+    if (StringUtils.isNotEmpty(recordName) &&
+        recordName.startsWith(ROCKSDB_CONTEXT_PREFIX)) {
+      return recordName.toLowerCase() + "_" + metricName.toLowerCase();
+    }
     String baseName = upperFirst(recordName) + upperFirst(metricName);
     Matcher m = UPPER_CASE_SEQ.matcher(baseName);
     StringBuffer sb = new StringBuffer();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
@@ -82,6 +82,11 @@ public class TestPrometheusMetricsSink {
 
     Assert.assertEquals("rpc_time_small",
         sink.prometheusName("RpcTime", "small"));
+
+    //RocksDB metrics are handled differently.
+
+    Assert.assertEquals("rocksdb_om.db_num_open_connections",
+        sink.prometheusName("Rocksdb_om.db", "num_open_connections"));
   }
 
   /**


### PR DESCRIPTION
RocksDB statistics need to sinked to hadoop-metrics2 for Ozone Manager to understand how OM behaves under heavy load.
Example: "rocksdb.bytes.written"