### PR TITLE
MAPREDUCE-7210. Replace `mapreduce.job.counters.limit` with `mapreduce.job.counters.max` in mapred-default.xml

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -1314,9 +1314,9 @@
 </property>
 
 <property>
- <name>mapreduce.job.counters.limit</name>
+ <name>mapreduce.job.counters.max</name>
   <value>120</value>
-  <description>Limit on the number of user counters allowed per job.
+  <description>The max number of user counters allowed per job.
   </description>
 </property>
 


### PR DESCRIPTION
Because the `mapreduce.job.counters.limit` is deprecated, the new property name is `mapreduce.job.counter.max`, so we need update the `mapred-default.xml`.