### PR TITLE
HDDS-1625 : ConcurrentModificationException when SCM has containers o…

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -469,15 +470,17 @@ public class SCMContainerManager implements ContainerManager {
    */
   private NavigableSet<ContainerID> getContainersForOwner(
       NavigableSet<ContainerID> containerIDs, String owner) {
-    for (ContainerID cid : containerIDs) {
+    Iterator<ContainerID> containerIDIterator = containerIDs.iterator();
+    while (containerIDIterator.hasNext()) {
+      ContainerID cid = containerIDIterator.next();
       try {
         if (!getContainer(cid).getOwner().equals(owner)) {
-          containerIDs.remove(cid);
+          containerIDIterator.remove();
         }
       } catch (ContainerNotFoundException e) {
         LOG.error("Could not find container info for container id={} {}", cid,
             e);
-        containerIDs.remove(cid);
+        containerIDIterator.remove();
       }
     }
     return containerIDs;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -123,6 +123,30 @@ public class TestContainerStateManagerIntegration {
   }
 
   @Test
+  public void testAllocateContainerWithDifferentOwner() throws IOException {
+
+    // Allocate a container and verify the container info
+    ContainerWithPipeline container1 = scm.getClientProtocolServer()
+        .allocateContainer(xceiverClientManager.getType(),
+            xceiverClientManager.getFactor(), containerOwner);
+    ContainerInfo info = containerManager
+        .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+            container1.getPipeline());
+    Assert.assertNotNull(info);
+
+    String newContainerOwner = "OZONE_NEW";
+    ContainerWithPipeline container2 = scm.getClientProtocolServer()
+        .allocateContainer(xceiverClientManager.getType(),
+            xceiverClientManager.getFactor(), newContainerOwner);
+    ContainerInfo info2 = containerManager
+        .getMatchingContainer(OzoneConsts.GB * 3, newContainerOwner,
+            container1.getPipeline());
+    Assert.assertNotNull(info2);
+
+    Assert.assertNotEquals(info.containerID(), info2.containerID());
+  }
+
+  @Test
   public void testContainerStateManagerRestart() throws IOException,
       TimeoutException, InterruptedException, AuthenticationException {
     // Allocate 5 containers in ALLOCATED state and 5 in CREATING state


### PR DESCRIPTION
…f different owners.

SCMBlockProtocolServer#allocateBlock throws ConcurrentModificationException when SCM has containers of different owners.

> 2019-05-31 13:53:16,808 WARN org.apache.hadoop.hdds.scm.container.SCMContainerManager: Container allocation failed for pipeline=Pipeline[ Id: 3e0eec4d-67d1-4582-a9e9-e68b0a340de6, Nodes: abaea3d2-a8c1-47de-8cdb-7cc5ed8f23a6{ip: 10.17.219.50, host: v

> c1340.halxg.cloudera.com, certSerialId: null}, Type:RATIS, Factor:ONE, State:OPEN] requiredSize=268435456 {}
> java.util.ConcurrentModificationException
>         at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1211)
>         at java.util.TreeMap$KeyIterator.next(TreeMap.java:1265)
>         at org.apache.hadoop.hdds.scm.container.SCMContainerManager.getContainersForOwner(SCMContainerManager.java:473)
>         at org.apache.hadoop.hdds.scm.container.SCMContainerManager.getMatchingContainer(SCMContainerManager.java:394)
>         at org.apache.hadoop.hdds.scm.block.BlockManagerImpl.allocateBlock(BlockManagerImpl.java:203)
>         at org.apache.hadoop.hdds.scm.server.SCMBlockProtocolServer.allocateBlock(SCMBlockProtocolServer.java:172)