### PR TITLE
HDDS-1629. Tar file creation can be optional for non-dist builds

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -225,24 +225,6 @@
               </arguments>
             </configuration>
           </execution>
-          <execution>
-            <id>tar-ozone</id>
-            <phase>package</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>${shell-executable}</executable>
-              <workingDirectory>${project.build.directory}
-              </workingDirectory>
-              <arguments>
-                <argument>${basedir}/dev-support/bin/dist-tar-stitching
-                </argument>
-                <argument>${hdds.version}</argument>
-                <argument>${project.build.directory}</argument>
-              </arguments>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
       <!-- there is no problem to have multiple versions of the jar files from
@@ -368,6 +350,37 @@
                   <goal>push</goal>
                 </goals>
                 <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>tar-ozone</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>${shell-executable}</executable>
+                  <workingDirectory>${project.build.directory}
+                  </workingDirectory>
+                  <arguments>
+                    <argument>${basedir}/dev-support/bin/dist-tar-stitching
+                    </argument>
+                    <argument>${hdds.version}</argument>
+                    <argument>${project.build.directory}</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Ozone tar file creation is a very time consuming step. I propose to make it optional and create the tar file only if the dist profile is enabled (-Pdist)

The tar file is not required to test ozone as the same content is available from hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT which is enough to run docker-compose pseudo clusters, smoketests. 

If it's required, the tar file creation can be requested by the dist profile.
 
On my machine (ssd based) it can cause 5-10% time improvements as the tar size is ~500MB and it requires a lot of IO.

See: https://issues.apache.org/jira/browse/HDDS-1629