### PR TITLE
HDDS-1631. Fix auditparser smoketests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -26,7 +26,7 @@ start_docker_env
 #Due to the limitation of the current auditparser test, it should be the
 #first test in a clean cluster.
 
-execute_robot_test scm auditparser
+execute_robot_test om auditparser
 
 execute_robot_test scm basic/basic.robot
 

--- a/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
@@ -36,8 +36,9 @@ Initiating freon to generate data
                        Should Not Contain               ${result}  ERROR
 
 Testing audit parser
-    ${logfile} =       Execute              ls -t /opt/hadoop/logs | grep om-audit | head -1
-                       Execute              ozone auditparser /opt/hadoop/audit.db load "/opt/hadoop/logs/${logfile}"
+    ${logdir} =        Get Environment Variable      HADOOP_LOG_DIR     /var/log/hadoop
+    ${logfile} =       Execute              ls -t "${logdir}" | grep om-audit | head -1
+                       Execute              ozone auditparser /opt/hadoop/audit.db load "${logdir}/${logfile}"
     ${result} =        Execute              ozone auditparser /opt/hadoop/audit.db template top5cmds
                        Should Contain       ${result}  ALLOCATE_KEY
     ${result} =        Execute              ozone auditparser /opt/hadoop/audit.db template top5users


### PR DESCRIPTION
In HDDS-1518 we modified the location of the var and config files inside the container.

There are three problems with the current auditparser smokest:

 1. The default audit log4j files are not part of the new config directory (fixed with HDDS-1630)
 2. The smoketest is executed in scm container instead of om
 3. The log directory is hard coded

The 2 and 3 will be fined in this patch. 

See: https://issues.apache.org/jira/browse/HDDS-1631