### PR TITLE
HDDS-1510. Classpath files are deployed to the maven repository as pom/jar files

### DIFF
--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -320,10 +320,32 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>build-classpath</goal>
             </goals>
             <configuration>
-              <attach>true</attach>
+              <outputFile>${project.build.directory}/classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>
               <outputFilterFile>true</outputFilterFile>
               <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-classpath-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/classpath</file>
+                  <type>cp</type>
+                  <classifier>classpath</classifier>
+                </artifact>
+              </artifacts>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -52,6 +52,7 @@
                   <artifactId>hadoop-hdds-server-scm</artifactId>
                   <version>${hdds.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-hdds-server-scm.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -59,6 +60,7 @@
                   <artifactId>hadoop-hdds-tools</artifactId>
                   <version>${hdds.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-hdds-tools.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -66,6 +68,7 @@
                   <artifactId>hadoop-ozone-s3gateway</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-s3gateway.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -73,6 +76,7 @@
                   <artifactId>hadoop-ozone-csi</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-csi.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -80,6 +84,7 @@
                   <artifactId>hadoop-ozone-ozone-manager</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-ozone-manager.classpath
                   </destFileName>
                 </artifactItem>
@@ -88,6 +93,7 @@
                   <artifactId>hadoop-ozone-tools</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-tools.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -95,6 +101,7 @@
                   <artifactId>hadoop-ozone-filesystem</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-filesystem.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -102,6 +109,7 @@
                   <artifactId>hadoop-ozone-common</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-common.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -109,6 +117,7 @@
                   <artifactId>hadoop-ozone-datanode</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-datanode.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -116,6 +125,7 @@
                   <artifactId>hadoop-ozone-recon</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-recon.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
@@ -123,6 +133,7 @@
                   <artifactId>hadoop-ozone-upgrade</artifactId>
                   <version>${ozone.version}</version>
                   <classifier>classpath</classifier>
+                  <type>cp</type>
                   <destFileName>hadoop-ozone-upgrade.classpath</destFileName>
                 </artifactItem>
               </artifactItems>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -309,10 +309,32 @@
               <goal>build-classpath</goal>
             </goals>
             <configuration>
-              <attach>true</attach>
+              <outputFile>${project.build.directory}/classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>
               <outputFilterFile>true</outputFilterFile>
               <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-classpath-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/classpath</file>
+                  <type>cp</type>
+                  <classifier>classpath</classifier>
+                </artifact>
+              </artifacts>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
1. Classpath files are plain text files which are generatede for each ozone projects. Classpath files are used to defined the classpath of a module (om, scm, etc) based on the maven classpath.

Example classpath file:

{code}
classpath=$HDDS_LIB_JARS_DIR/kerb-simplekdc-1.0.1.jar:$HDDS_LIB_JARS_DIR/hk2-utils-2.5.0.jar:$HDDS_LIB_JARS_DIR/jackson-core-2.9.5.jar:$HDDS_LIB_JARS_DIR/ratis-netty-0.4.0-fe2b15d-SNAPSHOT.jar:$HDDS_LIB_JARS_DIR/protobuf-java-2.5.0.jar:... 
{code}

Classpath files are maven artifacts and copied to share/ozone/classpath in the distribution

2. 0.4.0 was the first release when we deployed the artifacts to the apache nexus. [~ajayydv] reported the problem that the staging repository can't be closed: INFRA-18344

It turned out that the classpath files are uploaded with jar extension to the repository. We deleted all the classpath files manually and the repository became closable.

To avoid similar issues we need to fix this problem and make sure that the classpath files are not uploaded to the repository during a 'mvn deploy' or uploaded but with a good extension.

ps: I don't know the exact solution yet, but I can imagine that bumping the version of maven deploy plugin can help. Seems to be a bug in the plugin.

ps2: This is blocker as we need to fix it before the next release

See: https://issues.apache.org/jira/browse/HDDS-1510