### PR TITLE
HDDS-1628. Fix the execution and return code of smoketest executor shell script

### DIFF
--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -15,5 +15,5 @@
 # limitations under the License.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export HADOOP_VERSION=3
-$DIR/../../../hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/test-all.sh
+"$DIR/../../../hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/test-all.sh"
 exit $?

--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export HADOOP_VERSION=3
-hadoop-ozone/dist/target/ozone-*-SNAPSHOT/smoketest/test.sh
+$DIR/../../../hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/test-all.sh
 exit $?

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -34,7 +34,7 @@ for test in $(find $SCRIPT_DIR -name test.sh); do
 
   #required to read the .env file from the right location
   cd "$(dirname "$test")" || continue
-  $test
+  ./test.sh
   ret=$?
   if [[ $ret -ne 0 ]]; then
       RESULT=-1

--- a/hadoop-ozone/dist/src/main/smoketest/test.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/test.sh
@@ -23,5 +23,6 @@ REPLACEMENT="$DIR/../compose/test-all.sh"
 echo "THIS SCRIPT IS DEPRECATED. Please use $REPLACEMENT instead."
 
 ${REPLACEMENT}
-
+RESULT=$?
 cp -r "$DIR/../compose/result" "$DIR"
+exit $RESULT


### PR DESCRIPTION
Problem: Some of the smoketest executions were reported to green even if they contained failed tests.

Root cause: the legacy test executor (hadoop-ozone/dist/src/main/smoketest/test.sh) which just calls the new executor script (hadoop-ozone/dist/src/main/compose/test-all.sh) didn't handle the return code well (the failure of the smoketests should be signalled by the bash return code)

This patch:
 * Fixes the error code handling in smoketest/test.sh
 * Fixes the test execution in compose/test-all.sh (should work from any other directories)
 * Updates hadoop-ozone/dev-support/checks/acceptance.sh to use the newer test-all.sh executor instead of the old one.

See: https://issues.apache.org/jira/browse/HDDS-1628