### PR TITLE
HDDS-1641. Csi server fails because transitive Netty dependencies

### DIFF
--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -46,6 +46,16 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-config</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -65,6 +75,11 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
+      <version>4.1.30.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
       <version>4.1.30.Final</version>
     </dependency>
     <dependency>
@@ -98,6 +113,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
CSI server can't be started because an ClassNotFound exception.

It turned out that with using the new configuration api we got old netty jar files as transitive dependencies. (hdds-configuration depends on hadoop-common, hadoop-commons depends on the word)

We should exclude all the old netty version from the classpath of the CSI server.

See: https://issues.apache.org/jira/browse/HDDS-1641