### PR TITLE
HDDS-1640. Reduce the size of recon jar file

### DIFF
--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -342,6 +342,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/node_modules/*</exclude>
+            <exclude>**/ozone-recon-web/**</exclude>
+          </excludes>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
hadoop-ozone-recon-0.5.0-SNAPSHOT.jar is 73 MB, mainly because the node_modules are included (full typescript source, eslint, babel, etc.)

This PR reduces the size of recon jar file to 1.7MB after excluding node_modules.

 