### PR TITLE
YARN-9601:Potential NPE in ZookeeperFederationStateStore#getPoliciesC…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -422,6 +422,10 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     try {
       for (String child : zkManager.getChildren(policiesZNode)) {
         SubClusterPolicyConfiguration policy = getPolicy(child);
+        if (policy == null) {
+          LOG.warn("Policy for queue: {} does not exist.", child);
+          continue;
+        }
         result.add(policy);
       }
     } catch (Exception e) {


### PR DESCRIPTION
Potential NPE in ZookeeperFederationStateStore#getPoliciesConfigurations

The code of ZookeeperFederationStateStore#getPoliciesConfigurations
``` java
for (String child : zkManager.getChildren(policiesZNode)) {
  SubClusterPolicyConfiguration policy = getPolicy(child);
  result.add(policy);
}
```
The result of `getPolicy` may be null, so policy should be checked 

The new code 
``` java
for (String child : zkManager.getChildren(policiesZNode)) {
  SubClusterPolicyConfiguration policy = getPolicy(child);
  // policy maybe null, should check
  if (policy == null) {
    LOG.warn("Policy for queue: {} does not exist.", child);
    continue;
  }
  result.add(policy);
}
```