### PR TITLE
HDDS-1645 Change the version of Pico CLI to the latest 3.x release - 3.9.6

### DIFF
--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -239,7 +239,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>3.5.2</version>
+      <version>3.9.6</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShell.java
@@ -631,7 +631,8 @@ public class TestOzoneShell {
     err.reset();
     args = new String[] {"volume", "list", url + "/", "--user",
         user2, "--length", "invalid-length"};
-    executeWithError(shell, args, "For input string: \"invalid-length\"");
+    executeWithError(shell, args, "Invalid value for option " +
+        "'--length': 'invalid-length' is not an int");
   }
 
   @Test


### PR DESCRIPTION
The version of Pico CLI used in the project is 3.5.2. The current stable release is 3.9.6 and it supports some good new features, such as being able to create sub-commands as methods rather than standalone classes.

We should increase the Pico CLI version in the project pom.xml to 3.9.6 to take advantage of these new features as the CLI code is refactored to use Pico CLI, such as in HDDS-1622.