### PR TITLE
HDDS-1621. writeData in ChunkUtils should not use AsynchronousFileChannel. Contributed by Supratim Deka

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.StandardOpenOption;
 import java.security.NoSuchAlgorithmException;
@@ -84,23 +85,20 @@ public final class ChunkUtils {
       throw new StorageContainerException(err, INVALID_WRITE_SIZE);
     }
 
-    AsynchronousFileChannel file = null;
+    FileChannel file = null;
     FileLock lock = null;
 
     try {
       long writeTimeStart = Time.monotonicNow();
-      file = sync ?
-          AsynchronousFileChannel.open(chunkFile.toPath(),
-              StandardOpenOption.CREATE,
-              StandardOpenOption.WRITE,
-              StandardOpenOption.SPARSE,
-              StandardOpenOption.SYNC) :
-          AsynchronousFileChannel.open(chunkFile.toPath(),
+
+      // skip SYNC and DSYNC to reduce contention on file.lock
+      file = FileChannel.open(chunkFile.toPath(),
               StandardOpenOption.CREATE,
               StandardOpenOption.WRITE,
               StandardOpenOption.SPARSE);
-      lock = file.lock().get();
-      int size = file.write(data, chunkInfo.getOffset()).get();
+
+      lock = file.lock();
+      int size = file.write(data, chunkInfo.getOffset());
       // Increment volumeIO stats here.
       volumeIOStats.incWriteTime(Time.monotonicNow() - writeTimeStart);
       volumeIOStats.incWriteOpCount();
@@ -128,6 +126,10 @@ public final class ChunkUtils {
       }
       if (file != null) {
         try {
+          if (sync) {
+            // ensure data and metadata is persisted. Outside the lock
+            file.force(true);
+          }
           file.close();
         } catch (IOException e) {
           throw new StorageContainerException("Error closing chunk file",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-1621

2 changes:
1. invoking a force+close on the channel inside writeData if dfs.container.chunk.write.sync is true. The force is triggered outside of the file lock, to avoid unnecessary lock contention.
2. change AsynchronousFileChannel to FileChannel for writing the file. This is the right thing to do because writeStateMachineData is already scheduling the write chunk requests asynchronously on threads from XceiverServerRatis.chunkExecutor.