### PR TITLE
HDDS-1622 Use picocli for StorageContainerManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStarterInterface.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStarterInterface.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache
+ * License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.server;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import java.io.IOException;
+
+/**
+ * This interface is used by the StorageContainerManager to allow the
+ * dependencies to be injected to the CLI class
+ */
+public interface SCMStarterInterface {
+
+  public void start(OzoneConfiguration conf) throws Exception;
+  public boolean init(OzoneConfiguration conf, String clusterId)
+      throws IOException;
+  public String generateClusterId();
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStarterInterface.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStarterInterface.java
@@ -26,12 +26,12 @@ import java.io.IOException;
 
 /**
  * This interface is used by the StorageContainerManager to allow the
- * dependencies to be injected to the CLI class
+ * dependencies to be injected to the CLI class.
  */
 public interface SCMStarterInterface {
 
-  public void start(OzoneConfiguration conf) throws Exception;
-  public boolean init(OzoneConfiguration conf, String clusterId)
+  void start(OzoneConfiguration conf) throws Exception;
+  boolean init(OzoneConfiguration conf, String clusterId)
       throws IOException;
-  public String generateClusterId();
+  String generateClusterId();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -81,7 +81,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.authority.DefaultCAServe
 import org.apache.hadoop.hdds.server.ServiceRuntimeInfoImpl;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.RPC;
@@ -90,7 +89,6 @@ import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
-import org.apache.hadoop.ozone.common.StorageInfo;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.apache.hadoop.ozone.lock.LockManager;
 import org.apache.hadoop.ozone.protocol.commands.RetriableDatanodeEventWatcher;
@@ -98,16 +96,13 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.util.JvmPauseMonitor;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.utils.HddsVersionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.management.ObjectName;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -120,7 +115,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_KERBEROS_KEYTAB_
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ENABLED;
-import static org.apache.hadoop.util.ExitUtil.terminate;
 
 /**
  * StorageContainerManager is the main entry point for the service that
@@ -590,7 +584,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       System.exit(1);
     }
     return new StorageContainerManager(conf);
-    }
+  }
 
   /**
    * Routine to set up the Version info for StorageContainerManager.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -94,7 +94,7 @@ public class StorageContainerManagerStarter extends GenericCli {
   @CommandLine.Command(name = "--init",
       customSynopsis = "ozone scm [global options] --init [options]",
       hidden = false,
-      description = "Initialize / format the SCM",
+      description = "Initialize the SCM if not already initialized",
       mixinStandardHelpOptions = true,
       versionProvider = HddsVersionProvider.class)
   public void initScm(@CommandLine.Option(names = { "--clusterid" },
@@ -104,7 +104,7 @@ public class StorageContainerManagerStarter extends GenericCli {
     commonInit();
     boolean result = receiver.init(conf, clusterId);
     if (!result) {
-      throw new IOException("SCM Init failed. Check the log for more details");
+      throw new IOException("scm init failed");
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache
+ * License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.server;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ozone.common.StorageInfo;
+import org.apache.hadoop.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import static org.apache.hadoop.util.ExitUtil.terminate;
+
+/**
+ * This class provides a command line interface to start the SCM
+ * using Picocli.
+ */
+
+@Command(name = "ozone scm",
+    hidden = true, description = "Start or initialize the scm server.",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true)
+public class StorageContainerManagerStarter extends GenericCli {
+
+  private OzoneConfiguration conf;
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(StorageContainerManagerStarter.class);
+
+  public static void main(String[] args) throws Exception {
+    TracingUtil.initTracing("StorageContainerManager");
+    new StorageContainerManagerStarter().run(args);
+  }
+
+  public StorageContainerManagerStarter() {
+    super();
+  }
+
+  @Override
+  public Void call() throws Exception {
+    commonInit();
+    startScm();
+    return null;
+  }
+
+  /**
+   * This function implements a sub-command to generate a new
+   * cluster ID from the command line.
+   */
+  @CommandLine.Command(name = "--genclusterid",
+      customSynopsis = "ozone scm [global options] --genclusterid [options]",
+      hidden = false,
+      description = "Generate a new Cluster ID",
+      mixinStandardHelpOptions = true,
+      versionProvider = HddsVersionProvider.class)
+  public void generateClusterId() {
+    commonInit();
+    System.out.println("Generating new cluster id:");
+    System.out.println(StorageInfo.newClusterID());
+    terminate(0);
+  }
+
+  /**
+   * This function implements a sub-command to allow the SCM to be
+   * initialized from the command line.
+   *
+   * @param clusterId - Cluster ID to use when initializing. If null,
+   *                  a random ID will be generated and used.
+   */
+  @CommandLine.Command(name = "--init",
+      customSynopsis = "ozone scm [global options] --init [options]",
+      hidden = false,
+      description = "Initialize / format the SCM",
+      mixinStandardHelpOptions = true,
+      versionProvider = HddsVersionProvider.class)
+  public void initScm(@CommandLine.Option(names = { "--clusterid" },
+      description = "Optional: The cluster id to use when formatting SCM",
+      paramLabel = "id") String clusterId)
+      throws Exception {
+    commonInit();
+    terminate(StorageContainerManager.scmInit(conf, clusterId) ? 0 : 1);
+  }
+
+  /**
+   * This function is used by the command line to start the SCM.
+   */
+  private void startScm() throws Exception {
+    StorageContainerManager stm = StorageContainerManager.createSCM(conf);
+    stm.start();
+    stm.join();
+  }
+
+  /**
+   * This function should be called by each command to ensure the configuration
+   * is set and print the startup banner message.
+   */
+  private void commonInit() {
+    conf = createOzoneConfiguration();
+
+    String[] originalArgs = getCmd().getParseResult().originalArgs()
+        .toArray(new String[0]);
+    StringUtils.startupShutdownMessage(StorageContainerManager.class,
+        originalArgs, LOG);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -34,8 +34,6 @@ import picocli.CommandLine.Command;
 
 import java.io.IOException;
 
-import static org.apache.hadoop.util.ExitUtil.terminate;
-
 /**
  * This class provides a command line interface to start the SCM
  * using Picocli.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -91,7 +91,7 @@ public final class HddsTestUtils {
       // writes the version file properties
       scmStore.initialize();
     }
-    return StorageContainerManager.createSCM(null, conf);
+    return StorageContainerManager.createSCM(conf);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
@@ -1,0 +1,144 @@
+package org.apache.hadoop.hdds.scm.server;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static org.junit.Assert.*;
+
+public class TestStorageContainerManagerStarter {
+
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+
+  private MockSCMStarter mock;
+
+  @Before
+  public void setUpStreams() {
+    System.setOut(new PrintStream(outContent));
+    System.setErr(new PrintStream(errContent));
+    mock = new MockSCMStarter();
+  }
+
+  @After
+  public void restoreStreams() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void TestCallsStartWhenServerStarted() throws Exception {
+    executeCommand();
+    assertTrue(mock.startCalled);
+  }
+
+  @Test
+  public void TestExceptionThrownWhenStartFails() throws Exception {
+    mock.throwOnStart = true;
+    try {
+      executeCommand();
+      fail("Exception show have been thrown");
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
+  public void TestStartNotCalledWithInvalidParam() throws Exception {
+    executeCommand("--invalid");
+    assertFalse(mock.startCalled);
+  }
+
+  @Test
+  public void TestPassingInitSwitchCallsInit() {
+    executeCommand("--init");
+    assertTrue(mock.initCalled);
+  }
+
+  @Test
+  public void TestInitSwitchAcceptsClusterIdSSwitch() {
+    executeCommand("--init", "--clusterid=abcdefg");
+    assertEquals("abcdefg", mock.clusterId);
+  }
+
+  @Test
+  public void TestInitSwitchWithInvalidParamDoesNotRun() {
+    executeCommand("--init", "--clusterid=abcdefg", "--invalid" );
+    assertFalse(mock.initCalled);
+  }
+
+  @Test
+  public void TestUnSuccessfulInitThrowsException() {
+    mock.throwOnInit = true;
+      try {
+        executeCommand("--init");
+      fail("Exception show have been thrown");
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
+  public void TestGenClusterIdRunsGenerate() {
+    executeCommand("--genclusterid");
+    assertTrue(mock.generateCalled);
+  }
+
+  @Test
+  public void TestGenClusterIdWithInvalidParamDoesNotRun() {
+    executeCommand("--genclusterid", "--invalid");
+    assertFalse(mock.generateCalled);
+  }
+
+  @Test
+  public void TestUsagePrintedOnInvalidInput() {
+    executeCommand("--invalid");
+    Pattern p = Pattern.compile("^Unknown option:.*--invalid.*\nUsage");
+    Matcher m = p.matcher(errContent.toString());
+    assertTrue(m.find());
+  }
+
+  private void executeCommand(String ... args) {
+    new StorageContainerManagerStarter(mock).execute(args);
+  }
+
+  static class MockSCMStarter implements SCMStarterInterface {
+
+    public boolean initStatus = true;
+    public boolean throwOnStart = false;
+    public boolean throwOnInit  = false;
+    public boolean startCalled = false;
+    public boolean initCalled = false;
+    public boolean generateCalled = false;
+    public String clusterId = null;
+
+    public void start(OzoneConfiguration conf) throws Exception {
+      if (throwOnStart) {
+        throw new Exception("Simulated error on start");
+      }
+      startCalled = true;
+    }
+
+    public boolean init(OzoneConfiguration conf, String cid)
+        throws IOException {
+      if (throwOnInit) {
+        throw new IOException("Simulated error on init");
+      }
+      initCalled = true;
+      clusterId = cid;
+      return initStatus;
+    }
+
+    public String generateClusterId() {
+      generateCalled = true;
+      return "static-cluster-id";
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
@@ -11,6 +11,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import static org.junit.Assert.*;
 
+
+/**
+ * This class is used to test the StorageContainerManagerStarter using a mock
+ * class to avoid starting any services and hence just test the CLI component.
+ */
 public class TestStorageContainerManagerStarter {
 
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
@@ -34,13 +39,13 @@ public class TestStorageContainerManagerStarter {
   }
 
   @Test
-  public void TestCallsStartWhenServerStarted() throws Exception {
+  public void testCallsStartWhenServerStarted() throws Exception {
     executeCommand();
     assertTrue(mock.startCalled);
   }
 
   @Test
-  public void TestExceptionThrownWhenStartFails() throws Exception {
+  public void testExceptionThrownWhenStartFails() throws Exception {
     mock.throwOnStart = true;
     try {
       executeCommand();
@@ -51,34 +56,34 @@ public class TestStorageContainerManagerStarter {
   }
 
   @Test
-  public void TestStartNotCalledWithInvalidParam() throws Exception {
+  public void testStartNotCalledWithInvalidParam() throws Exception {
     executeCommand("--invalid");
     assertFalse(mock.startCalled);
   }
 
   @Test
-  public void TestPassingInitSwitchCallsInit() {
+  public void testPassingInitSwitchCallsInit() {
     executeCommand("--init");
     assertTrue(mock.initCalled);
   }
 
   @Test
-  public void TestInitSwitchAcceptsClusterIdSSwitch() {
+  public void testInitSwitchAcceptsClusterIdSSwitch() {
     executeCommand("--init", "--clusterid=abcdefg");
     assertEquals("abcdefg", mock.clusterId);
   }
 
   @Test
-  public void TestInitSwitchWithInvalidParamDoesNotRun() {
-    executeCommand("--init", "--clusterid=abcdefg", "--invalid" );
+  public void testInitSwitchWithInvalidParamDoesNotRun() {
+    executeCommand("--init", "--clusterid=abcdefg", "--invalid");
     assertFalse(mock.initCalled);
   }
 
   @Test
-  public void TestUnSuccessfulInitThrowsException() {
+  public void testUnSuccessfulInitThrowsException() {
     mock.throwOnInit = true;
-      try {
-        executeCommand("--init");
+    try {
+      executeCommand("--init");
       fail("Exception show have been thrown");
     } catch (Exception e) {
       assertTrue(true);
@@ -86,38 +91,38 @@ public class TestStorageContainerManagerStarter {
   }
 
   @Test
-  public void TestGenClusterIdRunsGenerate() {
+  public void testGenClusterIdRunsGenerate() {
     executeCommand("--genclusterid");
     assertTrue(mock.generateCalled);
   }
 
   @Test
-  public void TestGenClusterIdWithInvalidParamDoesNotRun() {
+  public void testGenClusterIdWithInvalidParamDoesNotRun() {
     executeCommand("--genclusterid", "--invalid");
     assertFalse(mock.generateCalled);
   }
 
   @Test
-  public void TestUsagePrintedOnInvalidInput() {
+  public void testUsagePrintedOnInvalidInput() {
     executeCommand("--invalid");
     Pattern p = Pattern.compile("^Unknown option:.*--invalid.*\nUsage");
     Matcher m = p.matcher(errContent.toString());
     assertTrue(m.find());
   }
 
-  private void executeCommand(String ... args) {
+  private void executeCommand(String... args) {
     new StorageContainerManagerStarter(mock).execute(args);
   }
 
   static class MockSCMStarter implements SCMStarterInterface {
 
-    public boolean initStatus = true;
-    public boolean throwOnStart = false;
-    public boolean throwOnInit  = false;
-    public boolean startCalled = false;
-    public boolean initCalled = false;
-    public boolean generateCalled = false;
-    public String clusterId = null;
+    private boolean initStatus = true;
+    private boolean throwOnStart = false;
+    private boolean throwOnInit  = false;
+    private boolean startCalled = false;
+    private boolean initCalled = false;
+    private boolean generateCalled = false;
+    private String clusterId = null;
 
     public void start(OzoneConfiguration conf) throws Exception {
       if (throwOnStart) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds.scm.server;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -144,7 +144,7 @@ function ozonecmd_case
     ;;
     scm)
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
-      HADOOP_CLASSNAME='org.apache.hadoop.hdds.scm.server.StorageContainerManager'
+      HADOOP_CLASSNAME='org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter'
       hadoop_debug "Appending HDFS_STORAGECONTAINERMANAGER_OPTS onto HADOOP_OPTS"
       HDFS_STORAGECONTAINERMANAGER_OPTS="${HDFS_STORAGECONTAINERMANAGER_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/scm-audit-log4j2.properties"
       HADOOP_OPTS="${HADOOP_OPTS} ${HDFS_STORAGECONTAINERMANAGER_OPTS}"

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -254,7 +254,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       AuthenticationException {
     scm.stop();
     scm.join();
-    scm = StorageContainerManager.createSCM(null, conf);
+    scm = StorageContainerManager.createSCM(conf);
     scm.start();
     if (waitForDatanode) {
       waitForClusterToBeReady();
@@ -475,7 +475,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       configureSCM();
       SCMStorageConfig scmStore = new SCMStorageConfig(conf);
       initializeScmStorage(scmStore);
-      return StorageContainerManager.createSCM(null, conf);
+      return StorageContainerManager.createSCM(conf);
     }
 
     private void initializeScmStorage(SCMStorageConfig scmStore)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -260,7 +260,7 @@ public final class TestSecureOzoneCluster {
   public void testSecureScmStartupSuccess() throws Exception {
 
     initSCM();
-    scm = StorageContainerManager.createSCM(null, conf);
+    scm = StorageContainerManager.createSCM(conf);
     //Reads the SCM Info from SCM instance
     ScmInfo scmInfo = scm.getClientProtocolServer().getScmInfo();
     Assert.assertEquals(clusterId, scmInfo.getClusterId());
@@ -271,7 +271,7 @@ public final class TestSecureOzoneCluster {
   public void testSCMSecurityProtocol() throws Exception {
 
     initSCM();
-    scm = StorageContainerManager.createSCM(null, conf);
+    scm = StorageContainerManager.createSCM(conf);
     //Reads the SCM Info from SCM instance
     try {
       scm.start();
@@ -340,7 +340,7 @@ public final class TestSecureOzoneCluster {
     LambdaTestUtils.intercept(IOException.class,
         "Running in secure mode, but config doesn't have a keytab",
         () -> {
-          StorageContainerManager.createSCM(null, conf);
+          StorageContainerManager.createSCM(conf);
         });
 
     conf.set(ScmConfigKeys.HDDS_SCM_KERBEROS_PRINCIPAL_KEY,
@@ -349,7 +349,7 @@ public final class TestSecureOzoneCluster {
         "/etc/security/keytabs/scm.keytab");
 
     testCommonKerberosFailures(
-        () -> StorageContainerManager.createSCM(null, conf));
+        () -> StorageContainerManager.createSCM(conf));
 
   }
 
@@ -379,7 +379,7 @@ public final class TestSecureOzoneCluster {
   public void testSecureOMInitializationFailure() throws Exception {
     initSCM();
     // Create a secure SCM instance as om client will connect to it
-    scm = StorageContainerManager.createSCM(null, conf);
+    scm = StorageContainerManager.createSCM(conf);
     setupOm(conf);
     conf.set(OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY,
         "non-existent-user@EXAMPLE.com");
@@ -395,7 +395,7 @@ public final class TestSecureOzoneCluster {
   public void testSecureOmInitializationSuccess() throws Exception {
     initSCM();
     // Create a secure SCM instance as om client will connect to it
-    scm = StorageContainerManager.createSCM(null, conf);
+    scm = StorageContainerManager.createSCM(conf);
     LogCapturer logs = LogCapturer.captureLogs(OzoneManager.LOG);
     GenericTestUtils.setLogLevel(OzoneManager.LOG, INFO);
 
@@ -719,7 +719,7 @@ public final class TestSecureOzoneCluster {
     omLogs.clearOutput();
     initSCM();
     try {
-      scm = StorageContainerManager.createSCM(null, conf);
+      scm = StorageContainerManager.createSCM(conf);
       scm.start();
       conf.setBoolean(OZONE_SECURITY_ENABLED_KEY, false);
       OMStorage omStore = new OMStorage(conf);
@@ -765,7 +765,7 @@ public final class TestSecureOzoneCluster {
     omLogs.clearOutput();
     initSCM();
     try {
-      scm = StorageContainerManager.createSCM(null, conf);
+      scm = StorageContainerManager.createSCM(conf);
       scm.start();
 
       OMStorage omStore = new OMStorage(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -75,7 +75,6 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.utils.HddsVersionInfo;
 import org.junit.Assert;
 import org.junit.Rule;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.server.SCMClientProtocolServer;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.hdds.scm.server.StorageContainerManager.StartupOption;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.TypedEvent;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
@@ -417,15 +416,13 @@ public class TestStorageContainerManager {
     Path scmPath = Paths.get(path, "scm-meta");
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, scmPath.toString());
 
-    StartupOption.INIT.setClusterId("testClusterId");
     // This will initialize SCM
-    StorageContainerManager.scmInit(conf);
+    StorageContainerManager.scmInit(conf, "testClusterId");
 
     SCMStorageConfig scmStore = new SCMStorageConfig(conf);
     Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
     Assert.assertEquals("testClusterId", scmStore.getClusterID());
-    StartupOption.INIT.setClusterId("testClusterIdNew");
-    StorageContainerManager.scmInit(conf);
+    StorageContainerManager.scmInit(conf, "testClusterIdNew");
     Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
     Assert.assertEquals("testClusterId", scmStore.getClusterID());
   }
@@ -441,9 +438,8 @@ public class TestStorageContainerManager {
     MiniOzoneCluster cluster =
         MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
     cluster.waitForClusterToBeReady();
-    StartupOption.INIT.setClusterId("testClusterId");
     // This will initialize SCM
-    StorageContainerManager.scmInit(conf);
+    StorageContainerManager.scmInit(conf, "testClusterId");
     SCMStorageConfig scmStore = new SCMStorageConfig(conf);
     Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
     Assert.assertNotEquals("testClusterId", scmStore.getClusterID());
@@ -462,20 +458,7 @@ public class TestStorageContainerManager {
     exception.expect(SCMException.class);
     exception.expectMessage(
         "SCM not initialized due to storage config failure");
-    StorageContainerManager.createSCM(null, conf);
-  }
-
-  @Test
-  public void testSCMInitializationReturnCode() throws IOException,
-      AuthenticationException {
-    ExitUtil.disableSystemExit();
-    OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setBoolean(OzoneConfigKeys.OZONE_ENABLED, true);
-    // Set invalid args
-    String[] invalidArgs = {"--zxcvbnm"};
-    exception.expect(ExitUtil.ExitException.class);
-    exception.expectMessage("ExitException");
-    StorageContainerManager.createSCM(invalidArgs, conf);
+    StorageContainerManager.createSCM(conf);
   }
 
   @Test
@@ -493,7 +476,7 @@ public class TestStorageContainerManager {
     scmStore.setScmId(scmId);
     // writes the version file properties
     scmStore.initialize();
-    StorageContainerManager scm = StorageContainerManager.createSCM(null, conf);
+    StorageContainerManager scm = StorageContainerManager.createSCM(conf);
     //Reads the SCM Info from SCM instance
     ScmInfo scmInfo = scm.getClientProtocolServer().getScmInfo();
     Assert.assertEquals(clusterId, scmInfo.getClusterId());


### PR DESCRIPTION
This change requires HDDS-1645 (increase Pico CLI verison to 3.9.6) before it can be committed, but it also contains the change to the POM so the build does not fail and the full test suit can run.

This chance is to change the CLI code used to start the SCM to use Pico CLI to make it consistent with the S3 gateway.