### PR TITLE
HADOOP-16353. Backport ABFS changes from trunk to branch-3.2

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
@@ -1762,7 +1762,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
       throw new AzureException(e);
     } catch (IOException e) {
       Throwable t = e.getCause();
-      if (t != null && t instanceof StorageException) {
+      if (t instanceof StorageException) {
         StorageException se = (StorageException) t;
         // If we got this exception, the blob should have already been created
         if (!"LeaseIdMissing".equals(se.getErrorCode())) {
@@ -2638,7 +2638,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
       return delete(key, null);
     } catch (IOException e) {
       Throwable t = e.getCause();
-      if (t != null && t instanceof StorageException) {
+      if (t instanceof StorageException) {
         StorageException se = (StorageException) t;
         if ("LeaseIdMissing".equals(se.getErrorCode())){
           SelfRenewingLease lease = null;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -176,6 +176,8 @@ public class AzureBlobFileSystem extends FileSystem {
         overwrite,
         blockSize);
 
+    trailingPeriodCheck(f);
+
     Path qualifiedPath = makeQualified(f);
     performAbfsAuthCheck(FsAction.WRITE, qualifiedPath);
 
@@ -254,6 +256,8 @@ public class AzureBlobFileSystem extends FileSystem {
   public boolean rename(final Path src, final Path dst) throws IOException {
     LOG.debug(
         "AzureBlobFileSystem.rename src: {} dst: {}", src.toString(), dst.toString());
+
+    trailingPeriodCheck(dst);
 
     Path parentFolder = src.getParent();
     if (parentFolder == null) {
@@ -359,10 +363,37 @@ public class AzureBlobFileSystem extends FileSystem {
     }
   }
 
+  /**
+   * Performs a check for (.) until root in the path to throw an exception.
+   * The purpose is to differentiate between dir/dir1 and dir/dir1.
+   * Without the exception the behavior seen is dir1. will appear
+   * to be present without it's actual creation as dir/dir1 and dir/dir1. are
+   * treated as identical.
+   * @param path the path to be checked for trailing period (.)
+   * @throws IllegalArgumentException if the path has a trailing period (.)
+   */
+  private void trailingPeriodCheck(Path path) throws IllegalArgumentException {
+    while (!path.isRoot()){
+      String pathToString = path.toString();
+      if (pathToString.length() != 0) {
+        if (pathToString.charAt(pathToString.length() - 1) == '.') {
+          throw new IllegalArgumentException(
+              "ABFS does not allow files or directories to end with a dot.");
+        }
+        path = path.getParent();
+      }
+      else {
+        break;
+      }
+    }
+  }
+
   @Override
   public boolean mkdirs(final Path f, final FsPermission permission) throws IOException {
     LOG.debug(
         "AzureBlobFileSystem.mkdirs path: {} permissions: {}", f, permission);
+
+    trailingPeriodCheck(f);
 
     final Path parentFolder = f.getParent();
     if (parentFolder == null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
@@ -35,6 +35,7 @@ public final class HttpQueryParams {
   public static final String QUERY_PARAM_POSITION = "position";
   public static final String QUERY_PARAM_TIMEOUT = "timeout";
   public static final String QUERY_PARAM_RETAIN_UNCOMMITTED_DATA = "retainUncommittedData";
+  public static final String QUERY_PARAM_CLOSE = "close";
   public static final String QUERY_PARAM_UPN = "upn";
 
   private HttpQueryParams() {}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -110,9 +110,6 @@ public final class AzureADAuthenticator {
    */
   public static AzureADToken getTokenFromMsi(String tenantGuid, String clientId,
                                              boolean bypassCache) throws IOException {
-    Preconditions.checkNotNull(tenantGuid, "tenantGuid");
-    Preconditions.checkNotNull(clientId, "clientId");
-
     String authEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
 
     QueryParams qp = new QueryParams();
@@ -120,12 +117,12 @@ public final class AzureADAuthenticator {
     qp.add("resource", RESOURCE_NAME);
 
 
-    if (tenantGuid.length() > 0) {
+    if (tenantGuid != null && tenantGuid.length() > 0) {
       String authority = "https://login.microsoftonline.com/" + tenantGuid;
       qp.add("authority", authority);
     }
 
-    if (clientId.length() > 0) {
+    if (clientId != null && clientId.length() > 0) {
       qp.add("client_id", clientId);
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -290,7 +290,7 @@ public class AbfsClient {
     return op;
   }
 
-  public AbfsRestOperation flush(final String path, final long position, boolean retainUncommittedData)
+  public AbfsRestOperation flush(final String path, final long position, boolean retainUncommittedData, boolean isClose)
       throws AzureBlobFileSystemException {
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     // JDK7 does not support PATCH, so to workaround the issue we will use
@@ -302,6 +302,7 @@ public class AbfsClient {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_ACTION, FLUSH_ACTION);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_POSITION, Long.toString(position));
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RETAIN_UNCOMMITTED_DATA, String.valueOf(retainUncommittedData));
+    abfsUriQueryBuilder.addQuery(QUERY_PARAM_CLOSE, String.valueOf(isClose));
 
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = new AbfsRestOperation(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/SSLSocketFactoryEx.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/SSLSocketFactoryEx.java
@@ -120,9 +120,12 @@ public final class SSLSocketFactoryEx extends SSLSocketFactory {
     switch (preferredChannelMode) {
       case Default:
         try {
-          java.util.logging.Logger.getLogger(SSL.class.getName()).setLevel(Level.WARNING);
+          java.util.logging.Logger logger = java.util.logging.Logger.getLogger(SSL.class.getName());
+          logger.setLevel(Level.WARNING);
           ctx = SSLContext.getInstance("openssl.TLS");
           ctx.init(null, null, null);
+          // Strong reference needs to be kept to logger until initialization of SSLContext finished (see HADOOP-16174):
+          logger.setLevel(Level.INFO);
           channelMode = SSLChannelMode.OpenSSL;
         } catch (NoSuchAlgorithmException e) {
           LOG.warn("Failed to load OpenSSL. Falling back to the JSSE default.");

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/SSLSocketFactoryEx.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/SSLSocketFactoryEx.java
@@ -25,6 +25,7 @@ import java.net.SocketException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.logging.Level;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
@@ -33,6 +34,7 @@ import javax.net.ssl.SSLSocketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wildfly.openssl.OpenSSLProvider;
+import org.wildfly.openssl.SSL;
 
 
 /**
@@ -118,6 +120,7 @@ public final class SSLSocketFactoryEx extends SSLSocketFactory {
     switch (preferredChannelMode) {
       case Default:
         try {
+          java.util.logging.Logger.getLogger(SSL.class.getName()).setLevel(Level.WARNING);
           ctx = SSLContext.getInstance("openssl.TLS");
           ctx.init(null, null, null);
           channelMode = SSLChannelMode.OpenSSL;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -133,7 +133,8 @@ public abstract class AbstractAbfsIntegrationTest extends
     //Create filesystem first to make sure getWasbFileSystem() can return an existing filesystem.
     createFileSystem();
 
-    if (!isIPAddress && authType == AuthType.SharedKey) {
+    // Only live account without namespace support can run ABFS&WASB compatibility tests
+    if (!isIPAddress && !abfs.getIsNamespaceEnabled()) {
       final URI wasbUri = new URI(abfsUrlToWasbUrl(getTestUrl()));
       final AzureNativeFileSystemStore azureNativeFileSystemStore =
           new AzureNativeFileSystemStore();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
@@ -26,7 +26,6 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.Assume;
 import org.junit.Test;
 
-import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
@@ -38,14 +37,13 @@ public class ITestAzureBlobFileSystemBackCompat extends
 
   public ITestAzureBlobFileSystemBackCompat() throws Exception {
     super();
-    Assume.assumeTrue(this.getAuthType() == AuthType.SharedKey);
   }
 
   @Test
   public void testBlobBackCompat() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
-    // test only valid for non-namespace enabled account
-    Assume.assumeFalse(fs.getIsNamespaceEnabled());
+    Assume.assumeFalse("This test does not support namespace enabled account",
+            this.getFileSystem().getIsNamespaceEnabled());
     String storageConnectionString = getBlobConnectionString();
     CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageConnectionString);
     CloudBlobClient blobClient = storageAccount.createCloudBlobClient();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
-import org.apache.hadoop.fs.azurebfs.services.AuthType;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -37,6 +35,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
   private static final String DEFAULT_FILE_PERMISSION_VALUE = "640";
   private static final String DEFAULT_DIR_PERMISSION_VALUE = "750";
   private static final String DEFAULT_UMASK_VALUE = "027";
+  private static final String FULL_PERMISSION = "777";
 
   private static final Path TEST_FILE = new Path("testFile");
   private static final Path TEST_FOLDER = new Path("testDir");
@@ -54,7 +53,6 @@ public class ITestAzureBlobFileSystemFileStatus extends
     assertEquals("root listing", 0, rootls.length);
   }
 
-  @Ignore("When running against live abfs with Oauth account, this test will fail. Need to check the tenant.")
   @Test
   public void testFileStatusPermissionsAndOwnerAndGroup() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
@@ -69,13 +67,16 @@ public class ITestAzureBlobFileSystemFileStatus extends
 
     String errorInStatus = "error in " + fileStatus + " from " + fs;
 
-    // When running with Oauth, the owner and group info retrieved from server will be digit ids.
-    if (this.getAuthType() != AuthType.OAuth && !fs.isSecureScheme()) {
+    if (!fs.getIsNamespaceEnabled()) {
       assertEquals(errorInStatus + ": owner",
               fs.getOwnerUser(), fileStatus.getOwner());
       assertEquals(errorInStatus + ": group",
               fs.getOwnerUserPrimaryGroup(), fileStatus.getGroup());
+      assertEquals(new FsPermission(FULL_PERMISSION), fileStatus.getPermission());
     } else {
+      // When running with namespace enabled account,
+      // the owner and group info retrieved from server will be digit ids.
+      // hence skip the owner and group validation
       if (isDir) {
         assertEquals(errorInStatus + ": permission",
                 new FsPermission(DEFAULT_DIR_PERMISSION_VALUE), fileStatus.getPermission());
@@ -88,7 +89,6 @@ public class ITestAzureBlobFileSystemFileStatus extends
     return fileStatus;
   }
 
-  @Ignore("When running against live abfs with Oauth account, this test will fail. Need to check the tenant.")
   @Test
   public void testFolderStatusPermissionsAndOwnerAndGroup() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFinalize.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFinalize.java
@@ -25,14 +25,13 @@ import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.azurebfs.services.AuthType;
 
 /**
  * Test finalize() method when "fs.abfs.impl.disable.cache" is enabled.
  */
 public class ITestAzureBlobFileSystemFinalize extends AbstractAbfsScaleTest{
   static final String DISABLE_ABFS_CACHE_KEY = "fs.abfs.impl.disable.cache";
-  static final String DISABLE_ABFSSS_CACHE_KEY = "fs.abfss.impl.disable.cache";
+  static final String DISABLE_ABFSS_CACHE_KEY = "fs.abfss.impl.disable.cache";
 
   public ITestAzureBlobFileSystemFinalize() throws Exception {
     super();
@@ -42,9 +41,8 @@ public class ITestAzureBlobFileSystemFinalize extends AbstractAbfsScaleTest{
   public void testFinalize() throws Exception {
     // Disable the cache for filesystem to make sure there is no reference.
     Configuration rawConfig = this.getRawConfiguration();
-    rawConfig.setBoolean(
-            this.getAuthType() == AuthType.SharedKey ? DISABLE_ABFS_CACHE_KEY : DISABLE_ABFSSS_CACHE_KEY,
-    true);
+    rawConfig.setBoolean(DISABLE_ABFS_CACHE_KEY, true);
+    rawConfig.setBoolean(DISABLE_ABFSS_CACHE_KEY, true);
 
     AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.get(rawConfig);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -41,8 +40,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
-import org.apache.hadoop.fs.azurebfs.services.AuthType;
 
 /**
  * Test flush operation.
@@ -221,8 +218,6 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   }
 
   private void testFlush(boolean flushEnabled) throws Exception {
-    Assume.assumeTrue(this.getAuthType() == AuthType.SharedKey);
-
     final AzureBlobFileSystem fs = (AzureBlobFileSystem) getFileSystem();
 
     // Simulate setting "fs.azure.enable.flush" to true or false

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -46,8 +46,7 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
 
   @Test (expected = FileNotFoundException.class)
   public void ensureFilesystemWillNotBeCreatedIfCreationConfigIsNotSet() throws Exception {
-    super.setup();
-    final AzureBlobFileSystem fs = this.getFileSystem();
+    final AzureBlobFileSystem fs = this.createFileSystem();
     FileStatus[] fileStatuses = fs.listStatus(new Path("/"));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMainOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMainOperation.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import org.junit.Ignore;
+
+import org.apache.hadoop.fs.FSMainOperationsBaseTest;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
+
+/**
+ * Test AzureBlobFileSystem main operations.
+ * */
+public class ITestAzureBlobFileSystemMainOperation extends FSMainOperationsBaseTest {
+
+  private static final String TEST_ROOT_DIR =
+          "/tmp/TestAzureBlobFileSystemMainOperations";
+
+  private final ABFSContractTestBinding binding;
+
+  public ITestAzureBlobFileSystemMainOperation () throws Exception {
+    super(TEST_ROOT_DIR);
+    // Note: There are shared resources in this test suite (eg: "test/new/newfile")
+    // To make sure this test suite can be ran in parallel, different containers
+    // will be used for each test.
+    binding = new ABFSContractTestBinding(false);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    binding.setup();
+    fSys = binding.getFileSystem();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    // Note: Because "tearDown()" is called during the testing,
+    // here we should not call binding.tearDown() to destroy the container.
+    // Instead we should remove the test containers manually with
+    // AbfsTestUtils.
+    super.tearDown();
+  }
+
+  @Override
+  protected FileSystem createFileSystem() throws Exception {
+    return fSys;
+  }
+
+  @Override
+  @Ignore("Permission check for getFileInfo doesn't match the HdfsPermissionsGuide")
+  public void testListStatusThrowsExceptionForUnreadableDir() {
+    // Permission Checks:
+    // https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsPermissionsGuide.html
+  }
+
+  @Override
+  @Ignore("Permission check for getFileInfo doesn't match the HdfsPermissionsGuide")
+  public void testGlobStatusThrowsExceptionForUnreadableDir() {
+    // Permission Checks:
+    // https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsPermissionsGuide.html
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
-import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -67,7 +66,6 @@ public class ITestAzureBlobFileSystemRandomRead extends
 
   public ITestAzureBlobFileSystemRandomRead() throws Exception {
     super();
-    Assume.assumeTrue(this.getAuthType() == AuthType.SharedKey);
   }
 
   @Test
@@ -98,6 +96,8 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testRandomRead() throws Exception {
+    Assume.assumeFalse("This test does not support namespace enabled account",
+            this.getFileSystem().getIsNamespaceEnabled());
     assumeHugeFileExists();
     try (
             FSDataInputStream inputStreamV1
@@ -413,6 +413,8 @@ public class ITestAzureBlobFileSystemRandomRead extends
 
   @Test
   public void testRandomReadPerformance() throws Exception {
+    Assume.assumeFalse("This test does not support namespace enabled account",
+            this.getFileSystem().getIsNamespaceEnabled());
     createTestFile();
     assumeHugeFileExists();
 
@@ -523,11 +525,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
   }
 
   private void createTestFile() throws Exception {
-    final AzureBlobFileSystem abFs = this.getFileSystem();
-    // test only valid for non-namespace enabled account
-    Assume.assumeFalse(abFs.getIsNamespaceEnabled());
-    FileSystem fs = this.getWasbFileSystem();
-
+    final AzureBlobFileSystem fs = this.getFileSystem();
     if (fs.exists(TEST_FILE_PATH)) {
       FileStatus status = fs.getFileStatus(TEST_FILE_PATH);
       if (status.getLen() >= TEST_FILE_SIZE) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.fs.azurebfs.services.AuthType;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertDeleted;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertIsDirectory;
@@ -51,7 +50,6 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
   public ITestWasbAbfsCompatibility() throws Exception {
     Assume.assumeFalse("Emulator is not supported", isIPAddress());
-    Assume.assumeTrue(this.getAuthType() == AuthType.SharedKey);
   }
 
   @Test
@@ -59,7 +57,8 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     // crate file using abfs
     AzureBlobFileSystem fs = getFileSystem();
     // test only valid for non-namespace enabled account
-    Assume.assumeFalse(fs.getIsNamespaceEnabled());
+    Assume.assumeFalse("Namespace enabled account does not support this test,",
+            fs.getIsNamespaceEnabled());
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
@@ -93,7 +92,8 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     AzureBlobFileSystem abfs = getFileSystem();
     // test only valid for non-namespace enabled account
-    Assume.assumeFalse(abfs.getIsNamespaceEnabled());
+    Assume.assumeFalse("Namespace enabled account does not support this test",
+            abfs.getIsNamespaceEnabled());
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
@@ -132,7 +132,8 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     AzureBlobFileSystem abfs = getFileSystem();
     // test only valid for non-namespace enabled account
-    Assume.assumeFalse(abfs.getIsNamespaceEnabled());
+    Assume.assumeFalse("Namespace enabled account does not support this test",
+            abfs.getIsNamespaceEnabled());
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
@@ -166,7 +167,8 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     //create folders
     AzureBlobFileSystem abfs = getFileSystem();
     // test only valid for non-namespace enabled account
-    Assume.assumeFalse(abfs.getIsNamespaceEnabled());
+    Assume.assumeFalse("Namespace enabled account does not support this test",
+            abfs.getIsNamespaceEnabled());
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 


### PR DESCRIPTION
This chain of cherrypicked patches from trunk fills out branch-3.2 with those changes which aren't there. It doesn't (yet) include the delegation token work because that change also does some POM changes to import bouncy-castle which would create build problems unless I changed it.

As these patches are already in trunk, this PR doesn't need voting on, it's a due diligence to make sure yetus is happy, and to give people who care an opportunity to suggest changes.