### PR TITLE
HDDS-1660 Use Picocli for Ozone Manager

### DIFF
--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -129,7 +129,7 @@ function ozonecmd_case
     ;;
     om)
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
-      HADOOP_CLASSNAME=org.apache.hadoop.ozone.om.OzoneManager
+      HADOOP_CLASSNAME=org.apache.hadoop.ozone.om.OzoneManagerStarter
       HDFS_OM_OPTS="${HDFS_OM_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/om-audit-log4j2.properties"
       HADOOP_OPTS="${HADOOP_OPTS} ${HDFS_OM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/OzoneManager.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/OzoneManager.xml
@@ -16,7 +16,7 @@
 -->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="OzoneManager" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManager" />
+    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManagerStarter" />
     <module name="hadoop-ozone-ozone-manager" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/OzoneManagerInit.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/OzoneManagerInit.xml
@@ -16,7 +16,7 @@
 -->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="OzoneManagerInit" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManager" />
+    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManagerStarter" />
     <module name="hadoop-ozone-ozone-manager" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --init" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -517,7 +517,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       configureOM();
       OMStorage omStore = new OMStorage(conf);
       initializeOmStorage(omStore);
-      return OzoneManager.createOm(null, conf);
+      return OzoneManager.createOm(conf);
     }
 
     /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -211,7 +211,7 @@ public final class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
             OMStorage omStore = new OMStorage(conf);
             initializeOmStorage(omStore);
 
-            OzoneManager om = OzoneManager.createOm(null, conf);
+            OzoneManager om = OzoneManager.createOm(conf);
             om.setCertClient(certClient);
             omMap.put(nodeId, om);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -383,7 +383,7 @@ public final class TestSecureOzoneCluster {
     setupOm(conf);
     conf.set(OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY,
         "non-existent-user@EXAMPLE.com");
-    testCommonKerberosFailures(() -> OzoneManager.createOm(null, conf));
+    testCommonKerberosFailures(() -> OzoneManager.createOm(conf));
   }
 
   /**
@@ -662,7 +662,7 @@ public final class TestSecureOzoneCluster {
     // writes the version file properties
     omStore.initialize();
     OzoneManager.setTestSecureOmFlag(true);
-    om = OzoneManager.createOm(null, config);
+    om = OzoneManager.createOm(config);
   }
 
   @Test
@@ -725,7 +725,7 @@ public final class TestSecureOzoneCluster {
       OMStorage omStore = new OMStorage(conf);
       initializeOmStorage(omStore);
       OzoneManager.setTestSecureOmFlag(true);
-      om = OzoneManager.createOm(null, conf);
+      om = OzoneManager.createOm(conf);
 
       assertNull(om.getCertificateClient());
       assertFalse(omLogs.getOutput().contains("Init response: GETCERT"));
@@ -735,7 +735,7 @@ public final class TestSecureOzoneCluster {
       conf.setBoolean(OZONE_SECURITY_ENABLED_KEY, true);
       OzoneManager.omInit(conf);
       om.stop();
-      om = OzoneManager.createOm(null, conf);
+      om = OzoneManager.createOm(conf);
 
       Assert.assertNotNull(om.getCertificateClient());
       Assert.assertNotNull(om.getCertificateClient().getPublicKey());
@@ -771,7 +771,7 @@ public final class TestSecureOzoneCluster {
       OMStorage omStore = new OMStorage(conf);
       initializeOmStorage(omStore);
       OzoneManager.setTestSecureOmFlag(true);
-      om = OzoneManager.createOm(null, conf);
+      om = OzoneManager.createOm(conf);
 
       Assert.assertNotNull(om.getCertificateClient());
       Assert.assertNotNull(om.getCertificateClient().getPublicKey());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmInit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmInit.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.web.handlers.UserArgs;
 import org.apache.hadoop.ozone.web.interfaces.StorageHandler;
 import org.apache.hadoop.ozone.web.utils.OzoneUtils;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -90,10 +91,11 @@ public class TestOmInit {
 
   /**
    * Tests the OM Initialization.
-   * @throws IOException
+   * @throws IOException, AuthenticationException
    */
   @Test
-  public void testOmInitAgain() throws IOException {
+  public void testOmInitAgain() throws IOException,
+      AuthenticationException {
     // Stop the Ozone Manager
     cluster.getOzoneManager().stop();
     // Now try to init the OM again. It should succeed

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManager.java
@@ -1326,7 +1326,7 @@ public class TestOzoneManager {
         conf.get(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY));
 
     OzoneTestUtils.expectOmException(ResultCodes.OM_NOT_INITIALIZED, () -> {
-      OzoneManager.createOm(null, config);
+      OzoneManager.createOm(config);
     });
 
     OzoneTestUtils
@@ -1336,7 +1336,7 @@ public class TestOzoneManager {
           omStore.setScmId("testScmId");
           // writes the version file properties
           omStore.initialize();
-          OzoneManager.createOm(null, config);
+          OzoneManager.createOm(config);
         });
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import java.io.IOException;
+
+/**
+ * This interface is used by the OzoneManagerStarter class to allow the
+ * dependencies to be injected to the CLI class.
+ */
+public interface OMStarterInterface {
+  void start(OzoneConfiguration conf) throws IOException,
+      AuthenticationException;
+  boolean init(OzoneConfiguration conf) throws IOException,
+      AuthenticationException;
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
@@ -28,6 +28,5 @@ import java.io.IOException;
 public interface OMStarterInterface {
   void start(OzoneConfiguration conf) throws IOException,
       AuthenticationException;
-  boolean init(OzoneConfiguration conf) throws IOException,
-      AuthenticationException;
+  boolean init(OzoneConfiguration conf) throws IOException;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
@@ -28,5 +28,6 @@ import java.io.IOException;
 public interface OMStarterInterface {
   void start(OzoneConfiguration conf) throws IOException,
       AuthenticationException;
-  boolean init(OzoneConfiguration conf) throws IOException;
+  boolean init(OzoneConfiguration conf) throws IOException,
+      AuthenticationException;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -930,22 +930,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   public static OzoneManager createOm(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
-    loginOMUserIfSecurityEnabled(conf);
-    return new OzoneManager(conf);
-  }
-
-  /**
-   * Logs in the OM use if security is enabled in the configuration.
-   *
-   * @param conf OzoneConfiguration
-   * @throws IOException, AuthenticationException in case login failes.
-   */
-  private static void loginOMUserIfSecurityEnabled(OzoneConfiguration  conf)
-      throws IOException, AuthenticationException {
     securityEnabled = OzoneSecurityUtil.isSecurityEnabled(conf);
     if (securityEnabled) {
       loginOMUser(conf);
     }
+    return new OzoneManager(conf);
   }
 
   /**
@@ -957,9 +946,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *                     accessible
    */
   @VisibleForTesting
-  public static boolean omInit(OzoneConfiguration conf) throws IOException,
-      AuthenticationException {
-    loginOMUserIfSecurityEnabled(conf);
+  public static boolean omInit(OzoneConfiguration conf) throws IOException {
     OMStorage omStorage = new OMStorage(conf);
     StorageState state = omStorage.getState();
     if (state != StorageState.INITIALIZED) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -930,11 +930,22 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   public static OzoneManager createOm(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
+    loginOMUserIfSecurityEnabled(conf);
+    return new OzoneManager(conf);
+  }
+
+  /**
+   * Logs in the OM use if security is enabled in the configuration.
+   *
+   * @param conf OzoneConfiguration
+   * @throws IOException, AuthenticationException in case login failes.
+   */
+  private static void loginOMUserIfSecurityEnabled(OzoneConfiguration  conf)
+      throws IOException, AuthenticationException {
     securityEnabled = OzoneSecurityUtil.isSecurityEnabled(conf);
     if (securityEnabled) {
       loginOMUser(conf);
     }
-    return new OzoneManager(conf);
   }
 
   /**
@@ -946,7 +957,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *                     accessible
    */
   @VisibleForTesting
-  public static boolean omInit(OzoneConfiguration conf) throws IOException {
+  public static boolean omInit(OzoneConfiguration conf) throws IOException,
+      AuthenticationException {
+    loginOMUserIfSecurityEnabled(conf);
     OMStorage omStorage = new OMStorage(conf);
     StorageState state = omStorage.getState();
     if (state != StorageState.INITIALIZED) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.io.IOException;
+
+/**
+ * This class provides a command line interface to start the OM
+ * using Picocli.
+ */
+@Command(name = "ozone om",
+    hidden = true, description = "Start or initialize the Ozone Manager.",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true)
+public class OzoneManagerStarter extends GenericCli {
+
+  private OzoneConfiguration conf;
+  private OMStarterInterface receiver;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OzoneManagerStarter.class);
+
+  public static void main(String[] args) throws Exception {
+    TracingUtil.initTracing("OzoneManager");
+    new OzoneManagerStarter(
+        new OzoneManagerStarter.OMStarterHelper()).run(args);
+  }
+
+  public OzoneManagerStarter(OMStarterInterface receiverObj) {
+    super();
+    receiver = receiverObj;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    /**
+     * This method is invoked only when a sub-command is not called. Therefore
+     * if someone runs "ozone om" with no parameters, this is the methood
+     * which runs and starts the OM.
+     */
+    commonInit();
+    startOm();
+    return null;
+  }
+
+  /**
+   * This function is used by the command line to start the OM.
+   */
+  private void startOm() throws Exception {
+    receiver.start(conf);
+  }
+
+  /**
+   * This function implements a sub-command to allow the OM to be
+   * initialized from the command line.
+   */
+  @CommandLine.Command(name = "--init",
+      customSynopsis = "ozone om [global options] --init",
+      hidden = false,
+      description = "Initialize the Ozone Manager if not already initialized",
+      mixinStandardHelpOptions = true,
+      versionProvider = HddsVersionProvider.class)
+  public void initOm()
+      throws Exception {
+    commonInit();
+    boolean result = receiver.init(conf);
+    if (!result) {
+      throw new IOException("OM Init failed.");
+    }
+  }
+
+  /**
+   * This function should be called by each command to ensure the configuration
+   * is set and print the startup banner message.
+   */
+  private void commonInit() {
+    conf = createOzoneConfiguration();
+
+    String[] originalArgs = getCmd().getParseResult().originalArgs()
+        .toArray(new String[0]);
+    StringUtils.startupShutdownMessage(OzoneManager.class,
+        originalArgs, LOG);
+  }
+
+  /**
+   * This static class wraps the external dependencies needed for this command
+   * to execute its tasks. This allows the dependency to be injected for unit
+   * testing.
+   */
+  static class OMStarterHelper implements OMStarterInterface{
+
+    public void start(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
+      OzoneManager om = OzoneManager.createOm(conf);
+      om.start();
+      om.join();
+    }
+
+    public boolean init(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
+      return OzoneManager.omInit(conf);
+    }
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -121,8 +121,7 @@ public class OzoneManagerStarter extends GenericCli {
       om.join();
     }
 
-    public boolean init(OzoneConfiguration conf) throws IOException,
-        AuthenticationException {
+    public boolean init(OzoneConfiguration conf) throws IOException {
       return OzoneManager.omInit(conf);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -121,7 +121,8 @@ public class OzoneManagerStarter extends GenericCli {
       om.join();
     }
 
-    public boolean init(OzoneConfiguration conf) throws IOException {
+    public boolean init(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
       return OzoneManager.omInit(conf);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static org.junit.Assert.*;
+
+/**
+ * This class is used to test the CLI provided by OzoneManagerStarter, which is
+ * used to start and init the OzoneManager. The calls to the Ozone Manager are
+ * mocked so the tests only validate the CLI calls the correct methods are
+ * invoked.
+ */
+public class TestOzoneManagerStarter {
+
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+
+  private MockOMStarter mock;
+
+  @Before
+  public void setUpStreams() {
+    System.setOut(new PrintStream(outContent));
+    System.setErr(new PrintStream(errContent));
+    mock = new MockOMStarter();
+  }
+
+  @After
+  public void restoreStreams() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void testCallsStartWhenServerStarted() throws Exception {
+    executeCommand();
+    assertTrue(mock.startCalled);
+  }
+
+  @Test
+  public void testExceptionThrownWhenStartFails() throws Exception {
+    mock.throwOnStart = true;
+    try {
+      executeCommand();
+      fail("Exception should have been thrown");
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
+  public void testStartNotCalledWithInvalidParam() throws Exception {
+    executeCommand("--invalid");
+    assertFalse(mock.startCalled);
+  }
+
+  @Test
+  public void testPassingInitSwitchCallsInit() {
+    executeCommand("--init");
+    assertTrue(mock.initCalled);
+  }
+
+  @Test
+  public void testInitSwitchWithInvalidParamDoesNotRun() {
+    executeCommand("--init", "--invalid");
+    assertFalse(mock.initCalled);
+  }
+
+  @Test
+  public void testUnSuccessfulInitThrowsException() {
+    mock.throwOnInit = true;
+    try {
+      executeCommand("--init");
+      fail("Exception show have been thrown");
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
+  public void testInitThatReturnsFalseThrowsException() {
+    mock.initStatus = false;
+    try {
+      executeCommand("--init");
+      fail("Exception show have been thrown");
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
+  public void testUsagePrintedOnInvalidInput() {
+    executeCommand("--invalid");
+    Pattern p = Pattern.compile("^Unknown option:.*--invalid.*\nUsage");
+    Matcher m = p.matcher(errContent.toString());
+    assertTrue(m.find());
+  }
+
+  private void executeCommand(String... args) {
+    new OzoneManagerStarter(mock).execute(args);
+  }
+
+  static class MockOMStarter implements OMStarterInterface {
+
+    private boolean startCalled = false;
+    private boolean initCalled = false;
+    private boolean initStatus = true;
+    private boolean throwOnStart = false;
+    private boolean throwOnInit = false;
+
+    public void start(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
+      startCalled = true;
+      if (throwOnStart) {
+        throw new IOException("Simulated Exception");
+      }
+    }
+
+    public boolean init(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
+      initCalled = true;
+      if (throwOnInit) {
+        throw new IOException("Simulated Exception");
+      }
+      return initStatus;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -142,7 +142,8 @@ public class TestOzoneManagerStarter {
       }
     }
 
-    public boolean init(OzoneConfiguration conf) throws IOException {
+    public boolean init(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
       initCalled = true;
       if (throwOnInit) {
         throw new IOException("Simulated Exception");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -142,8 +142,7 @@ public class TestOzoneManagerStarter {
       }
     }
 
-    public boolean init(OzoneConfiguration conf) throws IOException,
-        AuthenticationException {
+    public boolean init(OzoneConfiguration conf) throws IOException {
       initCalled = true;
       if (throwOnInit) {
         throw new IOException("Simulated Exception");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/GenesisUtil.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/GenesisUtil.java
@@ -186,7 +186,7 @@ public final class GenesisUtil {
       omStorage.setOmId(UUID.randomUUID().toString());
       omStorage.initialize();
     }
-    return OzoneManager.createOm(null, conf);
+    return OzoneManager.createOm(conf);
   }
 
   static void configureOM(Configuration conf, int numHandlers) {


### PR DESCRIPTION
Replicate the changes made in HDDS-1622 for the StorageContainerManager to the Ozone Manager, so it also uses Picocli for the command line interface.