### PR TITLE
HDDS-1655. Redundant toString() call for metaDataPath in KeyValueContainerCheck

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -279,9 +279,8 @@ public class KeyValueContainerCheck {
   }
 
   private void loadContainerData() throws IOException {
-
     File containerFile = KeyValueContainer
-        .getContainerFile(metadataPath.toString(), containerID);
+        .getContainerFile(metadataPath, containerID);
 
     onDiskContainerData = (KeyValueContainerData) ContainerDataYaml
         .readContainerFile(containerFile);


### PR DESCRIPTION
Change-Id: Idf91e6367cf1a6e27986034e13cf34f59e79fc25

Redundant toString() call for variable metadataPath at:

https://github.com/apache/hadoop/blob/trunk/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java#L284