### PR TITLE
YARN-9537.Add configuration to disable AM preemption

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
@@ -99,6 +99,9 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
   private final Map<String, Set<String>> reservations = new HashMap<>();
 
   private final List<FSSchedulerNode> blacklistNodeIds = new ArrayList<>();
+
+  private boolean enableAMPreemption = false;
+
   /**
    * Delay scheduling: We often want to prioritize scheduling of node-local
    * containers over rack-local or off-switch containers. To achieve this
@@ -121,6 +124,7 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
     this.startTime = scheduler.getClock().getTime();
     this.lastTimeAtFairShare = this.startTime;
     this.appPriority = Priority.newInstance(1);
+    this.enableAMPreemption = scheduler.getConf().getAMPreemptionEnabled();
   }
 
   /**
@@ -586,6 +590,10 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
   boolean canContainerBePreempted(RMContainer container,
                                   Resource alreadyConsideringForPreemption) {
     if (!isPreemptable()) {
+      return false;
+    }
+
+    if (container.isAMContainer() && !enableAMPreemption) {
       return false;
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -100,7 +101,7 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
 
   private final List<FSSchedulerNode> blacklistNodeIds = new ArrayList<>();
 
-  private boolean enableAMPreemption = false;
+  private boolean enableAMPreemption = FairSchedulerConfiguration.DEFAULT_AM_PREEMPTION;
 
   /**
    * Delay scheduling: We often want to prioritize scheduling of node-local
@@ -124,7 +125,10 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
     this.startTime = scheduler.getClock().getTime();
     this.lastTimeAtFairShare = this.startTime;
     this.appPriority = Priority.newInstance(1);
-    this.enableAMPreemption = scheduler.getConf().getAMPreemptionEnabled();
+    if (scheduler.getConf() != null) {
+      // For test
+      this.enableAMPreemption = scheduler.getConf().getAMPreemptionEnabled();
+    }
   }
 
   /**
@@ -1423,5 +1427,10 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
   @Override
   public boolean isPreemptable() {
     return getQueue().isPreemptable();
+  }
+
+  @VisibleForTesting
+  public void setEnableAMPreemption(boolean enableAMPreemption) {
+    this.enableAMPreemption = enableAMPreemption;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerConfiguration.java
@@ -157,6 +157,9 @@ public class FairSchedulerConfiguration extends Configuration {
   protected static final String  PREEMPTION = CONF_PREFIX + "preemption";
   protected static final boolean DEFAULT_PREEMPTION = false;
 
+  protected static final String  AM_PREEMPTION = CONF_PREFIX + "am.preemption";
+  protected static final boolean DEFAULT_AM_PREEMPTION = false;
+
   protected static final String PREEMPTION_THRESHOLD =
       CONF_PREFIX + "preemption.cluster-utilization-threshold";
   protected static final float DEFAULT_PREEMPTION_THRESHOLD = 0.8f;
@@ -370,6 +373,10 @@ public class FairSchedulerConfiguration extends Configuration {
 
   public boolean getPreemptionEnabled() {
     return getBoolean(PREEMPTION, DEFAULT_PREEMPTION);
+  }
+
+  public boolean getAMPreemptionEnabled() {
+    return getBoolean(AM_PREEMPTION, DEFAULT_AM_PREEMPTION);
   }
 
   public float getPreemptionUtilizationThreshold() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerConfiguration.java
@@ -158,7 +158,7 @@ public class FairSchedulerConfiguration extends Configuration {
   protected static final boolean DEFAULT_PREEMPTION = false;
 
   protected static final String  AM_PREEMPTION = CONF_PREFIX + "am.preemption";
-  protected static final boolean DEFAULT_AM_PREEMPTION = false;
+  protected static final boolean DEFAULT_AM_PREEMPTION = true;
 
   protected static final String PREEMPTION_THRESHOLD =
       CONF_PREFIX + "preemption.cluster-utilization-threshold";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairSchedulerPreemption.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairSchedulerPreemption.java
@@ -422,6 +422,18 @@ public class TestFairSchedulerPreemption extends FairSchedulerTestBase {
   }
 
   @Test
+  public void testDisableAMPreemption() throws Exception {
+    takeAllResources("root.preemptable.child-1");
+    setNumAMContainersPerNode(2);
+    RMContainer container = greedyApp.getLiveContainers().stream()
+            .filter(rmContainer -> rmContainer.isAMContainer())
+            .findFirst()
+            .get();
+    greedyApp.setEnableAMPreemption(false);
+    assertFalse(greedyApp.canContainerBePreempted(container, null));
+  }
+
+  @Test
   public void testPreemptionBetweenSiblingQueuesWithParentAtFairShare()
       throws InterruptedException {
     // Run this test only for fairshare preemption


### PR DESCRIPTION
Add a configuration to support disable AM preemption. Which can be useful for some case when we have a cluster do not want app to be preempted and restart.