### PR TITLE
HADOOP-16340. ABFS driver continues to retry on IOException responses from REST operations

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -165,6 +165,8 @@ public final class AzureADAuthenticator {
    * requestId and error message, it is thrown when AzureADAuthenticator
    * failed to get the Azure Active Directory token.
    */
+  @InterfaceAudience.LimitedPrivate("authorization-subsystems")
+  @InterfaceStability.Unstable
   public static class HttpException extends IOException {
     private final int httpErrorCode;
     private final String requestId;
@@ -191,7 +193,7 @@ public final class AzureADAuthenticator {
       return this.requestId;
     }
 
-    HttpException(
+    protected HttpException(
         final int httpErrorCode,
         final String requestId,
         final String message,


### PR DESCRIPTION
ABFS driver continues to retry (until retry count is exhausted) upon IOException responses from REST operations.  

In the exception hander for IOExceptions at https://github.com/apache/hadoop/blob/65f60e56b082faf92e1cd3daee2569d8fc669c67/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java#L174-L197, there is no way exit out of the retry loop by re-throwing an exception unless one of the following conditions have been met:

- The retry limit was hit
- An HttpException was encountered

From an org.apache.hadoop.fs.azurebfs.extensions.CustomTokenProviderAdaptee or org.apache.hadoop.fs.azurebfs.extensions.CustomDelegationTokenManager implementation, there is no way to create an org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.HttpException since the constructor is package private. 

To solve this issue, access to org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.HttpException needs to be set to that custom implementations can use it.   

This patch changes the org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.HttpException constructor to private rather than package private. 
