### PR TITLE
HDDS-1666. Issue in openKey when allocating block.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -436,7 +436,7 @@ public class KeyManagerImpl implements KeyManager {
     // client should expect, in terms of current size of key. If client sets
     // a value, then this value is used, otherwise, we allocate a single
     // block which is the current size, if read by the client.
-    final long size = args.getDataSize() >= 0 ?
+    final long size = args.getDataSize() > 0 ?
         args.getDataSize() : scmBlockSize;
     final List<OmKeyLocationInfo> locations = new ArrayList<>();
 
@@ -477,7 +477,7 @@ public class KeyManagerImpl implements KeyManager {
     openVersion = keyInfo.getLatestVersionLocations().getVersion();
     LOG.debug("Key {} allocated in volume {} bucket {}",
         keyName, volumeName, bucketName);
-    allocateBlockInKey(keyInfo, args.getDataSize(), currentTime);
+    allocateBlockInKey(keyInfo, size, currentTime);
     return new OpenKeySession(currentTime, keyInfo, openVersion);
   }
 


### PR DESCRIPTION
We set size as below

final long size = args.getDataSize() >= 0 ?
 args.getDataSize() : scmBlockSize;
 

and create OmKeyInfo with below size set. But when allocating Block for openKey, we use as below.

allocateBlockInKey(keyInfo, args.getDataSize(), currentTime);

 

I feel here, we should use size which is set above so that we allocate at least a block when the openKey call happens.

Current Code also works fine, but for readability I believe this should be good.