### PR TITLE
HDDS-1669. SCM startup is failing if network-topology-default.xml is part of a jar

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
@@ -70,9 +70,9 @@ public final class NodeSchemaManager {
       maxLevel = allSchema.size();
     } catch (Throwable e) {
       String msg = "Failed to load schema file:" + schemaFile
-          + ", error:" + e.getMessage();
-      LOG.error(msg);
-      throw new RuntimeException(msg);
+          + ", error: " + e.getMessage();
+      LOG.error(msg, e);
+      throw new RuntimeException(msg, e);
     }
   }
 

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -127,14 +127,5 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
   </dependencies>
 
-  <build>
-    <testResources>
-      <testResource>
-        <directory>${basedir}/../../hadoop-hdds/common/src/main/resources</directory>
-      </testResource>
-      <testResource>
-        <directory>${basedir}/src/test/resources</directory>
-      </testResource>
-    </testResources>
-  </build>
+
 </project>


### PR DESCRIPTION
network-topology-default.xml can be loaded from file or classpath. But the NodeSchemaLoader assumes that the files on the classpath can be opened as a file. It's true if the file is in etc/hadoop (which is part of the classpath) but not true if the file is packaged to a jajr file:

{code}
scm_1         | 2019-06-11 13:18:03 INFO  NodeSchemaLoader:118 - Loading file from jar:file:/opt/hadoop/share/ozone/lib/hadoop-hdds-common-0.5.0-SNAPSHOT.jar!/network-topology-default.xml
scm_1         | 2019-06-11 13:18:03 ERROR NodeSchemaManager:74 - Failed to load schema file:network-topology-default.xml, error:
scm_1         | java.lang.IllegalArgumentException: URI is not hierarchical
scm_1         | 	at java.io.File.<init>(File.java:418)
scm_1         | 	at org.apache.hadoop.hdds.scm.net.NodeSchemaLoader.loadSchemaFromFile(NodeSchemaLoader.java:119)
scm_1         | 	at org.apache.hadoop.hdds.scm.net.NodeSchemaManager.init(NodeSchemaManager.java:67)
scm_1         | 	at org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl.<init>(NetworkTopologyImpl.java:63)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.initializeSystemManagers(StorageContainerManager.java:382)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:275)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:208)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:586)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter$SCMStarterHelper.start(StorageContainerManagerStarter.java:139)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.startScm(StorageContainerManagerStarter.java:115)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:67)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:42)
scm_1         | 	at picocli.CommandLine.execute(CommandLine.java:1173)
scm_1         | 	at picocli.CommandLine.access$800(CommandLine.java:141)
scm_1         | 	at picocli.CommandLine$RunLast.handle(CommandLine.java:1367)
scm_1         | 	at picocli.CommandLine$RunLast.handle(CommandLine.java:1335)
scm_1         | 	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:1243)
scm_1         | 	at picocli.CommandLine.parseWithHandlers(CommandLine.java:1526)
scm_1         | 	at picocli.CommandLine.parseWithHandler(CommandLine.java:1465)
scm_1         | 	at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:65)
scm_1         | 	at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:56)
scm_1         | 	at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.main(StorageContainerManagerStarter.java:56)
scm_1         | Failed to load schema file:network-topology-default.xml, error:
{code}

The quick fix is to keep the current behaviour but read the file from classloader.getResourceAsStream() instead of classloader.getResource().toURI()

See: https://issues.apache.org/jira/browse/HDDS-1669