### PR TITLE
HDDS-1670. Add limit support to /api/containers and /api/containers/{id} endpoints

### DIFF
--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
@@ -70,8 +70,17 @@ public interface ContainerDBServiceProvider {
       throws IOException;
 
   /**
+   * Get a Map of containerID, containerMetadata of all the Containers.
+   *
+   * @return Map of containerID -> containerMetadata.
+   * @throws IOException
+   */
+  Map<Long, ContainerMetadata> getContainers() throws IOException;
+
+  /**
    * Get a Map of containerID, containerMetadata of Containers only for the
-   * given limit.
+   * given limit. If the limit is -1 or any integer <0, then return all
+   * the containers without any limit.
    *
    * @return Map of containerID -> containerMetadata.
    * @throws IOException

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
@@ -70,12 +70,13 @@ public interface ContainerDBServiceProvider {
       throws IOException;
 
   /**
-   * Get a Map of containerID, containerMetadata of all Containers.
+   * Get a Map of containerID, containerMetadata of Containers only for the
+   * given limit.
    *
    * @return Map of containerID -> containerMetadata.
    * @throws IOException
    */
-  Map<Long, ContainerMetadata> getContainers() throws IOException;
+  Map<Long, ContainerMetadata> getContainers(int limit) throws IOException;
 
   /**
    * Delete an entry in the container DB.

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -165,8 +165,22 @@ public class ContainerDBServiceProviderImpl
   }
 
   /**
+   * Get all the containers.
+   *
+   * @return Map of containerID -> containerMetadata.
+   * @throws IOException
+   */
+  @Override
+  public Map<Long, ContainerMetadata> getContainers() throws IOException {
+    // Set a negative limit to get all the containers.
+    return getContainers(-1);
+  }
+
+  /**
    * Iterate the DB to construct a Map of containerID -> containerMetadata
    * only for the given limit.
+   *
+   * Return all the containers if limit < 0.
    *
    * @return Map of containerID -> containerMetadata.
    * @throws IOException

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_KEY_TABLE;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -139,7 +138,7 @@ public class ContainerDBServiceProviderImpl
   public Map<ContainerKeyPrefix, Integer> getKeyPrefixesForContainer(
       long containerId) throws IOException {
 
-    Map<ContainerKeyPrefix, Integer> prefixes = new HashMap<>();
+    Map<ContainerKeyPrefix, Integer> prefixes = new LinkedHashMap<>();
     TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix,
         Integer>> containerIterator = containerKeyTable.iterator();
     containerIterator.seek(new ContainerKeyPrefix(containerId));
@@ -166,13 +165,15 @@ public class ContainerDBServiceProviderImpl
   }
 
   /**
-   * Iterate the DB to construct a Map of containerID -> containerMetadata.
+   * Iterate the DB to construct a Map of containerID -> containerMetadata
+   * only for the given limit.
    *
    * @return Map of containerID -> containerMetadata.
    * @throws IOException
    */
   @Override
-  public Map<Long, ContainerMetadata> getContainers() throws IOException {
+  public Map<Long, ContainerMetadata> getContainers(int limit)
+      throws IOException {
     Map<Long, ContainerMetadata> containers = new LinkedHashMap<>();
     TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix,
         Integer>> containerIterator = containerKeyTable.iterator();
@@ -180,6 +181,12 @@ public class ContainerDBServiceProviderImpl
       KeyValue<ContainerKeyPrefix, Integer> keyValue = containerIterator.next();
       Long containerID = keyValue.getKey().getContainerId();
       Integer numberOfKeys = keyValue.getValue();
+
+      // break the loop if limit has been reached
+      // and one more new entity needs to be added to the containers map
+      if (containers.size() == limit && !containers.containsKey(containerID)) {
+        break;
+      }
 
       // initialize containerMetadata with 0 as number of keys.
       containers.computeIfAbsent(containerID, ContainerMetadata::new);

--- a/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerKeyService.java
+++ b/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerKeyService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon.api;
 
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -200,56 +201,67 @@ public class TestContainerKeyService extends AbstractOMMetadataManagerTest {
   @Test
   public void testGetKeysForContainer() {
 
-    Response response = containerKeyService.getKeysForContainer(1L);
+    Response response = containerKeyService.getKeysForContainer(1L, 2);
 
     Collection<KeyMetadata> keyMetadataList =
         (Collection<KeyMetadata>) response.getEntity();
-    assertTrue(keyMetadataList.size() == 2);
+    assertEquals(keyMetadataList.size(), 2);
 
     Iterator<KeyMetadata> iterator = keyMetadataList.iterator();
 
     KeyMetadata keyMetadata = iterator.next();
-    assertTrue(keyMetadata.getKey().equals("key_one"));
-    assertTrue(keyMetadata.getVersions().size() == 1);
-    assertTrue(keyMetadata.getBlockIds().size() == 1);
+    assertEquals(keyMetadata.getKey(), "key_one");
+    assertEquals(keyMetadata.getVersions().size(), 1);
+    assertEquals(keyMetadata.getBlockIds().size(), 1);
     Map<Long, List<KeyMetadata.ContainerBlockMetadata>> blockIds =
         keyMetadata.getBlockIds();
-    assertTrue(blockIds.get(0L).iterator().next().getLocalID() == 101);
+    assertEquals(blockIds.get(0L).iterator().next().getLocalID(), 101);
 
     keyMetadata = iterator.next();
-    assertTrue(keyMetadata.getKey().equals("key_two"));
-    assertTrue(keyMetadata.getVersions().size() == 2);
+    assertEquals(keyMetadata.getKey(), "key_two");
+    assertEquals(keyMetadata.getVersions().size(), 2);
     assertTrue(keyMetadata.getVersions().contains(0L) && keyMetadata
         .getVersions().contains(1L));
-    assertTrue(keyMetadata.getBlockIds().size() == 2);
+    assertEquals(keyMetadata.getBlockIds().size(), 2);
     blockIds = keyMetadata.getBlockIds();
-    assertTrue(blockIds.get(0L).iterator().next().getLocalID() == 103);
-    assertTrue(blockIds.get(1L).iterator().next().getLocalID() == 104);
+    assertEquals(blockIds.get(0L).iterator().next().getLocalID(), 103);
+    assertEquals(blockIds.get(1L).iterator().next().getLocalID(), 104);
 
-    response = containerKeyService.getKeysForContainer(3L);
+    response = containerKeyService.getKeysForContainer(3L, 1);
     keyMetadataList = (Collection<KeyMetadata>) response.getEntity();
     assertTrue(keyMetadataList.isEmpty());
+
+    // test if limit works as expected
+    response = containerKeyService.getKeysForContainer(1L, 1);
+    keyMetadataList = (Collection<KeyMetadata>) response.getEntity();
+    assertEquals(keyMetadataList.size(), 1);
   }
 
   @Test
   public void testGetContainers() {
 
-    Response response = containerKeyService.getContainers();
+    Response response = containerKeyService.getContainers(2);
 
     List<ContainerMetadata> containers = new ArrayList<>(
         (Collection<ContainerMetadata>) response.getEntity());
 
-    assertTrue(containers.size() == 2);
-
     Iterator<ContainerMetadata> iterator = containers.iterator();
 
     ContainerMetadata containerMetadata = iterator.next();
-    assertTrue(containerMetadata.getContainerID() == 1L);
-    assertTrue(containerMetadata.getNumberOfKeys() == 3L);
+    assertEquals(containerMetadata.getContainerID(), 1L);
+    // Number of keys for CID:1 should be 3 because of two different versions
+    // of key_two stored in CID:1
+    assertEquals(containerMetadata.getNumberOfKeys(), 3L);
 
     containerMetadata = iterator.next();
-    assertTrue(containerMetadata.getContainerID() == 2L);
-    assertTrue(containerMetadata.getNumberOfKeys() == 2L);
+    assertEquals(containerMetadata.getContainerID(), 2L);
+    assertEquals(containerMetadata.getNumberOfKeys(), 2L);
+
+    // test if limit works as expected
+    response = containerKeyService.getContainers(1);
+    containers = new ArrayList<>(
+        (Collection<ContainerMetadata>) response.getEntity());
+    assertEquals(containers.size(), 1);
   }
 
   /**

--- a/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerKeyService.java
+++ b/hadoop-ozone/ozone-recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerKeyService.java
@@ -201,7 +201,7 @@ public class TestContainerKeyService extends AbstractOMMetadataManagerTest {
   @Test
   public void testGetKeysForContainer() {
 
-    Response response = containerKeyService.getKeysForContainer(1L, 2);
+    Response response = containerKeyService.getKeysForContainer(1L, -1);
 
     Collection<KeyMetadata> keyMetadataList =
         (Collection<KeyMetadata>) response.getEntity();
@@ -227,7 +227,7 @@ public class TestContainerKeyService extends AbstractOMMetadataManagerTest {
     assertEquals(blockIds.get(0L).iterator().next().getLocalID(), 103);
     assertEquals(blockIds.get(1L).iterator().next().getLocalID(), 104);
 
-    response = containerKeyService.getKeysForContainer(3L, 1);
+    response = containerKeyService.getKeysForContainer(3L, -1);
     keyMetadataList = (Collection<KeyMetadata>) response.getEntity();
     assertTrue(keyMetadataList.isEmpty());
 
@@ -240,7 +240,7 @@ public class TestContainerKeyService extends AbstractOMMetadataManagerTest {
   @Test
   public void testGetContainers() {
 
-    Response response = containerKeyService.getContainers(2);
+    Response response = containerKeyService.getContainers(-1);
 
     List<ContainerMetadata> containers = new ArrayList<>(
         (Collection<ContainerMetadata>) response.getEntity());
@@ -278,5 +278,4 @@ public class TestContainerKeyService extends AbstractOMMetadataManagerTest {
         .getAbsolutePath());
     return configuration;
   }
-
 }


### PR DESCRIPTION
This PR adds support for limit query param to limit the results of /api/containers and /api/containers/{id} endpoints. This will help the UI to load and show results faster with infinite scrolling.
