### PR TITLE
HDDS-1677. Auditparser robot test shold use a world writable working directory

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
@@ -20,8 +20,9 @@ Library             BuiltIn
 Resource            ../commonlib.robot
 
 *** Variables ***
-${user}        hadoop
-${count}       4
+${user}              hadoop
+${count}             4
+${auditworkdir}      /tmp/
 
 *** Keywords ***
 Set username
@@ -38,15 +39,15 @@ Initiating freon to generate data
 Testing audit parser
     ${logdir} =        Get Environment Variable      HADOOP_LOG_DIR     /var/log/hadoop
     ${logfile} =       Execute              ls -t "${logdir}" | grep om-audit | head -1
-                       Execute              ozone auditparser /opt/hadoop/audit.db load "${logdir}/${logfile}"
-    ${result} =        Execute              ozone auditparser /opt/hadoop/audit.db template top5cmds
+                       Execute              ozone auditparser "${auditworkdir}/audit.db" load "${logdir}/${logfile}"
+    ${result} =        Execute              ozone auditparser "${auditworkdir}/audit.db" template top5cmds
                        Should Contain       ${result}  ALLOCATE_KEY
-    ${result} =        Execute              ozone auditparser /opt/hadoop/audit.db template top5users
+    ${result} =        Execute              ozone auditparser "${auditworkdir}/audit.db" template top5users
     Run Keyword If     '${SECURITY_ENABLED}' == 'true'      Set username
                        Should Contain       ${result}  ${user}
-    ${result} =        Execute              ozone auditparser /opt/hadoop/audit.db query "select count(*) from audit where op='CREATE_VOLUME' and RESULT='SUCCESS'"
+    ${result} =        Execute              ozone auditparser "${auditworkdir}/audit.db" query "select count(*) from audit where op='CREATE_VOLUME' and RESULT='SUCCESS'"
     ${result} =        Convert To Number     ${result}
                        Should be true       ${result}>${count}
-    ${result} =        Execute              ozone auditparser /opt/hadoop/audit.db query "select count(*) from audit where op='CREATE_BUCKET' and RESULT='SUCCESS'"
+    ${result} =        Execute              ozone auditparser "${auditworkdir}/audit.db" query "select count(*) from audit where op='CREATE_BUCKET' and RESULT='SUCCESS'"
     ${result} =        Convert To Number     ${result}
                        Should be true       ${result}>${count}


### PR DESCRIPTION
When I tried to reproduce a problem which is reported by [~eyang], I found that the auditparser robot test uses the /opt/hadoop directory as a working directory to generate the audit.db export.

/opt/hadoop is may or may not be writable, it's better to use /tmp instead.

See: https://issues.apache.org/jira/browse/HDDS-1677