### PR TITLE
HDDS-1678. Default image name for kubernetes examples should be ozone and not hadoop

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.image>apache/hadoop:${project.version}</docker.image>
+    <docker.image>apache/ozone:${project.version}</docker.image>
     <docker.hadoop-runner.version>jdk11</docker.hadoop-runner.version>
   </properties>
 


### PR DESCRIPTION
During the build the kubernetes example files are adjusted to use a specific docker image name.

By default it should be the apache/ozone:${VERSION} to make it possible to use the examples without any build from the release artifact. With the examples of the release artifact the user can use the latest released apache/ozone:${VERSION} from docker hub.

For development build the image can be set with -Ddocker.image (or -Dozone.docker.image with HDDS-1667).

Unfortunately -- due to a small typo -- apace/hadoop image is used by default instead of apache/ozone.  

See: https://issues.apache.org/jira/browse/HDDS-1678