### PR TITLE
HADOOP-16371: Option to disable GCM for SSL connections when running on Java 8

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -343,6 +343,16 @@
       <artifactId>dnsjava</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.openssl</groupId>
+      <artifactId>wildfly-openssl</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1973,6 +1973,20 @@
   </description>
 </property>
 
+<property>
+  <name>fs.s3a.ssl.channel.mode</name>
+  <value>default_jsse</value>
+  <description>
+    If secure connections to S3 are enabled, configures the SSL
+    implementation used to encrypt connections to S3. Supported values are:
+    "default_jsse" and "default_jsse_with_gcm". "default_jsse" uses the Java
+    Secure Socket Extension package (JSSE). However, when running on Java 8,
+    the GCM cipher is removed from the list of enabled ciphers. This is due
+    to performance issues with GCM in Java 8. "default_jsse_with_gcm" uses
+    the JSSE with the default list of cipher suites.
+  </description>
+</property>
+
 <!-- Azure file system properties -->
 <property>
   <name>fs.AbstractFileSystem.wasb.impl</name>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.ssl;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import org.apache.hadoop.util.NativeCodeLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests for {@link DelegatingSSLSocketFactory}.
+ */
+public class TestDelegatingSSLSocketFactory {
+
+  @Test
+  public void testOpenSSL() throws IOException {
+    assumeTrue("Unable to load native libraries",
+            NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue("Build was not compiled with support for OpenSSL",
+            NativeCodeLoader.buildSupportsOpenssl());
+    DelegatingSSLSocketFactory.initializeDefaultFactory(
+            DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
+    assertThat(DelegatingSSLSocketFactory.getDefaultFactory()
+            .getProviderName()).contains("openssl");
+  }
+
+  @Test
+  public void testJSEENoGCMJava8() throws IOException {
+    assumeTrue("Not running on Java 8",
+            System.getProperty("java.version").startsWith("1.8"));
+    DelegatingSSLSocketFactory.initializeDefaultFactory(
+            DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE);
+    assertThat(Arrays.stream(DelegatingSSLSocketFactory.getDefaultFactory()
+            .getSupportedCipherSuites())).noneMatch("GCM"::contains);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -152,6 +153,12 @@ public final class Constants {
   public static final String SECURE_CONNECTIONS =
       "fs.s3a.connection.ssl.enabled";
   public static final boolean DEFAULT_SECURE_CONNECTIONS = true;
+
+  // use OpenSSL or JSEE for secure connections
+  public static final String SSL_CHANNEL_MODE =  "fs.s3a.ssl.channel.mode";
+  public static final DelegatingSSLSocketFactory.SSLChannelMode
+      DEFAULT_SSL_CHANNEL_MODE =
+          DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE;
 
   //use a custom endpoint?
   public static final String ENDPOINT = "fs.s3a.endpoint";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/NetworkBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/NetworkBinding.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+
+import com.amazonaws.ClientConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
+
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SSL_CHANNEL_MODE;
+import static org.apache.hadoop.fs.s3a.Constants.SSL_CHANNEL_MODE;
+
+/**
+ * Configures network settings when communicating with AWS services.
+ */
+public class NetworkBinding {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(NetworkBinding.class);
+  private static final String AWS_SOCKET_FACTORY_CLASSNAME = "com.amazonaws" +
+          ".thirdparty.apache.http.conn.ssl.SSLConnectionSocketFactory";
+
+  /**
+   * Configures the {@link com.amazonaws.thirdparty.apache.http.conn.ssl
+   * .SSLConnectionSocketFactory} used by the AWS SDK. A custom
+   * SSLConnectionSocketFactory can be set using the method
+   * {@link com.amazonaws.ApacheHttpClientConfig#setSslSocketFactory(
+   * com.amazonaws.thirdparty.apache.http.conn.socket.ConnectionSocketFactory)}.
+   * If {@link com.amazonaws.thirdparty.apache.http.conn.ssl
+   * .SSLConnectionSocketFactory} cannot be found on the classpath, the value
+   * of {@link org.apache.hadoop.fs.s3a.Constants#SSL_CHANNEL_MODE} is ignored.
+   *
+   * @param conf the {@link Configuration} used to get the client specified
+   *             value of {@link org.apache.hadoop.fs.s3a.Constants
+   *             #SSL_CHANNEL_MODE}
+   * @param awsConf the {@link ClientConfiguration} to set the
+   *                SSLConnectionSocketFactory for.
+   * @throws IOException if there is an error while initializing the
+   *                     {@link SSLSocketFactory}.
+   */
+  public static void bindSSLChannelMode(Configuration conf,
+      ClientConfiguration awsConf) throws IOException {
+    try {
+      // Validate that SSL_CHANNEL_MODE is set to a valid value.
+      String channelModeString = conf.get(
+              SSL_CHANNEL_MODE, DEFAULT_SSL_CHANNEL_MODE.name());
+      DelegatingSSLSocketFactory.SSLChannelMode channelMode = null;
+      for (DelegatingSSLSocketFactory.SSLChannelMode mode :
+              DelegatingSSLSocketFactory.SSLChannelMode.values()) {
+        if (mode.name().equalsIgnoreCase(channelModeString)) {
+          channelMode = mode;
+        }
+      }
+      if (channelMode == null) {
+        throw new IllegalArgumentException(channelModeString +
+                " is not a valid value for " + SSL_CHANNEL_MODE);
+      }
+      if (channelMode == DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL ||
+          channelMode == DelegatingSSLSocketFactory.SSLChannelMode.Default) {
+        throw new UnsupportedOperationException("S3A does not support " +
+                "setting " + SSL_CHANNEL_MODE + " " +
+                DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL + " or " +
+                DelegatingSSLSocketFactory.SSLChannelMode.Default);
+      }
+
+      // Look for AWS_SOCKET_FACTORY_CLASSNAME on the classpath and instantiate
+      // an instance using the DelegatingSSLSocketFactory as the
+      // SSLSocketFactory.
+      Class<?> sslConnectionSocketFactory = Class.forName(
+              AWS_SOCKET_FACTORY_CLASSNAME);
+      Constructor<?> factoryConstructor =
+              sslConnectionSocketFactory.getDeclaredConstructor(
+                      SSLSocketFactory.class, HostnameVerifier.class);
+      DelegatingSSLSocketFactory.initializeDefaultFactory(channelMode);
+      awsConf.getApacheHttpClientConfig().setSslSocketFactory(
+              (com.amazonaws.thirdparty.apache.http.conn.ssl.
+                      SSLConnectionSocketFactory) factoryConstructor
+                      .newInstance(DelegatingSSLSocketFactory
+                                      .getDefaultFactory(),
+                              (HostnameVerifier) null));
+    } catch (ClassNotFoundException | NoSuchMethodException |
+            IllegalAccessException | InstantiationException |
+            InvocationTargetException e) {
+      LOG.debug("Unable to create class {}, value of {} will be ignored",
+              AWS_SOCKET_FACTORY_CLASSNAME, SSL_CHANNEL_MODE, e);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -56,7 +56,7 @@ import org.apache.hadoop.fs.azurebfs.security.AbfsDelegationTokenManager;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.azurebfs.services.KeyProvider;
 import org.apache.hadoop.fs.azurebfs.services.SimpleKeyProvider;
-import org.apache.hadoop.fs.azurebfs.utils.SSLSocketFactoryEx;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 import org.apache.hadoop.security.ProviderUtils;
 import org.apache.hadoop.util.ReflectionUtils;
 
@@ -435,7 +435,7 @@ public class AbfsConfiguration{
     return this.userAgentId;
   }
 
-  public SSLSocketFactoryEx.SSLChannelMode getPreferredSSLFactoryOption() {
+  public DelegatingSSLSocketFactory.SSLChannelMode getPreferredSSLFactoryOption() {
     return getEnum(FS_AZURE_SSL_CHANNEL_MODE_KEY, DEFAULT_FS_AZURE_SSL_CHANNEL_MODE);
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azurebfs.constants;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.azurebfs.utils.SSLSocketFactoryEx;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 /**
  * Responsible to keep all the Azure Blob File System related configurations.
@@ -59,8 +59,8 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_ENABLE_FLUSH = true;
   public static final boolean DEFAULT_ENABLE_AUTOTHROTTLING = true;
 
-  public static final SSLSocketFactoryEx.SSLChannelMode DEFAULT_FS_AZURE_SSL_CHANNEL_MODE
-      = SSLSocketFactoryEx.SSLChannelMode.Default;
+  public static final DelegatingSSLSocketFactory.SSLChannelMode DEFAULT_FS_AZURE_SSL_CHANNEL_MODE
+      = DelegatingSSLSocketFactory.SSLChannelMode.Default;
 
   public static final boolean DEFAULT_ENABLE_DELEGATION_TOKEN = false;
   public static final boolean DEFAULT_ENABLE_HTTPS = true;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Locale;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.fs.azurebfs.utils.SSLSocketFactoryEx;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams;
@@ -79,10 +79,10 @@ public class AbfsClient implements Closeable {
 
     if (this.baseUrl.toString().startsWith(HTTPS_SCHEME)) {
       try {
-        SSLSocketFactoryEx.initializeDefaultFactory(this.abfsConfiguration.getPreferredSSLFactoryOption());
-        sslProviderName = SSLSocketFactoryEx.getDefaultFactory().getProviderName();
+        DelegatingSSLSocketFactory.initializeDefaultFactory(this.abfsConfiguration.getPreferredSSLFactoryOption());
+        sslProviderName = DelegatingSSLSocketFactory.getDefaultFactory().getProviderName();
       } catch (IOException e) {
-        // Suppress exception. Failure to init SSLSocketFactoryEx would have only performance impact.
+        // Suppress exception. Failure to init DelegatingSSLSocketFactory would have only performance impact.
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
-import org.apache.hadoop.fs.azurebfs.utils.SSLSocketFactoryEx;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
@@ -180,7 +180,7 @@ public class AbfsHttpOperation {
     this.connection = openConnection();
     if (this.connection instanceof HttpsURLConnection) {
       HttpsURLConnection secureConn = (HttpsURLConnection) this.connection;
-      SSLSocketFactory sslSocketFactory = SSLSocketFactoryEx.getDefaultFactory();
+      SSLSocketFactory sslSocketFactory = DelegatingSSLSocketFactory.getDefaultFactory();
       if (sslSocketFactory != null) {
         secureConn.setSSLSocketFactory(sslSocketFactory);
       }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsConfigurationFieldsValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsConfigurationFieldsValidation.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationValueException;
-import org.apache.hadoop.fs.azurebfs.utils.SSLSocketFactoryEx;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 import org.junit.Test;
 
 /**
@@ -167,19 +167,19 @@ public class TestAbfsConfigurationFieldsValidation {
   @Test
   public void testSSLSocketFactoryConfiguration()
       throws InvalidConfigurationValueException, IllegalAccessException, IOException {
-    assertEquals(SSLSocketFactoryEx.SSLChannelMode.Default, abfsConfiguration.getPreferredSSLFactoryOption());
-    assertNotEquals(SSLSocketFactoryEx.SSLChannelMode.Default_JSSE, abfsConfiguration.getPreferredSSLFactoryOption());
-    assertNotEquals(SSLSocketFactoryEx.SSLChannelMode.OpenSSL, abfsConfiguration.getPreferredSSLFactoryOption());
+    assertEquals(DelegatingSSLSocketFactory.SSLChannelMode.Default, abfsConfiguration.getPreferredSSLFactoryOption());
+    assertNotEquals(DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE, abfsConfiguration.getPreferredSSLFactoryOption());
+    assertNotEquals(DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL, abfsConfiguration.getPreferredSSLFactoryOption());
 
     Configuration configuration = new Configuration();
-    configuration.setEnum(FS_AZURE_SSL_CHANNEL_MODE_KEY, SSLSocketFactoryEx.SSLChannelMode.Default_JSSE);
+    configuration.setEnum(FS_AZURE_SSL_CHANNEL_MODE_KEY, DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE);
     AbfsConfiguration localAbfsConfiguration = new AbfsConfiguration(configuration, accountName);
-    assertEquals(SSLSocketFactoryEx.SSLChannelMode.Default_JSSE, localAbfsConfiguration.getPreferredSSLFactoryOption());
+    assertEquals(DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE, localAbfsConfiguration.getPreferredSSLFactoryOption());
 
     configuration = new Configuration();
-    configuration.setEnum(FS_AZURE_SSL_CHANNEL_MODE_KEY, SSLSocketFactoryEx.SSLChannelMode.OpenSSL);
+    configuration.setEnum(FS_AZURE_SSL_CHANNEL_MODE_KEY, DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
     localAbfsConfiguration = new AbfsConfiguration(configuration, accountName);
-    assertEquals(SSLSocketFactoryEx.SSLChannelMode.OpenSSL, localAbfsConfiguration.getPreferredSSLFactoryOption());
+    assertEquals(DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL, localAbfsConfiguration.getPreferredSSLFactoryOption());
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -25,9 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
-import org.apache.hadoop.fs.azurebfs.utils.SSLSocketFactoryEx;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
+import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 import org.apache.hadoop.util.VersionInfo;
 
 /**
@@ -46,7 +46,7 @@ public final class TestAbfsClient {
         config, null, null);
     String sslProviderName = null;
     if (includeSSLProvider) {
-      sslProviderName = SSLSocketFactoryEx.getDefaultFactory().getProviderName();
+      sslProviderName = DelegatingSSLSocketFactory.getDefaultFactory().getProviderName();
     }
     String userAgent = client.initializeUserAgent(config, sslProviderName);
     Pattern pattern = Pattern.compile(expectedPattern);
@@ -86,7 +86,7 @@ public final class TestAbfsClient {
     final Configuration configuration = new Configuration();
     configuration.set(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY, "Partner Service");
     configuration.set(ConfigurationKeys.FS_AZURE_SSL_CHANNEL_MODE_KEY,
-        SSLSocketFactoryEx.SSLChannelMode.Default_JSSE.name());
+        DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE.name());
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, accountName);
     validateUserAgent(expectedUserAgentPattern, new URL("https://azure.com"),
         abfsConfiguration, true);


### PR DESCRIPTION
[HADOOP-16371: Option to disable GCM for SSL connections when running on Java 8](https://issues.apache.org/jira/browse/HADOOP-16371)

Changes:
* Patch is based on the merged patch from HADOOP-16050
* Decided a better name for `SSLSocketFactoryEx` would be `DelegatingSSLSocketFactory` because the class is not OpenSSL specific (e.g. it is capable of just delegating to the JSSE)
* Add a bunch of code comments to `DelegatingSSLSocketFactory`
* Documented `fs.s3a.ssl.channel.mode` in `performance.md` and `core-default.xml`
* If a user tries to configure OpenSSL as the mode via `fs.s3a.ssl.channel.mode` an `UnsupportedOperationException` is thrown.

Testing Done:
* Ran all S3 tests `mvn verify` and S3 scale tests `mvn verify -Dparallel-tests -Dscale -DtestsThreadCount=16` (did not have S3Guard or kms tests setup)
* Ran `TestDelegatingSSLSocketFactory` on Ubuntu and OSX with `-Pnative` and confirmed the test passes on both systems (on OSX it is skipped, on Ubuntu it actually runs)
* Ran the ABFS tests against "East US 2" and the only failure was `ITestGetNameSpaceEnabled.testNonXNSAccount` (known issue)
* Ran `mvn package -Pdist -DskipTests -Dmaven.javadoc.skip=true -DskipShade`, un-tarred `hadoop-dist/target/hadoop-3.3.0-SNAPSHOT.tar.gz` and ran `./bin/hadoop fs -ls s3a://[my-bucket-name]/` successfully and that I could upload and read a file to S3 using the CLI without the wildlfy jar on the classpath