### PR TITLE
YARN-2695. Added support for reservation continue looking with node labels

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
@@ -439,6 +439,10 @@ public class SchedulerApplicationAttempt implements SchedulableEntity {
   public Resource getCurrentReservation() {
     return attemptResourceUsage.getReserved();
   }
+
+  public Resource getCurrentReservation(String partition) {
+    return attemptResourceUsage.getReserved(partition);
+  }
   
   public Queue getQueue() {
     return queue;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
@@ -965,12 +965,10 @@ public abstract class AbstractCSQueue implements CSQueue {
       if (Resources.greaterThanOrEqual(resourceCalculator, clusterResource,
           usedExceptKillable, currentLimitResource)) {
 
-        // if reservation continous looking enabled, check to see if could we
+        // if reservation continue looking enabled, check to see if could we
         // potentially use this node instead of a reserved node if the application
         // has reserved containers.
-        // TODO, now only consider reservation cases when the node has no label
-        if (this.reservationsContinueLooking && nodePartition.equals(
-            RMNodeLabelsManager.NO_LABEL) && Resources.greaterThan(
+        if (this.reservationsContinueLooking && Resources.greaterThan(
             resourceCalculator, clusterResource, resourceCouldBeUnreserved,
             Resources.none())) {
           // resource-without-reserved = used - reserved

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -1106,7 +1106,7 @@ public class LeafQueue extends AbstractCSQueue {
           node, SystemClock.getInstance().getTime(), application);
 
       // Check queue max-capacity limit
-      Resource appReserved = application.getCurrentReservation();
+      Resource appReserved = application.getCurrentReservation(node.getPartition());
       if (needAssignToQueueCheck) {
         if (!super.canAssignToThisQueue(clusterResource,
             candidates.getPartition(), currentResourceLimits, appReserved,
@@ -1552,8 +1552,7 @@ public class LeafQueue extends AbstractCSQueue {
           user.getUsed(nodePartition), limit)) {
         // if enabled, check to see if could we potentially use this node instead
         // of a reserved node if the application has reserved containers
-        if (this.reservationsContinueLooking && nodePartition.equals(
-            CommonNodeLabelsManager.NO_LABEL)) {
+        if (this.reservationsContinueLooking) {
           if (Resources.lessThanOrEqual(resourceCalculator, clusterResource,
               Resources.subtract(user.getUsed(),
                   application.getCurrentReservation()), limit)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservations.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservations.java
@@ -943,27 +943,119 @@ public class TestReservations {
 
     // no reserved containers
     NodeId unreserveId = app_0.getNodeIdToUnreserve(priorityMap, capability,
-            cs.getResourceCalculator());
+            cs.getResourceCalculator(), node_0,
+            SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY);
     assertEquals(null, unreserveId);
 
     // no reserved containers - reserve then unreserve
     app_0.reserve(node_0, priorityMap, rmContainer_1, container_1);
     app_0.unreserve(priorityMap, node_0, rmContainer_1);
     unreserveId = app_0.getNodeIdToUnreserve(priorityMap, capability,
-        cs.getResourceCalculator());
+        cs.getResourceCalculator(), node_0,
+        SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY);
     assertEquals(null, unreserveId);
 
     // no container large enough is reserved
     app_0.reserve(node_0, priorityMap, rmContainer_1, container_1);
     unreserveId = app_0.getNodeIdToUnreserve(priorityMap, capability,
-        cs.getResourceCalculator());
+        cs.getResourceCalculator(), node_0,
+        SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY);
     assertEquals(null, unreserveId);
 
     // reserve one that is now large enough
     app_0.reserve(node_1, priorityMap, rmContainer, container);
     unreserveId = app_0.getNodeIdToUnreserve(priorityMap, capability,
-        cs.getResourceCalculator());
+        cs.getResourceCalculator(), node_0,
+        SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY);
     assertEquals(node_1.getNodeID(), unreserveId);
+  }
+
+  private FiCaSchedulerApp getFiCaSchedulerApp() {
+    final String user = "user";
+    final ApplicationAttemptId appAttemptId = TestUtils
+        .getMockApplicationAttemptId(0, 0);
+    LeafQueue a = stubLeafQueue((LeafQueue) queues.get(A));
+    FiCaSchedulerApp app = new FiCaSchedulerApp(appAttemptId, user, a,
+        mock(ActiveUsersManager.class), spyRMContext);
+    return app;
+  }
+
+  private RMContainer getRMContainerMock(String nodeLabel, boolean hasIncreaseReservation, int memory) {
+    RMContainer container = mock(RMContainer.class);
+    when(container.getNodeLabelExpression()).thenReturn(nodeLabel);
+    Resource reservedResource = Resources.createResource(memory * GB, 0);
+    when(container.getReservedResource()).thenReturn(reservedResource);
+    return container;
+  }
+
+  private FiCaSchedulerNode getFiCaSchedulerNodeMock(String nodeLabel) {
+    FiCaSchedulerNode node = mock(FiCaSchedulerNode.class);
+    when(node.getPartition()).thenReturn(nodeLabel);
+    return node;
+  }
+
+  @Test
+  public void testCanContainerBeUnreservedWithoutNodeLabel() throws Exception {
+    CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration();
+    setup(csConf);
+    FiCaSchedulerApp app = getFiCaSchedulerApp();
+
+    FiCaSchedulerNode node = getFiCaSchedulerNodeMock(RMNodeLabelsManager.NO_LABEL);
+    RMContainer container = getRMContainerMock(RMNodeLabelsManager.NO_LABEL, false, 10);
+
+    Resource resourceNeedUnreserve = Resources.createResource(10 * GB, 0);
+    assertTrue(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY));
+    assertTrue(app.canContainerBeUnreserved(container,  resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.IGNORE_PARTITION_EXCLUSIVITY));
+  }
+
+  @Test
+  public void testCanContainerBeUnreservedWithNodeLabel() throws Exception {
+    CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration();
+    setup(csConf);
+    FiCaSchedulerApp app = getFiCaSchedulerApp();
+
+    FiCaSchedulerNode node = getFiCaSchedulerNodeMock("dummy");
+    RMContainer container = getRMContainerMock(RMNodeLabelsManager.NO_LABEL, false, 10);
+
+    Resource resourceNeedUnreserve = Resources.createResource(10 * GB, 0);
+    assertFalse(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY));
+    assertTrue(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.IGNORE_PARTITION_EXCLUSIVITY));
+  }
+
+  @Test
+  public void testCanContainerBeUnreservedWithContainerNodeLabel() throws Exception {
+    CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration();
+    setup(csConf);
+    FiCaSchedulerApp app = getFiCaSchedulerApp();
+
+    FiCaSchedulerNode node = getFiCaSchedulerNodeMock("dummy");
+    RMContainer container = getRMContainerMock("dummy", false, 10);
+
+    Resource resourceNeedUnreserve = Resources.createResource(10 * GB, 0);
+    assertTrue(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY));
+    assertFalse(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.IGNORE_PARTITION_EXCLUSIVITY));
+  }
+
+  @Test
+  public void testCanContainerBeUnreservedWithoutEnoughResources() throws Exception {
+    CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration();
+    setup(csConf);
+    FiCaSchedulerApp app = getFiCaSchedulerApp();
+
+    FiCaSchedulerNode node = getFiCaSchedulerNodeMock(RMNodeLabelsManager.NO_LABEL);
+    RMContainer container = getRMContainerMock(RMNodeLabelsManager.NO_LABEL, false, 9);
+
+    Resource resourceNeedUnreserve = Resources.createResource(10 * GB, 0);
+    assertFalse(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY));
+    assertFalse(app.canContainerBeUnreserved(container, resourceNeedUnreserve,
+        new DefaultResourceCalculator(), node, SchedulingMode.IGNORE_PARTITION_EXCLUSIVITY));
   }
 
   @Test
@@ -1010,14 +1102,14 @@ public class TestReservations {
 
     // nothing reserved
     RMContainer toUnreserveContainer = app_0.findNodeToUnreserve(node_1,
-            priorityMap, capability);
+            priorityMap, capability, SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY);
     assertTrue(toUnreserveContainer == null);
 
     // reserved but scheduler doesn't know about that node.
     app_0.reserve(node_1, priorityMap, rmContainer, container);
     node_1.reserveResource(app_0, priorityMap, rmContainer);
     toUnreserveContainer = app_0.findNodeToUnreserve(node_1,
-            priorityMap, capability);
+            priorityMap, capability, SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY);
     assertTrue(toUnreserveContainer == null);
   }
 


### PR DESCRIPTION
When a resource deprived node is scheduled by resource manager,
capacity scheduler will reserve a container on this node even though
there are resources available on other nodes. Since reserved containers
take up headroom, sometimes resources available on other nodes will
never be utilized. After this change, headroom calculation will include
resources that could be unreserved on other nodes in the same partition,
and unreserve the container after allocation of another container on the
scheduled node.