### PR TITLE
HDDS-1698. Switch to use apache/ozone-runner in the compose/Dockerfile

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -96,7 +96,7 @@ run cp "${ROOT}/hadoop-hdds/common/src/main/resources/network-topology-nodegroup
 run cp "${ROOT}/hadoop-common-project/hadoop-common/src/main/bin/hadoop" "bin/"
 run cp "${ROOT}/hadoop-common-project/hadoop-common/src/main/bin/hadoop.cmd" "bin/"
 run cp "${ROOT}/hadoop-ozone/common/src/main/bin/ozone" "bin/"
-run cp -r "${ROOT}/hadoop-ozone/dist/src/main/dockerbin" "bin/"
+run cp -r "${ROOT}/hadoop-ozone/dist/src/main/dockerbin" "bin/docker"
 
 run cp "${ROOT}/hadoop-common-project/hadoop-common/src/main/bin/hadoop-config.sh" "libexec/"
 run cp "${ROOT}/hadoop-common-project/hadoop-common/src/main/bin/hadoop-config.cmd" "libexec/"
@@ -125,7 +125,7 @@ cp -r "${ROOT}/hadoop-hdds/docs/target/classes/docs" ./
 run cp -p -R "${ROOT}/hadoop-ozone/dist/target/compose" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/src/main/smoketest" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/k8s" kubernetes
-run cp -p -r "${ROOT}/hadoop-ozone/dist/src/main/Dockerfile" .
+run cp -p -r "${ROOT}/hadoop-ozone/dist/target/Dockerfile" .
 
 #workaround for https://issues.apache.org/jira/browse/MRESOURCES-236
 find ./compose -name "*.sh" -exec chmod 755 {} \;

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,8 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.hadoop-runner.version>jdk11</docker.hadoop-runner.version>
+    <docker.image>apache/hadoop:${project.version}</docker.image>
+    <docker.ozone-runner.version>20190617-2</docker.ozone-runner.version>
   </properties>
 
   <build>
@@ -191,6 +192,22 @@
               <resources>
                 <resource>
                   <directory>src/main/compose</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-and-filter-dockerfile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/docker</directory>
                   <filtering>true</filtering>
                 </resource>
               </resources>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,6 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.image>apache/hadoop:${project.version}</docker.image>
     <docker.ozone-runner.version>20190617-2</docker.ozone-runner.version>
   </properties>
 

--- a/hadoop-ozone/dist/src/main/compose/README.md
+++ b/hadoop-ozone/dist/src/main/compose/README.md
@@ -49,9 +49,3 @@ docker-compose scale datanode=5
 ```
 
 Usually the key webui ports are published on the docker host.
-
-## Known issues
-
-The base image used here is apache/hadoop-runner, which runs with JDK8 by default.
-You may run with JDK11 by specify apache/hadoop-runner:jdk11 as base image in simple mode.
-But in secure mode, JDK 11 is not fully supported yet due to JDK8 dependencies from hadoop-common jars.

--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HADOOP_VERSION=3
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -48,7 +48,7 @@ services:
           - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -59,7 +59,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    s3g:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/.env
@@ -17,3 +17,4 @@
 HDDS_VERSION=${hdds.version}
 HADOOP_IMAGE=apache/hadoop
 HADOOP_VERSION=3
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
   datanode:
-    image: apache/hadoop-runner
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     ports:
@@ -26,7 +26,7 @@ services:
     env_file:
       - docker-config
   om:
-    image: apache/hadoop-runner
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../..:/opt/hadoop
@@ -39,7 +39,7 @@ services:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/hadoop-runner
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../..:/opt/hadoop
@@ -49,7 +49,7 @@ services:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/hadoop-runner:latest
+    image: apache/ozone-runner:latest:${HADOOP_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-net-topology/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-net-topology/.env
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=0.5.0-SNAPSHOT
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozone-net-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-net-topology/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode_1:
-      image: apache/hadoop-runner:jdk11
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -31,7 +31,7 @@ services:
          service_network:
             ipv4_address: 10.5.0.4
    datanode_2:
-      image: apache/hadoop-runner:jdk11
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -45,7 +45,7 @@ services:
          service_network:
             ipv4_address: 10.5.0.5
    datanode_3:
-      image: apache/hadoop-runner:jdk11
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -59,7 +59,7 @@ services:
          service_network:
             ipv4_address: 10.5.0.6
    datanode_4:
-      image: apache/hadoop-runner:jdk11
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -73,7 +73,7 @@ services:
          service_network:
             ipv4_address: 10.5.0.7
    om:
-      image: apache/hadoop-runner:jdk11
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -88,7 +88,7 @@ services:
          service_network:
             ipv4_address: 10.5.0.70
    scm:
-      image: apache/hadoop-runner:jdk11
+      image: apache/ozone-runner::${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -27,7 +27,7 @@ services:
       env_file:
         - ./docker-config
    om1:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -40,7 +40,7 @@ services:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    om2:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -53,7 +53,7 @@ services:
          - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    om3:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -66,7 +66,7 @@ services:
          - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-recon/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-recon/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozone-recon/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-recon/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:
+      image: apache/ozone-runner:
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -28,7 +28,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -40,7 +40,7 @@ services:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -52,7 +52,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["/opt/hadoop/bin/ozone","scm"]
    recon:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -28,7 +28,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -40,7 +40,7 @@ services:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -26,7 +26,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -37,7 +37,7 @@ services:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -48,7 +48,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["/opt/hadoop/bin/ozone","scm"]
    ozone_client:
-       image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
        volumes:
          - ../..:/opt/hadoop
        ports:

--- a/hadoop-ozone/dist/src/main/compose/ozonefs/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonefs/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozonefs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonefs/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -26,7 +26,7 @@ services:
       env_file:
          - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       hostname: om
       volumes:
          - ../..:/opt/hadoop
@@ -38,7 +38,7 @@ services:
          - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -26,7 +26,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -37,7 +37,7 @@ services:
           - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -55,7 +55,7 @@ services:
      ports:
         - 9090:9090
    freon:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       environment:

--- a/hadoop-ozone/dist/src/main/compose/ozones3/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozones3/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozones3/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozones3/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -26,7 +26,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -37,7 +37,7 @@ services:
           - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -48,7 +48,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    s3g:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/.env
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM apache/hadoop-runner
+FROM apache/ozone-runner
 RUN sudo apt-get update && sudo apt-get install -y openssh-server
 
 RUN sudo mkdir -p /run/sshd

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
@@ -16,4 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 HADOOP_VERSION=3
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - ./docker-config
       command: ["hadoop", "kms"]
   datanode:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     ports:
@@ -42,7 +42,7 @@ services:
     env_file:
       - docker-config
   om:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../..:/opt/hadoop
@@ -54,7 +54,7 @@ services:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../..:/opt/hadoop
@@ -64,7 +64,7 @@ services:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/hadoop-runner:latest:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:latest:${HADOOP_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/.env
@@ -16,4 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 HADOOP_VERSION=3
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       command: ["hadoop", "kms"]
 
   datanode:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     ports:
@@ -44,7 +44,7 @@ services:
     env_file:
       - docker-config
   om:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../..:/opt/hadoop
@@ -56,7 +56,7 @@ services:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../..:/opt/hadoop
@@ -66,7 +66,7 @@ services:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonetrace/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonetrace/.env
@@ -16,4 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 HADOOP_VERSION=3
-HADOOP_RUNNER_VERSION=${docker.hadoop-runner.version}
+HADOOP_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/ozonetrace/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonetrace/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       ports:
          - 16686:16686
    datanode:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -32,7 +32,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -43,7 +43,7 @@ services:
           - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -54,7 +54,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    s3g:
-      image: apache/hadoop-runner:${HADOOP_RUNNER_VERSION}
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -43,5 +43,5 @@ for test in $(find $SCRIPT_DIR -name test.sh); do
   cp "$RESULT_DIR"/robot-*.xml "$ALL_RESULT_DIR"
 done
 
-docker run --rm -v "$SCRIPT_DIR/result:/opt/result" apache/hadoop-runner rebot -N "smoketests" -d "/opt/result" "/opt/result/robot-*.xml"
+docker run --rm -v "$SCRIPT_DIR/result:/opt/result" apache/ozone-runner rebot -N "smoketests" -d "/opt/result" "/opt/result/robot-*.xml"
 exit $RESULT

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -94,5 +94,5 @@ stop_docker_env(){
 ## @description  Generate robot framework reports based on the saved results.
 generate_report(){
   #Generate the combined output and return with the right exit code (note: robot = execute test, rebot = generate output)
-  docker run --rm -v "$DIR/..:${OZONE_DIR:-/opt/hadoop}" apache/hadoop-runner rebot -d "$RESULT_DIR_INSIDE" "$RESULT_DIR_INSIDE/robot-*.xml"
+  docker run --rm -v "$DIR/..:${OZONE_DIR:-/opt/hadoop}" apache/ozone-runner rebot -d "$RESULT_DIR_INSIDE" "$RESULT_DIR_INSIDE/robot-*.xml"
 }

--- a/hadoop-ozone/dist/src/main/docker/Dockerfile
+++ b/hadoop-ozone/dist/src/main/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/hadoop-runner:jdk11
+FROM apache/ozone-runner:@docker.ozone-runner.version@
 
 ADD --chown=hadoop . /opt/hadoop
 


### PR DESCRIPTION
Since HDDS-1634 we have an ozone specific runner image to run ozone with docker-compose based pseudo clusters.

As the new apache/ozone-runner image is uploaded to the dockerhub we can switch our scripts and use the new image.

See: https://issues.apache.org/jira/browse/HDDS-1698