### PR TITLE
Update RocksDB version to 6.0.1

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -88,7 +88,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <version>5.14.2</version>
+      <version>6.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
In RocksDb 6.0.1, some useful tuning features were brought into the JNI API. We need to upgrade the version in ozone to pick those up.

https://github.com/facebook/rocksdb/pull/4833