### PR TITLE
HDDS-1702. Optimize Ozone Recon build time

### DIFF
--- a/hadoop-ozone/ozone-recon/pom.xml
+++ b/hadoop-ozone/ozone-recon/pom.xml
@@ -28,6 +28,14 @@
     <spring.version>5.1.3.RELEASE</spring.version>
   </properties>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>**/node_modules/**</exclude>
+        </excludes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Currently, hadoop-ozone-recon node_modules folder is copied to target folder and this takes a lot of time while building hadoop-ozone project. 

This PR reduces the build time by excluding node_modules folder. With this patch it only takes approximately ~10 seconds to compile Recon.  