### PR TITLE
HDDS-1674 Make ScmBlockLocationProtocol message type based

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -162,7 +162,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
         .build();
 
     SCMBlockLocationRequest wrapper = createSCMBlockRequest(
-        Type.AllocateScmBlock)
+        Type.DeleteScmKeyBlocks)
         .setDeleteScmKeyBlocksRequest(request)
         .build();
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -82,8 +82,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
   private SCMBlockLocationRequest.Builder createSCMBlockRequest(Type cmdType) {
     return SCMBlockLocationRequest.newBuilder()
         .setCmdType(cmdType)
-        .setTraceID(TracingUtil.exportCurrentSpan())
-        .setClientId("The Client"); // TODO - what should this be? Where does it come from?
+        .setTraceID(TracingUtil.exportCurrentSpan());
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -110,7 +110,6 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
             .setType(type)
             .setFactor(factor)
             .setOwner(owner)
-            .setTraceID(TracingUtil.exportCurrentSpan())
             .setExcludeList(excludeList.getProtoBuf())
             .build();
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/protocolPB/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/protocolPB/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -97,26 +97,20 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
         traceId);
 
     switch (request.getCmdType()) {
-      case AllocateScmBlock: {
-        AllocateScmBlockResponseProto res = allocateScmBlock(traceId,
-            request.getAllocateScmBlockRequest());
-        response.setAllocateScmBlockResponse(res);
-        break;
-      }
-      case DeleteScmKeyBlocks: {
-        DeleteScmKeyBlocksResponseProto res = deleteScmKeyBlocks(traceId,
-            request.getDeleteScmKeyBlocksRequest());
-        response.setDeleteScmKeyBlocksResponse(res);
-        break;
-      }
-      case GetScmInfo: {
-        HddsProtos.GetScmInfoResponseProto res = getScmInfo(traceId,
-            request.getGetScmInfoRequest());
-        response.setGetScmInfoResponse(res);
-        break;
-      }
-      default:
-        throw new ServiceException("Unknown Operation");
+    case AllocateScmBlock:
+      response.setAllocateScmBlockResponse(
+          allocateScmBlock(traceId, request.getAllocateScmBlockRequest()));
+      break;
+    case DeleteScmKeyBlocks:
+      response.setDeleteScmKeyBlocksResponse(
+          deleteScmKeyBlocks(traceId, request.getDeleteScmKeyBlocksRequest()));
+      break;
+    case GetScmInfo:
+      response.setGetScmInfoResponse(
+          getScmInfo(traceId, request.getGetScmInfoRequest()));
+      break;
+    default:
+      throw new ServiceException("Unknown Operation");
     }
     response.setSuccess(true)
         .setStatus(Status.OK);

--- a/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
+++ b/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
@@ -98,7 +98,6 @@ message AllocateScmBlockRequestProto {
   required ReplicationType type = 3;
   required hadoop.hdds.ReplicationFactor factor = 4;
   required string owner = 5;
-  optional string traceID = 6;
   optional ExcludeListProto excludeList = 7;
 }
 
@@ -129,8 +128,6 @@ message KeyBlocks {
  */
 message DeleteScmKeyBlocksResponseProto {
   repeated DeleteKeyBlocksResultProto results = 1;
-  optional string traceID = 2;
-
 }
 
 /**
@@ -180,21 +177,4 @@ service ScmBlockLocationProtocolService {
 
   rpc send(SCMBlockLocationRequest)
       returns (SCMBlockLocationResponse);
-
-  /**
-   * Creates a block entry in SCM.
-   */
-//  rpc allocateScmBlock(AllocateScmBlockRequestProto)
-//      returns (AllocateScmBlockResponseProto);
-  /**
-   * Deletes blocks for a set of object keys from SCM.
-   */
-//  rpc deleteScmKeyBlocks(DeleteScmKeyBlocksRequestProto)
-//      returns (DeleteScmKeyBlocksResponseProto);
-
-  /**
-   * Gets the scmInfo from SCM.
-   */
-//  rpc getScmInfo(hadoop.hdds.GetScmInfoRequestProto)
-//      returns (hadoop.hdds.GetScmInfoResponseProto);
 }

--- a/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
+++ b/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
@@ -46,9 +46,7 @@ message SCMBlockLocationRequest {
   // frontend and this allows us to trace that command all over ozone.
   optional string traceID = 2;
 
-  required string clientId = 3;
-
-  optional UserInfo userInfo = 4;
+  optional UserInfo userInfo = 3;
 
   optional AllocateScmBlockRequestProto       allocateScmBlockRequest   = 11;
   optional DeleteScmKeyBlocksRequestProto     deleteScmKeyBlocksRequest = 12;

--- a/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
+++ b/hadoop-hdds/common/src/main/proto/ScmBlockLocationProtocol.proto
@@ -33,6 +33,62 @@ import "hdds.proto";
 
 // SCM Block protocol
 
+enum Type {
+  AllocateScmBlock   = 11;
+  DeleteScmKeyBlocks = 12;
+  GetScmInfo         = 13;
+}
+
+message SCMBlockLocationRequest {
+  required Type cmdType = 1; // Type of the command
+
+  // A string that identifies this command, we generate  Trace ID in Ozone
+  // frontend and this allows us to trace that command all over ozone.
+  optional string traceID = 2;
+
+  required string clientId = 3;
+
+  optional UserInfo userInfo = 4;
+
+  optional AllocateScmBlockRequestProto       allocateScmBlockRequest   = 11;
+  optional DeleteScmKeyBlocksRequestProto     deleteScmKeyBlocksRequest = 12;
+  optional hadoop.hdds.GetScmInfoRequestProto getScmInfoRequest         = 13;
+}
+
+message SCMBlockLocationResponse {
+  required Type cmdType = 1; // Type of the command
+
+  // A string that identifies this command, we generate  Trace ID in Ozone
+  // frontend and this allows us to trace that command all over ozone.
+  optional string traceID = 2;
+
+  optional bool success = 3 [default=true];
+
+  optional string message = 4;
+
+  required Status status = 5;
+
+  optional string leaderOMNodeId = 6;
+
+  optional AllocateScmBlockResponseProto       allocateScmBlockResponse   = 11;
+  optional DeleteScmKeyBlocksResponseProto     deleteScmKeyBlocksResponse = 12;
+  optional hadoop.hdds.GetScmInfoResponseProto getScmInfoResponse         = 13;
+}
+
+/**
+    User information which will be extracted during RPC context and used
+    during validating Acl.
+*/
+message UserInfo {
+  optional string userName = 1;
+  optional string remoteAddress = 3;
+}
+
+enum Status {
+  OK = 1;
+  UNKNOWN = 2;
+}
+
 /**
 * Request send to SCM asking allocate block of specified size.
 */
@@ -122,21 +178,23 @@ message AllocateScmBlockResponseProto {
  */
 service ScmBlockLocationProtocolService {
 
+  rpc send(SCMBlockLocationRequest)
+      returns (SCMBlockLocationResponse);
+
   /**
    * Creates a block entry in SCM.
    */
-  rpc allocateScmBlock(AllocateScmBlockRequestProto)
-      returns (AllocateScmBlockResponseProto);
-
+//  rpc allocateScmBlock(AllocateScmBlockRequestProto)
+//      returns (AllocateScmBlockResponseProto);
   /**
    * Deletes blocks for a set of object keys from SCM.
    */
-  rpc deleteScmKeyBlocks(DeleteScmKeyBlocksRequestProto)
-      returns (DeleteScmKeyBlocksResponseProto);
+//  rpc deleteScmKeyBlocks(DeleteScmKeyBlocksRequestProto)
+//      returns (DeleteScmKeyBlocksResponseProto);
 
   /**
    * Gets the scmInfo from SCM.
    */
-  rpc getScmInfo(hadoop.hdds.GetScmInfoRequestProto)
-      returns (hadoop.hdds.GetScmInfoResponseProto);
+//  rpc getScmInfo(hadoop.hdds.GetScmInfoRequestProto)
+//      returns (hadoop.hdds.GetScmInfoResponseProto);
 }


### PR DESCRIPTION
This PR is a first attempt at refactoring the ScmBlockLocationProtocol using a single message type as is used in the OzoneManagerProtocol. In this change, the new message wraps the existing messages and the translator classes simply wrap or unwrap it.

Only TraceID has been moved to the wrapper message - Moving error handling and error codes to the wrapper will be done in a separate change.

Before this can be merged we still need to determine if the clientId should be present in the  ScmBlockLocationProtocol. It is in OzoneManagerProtocol and has been replicated here for now, but it can be removed if needed.