### PR TITLE
HADOOP-16380. S3Guard Tombstones can get in the way

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -1322,7 +1322,7 @@ public class ContractTestUtils extends Assert {
   public static String pathsToString(Collection<Path> paths) {
     StringBuilder builder = new StringBuilder(paths.size() * 100);
     String nl = System.lineSeparator();
-    builder.append(nl);
+    builder.append(nl).append('[').append(nl);
     for (Path path : paths) {
       builder.append("  \"").append(path.toString())
           .append("\"").append(nl);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
@@ -583,8 +583,11 @@ public class DynamoDBMetadataStore implements MetadataStore,
   public DDBPathMetadata get(Path path, boolean wantEmptyDirectoryFlag)
       throws IOException {
     checkPath(path);
-    LOG.debug("Get from table {} in region {}: {}", tableName, region, path);
-    return innerGet(path, wantEmptyDirectoryFlag);
+    LOG.debug("Get from table {} in region {}: {}. wantEmptyDirectory={}",
+        tableName, region, path, wantEmptyDirectoryFlag);
+    DDBPathMetadata result = innerGet(path, wantEmptyDirectoryFlag);
+    LOG.debug("result of get {} is: {}", path, result);
+    return result;
   }
 
   /**
@@ -902,9 +905,13 @@ public class DynamoDBMetadataStore implements MetadataStore,
     // write item request to save the items.
     LOG.debug("Saving to table {} in region {}: {}", tableName, region, meta);
 
-    Collection<PathMetadata> wrapper = new ArrayList<>(1);
-    wrapper.add(meta);
-    put(wrapper);
+    if (!meta.getFileStatus().getPath().isRoot()) {
+      Collection<PathMetadata> wrapper = new ArrayList<>(1);
+      wrapper.add(meta);
+      put(wrapper);
+    } else {
+      LOG.debug("Ignoring root entry");
+    }
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.S3A_TEST_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeEnableS3Guard;
 
 /**
@@ -38,6 +39,11 @@ public class ITestS3AContractRootDir extends
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3AContractRootDir.class);
+
+  @Override
+  protected int getTestTimeoutMillis() {
+    return S3A_TEST_TIMEOUT;
+  }
 
   /**
    * Create a configuration, possibly patching in S3Guard options.


### PR DESCRIPTION
Cause: tombstones mislead about directory empty status

This is not the fix, though it provides diagnostics about the problem with more checks and more details in assertions.

Change-Id: I583071b254a89f64687b87e653afd01d65a8e8de