### PR TITLE
HADOOP-16382: clock skew can cause S3Guard to think object metadata is out of date

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadata.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PathMetadata.java
@@ -61,6 +61,14 @@ public class PathMetadata extends ExpirableMetadata {
     this(fileStatus, isEmptyDir, false);
   }
 
+  /**
+   * Construct from a file status entry.
+   * The last updated time is take from the modification time of the
+   * status entry.
+   * @param fileStatus the status
+   * @param isEmptyDir the empty directory state
+   * @param isDeleted does this represent a deleed object.
+   */
   public PathMetadata(S3AFileStatus fileStatus, Tristate isEmptyDir, boolean
       isDeleted) {
     Preconditions.checkNotNull(fileStatus, "fileStatus must be non-null");
@@ -71,6 +79,8 @@ public class PathMetadata extends ExpirableMetadata {
     this.fileStatus = fileStatus;
     this.isEmptyDirectory = isEmptyDir;
     this.isDeleted = isDeleted;
+    // modtime is derived from file status
+    setLastUpdated(fileStatus.getModificationTime());
   }
 
   /**


### PR DESCRIPTION
This patch sets the PathMetadata lastUpdated value from the lastModified value of the S3AFileStatus used in the constructor -the one later used to determine if a metastore entry is out of date.

In putWithTTL the time of the TTL provider is compared with the status value and whichever is highest sets the TTL.

Change-Id: I0ed2871df0b29a17c4df03a4b474c777290f2672