### PR TITLE
HDDS-1715 - Update the Intellij runner definitition of SCM to use the new class name 

### DIFF
--- a/hadoop-ozone/dev-support/intellij/runConfigurations/StorageContainerManager.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/StorageContainerManager.xml
@@ -16,7 +16,7 @@
 -->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="StorageContainerManager" type="Application" factoryName="Application" nameIsGenerated="falsee">
-    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManager" />
+    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hadoop-hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/StorageContainerManagerInit.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/StorageContainerManagerInit.xml
@@ -16,7 +16,7 @@
 -->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="StorageContainerManagerInit" type="Application" factoryName="Application" nameIsGenerated="false">
-    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManager" />
+    <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hadoop-hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --init" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />


### PR DESCRIPTION
HDDS-1622 changed the CLI framework of SCM and with a new additional class (StorageContainerMangerStarter) it made it more testable.

But the intellij runner definitions are not (yet) updated to use the new class name for SCM/SCM-init (they are updated for OM in HDDS-1660).

We need to adjust the main class names in:

hadoop-ozone/dev-support/intellij/runConfigurations/StorageContainerManager.xml
hadoop-ozone/dev-support/intellij/runConfigurations/StorageContainerManagerInit.xml

