### PR TITLE
HDDS-1716. Smoketest results are generated with an internal user

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -43,5 +43,5 @@ for test in $(find $SCRIPT_DIR -name test.sh); do
   cp "$RESULT_DIR"/robot-*.xml "$ALL_RESULT_DIR"
 done
 
-docker run --rm -v "$SCRIPT_DIR/result:/opt/result" apache/ozone-runner rebot -N "smoketests" -d "/opt/result" "/opt/result/robot-*.xml"
+rebot -N "smoketests" -d "$SCRIPT_DIR/result" "$SCRIPT_DIR/result/robot-*.xml"
 exit $RESULT

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -20,7 +20,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COMPOSE_ENV_NAME=$(basename "$COMPOSE_DIR")
 COMPOSE_FILE=$COMPOSE_DIR/docker-compose.yaml
 RESULT_DIR="$COMPOSE_DIR/result"
-RESULT_DIR_INSIDE="${OZONE_DIR:-/opt/hadoop}/compose/$(basename "$COMPOSE_ENV_NAME")/result"
+RESULT_DIR_INSIDE="/tmp/smoketest/$(basename "$COMPOSE_ENV_NAME")/result"
 SMOKETEST_DIR_INSIDE="${OZONE_DIR:-/opt/hadoop}/smoketest"
 
 #delete previous results
@@ -75,10 +75,14 @@ execute_robot_test(){
   CONTAINER="$1"
   TEST="$2"
   TEST_NAME=$(basename "$TEST")
-  TEST_NAME=${TEST_NAME%.*}
+  TEST_NAME="$(basename $COMPOSE_DIR)-${TEST_NAME%.*}"
   set +e
   OUTPUT_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
+  docker-compose -f "$COMPOSE_FILE" exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE"
   docker-compose -f "$COMPOSE_FILE" exec -e  SECURITY_ENABLED="${SECURITY_ENABLED}" -T "$CONTAINER" python -m robot --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$RESULT_DIR_INSIDE/robot-$OUTPUT_NAME.xml" "$SMOKETEST_DIR_INSIDE/$TEST"
+
+  export FULL_CONTAINER_NAME=$(docker-compose -f "$COMPOSE_FILE" ps | grep "_${CONTAINER}_" | head -n 1 | awk '{print $1}')
+  docker cp $FULL_CONTAINER_NAME:$RESULT_DIR_INSIDE "$COMPOSE_DIR"
   set -e
 
 }
@@ -93,6 +97,12 @@ stop_docker_env(){
 
 ## @description  Generate robot framework reports based on the saved results.
 generate_report(){
-  #Generate the combined output and return with the right exit code (note: robot = execute test, rebot = generate output)
-  docker run --rm -v "$DIR/..:${OZONE_DIR:-/opt/hadoop}" apache/ozone-runner rebot -d "$RESULT_DIR_INSIDE" "$RESULT_DIR_INSIDE/robot-*.xml"
+  which rebot > /dev/null 2>&1
+  if [ "$?" == "0" ]; then
+     #Generate the combined output and return with the right exit code (note: robot = execute test, rebot = generate output)
+     rebot -d "$RESULT_DIR" "$RESULT_DIR/robot-*.xml"
+  else
+     echo "Robot framework is not installed, the reports can be generated (sudo pip install robotframework)."
+     exit 1
+  fi
 }


### PR DESCRIPTION
[~eyang] reported the problem in HDDS-1609 that the smoketest results are generated a user (the user inside the docker container) which can be different from the host user.

There is a minimal risk that the test results can be deleted/corrupted by an other users if the current user is different from uid=1000

I opened this issue because [~eyang] said me during an offline discussion that HDDS-1609 is a more complex issue and not only about the ownership of the test results.

I suggest to handle the two problems in different way. With this patch, the permission of the test result files can be fixed easily.

In HDDS-1609 we can discuss about general security problems and try to find generic solution for them.

Steps to reproduce _this_ the problem:
  * Use a user which is different from uid=1000
  * Create a new ozone build (mvn clean install -f pom.ozone.xml -DskipTests)
  * Go to a compose directory (cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/)
  * Execute tests (./test.sh)
  * check the ownership of the results (ls -lah ./results)

Current result: the owner of the result files are the user uid=1000

Expected result: the owner of the files should be always the current user (even if the current uid is different)

 

See: https://issues.apache.org/jira/browse/HDDS-1716