### PR TITLE
HDDS-1719 : Increase ratis log segment size to 1MB.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -74,7 +74,7 @@ public final class ScmConfigKeys {
   public static final String DFS_CONTAINER_RATIS_SEGMENT_SIZE_KEY =
       "dfs.container.ratis.segment.size";
   public static final String DFS_CONTAINER_RATIS_SEGMENT_SIZE_DEFAULT =
-      "16KB";
+      "1MB";
   public static final String DFS_CONTAINER_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY =
       "dfs.container.ratis.segment.preallocated.size";
   public static final String

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -205,7 +205,7 @@
   </property>
   <property>
     <name>dfs.container.ratis.segment.size</name>
-    <value>16KB</value>
+    <value>1MB</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>The size of the raft segment used by Apache Ratis on datanodes.
       (16 KB by default)

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -208,7 +208,7 @@
     <value>1MB</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>The size of the raft segment used by Apache Ratis on datanodes.
-      (16 KB by default)
+      (1 MB by default)
     </description>
   </property>
   <property>


### PR DESCRIPTION
While testing out ozone with long running clients which continuously write data, it was noted ratis logs were rolled 1-2 times every second. This adds unnecessary overhead to the pipeline thereby affecting write throughput. Increasing the size of the log segment to 1MB will decrease the overhead.