### PR TITLE
HADOOP-16393. S3Guard init command uses global settings, not those of target bucket

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.util.ToolRunner;
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.Invoker.LOG_EVENT;
 import static org.apache.hadoop.fs.s3a.S3AUtils.clearBucketOption;
+import static org.apache.hadoop.fs.s3a.S3AUtils.propagateBucketOptions;
 import static org.apache.hadoop.service.launcher.LauncherExitCodes.*;
 
 /**
@@ -479,6 +480,13 @@ public abstract class S3GuardTool extends Configured implements Tool {
       if (writeCap != null && !writeCap.isEmpty()) {
         int writeCapacity = Integer.parseInt(writeCap);
         getConf().setInt(S3GUARD_DDB_TABLE_CAPACITY_WRITE_KEY, writeCapacity);
+      }
+      if (!paths.isEmpty()) {
+        String s3path = paths.get(0);
+        URI fsURI = new URI(s3path);
+        Configuration bucketConf = propagateBucketOptions(getConf(),
+            fsURI.getHost());
+        setConf(bucketConf);
       }
 
       String tags = getCommandFormat().getOptValue(TAG_FLAG);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolDynamoDB.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolDynamoDB.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.Init;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_REGION_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_NAME_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_TAG;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3AUtils.setBucketOption;
 import static org.apache.hadoop.fs.s3a.s3guard.DynamoDBMetadataStore.*;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.*;
@@ -120,6 +121,11 @@ public class ITestS3GuardToolDynamoDB extends AbstractS3GuardToolTestBase {
 
     conf.set(S3GUARD_DDB_TABLE_NAME_KEY,
         getTestTableName("testDynamoTableTagging-" + UUID.randomUUID()));
+    String bucket = getFileSystem().getBucket();
+    removeBucketOverrides(bucket, conf,
+        S3GUARD_DDB_TABLE_NAME_KEY,
+        S3GUARD_DDB_REGION_KEY);
+
     S3GuardTool.Init cmdR = new S3GuardTool.Init(conf);
     Map<String, String> tagMap = new HashMap<>();
     tagMap.put("hello", "dynamo");
@@ -128,7 +134,7 @@ public class ITestS3GuardToolDynamoDB extends AbstractS3GuardToolTestBase {
     String[] argsR = new String[]{
         cmdR.getName(),
         "-tag", tagMapToStringParams(tagMap),
-        getFileSystem().getBucket()
+        "s3a://" + bucket + "/"
     };
 
     // run


### PR DESCRIPTION
This does the bucket propagation, and patches `ITestS3GuardToolDynamoDB.testDynamoTableTagging`

Tested: S3 ireland.

This has not added any new tests: IMO it should, so as to verify propagation. We could actually add it to the tagging test, maybe, though the real one I want to verify is that bucket ref