### PR TITLE
HDDS-1727. Use generation of resourceName for locks in OzoneManagerLock.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -171,6 +171,7 @@ public final class OzoneConsts {
   public static final String OM_S3_PREFIX ="S3:";
   public static final String OM_S3_VOLUME_PREFIX = "s3";
   public static final String OM_S3_SECRET = "S3Secret:";
+  public static final String OM_PREFIX = "Prefix:";
 
   /**
    *   Max chunk size limit.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -125,10 +125,10 @@ public class OzoneManagerLock {
    * @param resources
    */
   private String generateResourceName(Resource resource, String... resources) {
-    if (resources.length == 1 && resource.name != Resource.BUCKET.name) {
+    if (resources.length == 1 && resource != Resource.BUCKET) {
       return OzoneManagerLockUtil.generateResourceLockName(resource,
           resources[0]);
-    } else if (resources.length == 2 && resource.name == Resource.BUCKET.name) {
+    } else if (resources.length == 2 && resource == Resource.BUCKET) {
       return OzoneManagerLockUtil.generateBucketLockName(resources[0],
           resources[1]);
     } else {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -99,10 +99,14 @@ public class OzoneManagerLock {
    *
    * Special Note for UserLock: Single thread can acquire single user lock/
    * multi user lock. But not both at the same time.
-   * @param resourceName - Resource name on which user want to acquire lock.
    * @param resource - Type of the resource.
+   * @param resources - Resource names on which user want to acquire lock.
+   * For Resource type bucket, first param should be volume, second param
+   * should be bucket name. For remaining all resource only one param should
+   * be passed.
    */
-  public void acquireLock(String resourceName, Resource resource) {
+  public void acquireLock(Resource resource, String... resources) {
+    String resourceName = generateResourceName(resource, resources);
     if (!resource.canLock(lockSet.get())) {
       String errorMessage = getErrorMessage(resource);
       LOG.error(errorMessage);
@@ -115,6 +119,24 @@ public class OzoneManagerLock {
     }
   }
 
+  /**
+   * Generate resource name to be locked.
+   * @param resource
+   * @param resources
+   */
+  private String generateResourceName(Resource resource, String... resources) {
+    if (resources.length == 1 && resource.name != Resource.BUCKET.name) {
+      return OzoneManagerLockUtil.generateResourceLockName(resource,
+          resources[0]);
+    } else if (resources.length == 2 && resource.name == Resource.BUCKET.name) {
+      return OzoneManagerLockUtil.generateBucketLockName(resources[0],
+          resources[1]);
+    } else {
+      throw new IllegalArgumentException("acquire lock is supported on single" +
+          " resource for all locks except for resource bucket");
+    }
+  }
+
   private String getErrorMessage(Resource resource) {
     return "Thread '" + Thread.currentThread().getName() + "' cannot " +
         "acquire " + resource.name + " lock while holding " +
@@ -124,7 +146,6 @@ public class OzoneManagerLock {
 
   private List<String> getCurrentLocks() {
     List<String> currentLocks = new ArrayList<>();
-    int i=0;
     short lockSetVal = lockSet.get();
     for (Resource value : Resource.values()) {
       if (value.isLevelLocked(lockSetVal)) {
@@ -141,6 +162,9 @@ public class OzoneManagerLock {
    */
   public void acquireMultiUserLock(String firstUser, String secondUser) {
     Resource resource = Resource.USER;
+    firstUser = generateResourceName(resource, firstUser);
+    secondUser = generateResourceName(resource, secondUser);
+
     if (!resource.canLock(lockSet.get())) {
       String errorMessage = getErrorMessage(resource);
       LOG.error(errorMessage);
@@ -199,10 +223,12 @@ public class OzoneManagerLock {
    */
   public void releaseMultiUserLock(String firstUser, String secondUser) {
     Resource resource = Resource.USER;
+    firstUser = generateResourceName(resource, firstUser);
+    secondUser = generateResourceName(resource, secondUser);
+
     int compare = firstUser.compareTo(secondUser);
 
     String temp;
-
     // Order the user names in sorted order. Swap them.
     if (compare > 0) {
       temp = secondUser;
@@ -222,9 +248,16 @@ public class OzoneManagerLock {
     lockSet.set(resource.clearLock(lockSet.get()));
   }
 
-
-  public void releaseLock(String resourceName, Resource resource) {
-
+  /**
+   * Release lock on resource.
+   * @param resource - Type of the resource.
+   * @param resources - Resource names on which user want to acquire lock.
+   * For Resource type bucket, first param should be volume, second param
+   * should be bucket name. For remaining all resource only one param should
+   * be passed.
+   */
+  public void releaseLock(Resource resource, String... resources) {
+    String resourceName = generateResourceName(resource, resources);
     // TODO: Not checking release of higher order level lock happened while
     // releasing lower order level lock, as for that we need counter for
     // locks, as some locks support acquiring lock again.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLockUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLockUtil.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.lock;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_S3_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_S3_SECRET;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_USER_PREFIX;
@@ -26,7 +27,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_USER_PREFIX;
 /**
  * Utility class contains helper functions required for OM lock.
  */
-public final class OzoneManagerLockUtil {
+final class OzoneManagerLockUtil {
 
 
   private OzoneManagerLockUtil() {
@@ -50,7 +51,7 @@ public final class OzoneManagerLockUtil {
     } else if (resource == OzoneManagerLock.Resource.S3_SECRET) {
       return OM_S3_SECRET + resourceName;
     } else if (resource == OzoneManagerLock.Resource.PREFIX) {
-      return OM_S3_PREFIX + resourceName;
+      return OM_PREFIX + resourceName;
     } else {
       // This is for developers who mistakenly call this method with resource
       // bucket type, as for bucket type we need bucket and volumeName.


### PR DESCRIPTION
In this Jira, we shall use generate Resourcename from actual resource names like volume/bucket/user/key inside OzoneManagerLock. In this way, users using these locking API's no need to worry of calling these additional API of generateResourceName in OzoneManagerLockUtil. And this also reduces code during acquiring locks in OM operations.

