### PR TITLE
HashMap is not thread safe. Field storageMap is typically synchronized by storageMap. However, in one place, field storageMap is not protected with synchronized.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -451,8 +451,11 @@ public class DatanodeDescriptor extends DatanodeInfo {
     this.volumeFailureSummary = volumeFailureSummary;
     for (StorageReport report : reports) {
 
-      DatanodeStorageInfo storage =
-          storageMap.get(report.getStorage().getStorageID());
+      DatanodeStorageInfo storage = null;
+      synchronized (storageMap) {
+        storage =
+            storageMap.get(report.getStorage().getStorageID());
+      }
       if (checkFailedStorages) {
         failedStorageInfos.remove(storage);
       }


### PR DESCRIPTION
The field ```storageMap```  (a ```HashMap```)

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L155

is typically protected by synchronization on ```storageMap```, e.g., 

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L294

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L443

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L484

For a total of 9 locations.

The reason is because ```HashMap``` is not thread safe.

However, here:

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L455

```
DatanodeStorageInfo storage =
  storageMap.get(report.getStorage().getStorageID());
```

It is not synchronized.

Note that in the same method (about 30 lines below):

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java#L484

```storageMap``` is again protected by synchronization:

```
synchronized (storageMap) {
  storageMapSize = storageMap.size();
}
```

This CR protected the above instance (line 455 ) with synchronization
like in line 484 and in all other occurrences.
