### PR TITLE
YARN-9643:Federation: Add subClusterID in nodes page of Router web

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
@@ -131,6 +131,8 @@ public class ResourceTrackerService extends AbstractService implements
   private boolean checkIpHostnameInRegistration;
   private boolean timelineServiceV2Enabled;
 
+  private String clusterId;
+
   public ResourceTrackerService(RMContext rmContext,
       NodesListManager nodesListManager,
       NMLivelinessMonitor nmLivelinessMonitor,
@@ -264,6 +266,7 @@ public class ResourceTrackerService extends AbstractService implements
         YarnConfiguration.RM_RESOURCE_TRACKER_ADDRESS,
         YarnConfiguration.DEFAULT_RM_RESOURCE_TRACKER_ADDRESS,
         server.getListenerAddress());
+    clusterId = conf.get(YarnConfiguration.RM_CLUSTER_ID, "default-cluster");
   }
 
   @Override
@@ -419,7 +422,7 @@ public class ResourceTrackerService extends AbstractService implements
         .getCurrentKey());
 
     RMNode rmNode = new RMNodeImpl(nodeId, rmContext, host, cmPort, httpPort,
-        resolve(host), capability, nodeManagerVersion, physicalResource);
+        resolve(host), capability, nodeManagerVersion, physicalResource, clusterId);
 
     RMNode oldNode = this.rmContext.getRMNodes().putIfAbsent(nodeId, rmNode);
     if (oldNode == null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNode.java
@@ -54,7 +54,13 @@ public interface RMNode {
    * @return hostname of this node
    */
   public String getHostName();
-  
+
+  /**
+   * the clusterId of this node
+   * @return clusterId of this node
+   */
+  public String getClusterID();
+
   /**
    * the command port for this node
    * @return command port for this node

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -119,6 +119,7 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
   private final NodeId nodeId;
   private final RMContext context;
   private final String hostName;
+  private String clusterId;
   private final int commandPort;
   private int httpPort;
   private final String nodeAddress; // The containerManager address
@@ -378,12 +379,12 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       int cmPort, int httpPort, Node node, Resource capability,
       String nodeManagerVersion) {
     this(nodeId, context, hostName, cmPort, httpPort, node, capability,
-        nodeManagerVersion, null);
+        nodeManagerVersion, null, "default-cluster");
   }
 
   public RMNodeImpl(NodeId nodeId, RMContext context, String hostName,
       int cmPort, int httpPort, Node node, Resource capability,
-      String nodeManagerVersion, Resource physResource) {
+      String nodeManagerVersion, Resource physResource, String clusterId) {
     this.nodeId = nodeId;
     this.context = context;
     this.hostName = hostName;
@@ -410,6 +411,8 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
     this.nodeUpdateQueue = new ConcurrentLinkedQueue<UpdatedContainerInfo>();
 
     this.containerAllocationExpirer = context.getContainerAllocationExpirer();
+
+    this.clusterId = clusterId;
   }
 
   @Override
@@ -420,6 +423,11 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
   @Override
   public String getHostName() {
     return hostName;
+  }
+
+  @Override
+  public String getClusterID() {
+    return clusterId;
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeInfo.java
@@ -65,6 +65,7 @@ public class NodeInfo {
   protected ResourceInfo availableResource;
   protected NodeAttributesInfo nodeAttributesInfo;
   private ResourceInfo totalResource;
+  private String clusterId;
 
   public NodeInfo() {
   } // JAXB needs this
@@ -135,6 +136,7 @@ public class NodeInfo {
 
     // update node and containers resource utilization
     this.resourceUtilization = new ResourceUtilizationInfo(ni);
+    this.clusterId = ni.getClusterID();
   }
 
   public String getRack() {
@@ -250,5 +252,9 @@ public class NodeInfo {
 
   public ResourceInfo getTotalResource() {
     return this.totalResource;
+  }
+
+  public String getClusterId() {
+    return clusterId;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockNodes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockNodes.java
@@ -120,6 +120,7 @@ public class MockNodes {
     private ResourceUtilization nodeUtilization;
     private Resource physicalResource;
     private RMContext rmContext;
+    private String clusterId;
 
     MockRMNodeImpl(NodeId nodeId, String nodeAddr, String httpAddress,
         Resource perNode, String rackName, String healthReport,
@@ -141,6 +142,7 @@ public class MockNodes {
       this.containersUtilization = containersUtilization;
       this.nodeUtilization = nodeUtilization;
       this.physicalResource = pPhysicalResource;
+      this.clusterId = "default-cluster";
     }
 
     public MockRMNodeImpl(NodeId nodeId, String nodeAddr, String httpAddress,
@@ -163,6 +165,11 @@ public class MockNodes {
     @Override
     public String getHostName() {
       return this.hostName;
+    }
+
+    @Override
+    public String getClusterID() {
+      return clusterId;
     }
 
     @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/NodesBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/NodesBlock.java
@@ -61,6 +61,7 @@ public class NodesBlock extends HtmlBlock {
     setTitle("Nodes");
 
     TBODY<TABLE<Hamlet>> tbody = html.table("#nodes").thead().tr()
+        .th(".subCluster", "SubCluster")
         .th(".nodelabels", "Node Labels")
         .th(".rack", "Rack")
         .th(".state", "Node State")
@@ -81,6 +82,7 @@ public class NodesBlock extends HtmlBlock {
       int usedMemory = (int) info.getUsedMemory();
       int availableMemory = (int) info.getAvailableMemory();
       TR<TBODY<TABLE<Hamlet>>> row = tbody.tr();
+      row.td().__(info.getClusterId());
       row.td().__(StringUtils.join(",", info.getNodeLabels())).__();
       row.td().__(info.getRack()).__();
       row.td().__(info.getState()).__();


### PR DESCRIPTION
In nodes page of router web, there only are node info, No cluster id corresponding to the node.
