### PR TITLE
HDDS-1603. Handle Ratis Append Failure in Container State Machine. Contributed by Supratim Deka

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -666,6 +666,11 @@ public class ContainerStateMachine extends BaseStateMachine {
   }
 
   @Override
+  public void notifyLogFailed(Throwable t, LogEntryProto failedEntry) {
+    ratisServer.handleNodeLogFailure(gid, t);
+  }
+
+  @Override
   public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
       RoleInfoProto roleInfoProto, TermIndex firstTermIndexInLog) {
     ratisServer.handleInstallSnapshotFromLeader(gid, roleInfoProto,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -546,7 +546,7 @@ public final class XceiverServerRatis extends XceiverServer {
     }
 
     triggerPipelineClose(groupId, msg,
-        ClosePipelineInfo.Reason.PIPELINE_FAILED,false);
+        ClosePipelineInfo.Reason.PIPELINE_FAILED, false);
   }
 
   private void triggerPipelineClose(RaftGroupId groupId, String detail,
@@ -652,6 +652,6 @@ public final class XceiverServerRatis extends XceiverServer {
         : t.getMessage();
 
     triggerPipelineClose(groupId, msg,
-        ClosePipelineInfo.Reason.PIPELINE_LOG_FAILED,true);
+        ClosePipelineInfo.Reason.PIPELINE_LOG_FAILED, true);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -545,18 +545,28 @@ public final class XceiverServerRatis extends XceiverServer {
           + roleInfoProto.getRole());
     }
 
+    triggerPipelineClose(groupId, msg,
+        ClosePipelineInfo.Reason.PIPELINE_FAILED,false);
+  }
+
+  private void triggerPipelineClose(RaftGroupId groupId, String detail,
+      ClosePipelineInfo.Reason reasonCode, boolean triggerHB) {
     PipelineID pipelineID = PipelineID.valueOf(groupId.getUuid());
     ClosePipelineInfo.Builder closePipelineInfo =
         ClosePipelineInfo.newBuilder()
             .setPipelineID(pipelineID.getProtobuf())
-            .setReason(ClosePipelineInfo.Reason.PIPELINE_FAILED)
-            .setDetailedReason(msg);
+            .setReason(reasonCode)
+            .setDetailedReason(detail);
 
     PipelineAction action = PipelineAction.newBuilder()
         .setClosePipeline(closePipelineInfo)
         .setAction(PipelineAction.Action.CLOSE)
         .build();
     context.addPipelineActionIfAbsent(action);
+    // wait for the next HB timeout or right away?
+    if (triggerHB) {
+      context.getParent().triggerHeartbeat();
+    }
     LOG.debug(
         "pipeline Action " + action.getAction() + "  on pipeline " + pipelineID
             + ".Reason : " + action.getClosePipeline().getDetailedReason());
@@ -627,5 +637,21 @@ public final class XceiverServerRatis extends XceiverServer {
         "termIndex: {}, terminating pipeline: {}",
         firstTermIndexInLog, groupId);
     handlePipelineFailure(groupId, roleInfoProto);
+  }
+
+  /**
+   * Notify the Datanode Ratis endpoint of Ratis log failure.
+   * Expected to be invoked from the Container StateMachine
+   * @param groupId the Ratis group/pipeline for which log has failed
+   * @param t exception encountered at the time of the failure
+   *
+   */
+  @VisibleForTesting
+  public void handleNodeLogFailure(RaftGroupId groupId, Throwable t) {
+    String msg = (t == null) ? "Unspecified failure reported in Ratis log"
+        : t.getMessage();
+
+    triggerPipelineClose(groupId, msg,
+        ClosePipelineInfo.Reason.PIPELINE_LOG_FAILED,true);
   }
 }

--- a/hadoop-hdds/container-service/src/main/proto/StorageContainerDatanodeProtocol.proto
+++ b/hadoop-hdds/container-service/src/main/proto/StorageContainerDatanodeProtocol.proto
@@ -211,6 +211,7 @@ message PipelineActionsProto {
 message ClosePipelineInfo {
   enum Reason {
     PIPELINE_FAILED = 1;
+    PIPELINE_LOG_FAILED = 2;
   }
   required PipelineID pipelineID = 1;
   optional Reason reason = 3;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-1603

The scope of this jira is to build on https://issues.apache.org/jira/browse/RATIS-573
and define the handling for Ratis log append failure in Ozone Container State Machine.
1. Enqueue pipeline unhealthy action to SCM, add a reason code to the message.
2. Trigger immediate heartbeat to SCM

Ratis-573 is not available in trunk. So this patch starts with an entry point in XceiverServerRatis which will be hooked up to notifyLogFailed() callback defined in StateMachine as part of RATIS-573.

Notify Ratis volume unhealthy to the Datanode is not implemented in this patch