### PR TITLE
huowang

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
@@ -2912,7 +2912,7 @@ public abstract class FSEditLogOp {
       this.newLength = Long.parseLong(st.getValue("NEWLENGTH"));
       this.timestamp = Long.parseLong(st.getValue("TIMESTAMP"));
       if (st.hasChildren("BLOCK"))
-        this.truncateBlock = FSEditLogOp.blockFromXml(st);
+        this.truncateBlock = FSEditLogOp.blockFromXml(st.getChildren("BLOCK").get(0));
     }
 
     @Override


### PR DESCRIPTION
I encountered a problem when I converted edits files from XML to binary using the HDFS oev command
   Usually this conversion operation will not be a problem, but my XML culture contains an OP_TRUNCATE operation node, in this case, the error is reported, the specific error is as follows. (sorry, I can only take a screenshot because the company environment does not allow copying code, the name of the file is not NameNode's default name because I backed up the edits file for testing).
![image](https://user-images.githubusercontent.com/20262356/60243523-016a7000-98eb-11e9-84c1-05b4ef2c96e6.png)

The contents of the XML file are as follows
![image](https://user-images.githubusercontent.com/20262356/60243723-73db5000-98eb-11e9-977e-4f9ffea068ba.png)
I found the error-reporting code and found that the blockFromXml method passed the entire data node instead of the subordinate BLOCK node. I think this was the reason. So I modified the code and recompiled it. Then I installed a single node Hadoop cluster and tested the HDFS oev command conversion file successfully. This is my first time to submit a patch. My English is not particularly good, I am not sure. Should the modified code be submitted in this way?

I hope I can contribute to the community.
