### PR TITLE
YARN-9655:AllocateResponse in FederationInterceptor lost applicationPriority

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -1446,6 +1446,10 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       }
     }
 
+    if (otherResponse.getApplicationPriority() != null) {
+      homeResponse.setApplicationPriority(otherResponse.getApplicationPriority());
+    }
+
     homeResponse.setNumClusterNodes(
         homeResponse.getNumClusterNodes() + otherResponse.getNumClusterNodes());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -1447,7 +1447,8 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
     }
 
     if (otherResponse.getApplicationPriority() != null) {
-      homeResponse.setApplicationPriority(otherResponse.getApplicationPriority());
+      homeResponse.setApplicationPriority(
+          otherResponse.getApplicationPriority());
     }
 
     homeResponse.setNumClusterNodes(


### PR DESCRIPTION
In YARN Federation mode using FederationInterceptor, when submitting application, am will report an error.
``` java
2019-06-25 11:44:00,977 ERROR [RMCommunicator Allocator] org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator: ERROR IN CONTACTING RM. java.lang.NullPointerException 
at org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator.handleJobPriorityChange(RMContainerAllocator.java:1025) 
at org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator.getResources(RMContainerAllocator.java:880) 
at org.apache.hadoop.mapreduce.v2.app.rm.RMContainerAllocator.heartbeat(RMContainerAllocator.java:286) 
at org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator$AllocatorRunnable.run(RMCommunicator.java:280) 
at java.lang.Thread.run(Thread.java:748)
```
The reason is that applicationPriority is lost.