### PR TITLE
ArrayList is not thread safe. Field timedOutItems is typically protected by synchronization on itself. However, in one place, the field is inside a synchronized on a different object, which does not ensure protection

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
@@ -132,7 +132,9 @@ class PendingReconstructionBlocks {
   public void clear() {
     synchronized (pendingReconstructions) {
       pendingReconstructions.clear();
-      timedOutItems.clear();
+      synchronized (timedOutItems) {
+        timedOutItems.clear();
+      }
       timedOutCount = 0L;
     }
   }


### PR DESCRIPTION
The field ```timedOutItems```  (an ```ArrayList```, i.e., not thread safe):

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java#L70

is protected by synchronization on itself (```timedOutItems```):

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java#L167-L168

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java#L267-L268

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java#L178

However, in one place:

https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java#L133-L135

it is (trying to be) protected by synchronized using ```pendingReconstructions``` --- but this cannot protect ```timedOutItems```.

Synchronized on different objects does not ensure mutual exclusion with the other locations.

I.e., 2 code locations, one synchronized by ```pendingReconstructions``` and the other by ```timedOutItems``` can still executed concurrently.


This CR adds the synchronized on ```timedOutItems```.

Note that this CR keeps the synchronized on ```pendingReconstructions```, which is needed for a different purpose (protect ```pendingReconstructions```)
