### PR TITLE
HDDS-1616. ManagedChannel references are being leaked in while removing RaftGroup. Contributed by Mukul Kumar Singh.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
@@ -90,10 +90,11 @@ public final class RatisPipelineUtils {
         new SecurityConfig(ozoneConf));
     final TimeDuration requestTimeout =
         RatisHelper.getClientRequestTimeout(ozoneConf);
-    RaftClient client = RatisHelper
+    try(RaftClient client = RatisHelper
         .newRaftClient(SupportedRpcType.valueOfIgnoreCase(rpcType), p,
-            retryPolicy, maxOutstandingRequests, tlsConfig, requestTimeout);
-    client
-        .groupRemove(RaftGroupId.valueOf(pipelineID.getId()), true, p.getId());
+            retryPolicy, maxOutstandingRequests, tlsConfig, requestTimeout)) {
+      client.groupRemove(RaftGroupId.valueOf(pipelineID.getId()),
+          true, p.getId());
+    }
   }
 }


### PR DESCRIPTION
RaftClient references are being leaked while removing pipeline.