### PR TITLE
YARN-9661. Fix typos in LocalityMulticastAMRMProxyPolicy and AbstractConfigurableFederationPolicy

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/AbstractConfigurableFederationPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/AbstractConfigurableFederationPolicy.java
@@ -83,7 +83,7 @@ public abstract class AbstractConfigurableFederationPolicy
   /**
    * Returns true whether the last reinitialization requires actual changes, or
    * was "free" as the weights have not changed. This is used by subclasses
-   * overriding reinitialize and calling super.reinitialize() to know wheter to
+   * overriding reinitialize and calling super.reinitialize() to know whether to
    * quit early.
    *
    * @return whether more work is needed to initialize.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
@@ -68,7 +68,7 @@ import com.google.common.base.Preconditions;
  * <p>
  * Rack localized {@link ResourceRequest}s are forwarded to the RMs that owns
  * the corresponding rack. Note that in some deployments each rack could be
- * striped across multiple RMs. Thsi policy respects that. If the
+ * striped across multiple RMs. This policy respects that. If the
  * {@link SubClusterResolver} cannot resolve this rack we default to forwarding
  * the {@link ResourceRequest} to the home sub-cluster.
  * </p>
@@ -463,7 +463,7 @@ public class LocalityMulticastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
     float headroomWeighting =
         1 / (float) allocationBookkeeper.getActiveAndEnabledSC().size();
 
-    // if we have headroom infomration for this sub-cluster (and we are safe
+    // if we have headroom information for this sub-cluster (and we are safe
     // from /0 issues)
     if (headroom.containsKey(targetId)
         && allocationBookkeeper.totHeadroomMemory > 0) {
@@ -604,7 +604,7 @@ public class LocalityMulticastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
     }
 
     /**
-     * Add a rack-local request to the final asnwer.
+     * Add a rack-local request to the final answer.
      */
     private void addRackRR(SubClusterId targetId, ResourceRequest rr) {
       Preconditions


### PR DESCRIPTION
There are some typo in LocalityMulticastAMRMProxyPolicy.java and AbstractConfigurableFederationPolicy.java