### PR TITLE
HDDS-1750. Add block allocation metrics for pipelines in SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -243,6 +243,7 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
           .setPipeline(pipeline);
       LOG.trace("New block allocated : {} Container ID: {}", localID,
           containerID);
+      pipelineManager.incNumBlocksAllocatedMetric(pipeline.getId());
       return abb.build();
     } catch (PipelineNotFoundException ex) {
       LOG.error("Pipeline Machine count is zero.", ex);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -75,4 +75,6 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
   void startPipelineCreator();
 
   void triggerPipelineCreation();
+
+  void incNumBlocksAllocatedMetric(PipelineID id);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -152,6 +152,7 @@ public class SCMPipelineManager implements PipelineManager {
       stateManager.addPipeline(pipeline);
       nodeManager.addPipeline(pipeline);
       metrics.incNumPipelineCreated();
+      metrics.createNumBlocksAllocatedMetric(pipeline);
       return pipeline;
     } catch (InsufficientDatanodesException idEx) {
       throw idEx;
@@ -285,7 +286,8 @@ public class SCMPipelineManager implements PipelineManager {
   public void openPipeline(PipelineID pipelineId) throws IOException {
     lock.writeLock().lock();
     try {
-      stateManager.openPipeline(pipelineId);
+      Pipeline pipeline = stateManager.openPipeline(pipelineId);
+      metrics.createNumBlocksAllocatedMetric(pipeline);
     } finally {
       lock.writeLock().unlock();
     }
@@ -362,6 +364,7 @@ public class SCMPipelineManager implements PipelineManager {
       for (ContainerID containerID : containerIDs) {
         eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
       }
+      metrics.clearMetrics(pipelineId);
     } finally {
       lock.writeLock().unlock();
     }
@@ -400,6 +403,11 @@ public class SCMPipelineManager implements PipelineManager {
     } finally {
       lock.writeLock().unlock();
     }
+  }
+
+  @Override
+  public void incNumBlocksAllocatedMetric(PipelineID id) {
+    metrics.incNumBlocksAllocated(id);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -152,7 +152,7 @@ public class SCMPipelineManager implements PipelineManager {
       stateManager.addPipeline(pipeline);
       nodeManager.addPipeline(pipeline);
       metrics.incNumPipelineCreated();
-      metrics.createNumBlocksAllocatedMetric(pipeline);
+      metrics.createPerPipelineMetrics(pipeline);
       return pipeline;
     } catch (InsufficientDatanodesException idEx) {
       throw idEx;
@@ -287,7 +287,7 @@ public class SCMPipelineManager implements PipelineManager {
     lock.writeLock().lock();
     try {
       Pipeline pipeline = stateManager.openPipeline(pipelineId);
-      metrics.createNumBlocksAllocatedMetric(pipeline);
+      metrics.createPerPipelineMetrics(pipeline);
     } finally {
       lock.writeLock().unlock();
     }
@@ -364,7 +364,7 @@ public class SCMPipelineManager implements PipelineManager {
       for (ContainerID containerID : containerIDs) {
         eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
       }
-      metrics.clearMetrics(pipelineId);
+      metrics.removePipelineMetrics(pipelineId);
     } finally {
       lock.writeLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
@@ -93,7 +93,7 @@ public final class SCMPipelineMetrics implements MetricsSource {
         .forEach((pid, metric) -> metric.snapshot(recordBuilder, true));
   }
 
-  void createNumBlocksAllocatedMetric(Pipeline pipeline) {
+  void createPerPipelineMetrics(Pipeline pipeline) {
     numBlocksAllocated.put(pipeline.getId(), new MutableCounterLong(Interns
         .info(getBlockAllocationMetricName(pipeline),
             "Number of blocks allocated in pipeline " + pipeline.getId()), 0L));
@@ -104,7 +104,7 @@ public final class SCMPipelineMetrics implements MetricsSource {
         .getFactor() + "-" + pipeline.getId().getId();
   }
 
-  void clearMetrics(PipelineID pipelineID) {
+  void removePipelineMetrics(PipelineID pipelineID) {
     numBlocksAllocated.remove(pipelineID);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
@@ -19,21 +19,32 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class maintains Pipeline related metrics.
  */
 @InterfaceAudience.Private
 @Metrics(about = "SCM PipelineManager Metrics", context = "ozone")
-public final class SCMPipelineMetrics {
+public final class SCMPipelineMetrics implements MetricsSource {
 
   private static final String SOURCE_NAME =
       SCMPipelineMetrics.class.getSimpleName();
+
+  private MetricsRegistry registry;
 
   private @Metric MutableCounterLong numPipelineCreated;
   private @Metric MutableCounterLong numPipelineCreationFailed;
@@ -41,9 +52,13 @@ public final class SCMPipelineMetrics {
   private @Metric MutableCounterLong numPipelineDestroyFailed;
   private @Metric MutableCounterLong numPipelineReportProcessed;
   private @Metric MutableCounterLong numPipelineReportProcessingFailed;
+  private Map<PipelineID, MutableCounterLong> numBlocksAllocated;
 
   /** Private constructor. */
-  private SCMPipelineMetrics() { }
+  private SCMPipelineMetrics() {
+    this.registry = new MetricsRegistry(SOURCE_NAME);
+    numBlocksAllocated = new ConcurrentHashMap<>();
+  }
 
   /**
    * Create and returns SCMPipelineMetrics instance.
@@ -62,6 +77,43 @@ public final class SCMPipelineMetrics {
   public void unRegister() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(SOURCE_NAME);
+  }
+
+  @Override
+  @SuppressWarnings("SuspiciousMethodCalls")
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME);
+    numPipelineCreated.snapshot(recordBuilder, true);
+    numPipelineCreationFailed.snapshot(recordBuilder, true);
+    numPipelineDestroyed.snapshot(recordBuilder, true);
+    numPipelineDestroyFailed.snapshot(recordBuilder, true);
+    numPipelineReportProcessed.snapshot(recordBuilder, true);
+    numPipelineReportProcessingFailed.snapshot(recordBuilder, true);
+    numBlocksAllocated
+        .forEach((pid, metric) -> metric.snapshot(recordBuilder, true));
+  }
+
+  void createNumBlocksAllocatedMetric(Pipeline pipeline) {
+    numBlocksAllocated.put(pipeline.getId(), new MutableCounterLong(Interns
+        .info(getBlockAllocationMetricName(pipeline),
+            "Number of blocks allocated in pipeline " + pipeline.getId()), 0L));
+  }
+
+  public static String getBlockAllocationMetricName(Pipeline pipeline) {
+    return "NumBlocksAllocated-" + pipeline.getType() + "-" + pipeline
+        .getFactor() + "-" + pipeline.getId().getId();
+  }
+
+  void clearMetrics(PipelineID pipelineID) {
+    numBlocksAllocated.remove(pipelineID);
+  }
+
+  /**
+   * Increments number of blocks allocated for the pipeline.
+   */
+  void incNumBlocksAllocated(PipelineID pipelineID) {
+    Optional.of(numBlocksAllocated.get(pipelineID)).ifPresent(
+        MutableCounterLong::incr);
   }
 
   /**


### PR DESCRIPTION
This Jira aims to add block allocation metrics for pipelines in SCM. This would help in determining the distribution of block allocations among various pipelines in SCM.