### PR TITLE
HDDS-1748. Error message for 3 way commit failure is not verbose. Contributed by Supratim Deka

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -258,8 +258,15 @@ public final class XceiverClientRatis extends XceiverClientSpi {
           .sendWatchAsync(index, RaftProtos.ReplicationLevel.ALL_COMMITTED);
       replyFuture.get(timeout, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
+      String nodes = " with Datanodes : ";
       Throwable t = HddsClientUtils.checkForException(e);
-      LOG.warn("3 way commit failed ", e);
+      for (DatanodeDetails datanodeDetails : pipeline.getNodes()) {
+        nodes += datanodeDetails.getHostName() + "["
+            + datanodeDetails.getIpAddress() + "] ";
+      }
+      LOG.warn("3 way commit failed on pipeline "
+          + pipeline.getId().getId()
+          + nodes, e);
       if (t instanceof GroupMismatchException) {
         throw e;
       }
@@ -278,8 +285,9 @@ public final class XceiverClientRatis extends XceiverClientSpi {
         // replication.
         commitInfoMap.remove(address);
         LOG.info(
-            "Could not commit " + index + " to all the nodes. Server " + address
-                + " has failed." + " Committed by majority.");
+            "Could not commit " + index + " on pipeline "
+                + pipeline.getId().getId() + " to all the nodes. Server "
+                + address + " has failed. Committed by majority.");
       });
     }
     clientReply.setLogIndex(index);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -259,7 +259,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
       replyFuture.get(timeout, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
       Throwable t = HddsClientUtils.checkForException(e);
-      LOG.warn("3 way commit failed on pipeline " + pipeline, e);
+      LOG.warn("3 way commit failed on pipeline {}", pipeline, e);
       if (t instanceof GroupMismatchException) {
         throw e;
       }
@@ -278,9 +278,9 @@ public final class XceiverClientRatis extends XceiverClientSpi {
         // replication.
         commitInfoMap.remove(address);
         LOG.info(
-            "Could not commit " + index + " on pipeline "
-                + pipeline + " to all the nodes. Server "
-                + address + " has failed. Committed by majority.");
+            "Could not commit index {} on pipeline {} to all the nodes. " +
+            "Server {} has failed. Committed by majority.",
+            index, pipeline, address);
       });
     }
     clientReply.setLogIndex(index);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -258,15 +258,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
           .sendWatchAsync(index, RaftProtos.ReplicationLevel.ALL_COMMITTED);
       replyFuture.get(timeout, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
-      String nodes = " with Datanodes : ";
       Throwable t = HddsClientUtils.checkForException(e);
-      for (DatanodeDetails datanodeDetails : pipeline.getNodes()) {
-        nodes += datanodeDetails.getHostName() + "["
-            + datanodeDetails.getIpAddress() + "] ";
-      }
-      LOG.warn("3 way commit failed on pipeline "
-          + pipeline.getId().getId()
-          + nodes, e);
+      LOG.warn("3 way commit failed on pipeline " + pipeline, e);
       if (t instanceof GroupMismatchException) {
         throw e;
       }
@@ -286,7 +279,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
         commitInfoMap.remove(address);
         LOG.info(
             "Could not commit " + index + " on pipeline "
-                + pipeline.getId().getId() + " to all the nodes. Server "
+                + pipeline + " to all the nodes. Server "
                 + address + " has failed. Committed by majority.");
       });
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -358,14 +358,8 @@ public class BlockOutputStream extends OutputStream {
         if (!dnList.isEmpty()) {
           Pipeline pipe = xceiverClient.getPipeline();
 
-          StringBuilder err = new StringBuilder();
-          err.append("Failed to commit BlockId ").append(blockID);
-          err.append(" on Pipeline ").append(pipe);
-
-          err.append(" failed nodes: ");
-          dnList.forEach(err::append);
-
-          LOG.warn(err.toString());
+          LOG.warn("Failed to commit BlockId {} on {}. Failed nodes: {}",
+              blockID, pipe, dnList);
           failedServers.addAll(dnList);
         }
       }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -356,9 +356,17 @@ public class BlockOutputStream extends OutputStream {
       if (reply != null) {
         List<DatanodeDetails> dnList = reply.getDatanodes();
         if (!dnList.isEmpty()) {
+          Pipeline pipe = xceiverClient.getPipeline();
+          String err = "Failed to commit BlockId " + blockID
+              + " on Pipeline " + pipe.getId().getId()
+              + " to Datanodes : ";
           if (failedServers.isEmpty()) {
             failedServers = new ArrayList<>();
           }
+          for (DatanodeDetails dn : dnList) {
+            err += dn.getHostName() + "[" + dn.getIpAddress() + "] ";
+          }
+          LOG.warn(err);
           failedServers.addAll(dnList);
         }
       }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -357,16 +357,15 @@ public class BlockOutputStream extends OutputStream {
         List<DatanodeDetails> dnList = reply.getDatanodes();
         if (!dnList.isEmpty()) {
           Pipeline pipe = xceiverClient.getPipeline();
-          String err = "Failed to commit BlockId " + blockID
-              + " on Pipeline " + pipe.getId().getId()
-              + " to Datanodes : ";
-          if (failedServers.isEmpty()) {
-            failedServers = new ArrayList<>();
-          }
-          for (DatanodeDetails dn : dnList) {
-            err += dn.getHostName() + "[" + dn.getIpAddress() + "] ";
-          }
-          LOG.warn(err);
+
+          StringBuilder err = new StringBuilder();
+          err.append("Failed to commit BlockId ").append(blockID);
+          err.append(" on Pipeline ").append(pipe);
+
+          err.append(" failed nodes: ");
+          dnList.forEach(err::append);
+
+          LOG.warn(err.toString());
           failedServers.addAll(dnList);
         }
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-1748

Added logs to print pipeline id, block id and datanode addresses when 3 way commit failure is encountered
in watchForCommit.