### PR TITLE
HDDS-1764. Fix hidden errors in acceptance tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:latest:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:latest:${HADOOP_RUNNER_VERSION}
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -37,7 +37,8 @@ for test in $(find "$SCRIPT_DIR" -name test.sh); do
   ./test.sh
   ret=$?
   if [[ $ret -ne 0 ]]; then
-      RESULT=-1
+      RESULT=1
+      echo "ERROR: Test execution of $(dirname "$test") is FAILED!!!!"
   fi
   RESULT_DIR="$(dirname "$test")/result"
   cp "$RESULT_DIR"/robot-*.xml "$ALL_RESULT_DIR"


### PR DESCRIPTION
[~bharatviswa] pinged me offline with the problem that in some cases the smoketest is failing even if the reports are green:

> All smoke tests are passed, but CI is showing as Failed.
> 
> https://ci.anzix.net/job/ozone/17284/RobotTests/log.html
> https://github.com/apache/hadoop/pull/1048
> 

The root cause is a few typo after HDDS-1698, which can be fixed with the uploaded PR.

***What is the problem?***

In case of any error during the test execution the smoketest is failed. In this case because the typo in two docker-compose.yaml files two of the tests can't be started.

But there is no separated robot test report and the error is visible only in the console.

***How did it happen?***

The ACL work improved some intermittency in the acceptance tests. HDDS-1698 is committed because the acceptance tests were failed with ACL errors which hide the real error (the test was red anyway).

 

See: https://issues.apache.org/jira/browse/HDDS-1764