### PR TITLE
HADOOP-16380 S3Guard tombstones can mislead about directory empty status

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -819,6 +819,22 @@ public final class S3ATestUtils {
   }
 
   /**
+   * Get a file status from S3A with the {@code needEmptyDirectoryFlag}
+   * state probed.
+   * This accesses a package-private method in the
+   * S3A filesystem.
+   * @param fs filesystem
+   * @param dir directory
+   * @return a status
+   * @throws IOException
+   */
+  public static S3AFileStatus getStatusWithEmptyDirFlag(
+      final S3AFileSystem fs,
+      final Path dir) throws IOException {
+    return fs.innerGetFileStatus(dir, true);
+  }
+
+  /**
    * Helper class to do diffs of metrics.
    */
   public static final class MetricDiff {


### PR DESCRIPTION

Initial patch changes ITestS3GuardEmptyDirs to replicate tombstone problem. 

Moved the access to the innerGetFileStatus call into S3ATestUtils so that tests in the s3guard package can also get at it

Change-Id: I5e0aecea008ea281c12ca2ff16388effef45956c

Tested: s3 ireland. Now successfully fails :)