### PR TITLE
HDDS-1784. Missing HostName and IpAddress in the response of register command.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -271,6 +271,8 @@ public class SCMDatanodeProtocolServer implements
         .setErrorCode(cmd.getError())
         .setClusterID(cmd.getClusterID())
         .setDatanodeUUID(cmd.getDatanodeUUID())
+        .setIpAddress(cmd.getIpAddress())
+        .setHostname(cmd.getHostName())
         .build();
   }
 


### PR DESCRIPTION
`SCMNodeManager` sets the HostName and IpAddress to the response of register command, but that is being ignored in `SCMDatanodeProtocolServer` while sending the response back to the datanode.