### PR TITLE
HDDS-1754. getContainerWithPipeline fails with PipelineNotFoundException. Contributed by Supratim Deka

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -467,4 +467,12 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     return state == HddsProtos.LifeCycleState.OPEN
         || state == HddsProtos.LifeCycleState.CLOSING;
   }
+
+  /**
+   * Check if a container is in Open state, but Close has not been initiated.
+   * @return true if Open, false otherwise.
+   */
+  public boolean isOpenNotClosing() {
+    return state == HddsProtos.LifeCycleState.OPEN;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -238,7 +238,7 @@ public class SCMClientProtocolServer implements
           getContainer(id);
       final Pipeline pipeline;
 
-      if (container.isOpen()) {
+      if (container.isOpenNotClosing()) {
         // Ratis pipeline
         pipeline = scm.getPipelineManager()
             .getPipeline(container.getPipelineID());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-1754

DeadNodeHandler can clean up the pipeline while containers are still in CLOSING state.
modified getContainerWithPipeline() to refer the pipeline only if the container is in OPEN state.
In CLOSING state, the read pipeline will be constructed from the Replicas known to SCM - this is already existing behavior for CLOSED state.
