### PR TITLE
HDDS-1791. Update network-tests/src/test/blockade/README.md file

### DIFF
--- a/hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/README.md
+++ b/hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/README.md
@@ -16,45 +16,27 @@
 Following python packages need to be installed before running the tests :
 
 1. blockade
-2. pytest==2.8.7
+2. pytest==3.2.0
 
 Running test as part of the maven build:
 
+```
 mvn clean verify -Pit
+```
 
 Running test as part of the released binary:
 
-You can execute all blockade tests with following command-lines:
+You can execute all blockade tests with following command:
 
 ```
-cd $DIRECTORY_OF_OZONE
-python -m pytest -s  tests/blockade/
+cd $OZONE_HOME
+python -m pytest tests/blockade
 ```
 
-You can also execute fewer blockade tests with following command-lines:
+You can also execute specific blockade tests with following command:
 
 ```
-cd $DIRECTORY_OF_OZONE
-python -m pytest -s  tests/blockade/<PATH_TO_PYTHON_FILE>
-e.g: python -m pytest -s tests/blockade/test_blockade_datanode_isolation.py
-```
-
-You can change the default 'sleep' interval in the tests with following
-command-lines:
-
-```
-cd $DIRECTORY_OF_OZONE
-python -m pytest -s  tests/blockade/ --containerStatusSleep=<SECONDS>
-
-e.g: python -m pytest -s  tests/blockade/ --containerStatusSleep=720
-```
-
-By default, second phase of the tests will not be run.
-In order to run the second phase of the tests, you can run following
-command-lines:
-
-```
-cd $DIRECTORY_OF_OZONE
-python -m pytest -s  tests/blockade/ --runSecondPhase=true
-
+cd $OZONE_HOME
+python -m pytest tests/blockade/< PATH TO PYTHON FILE >
+e.g: python -m pytest tests/blockade/test_blockade_datanode_isolation.py
 ```

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
@@ -154,17 +154,20 @@ public class TestDataScrubber {
     Assert.assertTrue(cs.containerCount() > 0);
 
     // delete the chunks directory.
-    File chunksDir = new File(c.getContainerData().getContainerPath(), "chunks");
+    File chunksDir = new File(c.getContainerData().getContainerPath(),
+        "chunks");
     deleteDirectory(chunksDir);
     Assert.assertFalse(chunksDir.exists());
 
-    ContainerScrubber sb = new ContainerScrubber(ozoneConfig, oc.getController());
+    ContainerScrubber sb = new ContainerScrubber(ozoneConfig,
+        oc.getController());
     sb.scrub(c);
 
     // wait for the incremental container report to propagate to SCM
     Thread.sleep(5000);
 
-    ContainerManager cm = cluster.getStorageContainerManager().getContainerManager();
+    ContainerManager cm = cluster.getStorageContainerManager()
+        .getContainerManager();
     Set<ContainerReplica> replicas = cm.getContainerReplicas(
         ContainerID.valueof(c.getContainerData().getContainerID()));
     Assert.assertEquals(1, replicas.size());
@@ -184,7 +187,8 @@ public class TestDataScrubber {
   }
 
   private boolean verifyRatisReplication(String volumeName, String bucketName,
-                                         String keyName, ReplicationType type, ReplicationFactor factor)
+                                         String keyName, ReplicationType type,
+                                         ReplicationFactor factor)
       throws IOException {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)


### PR DESCRIPTION
`hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/README.md` has to be updated after #1068 