### PR TITLE
HDDS-1800. Result of author check is inverted

### DIFF
--- a/hadoop-ozone/dev-support/checks/author.sh
+++ b/hadoop-ozone/dev-support/checks/author.sh
@@ -20,7 +20,6 @@ cd "$DIR/../../.." || exit 1
 AUTHOR="uthor"
 AUTHOR="@a${AUTHOR}"
 
-grep -r --include="*.java" "$AUTHOR" .
 if grep -r --include="*.java" "$AUTHOR" .; then
   exit 1
 else

--- a/hadoop-ozone/dev-support/checks/author.sh
+++ b/hadoop-ozone/dev-support/checks/author.sh
@@ -22,7 +22,7 @@ AUTHOR="@a${AUTHOR}"
 
 grep -r --include="*.java" "$AUTHOR" .
 if grep -r --include="*.java" "$AUTHOR" .; then
-  exit 0
-else
   exit 1
+else
+  exit 0
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix:

 1. author check fails when no violations are found
 2. author check violations are duplicated in the output

Eg. https://ci.anzix.net/job/ozone-nightly/173/consoleText says that:

```
The following tests are FAILED:

[author]: author check is failed (https://ci.anzix.net/job/ozone-nightly/173//artifact/build/author.out/*view*/)
```

but no actual `@author` tags were found:

```
$ curl -s 'https://ci.anzix.net/job/ozone-nightly/173//artifact/build/author.out/*view*/' | wc
       0       0       0
```

## How was this patch tested?

```
$ bash -o pipefail -c 'hadoop-ozone/dev-support/checks/author.sh | tee build/author.out'; echo $?
0

$ wc build/author.out
       0       0       0 build/author.out

$ echo '// @author Tolkien' >> hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManager.java

$ bash -o pipefail -c 'hadoop-ozone/dev-support/checks/author.sh | tee build/author.out'; echo $?
./hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManager.java:// @author Tolkien
1

$ wc build/author.out
       1       3     108 build/author.out
```