### PR TITLE
HDFS-14646. Standby NameNode should terminate the FsImage put process…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageServlet.java
@@ -597,7 +597,15 @@ public class ImageServlet extends HttpServlet {
     } catch (Throwable t) {
       String errMsg = "PutImage failed. " + StringUtils.stringifyException(t);
       response.sendError(HttpServletResponse.SC_GONE, errMsg);
-      throw new IOException(errMsg);
+      /*
+       *  Do not throw exceptions here to prevent Jetty from printing too
+       *  many unnecessary warn logs, since it is very likely that the peer
+       *  Standby NameNode is testing whether it needs to really put an image.
+       *
+       *  Note the peer Standby NameNode's log will still contain the complete
+       *  warnings.
+       */
+      return;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
@@ -246,7 +246,6 @@ public class StandbyCheckpointer {
     for (; i < uploads.size(); i++) {
       Future<TransferFsImage.TransferResult> upload = uploads.get(i);
       try {
-        // TODO should there be some smarts here about retries nodes that are not the active NN?
         if (upload.get() == TransferFsImage.TransferResult.SUCCESS) {
           success = true;
           //avoid getting the rest of the results - we don't care since we had a successful upload


### PR DESCRIPTION
… immediately if the peer NN is not in the appropriate state to receive an image.