### PR TITLE
HDDS-1756. DeleteContainerCommandHandler fails with NPE.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -137,7 +137,9 @@ public class ContainerController {
   public void deleteContainer(final long containerId, boolean force)
       throws IOException {
     final Container container = containerSet.getContainer(containerId);
-    getHandler(container).deleteContainer(container, force);
+    if (container != null) {
+      getHandler(container).deleteContainer(container, force);
+    }
   }
 
   /**


### PR DESCRIPTION
This change will make delete container an idempotent operation in datanode.