### PR TITLE
HDDS-1793. Acceptance test of ozone-topology cluster is failing

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
    datanode_1:
       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
-      container_name: datanode_1
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -34,7 +33,6 @@ services:
    datanode_2:
       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
-      container_name: datanode_2
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -49,7 +47,6 @@ services:
    datanode_3:
       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
-      container_name: datanode_3
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -64,7 +61,6 @@ services:
    datanode_4:
       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
-      container_name: datanode_4
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -79,7 +75,6 @@ services:
    om:
       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
-      container_name: om
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -95,7 +90,6 @@ services:
    scm:
       image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
-      container_name: scm
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
@@ -15,15 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DATANODE_COUNT=4
-
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-start_docker_env
+start_docker_env 4
 
 #Due to the limitation of the current auditparser test, it should be the
 #first test in a clean cluster.

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DATANODE_COUNT=4
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove explicit container names from `ozone-topology`, since they are not handled by `execute_robot_test`
   (`must specify at least one container source`)
2. Allow more than 3 datanodes (`ozone-topology` has 4) in `wait_for_datanodes`

https://issues.apache.org/jira/browse/HDDS-1793

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone-topology
$ ./test.sh
Removing network ozone-topology_net
WARNING: Network ozone-topology_net not found.
Creating network "ozone-topology_net" with driver "bridge"
Creating ozone-topology_om_1         ... done
Creating ozone-topology_scm_1        ... done
Creating ozone-topology_datanode_2_1 ... done
Creating ozone-topology_datanode_1_1 ... done
Creating ozone-topology_datanode_3_1 ... done
Creating ozone-topology_datanode_4_1 ... done
0 datanode is up and healthy (until now)
0 datanode is up and healthy (until now)
4 datanodes are up and registered to the scm
==============================================================================
ozone-topology-auditparser
==============================================================================
ozone-topology-auditparser.Auditparser :: Smoketest ozone cluster startup
==============================================================================
Initiating freon to generate data                                     | PASS |
------------------------------------------------------------------------------
Testing audit parser                                                  | PASS |
------------------------------------------------------------------------------
ozone-topology-auditparser.Auditparser :: Smoketest ozone cluster ... | PASS |
2 critical tests, 2 passed, 0 failed
2 tests total, 2 passed, 0 failed
==============================================================================
ozone-topology-auditparser                                            | PASS |
2 critical tests, 2 passed, 0 failed
2 tests total, 2 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/ozone-topology/result/robot-ozone-topology-ozone-topology-auditparser-om.xml
==============================================================================
ozone-topology-basic :: Smoketest ozone cluster startup
==============================================================================
Check webui static resources                                          | PASS |
------------------------------------------------------------------------------
Start freon testing                                                   | PASS |
------------------------------------------------------------------------------
ozone-topology-basic :: Smoketest ozone cluster startup               | PASS |
2 critical tests, 2 passed, 0 failed
2 tests total, 2 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/ozone-topology/result/robot-ozone-topology-ozone-topology-basic-scm.xml
Stopping ozone-topology_datanode_1_1 ... done
Stopping ozone-topology_datanode_2_1 ... done
Stopping ozone-topology_datanode_3_1 ... done
Stopping ozone-topology_datanode_4_1 ... done
Stopping ozone-topology_scm_1        ... done
Stopping ozone-topology_om_1         ... done
Removing ozone-topology_datanode_1_1 ... done
Removing ozone-topology_datanode_2_1 ... done
Removing ozone-topology_datanode_3_1 ... done
Removing ozone-topology_datanode_4_1 ... done
Removing ozone-topology_scm_1        ... done
Removing ozone-topology_om_1         ... done
Removing network ozone-topology_net
Log:     hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone-topology/result/log.html
Report:  hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone-topology/result/report.html
```