### PR TITLE
HDDS-1803. shellcheck.sh does not work on Mac

### DIFF
--- a/hadoop-ozone/dev-support/checks/shellcheck.sh
+++ b/hadoop-ozone/dev-support/checks/shellcheck.sh
@@ -19,9 +19,14 @@ cd "$DIR/../../.." || exit 1
 OUTPUT_FILE="$DIR/../../../target/shell-problems.txt"
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 echo "" > "$OUTPUT_FILE"
-find "./hadoop-hdds" -type f -executable | grep -v target | grep -v node_modules | grep -v py | xargs -n1 shellcheck  | tee "$OUTPUT_FILE"
-find "./hadoop-ozone" -type f -executable | grep -v target | grep -v node_modules | grep -v py | xargs -n1 shellcheck  | tee "$OUTPUT_FILE"
-
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  find hadoop-hdds hadoop-ozone -type f -perm '-500'
+else
+  find hadoop-hdds hadoop-ozone -type f -executable
+fi \
+  | grep -v -e target/ -e node_modules/ -e '\.\(ico\|py\|yml\)$' \
+  | xargs -n1 shellcheck \
+  | tee "$OUTPUT_FILE"
 
 if [ "$(cat "$OUTPUT_FILE")" ]; then
    exit 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Filter for file permission on Mac.
 * Merge two separate `find` calls to avoid overwriting output (and eliminate code duplication).

https://issues.apache.org/jira/browse/HDDS-1803

## How was this patch tested?

```
$ hadoop-ozone/dev-support/checks/shellcheck.sh | wc
     133     600    6065

$ wc target/shell-problems.txt
     133     600    6065 target/shell-problems.txt
```