### PR TITLE
HDFS-14646. Standby NameNode should terminate the FsImage put process immediately if the peer NN is not in the appropriate state to receive an image.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageServlet.java
@@ -658,7 +658,15 @@ public class ImageServlet extends HttpServlet {
     } catch (Throwable t) {
       String errMsg = "PutImage failed. " + StringUtils.stringifyException(t);
       response.sendError(HttpServletResponse.SC_GONE, errMsg);
-      throw new IOException(errMsg);
+      /*
+       *  Do not throw exceptions here to prevent Jetty from printing too
+       *  many unnecessary warn logs, since it is very likely that the peer
+       *  Standby NameNode is testing whether it needs to really put an image.
+       *
+       *  Note the peer Standby NameNode's log will still contain the complete
+       *  warnings.
+       */
+      return;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
@@ -288,9 +288,7 @@ public class StandbyCheckpointer {
         uploads.entrySet()) {
       String url = entry.getKey();
       Future<TransferFsImage.TransferResult> upload = entry.getValue();
-      try {
-        // TODO should there be some smarts here about retries nodes that
-        //  are not the active NN?
+      try {        
         CheckpointReceiverEntry receiverEntry = checkpointReceivers.get(url);
         if (upload.get() == TransferFsImage.TransferResult.SUCCESS) {
           receiverEntry.setLastUploadTime(monotonicNow());


### PR DESCRIPTION
… immediately if the peer NN is not in the appropriate state to receive an image.