### PR TITLE
HDDS-1799. Add goofyfs to the ozone-runner docker image

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20190716-TODO</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20190717-1</docker.ozone-runner.version>
   </properties>
 
   <build>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20190617-2</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20190716-TODO</docker.ozone-runner.version>
   </properties>
 
   <build>

--- a/hadoop-ozone/dist/src/main/docker/Dockerfile
+++ b/hadoop-ozone/dist/src/main/docker/Dockerfile
@@ -19,7 +19,3 @@ FROM apache/ozone-runner:@docker.ozone-runner.version@
 ADD --chown=hadoop . /opt/hadoop
 
 WORKDIR /opt/hadoop
-
-RUN sudo wget https://os.anzix.net/goofys -O /usr/bin/goofys
-RUN sudo chmod 755 /usr/bin/goofys
-RUN sudo yum install -y fuse


### PR DESCRIPTION
Goofys is a s3 fuse driver which is required for the ozone csi setup.

As of now it's installed in hadoop-ozone/dist/src/main/docker/Dockerfile from a non-standard location (because it couldn't be part of hadoop-runner earlier as it's ozone specific).

It should be installed to the ozone-runner from a canonical goffys release URL.

See: https://issues.apache.org/jira/browse/HDDS-1799