### PR TITLE
HADOOP-16341. ShutDownHookManager: Regressed performance on Hook removals after HADOOP-15679

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
@@ -254,7 +254,9 @@ public final class ShutdownHookManager {
   private AtomicBoolean shutdownInProgress = new AtomicBoolean(false);
 
   //private to constructor to ensure singularity
-  private ShutdownHookManager() {
+  @VisibleForTesting
+  @InterfaceAudience.Private
+  ShutdownHookManager() {
   }
 
   /**
@@ -267,8 +269,8 @@ public final class ShutdownHookManager {
   @VisibleForTesting
   List<HookEntry> getShutdownHooksInOrder() {
     List<HookEntry> list;
-    synchronized (MGR.hooks) {
-      list = new ArrayList<>(MGR.hooks);
+    synchronized (hooks) {
+      list = new ArrayList<>(hooks);
     }
     Collections.sort(list, new Comparator<HookEntry>() {
 
@@ -342,7 +344,9 @@ public final class ShutdownHookManager {
       throw new IllegalStateException("Shutdown in progress, cannot remove a " +
           "shutdownHook");
     }
-    return hooks.remove(new HookEntry(shutdownHook, 0));
+    // hooks are only == by runnable
+    return hooks.remove(new HookEntry(shutdownHook, 0, TIMEOUT_MINIMUM,
+      TIME_UNIT_DEFAULT));
   }
 
   /**
@@ -354,7 +358,8 @@ public final class ShutdownHookManager {
   @InterfaceAudience.Public
   @InterfaceStability.Stable
   public boolean hasShutdownHook(Runnable shutdownHook) {
-    return hooks.contains(new HookEntry(shutdownHook, 0));
+    return hooks.contains(new HookEntry(shutdownHook, 0, TIMEOUT_MINIMUM,
+      TIME_UNIT_DEFAULT));
   }
   
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
@@ -92,7 +92,7 @@ public final class ShutdownHookManager {
               return;
             }
             long started = System.currentTimeMillis();
-            int timeoutCount = executeShutdown();
+            int timeoutCount = MGR.executeShutdown();
             long ended = System.currentTimeMillis();
             LOG.debug(String.format(
                 "Completed shutdown in %.3f seconds; Timeouts: %d",
@@ -116,9 +116,9 @@ public final class ShutdownHookManager {
    */
   @InterfaceAudience.Private
   @VisibleForTesting
-  static int executeShutdown() {
+  int executeShutdown() {
     int timeouts = 0;
-    for (HookEntry entry: MGR.getShutdownHooksInOrder()) {
+    for (HookEntry entry: getShutdownHooksInOrder()) {
       Future<?> future = EXECUTOR.submit(entry.getHook());
       try {
         future.get(entry.getTimeout(), entry.getTimeUnit());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
@@ -43,13 +43,10 @@ public class TestShutdownHookManager {
       LoggerFactory.getLogger(TestShutdownHookManager.class.getName());
 
   /**
-   * remove all the shutdown hooks so that they never get invoked later
-   * on in this test process.
+   * A new instance of ShutdownHookManager to ensure parallel tests
+   * don't have shared context
    */
-  @After
-  public void clearShutdownHooks() {
-    ShutdownHookManager.get().clearShutdownHooks();
-  }
+  private final ShutdownHookManager mgr = new ShutdownHookManager();
 
   /**
    * Verify hook registration, then execute the hook callback stage
@@ -58,7 +55,6 @@ public class TestShutdownHookManager {
    */
   @Test
   public void shutdownHookManager() {
-    ShutdownHookManager mgr = ShutdownHookManager.get();
     assertNotNull("No ShutdownHookManager", mgr);
     assertEquals(0, mgr.getShutdownHooksInOrder().size());
     Hook hook1 = new Hook("hook1", 0, false);
@@ -193,7 +189,6 @@ public class TestShutdownHookManager {
    */
   @Test
   public void testDuplicateRegistration() throws Throwable {
-    ShutdownHookManager mgr = ShutdownHookManager.get();
     Hook hook = new Hook("hook1", 0, false);
 
     // add the hook
@@ -220,6 +215,20 @@ public class TestShutdownHookManager {
     assertEquals("priority of hook", 5, entry.getPriority());
     assertNotEquals("timeout of hook", 1, entry.getTimeout());
 
+  }
+
+  @Test
+  public void testShutdownRemove() throws Throwable {
+    assertNotNull("No ShutdownHookManager", mgr);
+    assertEquals(0, mgr.getShutdownHooksInOrder().size());
+    Hook hook1 = new Hook("hook1", 0, false);
+    Hook hook2 = new Hook("hook2", 0, false);
+    mgr.addShutdownHook(hook1, 9); // create Hook1 with priority 9
+    assertTrue(mgr.hasShutdownHook(hook1)); // hook1 lookup works
+    assertEquals(1, mgr.getShutdownHooksInOrder().size()); // 1 hook
+    assertFalse(mgr.removeShutdownHook(hook2)); // can't delete hook2
+    assertTrue(mgr.removeShutdownHook(hook1)); // can delete hook1
+    assertEquals(0, mgr.getShutdownHooksInOrder().size()); // no more hooks
   }
 
   private static final AtomicInteger INVOCATION_COUNT = new AtomicInteger();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.After;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -226,9 +225,10 @@ public class TestShutdownHookManager {
     mgr.addShutdownHook(hook1, 9); // create Hook1 with priority 9
     assertTrue("No hook1", mgr.hasShutdownHook(hook1)); // hook1 lookup works
     assertEquals(1, mgr.getShutdownHooksInOrder().size()); // 1 hook
-    assertFalse("Delete hook2 should not be allowed", mgr.removeShutdownHook(hook2)); // can't delete hook2
-    assertTrue("Can't delete hook1", mgr.removeShutdownHook(hook1)); // can delete hook1
-    assertEquals(0, mgr.getShutdownHooksInOrder().size()); // no more hooks
+    assertFalse("Delete hook2 should not be allowed",
+      mgr.removeShutdownHook(hook2));
+    assertTrue("Can't delete hook1", mgr.removeShutdownHook(hook1));
+    assertEquals(0, mgr.getShutdownHooksInOrder().size());
   }
 
   private static final AtomicInteger INVOCATION_COUNT = new AtomicInteger();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
@@ -44,7 +44,7 @@ public class TestShutdownHookManager {
 
   /**
    * A new instance of ShutdownHookManager to ensure parallel tests
-   * don't have shared context
+   * don't have shared context.
    */
   private final ShutdownHookManager mgr = new ShutdownHookManager();
 
@@ -224,10 +224,10 @@ public class TestShutdownHookManager {
     Hook hook1 = new Hook("hook1", 0, false);
     Hook hook2 = new Hook("hook2", 0, false);
     mgr.addShutdownHook(hook1, 9); // create Hook1 with priority 9
-    assertTrue(mgr.hasShutdownHook(hook1)); // hook1 lookup works
+    assertTrue("No hook1", mgr.hasShutdownHook(hook1)); // hook1 lookup works
     assertEquals(1, mgr.getShutdownHooksInOrder().size()); // 1 hook
-    assertFalse(mgr.removeShutdownHook(hook2)); // can't delete hook2
-    assertTrue(mgr.removeShutdownHook(hook1)); // can delete hook1
+    assertFalse("Delete hook2 should not be allowed", mgr.removeShutdownHook(hook2)); // can't delete hook2
+    assertTrue("Can't delete hook1", mgr.removeShutdownHook(hook1)); // can delete hook1
     assertEquals(0, mgr.getShutdownHooksInOrder().size()); // no more hooks
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestShutdownHookManager.java
@@ -115,7 +115,7 @@ public class TestShutdownHookManager {
     // now execute the hook shutdown sequence
     INVOCATION_COUNT.set(0);
     LOG.info("invoking executeShutdown()");
-    int timeouts = ShutdownHookManager.executeShutdown();
+    int timeouts = mgr.executeShutdown();
     LOG.info("Shutdown completed");
     assertEquals("Number of timed out hooks", 1, timeouts);
 


### PR DESCRIPTION
clone of #1086 but for 3.2