### PR TITLE
HADOOP-16437 documentation typo fix: fs.s3a.experimental.fadvise -> fs.s3a.experimental.input.fadvise

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstreambuilder.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstreambuilder.md
@@ -54,7 +54,7 @@ of `FileSystem`.
 
 ```java
 out = fs.openFile(path)
-    .opt("fs.s3a.experimental.fadvise", "random")
+    .opt("fs.s3a.experimental.input.fadvise", "random")
     .must("fs.s3a.readahead.range", 256 * 1024)
     .build()
     .get();

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -281,7 +281,7 @@ killer.
 `fs.s3a.threads.max` and `fs.s3a.connection.maximum`.
 
 1. Make sure that the bucket is using `sequential` or `normal` fadvise seek policies,
-that is, `fs.s3a.experimental.fadvise` is not set to `random`
+that is, `fs.s3a.experimental.input.fadvise` is not set to `random`
 
 1. Perform listings in parallel by setting `-numListstatusThreads`
 to a higher number. Make sure that `fs.s3a.connection.maximum`
@@ -314,7 +314,7 @@ the S3 bucket/shard.
 </property>
 
 <property>
-  <name>fs.s3a.experimental.fadvise</name>
+  <name>fs.s3a.experimental.input.fadvise</name>
   <value>normal</value>
 </property>
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -1129,7 +1129,7 @@ shows that it is generally more efficient to abort the TCP connection and initia
 a new one than read to the end of a large file.
 
 Note: the threshold when data is read rather than the stream aborted can be tuned
-by `fs.s3a.readahead.range`; seek policy in `fs.s3a.experimental.fadvise`.
+by `fs.s3a.readahead.range`; seek policy in `fs.s3a.experimental.input.fadvise`.
 
 ### <a name="no_such_bucket"></a> `FileNotFoundException` Bucket does not exist.
 


### PR DESCRIPTION
This PR fixes a typo in the Hadoop documentation: `fs.s3a.experimental.fadvise` should be `fs.s3a.experimental.input.fadvise` (the `.input` was missing previously).