### PR TITLE
HDDS-1811. Prometheus metrics are broken

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -62,7 +62,7 @@ public class CSMMetrics {
   public CSMMetrics() {
     int numCmdTypes = ContainerProtos.Type.values().length;
     this.opsLatency = new MutableRate[numCmdTypes];
-    this.registry = new MetricsRegistry(CSMMetrics.class.getName());
+    this.registry = new MetricsRegistry(CSMMetrics.class.getSimpleName());
     for (int i = 0; i < numCmdTypes; i++) {
       opsLatency[i] = registry.newRate(
           ContainerProtos.Type.forNumber(i + 1).toString(),

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.server;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
@@ -31,7 +30,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Test prometheus Sink.
@@ -53,17 +52,18 @@ public class TestPrometheusMetricsSink {
     testMetrics.numBucketCreateFails.incr();
     metrics.publishMetricsNow();
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    OutputStreamWriter writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8);
+    OutputStreamWriter writer = new OutputStreamWriter(stream, UTF_8);
 
     //WHEN
     sink.writeMetrics(writer);
     writer.flush();
 
     //THEN
-    System.out.println(stream.toString(UTF_8));
+    String writtenMetrics = stream.toString(UTF_8.name());
+    System.out.println(writtenMetrics);
     Assert.assertTrue(
         "The expected metric line is missing from prometheus metrics output",
-        stream.toString(UTF_8).contains(
+        writtenMetrics.contains(
             "test_metrics_num_bucket_create_fails{context=\"dfs\"")
     );
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix invalid metric type errors:

```
target=http://192.168.69.76:9882/prom err="invalid metric type \"apache.hadoop.ozone.container.common.transport.server.ratis._csm_metrics_delete_container_avg_time gauge\""
```

and

```
target=http://scm:9876/prom err="invalid metric type \"_rati_s-_thre_e-d7116831-ac55-4bf2-a259-d85cfba0572d counter\""
```

 1. datanode: avoid `.` in record name by using simple class name
 2. SCM: replace `-` with `_`.  Also properly convert `ALL_CAPS` names, eg. `RATIS_THREE` to `ratis_three` instead of `_rati_s-_thre_e`.

https://issues.apache.org/jira/browse/HDDS-1811

## How was this patch tested?

Updated unit test.

Checked metrics in `ozoneperf` pseudo-cluster.