### PR TITLE
HADOOP-16380 S3Guard to determine empty directory status for all non-root directories

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -220,21 +220,21 @@ directory contains many thousands of files.
 
 Consider a directory `"/d"` with the contents:
 
-	a
-	part-0000001
-	part-0000002
-	...
-	part-9999999
+    a
+    part-0000001
+    part-0000002
+    ...
+    part-9999999
 
 
 If the number of files is such that HDFS returns a partial listing in each
 response, then, if a listing `listStatus("/d")` takes place concurrently with the operation
 `rename("/d/a","/d/z"))`, the result may be one of:
 
-	[a, part-0000001, ... , part-9999999]
-	[part-0000001, ... , part-9999999, z]
-	[a, part-0000001, ... , part-9999999, z]
-	[part-0000001, ... , part-9999999]
+    [a, part-0000001, ... , part-9999999]
+    [part-0000001, ... , part-9999999, z]
+    [a, part-0000001, ... , part-9999999, z]
+    [part-0000001, ... , part-9999999]
 
 While this situation is likely to be a rare occurrence, it MAY happen. In HDFS
 these inconsistent views are only likely when listing a directory with many children.
@@ -964,7 +964,7 @@ A path referring to a file is removed, return value: `True`
 Deleting an empty root does not change the filesystem state
 and may return true or false.
 
-    if isDir(FS, p) and isRoot(p) and children(FS, p) == {} :
+    if isRoot(p) and children(FS, p) == {} :
         FS ' = FS
         result = (undetermined)
 
@@ -973,8 +973,8 @@ There is no consistent return code from an attempt to delete the root directory.
 Implementations SHOULD return true; this avoids code which checks for a false
 return value from overreacting.
 
-Note: Some of the object store based filesystem implementations always return
-false when deleting the root.
+*Object Stores*: see [Object Stores: root directory deletion](#object-stores-rm-root).
+
 
 ##### Empty (non-root) directory `recursive == False`
 
@@ -989,7 +989,7 @@ return true.
 ##### Recursive delete of non-empty root directory
 
 Deleting a root path with children and `recursive==True`
- can do one of two things.
+can generally have three outcomes:
 
 1. The POSIX model assumes that if the user has
 the correct permissions to delete everything,
@@ -1007,6 +1007,8 @@ filesystem is desired.
             FS' = FS
             result = False
 
+1. Object Stores: see [Object Stores: root directory deletion](#object-stores-rm-root).
+
 HDFS has the notion of *Protected Directories*, which are declared in
 the option `fs.protected.directories`. Any attempt to delete such a directory
 or a parent thereof raises an `AccessControlException`. Accordingly, any
@@ -1022,8 +1024,22 @@ Any filesystem client which interacts with a remote filesystem which lacks
 such a security model, MAY reject calls to `delete("/", true)` on the basis
 that it makes it too easy to lose data.
 
-Note: Some of the object store based filesystem implementations always return
-false when deleting the root.
+
+### <a name="object-stores-rm-root"></a> Object Stores: root directory deletion
+
+Some of the object store based filesystem implementations always return
+false when deleting the root, leaving the state of the store unchanged.
+
+    if isRoot(p) :
+        FS ' = FS
+        result = False
+
+This is irrespective of the recursive flag status or the state of the directory.
+
+This is a simplification which avoids the inevitably non-atomic scan and delete
+of the contents of the store. It also avoids any confusion about whether
+the operation actually deletes that specific store/container itself, and
+adverse consequences of the simpler permissions models of stores.
 
 ##### Recursive delete of non-root directory
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -973,6 +973,9 @@ There is no consistent return code from an attempt to delete the root directory.
 Implementations SHOULD return true; this avoids code which checks for a false
 return value from overreacting.
 
+Note: Some of the object store based filesystem implementations always return
+false when deleting the root.
+
 ##### Empty (non-root) directory `recursive == False`
 
 Deleting an empty directory that is not root will remove the path from the FS and
@@ -1018,6 +1021,9 @@ which only system administrators should be able to perform.
 Any filesystem client which interacts with a remote filesystem which lacks
 such a security model, MAY reject calls to `delete("/", true)` on the basis
 that it makes it too easy to lose data.
+
+Note: Some of the object store based filesystem implementations always return
+false when deleting the root.
 
 ##### Recursive delete of non-root directory
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -189,7 +189,7 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
     Path root = new Path("/");
     FileStatus[] statuses = fs.listStatus(root);
     for (FileStatus status : statuses) {
-      ContractTestUtils.assertDeleted(fs, status.getPath(), true);
+      ContractTestUtils.assertDeleted(fs, status.getPath(), false,true, false);
     }
     FileStatus[] rootListStatus = fs.listStatus(root);
     assertEquals("listStatus on empty root-directory returned found: "

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -674,7 +674,8 @@ public class ContractTestUtils extends Assert {
   /**
    * Delete a file/dir and assert that delete() returned true
    * <i>and</i> that the path no longer exists. This variant rejects
-   * all operations on root directories.
+   * all operations on root directories and requires the target path
+   * to exist before the deletion operation.
    * @param fs filesystem
    * @param file path to delete
    * @param recursive flag to enable recursive delete
@@ -688,8 +689,9 @@ public class ContractTestUtils extends Assert {
 
   /**
    * Delete a file/dir and assert that delete() returned true
-   * <i>and</i> that the path no longer exists. This variant rejects
-   * all operations on root directories
+   * <i>and</i> that the path no longer exists.
+   * This variant requires the target path
+   * to exist before the deletion operation.
    * @param fs filesystem
    * @param file path to delete
    * @param recursive flag to enable recursive delete
@@ -700,8 +702,28 @@ public class ContractTestUtils extends Assert {
       Path file,
       boolean recursive,
       boolean allowRootOperations) throws IOException {
+    assertDeleted(fs, file, true, recursive, allowRootOperations);
+  }
+
+  /**
+   * Delete a file/dir and assert that delete() returned true
+   * <i>and</i> that the path no longer exists.
+   * @param fs filesystem
+   * @param file path to delete
+   * @param requirePathToExist check for the path existing first?
+   * @param recursive flag to enable recursive delete
+   * @param allowRootOperations can the root dir be deleted?
+   * @throws IOException IO problems
+   */
+  public static void assertDeleted(FileSystem fs,
+      Path file,
+      boolean requirePathToExist,
+      boolean recursive,
+      boolean allowRootOperations) throws IOException {
     rejectRootOperation(file, allowRootOperations);
-    assertPathExists(fs, "about to be deleted file", file);
+    if (requirePathToExist) {
+      assertPathExists(fs, "about to be deleted file", file);
+    }
     boolean deleted = fs.delete(file, recursive);
     String dir = ls(fs, file.getParent());
     assertTrue("Delete failed on " + file + ": " + dir, deleted);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2609,7 +2609,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // Check MetadataStore, if any.
     PathMetadata pm = null;
     if (hasMetadataStore()) {
-      pm = S3Guard.getWithTtl(metadataStore, path, ttlTimeProvider);
+      pm = S3Guard.getWithTtl(metadataStore, path, ttlTimeProvider,
+          needEmptyDirectoryFlag);
     }
     Set<Path> tombstones = Collections.emptySet();
     if (pm != null) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2193,6 +2193,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    */
   @Retries.RetryTranslated
   public boolean delete(Path f, boolean recursive) throws IOException {
+    if (f.isRoot()) {
+      if (!recursive) {
+        return false;
+      }
+      LOG.debug("Deleting root content recursively");
+    }
+
     try {
       entryPoint(INVOCATION_DELETE);
       boolean outcome = innerDelete(innerGetFileStatus(f, true), recursive);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -712,12 +712,15 @@ public final class S3Guard {
    * @param ms metastore
    * @param path path to look up.
    * @param timeProvider nullable time provider
+   * @param needEmptyDirectoryFlag if true, implementation will
+   * return known state of directory emptiness.
    * @return the metadata or null if there as no entry.
    * @throws IOException failure.
    */
   public static PathMetadata getWithTtl(MetadataStore ms, Path path,
-      @Nullable ITtlTimeProvider timeProvider) throws IOException {
-    final PathMetadata pathMetadata = ms.get(path);
+      @Nullable ITtlTimeProvider timeProvider,
+      final boolean needEmptyDirectoryFlag) throws IOException {
+    final PathMetadata pathMetadata = ms.get(path, needEmptyDirectoryFlag);
     // if timeProvider is null let's return with what the ms has
     if (timeProvider == null) {
       LOG.debug("timeProvider is null, returning pathMetadata as is");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 
+import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +61,11 @@ public class ITestS3AContractRootDir extends
   @Override
   public S3AFileSystem getFileSystem() {
     return (S3AFileSystem) super.getFileSystem();
+  }
+
+  @Override
+  @Ignore("S3 always return false when non-recursively remove root dir")
+  public void testRmNonEmptyRootDirNonRecursive() throws Throwable {
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
@@ -75,9 +75,6 @@ public class ITestS3AContractRootDir extends
   @Override
   public void testListEmptyRootDirectory() throws IOException {
     int maxAttempts = 10;
-    if (getFileSystem().hasMetadataStore()) {
-      maxAttempts = 1;
-    }
     describe("Listing root directory; for consistency allowing "
         + maxAttempts + " attempts");
     for (int attempt = 1; attempt <= maxAttempts; ++attempt) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardEmptyDirs.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardEmptyDirs.java
@@ -20,16 +20,29 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.s3a.s3guard.DDBPathMetadata;
+import org.apache.hadoop.fs.s3a.s3guard.DynamoDBMetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.NullMetadataStore;
-import org.junit.Assume;
-import org.junit.Test;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertRenameOutcome;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.assume;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeFilesystemHasMetadatastore;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.getStatusWithEmptyDirFlag;
 
 /**
  * Test logic around whether or not a directory is empty, with S3Guard enabled.
@@ -84,7 +97,7 @@ public class ITestS3GuardEmptyDirs extends AbstractS3ATestBase {
   @Test
   public void testEmptyDirs() throws Exception {
     S3AFileSystem fs = getFileSystem();
-    Assume.assumeTrue(fs.hasMetadataStore());
+    assumeFilesystemHasMetadatastore(getFileSystem());
     MetadataStore configuredMs = fs.getMetadataStore();
     Path existingDir = path("existing-dir");
     Path existingFile = path("existing-dir/existing-file");
@@ -126,4 +139,124 @@ public class ITestS3GuardEmptyDirs extends AbstractS3ATestBase {
       configuredMs.forgetMetadata(existingDir);
     }
   }
+
+  /**
+   * Test tombstones don't get in the way of a listing of the
+   * root dir.
+   * This test needs to create a path which appears first in the listing,
+   * and an entry which can come later. To allow the test to proceed
+   * while other tests are running, the filename "0000" is used for that
+   * deleted entry.
+   */
+  @Test
+  public void testTombstonesAndEmptyDirectories() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    assumeFilesystemHasMetadatastore(getFileSystem());
+
+    // Create the first and last files.
+    Path base = path(getMethodName());
+    // use something ahead of all the ASCII alphabet characters so
+    // even during parallel test runs, this test is expected to work.
+    String first = "0000";
+    Path firstPath = new Path(base, first);
+
+    // this path is near the bottom of the ASCII string space.
+    // This isn't so critical.
+    String last = "zzzz";
+    Path lastPath = new Path(base, last);
+    touch(fs, firstPath);
+    touch(fs, lastPath);
+    // Delete first entry (+assert tombstone)
+    assertDeleted(firstPath, false);
+    DynamoDBMetadataStore ddbMs = getRequiredDDBMetastore(fs);
+    DDBPathMetadata firstMD = ddbMs.get(firstPath);
+    assertNotNull("No MD for " + firstPath, firstMD);
+    assertTrue("Not a tombstone " + firstMD,
+        firstMD.isDeleted());
+    // PUT child to store going past the FS entirely.
+    // This is not going to show up on S3Guard.
+    Path child = new Path(firstPath, "child");
+    StoreContext ctx = fs.createStoreContext();
+    String childKey = ctx.pathToKey(child);
+    String baseKey = ctx.pathToKey(base) + "/";
+    AmazonS3 s3 = fs.getAmazonS3ClientForTesting("LIST");
+    String bucket = ctx.getBucket();
+    try {
+      createEmptyObject(fs, childKey);
+
+      // Do a list
+      ListObjectsV2Request listReq = new ListObjectsV2Request()
+          .withBucketName(bucket)
+          .withPrefix(baseKey)
+          .withMaxKeys(10)
+          .withDelimiter("/");
+      ListObjectsV2Result listing = s3.listObjectsV2(listReq);
+
+      // the listing has the first path as a prefix, because of the child
+      Assertions.assertThat(listing.getCommonPrefixes())
+          .describedAs("The prefixes of a LIST of %s", base)
+          .contains(baseKey + first + "/");
+
+      // and the last file is one of the files
+      Stream<String> files = listing.getObjectSummaries()
+          .stream()
+          .map(s -> s.getKey());
+      Assertions.assertThat(files)
+          .describedAs("The files of a LIST of %s", base)
+          .contains(baseKey + last);
+
+      // verify absolutely that the last file exists
+      assertPathExists("last file", lastPath);
+
+      // do a getFile status with empty dir flag
+      S3AFileStatus status = getStatusWithEmptyDirFlag(fs, base);
+      assertNonEmptyDir(status);
+    } finally {
+      // try to recover from the defective state.
+      s3.deleteObject(bucket, childKey);
+      fs.delete(lastPath, true);
+      ddbMs.forgetMetadata(firstPath);
+    }
+  }
+
+  protected void assertNonEmptyDir(final S3AFileStatus status) {
+    assertEquals("Should not be empty dir: " + status, Tristate.FALSE,
+        status.isEmptyDirectory());
+  }
+
+  /**
+   * Get the DynamoDB metastore; assume false if it is of a different
+   * type.
+   * @return extracted and cast metadata store.
+   */
+  @SuppressWarnings("ConstantConditions")
+  private DynamoDBMetadataStore getRequiredDDBMetastore(S3AFileSystem fs) {
+    MetadataStore ms = fs.getMetadataStore();
+    assume("Not a DynamoDBMetadataStore: " + ms,
+        ms instanceof DynamoDBMetadataStore);
+    return (DynamoDBMetadataStore) ms;
+  }
+
+  /**
+   * From {@code S3AFileSystem.createEmptyObject()}.
+   * @param fs filesystem
+   * @param key key
+   * @throws IOException failure
+   */
+  private void createEmptyObject(S3AFileSystem fs, String key)
+      throws IOException {
+    final InputStream im = new InputStream() {
+      @Override
+      public int read() throws IOException {
+        return -1;
+      }
+    };
+
+    PutObjectRequest putObjectRequest = fs.newPutObjectRequest(key,
+        fs.newObjectMetadata(0L),
+        im);
+    AmazonS3 s3 = fs.getAmazonS3ClientForTesting("PUT");
+    s3.putObject(putObjectRequest);
+  }
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -506,6 +506,16 @@ public final class S3ATestUtils {
   }
 
   /**
+   * Require a filesystem to have a metadata store; skip test
+   * if not.
+   * @param fs filesystem to check
+   */
+  public static void assumeFilesystemHasMetadatastore(S3AFileSystem fs) {
+    assume("Filesystem does not have a metastore",
+        fs.hasMetadataStore());
+  }
+
+  /**
    * Reset all metrics in a list.
    * @param metrics metrics to reset
    */
@@ -816,6 +826,22 @@ public final class S3ATestUtils {
   public static <T extends Service> T terminateService(final T service) {
     ServiceOperations.stopQuietly(LOG, service);
     return null;
+  }
+
+  /**
+   * Get a file status from S3A with the {@code needEmptyDirectoryFlag}
+   * state probed.
+   * This accesses a package-private method in the
+   * S3A filesystem.
+   * @param fs filesystem
+   * @param dir directory
+   * @return a status
+   * @throws IOException
+   */
+  public static S3AFileStatus getStatusWithEmptyDirFlag(
+      final S3AFileSystem fs,
+      final Path dir) throws IOException {
+    return fs.innerGetFileStatus(dir, true);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardDDBRootOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardDDBRootOperations.java
@@ -234,7 +234,7 @@ public class ITestS3GuardDDBRootOperations extends AbstractS3ATestBase {
       assertDeleted(file, false);
 
 
-      assertTrue("Root directory delete failed",
+      assertFalse("Root directory delete failed",
           fs.delete(root, true));
 
       ContractTestUtils.touch(fs, file2);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
@@ -154,7 +154,7 @@ public class TestS3Guard extends Assert {
     pm.setLastUpdated(100L);
 
     MetadataStore ms = mock(MetadataStore.class);
-    when(ms.get(path)).thenReturn(pm);
+    when(ms.get(path, false)).thenReturn(pm);
 
     ITtlTimeProvider timeProvider =
         mock(ITtlTimeProvider.class);
@@ -162,7 +162,8 @@ public class TestS3Guard extends Assert {
     when(timeProvider.getMetadataTtl()).thenReturn(1L);
 
     // act
-    final PathMetadata pmExpired = S3Guard.getWithTtl(ms, path, timeProvider);
+    final PathMetadata pmExpired = S3Guard.getWithTtl(ms, path, timeProvider,
+        false);
 
     // assert
     assertNull(pmExpired);
@@ -178,7 +179,7 @@ public class TestS3Guard extends Assert {
     pm.setLastUpdated(100L);
 
     MetadataStore ms = mock(MetadataStore.class);
-    when(ms.get(path)).thenReturn(pm);
+    when(ms.get(path, false)).thenReturn(pm);
 
     ITtlTimeProvider timeProvider =
         mock(ITtlTimeProvider.class);
@@ -187,7 +188,7 @@ public class TestS3Guard extends Assert {
 
     // act
     final PathMetadata pmNotExpired =
-        S3Guard.getWithTtl(ms, path, timeProvider);
+        S3Guard.getWithTtl(ms, path, timeProvider, false);
 
     // assert
     assertNotNull(pmNotExpired);
@@ -205,7 +206,7 @@ public class TestS3Guard extends Assert {
     pm.setLastUpdated(0L);
 
     MetadataStore ms = mock(MetadataStore.class);
-    when(ms.get(path)).thenReturn(pm);
+    when(ms.get(path, false)).thenReturn(pm);
 
     ITtlTimeProvider timeProvider =
         mock(ITtlTimeProvider.class);
@@ -213,7 +214,8 @@ public class TestS3Guard extends Assert {
     when(timeProvider.getMetadataTtl()).thenReturn(2L);
 
     // act
-    final PathMetadata pmExpired = S3Guard.getWithTtl(ms, path, timeProvider);
+    final PathMetadata pmExpired = S3Guard.getWithTtl(ms, path, timeProvider,
+        false);
 
     // assert
     assertNotNull(pmExpired);


### PR DESCRIPTION
Gabor's PR #1106 merged with the test of mine in #1079 with that test modified to show that yes, the tombstone problem goes all the way down

Fix: pass down the needEmptyDirectory flag all the way down from S3AFileSystem to metastore.get