### PR TITLE
HDDS-1749 : Ozone Client should randomize the list of nodes in pipeline for reads

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -269,6 +270,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       datanodeList = pipeline.getNodesInOrder();
     } else {
       datanodeList = pipeline.getNodes();
+      // Shuffle datanode list so that clients do not read in the same order
+      // every time.
+      Collections.shuffle(datanodeList);
     }
     for (DatanodeDetails dn : datanodeList) {
       try {


### PR DESCRIPTION

Currently the list of nodes returned by SCM are static and are returned in the same order to all the clients. Ideally these should be sorted by the network topology and then returned to client.

However even when network topology in not available, then SCM/client should randomly sort the nodes before choosing the replica's to connect.