### PR TITLE
Ozone Read fails with StatusRunTimeExceptions after 2 datanode fail i…

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -91,7 +91,7 @@ public class TestFailureHandlingByClient {
         OzoneConfigKeys.DFS_RATIS_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
         1, TimeUnit.SECONDS);
     conf.setBoolean(
-        ScmConfigKeys.DFS_NETWORK_TOPOLOGY_AWARE_READ_ENABLED, false);
+        ScmConfigKeys.DFS_NETWORK_TOPOLOGY_AWARE_READ_ENABLED, true);
 
     conf.setQuietMode(false);
     cluster = MiniOzoneCluster.newBuilder(conf)


### PR DESCRIPTION
…n Ratis pipeline

https://issues.apache.org/jira/browse/HDDS-1809

This issue is fixed by the code change in https://issues.apache.org/jira/browse/HDDS-1713. 

Previously network topology use Ipaddress as the node key in topology cluster, which results that three sorted Datanodes are the same node. 

Now datanode uuid is used as the node key in topology cluster, so sorted Datanodes will be three different nodes now. 