### PR TITLE
HADOOP-16450. ITestS3ACommitterFactory to not use useInconsistentClient.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestS3ACommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestS3ACommitterFactory.java
@@ -107,6 +107,11 @@ public class ITestS3ACommitterFactory extends AbstractCommitITest {
     taskConfRef = tContext.getConfiguration();
   }
 
+  @Override
+  public boolean useInconsistentClient() {
+    return false;
+  }
+
   @Test
   public void testEverything() throws Throwable {
     testImplicitFileBinding();


### PR DESCRIPTION
Contributed by Steve Loughran.

Change-Id: Ifb9771a73a07f744e4ed5f5e6be72473179db439

Tested: S3 Ireland, in both a sequential and a parallel test run