### PR TITLE
HADOOP-16461. Regression: FileSystem cache lock parses XML within the lock

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3385,6 +3385,9 @@ public abstract class FileSystem extends Configured
       }
 
       fs = createFileSystem(uri, conf);
+      final long timeout = conf.getTimeDuration(SERVICE_SHUTDOWN_TIMEOUT,
+          SERVICE_SHUTDOWN_TIMEOUT_DEFAULT,
+          ShutdownHookManager.TIME_UNIT_DEFAULT);
       synchronized (this) { // refetch the lock again
         FileSystem oldfs = map.get(key);
         if (oldfs != null) { // a file system is created while lock is releasing
@@ -3395,7 +3398,9 @@ public abstract class FileSystem extends Configured
         // now insert the new file system into the map
         if (map.isEmpty()
                 && !ShutdownHookManager.get().isShutdownInProgress()) {
-          ShutdownHookManager.get().addShutdownHook(clientFinalizer, SHUTDOWN_HOOK_PRIORITY);
+          ShutdownHookManager.get().addShutdownHook(clientFinalizer,
+              SHUTDOWN_HOOK_PRIORITY, timeout,
+              ShutdownHookManager.TIME_UNIT_DEFAULT);
         }
         fs.key = key;
         map.put(key, fs);


### PR DESCRIPTION
Instead of parsing a new configuration, rely on existing conf object within FileSystem