### PR TITLE
HDDS-1850. ReplicationManager should consider inflight replication and deletion while picking datanode for re-replication.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -483,8 +483,14 @@ public class ReplicationManager {
         final int replicationFactor = container
             .getReplicationFactor().getNumber();
         final int delta = replicationFactor - getReplicaCount(id, replicas);
+        final List<DatanodeDetails> excludeList = replicas.stream()
+            .map(ContainerReplica::getDatanodeDetails)
+            .collect(Collectors.toList());
+        inflightReplication.get(id).stream().map(r -> r.datanode)
+            .forEach(excludeList::add);
         final List<DatanodeDetails> selectedDatanodes = containerPlacement
-            .chooseDatanodes(source, null, delta, container.getUsedBytes());
+            .chooseDatanodes(excludeList, null, delta,
+                container.getUsedBytes());
 
         LOG.info("Container {} is under replicated. Expected replica count" +
                 " is {}, but found {}.", id, replicationFactor,


### PR DESCRIPTION
When choosing the target datanode for re-replication ReplicationManager should consider the datanodes which are in inflight replication and deletion for the same container.