### PR TITLE
HDDS-1864. Turn on topology aware read in TestFailureHandlingByClient.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -91,7 +91,7 @@ public class TestFailureHandlingByClient {
         OzoneConfigKeys.DFS_RATIS_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
         1, TimeUnit.SECONDS);
     conf.setBoolean(
-        ScmConfigKeys.DFS_NETWORK_TOPOLOGY_AWARE_READ_ENABLED, false);
+        ScmConfigKeys.DFS_NETWORK_TOPOLOGY_AWARE_READ_ENABLED, true);
 
     conf.setQuietMode(false);
     cluster = MiniOzoneCluster.newBuilder(conf)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-1864. 