### PR TITLE
HDDS-1834. parent directories not found in secure setup due to ACL check

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneObjInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneObjInfo.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone.security.acl;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -156,6 +157,14 @@ public final class OzoneObjInfo extends OzoneObj {
 
     public static Builder newBuilder() {
       return new Builder();
+    }
+
+    public static Builder fromKeyArgs(OmKeyArgs args) {
+      return new Builder()
+          .setVolumeName(args.getVolumeName())
+          .setBucketName(args.getBucketName())
+          .setKeyName(args.getKeyName())
+          .setResType(ResourceType.KEY);
     }
 
     public Builder setResType(OzoneObj.ResourceType res) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1637,24 +1637,38 @@ public class KeyManagerImpl implements KeyManager {
     String volume = ozObject.getVolumeName();
     String bucket = ozObject.getBucketName();
     String keyName = ozObject.getKeyName();
+    String objectKey = metadataManager.getOzoneKey(volume, bucket, keyName);
+    OmKeyArgs args = new OmKeyArgs.Builder()
+        .setVolumeName(volume)
+        .setBucketName(bucket)
+        .setKeyName(keyName)
+        .build();
 
     metadataManager.getLock().acquireLock(BUCKET_LOCK, volume, bucket);
     try {
       validateBucket(volume, bucket);
-      String objectKey = metadataManager.getOzoneKey(volume, bucket, keyName);
-      OmKeyInfo keyInfo = metadataManager.getKeyTable().get(objectKey);
-      if (keyInfo == null) {
-        objectKey = OzoneFSUtils.addTrailingSlashIfNeeded(objectKey);
-        keyInfo = metadataManager.getKeyTable().get(objectKey);
-        
-        if(keyInfo == null) {
+      OmKeyInfo keyInfo = null;
+      try {
+        OzoneFileStatus fileStatus = getFileStatus(args);
+        keyInfo = fileStatus.getKeyInfo();
+        if (keyInfo == null) {
+          // the key does not exist, but it is a parent "dir" of some key
+          // let access be determined based on volume/bucket/prefix ACL
+          LOG.debug("key:{} is non-existent parent, permit access to user:{}",
+              keyName, context.getClientUgi());
+          return true;
+        }
+      } catch (OMException e) {
+        if (e.getResult() == FILE_NOT_FOUND) {
           keyInfo = metadataManager.getOpenKeyTable().get(objectKey);
-          if (keyInfo == null) {
-            throw new OMException("Key not found, checkAccess failed. Key:" +
-                objectKey, KEY_NOT_FOUND);
-          }
         }
       }
+
+      if (keyInfo == null) {
+        throw new OMException("Key not found, checkAccess failed. Key:" +
+            objectKey, KEY_NOT_FOUND);
+      }
+
       boolean hasAccess = OzoneUtils.checkAclRight(keyInfo.getAcls(), context);
       LOG.debug("user:{} has access rights for key:{} :{} ",
           context.getClientUgi(), ozObject.getKeyName(), hasAccess);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let ACL check allow access for non-existent parent key instead of failing with "key not found".  Since the key does not exist, no ACL can be associated.  Actual access right will be determined based on volume, bucket and prefix ACLs.

https://issues.apache.org/jira/browse/HDDS-1834

## How was this patch tested?

Ran `ozonesecurity` and `ozonefs` smoketests in `ozonesecure` environment.