### PR TITLE
HDDS-1867. Invalid Prometheus metric name from JvmMetrics

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
@@ -49,6 +49,9 @@ public class PrometheusMetricsSink implements MetricsSink {
   private static final Pattern SPLIT_PATTERN =
       Pattern.compile("(?<!(^|[A-Z_]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])");
 
+  private static final Pattern REPLACE_PATTERN =
+      Pattern.compile("[^a-zA-Z0-9]+");
+
   public PrometheusMetricsSink() {
   }
 
@@ -101,9 +104,9 @@ public class PrometheusMetricsSink implements MetricsSink {
 
     String baseName = StringUtils.capitalize(recordName)
         + StringUtils.capitalize(metricName);
-    baseName = baseName.replace('-', '_');
     String[] parts = SPLIT_PATTERN.split(baseName);
-    return String.join("_", parts).toLowerCase();
+    String result = String.join("_", parts).toLowerCase();
+    return REPLACE_PATTERN.matcher(result).replaceAll("_");
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
@@ -107,6 +107,17 @@ public class TestPrometheusMetricsSink {
         sink.prometheusName(recordName, metricName));
   }
 
+  @Test
+  public void testNamingSpaces() {
+    PrometheusMetricsSink sink = new PrometheusMetricsSink();
+
+    String recordName = "JvmMetrics";
+    String metricName = "GcTimeMillisG1 Young Generation";
+    Assert.assertEquals(
+        "jvm_metrics_gc_time_millis_g1_young_generation",
+        sink.prometheusName(recordName, metricName));
+  }
+
   /**
    * Example metric pojo.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `invalid metric type` error introduced by using JVM Metrics.  Instead of adding replacement for space, replace all characters that cannot appear in [Prometheus metric names](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels) with `_`.

https://issues.apache.org/jira/browse/HDDS-1867

## How was this patch tested?

Verified in `ozoneperf` compose environment that `http://scm:9876/prom` endpoint is UP, and no `invalid metric type` error appears in the log.

Added unit test.