### PR TITLE
HADOOP-16460 : Upgrading wildfly-openssl to latest 1.0.7.Final release version

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1306,7 +1306,7 @@
       <dependency>
         <groupId>org.wildfly.openssl</groupId>
         <artifactId>wildfly-openssl</artifactId>
-        <version>1.0.4.Final</version>
+        <version>1.0.7.Final</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Upgrading wildfly-openssl to latest 1.0.7.Final release version