### PR TITLE
HDDS-1871. Remove anti-affinity rules from k8s minkube example

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone/datanode-ss.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone/datanode-ss.yaml
@@ -32,9 +32,9 @@ spec:
         app: ozone
         component: datanode
       annotations:
-        prdatanodeetheus.io/scrape: "true"
-        prdatanodeetheus.io/port: "9882"
-        prdatanodeetheus.io/path: "/prom"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9882"
+        prometheus.io/path: "/prom"
     spec:
       affinity:
         podAntiAffinity:

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/datanode-statefulset.yaml
@@ -33,9 +33,9 @@ spec:
         app: ozone
         component: datanode
       annotations:
-        prdatanodeetheus.io/scrape: "true"
-        prdatanodeetheus.io/port: "9882"
-        prdatanodeetheus.io/path: /prom
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9882"
+        prometheus.io/path: /prom
     spec:
       affinity:
         podAntiAffinity:

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/om-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/om-statefulset.yaml
@@ -39,22 +39,6 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
-      initContainers:
-      - name: init
-        image: '@docker.image@'
-        args:
-        - ozone
-        - om
-        - --init
-        env:
-        - name: WAITFOR
-          value: scm-0.scm:9876
-        envFrom:
-        - configMapRef:
-            name: config
-        volumeMounts:
-        - name: data
-          mountPath: /data
       containers:
       - name: om
         image: '@docker.image@'
@@ -64,6 +48,12 @@ spec:
         env:
         - name: WAITFOR
           value: scm-0.scm:9876
+        - name: ENSURE_OM_INITIALIZED
+          value: /data/metadata/om/current/VERSION
+        livenessProbe:
+          tcpSocket:
+            port: 9862
+          initialDelaySeconds: 30
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/s3g-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/s3g-statefulset.yaml
@@ -39,6 +39,11 @@ spec:
         args:
         - ozone
         - s3g
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9878
+          initialDelaySeconds: 30
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/scm-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/scm-statefulset.yaml
@@ -58,6 +58,10 @@ spec:
         args:
         - ozone
         - scm
+        livenessProbe:
+          tcpSocket:
+            port: 9861
+          initialDelaySeconds: 30
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/Flekszible
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/Flekszible
@@ -22,6 +22,15 @@ import:
       image: "@docker.image@"
     - type: PublishStatefulSet
     - type: ozone/emptydir
+    - type: Remove
+      trigger:
+         metadata:
+            name: datanode
+      path:
+        - spec
+        - template
+        - spec
+        - affinity
   - path: ozone/freon
     destination: freon
     transformations:

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/datanode-statefulset.yaml
@@ -33,9 +33,9 @@ spec:
         app: ozone
         component: datanode
       annotations:
-        prdatanodeetheus.io/scrape: "true"
-        prdatanodeetheus.io/port: "9882"
-        prdatanodeetheus.io/path: /prom
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9882"
+        prometheus.io/path: /prom
     spec:
       securityContext:
         fsGroup: 1000

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/datanode-statefulset.yaml
@@ -37,16 +37,6 @@ spec:
         prdatanodeetheus.io/port: "9882"
         prdatanodeetheus.io/path: /prom
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: component
-                operator: In
-                values:
-                - datanode
-            topologyKey: kubernetes.io/hostname
       securityContext:
         fsGroup: 1000
       containers:
@@ -55,12 +45,12 @@ spec:
         args:
         - ozone
         - datanode
-        volumeMounts:
-        - name: data
-          mountPath: /data
         envFrom:
         - configMapRef:
             name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
       volumes:
       - name: data
         emptyDir: {}

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/om-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/om-statefulset.yaml
@@ -54,12 +54,12 @@ spec:
           tcpSocket:
             port: 9862
           initialDelaySeconds: 30
-        volumeMounts:
-        - name: data
-          mountPath: /data
         envFrom:
         - configMapRef:
             name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
       volumes:
       - name: data
         emptyDir: {}

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/s3g-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/s3g-statefulset.yaml
@@ -44,12 +44,12 @@ spec:
             path: /
             port: 9878
           initialDelaySeconds: 30
-        volumeMounts:
-        - name: data
-          mountPath: /data
         envFrom:
         - configMapRef:
             name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
       volumes:
       - name: data
         emptyDir: {}

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/scm-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/scm-statefulset.yaml
@@ -46,12 +46,12 @@ spec:
         - ozone
         - scm
         - --init
-        volumeMounts:
-        - name: data
-          mountPath: /data
         envFrom:
         - configMapRef:
             name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
       containers:
       - name: scm
         image: '@docker.image@'
@@ -62,12 +62,12 @@ spec:
           tcpSocket:
             port: 9861
           initialDelaySeconds: 30
-        volumeMounts:
-        - name: data
-          mountPath: /data
         envFrom:
         - configMapRef:
             name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
       volumes:
       - name: data
         emptyDir: {}

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-ozone-clusterrole.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-ozone-clusterrole.yaml
@@ -17,7 +17,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-ozone
+  name: csi-ozone-default
 rules:
 - apiGroups:
   - ""

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-ozone-clusterrolebinding.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-ozone-clusterrolebinding.yaml
@@ -17,12 +17,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-ozone
+  name: csi-ozone-default
 subjects:
 - kind: ServiceAccount
   name: csi-ozone
-  namespace: weekly-test
+  namespace: default
 roleRef:
   kind: ClusterRole
-  name: csi-ozone
+  name: csi-ozone-default
   apiGroup: rbac.authorization.k8s.io

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-ozone-serviceaccount.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-ozone-serviceaccount.yaml
@@ -17,5 +17,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: weekly-test
+  namespace: default
   name: csi-ozone

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/datanode-statefulset.yaml
@@ -33,9 +33,9 @@ spec:
         app: ozone
         component: datanode
       annotations:
-        prdatanodeetheus.io/scrape: "true"
-        prdatanodeetheus.io/port: "9882"
-        prdatanodeetheus.io/path: /prom
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9882"
+        prometheus.io/path: /prom
     spec:
       affinity:
         podAntiAffinity:

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/prometheus-clusterrole.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/prometheus-clusterrole.yaml
@@ -17,7 +17,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: prometheus
+  name: prometheus-default
 rules:
 - apiGroups:
   - ""

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/prometheus-operator-clusterrolebinding.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/prometheus-operator-clusterrolebinding.yaml
@@ -17,12 +17,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-operator
+  name: prometheus-operator-default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus
+  name: prometheus-default
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: weekly-test
+  namespace: default

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-ozone-clusterrole.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-ozone-clusterrole.yaml
@@ -17,7 +17,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-ozone
+  name: csi-ozone-default
 rules:
 - apiGroups:
   - ""

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-ozone-clusterrolebinding.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-ozone-clusterrolebinding.yaml
@@ -17,12 +17,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-ozone
+  name: csi-ozone-default
 subjects:
 - kind: ServiceAccount
   name: csi-ozone
-  namespace: weekly-test
+  namespace: default
 roleRef:
   kind: ClusterRole
-  name: csi-ozone
+  name: csi-ozone-default
   apiGroup: rbac.authorization.k8s.io

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-ozone-serviceaccount.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-ozone-serviceaccount.yaml
@@ -17,5 +17,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: weekly-test
+  namespace: default
   name: csi-ozone

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/datanode-statefulset.yaml
@@ -33,9 +33,9 @@ spec:
         app: ozone
         component: datanode
       annotations:
-        prdatanodeetheus.io/scrape: "true"
-        prdatanodeetheus.io/port: "9882"
-        prdatanodeetheus.io/path: /prom
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9882"
+        prometheus.io/path: /prom
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
HDDS-1646 introduced real persistence for k8s example deployment files which means that we need anti-affinity scheduling rules: Even if we use statefulset instead of daemonset we would like to start one datanode per real nodes.

With minikube we have only one node therefore the scheduling rule should be removed to enable at least 3 datanodes on the same physical nodes.

How to test:

{code}
 mvn clean install -DskipTests -f pom.ozone.xml
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/kubernetes/examples/minikube
minikube start
kubectl apply -f .
kc get pod
{code}

You should see 3 datanode instances.


See: https://issues.apache.org/jira/browse/HDDS-1871