### PR TITLE
HADOOP-16472. findbugs warning on LocalMetadataStore.ttlTimeProvider sync

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/LocalMetadataStore.java
@@ -605,12 +605,12 @@ public class LocalMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void setTtlTimeProvider(ITtlTimeProvider ttlTimeProvider) {
+  public synchronized void setTtlTimeProvider(ITtlTimeProvider ttlTimeProvider) {
     this.ttlTimeProvider = ttlTimeProvider;
   }
 
   @Override
-  public void addAncestors(final Path qualifiedPath,
+  public synchronized void addAncestors(final Path qualifiedPath,
       @Nullable final BulkOperationState operationState) throws IOException {
 
     Collection<PathMetadata> newDirs = new ArrayList<>();


### PR DESCRIPTION
Moved the setter and addAncestors to synchronized

Untested! Let's see what findbugs says first