### PR TITLE
HDFS-14683. WebHDFS: Add erasureCodingPolicy field to GETCONTENTSUMMARY response

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
@@ -354,6 +354,7 @@ public class JsonUtil {
     m.put("length", contentsummary.getLength());
     m.put("fileCount", contentsummary.getFileCount());
     m.put("directoryCount", contentsummary.getDirectoryCount());
+    m.put("ecPolicy", contentsummary.getErasureCodingPolicy());
     // For ContentSummary we don't need this since we already have
     // separate count for file and directory.
     m.putAll(toJsonMap(contentsummary, false));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/WebHDFS.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/WebHDFS.md
@@ -761,6 +761,7 @@ Other File System Operations
           "ContentSummary":
           {
             "directoryCount": 2,
+            "ecPolicy"      : "RS-6-3-1024k",
             "fileCount"     : 1,
             "length"        : 24930,
             "quota"         : -1,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtil.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.XAttr;
 import org.apache.hadoop.fs.XAttrCodec;
+import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -255,6 +256,26 @@ public class TestJsonUtil {
     Assert.assertEquals(jsonString,
         JsonUtil.toJsonString(aclStatusBuilder.build()));
 
+  }
+
+  @Test
+  public void testToJsonFromContentSummary() {
+    String jsonString =
+        "{\"ContentSummary\":{\"directoryCount\":33333,\"ecPolicy\":\"RS-6-3-1024k\",\"fileCount\":22222,\"length\":11111,\"quota\":44444,\"spaceConsumed\":55555,\"spaceQuota\":66666,\"typeQuota\":{}}}";
+    long length = 11111;
+    long fileCount = 22222;
+    long directoryCount = 33333;
+    long quota = 44444;
+    long spaceConsumed = 55555;
+    long spaceQuota = 66666;
+    String ecPolicy = "RS-6-3-1024k";
+
+    ContentSummary contentSummary = new ContentSummary.Builder().length(length).
+        fileCount(fileCount).directoryCount(directoryCount).quota(quota).
+        spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).
+        erasureCodingPolicy(ecPolicy).build();
+
+    Assert.assertEquals(jsonString, JsonUtil.toJsonString(contentSummary));
   }
   
   @Test


### PR DESCRIPTION
Added a unit test for `JsonUtil#toJsonString(ContentSummary)`.
Amended WebHDFS doc.
Tested locally.

When the ecPolicy is empty, the request would just return empty string, i.e. `ecPolicy: ""`.