### PR TITLE
HDFS-14686. HttpFS: HttpFSFileSystem#getErasureCodingPolicy always returns null

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
@@ -432,10 +432,12 @@ public class JsonUtilClient {
     final long length = ((Number) m.get("length")).longValue();
     final long fileCount = ((Number) m.get("fileCount")).longValue();
     final long directoryCount = ((Number) m.get("directoryCount")).longValue();
+    final String ecPolicy = ((String) m.get("ecPolicy"));
     ContentSummary.Builder builder = new ContentSummary.Builder()
         .length(length)
         .fileCount(fileCount)
-        .directoryCount(directoryCount);
+        .directoryCount(directoryCount)
+        .erasureCodingPolicy(ecPolicy);
     builder = buildQuotaUsage(builder, m, ContentSummary.Builder.class);
     return builder.build();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -190,6 +190,7 @@ public class HttpFSFileSystem extends FileSystem
 
   public static final String CONTENT_SUMMARY_JSON = "ContentSummary";
   public static final String CONTENT_SUMMARY_DIRECTORY_COUNT_JSON = "directoryCount";
+  public static final String CONTENT_SUMMARY_ECPOLICY_JSON = "ecPolicy";
   public static final String CONTENT_SUMMARY_FILE_COUNT_JSON = "fileCount";
   public static final String CONTENT_SUMMARY_LENGTH_JSON = "length";
 
@@ -1137,7 +1138,8 @@ public class HttpFSFileSystem extends FileSystem
     ContentSummary.Builder builder = new ContentSummary.Builder()
         .length((Long) json.get(CONTENT_SUMMARY_LENGTH_JSON))
         .fileCount((Long) json.get(CONTENT_SUMMARY_FILE_COUNT_JSON))
-        .directoryCount((Long) json.get(CONTENT_SUMMARY_DIRECTORY_COUNT_JSON));
+        .directoryCount((Long) json.get(CONTENT_SUMMARY_DIRECTORY_COUNT_JSON))
+        .erasureCodingPolicy((String) json.get(CONTENT_SUMMARY_ECPOLICY_JSON));
     builder = buildQuotaUsage(builder, json, ContentSummary.Builder.class);
     return builder.build();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/FSOperations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/FSOperations.java
@@ -254,6 +254,8 @@ public class FSOperations {
     Map json = new LinkedHashMap();
     json.put(HttpFSFileSystem.CONTENT_SUMMARY_DIRECTORY_COUNT_JSON,
         contentSummary.getDirectoryCount());
+    json.put(HttpFSFileSystem.CONTENT_SUMMARY_ECPOLICY_JSON,
+        contentSummary.getErasureCodingPolicy());
     json.put(HttpFSFileSystem.CONTENT_SUMMARY_FILE_COUNT_JSON,
         contentSummary.getFileCount());
     json.put(HttpFSFileSystem.CONTENT_SUMMARY_LENGTH_JSON,

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -678,6 +678,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     fs.close();
     assertEquals(hdfsContentSummary.getDirectoryCount(),
         httpContentSummary.getDirectoryCount());
+    assertEquals(hdfsContentSummary.getErasureCodingPolicy(),
+        httpContentSummary.getErasureCodingPolicy());
     assertEquals(hdfsContentSummary.getFileCount(),
         httpContentSummary.getFileCount());
     assertEquals(hdfsContentSummary.getLength(),


### PR DESCRIPTION
Modified existing unit test to verify the validity of the fix. Without the fix, the modified unit test WILL fail. Tested locally.