### PR TITLE
HDDS-1788. Fix kerberos principal error in Ozone Recon

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -612,7 +612,7 @@
     <description>
       The actual address the OM web server will bind to using HTTPS.
       If this optional address is set, it overrides only the hostname portion of
-      ozone.om.http-address.
+      ozone.om.https-address.
     </description>
   </property>
   <property>
@@ -1040,7 +1040,7 @@
     <description>
       The actual address the SCM web server will bind to using HTTPS.
       If this optional address is set, it overrides only the hostname portion of
-      ozone.scm.http-address.
+      ozone.scm.https-address.
     </description>
   </property>
   <property>
@@ -1525,7 +1525,7 @@
     <value>5m</value>
     <tag>OZONE, OM</tag>
     <description>Time interval used to store the omMetrics in to a
-      file. Background thread perodically stores the OM metrics in to a
+      file. Background thread periodically stores the OM metrics in to a
       file. Unit could be defined with postfix (ns,ms,s,m,h,d)
     </description>
   </property>

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-image/docker-krb5/Dockerfile-krb5
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-image/docker-krb5/Dockerfile-krb5
@@ -11,7 +11,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License lsfor the specific language governing permissions and
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -65,6 +65,19 @@ services:
     env_file:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
+  recon:
+    image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
+    hostname: recon
+    volumes:
+      - ../..:/opt/hadoop
+    ports:
+      - 9888:9888
+    env_file:
+      - ./docker-config
+    environment:
+      WAITFOR: om:9874
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+    command: ["/opt/hadoop/bin/ozone","recon"]
   scm:
     image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
     hostname: scm

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -33,6 +33,10 @@ OZONE-SITE.XML_ozone.om.kerberos.principal=om/om@EXAMPLE.COM
 OZONE-SITE.XML_ozone.om.kerberos.keytab.file=/etc/security/keytabs/om.keytab
 OZONE-SITE.XML_ozone.s3g.keytab.file=/etc/security/keytabs/HTTP.keytab
 OZONE-SITE.XML_ozone.s3g.authentication.kerberos.principal=HTTP/s3g@EXAMPLE.COM
+OZONE-SITE.XML_ozone.recon.authentication.kerberos.principal=HTTP/recon@EXAMPLE.COM
+OZONE-SITE.XML_ozone.recon.keytab.file=/etc/security/keytabs/HTTP.keytab
+OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
+OZONE-SITE.XML_recon.om.snapshot.task.initial.delay=20s
 
 OZONE-SITE.XML_ozone.security.enabled=true
 OZONE-SITE.XML_ozone.acl.enabled=true

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-image/docker-krb5/Dockerfile-krb5
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-image/docker-krb5/Dockerfile-krb5
@@ -11,7 +11,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License lsfor the specific language governing permissions and
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ConfigurationProvider.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ConfigurationProvider.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.ozone.recon;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-
 import com.google.inject.Provider;
+import org.apache.hadoop.conf.Configuration;
+
 
 /**
  * Ozone Configuration Provider.
@@ -27,17 +27,17 @@ import com.google.inject.Provider;
  * As the OzoneConfiguration is created by the CLI application here we inject
  * it via a singleton instance to the Jax-RS/CDI instances.
  */
-public class OzoneConfigurationProvider implements
-    Provider<OzoneConfiguration> {
+public class ConfigurationProvider implements
+    Provider<Configuration> {
 
-  private static OzoneConfiguration configuration;
+  private static Configuration configuration;
 
-  static void setConfiguration(OzoneConfiguration conf) {
-    OzoneConfigurationProvider.configuration = conf;
+  static void setConfiguration(Configuration conf) {
+    ConfigurationProvider.configuration = conf;
   }
 
   @Override
-  public OzoneConfiguration get() {
+  public Configuration get() {
     return configuration;
   }
 }

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -29,6 +29,7 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SQ
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SQL_MAX_IDLE_CONNECTION_AGE;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SQL_MAX_IDLE_CONNECTION_TEST_STMT;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.recon.persistence.DataSourceConfiguration;
 import org.apache.hadoop.ozone.recon.persistence.JooqPersistenceModule;
@@ -53,7 +54,7 @@ import com.google.inject.Singleton;
 public class ReconControllerModule extends AbstractModule {
   @Override
   protected void configure() {
-    bind(OzoneConfiguration.class).toProvider(OzoneConfigurationProvider.class);
+    bind(Configuration.class).toProvider(ConfigurationProvider.class);
     bind(ReconHttpServer.class).in(Singleton.class);
     bind(DBStore.class)
         .toProvider(ReconContainerDBProvider.class).in(Singleton.class);

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -64,7 +64,7 @@ public class ReconServer extends GenericCli {
   @Override
   public Void call() throws Exception {
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
-    OzoneConfigurationProvider.setConfiguration(ozoneConfiguration);
+    ConfigurationProvider.setConfiguration(ozoneConfiguration);
 
     injector =  Guice.createInjector(new
         ReconControllerModule(), new ReconRestServletModule() {

--- a/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/ozone-recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
@@ -45,7 +44,9 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
@@ -75,13 +76,10 @@ public class OzoneManagerServiceProviderImpl
   private String omDBSnapshotUrl;
 
   @Inject
-  private OzoneConfiguration configuration;
-
-  @Inject
   private ReconOMMetadataManager omMetadataManager;
 
   @Inject
-  public OzoneManagerServiceProviderImpl(OzoneConfiguration configuration) {
+  public OzoneManagerServiceProviderImpl(Configuration configuration) {
 
     String ozoneManagerHttpAddress = configuration.get(OMConfigKeys
         .OZONE_OM_HTTP_ADDRESS_KEY);
@@ -92,8 +90,7 @@ public class OzoneManagerServiceProviderImpl
     omSnapshotDBParentDir = getReconDbDir(configuration,
         OZONE_RECON_OM_SNAPSHOT_DB_DIR);
 
-    boolean ozoneSecurityEnabled = configuration.getBoolean(
-        OZONE_SECURITY_ENABLED_KEY, false);
+    HttpConfig.Policy policy = DFSUtil.getHttpPolicy(configuration);
 
     int socketTimeout = (int) configuration.getTimeDuration(
         RECON_OM_SOCKET_TIMEOUT, RECON_OM_SOCKET_TIMEOUT_DEFAULT,
@@ -118,7 +115,7 @@ public class OzoneManagerServiceProviderImpl
     omDBSnapshotUrl = "http://" + ozoneManagerHttpAddress +
         OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
 
-    if (ozoneSecurityEnabled) {
+    if (policy.isHttpsEnabled()) {
       omDBSnapshotUrl = "https://" + ozoneManagerHttpsAddress +
           OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
     }


### PR DESCRIPTION
Recon fails to come up in a secure cluster with the following error:
```
Failed startup of context o.e.j.w.WebAppContext@2009f9b0{/,file:///tmp/jetty-0.0.0.0-9888-recon-_-any-2565178148822292652.dir/webapp/,UNAVAILABLE}{/recon} javax.servlet.ServletException: javax.servlet.ServletException: Principal not defined in configuration at org.apache.hadoop.security.authentication.server.KerberosAuthenticationHandler.init(KerberosAuthenticationHandler.java:188) at
```

This patch addresses this issue and enables Recon to come up in clusters secured by kerberos. I have manually tested the patch by creating the recon jar and replacing an old jar in a live secure CM deployed cluster and verified that Recon starts successfully and is able to login successfully with the kerberos ticket. Also updated ozonesecure docker-compose file to add recon and verified that recon is able to come up successfully. This patch also fixes various typos found in other parts of the source code not related to the title of this JIRA.