### PR TITLE
HDDS-1891. Ozone fs shell command should work with default port when port number is not specified

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -88,9 +88,10 @@ public class BasicOzoneFileSystem extends FileSystem {
   private static final Pattern URL_SCHEMA_PATTERN =
       Pattern.compile("([^\\.]+)\\.([^\\.]+)\\.{0,1}(.*)");
 
-  private static final String URI_EXCEPTION_TEXT = "Ozone file system url " +
-      "should be either one of the two forms: " +
+  private static final String URI_EXCEPTION_TEXT = "Ozone file system URL " +
+      "should be one of the following formats: " +
       "o3fs://bucket.volume/key  OR " +
+      "o3fs://bucket.volume.om-host.example.com/key  OR " +
       "o3fs://bucket.volume.om-host.example.com:5678/key";
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -55,7 +55,6 @@ import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_PORT_DEFAULT;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -117,7 +117,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     String omPort = String.valueOf(-1);
     if (!isEmpty(remaining)) {
       String[] parts = remaining.split(":");
-      // Array length should only be 1 or 2
+      // Array length should be either 1(host) or 2(host:port)
       if (parts.length > 2) {
         throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
       }
@@ -127,7 +127,6 @@ public class BasicOzoneFileSystem extends FileSystem {
       } else {
         // If port number is not specified, read it from config
         omPort = String.valueOf(OmUtils.getOmRpcPort(conf));
-        authority += ":" + omPort;
       }
       if (!isNumber(omPort)) {
         throw new IllegalArgumentException(URI_EXCEPTION_TEXT);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -120,9 +121,13 @@ public class BasicOzoneFileSystem extends FileSystem {
         throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
       }
       omHost = parts[0];
-      // If port number is not specified, try default OM port
-      omPort = parts.length == 2 ?
-          parts[1] : String.valueOf(OZONE_OM_PORT_DEFAULT);
+      if (parts.length == 2) {
+        omPort = parts[1];
+      } else {
+        // If port number is not specified, read it from config
+        omPort = String.valueOf(OmUtils.getOmRpcPort(conf));
+        authority += ":" + omPort;
+      }
       if (!isNumber(omPort)) {
         throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
       }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -54,6 +54,8 @@ import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_PORT_DEFAULT;
+
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,11 +115,14 @@ public class BasicOzoneFileSystem extends FileSystem {
     String omPort = String.valueOf(-1);
     if (!isEmpty(remaining)) {
       String[] parts = remaining.split(":");
-      if (parts.length != 2) {
+      // Array length should only be 1 or 2
+      if (parts.length > 2) {
         throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
       }
       omHost = parts[0];
-      omPort = parts[1];
+      // If port number is not specified, try default OM port
+      omPort = parts.length == 2 ?
+          parts[1] : String.valueOf(OZONE_OM_PORT_DEFAULT);
       if (!isNumber(omPort)) {
         throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
       }

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithMocks.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithMocks.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_PORT_DEFAULT;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithMocks.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithMocks.java
@@ -108,9 +108,10 @@ public class TestOzoneFileSystemWithMocks {
     OzoneFileSystem ozfs = (OzoneFileSystem) fileSystem;
 
     assertEquals(ozfs.getUri().getHost(), "bucket1.volume1.local.host");
-    // Check if FS has resolved the URI with the default port
-    assertEquals(ozfs.getUri().getPort(), OM_PORT_DEFAULT);
+    // The URI doesn't contain a port number, expect -1 from getPort()
+    assertEquals(ozfs.getUri().getPort(), -1);
     PowerMockito.verifyStatic();
+    // Check the actual port number in use
     OzoneClientFactory.getRpcClient("local.host", OM_PORT_DEFAULT, conf);
   }
 

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithMocks.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithMocks.java
@@ -82,7 +82,7 @@ public class TestOzoneFileSystemWithMocks {
   @Test
   public void testFSUriWithHostPortUnspecified() throws Exception {
     Configuration conf = new OzoneConfiguration();
-    final int OM_PORT_DEFAULT = OmUtils.getOmRpcPort(conf);
+    final int omPort = OmUtils.getOmRpcPort(conf);
 
     OzoneClient ozoneClient = mock(OzoneClient.class);
     ObjectStore objectStore = mock(ObjectStore.class);
@@ -95,7 +95,7 @@ public class TestOzoneFileSystemWithMocks {
 
     PowerMockito.mockStatic(OzoneClientFactory.class);
     PowerMockito.when(OzoneClientFactory.getRpcClient(eq("local.host"),
-        eq(OM_PORT_DEFAULT), eq(conf))).thenReturn(ozoneClient);
+        eq(omPort), eq(conf))).thenReturn(ozoneClient);
 
     UserGroupInformation ugi = mock(UserGroupInformation.class);
     PowerMockito.mockStatic(UserGroupInformation.class);
@@ -112,7 +112,7 @@ public class TestOzoneFileSystemWithMocks {
     assertEquals(ozfs.getUri().getPort(), -1);
     PowerMockito.verifyStatic();
     // Check the actual port number in use
-    OzoneClientFactory.getRpcClient("local.host", OM_PORT_DEFAULT, conf);
+    OzoneClientFactory.getRpcClient("local.host", omPort, conf);
   }
 
   @Test


### PR DESCRIPTION
Tested manually with ozone fs:

```bash
bash-4.2$ ozone fs -ls o3fs://bucket.volume.om:9862/
Found 1 items
-rw-rw-rw-   1 hadoop hadoop       1485 1970-01-01 00:03 o3fs://bucket.volume.om:9862/README.txt

bash-4.2$ ozone fs -ls o3fs://bucket.volume.om/
Found 1 items
-rw-rw-rw-   1 hadoop hadoop       1485 1970-01-01 00:03 o3fs://bucket.volume.om/README.txt
```

```bash
$ ozone fs -ls o3fs://bucket.volume.localhost/
2019-08-02 12:57:13,223 INFO ipc.Client: Retrying connect to server: localhost/127.0.0.1:9862. Already tried 0 time(s); retry policy is RetryUpToMaximumCountWithFixedSleep(maxRetries=10, sleepTime=1000 MILLISECONDS)
...

$ ozone fs -ls o3fs://bucket.volume.localhost:9861/
2019-08-02 12:57:21,604 INFO ipc.Client: Retrying connect to server: localhost/127.0.0.1:9861. Already tried 0 time(s); retry policy is RetryUpToMaximumCountWithFixedSleep(maxRetries=10, sleepTime=1000 MILLISECONDS)
...
```

Do we want to add a unit test for this? If yes, existing `TestOzoneShell` won't suit the need since `getOmAddress()` always returns the full address with port number. And the port number is almost always not default OM port 9862 when the running the test. So I might need to come up with a new unit test suite. e.g. test the parser only.