### PR TITLE
HDDS-1914. Ozonescript example docker-compose cluster can't be started

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/.ssh/environment
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/.ssh/environment
@@ -13,4 +13,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/
+JAVA_HOME=/usr/lib/jvm/jre

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM apache/ozone-runner
-RUN sudo apt-get update && sudo apt-get install -y openssh-server
+RUN sudo yum install -y openssh-clients openssh-server
 
+RUN sudo ssh-keygen -A
 RUN sudo mkdir -p /run/sshd
 RUN sudo sed -i "s/.*UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config
 RUN sudo sed -i "s/.*PermitUserEnvironment.*/PermitUserEnvironment yes/g" /etc/ssh/sshd_config
@@ -29,5 +30,5 @@ RUN sudo chown hadoop /opt
 RUN sudo chmod 600 /opt/.ssh/*
 RUN sudo chmod 700 /opt/.ssh
 
-RUN sudo sh -c 'echo "export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/" >> /etc/profile'
+RUN sudo sh -c 'echo "export JAVA_HOME=/usr/lib/jvm/jre/" >> /etc/profile'
 CMD ["sudo","/usr/sbin/sshd","-D"]

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/
 CORE-SITE.XML_fs.defaultFS=hdfs://namenode:9000
 OZONE-SITE.XML_ozone.ksm.address=ksm
 OZONE-SITE.XML_ozone.scm.names=scm

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/start.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/start.sh
@@ -14,7 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -x
 docker-compose ps | grep datanode | awk '{print $1}' | xargs -n1  docker inspect --format '{{ .Config.Hostname }}' > ../../etc/hadoop/workers
+docker-compose ps | grep ozonescripts | awk '{print $1}' | xargs -I CONTAINER -n1 docker exec CONTAINER cp /opt/hadoop/etc/hadoop/workers /etc/hadoop/workers
 docker-compose exec scm /opt/hadoop/bin/ozone scm --init
 docker-compose exec scm /opt/hadoop/sbin/start-ozone.sh
 #We need a running SCM for om objectstore creation


### PR DESCRIPTION
the compose/ozonescripts cluster provides an example environment to test the start-ozone.sh and stop-ozone.sh scripts.

It starts containers with sshd daemon but witout starting the ozone which makes it possible to start those scripts.

Unfortunately the docker files are broken since:
 * we switched from debian to centos with the base image
 * we started to use /etc/hadoop instead of /opt/hadoop/etc/hadoop for configuring the hadoop (workers file should be copied there)
 * we started to use jdk11 to execute ozone (instead of java8)

The configuration files should be updated according to these changes. 

# How to test this patch?

(1) Do a full build and try to start the ./compose/ozonescripts cluster (check the related README file in the directory):

```
docker-compose up -d
```

(2) start the ozone processes with ./start.sh (from compose/ozonescripts)

(3) wait and check if om/scm webui are working and you have 1 healthy datanode



See: https://issues.apache.org/jira/browse/HDDS-1914