### PR TITLE
HDDS-1915. Remove hadoop script from ozone distribution

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -94,8 +94,6 @@ run cp "${ROOT}/hadoop-ozone/dist/src/main/conf/ozone-site.xml" "etc/hadoop"
 run cp -f "${ROOT}/hadoop-ozone/dist/src/main/conf/log4j.properties" "etc/hadoop"
 run cp "${ROOT}/hadoop-hdds/common/src/main/resources/network-topology-default.xml" "etc/hadoop"
 run cp "${ROOT}/hadoop-hdds/common/src/main/resources/network-topology-nodegroup.xml" "etc/hadoop"
-run cp "${ROOT}/hadoop-common-project/hadoop-common/src/main/bin/hadoop" "bin/"
-run cp "${ROOT}/hadoop-common-project/hadoop-common/src/main/bin/hadoop.cmd" "bin/"
 run cp "${ROOT}/hadoop-ozone/common/src/main/bin/ozone" "bin/"
 run cp -r "${ROOT}/hadoop-ozone/dist/src/main/dockerbin" "bin/docker"
 


### PR DESCRIPTION
/bin/hadoop script is included in the ozone distribution even if we a dedicated /bin/ozone

[~arp] reported that it can be confusing, for example "hadoop classpath" returns with a bad classpath (ozone classpath <projectname>) should be used instead.

To avoid such confusions I suggest to remove the hadoop script from distribution as ozone script already provides all the functionalities.

It also helps as to reduce the dependencies between hadoop 3.2-SNAPSHOT and ozone as we use the snapshot hadoop script as of now.

See: https://issues.apache.org/jira/browse/HDDS-1915