### PR TITLE
HDDS-1918. hadoop-ozone-tools has integration tests run as unit

### DIFF
--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -18,7 +18,7 @@ cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
 mvn -B install -f pom.ozone.xml -DskipTests
-mvn -B -fn test -f pom.ozone.xml -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem
+mvn -B -fn test -f pom.ozone.xml -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem,:hadoop-ozone-tools
 module_failed_tests=$(find "." -name 'TEST*.xml' -print0 \
     | xargs -0 -n1 "grep" -l -E "<failure|<error"\
     | awk -F/ '{sub("'"TEST-JUNIT_TEST_OUTPUT_DIR"'",""); sub(".xml",""); print $NF}')

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 export MAVEN_OPTS="-Xmx4096m"
-mvn -fn test -f pom.ozone.xml -pl \!:hadoop-ozone-integration-test,\!:hadoop-ozone-filesystem
+mvn -fn test -f pom.ozone.xml -pl \!:hadoop-ozone-integration-test,\!:hadoop-ozone-filesystem,\!:hadoop-ozone-tools
 module_failed_tests=$(find "." -name 'TEST*.xml' -print0 \
     | xargs -n1 -0 "grep" -l -E "<failure|<error"\
     | awk -F/ '{sub("'"TEST-JUNIT_TEST_OUTPUT_DIR"'",""); sub(".xml",""); print $NF}')


### PR DESCRIPTION
## What changes were proposed in this pull request?

Run `hadoop-ozone-tools` tests as part of `integration.sh`, not `unit.sh`.

https://issues.apache.org/jira/browse/HDDS-1918

## How was this patch tested?

```
$ ./hadoop-ozone/dev-support/checks/unit.sh
...
(no Ozone Tools here)
...
$ ./hadoop-ozone/dev-support/checks/integration.sh
...
[INFO] Reactor Build Order:
[INFO]
[INFO] Apache Hadoop Ozone Integration Tests                              [jar]
[INFO] Apache Hadoop Ozone FileSystem                                     [jar]
[INFO] Apache Hadoop Ozone Tools                                          [jar]
...
```