### PR TITLE
HADOOP-16494. Add SHA-512 checksum to release artifact to comply with the release distribution policy

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -641,7 +641,7 @@ function signartifacts
 
   for i in ${ARTIFACTS_DIR}/*; do
     ${GPG} --use-agent --armor --output "${i}.asc" --detach-sig "${i}"
-    ${GPG} --print-mds "${i}" > "${i}.mds"
+    shasum -a 512 "${i}" > "${i}.sha512"
   done
 
   if [[ "${ASFRELEASE}" = true ]]; then

--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -641,7 +641,7 @@ function signartifacts
 
   for i in ${ARTIFACTS_DIR}/*; do
     ${GPG} --use-agent --armor --output "${i}.asc" --detach-sig "${i}"
-    shasum -a 512 "${i}" > "${i}.sha512"
+    sha512sum --tag "${i}" > "${i}.sha512"
   done
 
   if [[ "${ASFRELEASE}" = true ]]; then


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-16494