### PR TITLE
HDDS-1924. ozone sh bucket path command does not exist

### DIFF
--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -119,7 +119,7 @@ To show the storage location of a S3 bucket, use the `ozone s3 path <bucketname>
 ```
 aws s3api --endpoint-url http://localhost:9878 create-bucket --bucket=bucket1
 
-ozone sh bucket path bucket1
+ozone s3 path bucket1
 Volume name for S3Bucket is : s3thisisakey
 Ozone FileSystem Uri is : o3fs://bucket1.s3thisisakey
 ```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix leftover reference to `ozone sh bucket path`.  It was generally changed to `ozone s3 path` in [HDDS-761](https://issues.apache.org/jira/browse/HDDS-761).

https://issues.apache.org/jira/browse/HDDS-1924

## How was this patch tested?

```
$ aws s3api --endpoint http://localhost:9878/ create-bucket --bucket=wordcount
{
    "Location": "http://localhost:9878/wordcount"
}

$ docker-compose exec om ozone s3 path wordcount
Volume name for S3Bucket is : s3100b8cad7cf2a56f6df78f171f97a1ec
Ozone FileSystem Uri is : o3fs://wordcount.s3100b8cad7cf2a56f6df78f171f
```