### PR TITLE
HDDS-1925. ozonesecure acceptance test broken by HTTP auth requirement

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -33,7 +33,7 @@ execute_robot_test scm security
 
 execute_robot_test scm ozonefs/ozonefs.robot
 
-execute_robot_test scm s3
+execute_robot_test s3g s3
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
@@ -25,9 +25,8 @@ ${DATANODE_HOST}        datanode
 *** Test Cases ***
 
 Check webui static resources
-    ${result} =        Execute                curl -s -I http://scm:9876/static/bootstrap-3.3.7/js/bootstrap.min.js
-                       Should contain         ${result}    200
-    ${result} =        Execute                curl -s -I http://om:9874/static/bootstrap-3.3.7/js/bootstrap.min.js
+    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit HTTP user
+    ${result} =        Execute                curl --negotiate -u : -s -I http://scm:9876/static/bootstrap-3.3.7/js/bootstrap.min.js
                        Should contain         ${result}    200
 
 Start freon testing

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -17,6 +17,7 @@
 Documentation       Test ozone shell CLI usage
 Library             OperatingSystem
 Resource            ../commonlib.robot
+Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 Test Timeout        2 minute
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/commonlib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/commonlib.robot
@@ -54,6 +54,10 @@ Install aws cli
     ${rc}              ${output} =                 Run And Return Rc And Output           yum --help
     Run Keyword if     '${rc}' == '0'              Install aws cli s3 centos
 
+Kinit HTTP user
+    ${hostname} =       Execute                    hostname
+    Wait Until Keyword Succeeds      2min       10sec      Execute            kinit -k HTTP/${hostname}@EXAMPLE.COM -t /etc/security/keytabs/HTTP.keytab
+
 Kinit test user
     [arguments]                      ${user}       ${keytab}
     ${hostname} =       Execute                    hostname

--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -49,6 +49,7 @@ Setup v2 headers
                         Set Environment Variable   AWS_SECRET_ACCESS_KEY   ANYKEY
 
 Setup v4 headers
+    Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user    testuser    testuser.keytab
     ${result} =         Execute                    ozone s3 getsecret
     ${accessKey} =      Get Regexp Matches         ${result}     (?<=awsAccessKey=).*
     ${accessKey} =      Get Variable Value         ${accessKey}  sdsdasaasdasd

--- a/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
@@ -27,8 +27,9 @@ ${BUCKET}             generated
 
 *** Test Cases ***
 
-File upload and directory list
-    ${result} =         Execute                             curl -v ${ENDPOINT_URL}
+S3 Gateway Web UI
+    Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit HTTP user
+    ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}
                         Should contain      ${result}       HTTP/1.1 307 Temporary Redirect
-    ${result} =         Execute                             curl -v ${ENDPOINT_URL}/static/
+    ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}/static/index.html
                         Should contain      ${result}       Apache Hadoop Ozone S3


### PR DESCRIPTION
## What changes were proposed in this pull request?

Obtain Kerberos ticket for HTTP before web requests and use it for `curl`.  (Unfortunately it works only on the same host, eg. `scm` cannot make request to `om` using its own HTTP keytab.)

https://issues.apache.org/jira/browse/HDDS-1925

## How was this patch tested?

Ran both secure and unsecure acceptance tests.  (Some of them timed out locally...)