### PR TITLE
HDDS-1928. Cannot run ozone-recon compose due to syntax error

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-recon/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-recon/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone-runner:
+      image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-recon/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-recon/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
+
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
+
+start_docker_env
+
+execute_robot_test scm basic/basic.robot
+
+stop_docker_env
+
+generate_report


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add missing version tag for `datanode` service in `ozone-recon` compose.

https://issues.apache.org/jira/browse/HDDS-1928

## How was this patch tested?

```
$ docker-compose up -d --scale datanode=3
Creating network "ozone-recon_default" with the default driver
Creating ozone-recon_datanode_1 ... done
Creating ozone-recon_datanode_2 ... done
Creating ozone-recon_datanode_3 ... done
Creating ozone-recon_recon_1    ... done
Creating ozone-recon_scm_1      ... done
Creating ozone-recon_om_1       ... done
```