### PR TITLE
HDDS-1929. OM started on recon host in ozonesecure compose

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -76,7 +76,6 @@ services:
       - ./docker-config
     environment:
       WAITFOR: om:9874
-      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
     command: ["/opt/hadoop/bin/ozone","recon"]
   scm:
     image: apache/ozone-runner:${HADOOP_RUNNER_VERSION}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove unnecessary OM initialization for `recon` host.

https://issues.apache.org/jira/browse/HDDS-1929

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonesecure
$ docker-compose up -d --scale datanode=3
$ docker-compose logs -f recon
```