### PR TITLE
HDDS-1934. TestSecureOzoneCluster may fail due to port conflict

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -271,7 +272,7 @@ public final class TestSecureOzoneCluster {
   public void testSCMSecurityProtocol() throws Exception {
 
     initSCM();
-    scm = StorageContainerManager.createSCM(conf);
+    scm = HddsTestUtils.getScm(conf);
     //Reads the SCM Info from SCM instance
     try {
       scm.start();
@@ -739,7 +740,7 @@ public final class TestSecureOzoneCluster {
 
     initSCM();
     try {
-      scm = StorageContainerManager.createSCM(conf);
+      scm = HddsTestUtils.getScm(conf);
       scm.start();
       conf.setBoolean(OZONE_SECURITY_ENABLED_KEY, false);
       OMStorage omStore = new OMStorage(conf);
@@ -785,7 +786,7 @@ public final class TestSecureOzoneCluster {
     omLogs.clearOutput();
     initSCM();
     try {
-      scm = StorageContainerManager.createSCM(conf);
+      scm = HddsTestUtils.getScm(conf);
       scm.start();
 
       OMStorage omStore = new OMStorage(conf);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use random port for SCM for the test cases where it is started in `TestSecureOzoneCluster`.

https://issues.apache.org/jira/browse/HDDS-1934

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
$ docker-compose up -d
$ cd -
$ mvn -Phdds -pl :hadoop-ozone-integration-test test -Dtest=TestSecureOzoneCluster
...
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.32 s - in org.apache.hadoop.ozone.TestSecureOzoneCluster
```