### PR TITLE
HDDS-1927. Consolidate add/remove Acl into OzoneAclUtil class. Contri…

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -64,9 +64,10 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
 import org.apache.hadoop.ozone.om.helpers.OmPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
-import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.protocolPB
     .OzoneManagerProtocolClientSideTranslatorPB;
@@ -440,7 +441,7 @@ public class RpcClient implements ClientProtocol {
    * @return listOfAcls
    * */
   private List<OzoneAcl> getAclList() {
-    return OzoneUtils.getAclList(ugi.getUserName(), ugi.getGroups(),
+    return OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroups(),
         userRights, groupRights);
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
@@ -328,6 +328,11 @@ public class OzoneAcl {
         otherAcl.getAclScope().equals(this.getAclScope());
   }
 
+  public OzoneAcl setAclScope(AclScope scope) {
+    this.aclScope = scope;
+    return this;
+  }
+
   /**
    * Scope of ozone acl.
    * */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -36,8 +35,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 
 import com.google.common.base.Preconditions;
-
-import static org.apache.hadoop.ozone.OzoneAcl.ZERO_BITSET;
 
 /**
  * A class that encapsulates Bucket Info.
@@ -135,36 +132,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
    * already existing in the acl list.
    */
   public boolean addAcl(OzoneAcl ozoneAcl) {
-    // Case 1: When we are adding more rights to existing user/group.
-    boolean addToExistingAcl = false;
-    for(OzoneAcl existingAcl: getAcls()) {
-      if(existingAcl.getName().equals(ozoneAcl.getName()) &&
-          existingAcl.getType().equals(ozoneAcl.getType())) {
-
-        BitSet bits = (BitSet) ozoneAcl.getAclBitSet().clone();
-
-        // We need to do "or" before comparision because think of a case like
-        // existing acl is 777 and newly added acl is 444, we have already
-        // that acl set. In this case if we do direct check they will not
-        // be equal, but if we do or and then check, we shall know it
-        // has acl's already set or not.
-        bits.or(existingAcl.getAclBitSet());
-
-        if (bits.equals(existingAcl.getAclBitSet())) {
-          return false;
-        } else {
-          existingAcl.getAclBitSet().or(ozoneAcl.getAclBitSet());
-          addToExistingAcl = true;
-          break;
-        }
-      }
-    }
-
-    // Case 2: When a completely new acl is added.
-    if(!addToExistingAcl) {
-      getAcls().add(ozoneAcl);
-    }
-    return true;
+    return OzoneAclUtil.addAcl(acls, ozoneAcl);
   }
 
   /**
@@ -174,36 +142,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
    * to that acl is not in the existing acl list.
    */
   public boolean removeAcl(OzoneAcl ozoneAcl) {
-    boolean removed = false;
-
-    // When we are removing subset of rights from existing acl.
-    for(OzoneAcl existingAcl: getAcls()) {
-      if (existingAcl.getName().equals(ozoneAcl.getName()) &&
-          existingAcl.getType().equals(ozoneAcl.getType())) {
-        BitSet bits = (BitSet) ozoneAcl.getAclBitSet().clone();
-        bits.and(existingAcl.getAclBitSet());
-
-        // This happens when the acl bitset is not existing for current name
-        // and type.
-        // Like a case we have 444 permission, 333 is asked to removed.
-        if (bits.equals(ZERO_BITSET)) {
-          return false;
-        }
-
-        // We have some matching. Remove them.
-        existingAcl.getAclBitSet().xor(bits);
-
-        // If existing acl has same bitset as passed acl bitset, remove that
-        // acl from the list
-        if (existingAcl.getAclBitSet().equals(ZERO_BITSET)) {
-          getAcls().remove(existingAcl);
-        }
-        removed = true;
-        break;
-      }
-    }
-
-    return removed;
+    return OzoneAclUtil.removeAcl(acls, ozoneAcl);
   }
 
   /**
@@ -212,9 +151,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
    * @return true - if successfully able to reset.
    */
   public boolean setAcls(List<OzoneAcl> ozoneAcls) {
-    this.acls.clear();
-    this.acls = ozoneAcls;
-    return true;
+    return OzoneAclUtil.setAcl(acls, ozoneAcls);
   }
 
   /**
@@ -307,7 +244,9 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
     }
 
     public Builder setAcls(List<OzoneAcl> listOfAcls) {
-      this.acls = listOfAcls;
+      if (listOfAcls != null) {
+        this.acls.addAll(listOfAcls);
+      }
       return this;
     }
 
@@ -367,8 +306,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
     BucketInfo.Builder bib =  BucketInfo.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .addAllAcls(acls.stream().map(OzoneAcl::toProtobuf)
-            .collect(Collectors.toList()))
+        .addAllAcls(OzoneAclUtil.toProtobuf(acls))
         .setIsVersionEnabled(isVersionEnabled)
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmOzoneAclMap.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmOzoneAclMap.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.protocol.proto
     .OzoneManagerProtocolProtos.OzoneAclInfo.OzoneAclType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
-import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.util.BitSet;
@@ -235,12 +234,12 @@ public class OmOzoneAclMap {
 
     switch (identityType) {
     case USER:
-      return OzoneUtils.checkIfAclBitIsSet(acl, getAcl(identityType,
+      return OzoneAclUtil.checkIfAclBitIsSet(acl, getAcl(identityType,
           ugi.getUserName()));
     case GROUP:
       // Check access for user groups.
       for (String userGroup : ugi.getGroupNames()) {
-        if (OzoneUtils.checkIfAclBitIsSet(acl, getAcl(identityType,
+        if (OzoneAclUtil.checkIfAclBitIsSet(acl, getAcl(identityType,
             userGroup))) {
           // Return true if any user group has required permission.
           return true;
@@ -249,7 +248,7 @@ public class OmOzoneAclMap {
       break;
     default:
       // For type WORLD and ANONYMOUS we set acl type as name.
-      if(OzoneUtils.checkIfAclBitIsSet(acl, getAcl(identityType,
+      if(OzoneAclUtil.checkIfAclBitIsSet(acl, getAcl(identityType,
           identityType.name()))) {
         return true;
       }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ozone.security.acl.RequestContext;
 
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -159,31 +158,6 @@ public final class OzoneAclUtil {
   }
 
   /**
-   * Helper function to find and return all DEFAULT acls in input list with
-   * scope changed to ACCESS.
-   * @param acls
-   *
-   * @return list of default Acls.
-   * */
-  public static Collection<OzoneAclInfo> getDefaultAclsProto(
-      List<OzoneAcl> acls) {
-    return acls.stream().filter(a -> a.getAclScope() == DEFAULT)
-        .map(OzoneAcl::toProtobufWithAccessType).collect(Collectors.toList());
-  }
-
-  /**
-   * Helper function to find and return all DEFAULT acls in input list with
-   * scope changed to ACCESS.
-   * @param acls
-   *
-   * @return list of default Acls.
-   * */
-  public static List<OzoneAcl> getDefaultAcls(List<OzoneAcl> acls) {
-    return acls.stream().filter(a -> a.getAclScope() == DEFAULT)
-        .collect(Collectors.toList());
-  }
-
-  /**
    * Helper function to inherit default ACL as access ACL for child object.
    * 1. deep copy of OzoneAcl to avoid unexpected parent default ACL change
    * 2. merge inherited access ACL with existing access ACL via
@@ -232,8 +206,8 @@ public final class OzoneAclUtil {
 
   /**
    * Add an OzoneAcl to existing list of OzoneAcls.
-   * @param acl
    * @param existingAcls
+   * @param acl
    * @return true if current OzoneAcls are changed, false otherwise.
    */
   public static boolean addAcl(List<OzoneAcl> existingAcls, OzoneAcl acl) {
@@ -261,6 +235,7 @@ public final class OzoneAclUtil {
 
   /**
    * remove OzoneAcl from existing list of OzoneAcls.
+   * @param existingAcls
    * @param acl
    * @return true if current OzoneAcls are changed, false otherwise.
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -1,0 +1,311 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
+import org.apache.hadoop.ozone.security.acl.RequestContext;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.ALL;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.NONE;
+
+/**
+ * Helper class for ozone acls operations.
+ */
+public final class OzoneAclUtil {
+
+  private OzoneAclUtil(){
+  }
+
+  /**
+   * Helper function to get access acl list for current user.
+   *
+   * @param userName
+   * @param userGroups
+   * @return list of OzoneAcls
+   * */
+  public static List<OzoneAcl> getAclList(String userName,
+      List<String> userGroups, ACLType userRights, ACLType groupRights) {
+
+    List<OzoneAcl> listOfAcls = new ArrayList<>();
+
+    // User ACL.
+    listOfAcls.add(new OzoneAcl(USER, userName, userRights, ACCESS));
+    if(userGroups != null) {
+      // Group ACLs of the User.
+      userGroups.forEach((group) -> listOfAcls.add(
+          new OzoneAcl(GROUP, group, groupRights, ACCESS)));
+    }
+    return listOfAcls;
+  }
+
+  /**
+   * Check if acl right requested for given RequestContext exist
+   * in provided acl list.
+   * Acl validation rules:
+   * 1. If user/group has ALL bit set than all user should have all rights.
+   * 2. If user/group has NONE bit set than user/group will not have any right.
+   * 3. For all other individual rights individual bits should be set.
+   *
+   * @param acls
+   * @param context
+   * @return return true if acl list contains right requsted in context.
+   * */
+  public static boolean checkAclRight(List<OzoneAcl> acls,
+      RequestContext context) throws OMException {
+    String[] userGroups = context.getClientUgi().getGroupNames();
+    String userName = context.getClientUgi().getUserName();
+    ACLType aclToCheck = context.getAclRights();
+    for (OzoneAcl a : acls) {
+      if(checkAccessInAcl(a, userGroups, userName, aclToCheck)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean checkAccessInAcl(OzoneAcl a, String[] groups,
+      String username, ACLType aclToCheck) {
+    BitSet rights = a.getAclBitSet();
+    switch (a.getType()) {
+    case USER:
+      if (a.getName().equals(username)) {
+        return checkIfAclBitIsSet(aclToCheck, rights);
+      }
+      break;
+    case GROUP:
+      for (String grp : groups) {
+        if (a.getName().equals(grp)) {
+          return checkIfAclBitIsSet(aclToCheck, rights);
+        }
+      }
+      break;
+
+    default:
+      return checkIfAclBitIsSet(aclToCheck, rights);
+    }
+    return false;
+  }
+
+  /**
+   * Check if acl right requested for given RequestContext exist
+   * in provided acl list.
+   * Acl validation rules:
+   * 1. If user/group has ALL bit set than all user should have all rights.
+   * 2. If user/group has NONE bit set than user/group will not have any right.
+   * 3. For all other individual rights individual bits should be set.
+   *
+   * @param acls
+   * @param context
+   * @return return true if acl list contains right requsted in context.
+   * */
+  public static boolean checkAclRights(List<OzoneAcl> acls,
+      RequestContext context) throws OMException {
+    String[] userGroups = context.getClientUgi().getGroupNames();
+    String userName = context.getClientUgi().getUserName();
+    ACLType aclToCheck = context.getAclRights();
+    for (OzoneAcl acl : acls) {
+      if (checkAccessInAcl(acl, userGroups, userName, aclToCheck)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Helper function to check if bit for given acl is set.
+   * @param acl
+   * @param bitset
+   * @return True of acl bit is set else false.
+   * */
+  public static boolean checkIfAclBitIsSet(IAccessAuthorizer.ACLType acl,
+      BitSet bitset) {
+    if (bitset == null) {
+      return false;
+    }
+
+    return ((bitset.get(acl.ordinal())
+        || bitset.get(ALL.ordinal()))
+        && !bitset.get(NONE.ordinal()));
+  }
+
+  /**
+   * Helper function to find and return all DEFAULT acls in input list with
+   * scope changed to ACCESS.
+   * @param acls
+   *
+   * @return list of default Acls.
+   * */
+  public static Collection<OzoneAclInfo> getDefaultAclsProto(
+      List<OzoneAcl> acls) {
+    return acls.stream().filter(a -> a.getAclScope() == DEFAULT)
+        .map(OzoneAcl::toProtobufWithAccessType).collect(Collectors.toList());
+  }
+
+  /**
+   * Helper function to find and return all DEFAULT acls in input list with
+   * scope changed to ACCESS.
+   * @param acls
+   *
+   * @return list of default Acls.
+   * */
+  public static List<OzoneAcl> getDefaultAcls(List<OzoneAcl> acls) {
+    return acls.stream().filter(a -> a.getAclScope() == DEFAULT)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Helper function to inherit default ACL as access ACL for child object.
+   * 1. deep copy of OzoneAcl to avoid unexpected parent default ACL change
+   * 2. merge inherited access ACL with existing access ACL via
+   * OzoneUtils.addAcl().
+   * @param acls
+   * @param parentAcls
+   * @return true if acls inherited DEFAULT acls from parentAcls successfully,
+   * false otherwise.
+   */
+  public static boolean inheritDefaultAcls(List<OzoneAcl> acls,
+      List<OzoneAcl> parentAcls) {
+    List<OzoneAcl> inheritedAcls = null;
+    if (parentAcls != null && !parentAcls.isEmpty()) {
+      inheritedAcls = parentAcls.stream()
+          .filter(a -> a.getAclScope() == DEFAULT)
+          .map(acl -> new OzoneAcl(acl.getType(), acl.getName(),
+              acl.getAclBitSet(), OzoneAcl.AclScope.ACCESS))
+          .collect(Collectors.toList());
+    }
+    if (inheritedAcls != null && !inheritedAcls.isEmpty()) {
+      inheritedAcls.stream().forEach(acl -> addAcl(acls, acl));
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Convert a list of OzoneAclInfo(protoc) to list of OzoneAcl(java).
+   * @param protoAcls
+   * @return list of OzoneAcl.
+   */
+  public static List<OzoneAcl> fromProtobuf(List<OzoneAclInfo> protoAcls) {
+    return protoAcls.stream().map(acl->OzoneAcl.fromProtobuf(acl))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Convert a list of OzoneAcl(java) to list of OzoneAclInfo(protoc).
+   * @param protoAcls
+   * @return list of OzoneAclInfo.
+   */
+  public static List<OzoneAclInfo> toProtobuf(List<OzoneAcl> protoAcls) {
+    return protoAcls.stream().map(acl->OzoneAcl.toProtobuf(acl))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Add an OzoneAcl to existing list of OzoneAcls.
+   * @param acl
+   * @param existingAcls
+   * @return true if current OzoneAcls are changed, false otherwise.
+   */
+  public static boolean addAcl(List<OzoneAcl> existingAcls, OzoneAcl acl) {
+    if (existingAcls == null || acl == null) {
+      return false;
+    }
+
+    for (OzoneAcl a: existingAcls) {
+      if (a.getName().equals(acl.getName()) &&
+          a.getType().equals(acl.getType()) &&
+          a.getAclScope().equals(acl.getAclScope())) {
+        BitSet current = a.getAclBitSet();
+        BitSet original = (BitSet) current.clone();
+        current.or(acl.getAclBitSet());
+        if (current.equals(original)) {
+          return false;
+        }
+        return true;
+      }
+    }
+
+    existingAcls.add(acl);
+    return true;
+  }
+
+  /**
+   * remove OzoneAcl from existing list of OzoneAcls.
+   * @param acl
+   * @return true if current OzoneAcls are changed, false otherwise.
+   */
+  public static boolean removeAcl(List<OzoneAcl> existingAcls, OzoneAcl acl) {
+    if (existingAcls == null || existingAcls.isEmpty() || acl == null) {
+      return false;
+    }
+
+    for (OzoneAcl a: existingAcls) {
+      if (a.getName().equals(acl.getName()) &&
+          a.getType().equals(acl.getType()) &&
+          a.getAclScope().equals(acl.getAclScope())) {
+        BitSet current = a.getAclBitSet();
+        BitSet original = (BitSet) current.clone();
+        current.andNot(acl.getAclBitSet());
+
+        if (current.equals(original)) {
+          return false;
+        }
+
+        if (current.isEmpty()) {
+          existingAcls.remove(a);
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Set existingAcls to newAcls.
+   * @param existingAcls
+   * @param newAcls
+   * @return true if newAcls are set successfully, false otherwise.
+   */
+  public static boolean setAcl(List<OzoneAcl> existingAcls,
+      List<OzoneAcl> newAcls) {
+    if (existingAcls == null) {
+      return false;
+    } else {
+      existingAcls.clear();
+      if (newAcls != null) {
+        existingAcls.addAll(newAcls);
+      }
+    }
+    return true;
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
+import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for OzoneAcls utility class.
+ */
+public class TestOzoneAclUtil {
+
+  private static final List<OzoneAcl> DEFAULT_ACLS =
+      getDefaultAcls(new OzoneConfiguration());
+
+  private static final OzoneAcl USER1 = new OzoneAcl(USER, "user1",
+      ACLType.READ_ACL, ACCESS);
+
+  private static final OzoneAcl USER2 = new OzoneAcl(USER, "user2",
+      ACLType.WRITE, ACCESS);
+
+  private static final OzoneAcl GROUP1 = new OzoneAcl(GROUP, "group1",
+      ACLType.ALL, ACCESS);
+
+  @Test
+  public void testAddAcl() throws IOException {
+    List<OzoneAcl> currentAcls = getDefaultAcls(new OzoneConfiguration());
+    assertTrue(currentAcls.size() > 0);
+
+    // Add new permission to existing acl entry.
+    OzoneAcl oldAcl = currentAcls.get(0);
+    OzoneAcl newAcl = new OzoneAcl(oldAcl.getType(), oldAcl.getName(),
+        ACLType.READ_ACL, ACCESS);
+
+    addAndVerifyAcl(currentAcls, newAcl, true, DEFAULT_ACLS.size());
+    // Add same permission again and verify result
+    addAndVerifyAcl(currentAcls, newAcl, false, DEFAULT_ACLS.size());
+
+    // Add a new user acl entry.
+    addAndVerifyAcl(currentAcls, USER1, true, DEFAULT_ACLS.size() + 1);
+    // Add same acl entry again and verify result
+    addAndVerifyAcl(currentAcls, USER1, false, DEFAULT_ACLS.size() + 1);
+
+    // Add a new group acl entry.
+    addAndVerifyAcl(currentAcls, GROUP1, true, DEFAULT_ACLS.size() + 2);
+    // Add same acl entry again and verify result
+    addAndVerifyAcl(currentAcls, GROUP1, false, DEFAULT_ACLS.size() + 2);
+  }
+
+  @Test
+  public void testRemoveAcl() {
+    List<OzoneAcl> currentAcls = null;
+
+    // add/remove to/from null OzoneAcls
+    removeAndVerifyAcl(currentAcls, USER1, false, 0);
+    addAndVerifyAcl(currentAcls, USER1, false, 0);
+    removeAndVerifyAcl(currentAcls, USER1, false, 0);
+
+    currentAcls = getDefaultAcls(new OzoneConfiguration());
+    assertTrue(currentAcls.size() > 0);
+
+    // Add new permission to existing acl entru.
+    OzoneAcl oldAcl = currentAcls.get(0);
+    OzoneAcl newAcl = new OzoneAcl(oldAcl.getType(), oldAcl.getName(),
+        ACLType.READ_ACL, ACCESS);
+
+    // Remove non existing acl entry
+    removeAndVerifyAcl(currentAcls, USER1, false, DEFAULT_ACLS.size());
+
+    // Remove non existing acl permission
+    removeAndVerifyAcl(currentAcls, newAcl, false, DEFAULT_ACLS.size());
+
+    // Add new permission to existing acl entry.
+    addAndVerifyAcl(currentAcls, newAcl, true, DEFAULT_ACLS.size());
+
+    // Remove the new permission added.
+    removeAndVerifyAcl(currentAcls, newAcl, true, DEFAULT_ACLS.size());
+
+    removeAndVerifyAcl(currentAcls, oldAcl, true, DEFAULT_ACLS.size() - 1);
+  }
+
+  private void addAndVerifyAcl(List<OzoneAcl> currentAcls, OzoneAcl addedAcl,
+      boolean expectedResult, int expectedSize) {
+    assertEquals(expectedResult, OzoneAclUtil.addAcl(currentAcls, addedAcl));
+    if (currentAcls != null) {
+      boolean verified = verifyAclAdded(currentAcls, addedAcl);
+      assertTrue("addedAcl: " + addedAcl + " should exist in the" +
+          " current acls: " + currentAcls, verified);
+      assertEquals(expectedSize, currentAcls.size());
+    }
+  }
+
+  private void removeAndVerifyAcl(List<OzoneAcl> currentAcls,
+      OzoneAcl removedAcl, boolean expectedResult, int expectedSize) {
+    assertEquals(expectedResult, OzoneAclUtil.removeAcl(currentAcls,
+        removedAcl));
+    if (currentAcls != null) {
+      boolean verified = verifyAclRemoved(currentAcls, removedAcl);
+      assertTrue("removedAcl: " + removedAcl + " should not exist in the" +
+          " current acls: " + currentAcls, verified);
+      assertEquals(expectedSize, currentAcls.size());
+    }
+  }
+
+  private boolean verifyAclRemoved(List<OzoneAcl> acls, OzoneAcl removedAcl) {
+    for (OzoneAcl acl : acls) {
+      if (acl.getName().equals(removedAcl.getName()) &&
+          acl.getType().equals(removedAcl.getType()) &&
+          acl.getAclScope().equals(removedAcl.getAclScope())) {
+        BitSet temp = (BitSet) acl.getAclBitSet().clone();
+        temp.and(removedAcl.getAclBitSet());
+        return !temp.equals(removedAcl.getAclBitSet());
+      }
+    }
+    return true;
+  }
+
+  private boolean verifyAclAdded(List<OzoneAcl> acls, OzoneAcl newAcl) {
+    for (OzoneAcl acl : acls) {
+      if (acl.getName().equals(newAcl.getName()) &&
+          acl.getType().equals(newAcl.getType()) &&
+          acl.getAclScope().equals(newAcl.getAclScope())) {
+        BitSet temp = (BitSet) acl.getAclBitSet().clone();
+        temp.and(newAcl.getAclBitSet());
+        return temp.equals(newAcl.getAclBitSet());
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Helper function to get default acl list for current user.
+   *
+   * @return list of ozoneAcls.
+   * @throws IOException
+   * */
+  private static List<OzoneAcl> getDefaultAcls(OzoneConfiguration conf) {
+    List<OzoneAcl> ozoneAcls = new ArrayList<>();
+    //User ACL
+    UserGroupInformation ugi;
+    try {
+      ugi = UserGroupInformation.getCurrentUser();
+    } catch (IOException ioe) {
+      ugi = UserGroupInformation.createRemoteUser("user0");
+    }
+
+    OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
+    IAccessAuthorizer.ACLType userRights = aclConfig.getUserDefaultRights();
+    IAccessAuthorizer.ACLType groupRights = aclConfig.getGroupDefaultRights();
+
+    OzoneAclUtil.addAcl(ozoneAcls, new OzoneAcl(USER,
+        ugi.getUserName(), userRights, ACCESS));
+    //Group ACLs of the User
+    List<String> userGroups = Arrays.asList(ugi.getGroupNames());
+    userGroups.stream().forEach((group) -> OzoneAclUtil.addAcl(ozoneAcls,
+        new OzoneAcl(GROUP, group, groupRights, ACCESS)));
+    return ozoneAcls;
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -144,14 +144,15 @@ public abstract class TestOzoneRpcClientAbstract {
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   private static String remoteUserName = "remoteUser";
+  private static String remoteGroupName = "remoteGroup";
   private static OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
       READ, DEFAULT);
-  private static OzoneAcl defaultGroupAcl = new OzoneAcl(GROUP, remoteUserName,
+  private static OzoneAcl defaultGroupAcl = new OzoneAcl(GROUP, remoteGroupName,
       READ, DEFAULT);
   private static OzoneAcl inheritedUserAcl = new OzoneAcl(USER, remoteUserName,
       READ, ACCESS);
   private static OzoneAcl inheritedGroupAcl = new OzoneAcl(GROUP,
-      remoteUserName, READ, ACCESS);
+      remoteGroupName, READ, ACCESS);
 
   private static String scmId = UUID.randomUUID().toString();
 
@@ -2280,11 +2281,11 @@ public abstract class TestOzoneRpcClientAbstract {
       }
     }
     List<OzoneAcl> acls = store.getAcl(parentObj);
-    assertTrue("Current acls:" + StringUtils.join(",", acls) +
-            " inheritedUserAcl:" + inheritedUserAcl,
+    assertTrue("Current acls: " + StringUtils.join(",", acls) +
+            " inheritedUserAcl: " + inheritedUserAcl,
         acls.contains(defaultUserAcl));
-    assertTrue("Current acls:" + StringUtils.join(",", acls) +
-            " inheritedUserAcl:" + inheritedUserAcl,
+    assertTrue("Current acls: " + StringUtils.join(",", acls) +
+            " inheritedGroupAcl: " + inheritedGroupAcl,
         acls.contains(defaultGroupAcl));
 
     acls = store.getAcl(childObj);
@@ -2292,7 +2293,7 @@ public abstract class TestOzoneRpcClientAbstract {
             " inheritedUserAcl:" + inheritedUserAcl,
         acls.contains(inheritedUserAcl));
     assertTrue("Current acls:" + StringUtils.join(",", acls) +
-            " inheritedUserAcl:" + inheritedUserAcl,
+            " inheritedGroupAcl:" + inheritedGroupAcl,
         acls.contains(inheritedGroupAcl));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -67,6 +68,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -75,7 +77,6 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
-import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -130,6 +131,7 @@ public class TestKeyManagerImpl {
     conf = new OzoneConfiguration();
     dir = GenericTestUtils.getRandomizedTestDir();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.toString());
+    conf.set(OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY, "true");
     mockScmBlockLocationProtocol = Mockito.mock(ScmBlockLocationProtocol.class);
     metadataManager = new OmMetadataManagerImpl(conf);
     volumeManager = new VolumeManagerImpl(metadataManager, conf);
@@ -256,7 +258,7 @@ public class TestKeyManagerImpl {
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(KEY_NAME)
         .setDataSize(1000)
-        .setAcls(OzoneUtils.getAclList(ugi.getUserName(), ugi.getGroups(),
+        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroups(),
             ALL, ALL))
         .build();
     LambdaTestUtils.intercept(OMException.class,
@@ -960,7 +962,7 @@ public class TestKeyManagerImpl {
         .setFactor(ReplicationFactor.ONE)
         .setDataSize(0)
         .setType(ReplicationType.STAND_ALONE)
-        .setAcls(OzoneUtils.getAclList(ugi.getUserName(), ugi.getGroups(),
+        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroups(),
             ALL, ALL))
         .setVolumeName(VOLUME_NAME);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManager.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort;
@@ -1435,7 +1436,7 @@ public class TestOzoneManager {
         .setFactor(HddsProtos.ReplicationFactor.ONE)
         .setDataSize(0)
         .setType(HddsProtos.ReplicationType.STAND_ALONE)
-        .setAcls(OzoneUtils.getAclList(ugi.getUserName(), ugi.getGroups(),
+        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroups(),
             ALL, ALL))
         .setVolumeName("vol1")
         .setKeyName(UUID.randomUUID().toString())

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -38,9 +38,9 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
-import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.BeforeClass;
@@ -178,7 +178,7 @@ public class TestOzoneNativeAuthorizer {
         .setFactor(HddsProtos.ReplicationFactor.ONE)
         .setDataSize(0)
         .setType(HddsProtos.ReplicationType.STAND_ALONE)
-        .setAcls(OzoneUtils.getAclList(ugi.getUserName(), ugi.getGroups(),
+        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroups(),
             ALL, ALL))
         .build();
 

--- a/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/ozone/web/storage/DistributedStorageHandler.java
+++ b/hadoop-ozone/objectstore-service/src/main/java/org/apache/hadoop/ozone/web/storage/DistributedStorageHandler.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -434,7 +435,7 @@ public final class DistributedStorageHandler implements StorageHandler {
         .setDataSize(args.getSize())
         .setType(xceiverClientManager.getType())
         .setFactor(xceiverClientManager.getFactor())
-        .setAcls(OzoneUtils.getAclList(args.getUserName(),
+        .setAcls(OzoneAclUtil.getAclList(args.getUserName(),
             args.getGroups() != null ? Arrays.asList(args.getGroups()) : null,
             ACLType.ALL, ACLType.ALL))
         .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -26,6 +26,11 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,10 +43,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.file.OMDirectoryCreateResponse;
@@ -237,7 +238,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         .setReplicationType(HddsProtos.ReplicationType.RATIS)
         .setReplicationFactor(HddsProtos.ReplicationFactor.ONE)
         .setFileEncryptionInfo(encryptionInfo.orNull())
-        .setAcls(keyArgs.getAclsList())
+        .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -32,6 +32,12 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,11 +57,6 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ScmClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
@@ -352,7 +353,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
         .setReplicationFactor(factor)
         .setFileEncryptionInfo(encInfo);
     if(keyArgs.getAclsList() != null) {
-      builder.setAcls(keyArgs.getAclsList());
+      builder.setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
     }
     return builder.build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -29,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -43,14 +43,15 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
       LoggerFactory.getLogger(OMKeyAddAclRequest.class);
 
   private String path;
-  private List<OzoneAclInfo> ozoneAcls;
+  private List<OzoneAcl> ozoneAcls;
 
   public OMKeyAddAclRequest(OMRequest omRequest) {
     super(omRequest);
     OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
         getOmRequest().getAddAclRequest();
     path = addAclRequest.getObj().getPath();
-    ozoneAcls = Lists.newArrayList(addAclRequest.getAcl());
+    ozoneAcls = Lists.newArrayList(
+        OzoneAcl.fromProtobuf(addAclRequest.getAcl()));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -29,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclResponse;
@@ -43,14 +43,15 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
       LoggerFactory.getLogger(OMKeyAddAclRequest.class);
 
   private String path;
-  private List<OzoneAclInfo> ozoneAcls;
+  private List<OzoneAcl> ozoneAcls;
 
   public OMKeyRemoveAclRequest(OMRequest omRequest) {
     super(omRequest);
     OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
         getOmRequest().getRemoveAclRequest();
     path = removeAclRequest.getObj().getPath();
-    ozoneAcls = Lists.newArrayList(removeAclRequest.getAcl());
+    ozoneAcls = Lists.newArrayList(
+        OzoneAcl.fromProtobuf(removeAclRequest.getAcl()));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -21,14 +21,16 @@ package org.apache.hadoop.ozone.om.request.key.acl;
 import java.io.IOException;
 import java.util.List;
 
+import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclResponse;
@@ -42,14 +44,15 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
       LoggerFactory.getLogger(OMKeyAddAclRequest.class);
 
   private String path;
-  private List<OzoneAclInfo> ozoneAcls;
+  private List<OzoneAcl> ozoneAcls;
 
   public OMKeySetAclRequest(OMRequest omRequest) {
     super(omRequest);
     OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
         getOmRequest().getSetAclRequest();
     path = setAclRequest.getObj().getPath();
-    ozoneAcls = setAclRequest.getAclList();
+    ozoneAcls = Lists.newArrayList(
+        OzoneAclUtil.fromProtobuf(setAclRequest.getAclList()));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -163,7 +164,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
           .setReplicationFactor(keyArgs.getFactor())
           .setOmKeyLocationInfos(Collections.singletonList(
               new OmKeyLocationInfoGroup(0, new ArrayList<>())))
-          .setAcls(keyArgs.getAclsList())
+          .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
           .build();
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
+import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -231,7 +232,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             .setDataSize(size)
             .setOmKeyLocationInfos(
                 Collections.singletonList(keyLocationInfoGroup))
-            .setAcls(keyArgs.getAclsList()).build();
+            .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
+            .build();
       } else {
         // Already a version exists, so we should add it as a new version.
         // But now as versioning is not supported, just following the commit

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -403,10 +403,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
   private GetAclResponse getAcl(GetAclRequest req) throws IOException {
     List<OzoneAclInfo> acls = new ArrayList<>();
-
     List<OzoneAcl> aclList =
         impl.getAcl(OzoneObjInfo.fromProtobuf(req.getObj()));
-    aclList.forEach(a -> acls.add(OzoneAcl.toProtobuf(a)));
+    if (aclList != null) {
+      aclList.forEach(a -> acls.add(OzoneAcl.toProtobuf(a)));
+    }
     return GetAclResponse.newBuilder().addAllAcls(acls).build();
   }
 


### PR DESCRIPTION
What have been changed:
1. Change OzoneKeyInfo to use OzoneAcl instead of OzoneAclInfo
2. Adding OzoneAclUtil#addAcl, removeAcl to consolidate the logic applies to both bucket and key.
Will file a separate ticket to fix volume as it is currently using OzoneAclMap.
3. Adding TestOzoneAclUtil to cover misc add/remove cases
3. Fix the defaultAcl merge issue when inheriting by using the OzoneAclUtil#addAcl
5. Fix failures in TestOzoneRpcClientAbract and its subclasses.

