### PR TITLE
HDDS-1948. S3 MPU can't be created with octet-stream content-type 

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/HeaderPreprocessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/HeaderPreprocessor.java
@@ -29,11 +29,13 @@ import java.io.IOException;
 /**
  * Filter to adjust request headers for compatible reasons.
  *
- * It should be executed AFTER signature check (VirtualHostStyleFilter).
+ * It should be executed AFTER signature check (VirtualHostStyleFilter) as the
+ * original Content-Type could be part of the base of the signature.
  */
 @Provider
 @PreMatching
-@Priority(150)
+@Priority(VirtualHostStyleFilter.PRIORITY
+    + S3GatewayHttpServer.FILTER_PRIORITY_DO_AFTER)
 public class HeaderPreprocessor implements ContainerRequestFilter {
 
   public static final String MULTIPART_UPLOAD_MARKER = "ozone/mpu";

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/HeaderPreprocessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/HeaderPreprocessor.java
@@ -17,39 +17,58 @@
  */
 package org.apache.hadoop.ozone.s3;
 
+import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 
 /**
  * Filter to adjust request headers for compatible reasons.
+ *
+ * It should be executed AFTER signature check (VirtualHostStyleFilter).
  */
-
 @Provider
 @PreMatching
+@Priority(150)
 public class HeaderPreprocessor implements ContainerRequestFilter {
+
+  public static final String MULTIPART_UPLOAD_MARKER = "ozone/mpu";
 
   @Override
   public void filter(ContainerRequestContext requestContext) throws
       IOException {
-    if (requestContext.getUriInfo().getQueryParameters()
-        .containsKey("delete")) {
+    MultivaluedMap<String, String> queryParameters =
+        requestContext.getUriInfo().getQueryParameters();
+
+    if (queryParameters.containsKey("delete")) {
       //aws cli doesn't send proper Content-Type and by default POST requests
       //processed as form-url-encoded. Here we can fix this.
       requestContext.getHeaders()
           .putSingle("Content-Type", MediaType.APPLICATION_XML);
     }
 
-    if (requestContext.getUriInfo().getQueryParameters()
-        .containsKey("uploadId")) {
+    if (queryParameters.containsKey("uploadId")) {
       //aws cli doesn't send proper Content-Type and by default POST requests
       //processed as form-url-encoded. Here we can fix this.
       requestContext.getHeaders()
           .putSingle("Content-Type", MediaType.APPLICATION_XML);
+    } else if (queryParameters.containsKey("uploads")) {
+      // uploads defined but uploadId is not --> this is the creation of the
+      // multi-part-upload requests.
+      //
+      //In  AWS SDK for go uses application/octet-stream which also
+      //should be fixed to route the request to the right jaxrs method.
+      //
+      //Should be empty instead of XML as the body is empty which can not be
+      //serialized as as CompleteMultipartUploadRequest
+      requestContext.getHeaders()
+          .putSingle("Content-Type", MULTIPART_UPLOAD_MARKER);
     }
+
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayHttpServer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayHttpServer.java
@@ -27,6 +27,11 @@ import org.apache.hadoop.hdds.server.BaseHttpServer;
  */
 public class S3GatewayHttpServer extends BaseHttpServer {
 
+  /**
+   * Default offset between two filters.
+   */
+  public static final int FILTER_PRIORITY_DO_AFTER = 50;
+
   public S3GatewayHttpServer(Configuration conf,
       String name) throws IOException {
     super(conf, name);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/VirtualHostStyleFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/VirtualHostStyleFilter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.s3;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -46,6 +47,7 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_DOMAIN_NA
 
 @Provider
 @PreMatching
+@Priority(100)
 public class VirtualHostStyleFilter implements ContainerRequestFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/VirtualHostStyleFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/VirtualHostStyleFilter.java
@@ -47,8 +47,10 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_DOMAIN_NA
 
 @Provider
 @PreMatching
-@Priority(100)
+@Priority(VirtualHostStyleFilter.PRIORITY)
 public class VirtualHostStyleFilter implements ContainerRequestFilter {
+
+  public static final int PRIORITY = 100;
 
   private static final Logger LOG = LoggerFactory.getLogger(
       VirtualHostStyleFilter.class);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
@@ -56,7 +56,7 @@ public class TestAbortMultipartUpload {
     rest.setHeaders(headers);
     rest.setClient(client);
 
-    Response response = rest.multipartUpload(bucket, key, "", "", null);
+    Response response = rest.initializeMultipartUpload(bucket, key);
 
     assertEquals(response.getStatus(), 200);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
@@ -60,7 +60,7 @@ public class TestInitiateMultipartUpload {
     rest.setHeaders(headers);
     rest.setClient(client);
 
-    Response response = rest.multipartUpload(bucket, key, "", "", null);
+    Response response = rest.initializeMultipartUpload(bucket, key);
 
     assertEquals(response.getStatus(), 200);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
@@ -69,7 +69,7 @@ public class TestInitiateMultipartUpload {
     String uploadID = multipartUploadInitiateResponse.getUploadID();
 
     // Calling again should return different uploadID.
-    response = rest.multipartUpload(bucket, key, "", "", null);
+    response = rest.initializeMultipartUpload(bucket, key);
     assertEquals(response.getStatus(), 200);
     multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
@@ -61,7 +61,7 @@ public class TestListParts {
     REST.setHeaders(headers);
     REST.setClient(client);
 
-    Response response = REST.multipartUpload(BUCKET, KEY, "", "", null);
+    Response response = REST.initializeMultipartUpload(BUCKET, KEY);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -70,7 +70,7 @@ public class TestMultipartUploadComplete {
 
   private String initiateMultipartUpload(String key) throws IOException,
       OS3Exception {
-    Response response = REST.multipartUpload(BUCKET, key, "", "", null);
+    Response response = REST.initializeMultipartUpload(BUCKET, key);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());
@@ -99,7 +99,7 @@ public class TestMultipartUploadComplete {
   private void completeMultipartUpload(String key,
       CompleteMultipartUploadRequest completeMultipartUploadRequest,
       String uploadID) throws IOException, OS3Exception {
-    Response response = REST.multipartUpload(BUCKET, key, "", uploadID,
+    Response response = REST.completeMultipartUpload(BUCKET, key, uploadID,
         completeMultipartUploadRequest);
 
     assertEquals(response.getStatus(), 200);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -67,7 +67,7 @@ public class TestPartUpload {
   @Test
   public void testPartUpload() throws Exception {
 
-    Response response = REST.multipartUpload(BUCKET, KEY, "", "", null);
+    Response response = REST.initializeMultipartUpload(BUCKET, KEY);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());
@@ -86,7 +86,7 @@ public class TestPartUpload {
   @Test
   public void testPartUploadWithOverride() throws Exception {
 
-    Response response = REST.multipartUpload(BUCKET, KEY, "", "", null);
+    Response response = REST.initializeMultipartUpload(BUCKET, KEY);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());


### PR DESCRIPTION
This problem is reported offline by [~shanekumpf@gmail.com].

When aws-sdk-go is used to access to s3 gateway of Ozone it sends the Multi Part Upload initialize message with "application/octet-stream" Content-Type. 

This Content-Type is missing from the aws-cli which is used to reimplement s3 endpoint.

The problem is that we use the same rest endpoint for initialize and complete Multipart Upload request. For the completion we need the CompleteMultipartUploadRequest parameter which is parsed from the body.

For initialize we have an empty body which can't be serialized to CompleteMultipartUploadRequest.

The workaround is to set a specific content type from a filter which help up to create two different REST method for initialize and completion message.

Here is an example to test (using bogus AWS credentials).

{code}
curl -H 'Host:yourhost' -H 'User-Agent:aws-sdk-go/1.15.11 (go1.11.2; linux; amd64)' -H 'Content-Length:0' -H 'Authorization:AWS4-HMAC-SHA256 Credential=qwe/20190809/ozone/s3/aws4_request, SignedHeaders=content-type;host;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-storage-class, Signature=7726ed63990ba3f4f1f796d4ab263f5d9c3374528840f5e49d106dbef491f22c' -H 'Content-Type:application/octet-stream' -H 'X-Amz-Acl:private' -H 'X-Amz-Content-Sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' -H 'X-Amz-Date:20190809T070142Z' -H 'X-Amz-Storage-Class:STANDARD' -H 'Accept-Encoding:gzip' -X POST 'http://localhost:9999/docker/docker/registry/v2/repositories/apache/ozone-runner/_uploads/2173f019-09c3-466b-bb7d-c31ce749d826/data?uploads
{code}

Without the patch it returns with HTTP 405 (Not supported Media Type).

See: https://issues.apache.org/jira/browse/HDDS-1948