### PR TITLE
HDDS-1954. StackOverflowError in OzoneClientInvocationHandler

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientInvocationHandler.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientInvocationHandler.java
@@ -48,7 +48,7 @@ public class OzoneClientInvocationHandler implements InvocationHandler {
   @Override
   public Object invoke(Object proxy, Method method, Object[] args)
       throws Throwable {
-    LOG.trace("Invoking method {} on proxy {}", method, proxy);
+    LOG.trace("Invoking method {} on target {}", method, target);
     try {
       long startTime = Time.monotonicNow();
       Object result = method.invoke(target, args);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Including `proxy` in the trace message causes stack overflow, since it results in a call to `proxy.toString()`, which also wants to log, etc.

I would also argue that `target` is more interesting for logging than `proxy`: eg. `org.apache.hadoop.ozone.client.rpc.RpcClient@5c3d4f05` vs. `com.sun.proxy.$Proxy87`.

https://issues.apache.org/jira/browse/HDDS-1954

## How was this patch tested?

Set root log level to TRACE and ran some integration tests via Maven (eg. `TestOzoneRpcClientWithRatis`).  Verified that `surefire-reports` has no `StackOverflowError`, but has messages like:

```
TRACE client.OzoneClient (OzoneClientInvocationHandler.java:invoke(51)) - Invoking method public abstract org.apache.hadoop.ozone.client.OzoneVolume org.apache.hadoop.ozone.client.protocol.ClientProtocol.getVolumeDetails(java.lang.String) throws java.io.IOException on target org.apache.hadoop.ozone.client.rpc.RpcClient@5c3d4f05
```