### PR TITLE
HDDS-1952. Disable TestMiniChaosOzoneCluster in integration.sh

### DIFF
--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -18,7 +18,8 @@ cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
 mvn -B install -f pom.ozone.xml -DskipTests
-mvn -B -fn test -f pom.ozone.xml -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem,:hadoop-ozone-tools
+mvn -B -fn test -f pom.ozone.xml -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem,:hadoop-ozone-tools \
+  -Dtest=\!TestMiniChaosOzoneCluster
 module_failed_tests=$(find "." -name 'TEST*.xml' -print0 \
     | xargs -0 -n1 "grep" -l -E "<failure|<error"\
     | awk -F/ '{sub("'"TEST-JUNIT_TEST_OUTPUT_DIR"'",""); sub(".xml",""); print $NF}')


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable `TestMiniChaosOzoneCluster` in integration test (`integration.sh`) run by CI and nightly builds, since it always crashes after running for a long time.

It can still be run manually.

https://issues.apache.org/jira/browse/HDDS-1952