### PR TITLE
Fix syntax error in conftest.py

### DIFF
--- a/hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/conftest.py
+++ b/hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/conftest.py
@@ -64,7 +64,7 @@ def pytest_configure(config):
   OUTPUT_DIR = "%s/%s" % (config.option.output_dir, EPOCH_TIME)
   try:
     os.makedirs(OUTPUT_DIR)
-  except OSError, e:
+  except OSError as e:
     raise Exception(e.strerror + ": " + e.filename)
   log_file = os.path.join(OUTPUT_DIR, "output.log")
 


### PR DESCRIPTION
Old style exceptions are syntax errors on Python 3 while new style exceptions work as expected on both Python 2 and Python 3.