### PR TITLE
HDDS-1956. Aged IO Thread exits on first read

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -68,7 +68,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
 
     this.executorService =  Executors.newSingleThreadScheduledExecutor();
     this.numDatanodes = getHddsDatanodes().size();
-    LOG.info("Starting MiniOzoneChaosCluster with:{} datanodes" + numDatanodes);
+    LOG.info("Starting MiniOzoneChaosCluster with {} datanodes", numDatanodes);
     LogUtils.setLogLevel(GrpcClientProtocolClient.LOG, Level.WARN);
   }
 
@@ -108,7 +108,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
         LOG.info("{} Completed restarting Datanode: {}", failString,
             dn.getUuid());
       } catch (Exception e) {
-        LOG.error("Failed to restartNodes Datanode", dn.getUuid());
+        LOG.error("Failed to restartNodes Datanode {}", dn.getUuid(), e);
       }
     }
   }
@@ -119,7 +119,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
     for (int i = 0; i < numNodesToFail; i++) {
       boolean shouldStop = shouldStop();
       int failedNodeIndex = getNodeToFail();
-      String stopString = shouldStop ? "Stopping" : "Starting";
+      String stopString = shouldStop ? "Stopping" : "Restarting";
       DatanodeDetails dn =
           getHddsDatanodes().get(failedNodeIndex).getDatanodeDetails();
       try {
@@ -133,7 +133,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
         LOG.info("Completed {} DataNode {}", stopString, dn.getUuid());
 
       } catch (Exception e) {
-        LOG.error("Failed to shutdown Datanode", dn.getUuid());
+        LOG.error("Failed {} Datanode {}", stopString, dn.getUuid(), e);
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class MiniOzoneLoadGenerator {
 
-  static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(MiniOzoneLoadGenerator.class);
 
   private static String keyNameDelimiter = "_";
@@ -135,10 +135,12 @@ public class MiniOzoneLoadGenerator {
     int bufferCapacity = buffer.capacity();
 
     String keyName = getKeyName(keyIndex, threadName);
+    LOG.trace("LOADGEN: Writing key {}", keyName);
     try (OzoneOutputStream stream = bucket.createKey(keyName,
         bufferCapacity, ReplicationType.RATIS, ReplicationFactor.THREE,
         new HashMap<>())) {
       stream.write(buffer.array());
+      LOG.trace("LOADGEN: Written key {}", keyName);
     } catch (Throwable t) {
       LOG.error("LOADGEN: Create key:{} failed with exception, skipping",
           keyName, t);
@@ -149,6 +151,8 @@ public class MiniOzoneLoadGenerator {
   }
 
   private void readData(OzoneBucket bucket, String keyName) throws Exception {
+    LOG.trace("LOADGEN: Reading key {}", keyName);
+
     int index = Integer.valueOf(keyName.split(keyNameDelimiter)[1]);
 
 
@@ -169,6 +173,7 @@ public class MiniOzoneLoadGenerator {
         throw new IOException("Read mismatch, key:" + keyName +
             " read data does not match the written data");
       }
+      LOG.trace("LOADGEN: Read key {}", keyName);
     } catch (Throwable t) {
       LOG.error("LOADGEN: Read key:{} failed with exception", keyName, t);
       throw t;
@@ -176,8 +181,10 @@ public class MiniOzoneLoadGenerator {
   }
 
   private void deleteKey(OzoneBucket bucket, String keyName) throws Exception {
+    LOG.trace("LOADGEN: Deleting key {}", keyName);
     try {
       bucket.deleteKey(keyName);
+      LOG.trace("LOADGEN: Deleted key {}", keyName);
     } catch (Throwable t) {
       LOG.error("LOADGEN: Unable to delete key:{}", keyName, t);
       throw t;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -114,7 +114,7 @@ public class MiniOzoneLoadGenerator {
         int index = RandomUtils.nextInt();
         String keyName = writeData(index, bucket, threadName);
 
-        readData(bucket, keyName);
+        readData(bucket, keyName, index);
 
         deleteKey(bucket, keyName);
       } catch (Exception e) {
@@ -150,11 +150,9 @@ public class MiniOzoneLoadGenerator {
     return keyName;
   }
 
-  private void readData(OzoneBucket bucket, String keyName) throws Exception {
+  private void readData(OzoneBucket bucket, String keyName, int index)
+      throws Exception {
     LOG.trace("LOADGEN: Reading key {}", keyName);
-
-    int index = Integer.valueOf(keyName.split(keyNameDelimiter)[1]);
-
 
     ByteBuffer buffer = buffers.get(index % numBuffers);
     int bufferCapacity = buffer.capacity();
@@ -216,7 +214,7 @@ public class MiniOzoneLoadGenerator {
           Optional<Integer> index = randomKeyToRead();
           if (index.isPresent()) {
             keyName = getKeyName(index.get(), threadName);
-            readData(agedLoadBucket, keyName);
+            readData(agedLoadBucket, keyName, index.get());
           }
         }
       } catch (Throwable t) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -203,7 +203,7 @@ public class MiniOzoneLoadGenerator {
       String keyName = null;
       try {
         if (agedWriteProbability.isTrue()) {
-          keyName = writeData(agedFileWrittenIndex.incrementAndGet(),
+          keyName = writeData(agedFileWrittenIndex.getAndIncrement(),
               agedLoadBucket, threadName);
         } else {
           Optional<Integer> index = randomKeyToRead();

--- a/hadoop-ozone/integration-test/src/test/resources/log4j.properties
+++ b/hadoop-ozone/integration-test/src/test/resources/log4j.properties
@@ -15,7 +15,7 @@ log4j.rootLogger=info,stdout
 log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 
 log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
 log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Aged IO thread exits on first read due to `ArrayIndexOutOfBoundsException`.  This is caused by using `index` as the key name, while `readKey` expects a string separated by `_`.
2. After fixing the above, it randomly exits due to `OMException: Key not found`.  This is an off-by-one error.  The first key written has `index=1`, but the test randomly attempts to read `index=0`.
3. Add trace level message for read/write/delete operations.
4. Include thread name in log output pattern for `integration-test`.
5. Fix some log messages in `MiniOzoneChaosCluster`

https://issues.apache.org/jira/browse/HDDS-1956

## How was this patch tested?

Manually ran `TestMiniChaosOzoneCluster`:

```
mvn -Phdds -pl :hadoop-ozone-integration-test -Dtest=TestMiniChaosOzoneCluster test
```

Stopped it after a few minutes (see [HDDS-1952](https://issues.apache.org/jira/browse/HDDS-1952)).

Verified that aged IO thread was writing and reading keys (until it started failing due to chaos):

```
2019-08-13 10:19:18,307 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:writeData(138)) - LOADGEN: Writing key pool-245-thread-1_0
2019-08-13 10:19:18,433 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:writeData(143)) - LOADGEN: Written key pool-245-thread-1_0
2019-08-13 10:19:22,473 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_0
2019-08-13 10:19:22,992 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_0
...
2019-08-13 10:19:23,837 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_0
2019-08-13 10:19:23,866 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_0
2019-08-13 10:19:23,866 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:writeData(138)) - LOADGEN: Writing key pool-245-thread-1_1
2019-08-13 10:19:23,870 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:writeData(143)) - LOADGEN: Written key pool-245-thread-1_1
2019-08-13 10:19:23,891 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_1
2019-08-13 10:19:23,933 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_1
2019-08-13 10:19:23,933 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_0
2019-08-13 10:19:23,960 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_0
2019-08-13 10:19:23,960 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_0
2019-08-13 10:19:23,974 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_0
2019-08-13 10:19:23,974 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_0
2019-08-13 10:19:24,017 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_0
2019-08-13 10:19:24,017 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(154)) - LOADGEN: Reading key pool-245-thread-1_1
2019-08-13 10:19:24,044 [pool-245-thread-1] TRACE ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:readData(176)) - LOADGEN: Read key pool-245-thread-1_1
```