### PR TITLE
Hadoop 16438

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3351,6 +3351,17 @@
     </description>
   </property>
 
+  <property>
+    <name>adl.ssl.channel.mode</name>
+    <value></value>
+    <description>
+      When OpenSSL - SSL socket connections are created in OpenSSL mode.
+      When Default_JSSE - SSL socket connections are created in the default JSSE mode.
+      When Default (default) - SSL socket connections are attempted with OpenSSL
+      and will fallback to Default_JSSE mode if OpenSSL is not available at runtime.
+    </description>
+  </property>
+
   <!-- Azure Data Lake File System Configurations Ends Here-->
 
   <property>

--- a/hadoop-tools/hadoop-azure-datalake/pom.xml
+++ b/hadoop-tools/hadoop-azure-datalake/pom.xml
@@ -33,7 +33,7 @@
     <minimalJsonVersion>0.9.1</minimalJsonVersion>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <azure.data.lake.store.sdk.version>2.3.3</azure.data.lake.store.sdk.version>
+    <azure.data.lake.store.sdk.version>2.3.6</azure.data.lake.store.sdk.version>
   </properties>
   <build>
     <plugins>

--- a/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlConfKeys.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlConfKeys.java
@@ -106,6 +106,7 @@ public final class AdlConfKeys {
       "adl.feature.ownerandgroup.enableupn";
   static final boolean ADL_ENABLEUPN_FOR_OWNERGROUP_DEFAULT = false;
   public static final String ADL_HTTP_TIMEOUT = "adl.http.timeout";
+  public static final String ADL_SSL_CHANNEL_MODE = "adl.ssl.channel.mode";
 
   public static void addDeprecatedKeys() {
     Configuration.addDeprecations(new DeprecationDelta[]{

--- a/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/main/java/org/apache/hadoop/fs/adl/AdlFileSystem.java
@@ -203,6 +203,10 @@ public class AdlFileSystem extends FileSystem {
       LOG.info("No valid ADL SDK timeout configured: using SDK default.");
     }
 
+    String sslChannelMode = conf.get(ADL_SSL_CHANNEL_MODE,
+        "Default");
+    options.setSSLChannelMode(sslChannelMode);
+
     adlClient.setOptions(options);
 
     boolean trackLatency = conf

--- a/hadoop-tools/hadoop-azure-datalake/src/site/markdown/troubleshooting_adl.md
+++ b/hadoop-tools/hadoop-azure-datalake/src/site/markdown/troubleshooting_adl.md
@@ -153,3 +153,13 @@ addressed by lowering the timeout used by the SDK.  A lower timeout at the
 storage layer may allow more retries to be attempted and actually increase
 the likelihood of success before hitting the framework's timeout, as attempts
 that may ultimately fail will fail faster.
+
+## SSL Socket Channel Mode
+
+ADL SDK will by default attempt to create secure socket connections over
+OpenSSL as they provide significant performance improvements over Https. If
+there are runtime issues, SDK will default connections over Default_JSSE. This
+can be overridden with the hadoop property `adl.ssl.channel.mode`. Possible
+values for this config are OpenSSL, Default_JSSE and Default (default).
+Setting the config to OpenSSL or Default_JSSE will try the connection to
+only that mode.


### PR DESCRIPTION
Enabling config option to control the SSL channel mode. Possible channel modes being -
(a) OpenSSL
(b) Default_JSSE
(c) Default - This is the default choice if the config is not present or is invalid. When set to this, connection creation is attempted in OpenSSL mode and will fallback to Default_JSSE mode on any failure.