### PR TITLE
HDDS-1964. TestOzoneClientProducer fails with ConnectException

### DIFF
--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.s3;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,6 +79,7 @@ public class TestOzoneClientProducer {
     context = Mockito.mock(ContainerRequestContext.class);
     OzoneConfiguration config = new OzoneConfiguration();
     config.setBoolean(OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY, true);
+    config.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, "");
     setupContext();
     producer.setContext(context);
     producer.setOzoneConfiguration(config);

--- a/hadoop-ozone/s3gateway/src/test/resources/log4j.properties
+++ b/hadoop-ozone/s3gateway/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# log4j configuration used during build and unit tests
+
+log4j.rootLogger=info,stdout
+log4j.threshold=ALL
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+
+log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestOzoneClientProducer` verifies that `RpcClient` cannot be created because OM address is not configured.  The call to `producer.createClient()` is expected to fail with the message `Couldn't create protocol`, which is triggered by `IllegalArgumentException: Could not find any configured addresses for OM. Please configure the system with ozone.om.address`.  bf457797f607f3aeeb2292e63f440cb13e15a2d9 added the default address as explicitly configured value, so client creation now progresses further and fails when it cannot connect to OM (which is not started by the unit test).

This change simply sets the previous empty OM address for this test.

It also adds log4j config for `s3gateway` tests to produce better output next time, because [currently](https://raw.githubusercontent.com/elek/ozone-ci/master/trunk/trunk-nightly-wxhxr/unit/hadoop-ozone/s3gateway/org.apache.hadoop.ozone.s3.TestOzoneClientProducer-output.txt) it is not very helpful.

https://issues.apache.org/jira/browse/HDDS-1964

## How was this patch tested?

```
$ mvn -Phdds -pl :hadoop-ozone-s3gateway test
...
[INFO] Tests run: 77, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] BUILD SUCCESS
```