### PR TITLE
HADOOP-16138. hadoop fs mkdir / of nonexistent abfs container raises NPE

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Mkdir.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Mkdir.java
@@ -81,7 +81,9 @@ class Mkdir extends FsCommand {
       }
 
       if (!item.fs.exists(itemParentPath)) {
-        throw new PathNotFoundException(itemParentPath.toString());
+        throw new PathNotFoundException(String.format(
+            "mkdir failed for path: %s. Item parent path not found: %s.",
+        itemPath.toString(), itemParentPath.toString()));
       }
     }
     if (!item.fs.mkdirs(item.path)) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Mkdir.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Mkdir.java
@@ -73,6 +73,13 @@ class Mkdir extends FsCommand {
       // we want a/b
       final Path itemPath = new Path(item.path.toString());
       final Path itemParentPath = itemPath.getParent();
+
+      if(itemParentPath == null) {
+        throw new PathNotFoundException(String.format(
+            "Item: %s parent path's is null. This can happen if mkdir is " +
+                "called on root, so there's no parent.", itemPath.toString()));
+      }
+
       if (!item.fs.exists(itemParentPath)) {
         throw new PathNotFoundException(itemParentPath.toString());
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Mkdir.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Mkdir.java
@@ -76,7 +76,7 @@ class Mkdir extends FsCommand {
 
       if(itemParentPath == null) {
         throw new PathNotFoundException(String.format(
-            "Item: %s parent path's is null. This can happen if mkdir is " +
+            "Item: %s parent's path is null. This can happen if mkdir is " +
                 "called on root, so there's no parent.", itemPath.toString()));
       }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -30,7 +30,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
 
 /**
- * Tests for Azure Blob FileSystem CLI
+ * Tests for Azure Blob FileSystem CLI.
  */
 public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
 
@@ -42,7 +42,7 @@ public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
 
   /**
    * Test for HADOOP-16138: hadoop fs mkdir / of nonexistent abfs
-   * container raises NPE
+   * container raises NPE.
    *
    * The command should return with 1 exit status, but there should be no NPE.
    *

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.apache.hadoop.fs.FsShell;
 import org.apache.hadoop.conf.Configuration;
 
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_SCHEME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
 
@@ -35,6 +36,8 @@ public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
 
   public  ITestAzureBlobFileSystemCLI() throws Exception {
     super();
+    final AbfsConfiguration conf = getConfiguration();
+    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, false);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FsShell;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_SCHEME;
+import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
+
+/**
+ * Tests for Azure Blob FileSystem CLI
+ */
+public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
+
+  public  ITestAzureBlobFileSystemCLI() throws Exception {
+    super();
+  }
+
+  /**
+   * Test for HADOOP-16138: hadoop fs mkdir / of nonexistent abfs
+   * container raises NPE
+   *
+   * The command should return with 1 exit status, but there should be no NPE.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testMkdirRootNonExistentContainer() throws Exception {
+    final Configuration rawConf = getRawConfiguration();
+    FsShell fsShell = new FsShell(rawConf);
+    final String account =
+        rawConf.get(FS_AZURE_ABFS_ACCOUNT_NAME, null);
+
+    String nonExistentContainer = "nonexistent-" + UUID.randomUUID();
+
+    int result = fsShell.run(new String[] { "-mkdir",
+        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account + "/" });
+
+    assertEquals(1, result);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -18,11 +18,12 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FsShell;
+import java.util.UUID;
+
 import org.junit.Test;
 
-import java.util.UUID;
+import org.apache.hadoop.fs.FsShell;
+import org.apache.hadoop.conf.Configuration;
 
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_SCHEME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;


### PR DESCRIPTION
Change-Id: I2f637865c871e400b95fe7ddaa24bf99fa192023