### PR TITLE
HDDS-1946. CertificateClient should not persist keys/certs to ozone.m…

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -271,7 +271,7 @@ public class SecurityConfig {
   }
 
   /**
-   * Returns the File path to where keys are stored.
+   * Returns the File path to where certificates are stored.
    *
    * @return path Key location.
    */
@@ -282,7 +282,8 @@ public class SecurityConfig {
   }
 
   /**
-   * Returns the File path to where keys are stored with an addition component
+   * Returns the File path to where certificates are stored with an addition
+   * component
    * name inserted in between.
    *
    * @param component - Component Name - String.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -25,6 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+
+import java.nio.file.Paths;
+
 /**
  * Certificate client for DataNodes.
  */
@@ -32,13 +35,16 @@ public class DNCertificateClient extends DefaultCertificateClient {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(DNCertificateClient.class);
+
+  public static final String COMPONENT_NAME = Paths.get("dn").toString();
+
   public DNCertificateClient(SecurityConfig securityConfig,
       String certSerialId) {
-    super(securityConfig, LOG, certSerialId);
+    super(securityConfig, LOG, certSerialId, COMPONENT_NAME);
   }
 
   public DNCertificateClient(SecurityConfig securityConfig) {
-    super(securityConfig, LOG, null);
+    super(securityConfig, LOG, null, COMPONENT_NAME);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -89,16 +89,18 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   private X509Certificate x509Certificate;
   private Map<String, X509Certificate> certificateMap;
   private String certSerialId;
+  private String component;
 
 
   DefaultCertificateClient(SecurityConfig securityConfig, Logger log,
-      String certSerialId) {
+      String certSerialId, String component) {
     Objects.requireNonNull(securityConfig);
     this.securityConfig = securityConfig;
     keyCodec = new KeyCodec(securityConfig);
     this.logger = log;
     this.certificateMap = new ConcurrentHashMap<>();
     this.certSerialId = certSerialId;
+    this.component = component;
 
     loadAllCertificates();
   }
@@ -108,7 +110,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * */
   private void loadAllCertificates() {
     // See if certs directory exists in file system.
-    Path certPath = securityConfig.getCertificateLocation();
+    Path certPath = securityConfig.getCertificateLocation(component);
     if (Files.exists(certPath) && Files.isDirectory(certPath)) {
       getLogger().info("Loading certificate from location:{}.",
           certPath);
@@ -116,7 +118,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
       if (certFiles != null) {
         CertificateCodec certificateCodec =
-            new CertificateCodec(securityConfig);
+            new CertificateCodec(securityConfig, component);
         for (File file : certFiles) {
           if (file.isFile()) {
             try {
@@ -477,9 +479,10 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   @Override
   public void storeCertificate(String pemEncodedCert, boolean force,
       boolean caCert) throws CertificateException {
-    CertificateCodec certificateCodec = new CertificateCodec(securityConfig);
+    CertificateCodec certificateCodec = new CertificateCodec(securityConfig,
+        component);
     try {
-      Path basePath = securityConfig.getCertificateLocation();
+      Path basePath = securityConfig.getCertificateLocation(component);
 
       X509Certificate cert =
           CertificateCodec.getX509Certificate(pemEncodedCert);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/OMCertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/OMCertificateClient.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 
+import java.nio.file.Paths;
+
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.GETCERT;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.RECOVER;
@@ -39,13 +41,15 @@ public class OMCertificateClient extends DefaultCertificateClient {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMCertificateClient.class);
 
+  public static final String COMPONENT_NAME = Paths.get("om").toString();
+
   public OMCertificateClient(SecurityConfig securityConfig,
       String certSerialId) {
-    super(securityConfig, LOG, certSerialId);
+    super(securityConfig, LOG, certSerialId, COMPONENT_NAME);
   }
 
   public OMCertificateClient(SecurityConfig securityConfig) {
-    super(securityConfig, LOG, null);
+    super(securityConfig, LOG, null, COMPONENT_NAME);
   }
 
   protected InitResponse handleCase(InitCase init) throws

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
@@ -139,7 +139,8 @@ public class TestCertificateClientInit {
     }
 
     if (certPresent) {
-      CertificateCodec codec = new CertificateCodec(securityConfig);
+      CertificateCodec codec = new CertificateCodec(securityConfig,
+          DNCertificateClient.COMPONENT_NAME);
       codec.writeCertificate(new X509CertificateHolder(
           x509Certificate.getEncoded()));
     } else {
@@ -179,7 +180,8 @@ public class TestCertificateClientInit {
     }
 
     if (certPresent) {
-      CertificateCodec codec = new CertificateCodec(securityConfig);
+      CertificateCodec codec = new CertificateCodec(securityConfig,
+          OMCertificateClient.COMPONENT_NAME);
       codec.writeCertificate(new X509CertificateHolder(
           x509Certificate.getEncoded()));
     } else {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -284,9 +284,10 @@ public class TestDefaultCertificateClient {
     X509Certificate cert1 = generateX509Cert(keyPair);
     X509Certificate cert2 = generateX509Cert(keyPair);
     X509Certificate cert3 = generateX509Cert(keyPair);
+    String component = DNCertificateClient.COMPONENT_NAME;
 
-    Path certPath = dnSecurityConfig.getCertificateLocation();
-    CertificateCodec codec = new CertificateCodec(dnSecurityConfig);
+    Path certPath = dnSecurityConfig.getCertificateLocation(component);
+    CertificateCodec codec = new CertificateCodec(dnSecurityConfig, component);
 
     // Certificate not found.
     LambdaTestUtils.intercept(CertificateException.class, "Error while" +
@@ -308,7 +309,7 @@ public class TestDefaultCertificateClient {
     codec.writeCertificate(certPath, "3.crt",
         getPEMEncodedString(cert3), true);
 
-    // Re instentiate DN client which will load certificates from filesystem.
+    // Re instantiate DN client which will load certificates from filesystem.
     dnCertClient = new DNCertificateClient(dnSecurityConfig, certSerialId);
 
     assertNotNull(dnCertClient.getCertificate(cert1.getSerialNumber()
@@ -392,11 +393,13 @@ public class TestDefaultCertificateClient {
     FileUtils.deleteQuietly(Paths.get(dnSecurityConfig.getKeyLocation()
         .toString(), dnSecurityConfig.getCertificateFileName()).toFile());
 
-    CertificateCodec omCertCodec = new CertificateCodec(omSecurityConfig);
+    CertificateCodec omCertCodec = new CertificateCodec(omSecurityConfig,
+        OMCertificateClient.COMPONENT_NAME);
     omCertCodec.writeCertificate(new X509CertificateHolder(
         x509Certificate.getEncoded()));
 
-    CertificateCodec dnCertCodec = new CertificateCodec(dnSecurityConfig);
+    CertificateCodec dnCertCodec = new CertificateCodec(dnSecurityConfig,
+        DNCertificateClient.COMPONENT_NAME);
     dnCertCodec.writeCertificate(new X509CertificateHolder(
         x509Certificate.getEncoded()));
     // Check for DN.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -93,7 +93,8 @@ public class TestHddsSecureDatanodeInit {
       service.initializeCertificateClient(conf);
       return null;
     });
-    certCodec = new CertificateCodec(securityConfig);
+    certCodec = new CertificateCodec(securityConfig,
+        DNCertificateClient.COMPONENT_NAME);
     keyCodec = new KeyCodec(securityConfig);
     dnLogs.clearOutput();
     privateKey = service.getCertificateClient().getPrivateKey();
@@ -120,7 +121,7 @@ public class TestHddsSecureDatanodeInit {
     FileUtils.deleteQuietly(Paths.get(securityConfig.getKeyLocation()
         .toString(), securityConfig.getPublicKeyFileName()).toFile());
     FileUtils.deleteQuietly(Paths.get(securityConfig
-        .getCertificateLocation().toString(),
+        .getCertificateLocation(DNCertificateClient.COMPONENT_NAME).toString(),
         securityConfig.getCertificateFileName()).toFile());
     dnLogs.clearOutput();
     client = new DNCertificateClient(securityConfig,


### PR DESCRIPTION
…etadata.dir

The issue was that when OM and SCM are deployed on the same host with ozone.metadata.dir defined. SCM can start successfully but OM can not because the key/cert from OM will collide with SCM.

The solution implemented in this patch is to store certs in a sub directory inside ozone.metadata.dir based on the component. Ozone Manager will store its certs in `${ozone.metadata.dir}/om/certs` and Datanode will  store in `${ozone.metadata.dir}/dn/certs` to avoid conflicts. This solution was discussed with @anuengineer and I thank him for his guidance.

Testing done: 
I tested the patch in docker containers and verified that certs are now stored in `${ozone.metadata.dir}/${component}/certs` path. I modified the unit tests and verified that all unit tests pass.
 