### PR TITLE
Fix a typo in TextInputFormat.java

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TextInputFormat.java
@@ -54,7 +54,7 @@ public class TextInputFormat extends FileInputFormat<LongWritable, Text> {
   }
 
   @Override
-  protected boolean isSplitable(JobContext context, Path file) {
+  protected boolean isSplittable(JobContext context, Path file) {
     final CompressionCodec codec =
       new CompressionCodecFactory(context.getConfiguration()).getCodec(file);
     if (null == codec) {


### PR DESCRIPTION
When I read source code about TextInputFormat, I found a typo.