### PR TITLE
HDDS-1999. Basic acceptance test and SCM/OM web UI broken by Bootstrap upgrade

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/index.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/index.html
@@ -26,7 +26,7 @@
 
     <title>HDFS Storage Container Manager</title>
 
-    <link href="static/bootstrap-3.3.7/css/bootstrap.min.css" rel="stylesheet">
+    <link href="static/bootstrap-3.4.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="static/hadoop.css" rel="stylesheet">
     <link href="static/nvd3-1.8.5.min.css" rel="stylesheet">
 
@@ -63,7 +63,7 @@
 
 </div><!-- /.container -->
 
-<script src="static/jquery-3.3.1.min.js"></script>
+<script src="static/jquery-3.4.1.min.js"></script>
 <script src="static/angular-1.6.4.min.js"></script>
 <script src="static/angular-route-1.6.4.min.js"></script>
 <script src="static/d3-3.5.17.min.js"></script>
@@ -71,6 +71,6 @@
 <script src="static/angular-nvd3-1.0.9.min.js"></script>
 <script src="static/ozone.js"></script>
 <script src="scm.js"></script>
-<script src="static/bootstrap-3.3.7/js/bootstrap.min.js"></script>
+<script src="static/bootstrap-3.4.1/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
@@ -26,7 +26,7 @@ ${DATANODE_HOST}        datanode
 
 Check webui static resources
     Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit HTTP user
-    ${result} =        Execute                curl --negotiate -u : -s -I http://scm:9876/static/bootstrap-3.3.7/js/bootstrap.min.js
+    ${result} =        Execute                curl --negotiate -u : -s -I http://scm:9876/static/bootstrap-3.4.1/js/bootstrap.min.js
                        Should contain         ${result}    200
 
 Start freon testing

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/index.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/index.html
@@ -26,7 +26,7 @@
 
     <title>Ozone Manager</title>
 
-    <link href="static/bootstrap-3.3.7/css/bootstrap.min.css" rel="stylesheet">
+    <link href="static/bootstrap-3.4.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="static/hadoop.css" rel="stylesheet">
     <link href="static/nvd3-1.8.5.min.css" rel="stylesheet">
 
@@ -57,7 +57,7 @@
     <ng-view></ng-view>
 </div><!-- /.container -->
 
-<script src="static/jquery-3.3.1.min.js"></script>
+<script src="static/jquery-3.4.1.min.js"></script>
 <script src="static/angular-1.6.4.min.js"></script>
 <script src="static/angular-route-1.6.4.min.js"></script>
 <script src="static/d3-3.5.17.min.js"></script>
@@ -65,6 +65,6 @@
 <script src="static/angular-nvd3-1.0.9.min.js"></script>
 <script src="static/ozone.js"></script>
 <script src="ozoneManager.js"></script>
-<script src="static/bootstrap-3.3.7/js/bootstrap.min.js"></script>
+<script src="static/bootstrap-3.4.1/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/hadoop-ozone/s3gateway/src/main/resources/browser.html
+++ b/hadoop-ozone/s3gateway/src/main/resources/browser.html
@@ -24,7 +24,7 @@ permissions and limitations under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="static/images/ozone.ico">
     <link rel="stylesheet"
-          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <link rel="stylesheet"
           href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">
     <link rel="stylesheet"
@@ -138,8 +138,8 @@ permissions and limitations under the License.
 
 </html>
 
-<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/4.4.0/bootbox.min.js"></script>
 <script src="https://sdk.amazonaws.com/js/aws-sdk-2.207.0.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.0/moment.min.js"></script>

--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
@@ -26,7 +26,7 @@
 
     <title>S3 gateway -- Apache Hadoop Ozone</title>
 
-    <link href="bootstrap-3.3.7/css/bootstrap.min.css" rel="stylesheet">
+    <link href="bootstrap-3.4.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="hadoop.css" rel="stylesheet">
     <link href="ozone.css" rel="stylesheet">
 
@@ -74,6 +74,6 @@
     </p>
 </div><!-- /.container -->
 
-<script src="static/bootstrap-3.3.7/js/bootstrap.min.js"></script>
+<script src="static/bootstrap-3.4.1/js/bootstrap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update bootstrap/jquery version references in SCM/OM/S3G and in acceptance test.

https://issues.apache.org/jira/browse/HDDS-1999

## How was this patch tested?

Ran `basic.robot` in `ozones3` compose folder.

Checked SCM/OM/S3G web UI visually.