### PR TITLE
HDDS-1808. TestRatisPipelineCreateAndDestory times out

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -39,7 +39,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests for RatisPipelineUtils.
  */
-public class TestRatisPipelineCreateAndDestory {
+public class TestRatisPipelineCreateAndDestroy {
 
   private static MiniOzoneCluster cluster;
   private OzoneConfiguration conf = new OzoneConfiguration();
@@ -63,7 +63,7 @@ public class TestRatisPipelineCreateAndDestory {
     cluster.shutdown();
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 180000)
   public void testAutomaticPipelineCreationOnPipelineDestroy()
       throws Exception {
     init(6);
@@ -79,7 +79,7 @@ public class TestRatisPipelineCreateAndDestory {
     waitForPipelines(2);
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 180000)
   public void testPipelineCreationOnNodeRestart() throws Exception {
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL,
         5, TimeUnit.SECONDS);


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Increase timeout of the test cases (both of them are prone to intermittent timeout).  Rationale: (1) there is already a timeout on `waitForPipelines()`, which was increased in `0d62753da96` without increasing overall test timeout, (2) test timeout needs to account for mini cluster startup.
 * Fix typo in class name.

https://issues.apache.org/jira/browse/HDDS-1808

## How was this patch tested?

Ran the test several times.  It passed in all cases.  It took as long as 77 seconds in one case, so one of the two test cases would have failed with the original 30 second timeout.