### PR TITLE
HDDS-2024. Fix rat.sh problems

### DIFF
--- a/hadoop-ozone/dev-support/checks/rat.sh
+++ b/hadoop-ozone/dev-support/checks/rat.sh
@@ -26,7 +26,7 @@ cd ../hadoop-ozone || exit 1
 mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
 
 cd "$DIR/../../.." || exit 1
-grep -r --include=rat.txt "!????" | tee "$REPORT_FILE"
+grep -r --include=rat.txt "!????" hadoop-hdds hadoop-ozone | tee "$REPORT_FILE"
 if [ "$(cat target/rat-aggregated.txt)" ]; then
    exit 1
 fi

--- a/hadoop-ozone/dev-support/checks/rat.sh
+++ b/hadoop-ozone/dev-support/checks/rat.sh
@@ -17,7 +17,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 mkdir -p target
-REPORT_FILE="$DIR/../../../target/rat-aggretaged.txt"
+REPORT_FILE="$DIR/../../../target/rat-aggregated.txt"
 mkdir -p "$(dirname "$REPORT_FILE")"
 
 cd hadoop-hdds || exit 1
@@ -27,7 +27,7 @@ mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
 
 cd "$DIR/../../.." || exit 1
 grep -r --include=rat.txt "!????" hadoop-hdds hadoop-ozone | tee "$REPORT_FILE"
-if [ "$(cat target/rat-aggregated.txt)" ]; then
+if [[ -s "${REPORT_FILE}" ]]; then
    exit 1
 fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix problems in `rat.sh`:

1. `grep: warning: recursive search of stdin` due to missing search target (which works with GNU grep, but not with some others)
2. `cat: target/rat-aggregated.txt: No such file or directory` due mismatch of `REPORT_FILE` value vs. literal
3. typo in `REPORT_FILE` value

Also: use `-s` test instead of `cat` (probably cheaper and safer).

https://issues.apache.org/jira/browse/HDDS-2024

## How was this patch tested?

```
$ ./hadoop-ozone/dev-support/checks/rat.sh
...
[INFO] Build failures were ignored.
hadoop-hdds/common/target/rat.txt: !????? hadoop-hdds/common/src/main/java/org/apache/hadoop/utils/db/cache/CacheResult.java
hadoop-ozone/dist/target/rat.txt: !????? hadoop-ozone/dist/src/main/compose/ozones3-haproxy/haproxy-conf/haproxy.cfg
hadoop-ozone/integration-test/target/rat.txt: !????? hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
hadoop-ozone/common/target/rat.txt: !????? hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/BooleanBiFunction.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/bucket/TestS3BucketDeleteResponse.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerDoubleBufferHelper.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
hadoop-ozone/ozone-manager/target/rat.txt: !????? hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java

$ echo $?
1
```