### PR TITLE
YARN-9783. Remove low-level zookeeper test to be able to build Hadoop against zookeeper 3.5.5

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
@@ -24,9 +24,6 @@ import org.apache.hadoop.registry.client.impl.zk.ZKPathDumper;
 import org.apache.hadoop.registry.client.impl.zk.CuratorService;
 import org.apache.hadoop.registry.client.impl.zk.RegistrySecurity;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.Login;
-import org.apache.zookeeper.server.ZooKeeperSaslServer;
-import org.apache.zookeeper.server.auth.SaslServerCallbackHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,36 +51,6 @@ public class TestSecureRegistry extends AbstractSecureRegistryTest {
   public void afterTestSecureZKService() throws Throwable {
     disableKerberosDebugging();
     RegistrySecurity.clearZKSaslClientProperties();
-  }
-
-  /**
-  * this is a cut and paste of some of the ZK internal code that was
-   * failing on windows and swallowing its exceptions
-   */
-  @Test
-  public void testLowlevelZKSaslLogin() throws Throwable {
-    RegistrySecurity.bindZKToServerJAASContext(ZOOKEEPER_SERVER_CONTEXT);
-    String serverSection =
-        System.getProperty(ZooKeeperSaslServer.LOGIN_CONTEXT_NAME_KEY,
-            ZooKeeperSaslServer.DEFAULT_LOGIN_CONTEXT_NAME);
-    assertEquals(ZOOKEEPER_SERVER_CONTEXT, serverSection);
-
-    AppConfigurationEntry entries[];
-    entries = javax.security.auth.login.Configuration.getConfiguration()
-                                                     .getAppConfigurationEntry(
-                                                         serverSection);
-
-    assertNotNull("null entries", entries);
-
-    SaslServerCallbackHandler saslServerCallbackHandler =
-        new SaslServerCallbackHandler(
-            javax.security.auth.login.Configuration.getConfiguration());
-    Login login = new Login(serverSection, saslServerCallbackHandler);
-    try {
-      login.startThreadIfNeeded();
-    } finally {
-      login.shutdown();
-    }
   }
 
   @Test


### PR DESCRIPTION
Currently the Hadoop build (with ZooKeeper 3.5.5) fails because of a YARN test case: TestSecureRegistry.testLowlevelZKSaslLogin(). This test case seems to use low-level ZooKeeper internal code, which changed in the new ZooKeeper version.

Removing the testcase will enable us to build and test Hadoop with the latest ZooKeeper version.