### PR TITLE
HADOOP-16534. Exclude submarine from hadoop source build.

### DIFF
--- a/hadoop-assemblies/src/main/resources/assemblies/hadoop-src.xml
+++ b/hadoop-assemblies/src/main/resources/assemblies/hadoop-src.xml
@@ -58,6 +58,7 @@
         <exclude>**/SecurityAuth.audit*</exclude>
         <exclude>hadoop-ozone/**</exclude>
         <exclude>hadoop-hdds/**</exclude>
+        <exclude>hadoop-submarine/**</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -406,8 +406,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
             <exclude>**/*.js</exclude>
             <exclude>hadoop-hdds/**/</exclude>
             <exclude>hadoop-ozone/**/</exclude>
-            <exclude>hadoop-submarine/target/**</exclude>
-            <exclude>hadoop-submarine/**/target/**</exclude>
+            <exclude>hadoop-submarine/**/</exclude>
             <exclude>licenses/**</exclude>
             <exclude>licenses-binary/**</exclude>
          </excludes>


### PR DESCRIPTION
When we do source package of hadoop, it should not contain submarine project/code.