### PR TITLE
HDDS-2042. Avoid log on console with Ozone shell

### DIFF
--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -117,6 +117,8 @@ function ozonecmd_case
     ;;
     freon)
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.freon.Freon
+      OZONE_FREON_OPTS="${OZONE_FREON_OPTS} -Dhadoop.log.file=ozone-freon.log -Dlog4j.configuration=file:${HADOOP_CONF_DIR}/ozone-shell-log4j.properties"
+      HADOOP_OPTS="${HADOOP_OPTS} ${OZONE_FREON_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     genesis)
@@ -136,6 +138,7 @@ function ozonecmd_case
     ;;
     sh | shell)
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.web.ozShell.OzoneShell
+      HDFS_OM_SH_OPTS="${HDFS_OM_SH_OPTS} -Dhadoop.log.file=ozone-shell.log -Dlog4j.configuration=file:${HADOOP_CONF_DIR}/ozone-shell-log4j.properties"
       HADOOP_OPTS="${HADOOP_OPTS} ${HDFS_OM_SH_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"
     ;;

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -90,6 +90,7 @@ run cp -r "${ROOT}/hadoop-common-project/hadoop-common/src/main/conf" "etc/hadoo
 run cp "${ROOT}/hadoop-ozone/dist/src/main/conf/om-audit-log4j2.properties" "etc/hadoop"
 run cp "${ROOT}/hadoop-ozone/dist/src/main/conf/dn-audit-log4j2.properties" "etc/hadoop"
 run cp "${ROOT}/hadoop-ozone/dist/src/main/conf/scm-audit-log4j2.properties" "etc/hadoop"
+run cp "${ROOT}/hadoop-ozone/dist/src/main/conf/ozone-shell-log4j.properties" "etc/hadoop"
 run cp "${ROOT}/hadoop-ozone/dist/src/main/conf/ozone-site.xml" "etc/hadoop"
 run cp -f "${ROOT}/hadoop-ozone/dist/src/main/conf/log4j.properties" "etc/hadoop"
 run cp "${ROOT}/hadoop-hdds/common/src/main/resources/network-topology-default.xml" "etc/hadoop"

--- a/hadoop-ozone/dist/src/main/conf/ozone-shell-log4j.properties
+++ b/hadoop-ozone/dist/src/main/conf/ozone-shell-log4j.properties
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+hadoop.log.dir=.
+hadoop.log.file=ozone-shell.log
+
+log4j.rootLogger=INFO,FILE
+
+log4j.threshold=ALL
+
+log4j.appender.FILE=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.FILE.file=${hadoop.log.dir}/${hadoop.log.file}
+log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.FILE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{1}:%L - %m%n
+
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
+log4j.logger.org.apache.ratis.conf.ConfUtils=WARN
+log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
+log4j.logger.org.apache.ratis.grpc.client.GrpcClientProtocolClient=WARN

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -54,7 +54,6 @@ Test ozone shell
     [arguments]     ${protocol}         ${server}       ${volume}
     ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --quota 100TB
                     Should not contain  ${result}       Failed
-                    Should contain      ${result}       Creating Volume: ${volume}
     ${result} =     Execute             ozone sh volume list ${protocol}${server}/ | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
     ${result} =     Execute             ozone sh volume list | grep -Ev 'Removed|DEBUG|ERROR|INFO|TRACE|WARN' | jq -r '. | select(.name=="${volume}")'

--- a/hadoop-ozone/dist/src/main/smoketest/createbucketenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createbucketenv.robot
@@ -29,7 +29,6 @@ ${bucket}       bucket1
 Create volume
     ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --quota 100TB
                     Should not contain  ${result}       Failed
-                    Should contain      ${result}       Creating Volume: ${volume}
 Create bucket
                     Execute             ozone sh bucket create /${volume}/${bucket}
 

--- a/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
@@ -29,7 +29,6 @@ ${bucket}       bucket1
 Create volume
     ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --quota 100TB
                     Should not contain  ${result}       Failed
-                    Should contain      ${result}       Creating Volume: ${volume}
 Create bucket
                     Execute             ozone sh bucket create /${volume}/${bucket}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sample Docker Compose-based clusters are currently [configured](https://github.com/apache/hadoop/blob/3329257d99d2808e66ae6c2fe87a9c4f8877026f/hadoop-ozone/dist/src/main/compose/ozone/docker-config#L32-L33) to log almost everything to the console.  This is useful because logs can be accessed via `docker logs` or `docker-compose logs`.  Further, [default logs settings](https://github.com/apache/hadoop/blob/3329257d99d2808e66ae6c2fe87a9c4f8877026f/hadoop-ozone/dist/src/main/conf/log4j.properties#L137-L138) for non-Docker Compose clusters also direct INFO and higher level messages to the console.

However, it does not work well with interactive clients, eg. `ozone sh`, since regular console output and log messages are mixed.  Previously there [were](https://issues.apache.org/jira/browse/HDDS-1489) [attempts](https://issues.apache.org/jira/browse/HDDS-465) to work around this by setting specific class log levels to `WARN` or `ERROR`.  This approach has two problems:
1. it applies to Ozone server processes, too
2. new INFO or higher level messages may be introduced any time (eg. MetricsSystem startup)

This pull request proposes to collect logs for `ozone` subcommands `sh` and `freon` to files instead of the console.  It eliminates the need for per-class log level settings (though current ones are kept).

https://issues.apache.org/jira/browse/HDDS-2042

## How was this patch tested?

Tested commands in sample docker cluster.  Output is clean (except pesky warning (omitted here) about illegal access for key operations).

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozones3
$ docker-compose exec scm bash
bash-4.2$ ozone sh volume create vol1
bash-4.2$ ozone sh bucket create vol1/buck1
bash-4.2$ ozone sh key put vol1/buck1/key1 /etc/passwd
```

Verified that log file contains the messages previously sent to console:

```
bash-4.2$ tail /var/log/hadoop/ozone-shell.log
2019-08-27 14:45:02,695 [main] INFO  RpcClient:293 - Creating Volume: vol1, with hadoop as owner.
2019-08-27 14:45:13,099 [main] INFO  RpcClient:432 - Creating Bucket: vol1/buck1, with Versioning false and Storage Type set to DISK and Encryption set to false
2019-08-27 14:45:24,011 [main] INFO  MetricsConfig:118 - Loaded properties from hadoop-metrics2.properties
2019-08-27 14:45:24,160 [main] INFO  MetricsSystemImpl:374 - Scheduled Metric snapshot period at 10 second(s).
2019-08-27 14:45:24,160 [main] INFO  MetricsSystemImpl:191 - XceiverClientMetrics metrics system started
```

Verbose mode still works:

```
bash-4.2$ ozone sh --verbose key put vol1/buck1/key2 /etc/passwd
Volume Name : vol1
Bucket Name : buck1
Key Name : key2
File Hash : b01f053617ddfeb782a3e757d9c08912
```

Freon:

```
bash-4.2$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=20 --numOfThreads=1

 100.00% |?????????????????????????????????????????????????????????????????????????????????????????????????????|  20/20 Time: 0:00:03

***************************************************
Status: Success
Git Base Revision: e97acb3bd8f3befd27418996fa5d4b50bf2e17bf
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 20
Ratis replication factor: ONE
Ratis replication type: STAND_ALONE
Average Time spent in volume creation: 00:00:00,080
Average Time spent in bucket creation: 00:00:00,013
Average Time spent in key creation: 00:00:00,234
Average Time spent in key write: 00:00:02,310
Total bytes written: 204800
Total Execution time: 00:00:06,284
***************************************************
```