### PR TITLE
HDDS-1949. Missing or error-prone test cleanup

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -240,7 +240,7 @@ public interface MiniOzoneCluster {
     protected static final int ACTIVE_OMS_NOT_SET = -1;
 
     protected final OzoneConfiguration conf;
-    protected final String path;
+    protected String path;
 
     protected String clusterId;
     protected String omServiceId;
@@ -269,9 +269,7 @@ public interface MiniOzoneCluster {
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
-      this.clusterId = UUID.randomUUID().toString();
-      this.path = GenericTestUtils.getTempPath(
-          MiniOzoneClusterImpl.class.getSimpleName() + "-" + clusterId);
+      setClusterId(UUID.randomUUID().toString());
     }
 
     /**
@@ -283,6 +281,8 @@ public interface MiniOzoneCluster {
      */
     public Builder setClusterId(String id) {
       clusterId = id;
+      path = GenericTestUtils.getTempPath(
+          MiniOzoneClusterImpl.class.getSimpleName() + "-" + clusterId);
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -53,6 +54,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachin
 import org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.test.TestGenericTestUtils;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -64,7 +66,7 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class TestMiniOzoneCluster {
 
-  private static MiniOzoneCluster cluster;
+  private MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
 
   private final static File TEST_ROOT = TestGenericTestUtils.getTestDir();
@@ -78,15 +80,19 @@ public class TestMiniOzoneCluster {
     conf.setBoolean(DFS_CONTAINER_RATIS_IPC_RANDOM_PORT, true);
     WRITE_TMP.mkdirs();
     READ_TMP.mkdirs();
-    WRITE_TMP.deleteOnExit();
-    READ_TMP.deleteOnExit();
   }
 
-  @AfterClass
-  public static void cleanup() {
+  @After
+  public void cleanup() {
     if (cluster != null) {
       cluster.shutdown();
     }
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    FileUtils.deleteQuietly(WRITE_TMP);
+    FileUtils.deleteQuietly(READ_TMP);
   }
 
   @Test(timeout = 30000)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -41,6 +42,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -90,8 +92,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -103,8 +103,6 @@ public class TestStorageContainerManager {
   private static XceiverClientManager xceiverClientManager =
       new XceiverClientManager(
       new OzoneConfiguration());
-  private static final Logger LOG = LoggerFactory.getLogger(
-      TestStorageContainerManager.class);
 
   /**
    * Set the timeout for every test.
@@ -299,9 +297,7 @@ public class TestStorageContainerManager {
         }
       }, 1000, 10000);
     } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
+      cluster.shutdown();
     }
   }
 
@@ -322,50 +318,54 @@ public class TestStorageContainerManager {
         .build();
     cluster.waitForClusterToBeReady();
 
-    DeletedBlockLog delLog = cluster.getStorageContainerManager()
-        .getScmBlockManager().getDeletedBlockLog();
-    Assert.assertEquals(0, delLog.getNumOfValidTransactions());
+    try {
+      DeletedBlockLog delLog = cluster.getStorageContainerManager()
+          .getScmBlockManager().getDeletedBlockLog();
+      Assert.assertEquals(0, delLog.getNumOfValidTransactions());
 
-    int limitSize = 1;
-    // Reset limit value to 1, so that we only allow one TX is dealt per
-    // datanode.
-    SCMBlockDeletingService delService = cluster.getStorageContainerManager()
-        .getScmBlockManager().getSCMBlockDeletingService();
-    delService.setBlockDeleteTXNum(limitSize);
+      int limitSize = 1;
+      // Reset limit value to 1, so that we only allow one TX is dealt per
+      // datanode.
+      SCMBlockDeletingService delService = cluster.getStorageContainerManager()
+          .getScmBlockManager().getSCMBlockDeletingService();
+      delService.setBlockDeleteTXNum(limitSize);
 
-    // Create {numKeys} random names keys.
-    TestStorageContainerManagerHelper helper =
-        new TestStorageContainerManagerHelper(cluster, conf);
-    Map<String, OmKeyInfo> keyLocations = helper.createKeys(numKeys, 4096);
-    // Wait for container report
-    Thread.sleep(5000);
-    for (OmKeyInfo keyInfo : keyLocations.values()) {
-      OzoneTestUtils.closeContainers(keyInfo.getKeyLocationVersions(),
-          cluster.getStorageContainerManager());
-    }
+      // Create {numKeys} random names keys.
+      TestStorageContainerManagerHelper helper =
+          new TestStorageContainerManagerHelper(cluster, conf);
+      Map<String, OmKeyInfo> keyLocations = helper.createKeys(numKeys, 4096);
+      // Wait for container report
+      Thread.sleep(5000);
+      for (OmKeyInfo keyInfo : keyLocations.values()) {
+        OzoneTestUtils.closeContainers(keyInfo.getKeyLocationVersions(),
+            cluster.getStorageContainerManager());
+      }
 
-    createDeleteTXLog(delLog, keyLocations, helper);
-    // Verify a few TX gets created in the TX log.
-    Assert.assertTrue(delLog.getNumOfValidTransactions() > 0);
+      createDeleteTXLog(delLog, keyLocations, helper);
+      // Verify a few TX gets created in the TX log.
+      Assert.assertTrue(delLog.getNumOfValidTransactions() > 0);
 
-    // Verify the size in delete commands is expected.
-    GenericTestUtils.waitFor(() -> {
-      NodeManager nodeManager = cluster.getStorageContainerManager()
-          .getScmNodeManager();
-      List<SCMCommand> commands = nodeManager.processHeartbeat(
-          nodeManager.getNodes(NodeState.HEALTHY).get(0));
+      // Verify the size in delete commands is expected.
+      GenericTestUtils.waitFor(() -> {
+        NodeManager nodeManager = cluster.getStorageContainerManager()
+            .getScmNodeManager();
+        List<SCMCommand> commands = nodeManager.processHeartbeat(
+            nodeManager.getNodes(NodeState.HEALTHY).get(0));
 
-      if (commands != null) {
-        for (SCMCommand cmd : commands) {
-          if (cmd.getType() == SCMCommandProto.Type.deleteBlocksCommand) {
-            List<DeletedBlocksTransaction> deletedTXs =
-                ((DeleteBlocksCommand) cmd).blocksTobeDeleted();
-            return deletedTXs != null && deletedTXs.size() == limitSize;
+        if (commands != null) {
+          for (SCMCommand cmd : commands) {
+            if (cmd.getType() == SCMCommandProto.Type.deleteBlocksCommand) {
+              List<DeletedBlocksTransaction> deletedTXs =
+                  ((DeleteBlocksCommand) cmd).blocksTobeDeleted();
+              return deletedTXs != null && deletedTXs.size() == limitSize;
+            }
           }
         }
-      }
-      return false;
-    }, 500, 10000);
+        return false;
+      }, 500, 10000);
+    } finally {
+      cluster.shutdown();
+    }
   }
 
   private Map<Long, List<Long>> createDeleteTXLog(DeletedBlockLog delLog,
@@ -443,12 +443,15 @@ public class TestStorageContainerManager {
     MiniOzoneCluster cluster =
         MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
     cluster.waitForClusterToBeReady();
-    // This will initialize SCM
-    StorageContainerManager.scmInit(conf, "testClusterId");
-    SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-    Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
-    Assert.assertNotEquals("testClusterId", scmStore.getClusterID());
-    cluster.shutdown();
+    try {
+      // This will initialize SCM
+      StorageContainerManager.scmInit(conf, "testClusterId");
+      SCMStorageConfig scmStore = new SCMStorageConfig(conf);
+      Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
+      Assert.assertNotEquals("testClusterId", scmStore.getClusterID());
+    } finally {
+      cluster.shutdown();
+    }
   }
 
   @Test
@@ -471,25 +474,29 @@ public class TestStorageContainerManager {
     OzoneConfiguration conf = new OzoneConfiguration();
     final String path =
         GenericTestUtils.getTempPath(UUID.randomUUID().toString());
-    Path scmPath = Paths.get(path, "scm-meta");
-    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, scmPath.toString());
-    conf.setBoolean(OzoneConfigKeys.OZONE_ENABLED, true);
-    SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-    String clusterId = UUID.randomUUID().toString();
-    String scmId = UUID.randomUUID().toString();
-    scmStore.setClusterId(clusterId);
-    scmStore.setScmId(scmId);
-    // writes the version file properties
-    scmStore.initialize();
-    StorageContainerManager scm = StorageContainerManager.createSCM(conf);
-    //Reads the SCM Info from SCM instance
-    ScmInfo scmInfo = scm.getClientProtocolServer().getScmInfo();
-    Assert.assertEquals(clusterId, scmInfo.getClusterId());
-    Assert.assertEquals(scmId, scmInfo.getScmId());
+    try {
+      Path scmPath = Paths.get(path, "scm-meta");
+      conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, scmPath.toString());
+      conf.setBoolean(OzoneConfigKeys.OZONE_ENABLED, true);
+      SCMStorageConfig scmStore = new SCMStorageConfig(conf);
+      String clusterId = UUID.randomUUID().toString();
+      String scmId = UUID.randomUUID().toString();
+      scmStore.setClusterId(clusterId);
+      scmStore.setScmId(scmId);
+      // writes the version file properties
+      scmStore.initialize();
+      StorageContainerManager scm = StorageContainerManager.createSCM(conf);
+      //Reads the SCM Info from SCM instance
+      ScmInfo scmInfo = scm.getClientProtocolServer().getScmInfo();
+      Assert.assertEquals(clusterId, scmInfo.getClusterId());
+      Assert.assertEquals(scmId, scmInfo.getScmId());
 
-    String expectedVersion = HddsVersionInfo.HDDS_VERSION_INFO.getVersion();
-    String actualVersion = scm.getSoftwareVersion();
-    Assert.assertEquals(expectedVersion, actualVersion);
+      String expectedVersion = HddsVersionInfo.HDDS_VERSION_INFO.getVersion();
+      String actualVersion = scm.getSoftwareVersion();
+      Assert.assertEquals(expectedVersion, actualVersion);
+    } finally {
+      FileUtils.deleteQuietly(new File(path));
+    }
   }
 
   /**
@@ -557,48 +564,52 @@ public class TestStorageContainerManager {
         .build();
     cluster.waitForClusterToBeReady();
 
-    TestStorageContainerManagerHelper helper =
-        new TestStorageContainerManagerHelper(cluster, conf);
+    try {
+      TestStorageContainerManagerHelper helper =
+          new TestStorageContainerManagerHelper(cluster, conf);
 
-    helper.createKeys(10, 4096);
-    Thread.sleep(5000);
+      helper.createKeys(10, 4096);
+      Thread.sleep(5000);
 
-    StorageContainerManager scm = cluster.getStorageContainerManager();
-    List<ContainerInfo> containers = cluster.getStorageContainerManager()
-        .getContainerManager().getContainers();
-    Assert.assertNotNull(containers);
-    ContainerInfo selectedContainer = containers.iterator().next();
+      StorageContainerManager scm = cluster.getStorageContainerManager();
+      List<ContainerInfo> containers = cluster.getStorageContainerManager()
+          .getContainerManager().getContainers();
+      Assert.assertNotNull(containers);
+      ContainerInfo selectedContainer = containers.iterator().next();
 
-    // Stop processing HB
-    scm.getDatanodeProtocolServer().stop();
+      // Stop processing HB
+      scm.getDatanodeProtocolServer().stop();
 
-    scm.getContainerManager().updateContainerState(selectedContainer
-        .containerID(), HddsProtos.LifeCycleEvent.FINALIZE);
-    cluster.restartStorageContainerManager(true);
-    scm = cluster.getStorageContainerManager();
-    EventPublisher publisher = mock(EventPublisher.class);
-    ReplicationManager replicationManager = scm.getReplicationManager();
-    Field f = replicationManager.getClass().getDeclaredField("eventPublisher");
-    f.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
-    modifiersField.setAccessible(true);
-    modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
-    f.set(replicationManager, publisher);
-    scm.getReplicationManager().start();
-    Thread.sleep(2000);
+      scm.getContainerManager().updateContainerState(selectedContainer
+          .containerID(), HddsProtos.LifeCycleEvent.FINALIZE);
+      cluster.restartStorageContainerManager(true);
+      scm = cluster.getStorageContainerManager();
+      EventPublisher publisher = mock(EventPublisher.class);
+      ReplicationManager replicationManager = scm.getReplicationManager();
+      Field f = ReplicationManager.class.getDeclaredField("eventPublisher");
+      f.setAccessible(true);
+      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      modifiersField.setAccessible(true);
+      modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
+      f.set(replicationManager, publisher);
+      scm.getReplicationManager().start();
+      Thread.sleep(2000);
 
-    UUID dnUuid = cluster.getHddsDatanodes().iterator().next()
-        .getDatanodeDetails().getUuid();
+      UUID dnUuid = cluster.getHddsDatanodes().iterator().next()
+          .getDatanodeDetails().getUuid();
 
-    CloseContainerCommand closeContainerCommand =
-        new CloseContainerCommand(selectedContainer.getContainerID(),
-            selectedContainer.getPipelineID(), false);
+      CloseContainerCommand closeContainerCommand =
+          new CloseContainerCommand(selectedContainer.getContainerID(),
+              selectedContainer.getPipelineID(), false);
 
-    CommandForDatanode commandForDatanode = new CommandForDatanode(
-        dnUuid, closeContainerCommand);
+      CommandForDatanode commandForDatanode = new CommandForDatanode(
+          dnUuid, closeContainerCommand);
 
-    verify(publisher).fireEvent(eq(SCMEvents.DATANODE_COMMAND), argThat(new
-        CloseContainerCommandMatcher(dnUuid, commandForDatanode)));
+      verify(publisher).fireEvent(eq(SCMEvents.DATANODE_COMMAND), argThat(new
+          CloseContainerCommandMatcher(dnUuid, commandForDatanode)));
+    } finally {
+      cluster.shutdown();
+    }
   }
 
   @SuppressWarnings("visibilitymodifier")

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -49,7 +49,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer
     .writeChunkForContainer;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -64,16 +67,28 @@ public class TestContainerReplication {
   @Rule
   public Timeout testTimeout = new Timeout(300000);
 
+  private OzoneConfiguration conf;
+  private MiniOzoneCluster cluster;
+
+  @Before
+  public void setup() throws Exception {
+    conf = newOzoneConfiguration();
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(2)
+        .setRandomContainerPort(true).build();
+  }
+
+  @After
+  public void teardown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
   @Test
   public void testContainerReplication() throws Exception {
     //GIVEN
-    OzoneConfiguration conf = newOzoneConfiguration();
-
     long containerId = 1L;
 
-    MiniOzoneCluster cluster =
-        MiniOzoneCluster.newBuilder(conf).setNumDatanodes(2)
-            .setRandomContainerPort(true).build();
     cluster.waitForClusterToBeReady();
 
     HddsDatanodeService firstDatanode = cluster.getHddsDatanodes().get(0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.protocol.commands.RetriableDatanodeEventWatcher;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -119,6 +120,13 @@ public class TestBlockDeletion {
     om = cluster.getOzoneManager();
     scm = cluster.getStorageContainerManager();
     containerIdsWithDeletedBlocks = new HashSet<>();
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -17,9 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -41,23 +39,38 @@ import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test to behaviour of the datanode when recieve close container command.
+ * Test to behaviour of the datanode when receive close container command.
  */
 public class TestCloseContainerHandler {
 
-  @Test
-  public void test()
-      throws IOException, TimeoutException, InterruptedException {
+  private MiniOzoneCluster cluster;
+  private OzoneConfiguration conf;
 
+  @Before
+  public void setup() throws Exception {
     //setup a cluster (1G free space is enough for a unit test)
-    OzoneConfiguration conf = new OzoneConfiguration();
+    conf = new OzoneConfiguration();
     conf.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
-    MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf)
+    cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(1).build();
+  }
+
+  @After
+  public void teardown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void test() throws Exception {
     cluster.waitForClusterToBeReady();
 
     //the easiest way to create an open container is creating a key
@@ -109,7 +122,7 @@ public class TestCloseContainerHandler {
     Assert.assertTrue(isContainerClosed(cluster, containerId.getId()));
   }
 
-  private Boolean isContainerClosed(MiniOzoneCluster cluster,
+  private static Boolean isContainerClosed(MiniOzoneCluster cluster,
       long containerID) {
     ContainerData containerData;
     containerData = cluster.getHddsDatanodes().get(0)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -332,7 +332,7 @@ public class TestScmSafeMode {
 
   @Test(timeout = 300_000)
   public void testSCMSafeModeDisabled() throws Exception {
-    cluster.stop();
+    cluster.shutdown();
 
     // If safe mode is disabled, cluster should not be in safe mode even if
     // min number of datanodes are not started.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -64,6 +65,13 @@ public class TestSCMNodeManagerMXBean {
     cluster.waitForClusterToBeReady();
     scm = cluster.getStorageContainerManager();
     mbs = ManagementFactory.getPlatformMBeanServer();
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Make sure mini cluster is shutdown, even on test failure
 * Adjust cluster "path" when cluster ID is changed (to avoid dangling directories)

https://issues.apache.org/jira/browse/HDDS-1949

## How was this patch tested?

Ran `integration-test`, verified that no large directories are left (only few KB due to metrics output).