### PR TITLE
HDDS-2051. Rat check failure in decommissioning.md

### DIFF
--- a/hadoop-hdds/docs/content/design/decommissioning.md
+++ b/hadoop-hdds/docs/content/design/decommissioning.md
@@ -1,3 +1,17 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
 ---
 title: Decommissioning in Ozone
 summary: Formal process to shut down machines in a safe way after the required replications.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add license header in new `decommissioning.md`.

https://issues.apache.org/jira/browse/HDDS-2051

## How was this patch tested?

```
$ hadoop-ozone/dev-support/checks/rat.sh
...
[INFO] Apache Hadoop HDDS/Ozone Documentation ............. SUCCESS [  0.066 s]
...
```