### PR TITLE
HDDS-2048: State check during container state transition in datanode should be lock protected

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -78,7 +78,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Class to perform KeyValue Container operations.
+ * Class to perform KeyValue Container operations. Any modifications to
+ * KeyValueContainer object should ideally be done via api exposed in
+ * KeyValueHandler class.
  */
 public class KeyValueContainer implements Container<KeyValueContainerData> {
 
@@ -525,6 +527,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
    * Acquire write lock.
    */
   public void writeLock() {
+    // TODO: The lock for KeyValueContainer object should not be exposed
+    // publicly.
     this.lock.writeLock().lock();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -889,16 +889,19 @@ public class KeyValueHandler extends Handler {
   @Override
   public void markContainerForClose(Container container)
       throws IOException {
+    container.writeLock();
     // Move the container to CLOSING state only if it's OPEN
     if (container.getContainerState() == State.OPEN) {
       container.markContainerForClose();
       sendICR(container);
     }
+    container.writeUnlock();
   }
 
   @Override
   public void markContainerUnhealthy(Container container)
       throws IOException {
+    container.writeLock();
     if (container.getContainerState() != State.UNHEALTHY) {
       try {
         container.markContainerUnhealthy();
@@ -912,11 +915,13 @@ public class KeyValueHandler extends Handler {
         sendICR(container);
       }
     }
+    container.writeUnlock();
   }
 
   @Override
   public void quasiCloseContainer(Container container)
       throws IOException {
+    container.writeLock();
     final State state = container.getContainerState();
     // Quasi close call is idempotent.
     if (state == State.QUASI_CLOSED) {
@@ -932,11 +937,13 @@ public class KeyValueHandler extends Handler {
     }
     container.quasiClose();
     sendICR(container);
+    container.writeUnlock();
   }
 
   @Override
   public void closeContainer(Container container)
       throws IOException {
+    container.writeLock();
     final State state = container.getContainerState();
     // Close call is idempotent.
     if (state == State.CLOSED) {
@@ -958,6 +965,7 @@ public class KeyValueHandler extends Handler {
     }
     container.close();
     sendICR(container);
+    container.writeUnlock();
   }
 
   @Override


### PR DESCRIPTION
Currently container state checks during state transition are not lock protected in KeyValueHandler. These can cause invalid state transitions.