### PR TITLE
HDDS-2061. Add hdds.container.chunk.persistdata as exception to TestOzoneConfigurationFields

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1387,16 +1387,6 @@
   </property>
 
   <property>
-    <name>hdds.container.chunk.persistdata</name>
-    <value>true</value>
-    <tag>DATANODE</tag>
-    <description>
-      Determines if the Container Chunk Manager will write user data to disk.
-      Set to false only for specific performance tests.
-    </description>
-  </property>
-
-  <property>
     <name>hdds.pipeline.action.max.limit</name>
     <value>20</value>
     <tag>DATANODE</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1387,6 +1387,16 @@
   </property>
 
   <property>
+    <name>hdds.container.chunk.persistdata</name>
+    <value>true</value>
+    <tag>DATANODE</tag>
+    <description>
+      Determines if the Container Chunk Manager will write user data to disk.
+      Set to false only for specific performance tests.
+    </description>
+  </property>
+
+  <property>
     <name>hdds.pipeline.action.max.limit</name>
     <value>20</value>
     <tag>DATANODE</tag>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.s3.S3GatewayConfigKeys;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE;
+import java.util.Arrays;
 
 /**
  * Tests if configuration constants documented in ozone-defaults.xml.
@@ -47,12 +47,14 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
   }
 
   private void addPropertiesNotInXml() {
-    configurationPropsToSkipCompare.add(HddsConfigKeys.HDDS_KEY_ALGORITHM);
-    configurationPropsToSkipCompare.add(HddsConfigKeys.HDDS_SECURITY_PROVIDER);
-    configurationPropsToSkipCompare.add(HddsConfigKeys.HDDS_GRPC_TLS_TEST_CERT);
-    configurationPropsToSkipCompare.add(OMConfigKeys.OZONE_OM_NODES_KEY);
-    configurationPropsToSkipCompare.add(OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
-    configurationPropsToSkipCompare.add(OzoneConfigKeys.
-        OZONE_S3_TOKEN_MAX_LIFETIME_KEY);
+    configurationPropsToSkipCompare.addAll(Arrays.asList(
+        HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA,
+        HddsConfigKeys.HDDS_GRPC_TLS_TEST_CERT,
+        HddsConfigKeys.HDDS_KEY_ALGORITHM,
+        HddsConfigKeys.HDDS_SECURITY_PROVIDER,
+        OMConfigKeys.OZONE_OM_NODES_KEY,
+        OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
+        OzoneConfigKeys.OZONE_S3_TOKEN_MAX_LIFETIME_KEY
+    ));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `hdds.container.chunk.persistdata` as an exception in `TestOzoneConfigurationFields` to fix its [failure](https://github.com/elek/ozone-ci/blob/master/trunk/trunk-nightly-20190830-rr75b/integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.TestOzoneConfigurationFields.txt).

https://issues.apache.org/jira/browse/HDDS-2061

## How was this patch tested?

```
$ mvn -am -Phdds -pl :hadoop-ozone-integration-test -DfailIfNoTests=false clean test -Dtest=TestOzoneConfigurationFields
...
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.36 s - in org.apache.hadoop.ozone.TestOzoneConfigurationFields
```