### PR TITLE
In YARN ui2 applications tab, If finishTime is 0, 'NA' should be displayed at this time, indicating that the task is not finished yet

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/utils/converter.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/utils/converter.js
@@ -83,7 +83,7 @@ export default {
     return total * 1000;
   },
   timeStampToDate: function(timeStamp) {
-    return convertTimestampWithTz(timeStamp, "YYYY/MM/DD HH:mm:ss");
+    return timeStamp == 0 ? "NA" : (0, _yarnUiUtilsDateUtils.convertTimestampWithTz)(timeStamp, "YYYY/MM/DD HH:mm:ss");
   },
   timeStampToDateOnly: function(timeStamp) {
     return convertTimestampWithTz(timeStamp, "YYYY/MM/DD");


### PR DESCRIPTION
When a spark app is running, the finishTime returned by the server is always 0, so the Finished time of the Application on the page is always shown as :1970/01/01 08:00, which is very unfriendly.If finishTime is 0, 'NA' should be displayed at this time, indicating that the task is not finished yet