### PR TITLE
HDDS-2069. Default values of properties hdds.datanode.storage.utilization.{critical | warning}.threshold are not reasonable

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -358,12 +358,12 @@ public final class OzoneConfigKeys {
       HDDS_DATANODE_STORAGE_UTILIZATION_WARNING_THRESHOLD =
       "hdds.datanode.storage.utilization.warning.threshold";
   public static final double
-      HDDS_DATANODE_STORAGE_UTILIZATION_WARNING_THRESHOLD_DEFAULT = 0.95;
+      HDDS_DATANODE_STORAGE_UTILIZATION_WARNING_THRESHOLD_DEFAULT = 0.75;
   public static final String
       HDDS_DATANODE_STORAGE_UTILIZATION_CRITICAL_THRESHOLD =
       "hdds.datanode.storage.utilization.critical.threshold";
   public static final double
-      HDDS_DATANODE_STORAGE_UTILIZATION_CRITICAL_THRESHOLD_DEFAULT = 0.75;
+      HDDS_DATANODE_STORAGE_UTILIZATION_CRITICAL_THRESHOLD_DEFAULT = 0.95;
 
   public static final String OZONE_SECURITY_ENABLED_KEY =
       "ozone.security.enabled";


### PR DESCRIPTION
…on.critical.threshold and hdds.datanode.storage.utilization.warning.threshold are not reasonable.


https://issues.apache.org/jira/browse/HDDS-2069?filter=-1