### PR TITLE
HDDS-2064. OzoneManagerRatisServer#newOMRatisServer throws NPE when OM HA is configured incorrectly

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -284,35 +284,27 @@ public class TestOzoneManagerConfiguration {
   }
 
   /**
-   * Test a wrong configuration for OM HA. A configuration with an empty
-   * node list while service ID is configured should throw an error.
+   * A configuration with an empty node list while service ID is configured
+   * Should successfully start with no NPEs.
    * @throws Exception
    */
   @Test
-  public void testWrongConfigurationNoOMNodes() throws Exception {
+  public void testNoOMNodes() throws Exception {
     String omServiceId = "om-service-test1";
     conf.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, omServiceId);
     // Deliberately skip OZONE_OM_NODES_KEY and OZONE_OM_ADDRESS_KEY config
 
-    try {
-      startCluster();
-      Assert.fail("OM initialization should have failed.");
-    } catch (OzoneIllegalArgumentException e) {
-      GenericTestUtils.assertExceptionContains(
-          "Incorrect configuration. Unable to find OzoneManager" +
-          " node address for service id " + omServiceId + ". Please" +
-          " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +
-          ", " + OZONE_OM_NODES_KEY + " and " + OZONE_OM_ADDRESS_KEY, e);
-    }
+    // Should successfully start with no NPEs
+    startCluster();
   }
 
   /**
-   * Test a wrong configuration for OM HA. A configuration with no OM addresses
-   * while service ID is configured should throw an error.
+   * A configuration with no OM addresses while service ID is configured.
+   * Should successfully start with no NPEs.
    * @throws Exception
    */
   @Test
-  public void testWrongConfigurationNoOMAddrs() throws Exception {
+  public void testNoOMAddrs() throws Exception {
     String omServiceId = "om-service-test1";
 
     String omNode1Id = "omNode1";
@@ -326,16 +318,8 @@ public class TestOzoneManagerConfiguration {
     conf.set(omNodesKey, omNodesKeyValue);
     // Deliberately skip OZONE_OM_ADDRESS_KEY config
 
-    try {
-      startCluster();
-      Assert.fail("OM initialization should have failed.");
-    } catch (OzoneIllegalArgumentException e) {
-      GenericTestUtils.assertExceptionContains(
-          "Incorrect configuration. Unable to find OzoneManager" +
-              " node address for service id " + omServiceId + ". Please" +
-              " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +
-              ", " + OZONE_OM_NODES_KEY + " and " + OZONE_OM_ADDRESS_KEY, e);
-    }
+    // Should successfully start with no NPEs
+    startCluster();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -42,10 +42,6 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
-
 /**
  * Tests OM related configurations.
  */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -615,20 +615,27 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             " system with " + OZONE_OM_SERVICE_IDS_KEY + " and " +
             OZONE_OM_ADDRESS_KEY;
         throw new OzoneIllegalArgumentException(msg);
-      } else if (!isOMAddressSet && found == 0) {
-        String msg = "Incorrect configuration. Unable to find OzoneManager" +
-            " node address for service id " + serviceId + ". Please" +
-            " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +
-            ", " + OZONE_OM_NODES_KEY + " and " + OZONE_OM_ADDRESS_KEY;
-        throw new OzoneIllegalArgumentException(msg);
       }
     }
-
+/*
+    if (found == 0) {
+      String msg = "Incorrect configuration. Unable to perform" +
+          " self-discovery for current OzoneManager node. Please" +
+          " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +
+          ", " + OZONE_OM_NODES_KEY + " and " + OZONE_OM_ADDRESS_KEY;
+      throw new OzoneIllegalArgumentException(msg);
+    }
+*/
     if (!isOMAddressSet) {
       // No OM address is set. Fallback to default
       InetSocketAddress omAddress = OmUtils.getOmAddress(conf);
       int ratisPort = conf.getInt(OZONE_OM_RATIS_PORT_KEY,
           OZONE_OM_RATIS_PORT_DEFAULT);
+      // HDDS-2064: this.peerNodes would be null at this point because
+      // it is not initialized, we want to initialize it as an empty list
+      // to prevent NPE in OzoneManagerRatisServer#newOMRatisServer.
+      assert(this.peerNodes == null);
+      this.peerNodes = new ArrayList<>();
 
       LOG.info("Configuration either no {} set. Falling back to the default " +
           "OM address {}", OZONE_OM_ADDRESS_KEY, omAddress);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -615,7 +615,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             " system with " + OZONE_OM_SERVICE_IDS_KEY + " and " +
             OZONE_OM_ADDRESS_KEY;
         throw new OzoneIllegalArgumentException(msg);
-      } else if (found == 0) {
+      } else if (!isOMAddressSet && found == 0) {
         String msg = "Incorrect configuration. Unable to find OzoneManager" +
             " node address for service id " + serviceId + ". Please" +
             " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -205,7 +205,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_F
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODE_ID_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -205,6 +205,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_F
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODE_ID_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
@@ -613,6 +614,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             " addresses that match local node's address. Please configure the" +
             " system with " + OZONE_OM_SERVICE_IDS_KEY + " and " +
             OZONE_OM_ADDRESS_KEY;
+        throw new OzoneIllegalArgumentException(msg);
+      } else if (found == 0) {
+        String msg = "Incorrect configuration. Unable to find OzoneManager" +
+            " node address for service id " + serviceId + ". Please" +
+            " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +
+            ", " + OZONE_OM_NODES_KEY + " and " + OZONE_OM_ADDRESS_KEY;
         throw new OzoneIllegalArgumentException(msg);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -617,15 +617,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         throw new OzoneIllegalArgumentException(msg);
       }
     }
-/*
-    if (found == 0) {
-      String msg = "Incorrect configuration. Unable to perform" +
-          " self-discovery for current OzoneManager node. Please" +
-          " check and reconfigure: " + OZONE_OM_SERVICE_IDS_KEY +
-          ", " + OZONE_OM_NODES_KEY + " and " + OZONE_OM_ADDRESS_KEY;
-      throw new OzoneIllegalArgumentException(msg);
-    }
-*/
+
     if (!isOMAddressSet) {
       // No OM address is set. Fallback to default
       InetSocketAddress omAddress = OmUtils.getOmAddress(conf);
@@ -634,7 +626,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // HDDS-2064: this.peerNodes would be null at this point because
       // it is not initialized, we want to initialize it as an empty list
       // to prevent NPE in OzoneManagerRatisServer#newOMRatisServer.
-      assert(this.peerNodes == null);
       this.peerNodes = new ArrayList<>();
 
       LOG.info("Configuration either no {} set. Falling back to the default " +


### PR DESCRIPTION
The WIP patch can prevent NPE in `TestOzoneManagerConfiguration` unit test `testWrongConfigurationNoOMNodes` and `testWrongConfigurationNoOMAddrs`.

Before the second commit, it fails `testWrongConfiguration` and `testMultipleOMServiceIds`. - The reasons of the failures are that there is another logic checking `isOMAddressSet` right after my patch in `OzoneManager`. And those unit tests are expecting a different exception.

The second commit has addressed the unit test failures. Please review.