### PR TITLE
HDDS-2087. Remove the hard coded config key in ChunkManager

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -241,6 +241,10 @@ public final class HddsConfigKeys {
       "hdds.container.chunk.persistdata";
   public static final boolean HDDS_CONTAINER_PERSISTDATA_DEFAULT = true;
 
+  public static final String HDDS_CONTAINER_SCRUB_ENABLED =
+      "hdds.container.scrub.enabled";
+  public static final boolean HDDS_CONTAINER_SCRUB_ENABLED_DEFAULT = false;
+
   public static final String HDDS_DATANODE_HTTP_ENABLED_KEY =
       "hdds.datanode.http.enabled";
   public static final String HDDS_DATANODE_HTTP_BIND_HOST_KEY =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1367,7 +1367,7 @@
   </property>
 
   <property>
-    <name>hdds.containerscrub.enabled</name>
+    <name>hdds.container.scrub.enabled</name>
     <value>false</value>
     <tag>DATANODE</tag>
     <description>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_SCRUB_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_SCRUB_ENABLED_DEFAULT;
 
 /**
  * Select an appropriate ChunkManager implementation as per config setting.
@@ -64,12 +66,12 @@ public final class ChunkManagerFactory {
 
     if (!persist) {
       boolean scrubber = config.getBoolean(
-          "hdds.containerscrub.enabled",
-          false);
+          HDDS_CONTAINER_SCRUB_ENABLED,
+          HDDS_CONTAINER_SCRUB_ENABLED_DEFAULT);
       if (scrubber) {
         // Data Scrubber needs to be disabled for non-persistent chunks.
         LOG.warn("Failed to set " + HDDS_CONTAINER_PERSISTDATA + " to false."
-            + " Please set hdds.containerscrub.enabled"
+            + " Please set " + HDDS_CONTAINER_SCRUB_ENABLED
             + " also to false to enable non-persistent containers.");
         persist = true;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -44,7 +44,6 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     errorIfMissingXmlProps = true;
     xmlPropsToSkipCompare.add("hadoop.tags.custom");
     xmlPropsToSkipCompare.add("ozone.om.nodes.EXAMPLEOMSERVICEID");
-    xmlPropsToSkipCompare.add("hdds.container.scrub.enabled");
     addPropertiesNotInXml();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -44,7 +44,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     errorIfMissingXmlProps = true;
     xmlPropsToSkipCompare.add("hadoop.tags.custom");
     xmlPropsToSkipCompare.add("ozone.om.nodes.EXAMPLEOMSERVICEID");
-    xmlPropsToSkipCompare.add("hdds.containerscrub.enabled");
+    xmlPropsToSkipCompare.add("hdds.container.scrub.enabled");
     addPropertiesNotInXml();
   }
 


### PR DESCRIPTION
We have a hard-coded config key in the ChunkManagerFactory.java.

```
boolean scrubber = config.getBoolean(
 "hdds.containerscrub.enabled",
 false);
```

This patch fixes the hard coded config key by referring to it from a constant.