### PR TITLE
Avoiding logging Sasl message

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslRpcClient.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SaslRpcClient.java
@@ -449,9 +449,6 @@ public class SaslRpcClient {
 
   private void sendSaslMessage(OutputStream out, RpcSaslProto message)
       throws IOException {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Sending sasl message "+message);
-    }
     ResponseBuffer buf = new ResponseBuffer();
     saslHeader.writeDelimitedTo(buf);
     message.writeDelimitedTo(buf);


### PR DESCRIPTION
Based on a previous issue (HADOOP-11962), Sasl message should not be logged. Also, all of the instances of logging Sasl message have been removed except this one.