### PR TITLE
HDDS-2075. Tracing in OzoneManager call is propagated with wrong parent

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -156,8 +156,11 @@ public class RpcClient implements ClientProtocol {
     this.userRights = aclConfig.getUserDefaultRights();
     this.groupRights = aclConfig.getGroupDefaultRights();
 
-    this.ozoneManagerClient = new OzoneManagerProtocolClientSideTranslatorPB(
-        this.conf, clientId.toString(), ugi);
+    this.ozoneManagerClient = TracingUtil.createProxy(
+        new OzoneManagerProtocolClientSideTranslatorPB(
+            this.conf, clientId.toString(), ugi),
+        OzoneManagerProtocol.class, conf
+    );
     long scmVersion =
         RPC.getProtocolVersion(StorageContainerLocationProtocolPB.class);
     InetSocketAddress scmAddress = getScmAddressForClient();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -207,10 +207,9 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_KEY,
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_DEFAULT);
 
-    this.rpcProxy = TracingUtil.createProxy(
+    this.rpcProxy =
         createRetryProxy(omFailoverProxyProvider, maxRetries, maxFailovers,
-            sleepBase, sleepMax),
-        OzoneManagerProtocolPB.class, conf);
+            sleepBase, sleepMax);
     this.clientID = clientId;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apply tracing to `OzoneManagerProtocol` instead of `OzoneManagerProtocolPB`.  The latter only has a single public method, and no other `*ProtocolPB` interface is traced.

https://issues.apache.org/jira/browse/HDDS-2075

## How was this patch tested?

Verified operation hierarchy in Jaeger UI.