### PR TITLE
HDDS-2103. TestContainerReplication fails due to unhealthy container

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer;
-import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.test.GenericTestUtils;
 
@@ -121,11 +120,11 @@ public class TestContainerReplication {
             cluster.getHddsDatanodes());
 
     // Close the container
-    cluster.getStorageContainerManager().getScmNodeManager()
-        .addDatanodeCommand(
-            sourceDatanodes.get(0).getUuid(),
-            new CloseContainerCommand(containerId,
-                sourcePipelines.getId(), true));
+    ContainerCommandRequestProto closeContainerRequest = ContainerTestHelper
+        .getCloseContainer(sourcePipelines, containerId);
+    response = client.sendCommand(closeContainerRequest);
+    Assert.assertNotNull(response);
+    Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
     //WHEN: send the order to replicate the container
     cluster.getStorageContainerManager().getScmNodeManager()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.container;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +41,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
-import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer;
@@ -73,9 +71,6 @@ public class TestContainerReplication {
 
     long containerId = 1L;
 
-    conf.setSocketAddr("hdls.datanode.http-address",
-        new InetSocketAddress("0.0.0.0", 0));
-
     MiniOzoneCluster cluster =
         MiniOzoneCluster.newBuilder(conf).setNumDatanodes(2)
             .setRandomContainerPort(true).build();
@@ -105,9 +100,6 @@ public class TestContainerReplication {
     // Put Block to the test container
     ContainerCommandRequestProto putBlockRequest = ContainerTestHelper
         .getPutBlockRequest(sourcePipelines, requestProto.getWriteChunk());
-
-    ContainerProtos.BlockData blockData =
-        putBlockRequest.getPutBlock().getBlockData();
 
     ContainerCommandResponseProto response =
         client.sendCommand(putBlockRequest);
@@ -143,8 +135,6 @@ public class TestContainerReplication {
     OzoneContainer ozoneContainer =
         destinationDatanodeDatanodeStateMachine.getContainer();
 
-
-
     Container container =
         ozoneContainer
             .getContainerSet().getContainer(containerId);
@@ -157,9 +147,6 @@ public class TestContainerReplication {
         "ContainerData of the replicated container is null",
         container.getContainerData());
 
-    long keyCount = ((KeyValueContainerData) container.getContainerData())
-        .getKeyCount();
-
     KeyValueHandler handler = (KeyValueHandler) ozoneContainer.getDispatcher()
         .getHandler(ContainerType.KeyValueContainer);
 
@@ -170,7 +157,6 @@ public class TestContainerReplication {
     Assert.assertEquals(1, key.getChunks().size());
     Assert.assertEquals(requestProto.getWriteChunk().getChunkData(),
         key.getChunks().get(0));
-
   }
 
   private HddsDatanodeService chooseDatanodeWithoutContainer(Pipeline pipeline,
@@ -184,9 +170,8 @@ public class TestContainerReplication {
         "No datanode outside of the pipeline");
   }
 
-  static OzoneConfiguration newOzoneConfiguration() {
-    final OzoneConfiguration conf = new OzoneConfiguration();
-    return conf;
+  private static OzoneConfiguration newOzoneConfiguration() {
+    return new OzoneConfiguration();
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change `TestContainerReplication` to close the container directly via client.

https://issues.apache.org/jira/browse/HDDS-2103

## How was this patch tested?

Ran the changed unit test - passes, no other code changed.  Checkstyle passes.