### PR TITLE
HDDS-2107. Datanodes should retry forever to connect to SCM in an…

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -119,7 +119,7 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
    * transactions or not.
    * @throws Exception
    */
-  @Test(timeout = 300_000)
+  @Test(timeout = 500_000)
   public void testDoubleBuffer() throws Exception {
     // This test checks whether count in tables are correct or not.
     testDoubleBuffer(1, 10);
@@ -397,7 +397,7 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
         }
         return count == iterations;
 
-      }, 300, 40000);
+      }, 300, 300000);
 
 
       GenericTestUtils.waitFor(() -> {
@@ -409,7 +409,7 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
           fail("testDoubleBuffer failed");
         }
         return count == bucketCount * iterations;
-      }, 300, 40000);
+      }, 300, 300000);
 
       Assert.assertTrue(doubleBuffer.getFlushIterations() > 0);
     } finally {


### PR DESCRIPTION
… unsecure environment

 In an unsecure environment, the datanodes try upto 10 times after waiting for 1000 milliseconds each time before throwing this error:

```
Unable to communicate to SCM server at scm:9861 for past 0 seconds.
java.net.ConnectException: Call From scm:9861 failed on connection exception: java.net.ConnectException: Connection refused;
```

This PR fixes that issue by having datanodes try forever to connect with SCM and not throw an error from the state machine.

I have also increased timeouts on a unit test to improve its stability.
