### PR TITLE
HADOOP-16556. Fix some alerts raised by LGTM

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosName.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosName.java
@@ -281,7 +281,7 @@ public class KerberosName {
         if (paramNum != null) {
           try {
             int num = Integer.parseInt(paramNum);
-            if (num < 0 || num > params.length) {
+            if (num < 0 || num >= params.length) {
               throw new BadFormatString("index " + num + " from " + format +
                                         " is outside of the valid range 0 to " +
                                         (params.length - 1));

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/impl/zk/RegistrySecurity.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/impl/zk/RegistrySecurity.java
@@ -926,7 +926,7 @@ public class RegistrySecurity extends AbstractService {
       UserGroupInformation realUser = currentUser.getRealUser();
       LOG.info("Real User = {}" , realUser);
     } catch (IOException e) {
-      LOG.warn("Failed to get current user {}, {}", e);
+      LOG.warn("Failed to get current user, {}", e);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSExceptionProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSExceptionProvider.java
@@ -92,7 +92,7 @@ public class HttpFSExceptionProvider extends ExceptionProvider {
     String path = MDC.get("path");
     String message = getOneLineMessage(throwable);
     AUDIT_LOG.warn("FAILED [{}:{}] response [{}] {}", new Object[]{method, path, status, message});
-    LOG.warn("[{}:{}] response [{}] {}", new Object[]{method, path, status, message}, throwable);
+    LOG.warn("[{}:{}] response [{}] {}", method, path, status, message, throwable);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/GenericExceptionHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/GenericExceptionHandler.java
@@ -87,8 +87,6 @@ public class GenericExceptionHandler implements ExceptionMapper<Exception> {
       s = Response.Status.BAD_REQUEST;
     } else if (e instanceof IllegalArgumentException) {
       s = Response.Status.BAD_REQUEST;
-    } else if (e instanceof NumberFormatException) {
-      s = Response.Status.BAD_REQUEST;
     } else if (e instanceof BadRequestException) {
       s = Response.Status.BAD_REQUEST;
     } else if (e instanceof WebApplicationException


### PR DESCRIPTION
Fix the following alerts:

- `Array index out of bounds` in KerberosName.java

- `Contradictory type checks` in GenericExceptionHandler

- `Missing format argument` in RegistrySecurity and HttpFSExceptionProvider

These alerts are shown in https://lgtm.com/projects/g/apache/hadoop/?mode=tree


