### PR TITLE
HDDS-2120. Remove hadoop classes from ozonefs-current jar

### DIFF
--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -91,6 +91,16 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-filesystem</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
We have two kind of ozone file system jars: current and legacy. current is designed to work only with exactly the same hadoop version which is used for compilation (3.2 as of now).

But as of now the hadoop classes are included in the current jar which is not necessary as the jar is expected to be used in an environment where  the hadoop classes (exactly the same hadoop classes) are already there. They can be excluded.

See: https://issues.apache.org/jira/browse/HDDS-2120