### PR TITLE
HDFS-14846: libhdfs tests are failing on trunk due to jni usage bugs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/security/JniBasedUnixGroupsMapping.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/security/JniBasedUnixGroupsMapping.c
@@ -199,8 +199,5 @@ done:
   if (ginfo) {
     hadoop_group_info_free(ginfo);
   }
-  if (jgroupname) {
-    (*env)->DeleteLocalRef(env, jgroupname);
-  }
   return jgroups;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-tests/native_mini_dfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-tests/native_mini_dfs.c
@@ -184,8 +184,8 @@ struct NativeMiniDfsCluster* nmdCreate(struct NativeMiniDfsConf *conf)
                                   "Builder::numDataNodes");
             goto error;
         }
+        (*env)->DeleteLocalRef(env, val.l);
     }
-    (*env)->DeleteLocalRef(env, val.l);
     jthr = findClassAndInvokeMethod(env, &val, INSTANCE, bld, MINIDFS_CLUSTER_BUILDER,
             "build", "()L" MINIDFS_CLUSTER ";");
     if (jthr) {

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -3480,7 +3480,6 @@ done:
     destroyLocalReference(env, jUserName);
     destroyLocalReference(env, jGroupName);
     destroyLocalReference(env, jPermission);
-    destroyLocalReference(env, jPath);
     return jthr;
 }
 


### PR DESCRIPTION
[HDFS-14846](https://issues.apache.org/jira/browse/HDFS-14846): libhdfs tests are failing on trunk due to jni usage bugs

JIRA describes the issue. The fix is to remote any duplicate calls to `DeleteLocalRef`.