### PR TITLE
HDDS-2122. Broken logo image on category sub-pages

### DIFF
--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
@@ -24,7 +24,7 @@
         <span class="icon-bar"></span>
       </button>
       <a href="#" class="navbar-left" style="height: 50px; padding: 5px 5px 5px 0;">
-        <img src="ozone-logo-small.png" width="40"/>
+        <img src="{{ "ozone-logo-small.png" | relURL }}" width="40"/>
       </a>
       <a class="navbar-brand hidden-xs" href="#">
         Apache Hadoop Ozone/HDDS documentation


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make link to Ozone logo relative to current page to fix broken image on sub pages.

https://issues.apache.org/jira/browse/HDDS-2122

## How was this patch tested?

Built docs from source, verified that logo is OK in both top-level and sub pages.

```
$ mvn -Phdds -pl :hadoop-hdds-docs clean package
$ grep '<img' hadoop-hdds/docs/target/classes/docs/interface/javaapi.html
        <img src="../ozone-logo-small.png" width="40"/>
$ file hadoop-hdds/docs/target/classes/docs/ozone-logo-small.png
hadoop-hdds/docs/target/classes/docs/ozone-logo-small.png: PNG image ...
```