### PR TITLE
HDDS-2125. maven-javadoc-plugin.version is missing in pom.ozone.xml.

### DIFF
--- a/pom.ozone.xml
+++ b/pom.ozone.xml
@@ -198,6 +198,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-pdf-plugin.version>1.2</maven-pdf-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
+    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>


### PR DESCRIPTION
`maven-javadoc-plugin.version` is missing from `pom.ozone.xml` which is causing build failure.