### PR TITLE
HADOOP-16568. S3A FullCredentialsTokenBinding fails if local credentials are unset

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenBinding.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
 import org.apache.hadoop.fs.s3a.S3AUtils;
@@ -73,7 +75,6 @@ public class FullCredentialsTokenBinding extends
   @Override
   protected void serviceStart() throws Exception {
     super.serviceStart();
-    loadAWSCredentials();
   }
 
   /**
@@ -116,6 +117,7 @@ public class FullCredentialsTokenBinding extends
   @Override
   public AWSCredentialProviderList deployUnbonded() throws IOException {
     requireServiceStarted();
+    loadAWSCredentials();
     return new AWSCredentialProviderList(
         "Full Credentials Token Binding",
         new MarshalledCredentialProvider(
@@ -142,7 +144,8 @@ public class FullCredentialsTokenBinding extends
       final EncryptionSecrets encryptionSecrets,
       final Text renewer) throws IOException {
     requireServiceStarted();
-
+    Preconditions.checkNotNull(
+        awsCredentials, "No AWS credentials to use for a delegation token");
     return new FullCredentialsTokenIdentifier(getCanonicalUri(),
         getOwnerText(),
         renewer,


### PR DESCRIPTION

Move the local loading to deployUnbonded() (where they are required) and add a safety check when a new DT is requested

Change-Id: I516368c2c4a558a2a86e8cf107f77f1e40338261
