### PR TITLE
HDDS-2111. XSS fragments can be injected to the S3g landing page  

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
@@ -21,6 +21,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self';">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="Apache Hadoop Ozone S3 gateway">
 
@@ -68,12 +69,15 @@
 
     <p>For example with aws-cli:</p>
 
-    <pre>aws s3api --endpoint <script>document.write(window.location.href.replace("static/", ""))</script> create-bucket --bucket=wordcount</pre>
+    <pre>aws s3api --endpoint <span id="s3gurl"></span> create-bucket --bucket=wordcount</pre>
 
     <p>For more information, please check the <a href="docs">documentation.</a>
     </p>
 </div><!-- /.container -->
 
-<script src="static/bootstrap-3.4.1/js/bootstrap.min.js"></script>
+<script src="jquery-3.4.1.min.js"></script>
+<script src="bootstrap-3.4.1/js/bootstrap.min.js"></script>
+<script src="s3g.js"></script>
+
 </body>
 </html>

--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/static/s3g.js
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/static/s3g.js
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 window.onload = function () {
     var safeurl = window.location.protocol + "//" + window.location.host + window.location.pathname;
     safeurl = safeurl.replace("static/", "");

--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/static/s3g.js
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/static/s3g.js
@@ -1,0 +1,5 @@
+window.onload = function () {
+    var safeurl = window.location.protocol + "//" + window.location.host + window.location.pathname;
+    safeurl = safeurl.replace("static/", "");
+    document.getElementById('s3gurl').innerHTML = safeurl;
+};


### PR DESCRIPTION
VULNERABILITY DETAILS
There is a way to bypass anti-XSS filter for DOM XSS exploiting a "window.location.href".

Considering a typical URL:

scheme://domain:port/path?query_string#fragment_id

Browsers encode correctly both "path" and "query_string", but not the "fragment_id". 

So if used "fragment_id" the vector is also not logged on Web Server.

VERSION
Chrome Version: 10.0.648.134 (Official Build 77917) beta

REPRODUCTION CASE
This is an index.html page:


{code:java}
aws s3api --endpoint <script>document.write(window.location.href.replace("static/", ""))</script> create-bucket --bucket=wordcount</pre>
{code}


The attack vector is:
index.html?#<script>alert('XSS');</script>

* PoC:
For your convenience, a minimalist PoC is located on:
http://security.onofri.org/xss_location.html?#<script>alert('XSS');</script>

* References
- DOM Based Cross-Site Scripting or XSS of the Third Kind - http://www.webappsec.org/projects/articles/071105.shtml


reference:- 

https://bugs.chromium.org/p/chromium/issues/detail?id=76796

See: https://issues.apache.org/jira/browse/HDDS-2111