### PR TITLE
HDDS-2129. Using dist profile fails with pom.ozone.xml as parent pom

### DIFF
--- a/pom.ozone.xml
+++ b/pom.ozone.xml
@@ -199,6 +199,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
@@ -1604,9 +1605,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
-            <additionalOptions>
-              <additionalOption>-Xmaxwarns 10000</additionalOption>
-            </additionalOptions>
+            <additionalJOption>-Xdoclint:none</additionalJOption>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The build fails with the {{dist}} profile. Details in a comment below.

See: https://issues.apache.org/jira/browse/HDDS-2129