### PR TITLE
HDDS-2134. OM Metrics graphs include empty request type

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -69,7 +69,7 @@
                     var groupedMetrics = {others: [], nums: {}};
                     var metrics = result.data.beans[0]
                     for (var key in metrics) {
-                        var numericalStatistic = key.match(/Num([A-Z][a-z]+)(.+?)(Fails)?$/);
+                        var numericalStatistic = key.match(/Num([A-Z][a-z]+)([A-Z].+?)(Fails)?$/);
                         if (numericalStatistic) {
                             var type = numericalStatistic[1];
                             var name = numericalStatistic[2];


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle `numVolumes`, `numBuckets`, and `numKeys` metrics as "other", instead of including them in the Volume, Bucket, and Key request graphs.

https://issues.apache.org/jira/browse/HDDS-2134

## How was this patch tested?

Checked OM Metrics after running `freon`.  Verified that `NumVolumes`, etc. appear in the _Other JMX properties_ table, and that the number of volme/bucket/key requests in the graphs add up to the total shown above each graph.