### PR TITLE
HDDS-2121. Create a shaded ozone filesystem (client) jar

### DIFF
--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
   </properties>
 
   <build>
@@ -93,7 +94,8 @@
               <relocations>
                 <relocation>
                   <pattern>org</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded.org
+                  <shadedPattern>
+                    ${shaded.prefix}.org
                   </shadedPattern>
                   <includes>
                     <include>org.yaml.**.*</include>
@@ -113,15 +115,21 @@
                     <include>org.apache.commons.validator.**.*</include>
                     <include>org.sqlite.**.*</include>
                     <include>org.apache.thrift.**.*</include>
+                    <!-- level db -->
+                    <include>org.iq80.**.*</include>
+                    <include>org.fusesource.**.*</include>
+                    <!-- http client and core -->
+                    <include>org.apache.http.**.*</include>
                   </includes>
                 </relocation>
                 <relocation>
                   <pattern>com</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded.com
+                  <shadedPattern>
+                    ${shaded.prefix}.com
                   </shadedPattern>
                   <includes>
                     <include>com.google.common.**.*</include>
-                    <include>com.google.json.**.*</include>
+                    <include>com.google.gson.**.*</include>
                     <include>com.codahale.**.*</include>
                     <include>com.lmax.**.*</include>
                     <include>com.github.joshelser.**.*</include>
@@ -130,29 +138,36 @@
                 </relocation>
                 <relocation>
                   <pattern>picocli</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded.picocli
+                  <shadedPattern>
+                    ${shaded.prefix}.picocli
                   </shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>info</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded.info
+                  <shadedPattern>
+                    ${shaded.prefix}.info
                   </shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded.io
+                  <shadedPattern>
+                    ${shaded.prefix}.io
                   </shadedPattern>
                 </relocation>
 
-                <!-- handling some special packages with special namescd -->
+                <!-- handling some special packages with special names -->
                 <relocation>
                   <pattern>okio</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded.okio</shadedPattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.okio
+                  </shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>okhttp3</pattern>
-                  <shadedPattern>org.apache.hadoop.ozone.shaded
-                    .okhttp3</shadedPattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.okhttp3
+                    ${shaded.prefix}.okhttp3
+                  </shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -166,7 +166,6 @@
                   <pattern>okhttp3</pattern>
                   <shadedPattern>
                     ${shaded.prefix}.okhttp3
-                    ${shaded.prefix}.okhttp3
                   </shadedPattern>
                 </relocation>
               </relocations>

--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -88,7 +88,7 @@
                     <resource>META-INF/BC2048KE.SF</resource>
                   </resources>
                 </transformer>
-
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <relocations>
                 <relocation>
@@ -100,6 +100,19 @@
                     <include>org.sqlite.**.*</include>
                     <include>org.tukaani.**.*</include>
                     <include>org.bouncycastle.**.*</include>
+                    <include>org.fusesource.leveldbjni.**.*</include>
+                    <include>org.rocksdb.**.*</include>
+                    <include>org.apache.commons.cli.**.*</include>
+                    <include>org.apache.commons.compress.**.*</include>
+                    <include>org.apache.commons.codec.**.*</include>
+                    <include>org.apache.commons.beanutils.**.*</include>
+                    <include>org.apache.commons.collections.**.*</include>
+                    <include>org.apache.commons.digester.**.*</include>
+                    <include>org.apache.commons.logging.**.*</include>
+                    <include>org.apache.commons.pool2.**.*</include>
+                    <include>org.apache.commons.validator.**.*</include>
+                    <include>org.sqlite.**.*</include>
+                    <include>org.apache.thrift.**.*</include>
                   </includes>
                 </relocation>
                 <relocation>
@@ -108,8 +121,11 @@
                   </shadedPattern>
                   <includes>
                     <include>com.google.common.**.*</include>
+                    <include>com.google.json.**.*</include>
                     <include>com.codahale.**.*</include>
                     <include>com.lmax.**.*</include>
+                    <include>com.github.joshelser.**.*</include>
+                    <include>com.twitter.**.*</include>
                   </includes>
                 </relocation>
                 <relocation>
@@ -126,9 +142,17 @@
                   <pattern>io</pattern>
                   <shadedPattern>org.apache.hadoop.ozone.shaded.io
                   </shadedPattern>
-                  <includes>
-                    <include>io.netty.**.*</include>
-                  </includes>
+                </relocation>
+
+                <!-- handling some special packages with special namescd -->
+                <relocation>
+                  <pattern>okio</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded.okio</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>okhttp3</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded
+                    .okhttp3</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>
@@ -167,6 +191,10 @@
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -74,11 +74,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <artifactSet>
-                <excludes>
-                  <exclude>classworlds:classworlds</exclude>
-                </excludes>
-              </artifactSet>
               <transformers>
                 <transformer
                         implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">

--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -47,26 +47,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-              <outputDirectory>target/classes</outputDirectory>
-              <includeScope>compile</includeScope>
-              <excludes>META-INF/*.SF</excludes>
-              <excludeArtifactIds>
-                slf4j-api,slf4j-log4j12,log4j-api,log4j-core,log4j
-              </excludeArtifactIds>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <executions>
@@ -82,6 +62,78 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>classworlds:classworlds</exclude>
+                </excludes>
+              </artifactSet>
+              <transformers>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resources>
+                    <resource>META-INF/BC1024KE.DSA</resource>
+                    <resource>META-INF/BC2048KE.DSA</resource>
+                    <resource>META-INF/BC1024KE.SF</resource>
+                    <resource>META-INF/BC2048KE.SF</resource>
+                  </resources>
+                </transformer>
+
+              </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>org</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded.org
+                  </shadedPattern>
+                  <includes>
+                    <include>org.yaml.**.*</include>
+                    <include>org.sqlite.**.*</include>
+                    <include>org.tukaani.**.*</include>
+                    <include>org.bouncycastle.**.*</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded.com
+                  </shadedPattern>
+                  <includes>
+                    <include>com.google.common.**.*</include>
+                    <include>com.codahale.**.*</include>
+                    <include>com.lmax.**.*</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>picocli</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded.picocli
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>info</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded.info
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io</pattern>
+                  <shadedPattern>org.apache.hadoop.ozone.shaded.io
+                  </shadedPattern>
+                  <includes>
+                    <include>io.netty.**.*</include>
+                  </includes>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -99,6 +151,22 @@
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-hdfs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
We need a shaded Ozonefs jar that does not include Hadoop ecosystem components (Hadoop, HDFS, Ratis, Zookeeper).

A common expected use case for Ozone is Hadoop clients (3.2.0 and later) wanting to access Ozone via the Ozone Filesystem interface. For these clients, we want to add Ozone file system jar to the classpath, however we want to use Hadoop ecosystem dependencies that are `provided` and already expected to be in the client classpath.

Note that this is different from the legacy jar which bundles a shaded Hadoop 3.2.0.

See: https://issues.apache.org/jira/browse/HDDS-2121