### PR TITLE
HDDS-2135. OM Metric mismatch (MultipartUpload failures)

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -91,12 +91,11 @@ public class OMMetrics {
   private @Metric MutableCounterLong numVolumeListFails;
   private @Metric MutableCounterLong numKeyCommitFails;
   private @Metric MutableCounterLong numBlockAllocateCallFails;
-  private @Metric MutableCounterLong numAddAllocateBlockCallFails;
   private @Metric MutableCounterLong numGetServiceListFails;
   private @Metric MutableCounterLong numListS3BucketsFails;
   private @Metric MutableCounterLong numInitiateMultipartUploadFails;
   private @Metric MutableCounterLong numCommitMultipartUploadParts;
-  private @Metric MutableCounterLong getNumCommitMultipartUploadPartFails;
+  private @Metric MutableCounterLong numCommitMultipartUploadPartFails;
   private @Metric MutableCounterLong numCompleteMultipartUploadFails;
   private @Metric MutableCounterLong numAbortMultipartUploads;
   private @Metric MutableCounterLong numAbortMultipartUploadFails;
@@ -308,7 +307,7 @@ public class OMMetrics {
   }
 
   public void incNumCommitMultipartUploadPartFails() {
-    numInitiateMultipartUploadFails.incr();
+    numCommitMultipartUploadPartFails.incr();
   }
 
   public void incNumCompleteMultipartUploads() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Fix metric mismatch (wrong metric being incremented)
 * Remove unused metric `numAddAllocateBlockCallFails` (leftover from [HDDS-1736](https://issues.apache.org/jira/browse/HDDS-1736))

https://issues.apache.org/jira/browse/HDDS-2135