### PR TITLE
HDDS-2139. Update BeanUtils and Jackson Databind dependency versions.

### DIFF
--- a/pom.ozone.xml
+++ b/pom.ozone.xml
@@ -125,7 +125,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.9.5</jackson2.version>
+    <jackson2.version>2.9.9</jackson2.version>
 
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.2</httpclient.version>
@@ -1014,7 +1014,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
The following Ozone dependencies have known security vulnerabilities. We should update them to newer/ latest versions.
- Apache Common BeanUtils version 1.9.3
- Fasterxml Jackson version 2.9.5