### PR TITLE
HDDS-2132. TestKeyValueContainer is failing

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -198,8 +198,9 @@ public final class KeyValueContainerUtil {
       kvContainerData.setKeyCount(liveKeys.size());
       byte[] bcsId = metadata.getStore().get(DFSUtil.string2Bytes(
           OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID_PREFIX));
-      Preconditions.checkNotNull(bcsId);
-      kvContainerData.updateBlockCommitSequenceId(Longs.fromByteArray(bcsId));
+      if (bcsId != null) {
+        kvContainerData.updateBlockCommitSequenceId(Longs.fromByteArray(bcsId));
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix unit tests recently broken by new `Preconditions.checkNotNull` in `KeyValueContainerUtil#parseKVContainerData` (added in fe8cdf0ab846df9c2f3f59d1d4875185633a27ea for [HDDS-2076](https://issues.apache.org/jira/browse/HDDS-2076)).

https://issues.apache.org/jira/browse/HDDS-2132
https://issues.apache.org/jira/browse/HDDS-2133

## How was this patch tested?

```
$ mvn -am -Phdds -pl :hadoop-hdds-container-service clean test
...
[INFO] Apache Hadoop HDDS ................................. SUCCESS [  2.527 s]
[INFO] Apache Hadoop HDDS Config .......................... SUCCESS [  3.223 s]
[INFO] Apache Hadoop HDDS Common .......................... SUCCESS [01:53 min]
[INFO] Apache Hadoop HDDS Server Framework ................ SUCCESS [ 18.258 s]
[INFO] Apache Hadoop HDDS Container Service ............... SUCCESS [01:13 min]
```