### PR TITLE
HDDS-2141. Missing total number of operations

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-metrics.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-metrics.html
@@ -20,7 +20,7 @@
     <h2>{{type}}</h2>
     <div class="container">
         <div class="col-md-6">
-            <h3>Requests ({{numbers.ops}} ops)</h3>
+            <h3>Requests ({{numbers.ops || numbers.total}} ops)</h3>
             <nvd3 options="$ctrl.graphOptions"
                   data="numbers.all"></nvd3>
         </div>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -76,7 +76,8 @@
                             var failed = numericalStatistic[3];
                             groupedMetrics.nums[type] = groupedMetrics.nums[type] || {
                                     failures: [],
-                                    all: []
+                                    all: [],
+                                    total: 0,
                                 };
                             if (failed) {
                                 groupedMetrics.nums[type].failures.push({
@@ -87,6 +88,7 @@
                                 if (name == "Ops") {
                                     groupedMetrics.nums[type].ops = metrics[key]
                                 } else {
+                                    groupedMetrics.nums[type].total += metrics[key]
                                     groupedMetrics.nums[type].all.push({
                                         key: name,
                                         value: metrics[key]

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -88,7 +88,7 @@
                                 if (name == "Ops") {
                                     groupedMetrics.nums[type].ops = metrics[key]
                                 } else {
-                                    groupedMetrics.nums[type].total += metrics[key]
+                                    groupedMetrics.nums[type].total += metrics[key];
                                     groupedMetrics.nums[type].all.push({
                                         key: name,
                                         value: metrics[key]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sum request counts and use it as fallback in case explicit "Ops" metric is not available.

https://issues.apache.org/jira/browse/HDDS-2141

## How was this patch tested?

Ran `ozonefs` robot test, checked OM metrics page.