### PR TITLE
HDDS-2144. MR job failing on secure Ozone cluster.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -194,7 +194,8 @@ public class OMFailoverProxyProvider implements
         omProxyInfos.entrySet()) {
       count++;
       rpcAddress =
-          rpcAddress.append(omProxyInfoSet.getValue().toString());
+          rpcAddress.append(
+              omProxyInfoSet.getValue().getDelegationTokenService());
 
       if (omProxyInfos.size() != count) {
         rpcAddress.append(",");


### PR DESCRIPTION
With this patch, able to run the map-reduce job on a secure cluster.
This was caused by HDDS-2018, which has changed the return/computed value of delegationTokenService. Thank You @xiaoyuyao for helping in this issue.