### PR TITLE
HDDS-2147. Include dumpstream in test report

### DIFF
--- a/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+++ b/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
@@ -25,6 +25,7 @@ find "." -name 'TEST*.xml' -print0 \
 #Copy heap dump and dump leftovers
 find "." -name "*.hprof" -exec cp {} "$REPORT_DIR/" \;
 find "." -name "*.dump" -exec cp {} "$REPORT_DIR/" \;
+find "." -name "*.dumpstream" -exec cp {} "$REPORT_DIR/" \;
 
 ## Add the tests where the JVM is crashed
 grep -A1 'Crashed tests' "${REPORT_DIR}/output.log" \

--- a/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+++ b/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
@@ -23,9 +23,11 @@ find "." -name 'TEST*.xml' -print0 \
     | tee "$REPORT_DIR/summary.txt"
 
 #Copy heap dump and dump leftovers
-find "." -name "*.hprof" -exec cp {} "$REPORT_DIR/" \;
-find "." -name "*.dump" -exec cp {} "$REPORT_DIR/" \;
-find "." -name "*.dumpstream" -exec cp {} "$REPORT_DIR/" \;
+find "." -name "*.hprof" \
+    -or -name "*.dump" \
+    -or -name "*.dumpstream" \
+    -or -name "hs_err_*.log" \
+  -exec cp {} "$REPORT_DIR/" \;
 
 ## Add the tests where the JVM is crashed
 grep -A1 'Crashed tests' "${REPORT_DIR}/output.log" \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Copy `*.dumpstream` files to the unit test report dir.  It may help finding out the cause of `Corrupted STDOUT` warning of forked JVM.

http://maven.apache.org/surefire/maven-surefire-plugin/faq.html#dumpfiles

https://issues.apache.org/jira/browse/HDDS-2147