### PR TITLE
HDDS-2151. Ozone client logs the entire request payload at DEBUG level

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -231,20 +231,20 @@ public final class XceiverClientRatis extends XceiverClientSpi {
   private ContainerCommandRequestProto sanitizeForDebug(
       ContainerCommandRequestProto request) {
     switch (request.getCmdType()) {
-      case PutSmallFile:
-        return request.toBuilder()
-            .setPutSmallFile(request.getPutSmallFile().toBuilder()
-                .clearData()
-            )
-            .build();
-      case WriteChunk:
-        return request.toBuilder()
-            .setWriteChunk(request.getWriteChunk().toBuilder()
-                .clearData()
-            )
-            .build();
-      default:
-        return request;
+    case PutSmallFile:
+      return request.toBuilder()
+          .setPutSmallFile(request.getPutSmallFile().toBuilder()
+              .clearData()
+          )
+          .build();
+    case WriteChunk:
+      return request.toBuilder()
+          .setWriteChunk(request.getWriteChunk().toBuilder()
+              .clearData()
+          )
+          .build();
+    default:
+      return request;
     }
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -218,10 +218,33 @@ public final class XceiverClientRatis extends XceiverClientSpi {
               .build();
       boolean isReadOnlyRequest = HddsUtils.isReadOnly(finalPayload);
       ByteString byteString = finalPayload.toByteString();
-      LOG.debug("sendCommandAsync {} {}", isReadOnlyRequest, finalPayload);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("sendCommandAsync {} {}", isReadOnlyRequest,
+            sanitizeForDebug(finalPayload));
+      }
       return isReadOnlyRequest ?
           getClient().sendReadOnlyAsync(() -> byteString) :
           getClient().sendAsync(() -> byteString);
+    }
+  }
+
+  private ContainerCommandRequestProto sanitizeForDebug(
+      ContainerCommandRequestProto request) {
+    switch (request.getCmdType()) {
+      case PutSmallFile:
+        return request.toBuilder()
+            .setPutSmallFile(request.getPutSmallFile().toBuilder()
+                .clearData()
+            )
+            .build();
+      case WriteChunk:
+        return request.toBuilder()
+            .setWriteChunk(request.getWriteChunk().toBuilder()
+                .clearData()
+            )
+            .build();
+      default:
+        return request;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove byte data from container command request before logging it (applicable to `PutSmallFile` and `WriteChunk`).

https://issues.apache.org/jira/browse/HDDS-2151

## How was this patch tested?

Set root log level to DEBUG in `ozone-shell-log4j.properties`.  Created small and large keys via `ozone sh`.  Verified that `ozone-shell.log` contains detailed request without actual `data`.