### PR TITLE
HDFS-14856. Fetch file ACLs while mounting external store.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -379,7 +379,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_PROVIDED_ALIASMAP_TEXT_WRITE_DIR_DEFAULT = "file:///tmp/";
 
   public static final String DFS_PROVIDED_ALIASMAP_LEVELDB_PATH = "dfs.provided.aliasmap.leveldb.path";
-  public static final String DFS_PROVIDED_ACLS_IMPORT_ENABLED = "dfs.provided.acls.import.enabled";
+  public static final String DFS_PROVIDED_ACLS_IMPORT_ENABLED =
+      "dfs.provided.acls.import.enabled";
   public static final boolean DFS_PROVIDED_ACLS_IMPORT_ENABLED_DEFAULT = false;
 
   public static final String  DFS_LIST_LIMIT = "dfs.ls.limit";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -379,8 +379,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_PROVIDED_ALIASMAP_TEXT_WRITE_DIR_DEFAULT = "file:///tmp/";
 
   public static final String DFS_PROVIDED_ALIASMAP_LEVELDB_PATH = "dfs.provided.aliasmap.leveldb.path";
-  public static final String DFS_NAMENODE_MOUNT_ACLS_ENABLED = "dfs.namenode.mount.acls.enabled";
-  public static final boolean DFS_NAMENODE_MOUNT_ACLS_ENABLED_DEFAULT = false;
+  public static final String DFS_PROVIDED_ACLS_IMPORT_ENABLED = "dfs.provided.acls.import.enabled";
+  public static final boolean DFS_PROVIDED_ACLS_IMPORT_ENABLED_DEFAULT = false;
 
   public static final String  DFS_LIST_LIMIT = "dfs.ls.limit";
   public static final int     DFS_LIST_LIMIT_DEFAULT = 1000;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -379,6 +379,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_PROVIDED_ALIASMAP_TEXT_WRITE_DIR_DEFAULT = "file:///tmp/";
 
   public static final String DFS_PROVIDED_ALIASMAP_LEVELDB_PATH = "dfs.provided.aliasmap.leveldb.path";
+  public static final String DFS_NAMENODE_MOUNT_ACLS_ENABLED = "dfs.namenode.mount.acls.enabled";
+  public static final boolean DFS_NAMENODE_MOUNT_ACLS_ENABLED_DEFAULT = false;
 
   public static final String  DFS_LIST_LIMIT = "dfs.ls.limit";
   public static final int     DFS_LIST_LIMIT_DEFAULT = 1000;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5358,6 +5358,17 @@
   </property>
 
   <property>
+  <name>dfs.namenode.mount.acls.enabled</name>
+    <value>false</value>
+    <description>
+      Set to true to inherit ACLs (Access Control Lists) from remote stores
+      during mount. Disabled by default, i.e., ACLs are not inherited from
+      remote stores. Note had HDFS ACLs have to be enabled
+      (dfs.namenode.acls.enabled must be set to true) for this to take effect.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.provided.aliasmap.load.retries</name>
     <value>0</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5358,7 +5358,7 @@
   </property>
 
   <property>
-  <name>dfs.namenode.mount.acls.enabled</name>
+  <name>dfs.provided.acls.import.enabled</name>
     <value>false</value>
     <description>
       Set to true to inherit ACLs (Access Control Lists) from remote stores

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
@@ -57,7 +57,7 @@ public class FSTreeWalk extends TreeWalk {
     fs = root.getFileSystem(conf);
 
     boolean mountACLsEnabled = conf.getBoolean(DFS_PROVIDED_ACLS_IMPORT_ENABLED,
-                                               DFS_PROVIDED_ACLS_IMPORT_ENABLED_DEFAULT);
+        DFS_PROVIDED_ACLS_IMPORT_ENABLED_DEFAULT);
     boolean localACLsEnabled = conf.getBoolean(DFS_NAMENODE_ACLS_ENABLED_KEY,
         DFS_NAMENODE_ACLS_ENABLED_DEFAULT);
     if (!localACLsEnabled && mountACLsEnabled) {
@@ -121,14 +121,7 @@ public class FSTreeWalk extends TreeWalk {
   }
 
   private AclStatus getAclStatus(FileSystem fs, Path path) throws IOException {
-    if (enableACLs) {
-      try {
-        return fs.getAclStatus(path);
-      } catch (UnsupportedOperationException e) {
-        LOG.warn("Remote filesystem {} doesn't support ACLs", fs);
-      }
-    }
-    return null;
+    return enableACLs ? fs.getAclStatus(path) : null;
   }
 
   @Override

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
@@ -35,8 +35,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_ACLS_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_ACLS_ENABLED_KEY;
-import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MOUNT_ACLS_ENABLED;
-import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MOUNT_ACLS_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED_DEFAULT;
 
 /**
  * Traversal of an external FileSystem.
@@ -56,8 +56,8 @@ public class FSTreeWalk extends TreeWalk {
     this.root = root;
     fs = root.getFileSystem(conf);
 
-    boolean mountACLsEnabled = conf.getBoolean(DFS_NAMENODE_MOUNT_ACLS_ENABLED,
-        DFS_NAMENODE_MOUNT_ACLS_ENABLED_DEFAULT);
+    boolean mountACLsEnabled = conf.getBoolean(DFS_PROVIDED_ACLS_IMPORT_ENABLED,
+                                               DFS_PROVIDED_ACLS_IMPORT_ENABLED_DEFAULT);
     boolean localACLsEnabled = conf.getBoolean(DFS_NAMENODE_ACLS_ENABLED_KEY,
         DFS_NAMENODE_ACLS_ENABLED_DEFAULT);
     if (!localACLsEnabled && mountACLsEnabled) {

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
@@ -79,7 +79,8 @@ public class FSTreeWalk extends TreeWalk {
     try {
       ArrayList<TreePath> ret = new ArrayList<>();
       for (FileStatus s : fs.listStatus(path.getFileStatus().getPath())) {
-        ret.add(new TreePath(s, id, i, fs, getAclStatus(fs, s.getPath())));
+        AclStatus aclStatus = getAclStatus(fs, s.getPath());
+        ret.add(new TreePath(s, id, i, fs, aclStatus));
       }
       return ret;
     } catch (FileNotFoundException e) {
@@ -100,9 +101,7 @@ public class FSTreeWalk extends TreeWalk {
       try {
         acls = getAclStatus(fs, remotePath);
       } catch (IOException e) {
-        LOG.warn(
-            "Got exception when trying to get remote acls for path {} : {}",
-            remotePath, e.getMessage());
+        throw new RuntimeException(e);
       }
       getPendingQueue().addFirst(
           new TreePath(p.getFileStatus(), p.getParentId(), this, fs, acls));
@@ -150,4 +149,5 @@ public class FSTreeWalk extends TreeWalk {
       throw new RuntimeException(e);
     }
   }
+
 }

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
@@ -97,14 +97,15 @@ public class FSTreeWalk extends TreeWalk {
 
     FSTreeIterator(TreePath p) {
       AclStatus acls = null;
-      Path remotePath = p.getFileStatus().getPath();
+      FileStatus fileStatus = p.getFileStatus();
+      Path remotePath = fileStatus.getPath();
       try {
         acls = getAclStatus(fs, remotePath);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-      getPendingQueue().addFirst(
-          new TreePath(p.getFileStatus(), p.getParentId(), this, fs, acls));
+      TreePath treePath = new TreePath(fileStatus, p.getParentId(), this, fs, acls);
+      getPendingQueue().addFirst(treePath);
     }
 
     FSTreeIterator(Path p) throws IOException {

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSTreeWalk.java
@@ -107,7 +107,8 @@ public class FSTreeWalk extends TreeWalk {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-      getPendingQueue().addFirst(new TreePath(fileStatus, parentId, this, fs, acls));
+      TreePath treePath = new TreePath(fileStatus, parentId, this, fs, acls);
+      getPendingQueue().addFirst(treePath);
     }
 
     @Override
@@ -120,8 +121,9 @@ public class FSTreeWalk extends TreeWalk {
 
   }
 
-  private AclStatus getAclStatus(FileSystem fs, Path path) throws IOException {
-    return enableACLs ? fs.getAclStatus(path) : null;
+  private AclStatus getAclStatus(FileSystem fileSystem, Path path)
+      throws IOException {
+    return enableACLs ? fileSystem.getAclStatus(path) : null;
   }
 
   @Override

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/SingleUGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/SingleUGIResolver.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.security.UserGroupInformation;
 
 /**

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/SingleUGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/SingleUGIResolver.java
@@ -73,12 +73,12 @@ public class SingleUGIResolver extends UGIResolver implements Configurable {
   }
 
   @Override
-  public String user(FileStatus s) {
+  public String user(String s) {
     return user;
   }
 
   @Override
-  public String group(FileStatus s) {
+  public String group(String s) {
     return group;
   }
 

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
@@ -93,8 +93,8 @@ public class TreePath {
     return id;
   }
 
-  public void accept(long id) {
-    this.id = id;
+  public void accept(long pathId) {
+    this.id = pathId;
     i.onAccept(this, id);
   }
 

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
@@ -159,7 +159,8 @@ public class TreePath {
       }
     }
     if (aclStatus != null) {
-      throw new UnsupportedOperationException("ACLs not supported by ImageWriter");
+      throw new UnsupportedOperationException(
+          "ACLs not supported by ImageWriter");
     }
     //TODO: storage policy should be configurable per path; use BlockResolver
     long off = 0L;
@@ -187,7 +188,8 @@ public class TreePath {
         .setDsQuota(DEFAULT_STORAGE_SPACE_QUOTA)
         .setPermission(permissions);
     if (aclStatus != null) {
-      throw new UnsupportedOperationException("ACLs not supported by ImageWriter");
+      throw new UnsupportedOperationException(
+          "ACLs not supported by ImageWriter");
     }
     INode.Builder ib = INode.newBuilder()
         .setType(INode.Type.DIRECTORY)

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
@@ -159,8 +159,7 @@ public class TreePath {
       }
     }
     if (aclStatus != null) {
-      throw new UnsupportedOperationException(
-          "Acls not supported by ImageWriter");
+      throw new UnsupportedOperationException("ACLs not supported by ImageWriter");
     }
     //TODO: storage policy should be configurable per path; use BlockResolver
     long off = 0L;
@@ -188,8 +187,7 @@ public class TreePath {
         .setDsQuota(DEFAULT_STORAGE_SPACE_QUOTA)
         .setPermission(permissions);
     if (aclStatus != null) {
-      throw new UnsupportedOperationException(
-          "Acls not supported by ImageWriter");
+      throw new UnsupportedOperationException("ACLs not supported by ImageWriter");
     }
     INode.Builder ib = INode.newBuilder()
         .setType(INode.Type.DIRECTORY)

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreePath.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import java.io.IOException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -27,6 +28,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.PathHandle;
+import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos.BlockProto;
 import org.apache.hadoop.hdfs.server.common.FileRegion;
@@ -52,21 +54,36 @@ public class TreePath {
   private final FileStatus stat;
   private final TreeWalk.TreeIterator i;
   private final FileSystem fs;
+  private final AclStatus acls;
 
-  protected TreePath(FileStatus stat, long parentId, TreeWalk.TreeIterator i,
-      FileSystem fs) {
+  @VisibleForTesting
+  public TreePath(FileStatus stat, long parentId, TreeWalk.TreeIterator i) {
+    this(stat, parentId, i, null, null);
+  }
+
+  public TreePath(FileStatus stat, long parentId, TreeWalk.TreeIterator i,
+      FileSystem fs, AclStatus acls) {
     this.i = i;
     this.stat = stat;
     this.parentId = parentId;
     this.fs = fs;
+    this.acls = acls;
   }
 
   public FileStatus getFileStatus() {
     return stat;
   }
 
+  public AclStatus getAclStatus() {
+    return acls;
+  }
+
   public long getParentId() {
     return parentId;
+  }
+
+  public TreeWalk.TreeIterator getIterator() {
+    return i;
   }
 
   public long getId() {
@@ -76,7 +93,7 @@ public class TreePath {
     return id;
   }
 
-  void accept(long id) {
+  public void accept(long id) {
     this.id = id;
     i.onAccept(this, id);
   }
@@ -121,14 +138,14 @@ public class TreePath {
   INode toFile(UGIResolver ugi, BlockResolver blk,
       BlockAliasMap.Writer<FileRegion> out) throws IOException {
     final FileStatus s = getFileStatus();
-    ugi.addUser(s.getOwner());
-    ugi.addGroup(s.getGroup());
+    final AclStatus aclStatus = getAclStatus();
+    long permissions = ugi.getPermissionsProto(s, aclStatus);
     INodeFile.Builder b = INodeFile.newBuilder()
         .setReplication(blk.getReplication(s))
         .setModificationTime(s.getModificationTime())
         .setAccessTime(s.getAccessTime())
         .setPreferredBlockSize(blk.preferredBlockSize(s))
-        .setPermission(ugi.resolve(s))
+        .setPermission(permissions)
         .setStoragePolicyID(HdfsConstants.PROVIDED_STORAGE_POLICY_ID);
 
     // pathhandle allows match as long as the file matches exactly.
@@ -141,7 +158,11 @@ public class TreePath {
             "Exact path handle not supported by filesystem " + fs.toString());
       }
     }
-    // TODO: storage policy should be configurable per path; use BlockResolver
+    if (aclStatus != null) {
+      throw new UnsupportedOperationException(
+          "Acls not supported by ImageWriter");
+    }
+    //TODO: storage policy should be configurable per path; use BlockResolver
     long off = 0L;
     for (BlockProto block : blk.resolve(s)) {
       b.addBlocks(block);
@@ -159,13 +180,17 @@ public class TreePath {
 
   INode toDirectory(UGIResolver ugi) {
     final FileStatus s = getFileStatus();
-    ugi.addUser(s.getOwner());
-    ugi.addGroup(s.getGroup());
+    final AclStatus aclStatus = getAclStatus();
+    long permissions = ugi.getPermissionsProto(s, aclStatus);
     INodeDirectory.Builder b = INodeDirectory.newBuilder()
         .setModificationTime(s.getModificationTime())
         .setNsQuota(DEFAULT_NAMESPACE_QUOTA)
         .setDsQuota(DEFAULT_STORAGE_SPACE_QUOTA)
-        .setPermission(ugi.resolve(s));
+        .setPermission(permissions);
+    if (aclStatus != null) {
+      throw new UnsupportedOperationException(
+          "Acls not supported by ImageWriter");
+    }
     INode.Builder ib = INode.newBuilder()
         .setType(INode.Type.DIRECTORY)
         .setId(id)

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreeWalk.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
+import org.apache.hadoop.fs.Path;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -50,7 +52,7 @@ public abstract class TreeWalk implements Iterable<TreePath> {
 
     private final Deque<TreePath> pending;
 
-    TreeIterator() {
+    public TreeIterator() {
       this(new ArrayDeque<TreePath>());
     }
 

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/TreeWalk.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import org.apache.hadoop.fs.Path;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/UGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/UGIResolver.java
@@ -120,26 +120,29 @@ public abstract class UGIResolver {
   }
 
   public long resolve(FileStatus s) {
-    return buildPermissionStatus(user(s), group(s), permission(s).toShort());
-  }
-
-  public String user(FileStatus s) {
-    return s.getOwner();
-  }
-
-  public String group(FileStatus s) {
-    return s.getGroup();
-  }
-
-  public FsPermission permission(FileStatus s) {
-    return s.getPermission();
+    String resolvedGroup = group(s.getGroup());
+    String resolvedOwner = user(s.getOwner());
+    FsPermission resolvedPermission = permission(s.getPermission());
+    return buildPermissionStatus(resolvedOwner, resolvedGroup, resolvedPermission.toShort());
   }
 
   private long resolve(AclStatus aclStatus) {
-    String owner = aclStatus.getOwner();
-    String group = aclStatus.getGroup();
-    short permission = aclStatus.getPermission().toShort();
-    return buildPermissionStatus(owner, group, permission);
+    String resolvedOwner = user(aclStatus.getOwner());
+    String resolvedGroup = group(aclStatus.getGroup());
+    FsPermission resolvedPermision = permission(aclStatus.getPermission());
+    return buildPermissionStatus(resolvedOwner, resolvedGroup, resolvedPermision.toShort());
+  }
+
+  protected String user(String s) {
+    return s;
+  }
+
+  protected String group(String s) {
+    return s;
+  }
+
+  public FsPermission permission(FsPermission s) {
+    return s;
   }
 
   /**
@@ -151,8 +154,7 @@ public abstract class UGIResolver {
    * @param remoteAcl AclStatus on external store.
    * @return serialized, local permissions the FileStatus or AclStatus map to.
    */
-  public long getPermissionsProto(FileStatus remoteStatus,
-      AclStatus remoteAcl) {
+  public long getPermissionsProto(FileStatus remoteStatus, AclStatus remoteAcl) {
     addUGI(remoteStatus, remoteAcl);
     if (remoteAcl == null) {
       return resolve(remoteStatus);

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/UGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/UGIResolver.java
@@ -17,14 +17,20 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclEntryType;
+import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.permission.PermissionStatus;
 
 /**
  * Pluggable class for mapping ownership and permissions from an external
@@ -34,9 +40,9 @@ import org.apache.hadoop.fs.permission.FsPermission;
 @InterfaceStability.Unstable
 public abstract class UGIResolver {
 
-  static final int USER_STRID_OFFSET = 40;
-  static final int GROUP_STRID_OFFSET = 16;
-  static final long USER_GROUP_STRID_MASK = (1 << 24) - 1;
+  public static final int USER_STRID_OFFSET = 40;
+  public static final int GROUP_STRID_OFFSET = 16;
+  public static final long USER_GROUP_STRID_MASK = (1 << 24) - 1;
 
   /**
    * Permission is serialized as a 64-bit long. [0:24):[25:48):[48:64) (in Big
@@ -132,4 +138,134 @@ public abstract class UGIResolver {
     return s.getPermission();
   }
 
+  private long resolve(AclStatus aclStatus) {
+    return buildPermissionStatus(
+        user(aclStatus), group(aclStatus), permission(aclStatus).toShort());
+  }
+
+  /**
+   * Get the locally mapped user for external {@link AclStatus}.
+   *
+   * @param aclStatus AclStatus on external store.
+   * @return locally mapped user name.
+   */
+  public String user(AclStatus aclStatus) {
+    return aclStatus.getOwner();
+  }
+
+  /**
+   * Get the locally mapped group for the external {@link AclStatus}.
+   *
+   * @param aclStatus AclStatus on the external store.
+   * @return locally mapped group name.
+   */
+  public String group(AclStatus aclStatus) {
+    return aclStatus.getGroup();
+  }
+
+  /**
+   * Get the locally mapped {@link FsPermission} for the external
+   * {@link AclStatus}.
+   *
+   * @param aclStatus AclStatus on the external store.
+   * @return local {@link FsPermission} the external AclStatus maps to.
+   */
+  public FsPermission permission(AclStatus aclStatus) {
+    return aclStatus.getPermission();
+  }
+
+  /**
+   * Returns list of Acl entries to apply to local paths based on remote acls.
+   *
+   * @param aclStatus remote ACL status.
+   * @return local HDFS ACL entries.
+   */
+  public List<AclEntry> aclEntries(AclStatus aclStatus) {
+    List<AclEntry> newAclEntries = new ArrayList<>();
+    for (AclEntry entry : aclStatus.getEntries()) {
+      newAclEntries.add(getLocalAclEntry(entry));
+    }
+    return newAclEntries;
+  }
+
+  /**
+   * Map the {@link AclEntry} on the remote store to one on the local HDFS.
+   * @param remoteEntry the {@link AclEntry} on the remote store.
+   * @return the {@link AclEntry} on the local HDFS.
+   */
+  protected AclEntry getLocalAclEntry(AclEntry remoteEntry) {
+    return new AclEntry.Builder()
+        .setType(remoteEntry.getType())
+        .setName(remoteEntry.getName())
+        .setPermission(remoteEntry.getPermission())
+        .setScope(remoteEntry.getScope())
+        .build();
+  }
+
+  /**
+   * Get the local {@link PermissionStatus} the external {@link FileStatus} or
+   * {@link AclStatus} map to. {@code remoteAcl} is used when it
+   * is not null, otherwise {@code remoteStatus} is used.
+   *
+   * @param remoteStatus FileStatus on remote store.
+   * @param remoteAcl AclStatus on external store.
+   * @return the local {@link PermissionStatus}.
+   */
+  public PermissionStatus getPermissions(FileStatus remoteStatus,
+      AclStatus remoteAcl) {
+    addUGI(remoteStatus, remoteAcl);
+    if (remoteAcl == null) {
+      return new PermissionStatus(user(remoteStatus),
+          group(remoteStatus), permission(remoteStatus));
+    } else {
+      return new PermissionStatus(user(remoteAcl),
+          group(remoteAcl), permission(remoteAcl));
+    }
+  }
+
+  /**
+   * Get the serialized, local permissions for the external
+   * {@link FileStatus} or {@link AclStatus}. {@code remoteAcl} is used when it
+   * is not null, otherwise {@code remoteStatus} is used.
+   *
+   * @param remoteStatus FileStatus on remote store.
+   * @param remoteAcl AclStatus on external store.
+   * @return serialized, local permissions the FileStatus or AclStatus map to.
+   */
+  public long getPermissionsProto(FileStatus remoteStatus,
+      AclStatus remoteAcl) {
+    addUGI(remoteStatus, remoteAcl);
+    if (remoteAcl == null) {
+      return resolve(remoteStatus);
+    } else {
+      return resolve(remoteAcl);
+    }
+  }
+
+  /**
+   * Add the users and groups specified by the given {@link FileStatus} and
+   * {@link AclStatus}.
+   *
+   * @param remoteStatus
+   * @param remoteAcl
+   */
+  private void addUGI(FileStatus remoteStatus, AclStatus remoteAcl) {
+    if (remoteAcl != null) {
+      addUser(remoteAcl.getOwner());
+      addGroup(remoteAcl.getGroup());
+      for (AclEntry entry : remoteAcl.getEntries()) {
+        // add the users and groups in this acl entry to ugi
+        if (entry.getName() != null) {
+          if (entry.getType() == AclEntryType.USER) {
+            addUser(entry.getName());
+          } else if (entry.getType() == AclEntryType.GROUP) {
+            addGroup(entry.getName());
+          }
+        }
+      }
+    } else {
+      addUser(remoteStatus.getOwner());
+      addGroup(remoteStatus.getGroup());
+    }
+  }
 }

--- a/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/UGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/main/java/org/apache/hadoop/hdfs/server/namenode/UGIResolver.java
@@ -123,14 +123,16 @@ public abstract class UGIResolver {
     String resolvedGroup = group(s.getGroup());
     String resolvedOwner = user(s.getOwner());
     FsPermission resolvedPermission = permission(s.getPermission());
-    return buildPermissionStatus(resolvedOwner, resolvedGroup, resolvedPermission.toShort());
+    return buildPermissionStatus(
+        resolvedOwner, resolvedGroup, resolvedPermission.toShort());
   }
 
   private long resolve(AclStatus aclStatus) {
     String resolvedOwner = user(aclStatus.getOwner());
     String resolvedGroup = group(aclStatus.getGroup());
     FsPermission resolvedPermision = permission(aclStatus.getPermission());
-    return buildPermissionStatus(resolvedOwner, resolvedGroup, resolvedPermision.toShort());
+    return buildPermissionStatus(
+        resolvedOwner, resolvedGroup, resolvedPermision.toShort());
   }
 
   protected String user(String s) {
@@ -154,7 +156,8 @@ public abstract class UGIResolver {
    * @param remoteAcl AclStatus on external store.
    * @return serialized, local permissions the FileStatus or AclStatus map to.
    */
-  public long getPermissionsProto(FileStatus remoteStatus, AclStatus remoteAcl) {
+  public long getPermissionsProto(FileStatus remoteStatus,
+      AclStatus remoteAcl) {
     addUGI(remoteStatus, remoteAcl);
     if (remoteAcl == null) {
       return resolve(remoteStatus);

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/RandomTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/RandomTreeWalk.java
@@ -95,7 +95,7 @@ public class RandomTreeWalk extends TreeWalk {
     int nChildren = r.nextInt(children);
     ArrayList<TreePath> ret = new ArrayList<TreePath>();
     for (int i = 0; i < nChildren; ++i) {
-      ret.add(new TreePath(genFileStatus(p, r), p.getId(), walk, null));
+      ret.add(new TreePath(genFileStatus(p, r), p.getId(), walk));
     }
     return ret;
   }
@@ -163,12 +163,12 @@ public class RandomTreeWalk extends TreeWalk {
     RandomTreeIterator(long seed) {
       Random r = new Random(seed);
       FileStatus iroot = genFileStatus(null, r);
-      getPendingQueue().addFirst(new TreePath(iroot, -1, this, null));
+      getPendingQueue().addFirst(new TreePath(iroot, -1, this));
     }
 
     RandomTreeIterator(TreePath p) {
       getPendingQueue().addFirst(
-          new TreePath(p.getFileStatus(), p.getParentId(), this, null));
+          new TreePath(p.getFileStatus(), p.getParentId(), this));
     }
 
     @Override

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AclStatus;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate FSTreeWalk specific behavior
+ */
+public class TestFSTreeWalk {
+  // verify that the ACLs are fetched when configured
+  @Test
+  public void testImportAcl() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_MOUNT_ACLS_ENABLED, true);
+
+    FileSystem fs = mock(FileSystem.class);
+    Path root = mock(Path.class);
+    when(root.getFileSystem(conf)).thenReturn(fs);
+
+    Map<Path, FileStatus> expectedChildren = new HashMap<>();
+    FileStatus child1 = new FileStatus(0, true, 0, 0, 1, new Path("/a"));
+    FileStatus child2 = new FileStatus(0, true, 0, 0, 1, new Path("/b"));
+    expectedChildren.put(child1.getPath(), child1);
+    expectedChildren.put(child2.getPath(), child2);
+    when(fs.listStatus(root)).thenReturn(expectedChildren.values().toArray(new FileStatus[1]));
+
+    AclStatus expectedAcls = mock(AclStatus.class);
+    when(fs.getAclStatus(any(Path.class))).thenReturn(expectedAcls);
+
+    FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
+
+    FileStatus rootFileStatus = new FileStatus(0, true, 0, 0, 1, root);
+    TreePath treePath = new TreePath(rootFileStatus, 1, null);
+
+    Iterable<TreePath> result = fsTreeWalk.getChildren(treePath, 1, null);
+    for (TreePath path : result) {
+      FileStatus expectedChildStatus = expectedChildren.remove(path.getFileStatus().getPath());
+      assertNotNull(expectedChildStatus);
+
+      AclStatus childAcl = path.getAclStatus();
+      assertEquals(expectedAcls, childAcl);
+    }
+
+    assertEquals(0, expectedChildren.size());
+  }
+}

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -76,4 +76,22 @@ public class TestFSTreeWalk {
 
     assertEquals(0, expectedChildren.size());
   }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testACLNotSupported() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
+
+    FileSystem fs = mock(FileSystem.class);
+    when(fs.getAclStatus(any())).thenThrow(new UnsupportedOperationException());
+    Path root = mock(Path.class);
+    when(root.getFileSystem(conf)).thenReturn(fs);
+    FileStatus rootFileStatus = new FileStatus(0, true, 0, 0, 1, root);
+    when(fs.getFileStatus(root)).thenReturn(rootFileStatus);
+
+    FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
+    for (TreePath treePath : fsTreeWalk) {
+      System.out.println(treePath.getAclStatus());
+    }
+  }
 }

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -38,7 +38,9 @@ import static org.mockito.Mockito.when;
  * Validate FSTreeWalk specific behavior
  */
 public class TestFSTreeWalk {
-  // verify that the ACLs are fetched when configured
+  /**
+   * Verify that the ACLs are fetched when configured
+   */
   @Test
   public void testImportAcl() throws Exception {
     Configuration conf = new Configuration();

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -42,7 +42,7 @@ public class TestFSTreeWalk {
   @Test
   public void testImportAcl() throws Exception {
     Configuration conf = new Configuration();
-    conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_MOUNT_ACLS_ENABLED, true);
+    conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
 
     FileSystem fs = mock(FileSystem.class);
     Path root = mock(Path.class);

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -114,7 +114,7 @@ public class TestFSTreeWalk {
     TreePath treePath = new TreePath(rootFileStatus, 1, null, null, acls);
 
     UGIResolver ugiResolver = mock(UGIResolver.class);
-    when(ugiResolver.getPermissionsProto(null, acls)).thenReturn(1l);
+    when(ugiResolver.getPermissionsProto(null, acls)).thenReturn(1L);
     treePath.toINode(ugiResolver, blockResolver, null);
   }
 }

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -30,16 +30,17 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Validate FSTreeWalk specific behavior
+ * Validate FSTreeWalk specific behavior.
  */
 public class TestFSTreeWalk {
   /**
-   * Verify that the ACLs are fetched when configured
+   * Verify that the ACLs are fetched when configured.
    */
   @Test
   public void testImportAcl() throws Exception {
@@ -55,7 +56,8 @@ public class TestFSTreeWalk {
     FileStatus child2 = new FileStatus(0, true, 0, 0, 1, new Path("/b"));
     expectedChildren.put(child1.getPath(), child1);
     expectedChildren.put(child2.getPath(), child2);
-    when(fs.listStatus(root)).thenReturn(expectedChildren.values().toArray(new FileStatus[1]));
+    when(fs.listStatus(root))
+        .thenReturn(expectedChildren.values().toArray(new FileStatus[1]));
 
     AclStatus expectedAcls = mock(AclStatus.class);
     when(fs.getAclStatus(any(Path.class))).thenReturn(expectedAcls);
@@ -67,7 +69,8 @@ public class TestFSTreeWalk {
 
     Iterable<TreePath> result = fsTreeWalk.getChildren(treePath, 1, null);
     for (TreePath path : result) {
-      FileStatus expectedChildStatus = expectedChildren.remove(path.getFileStatus().getPath());
+      FileStatus expectedChildStatus
+          = expectedChildren.remove(path.getFileStatus().getPath());
       assertNotNull(expectedChildStatus);
 
       AclStatus childAcl = path.getAclStatus();
@@ -91,7 +94,7 @@ public class TestFSTreeWalk {
 
     FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
     for (TreePath treePath : fsTreeWalk) {
-      System.out.println(treePath.getAclStatus());
+      fail("Unexpected successful traversal of remote FS: " + treePath);
     }
   }
 }


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/HDFS-14856. 
If configuration `dfs.namenode.mount.acls.enabled` is set (true), `FsTreeWalk` will fetch ACLs of files on the external storage system provided at the time of mount.