### PR TITLE
HDFS-14857 FS operations fail in HA mode: DataNode fails to connect to NameNode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/AbstractNNFailoverProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/AbstractNNFailoverProxyProvider.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.net.DomainNameResolver;
 import org.apache.hadoop.net.DomainNameResolverFactory;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,6 +199,24 @@ public abstract class AbstractNNFailoverProxyProvider<T> implements
     // underlying IPC addresses so that the IPC code can find it.
     HAUtilClient.cloneDelegationTokenForLogicalUri(ugi, uri, addressesOfNns);
     return proxies;
+  }
+
+  /**
+   * Resets the NameNode proxy addresses in case they're stale
+   */
+  protected void resetProxyAddresses(List<NNProxyInfo<T>> proxies) {
+    try {
+      for (int i = 0; i < proxies.size(); ++i) {
+        InetSocketAddress oldAddress = proxies.get(i).getAddress();
+        InetSocketAddress address = NetUtils.createSocketAddr(
+                oldAddress.getHostName() + ":" + oldAddress.getPort());
+        LOG.debug("oldAddress {}, newAddress {}",
+                oldAddress, address);
+        proxies.set(i, new NNProxyInfo<T>(address));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Could not refresh NN address", e);
+    }
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ConfiguredFailoverProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ConfiguredFailoverProxyProvider.java
@@ -36,6 +36,8 @@ import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_NAMENODE_RP
 public class ConfiguredFailoverProxyProvider<T> extends
     AbstractNNFailoverProxyProvider<T> {
 
+  public static final String RESET_PROXY_ON_FAILOVER = "dfs.client.failover.proxy.provider.reset-proxy-on-failure";
+
   protected final List<NNProxyInfo<T>> proxies;
 
   private int currentProxyIndex = 0;
@@ -62,6 +64,11 @@ public class ConfiguredFailoverProxyProvider<T> extends
 
   @Override
   public  void performFailover(T currentProxy) {
+    if(conf.getBoolean(RESET_PROXY_ON_FAILOVER, false)) {
+      //reset the IP address in case  the stale IP was the cause for failover
+      LOG.info("Resetting cached proxy");
+      resetProxyAddresses(proxies);
+    }
     incrementProxyIndex();
   }
 


### PR DESCRIPTION
This is a fix for HDFS-14857 where the datanode fails to reconnect to the namenode when the namenodes IP address(es) change in an HA environment.
