### PR TITLE
HADOOP-16589. [pb-upgrade] Update docker image to make 3.7.1 protoc as default

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -111,7 +111,7 @@ ENV PATH "${PATH}:/opt/cmake/bin"
 # hadolint ignore=DL3003
 RUN mkdir -p /opt/protobuf-src \
     && curl -L -s -S \
-      https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz \
+      https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-java-3.7.1.tar.gz \
       -o /opt/protobuf.tar.gz \
     && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
     && cd /opt/protobuf-src \
@@ -200,17 +200,6 @@ RUN curl -L -s -S \
 ###
 ENV MAVEN_OPTS -Xms256m -Xmx1536m
 
-RUN mkdir -p /opt/protobuf-3.7-src \
-    && curl -L -s -S \
-      https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-java-3.7.1.tar.gz \
-      -o /opt/protobuf-3.7.1.tar.gz \
-    && tar xzf /opt/protobuf-3.7.1.tar.gz --strip-components 1 -C /opt/protobuf-3.7-src \
-    && cd /opt/protobuf-3.7-src \
-    && ./configure --prefix=/opt/protobuf-3.7 \
-    && make install \
-    && cd /root \
-    && rm -rf /opt/protobuf-3.7-src
-
 ###
 # Everything past this point is either not needed for testing or breaks Yetus.
 # So tell Yetus not to read the rest of the file:
@@ -222,11 +211,6 @@ RUN curl -L -o hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.30
     && dpkg --install hugo.deb \
     && rm hugo.deb
 
-######
-# Install Google Protobuf 3.7.1 (2.6.0 ships with Xenial)
-# Keep 2.5.0 as well, until 3.7.1 upgrade is complete.
-######
-# hadolint ignore=DL3003
 
 # Add a welcome message and environment checks.
 COPY hadoop_env_checks.sh /root/hadoop_env_checks.sh

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -106,7 +106,7 @@ ENV CMAKE_HOME /opt/cmake
 ENV PATH "${PATH}:/opt/cmake/bin"
 
 ######
-# Install Google Protobuf 2.5.0 (2.6.0 ships with Xenial)
+# Install Google Protobuf 3.7.1 (2.6.0 ships with Xenial)
 ######
 # hadolint ignore=DL3003
 RUN mkdir -p /opt/protobuf-src \

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1918,9 +1918,6 @@
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
-      <properties>
-        <protoc.path>/opt/protobuf-3.7/bin/protoc</protoc.path>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Make protoc 3.7.1 as default in Dockerfile.