### PR TITLE
HDDS-2157. checkstyle: print filenames relative to project root

### DIFF
--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -16,6 +16,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
+BASE_DIR="$(pwd -P)"
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
@@ -23,7 +24,16 @@ REPORT_FILE="$REPORT_DIR/summary.txt"
 mvn -B -fn checkstyle:check -f pom.ozone.xml
 
 #Print out the exact violations with parsing XML results with sed
-find "." -name checkstyle-errors.xml -print0  | xargs -0 sed  '$!N; /<file.*\n<\/file/d;P;D' | sed '/<\/.*/d;/<checkstyle.*/d;s/<error.*line="\([[:digit:]]*\)".*message="\([^"]\+\).*/ \1: \2/;s/<file name="\([^"]*\)".*/\1/;/<\?xml.*>/d' | tee "$REPORT_FILE"
+find "." -name checkstyle-errors.xml -print0 \
+  | xargs -0 sed '$!N; /<file.*\n<\/file/d;P;D' \
+  | sed \
+      -e '/<\?xml.*>/d' \
+      -e '/<checkstyle.*/d' \
+      -e '/<\/.*/d' \
+      -e 's/<file name="\([^"]*\)".*/\1/' \
+      -e 's/<error.*line="\([[:digit:]]*\)".*message="\([^"]*\)".*/ \1: \2/' \
+      -e "s!^${BASE_DIR}/!!" \
+  | tee "$REPORT_FILE"
 
 ## generate counter
 wc -l "$REPORT_DIR/summary.txt" | awk '{print $1}'> "$REPORT_DIR/failures"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove project root from filenames in `checkstyle.sh` output.  Also, make script slightly more readable by breaking long sed command.

https://issues.apache.org/jira/browse/HDDS-2157

## How was this patch tested?

Introduced some checkstyle errors, then ran check:

```bash
$ git revert --no-commit 126ef77a810
$ hadoop-ozone/dev-support/checks/checkstyle.sh
...
hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
 88: Line is longer than 80 characters (found 91).
hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreIterator.java
 29: Line is longer than 80 characters (found 90).
 46: Line is longer than 80 characters (found 105).
hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/LevelDBStoreIterator.java
 28: Line is longer than 80 characters (found 90).
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestMetadataStore.java
 124: Line is longer than 80 characters (found 87).
hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
 451: &apos;}&apos; at column 11 should be alone on a line.
hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
 136: Line is longer than 80 characters (found 89).
 144: Line is longer than 80 characters (found 81).
 154: Line is longer than 80 characters (found 99).
...
```