### PR TITLE
HDDS-2158. Fixing Json Injection Issue in JsonUtils.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -54,7 +54,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
     mapper
         .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-    WRITER = mapper.writer();
+    WRITER = mapper.writerWithDefaultPrettyPrinter();
   }
 
   private HddsProtos.LifeCycleState state;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/web/utils/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/web/utils/JsonUtils.java
@@ -43,10 +43,9 @@ public final class JsonUtils {
     // Never constructed
   }
 
-  public static String toJsonStringWithDefaultPrettyPrinter(String jsonString)
+  public static String toJsonStringWithDefaultPrettyPrinter(Object obj)
       throws IOException {
-    Object json = READER.readValue(jsonString);
-    return WRITTER.writeValueAsString(json);
+    return WRITTER.writeValueAsString(obj);
   }
 
   public static String toJsonString(Object obj) throws IOException {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
@@ -62,8 +62,7 @@ public class ListSubcommand implements Callable<Void> {
   private void outputContainerInfo(ContainerInfo containerInfo)
       throws IOException {
     // Print container report info.
-    LOG.info("{}", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        containerInfo.toJsonString()));
+    LOG.info("{}", containerInfo.toJsonString());
   }
 
   @Override

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.SCMCLI;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/ObjectPrinter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/ObjectPrinter.java
@@ -29,8 +29,7 @@ public final class ObjectPrinter {
   }
 
   public static String getObjectAsJson(Object o) throws IOException {
-    return JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString(o));
+    return JsonUtils.toJsonStringWithDefaultPrettyPrinter(o);
   }
 
   public static void printObjectAsJson(Object o) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/AddAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/AddAclBucketHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/AddAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/AddAclBucketHandler.java
@@ -92,8 +92,9 @@ public class AddAclBucketHandler extends Handler {
     boolean result = client.getObjectStore().addAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/AddAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/AddAclBucketHandler.java
@@ -92,8 +92,7 @@ public class AddAclBucketHandler extends Handler {
     boolean result = client.getObjectStore().addAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl added successfully: " + result);
 
     client.close();
     return null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/GetAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/GetAclBucketHandler.java
@@ -75,8 +75,8 @@ public class GetAclBucketHandler extends Handler {
 
     List<OzoneAcl> result = client.getObjectStore().getAcl(obj);
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString(result)));
+    System.out.printf("%s%n",
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/RemoveAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/RemoveAclBucketHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/RemoveAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/RemoveAclBucketHandler.java
@@ -92,8 +92,8 @@ public class RemoveAclBucketHandler extends Handler {
     boolean result = client.getObjectStore().removeAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl removed successfully: " + result)));
+    System.out.printf("%s%n", "Acl removed successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/RemoveAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/RemoveAclBucketHandler.java
@@ -68,7 +68,7 @@ public class RemoveAclBucketHandler extends Handler {
    */
   @Override
   public Void call() throws Exception {
-    Objects.requireNonNull(acl, "New acl to be added not specified.");
+    Objects.requireNonNull(acl, "ACL to be removed not specified.");
     OzoneAddress address = new OzoneAddress(uri);
     address.ensureBucketAddress();
     OzoneClient client = address.createClient(createOzoneConfiguration());
@@ -92,8 +92,8 @@ public class RemoveAclBucketHandler extends Handler {
     boolean result = client.getObjectStore().removeAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", "Acl removed successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl removed successfully: " + result);
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/SetAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/SetAclBucketHandler.java
@@ -92,8 +92,8 @@ public class SetAclBucketHandler extends Handler {
     boolean result = client.getObjectStore().setAcl(obj,
         OzoneAcl.parseAcls(acls));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/SetAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/SetAclBucketHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/SetAclBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/SetAclBucketHandler.java
@@ -92,8 +92,8 @@ public class SetAclBucketHandler extends Handler {
     boolean result = client.getObjectStore().setAcl(obj,
         OzoneAcl.parseAcls(acls));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl set successfully: " + result);
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/AddAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/AddAclKeyHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/AddAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/AddAclKeyHandler.java
@@ -95,8 +95,7 @@ public class AddAclKeyHandler extends Handler {
     boolean result = client.getObjectStore().addAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl added successfully: " + result);
 
     client.close();
     return null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/AddAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/AddAclKeyHandler.java
@@ -95,8 +95,9 @@ public class AddAclKeyHandler extends Handler {
     boolean result = client.getObjectStore().addAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/GetAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/GetAclKeyHandler.java
@@ -78,8 +78,8 @@ public class GetAclKeyHandler extends Handler {
 
     List<OzoneAcl> result = client.getObjectStore().getAcl(obj);
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString(result)));
+    System.out.printf("%s%n",
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/RemoveAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/RemoveAclKeyHandler.java
@@ -68,7 +68,7 @@ public class RemoveAclKeyHandler extends Handler {
    */
   @Override
   public Void call() throws Exception {
-    Objects.requireNonNull(acl, "New acl to be added not specified.");
+    Objects.requireNonNull(acl, "ACL to be removed not specified.");
     OzoneAddress address = new OzoneAddress(uri);
     address.ensureKeyAddress();
     OzoneClient client = address.createClient(createOzoneConfiguration());
@@ -95,8 +95,8 @@ public class RemoveAclKeyHandler extends Handler {
     boolean result = client.getObjectStore().removeAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl removed successfully: " + result);
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/RemoveAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/RemoveAclKeyHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/RemoveAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/RemoveAclKeyHandler.java
@@ -95,8 +95,8 @@ public class RemoveAclKeyHandler extends Handler {
     boolean result = client.getObjectStore().removeAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/SetAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/SetAclKeyHandler.java
@@ -94,8 +94,8 @@ public class SetAclKeyHandler extends Handler {
     boolean result = client.getObjectStore().setAcl(obj,
         OzoneAcl.parseAcls(acls));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/SetAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/SetAclKeyHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/SetAclKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/SetAclKeyHandler.java
@@ -94,8 +94,8 @@ public class SetAclKeyHandler extends Handler {
     boolean result = client.getObjectStore().setAcl(obj,
         OzoneAcl.parseAcls(acls));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl set successfully: " + result);
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/GetTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/GetTokenHandler.java
@@ -71,7 +71,7 @@ public class GetTokenHandler extends Handler {
     }
 
     System.out.printf("%s", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString(token.encodeToUrlString())));
+        token.encodeToUrlString()));
     return null;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/PrintTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/PrintTokenHandler.java
@@ -65,7 +65,7 @@ public class PrintTokenHandler extends Handler {
     token.decodeFromUrlString(encodedToken);
 
     System.out.printf("%s", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString(token.toString())));
+        token.toString()));
     return null;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/AddAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/AddAclVolumeHandler.java
@@ -89,8 +89,8 @@ public class AddAclVolumeHandler extends Handler {
     boolean result = client.getObjectStore().addAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl added successfully: " + result);
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/AddAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/AddAclVolumeHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/AddAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/AddAclVolumeHandler.java
@@ -89,8 +89,8 @@ public class AddAclVolumeHandler extends Handler {
     boolean result = client.getObjectStore().addAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/GetAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/GetAclVolumeHandler.java
@@ -69,8 +69,8 @@ public class GetAclVolumeHandler extends Handler {
             OzoneObj.StoreType.valueOf(storeType))
         .build();
     List<OzoneAcl> result = client.getObjectStore().getAcl(obj);
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString(result)));
+    System.out.printf("%s%n",
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/RemoveAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/RemoveAclVolumeHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/RemoveAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/RemoveAclVolumeHandler.java
@@ -89,8 +89,8 @@ public class RemoveAclVolumeHandler extends Handler {
     boolean result = client.getObjectStore().removeAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl removed successfully: " + result)));
+    System.out.printf("%s%n", "Acl removed successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/RemoveAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/RemoveAclVolumeHandler.java
@@ -68,7 +68,7 @@ public class RemoveAclVolumeHandler extends Handler {
    */
   @Override
   public Void call() throws Exception {
-    Objects.requireNonNull(acl, "New acl to be added not specified.");
+    Objects.requireNonNull(acl, "ACL to be removed not specified.");
     OzoneAddress address = new OzoneAddress(uri);
     address.ensureVolumeAddress();
     OzoneClient client = address.createClient(createOzoneConfiguration());
@@ -89,8 +89,8 @@ public class RemoveAclVolumeHandler extends Handler {
     boolean result = client.getObjectStore().removeAcl(obj,
         OzoneAcl.parseAcl(acl));
 
-    System.out.printf("%s%n", "Acl removed successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl removed successfully: " + result);
+
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/SetAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/SetAclVolumeHandler.java
@@ -92,8 +92,8 @@ public class SetAclVolumeHandler extends Handler {
     boolean result = client.getObjectStore().setAcl(obj,
         OzoneAcl.parseAcls(acls));
 
-    System.out.printf("%s%n", JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-        JsonUtils.toJsonString("Acl set successfully: " + result)));
+    System.out.printf("%s%n", "Acl set successfully: " +
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
     client.close();
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/SetAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/SetAclVolumeHandler.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/SetAclVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/SetAclVolumeHandler.java
@@ -92,8 +92,8 @@ public class SetAclVolumeHandler extends Handler {
     boolean result = client.getObjectStore().setAcl(obj,
         OzoneAcl.parseAcls(acls));
 
-    System.out.printf("%s%n", "Acl set successfully: " +
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(result));
+    System.out.printf("%s%n", "Acl set successfully: " + result);
+
     client.close();
     return null;
   }


### PR DESCRIPTION
JsonUtils#toJsonStringWithDefaultPrettyPrinter() does not validate the Json String  before serializing it which could result in Json Injection.
This method is mostly used along with JsonUtils#toJsonString() by first converting to String and then back to object. This can be avoided by directly writing the object through PrettyPrinter.