### PR TITLE
HDDS-2019. Handle Set DtService of token in S3Gateway for OM HA.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.s3;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -61,6 +62,9 @@ public class OzoneClientProducer {
 
   @Inject
   private Text omService;
+
+  @Inject
+  private String omServiceID;
 
 
   @Produces
@@ -105,7 +109,13 @@ public class OzoneClientProducer {
     } catch (Exception e) {
       LOG.error("Error: ", e);
     }
-    return OzoneClientFactory.getClient(ozoneConfiguration);
+
+    if (omServiceID == null) {
+      return OzoneClientFactory.getClient(ozoneConfiguration);
+    } else {
+      // As in HA case, we need to pass om service ID.
+      return OzoneClientFactory.getRpcClient(omServiceID, ozoneConfiguration);
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.s3;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
@@ -39,7 +39,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 @ApplicationScoped
 public class OzoneServiceProvider {
 
-  private Text omServiceAdd;
+  private Text omServiceAddr;
 
   private String omserviceID;
 
@@ -52,30 +52,27 @@ public class OzoneServiceProvider {
         conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
     if (serviceIdList.size() == 0) {
       // Non-HA cluster
-      omServiceAdd = SecurityUtil.buildTokenService(OmUtils.
+      omServiceAddr = SecurityUtil.buildTokenService(OmUtils.
           getOmAddressForClients(conf));
     } else {
-      // HA cluster
-      Collection<String> serviceIds =
-          conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
-
+      // HA cluster.
       //For now if multiple service id's are configured we throw exception.
       // As if multiple service id's are configured, S3Gateway will not be
       // knowing which one to talk to. In future, if OM federation is supported
       // we can resolve this by having another property like
       // ozone.om.internal.service.id.
       // TODO: Revisit this later.
-      if (serviceIds.size() > 1) {
+      if (serviceIdList.size() > 1) {
         throw new IllegalArgumentException("Multiple serviceIds are " +
-            "configured. " + serviceIds.toArray().toString());
+            "configured. " + serviceIdList.toArray().toString());
       } else {
-        String serviceId = serviceIds.iterator().next();
+        String serviceId = serviceIdList.iterator().next();
         Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, serviceId);
         if (omNodeIds.size() == 0) {
           throw new IllegalArgumentException(OZONE_OM_NODES_KEY
               + "." + serviceId + " is not defined");
         }
-        omServiceAdd = new Text(OzoneS3Util.buildServiceNameForToken(conf,
+        omServiceAddr = new Text(OzoneS3Util.buildServiceNameForToken(conf,
             serviceId, omNodeIds));
         omserviceID = serviceId;
       }
@@ -85,7 +82,7 @@ public class OzoneServiceProvider {
 
   @Produces
   public Text getService() {
-    return omServiceAdd;
+    return omServiceAddr;
   }
 
   @Produces

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
@@ -20,12 +20,19 @@ package org.apache.hadoop.ozone.s3;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.s3.util.OzoneS3Util;
 import org.apache.hadoop.security.SecurityUtil;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+
+import java.util.Collection;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
+
 /**
  * This class creates the OM service .
  */
@@ -34,19 +41,56 @@ public class OzoneServiceProvider {
 
   private Text omServiceAdd;
 
+  private String omserviceID;
+
   @Inject
   private OzoneConfiguration conf;
 
   @PostConstruct
   public void init() {
-    omServiceAdd = SecurityUtil.buildTokenService(OmUtils.
-        getOmAddressForClients(conf));
+    Collection<String> serviceIdList =
+        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
+    if (serviceIdList.size() == 0) {
+      // Non-HA cluster
+      omServiceAdd = SecurityUtil.buildTokenService(OmUtils.
+          getOmAddressForClients(conf));
+    } else {
+      // HA cluster
+      Collection<String> serviceIds =
+          conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
+
+      //For now if multiple service id's are configured we throw exception.
+      // As if multiple service id's are configured, S3Gateway will not be
+      // knowing which one to talk to. In future, if OM federation is supported
+      // we can resolve this by having another property like
+      // ozone.om.internal.service.id.
+      // TODO: Revisit this later.
+      if (serviceIds.size() > 1) {
+        throw new IllegalArgumentException("Multiple serviceIds are " +
+            "configured. " + serviceIds.toArray().toString());
+      } else {
+        String serviceId = serviceIds.iterator().next();
+        Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, serviceId);
+        if (omNodeIds.size() == 0) {
+          throw new IllegalArgumentException(OZONE_OM_NODES_KEY
+              + "." + serviceId + " is not defined");
+        }
+        omServiceAdd = new Text(OzoneS3Util.buildServiceNameForToken(conf,
+            serviceId, omNodeIds));
+        omserviceID = serviceId;
+      }
+    }
   }
 
 
   @Produces
   public Text getService() {
     return omServiceAdd;
+  }
+
+  @Produces
+  public String getOmServiceID() {
+    return omserviceID;
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
@@ -28,6 +28,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
@@ -64,7 +65,7 @@ public class OzoneServiceProvider {
       // TODO: Revisit this later.
       if (serviceIdList.size() > 1) {
         throw new IllegalArgumentException("Multiple serviceIds are " +
-            "configured. " + serviceIdList.toArray().toString());
+            "configured. " + Arrays.toString(serviceIdList.toArray()));
       } else {
         String serviceId = serviceIdList.iterator().next();
         Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, serviceId);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/OzoneS3Util.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/OzoneS3Util.java
@@ -43,6 +43,13 @@ public final class OzoneS3Util {
     return DigestUtils.md5Hex(userName);
   }
 
+  /**
+   * Generate service Name for token.
+   * @param configuration
+   * @param serviceId - ozone manager service ID
+   * @param omNodeIds - list of node ids for the given OM service.
+   * @return service Name.
+   */
   public static String buildServiceNameForToken(
       @Nonnull OzoneConfiguration configuration, @Nonnull String serviceId,
       @Nonnull Collection<String> omNodeIds) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/OzoneS3Util.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/OzoneS3Util.java
@@ -62,7 +62,7 @@ public final class OzoneS3Util {
       String rpcAddrKey = OmUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
           serviceId, nodeId);
       String rpcAddrStr = OmUtils.getOmRpcAddress(configuration, rpcAddrKey);
-      if (rpcAddrStr == null) {
+      if (rpcAddrStr == null || rpcAddrStr.isEmpty()) {
         throw new IllegalArgumentException("Could not find rpcAddress for " +
             OZONE_OM_ADDRESS_KEY + "." + serviceId + "." + nodeId);
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/OzoneS3Util.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/OzoneS3Util.java
@@ -54,7 +54,11 @@ public final class OzoneS3Util {
       @Nonnull OzoneConfiguration configuration, @Nonnull String serviceId,
       @Nonnull Collection<String> omNodeIds) {
     StringBuilder rpcAddress = new StringBuilder();
+
+    int nodesLength = omNodeIds.size();
+    int counter = 0;
     for (String nodeId : omNodeIds) {
+      counter++;
       String rpcAddrKey = OmUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
           serviceId, nodeId);
       String rpcAddrStr = OmUtils.getOmRpcAddress(configuration, rpcAddrKey);
@@ -62,8 +66,14 @@ public final class OzoneS3Util {
         throw new IllegalArgumentException("Could not find rpcAddress for " +
             OZONE_OM_ADDRESS_KEY + "." + serviceId + "." + nodeId);
       }
-      rpcAddress.append(SecurityUtil.buildTokenService(
-          NetUtils.createSocketAddr(rpcAddrStr)));
+
+      if (counter != nodesLength) {
+        rpcAddress.append(SecurityUtil.buildTokenService(
+            NetUtils.createSocketAddr(rpcAddrStr)) + ",");
+      } else {
+        rpcAddress.append(SecurityUtil.buildTokenService(
+            NetUtils.createSocketAddr(rpcAddrStr)));
+      }
     }
     return rpcAddress.toString();
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestOzoneS3Util.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestOzoneS3Util.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.util;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeys.HADOOP_SECURITY_TOKEN_SERVICE_USE_IP;
+import static org.junit.Assert.fail;
+
+/**
+ * Class used to test OzoneS3Util.
+ */
+public class TestOzoneS3Util {
+
+
+  private OzoneConfiguration configuration;
+
+  @Before
+  public void setConf() {
+    configuration = new OzoneConfiguration();
+    String serviceID = "omService";
+    String nodeIDs = "om1,om2,om3";
+    configuration.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, serviceID);
+    configuration.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeIDs);
+    configuration.setBoolean(HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
+  }
+
+  @Test
+  public void testBuildServiceNameForToken() {
+    String serviceID = "omService";
+    String nodeIDs = "om1,om2,om3";
+    configuration.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, serviceID);
+    configuration.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeIDs);
+    configuration.setBoolean(HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
+
+    Collection<String> nodeIDList = configuration.getStringCollection(
+        OMConfigKeys.OZONE_OM_NODE_ID_KEY);
+
+    String expectedOmServiceAddress = buildOMNodeAddresses(nodeIDList,
+        serviceID);
+
+    SecurityUtil.setConfiguration(configuration);
+    String omserviceAddr = OzoneS3Util.buildServiceNameForToken(configuration,
+        serviceID, nodeIDList);
+
+    Assert.assertEquals(expectedOmServiceAddress, omserviceAddr);
+  }
+
+  @Test
+  public void testBuildServiceNameForTokenIncorrectConfig() {
+    String serviceID = "omService";
+    String nodeIDs = "om1,om2,om3";
+    configuration.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, serviceID);
+    configuration.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeIDs);
+    configuration.setBoolean(HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
+
+    Collection<String> nodeIDList = configuration.getStringCollection(
+        OMConfigKeys.OZONE_OM_NODE_ID_KEY);
+
+    // Don't set om3 node rpc address.
+    configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+        serviceID, "om1"), "om1:9862");
+    configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+        serviceID, "om2"), "om2:9862");
+
+
+    SecurityUtil.setConfiguration(configuration);
+
+    try {
+      OzoneS3Util.buildServiceNameForToken(configuration,
+          serviceID, nodeIDList);
+      fail("testBuildServiceNameForTokenIncorrectConfig failed");
+    } catch (IllegalArgumentException ex) {
+      GenericTestUtils.assertExceptionContains("Could not find rpcAddress " +
+          "for", ex);
+    }
+
+
+  }
+
+
+  private String buildOMNodeAddresses(Collection<String> nodeIDList,
+      String serviceID) {
+    StringBuilder omServiceAddrBuilder = new StringBuilder();
+    int port = 9862;
+    int nodesLength = nodeIDList.size();
+    int counter = 0;
+    for (String nodeID : nodeIDList) {
+      counter++;
+      String addr = nodeID + ":" + port++;
+      configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+          serviceID, nodeID), addr);
+
+      if (counter != nodesLength) {
+        omServiceAddrBuilder.append(addr + ",");
+      } else {
+        omServiceAddrBuilder.append(addr);
+      }
+    }
+
+    return omServiceAddrBuilder.toString();
+  }
+
+}

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestOzoneS3Util.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestOzoneS3Util.java
@@ -39,30 +39,33 @@ public class TestOzoneS3Util {
 
 
   private OzoneConfiguration configuration;
+  private String serviceID = "omService";
 
   @Before
   public void setConf() {
     configuration = new OzoneConfiguration();
-    String serviceID = "omService";
+
     String nodeIDs = "om1,om2,om3";
     configuration.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, serviceID);
-    configuration.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeIDs);
+    configuration.set(OMConfigKeys.OZONE_OM_NODES_KEY + "." + serviceID,
+        nodeIDs);
     configuration.setBoolean(HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
   }
 
   @Test
   public void testBuildServiceNameForToken() {
-    String serviceID = "omService";
-    String nodeIDs = "om1,om2,om3";
-    configuration.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, serviceID);
-    configuration.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeIDs);
-    configuration.setBoolean(HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
 
-    Collection<String> nodeIDList = configuration.getStringCollection(
-        OMConfigKeys.OZONE_OM_NODE_ID_KEY);
-
-    String expectedOmServiceAddress = buildOMNodeAddresses(nodeIDList,
+    Collection<String> nodeIDList = OmUtils.getOMNodeIds(configuration,
         serviceID);
+
+    configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+        serviceID, "om1"), "om1:9862");
+    configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+        serviceID, "om2"), "om2:9862");
+    configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+        serviceID, "om3"), "om3:9862");
+
+    String expectedOmServiceAddress = buildServiceAddress(nodeIDList);
 
     SecurityUtil.setConfiguration(configuration);
     String omserviceAddr = OzoneS3Util.buildServiceNameForToken(configuration,
@@ -71,18 +74,15 @@ public class TestOzoneS3Util {
     Assert.assertEquals(expectedOmServiceAddress, omserviceAddr);
   }
 
+
   @Test
   public void testBuildServiceNameForTokenIncorrectConfig() {
-    String serviceID = "omService";
-    String nodeIDs = "om1,om2,om3";
-    configuration.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, serviceID);
-    configuration.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeIDs);
-    configuration.setBoolean(HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
 
-    Collection<String> nodeIDList = configuration.getStringCollection(
-        OMConfigKeys.OZONE_OM_NODE_ID_KEY);
+    Collection<String> nodeIDList = OmUtils.getOMNodeIds(configuration,
+        serviceID);
 
-    // Don't set om3 node rpc address.
+    // Don't set om3 node rpc address. Here we are skipping setting of one of
+    // the OM address. So buildServiceNameForToken will fail.
     configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
         serviceID, "om1"), "om1:9862");
     configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
@@ -103,18 +103,19 @@ public class TestOzoneS3Util {
 
   }
 
-
-  private String buildOMNodeAddresses(Collection<String> nodeIDList,
-      String serviceID) {
+  /**
+   * Build serviceName from list of node ids.
+   * @param nodeIDList
+   * @return service name for token.
+   */
+  private String buildServiceAddress(Collection<String> nodeIDList) {
     StringBuilder omServiceAddrBuilder = new StringBuilder();
-    int port = 9862;
     int nodesLength = nodeIDList.size();
     int counter = 0;
     for (String nodeID : nodeIDList) {
       counter++;
-      String addr = nodeID + ":" + port++;
-      configuration.set(OmUtils.addKeySuffixes(
-          OMConfigKeys.OZONE_OM_ADDRESS_KEY, serviceID, nodeID), addr);
+      String addr = configuration.get(OmUtils.addKeySuffixes(
+          OMConfigKeys.OZONE_OM_ADDRESS_KEY, serviceID, nodeID));
 
       if (counter != nodesLength) {
         omServiceAddrBuilder.append(addr + ",");

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestOzoneS3Util.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestOzoneS3Util.java
@@ -113,8 +113,8 @@ public class TestOzoneS3Util {
     for (String nodeID : nodeIDList) {
       counter++;
       String addr = nodeID + ":" + port++;
-      configuration.set(OmUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
-          serviceID, nodeID), addr);
+      configuration.set(OmUtils.addKeySuffixes(
+          OMConfigKeys.OZONE_OM_ADDRESS_KEY, serviceID, nodeID), addr);
 
       if (counter != nodesLength) {
         omServiceAddrBuilder.append(addr + ",");


### PR DESCRIPTION
Need some work on server-side for adding secure-om-s3-ha docker-compose cluster, as some fields like keytab are still not supporting parameter with serviceid and node id.

