### PR TITLE
HDDS-2163. Add 'Replication factor' to the output of list keys

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -52,13 +52,17 @@ public class OzoneKey {
 
   private ReplicationType replicationType;
 
+  private int replicationFactor;
+
   /**
    * Constructs OzoneKey from OmKeyInfo.
    *
    */
+  @SuppressWarnings("parameternumber")
   public OzoneKey(String volumeName, String bucketName,
                   String keyName, long size, long creationTime,
-                  long modificationTime, ReplicationType type) {
+                  long modificationTime, ReplicationType type,
+                  int replicationFactor) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.name = keyName;
@@ -66,6 +70,7 @@ public class OzoneKey {
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
     this.replicationType = type;
+    this.replicationFactor = replicationFactor;
   }
 
   /**
@@ -130,4 +135,14 @@ public class OzoneKey {
   public ReplicationType getReplicationType() {
     return replicationType;
   }
+
+  /**
+   * Returns the replication factor of the key.
+   *
+   * @return replicationFactor
+   */
+  public int getReplicationFactor() {
+    return replicationFactor;
+  }
+
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
@@ -46,9 +46,9 @@ public class OzoneKeyDetails extends OzoneKey {
                          long size, long creationTime, long modificationTime,
                          List<OzoneKeyLocation> ozoneKeyLocations,
                          ReplicationType type, Map<String, String> metadata,
-                         FileEncryptionInfo feInfo) {
+                         FileEncryptionInfo feInfo, int replicationFactor) {
     super(volumeName, bucketName, keyName, size, creationTime,
-        modificationTime, type);
+        modificationTime, type, replicationFactor);
     this.ozoneKeyLocations = ozoneKeyLocations;
     this.metadata = metadata;
     this.feInfo = feInfo;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -684,7 +684,8 @@ public class RpcClient implements ClientProtocol {
         key.getDataSize(),
         key.getCreationTime(),
         key.getModificationTime(),
-        ReplicationType.valueOf(key.getType().toString())))
+        ReplicationType.valueOf(key.getType().toString()),
+        key.getFactor().getNumber()))
         .collect(Collectors.toList());
   }
 
@@ -712,7 +713,7 @@ public class RpcClient implements ClientProtocol {
         keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
         keyInfo.getModificationTime(), ozoneKeyLocations, ReplicationType
         .valueOf(keyInfo.getType().toString()), keyInfo.getMetadata(),
-        keyInfo.getFileEncryptionInfo());
+        keyInfo.getFileEncryptionInfo(), keyInfo.getFactor().getNumber());
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -104,7 +104,8 @@ public class OzoneBucketStub extends OzoneBucket {
                 size,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
-                new ArrayList<>(), type, metadata, null
+                new ArrayList<>(), type, metadata, null,
+                factor.getValue()
             ));
             super.close();
           }


### PR DESCRIPTION
This patch adds replication factor to the output of list keys.

```
bash-4.2$ ozone sh key list /vol1/bucket1
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "dockerfile",
  "dataSize" : 876,
  "creationTime" : 1569022651963,
  "modificationTime" : 1569022654752,
  "replicationType" : "RATIS",
  "replicationFactor" : 1
}
```