### PR TITLE
YARN-9851: Make execution type check compatiable

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -1496,7 +1496,8 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
         launchedContainers.size() - numRemoteRunning);
     for (ContainerStatus remoteContainer : containerStatuses) {
       if (remoteContainer.getState() == ContainerState.RUNNING
-          && remoteContainer.getExecutionType() == ExecutionType.GUARANTEED) {
+          && (remoteContainer.getExecutionType() == null
+              || remoteContainer.getExecutionType() == ExecutionType.GUARANTEED)) {
         nodeContainers.add(remoteContainer.getContainerId());
       }
     }


### PR DESCRIPTION
During upgrade from 2.6 to 3.1, we encountered a problem:

`
2019-09-23,19:29:05,303 WARN org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl: Lost container container_e35_1568719110875_6460_08_000001, status: RUNNING, execution type: null
2019-09-23,19:29:05,303 WARN org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl: Lost container container_e35_1568886618758_11172_01_000062, status: RUNNING, execution type: null
2019-09-23,19:29:05,303 WARN org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl: Lost container container_e35_1568886618758_11172_01_000063, status: RUNNING, execution type: null
2019-09-23,19:29:05,303 WARN org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl: Lost container container_e35_1568886618758_11172_01_000064, status: RUNNING, execution type: null
2019-09-23,19:29:05,303 WARN org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl: Lost container container_e35_1568886618758_30617_01_000006, status: RUNNING, execution type: null
`
```
for (ContainerStatus remoteContainer : containerStatuses) {
  if (remoteContainer.getState() == ContainerState.RUNNING
      && remoteContainer.getExecutionType() == ExecutionType.GUARANTEED) {
    nodeContainers.add(remoteContainer.getContainerId());
  } else {
    LOG.warn("Lost container " + remoteContainer.getContainerId()
            + ", status: " + remoteContainer.getState()
            + ", execution type: " + remoteContainer.getExecutionType());
  }
}​
```

The cause is that we has nm with version 2.6, which do not have executionType for container status.
We should make the check more compatiable.