### PR TITLE
HDDS-2165. Freon fails if bucket does not exists

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -267,8 +267,9 @@ public class BaseFreonGenerator {
       } catch (OMException ex) {
         if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
           volume.createBucket(bucketName);
+        } else {
+          throw ex;
         }
-        throw ex;
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Freon should not fail after creating missing bucket.

https://issues.apache.org/jira/browse/HDDS-2165

## How was this patch tested?

```
$ ozone freon ockg -n 1 -b bucket3
...
Failures: 0
Successful executions: 1
```