### PR TITLE
HDDS-2166. Some RPC metrics are missing from SCM prometheus endpoint

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
@@ -69,8 +69,10 @@ public class PrometheusMetricsSink implements MetricsSink {
             .append(key)
             .append(" ")
             .append(metrics.type().toString().toLowerCase())
-            .append("\n")
-            .append(key)
+            .append("\n");
+
+        StringBuilder prometheusMetricKey = new StringBuilder();
+        prometheusMetricKey.append(key)
             .append("{");
         String sep = "";
 
@@ -80,7 +82,7 @@ public class PrometheusMetricsSink implements MetricsSink {
 
           //ignore specific tag which includes sub-hierarchy
           if (!tagName.equals("numopenconnectionsperuser")) {
-            builder.append(sep)
+            prometheusMetricKey.append(sep)
                 .append(tagName)
                 .append("=\"")
                 .append(tag.value())
@@ -88,10 +90,13 @@ public class PrometheusMetricsSink implements MetricsSink {
             sep = ",";
           }
         }
-        builder.append("} ");
+        prometheusMetricKey.append("}");
+
+        builder.append(prometheusMetricKey.toString());
+        builder.append(" ");
         builder.append(metrics.value());
         builder.append("\n");
-        metricLines.put(key, builder.toString());
+        metricLines.put(prometheusMetricKey.toString(), builder.toString());
 
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
@@ -92,11 +92,12 @@ public class PrometheusMetricsSink implements MetricsSink {
         }
         prometheusMetricKey.append("}");
 
-        builder.append(prometheusMetricKey.toString());
+        String prometheusMetricKeyAsString = prometheusMetricKey.toString();
+        builder.append(prometheusMetricKeyAsString);
         builder.append(" ");
         builder.append(metrics.value());
         builder.append("\n");
-        metricLines.put(prometheusMetricKey.toString(), builder.toString());
+        metricLines.put(prometheusMetricKeyAsString, builder.toString());
 
       }
     }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
@@ -21,16 +21,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.MetricsTag;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Test prometheus Sink.
@@ -66,6 +68,50 @@ public class TestPrometheusMetricsSink {
         writtenMetrics.contains(
             "test_metrics_num_bucket_create_fails{context=\"dfs\"")
     );
+
+    metrics.stop();
+    metrics.shutdown();
+  }
+
+  @Test
+  public void testPublishWithSameName() throws IOException {
+    //GIVEN
+    MetricsSystem metrics = DefaultMetricsSystem.instance();
+
+    metrics.init("test");
+    PrometheusMetricsSink sink = new PrometheusMetricsSink();
+    metrics.register("Prometheus", "Prometheus", sink);
+    metrics.register("FooBar", "fooBar", (MetricsSource) (collector, all) -> {
+      collector.addRecord("RpcMetrics").add(new MetricsTag(PORT_INFO, "1234"))
+          .addGauge(COUNTER_INFO, 123).endRecord();
+
+      collector.addRecord("RpcMetrics").add(new MetricsTag(
+          PORT_INFO, "2345")).addGauge(COUNTER_INFO, 234).endRecord();
+    });
+
+    metrics.start();
+    metrics.publishMetricsNow();
+
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    OutputStreamWriter writer = new OutputStreamWriter(stream, UTF_8);
+
+    //WHEN
+    sink.writeMetrics(writer);
+    writer.flush();
+
+    //THEN
+    String writtenMetrics = stream.toString(UTF_8.name());
+    System.out.println(writtenMetrics);
+    Assert.assertTrue(
+        "The expected metric line is missing from prometheus metrics output",
+        writtenMetrics.contains(
+            "rpc_metrics_counter{port=\"2345\""));
+
+    Assert.assertTrue(
+        "The expected metric line is missing from prometheus metrics "
+            + "output",
+        writtenMetrics.contains(
+            "rpc_metrics_counter{port=\"1234\""));
 
     metrics.stop();
     metrics.shutdown();
@@ -127,4 +173,29 @@ public class TestPrometheusMetricsSink {
     @Metric
     private MutableCounterLong numBucketCreateFails;
   }
+
+  public static final MetricsInfo PORT_INFO = new MetricsInfo() {
+    @Override
+    public String name() {
+      return "PORT";
+    }
+
+    @Override
+    public String description() {
+      return "port";
+    }
+  };
+
+  public static final MetricsInfo COUNTER_INFO = new MetricsInfo() {
+    @Override
+    public String name() {
+      return "COUNTER";
+    }
+
+    @Override
+    public String description() {
+      return "counter";
+    }
+  };
+
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
@@ -62,7 +62,6 @@ public class TestPrometheusMetricsSink {
 
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
-    System.out.println(writtenMetrics);
     Assert.assertTrue(
         "The expected metric line is missing from prometheus metrics output",
         writtenMetrics.contains(
@@ -101,7 +100,6 @@ public class TestPrometheusMetricsSink {
 
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
-    System.out.println(writtenMetrics);
     Assert.assertTrue(
         "The expected metric line is missing from prometheus metrics output",
         writtenMetrics.contains(


### PR DESCRIPTION
In Hadoop metrics it's possible to register multiple metrics with the same name but with different tags. For example each RpcServere has an own metrics instance in SCM.

{code}
    "name" : "Hadoop:service=StorageContainerManager,name=RpcActivityForPort9860",
    "name" : "Hadoop:service=StorageContainerManager,name=RpcActivityForPort9863",
{code}

They are converted by PrometheusSink to a prometheus metric line with proper name and tags. For example:

{code}
rpc_rpc_queue_time60s_num_ops{port="9860",servername="StorageContainerLocationProtocolService",context="rpc",hostname="72736061cbc5"} 0
{code}

The PrometheusSink uses a Map to cache all the recent values but unfortunately the key contains only the name (rpc_rpc_queue_time60s_num_ops in our example) but not the tags (port=...)

For this reason if there are multiple metrics with the same name, only the first one will be displayed.

As a result in SCM only the metrics of the first RPC server can be exported to the prometheus endpoint. 


See: https://issues.apache.org/jira/browse/HDDS-2166