### PR TITLE
HDDS-2174. Delete GDPR Encryption Key from metadata when a Key is deleted

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -503,9 +503,10 @@ public final class OmUtils {
   /**
    * Prepares key info to be moved to deletedTable.
    * 1. It strips GDPR metadata from key info
-   * 2. Check if an entry exists in deletedTable for given objectKey, if yes,
-   * then updated the instance to add keyInfo to existing list, else create a
-   * new instance of RepeatedOmKeyInfo to be saved to deletedTable.
+   * 2. For given object key, if the repeatedOmKeyInfo instance is null, it
+   * implies that no entry for the object key exists in deletedTable so we
+   * create a new instance to include this key, else we update the existing
+   * repeatedOmKeyInfo instance.
    * @param keyInfo args supplied by client
    * @param repeatedOmKeyInfo key details from deletedTable
    * @return {@link RepeatedOmKeyInfo}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -507,14 +507,12 @@ public final class OmUtils {
    * then updated the instance to add keyInfo to existing list, else create a
    * new instance of RepeatedOmKeyInfo to be saved to deletedTable.
    * @param keyInfo args supplied by client
-   * @param objectKey object name
-   * @param metadataManager
+   * @param repeatedOmKeyInfo key details from deletedTable
    * @return {@link RepeatedOmKeyInfo}
    * @throws IOException if I/O Errors when checking for key
    */
-  public static RepeatedOmKeyInfo prepareKeyForDelete(
-      OmKeyInfo keyInfo, String objectKey,
-      OMMetadataManager metadataManager) throws IOException{
+  public static RepeatedOmKeyInfo prepareKeyForDelete(OmKeyInfo keyInfo,
+      RepeatedOmKeyInfo repeatedOmKeyInfo) throws IOException{
     // If this key is in a GDPR enforced bucket, then before moving
     // KeyInfo to deletedTable, remove the GDPR related metadata from
     // KeyInfo.
@@ -523,13 +521,12 @@ public final class OmUtils {
       keyInfo.getMetadata().remove(OzoneConsts.GDPR_ALGORITHM);
       keyInfo.getMetadata().remove(OzoneConsts.GDPR_SECRET);
     }
-    //Check if key with same keyName exists in deletedTable and then
-    // insert/update accordingly.
-    RepeatedOmKeyInfo repeatedOmKeyInfo =
-        metadataManager.getDeletedTable().get(objectKey);
+
     if(repeatedOmKeyInfo == null) {
+      //The key doesn't exist in deletedTable, so create a new instance.
       repeatedOmKeyInfo = new RepeatedOmKeyInfo(keyInfo);
     } else {
+      //The key exists in deletedTable, so update existing instance.
       repeatedOmKeyInfo.addOmKeyInfo(keyInfo);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -783,8 +783,10 @@ public class KeyManagerImpl implements KeyManager {
           return;
         }
       }
-      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(keyInfo,
-          objectKey, metadataManager);
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          metadataManager.getDeletedTable().get(objectKey);
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(keyInfo,
+          repeatedOmKeyInfo);
       metadataManager.getKeyTable().delete(objectKey);
       metadataManager.getDeletedTable().put(objectKey, repeatedOmKeyInfo);
     } catch (OMException ex) {
@@ -1006,8 +1008,10 @@ public class KeyManagerImpl implements KeyManager {
         // will not be garbage collected, so move this part to delete table
         // and throw error
         // Move this part to delete table.
-        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            keyInfo, partName, metadataManager);
+        RepeatedOmKeyInfo repeatedOmKeyInfo =
+            metadataManager.getDeletedTable().get(partName);
+        repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+            keyInfo, repeatedOmKeyInfo);
         metadataManager.getDeletedTable().put(partName, repeatedOmKeyInfo);
         throw new OMException("No such Multipart upload is with specified " +
             "uploadId " + uploadID, ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
@@ -1039,8 +1043,12 @@ public class KeyManagerImpl implements KeyManager {
             OmKeyInfo partKey = OmKeyInfo.getFromProtobuf(
                 oldPartKeyInfo.getPartKeyInfo());
 
-            RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-                partKey, oldPartKeyInfo.getPartName(), metadataManager);
+            RepeatedOmKeyInfo repeatedOmKeyInfo =
+                metadataManager.getDeletedTable()
+                    .get(oldPartKeyInfo.getPartName());
+
+            repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+                partKey, repeatedOmKeyInfo);
 
             metadataManager.getDeletedTable().put(partName, repeatedOmKeyInfo);
             metadataManager.getDeletedTable().putWithBatch(batch,
@@ -1265,8 +1273,12 @@ public class KeyManagerImpl implements KeyManager {
             OmKeyInfo currentKeyPartInfo = OmKeyInfo.getFromProtobuf(
                 partKeyInfo.getPartKeyInfo());
 
-            RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-                currentKeyPartInfo, partKeyInfo.getPartName(), metadataManager);
+            RepeatedOmKeyInfo repeatedOmKeyInfo =
+                metadataManager.getDeletedTable()
+                    .get(partKeyInfo.getPartName());
+
+            repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+                currentKeyPartInfo, repeatedOmKeyInfo);
 
             metadataManager.getDeletedTable().putWithBatch(batch,
                 partKeyInfo.getPartName(), repeatedOmKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -70,7 +70,8 @@ public class OMKeyDeleteResponse extends OMClientResponse {
         // instance in deletedTable.
         RepeatedOmKeyInfo repeatedOmKeyInfo =
             omMetadataManager.getDeletedTable().get(ozoneKey);
-        OmUtils.prepareKeyForDelete(omKeyInfo, ozoneKey, omMetadataManager);
+        repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+            omKeyInfo, repeatedOmKeyInfo);
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             ozoneKey, repeatedOmKeyInfo);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -69,11 +70,7 @@ public class OMKeyDeleteResponse extends OMClientResponse {
         // instance in deletedTable.
         RepeatedOmKeyInfo repeatedOmKeyInfo =
             omMetadataManager.getDeletedTable().get(ozoneKey);
-        if (repeatedOmKeyInfo == null) {
-          repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfo);
-        } else {
-          repeatedOmKeyInfo.addOmKeyInfo(omKeyInfo);
-        }
+        OmUtils.prepareKeyForDelete(omKeyInfo, ozoneKey, omMetadataManager);
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             ozoneKey, repeatedOmKeyInfo);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -75,8 +75,10 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
             OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
 
         RepeatedOmKeyInfo repeatedOmKeyInfo =
-            OmUtils.prepareKeyForDelete(currentKeyPartInfo,
-                partKeyInfo.getPartName(), omMetadataManager);
+            omMetadataManager.getDeletedTable().get(partKeyInfo.getPartName());
+
+        repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+            currentKeyPartInfo, repeatedOmKeyInfo);
 
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             partKeyInfo.getPartName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -74,12 +75,8 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
             OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
 
         RepeatedOmKeyInfo repeatedOmKeyInfo =
-            omMetadataManager.getDeletedTable().get(partKeyInfo.getPartName());
-        if(repeatedOmKeyInfo == null) {
-          repeatedOmKeyInfo = new RepeatedOmKeyInfo(currentKeyPartInfo);
-        } else {
-          repeatedOmKeyInfo.addOmKeyInfo(currentKeyPartInfo);
-        }
+            OmUtils.prepareKeyForDelete(currentKeyPartInfo,
+                partKeyInfo.getPartName(), omMetadataManager);
 
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             partKeyInfo.getPartName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -71,8 +71,11 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       // Means by the time we try to commit part, some one has aborted this
       // multipart upload. So, delete this part information.
       RepeatedOmKeyInfo repeatedOmKeyInfo =
-          OmUtils.prepareKeyForDelete(deletePartKeyInfo,
-              openKey, omMetadataManager);
+          omMetadataManager.getDeletedTable().get(openKey);
+
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          deletePartKeyInfo, repeatedOmKeyInfo);
+
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
           openKey,
@@ -95,8 +98,11 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
             OmKeyInfo.getFromProtobuf(oldMultipartKeyInfo.getPartKeyInfo());
 
         RepeatedOmKeyInfo repeatedOmKeyInfo =
-            OmUtils.prepareKeyForDelete(partKey,
-                oldMultipartKeyInfo.getPartName(), omMetadataManager);
+            omMetadataManager.getDeletedTable()
+                .get(oldMultipartKeyInfo.getPartName());
+
+        repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(partKey,
+            repeatedOmKeyInfo);
 
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             oldMultipartKeyInfo.getPartName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -66,17 +67,13 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-
     if (getOMResponse().getStatus() == NO_SUCH_MULTIPART_UPLOAD_ERROR) {
       // Means by the time we try to commit part, some one has aborted this
       // multipart upload. So, delete this part information.
       RepeatedOmKeyInfo repeatedOmKeyInfo =
-          omMetadataManager.getDeletedTable().get(openKey);
-      if(repeatedOmKeyInfo == null) {
-        repeatedOmKeyInfo = new RepeatedOmKeyInfo(deletePartKeyInfo);
-      } else {
-        repeatedOmKeyInfo.addOmKeyInfo(deletePartKeyInfo);
-      }
+          OmUtils.prepareKeyForDelete(deletePartKeyInfo,
+              openKey, omMetadataManager);
+
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
           openKey,
           repeatedOmKeyInfo);
@@ -86,6 +83,7 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
 
       // If we have old part info:
       // Need to do 3 steps:
+      //   0. Strip GDPR related metadata from multipart info
       //   1. add old part to delete table
       //   2. Commit multipart info which has information about this new part.
       //   3. delete this new part entry from open key table.
@@ -93,21 +91,17 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       // This means for this multipart upload part upload, we have an old
       // part information, so delete it.
       if (oldMultipartKeyInfo != null) {
-        RepeatedOmKeyInfo repeatedOmKeyInfo = omMetadataManager.
-            getDeletedTable().get(oldMultipartKeyInfo.getPartName());
-        if(repeatedOmKeyInfo == null) {
-          repeatedOmKeyInfo = new RepeatedOmKeyInfo(
-              OmKeyInfo.getFromProtobuf(oldMultipartKeyInfo.getPartKeyInfo()));
-        } else {
-          repeatedOmKeyInfo.addOmKeyInfo(
-              OmKeyInfo.getFromProtobuf(oldMultipartKeyInfo.getPartKeyInfo()));
-        }
+        OmKeyInfo partKey =
+            OmKeyInfo.getFromProtobuf(oldMultipartKeyInfo.getPartKeyInfo());
+
+        RepeatedOmKeyInfo repeatedOmKeyInfo =
+            OmUtils.prepareKeyForDelete(partKey,
+                oldMultipartKeyInfo.getPartName(), omMetadataManager);
 
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             oldMultipartKeyInfo.getPartName(),
             repeatedOmKeyInfo);
       }
-
 
       omMetadataManager.getMultipartInfoTable().putWithBatch(batchOperation,
           multipartKey, omMultipartKeyInfo);
@@ -116,8 +110,6 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       //  safely delete part key info from open key table.
       omMetadataManager.getOpenKeyTable().deleteWithBatch(batchOperation,
           openKey);
-
-
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -374,13 +375,10 @@ public final class TestOMRequestUtils {
 
     // Delete key from KeyTable and put in DeletedKeyTable
     omMetadataManager.getKeyTable().delete(ozoneKey);
-    RepeatedOmKeyInfo repeatedOmKeyInfo =
-        omMetadataManager.getDeletedTable().get(ozoneKey);
-    if(repeatedOmKeyInfo == null) {
-      repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfo);
-    } else {
-      repeatedOmKeyInfo.addOmKeyInfo(omKeyInfo);
-    }
+
+    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+        omKeyInfo, ozoneKey, omMetadataManager);
+
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
 
     return ozoneKey;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -376,8 +376,11 @@ public final class TestOMRequestUtils {
     // Delete key from KeyTable and put in DeletedKeyTable
     omMetadataManager.getKeyTable().delete(ozoneKey);
 
-    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-        omKeyInfo, ozoneKey, omMetadataManager);
+    RepeatedOmKeyInfo repeatedOmKeyInfo =
+        omMetadataManager.getDeletedTable().get(ozoneKey);
+
+    repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omKeyInfo,
+        repeatedOmKeyInfo);
 
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
 


### PR DESCRIPTION
As advised, deleted GDPR related metadata from KeyInfo before moving it to deletedTable.
Added/updated test.

P.S. The changes in KeyManagerImpl are not really needed but made them for sanity & it is no harm.