### PR TITLE
HDDS-2175. Propagate stack trace for OM Exceptions to the Client. Contributed by Supratim Deka

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.UserGroupInformation;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -181,7 +180,8 @@ public abstract class OMClientRequest implements RequestAuditor {
 
     omResponse.setSuccess(false);
     if (ex.getMessage() != null) {
-      omResponse.setMessage(ex.getMessage());
+      omResponse.setMessage(org.apache.hadoop.util.StringUtils
+          .stringifyException(ex));
     }
     omResponse.setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(ex));
     return omResponse.build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -134,7 +134,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
         throw new OMException(ex.getMessage(),
             OMException.ResultCodes.SCM_IN_SAFE_MODE);
       }
-      throw ex;
+      throw new IOException(ex.getMessage(), ex);
     }
     for (AllocatedBlock allocatedBlock : allocatedBlocks) {
       OmKeyLocationInfo.Builder builder = new OmKeyLocationInfo.Builder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import io.opentracing.Scope;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
@@ -177,7 +178,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         .setCmdType(cmdType)
         .setSuccess(false);
     if (exception.getMessage() != null) {
-      omResponse.setMessage(exception.getMessage());
+      omResponse.setMessage(StringUtils.stringifyException(exception));
     }
     return omResponse.build();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2175

complete stack trace added into the message field of OM response.
SCM exceptions(allocate block) are wrapped into an IOException on the OM and propagated to the client.

Intent is to make debugging more convenient.