### PR TITLE
HDDS-2179. ConfigFileGenerator fails with Java 10 or newer

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
 import java.util.Set;
 
 /**
@@ -60,7 +61,7 @@ public class ConfigFileGenerator extends AbstractProcessor {
           .getResource(StandardLocation.CLASS_OUTPUT, "",
               OUTPUT_FILE_NAME).openInputStream()) {
         appender.load(input);
-      } catch (FileNotFoundException ex) {
+      } catch (FileNotFoundException | NoSuchFileException ex) {
         appender.init();
       }
 
@@ -105,7 +106,7 @@ public class ConfigFileGenerator extends AbstractProcessor {
 
     } catch (IOException e) {
       processingEnv.getMessager().printMessage(Kind.ERROR,
-          "Can't generate the config file from annotation: " + e.getMessage());
+          "Can't generate the config file from annotation: " + e);
     }
     return false;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow building HDDS Config (and Ozone in general) with newer JDKs.

Also change the error message that's printed in case of an `IOException` to include a bit more info about the error (exception type).  Example:

```diff
-[ERROR] Can't generate the config file from annotation: hadoop-hdds/config/target/test-classes/ozone-default-generated.xml
+[ERROR] Can't generate the config file from annotation: java.nio.file.NoSuchFileException: hadoop-hdds/config/target/test-classes/ozone-default-generated.xml
```

https://issues.apache.org/jira/browse/HDDS-2179

## How was this patch tested?

Tested HDDS Config build with Java 8, 10, 11, 13.

```
$ mvn -f pom.ozone.xml -DskipTests -am -pl :hadoop-hdds-config clean package
...
[INFO] Apache Hadoop Ozone Main ........................... SUCCESS [  0.472 s]
[INFO] Apache Hadoop HDDS ................................. SUCCESS [  1.718 s]
[INFO] Apache Hadoop HDDS Config .......................... SUCCESS [  1.651 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

$ wc hadoop-hdds/config/target/test-classes/ozone-default-generated.xml
      33      63    1060 hadoop-hdds/config/target/test-classes/ozone-default-generated.xml
```