### PR TITLE
HDDS-2198. SCM should not consider containers in CLOSING state to come out of safemode.

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -60,7 +61,7 @@ public class TestSCMSafeModeManager {
   private static EventQueue queue;
   private SCMSafeModeManager scmSafeModeManager;
   private static Configuration config;
-  private List<ContainerInfo> containers;
+  private List<ContainerInfo> containers = Collections.emptyList();
 
   @Rule
   public Timeout timeout = new Timeout(1000 * 300);
@@ -85,7 +86,8 @@ public class TestSCMSafeModeManager {
 
   @Test
   public void testSafeModeStateWithNullContainers() {
-    new SCMSafeModeManager(config, null, null, queue);
+    new SCMSafeModeManager(config, Collections.emptyList(),
+        null, queue);
   }
 
   private void testSafeMode(int numContainers) throws Exception {


### PR DESCRIPTION

There are cases where SCM can be stuck in safemode for ever if it considers containers in CLOSING state for coming out of safemode

* If there are 5 containers in OPEN state inside SCM
* Out of 5, 3 containers are created in datanodes by the client.
* 2 containers are yet to be created in datanodes
* Due to some pipeline issue, pipeline close action is sent.
* All 5 container's state are changed from OPEN to CLOSING in SCM.
* Eventually , 3 container's state moves from CLOSING to CLOSED in SCM as the datanodes closes those containers.
* 2 of the containers are still in CLOSING state.
* SCM is restarted.
* SCM will never gets container reports for the containers which were in CLOSING state as those containers were never created in datanodes.
* SCM will remain in safemode.
