### PR TITLE
HDDS-2140. Add robot test for GDPR feature

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest Ozone GDPR Feature
+Library             OperatingSystem
+Library             BuiltIn
+Resource            ../commonlib.robot
+
+*** Variables ***
+${volume}           testvol
+
+*** Test Cases ***
+Test GDPR(disabled) without explicit options
+                    Execute             ozone sh volume create /${volume} --quota 100TB
+                    Execute             ozone sh bucket create /${volume}/mybucket1
+    ${result} =     Execute             ozone sh bucket info /${volume}/mybucket1 | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mybucket1") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       null
+                    Execute             ozone sh key put /${volume}/mybucket1/mykey /opt/hadoop/NOTICE.txt
+                    Execute             rm -f NOTICE.txt.1
+    ${result} =     Execute             ozone sh key info /${volume}/mybucket1/mykey | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mykey") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       null
+                    Execute             ozone sh key delete /${volume}/mybucket1/mykey
+
+Test GDPR with --enforcegdpr=true
+
+                    Execute             ozone sh bucket create --enforcegdpr=true /${volume}/mybucket2
+    ${result} =     Execute             ozone sh bucket info /${volume}/mybucket2 | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mybucket2") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       true
+                    Execute             ozone sh key put /${volume}/mybucket2/mykey /opt/hadoop/NOTICE.txt
+                    Execute             rm -f NOTICE.txt.1
+    ${result} =     Execute             ozone sh key info /${volume}/mybucket2/mykey | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mykey") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       true
+                    Execute             ozone sh key delete /${volume}/mybucket2/mykey
+
+Test GDPR with -g=true
+
+                    Execute             ozone sh bucket create -g=true /${volume}/mybucket3
+    ${result} =     Execute             ozone sh bucket info /${volume}/mybucket3 | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mybucket3") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       true
+                    Execute             ozone sh key put /${volume}/mybucket3/mykey /opt/hadoop/NOTICE.txt
+                    Execute             rm -f NOTICE.txt.1
+    ${result} =     Execute             ozone sh key info /${volume}/mybucket3/mykey | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mykey") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       true
+                    Execute             ozone sh key delete /${volume}/mybucket3/mykey
+
+Test GDPR with -g=false
+
+                    Execute             ozone sh bucket create /${volume}/mybucket4
+    ${result} =     Execute             ozone sh bucket info /${volume}/mybucket4 | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mybucket4") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       null
+                    Execute             ozone sh key put /${volume}/mybucket4/mykey /opt/hadoop/NOTICE.txt
+                    Execute             rm -f NOTICE.txt.1
+    ${result} =     Execute             ozone sh key info /${volume}/mybucket4/mykey | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="mykey") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       null
+                    Execute             ozone sh key delete /${volume}/mybucket4/mykey


### PR DESCRIPTION
Tested using test-single script.

```
$ ../test-single.sh om gdpr/gdpr.robot
================================================
ozone-gdpr :: Smoketest Ozone GDPR Feature
================================================
Test GDPR(disabled) without explicit options                       | PASS |
------------------------------------------------------------------------------
Test GDPR with --enforcegdpr=true                                     | PASS |
------------------------------------------------------------------------------
Test GDPR with -g=true                                                         | PASS |
------------------------------------------------------------------------------
Test GDPR with -g=false                                                       | PASS |
------------------------------------------------------------------------------
ozone-gdpr :: Smoketest Ozone GDPR Feature                   | PASS |
4 critical tests, 4 passed, 0 failed
4 tests total, 4 passed, 0 failed
============================================================
Output:  /tmp/smoketest/ozone/result/robot-ozone-ozone-gdpr-om.xml
Log:     ~/apache/hadoop/hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone/result/log.html
Report:  ~/apache/hadoop/hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone/result/report.html
```