### PR TITLE
HDDS-2205. checkstyle.sh reports wrong failure count

### DIFF
--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -36,7 +36,7 @@ find "." -name checkstyle-errors.xml -print0 \
   | tee "$REPORT_FILE"
 
 ## generate counter
-wc -l "$REPORT_DIR/summary.txt" | awk '{print $1}'> "$REPORT_DIR/failures"
+grep -c ':' "$REPORT_FILE" > "$REPORT_DIR/failures"
 
 if [[ -s "${REPORT_FILE}" ]]; then
    exit 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid counting filenames as failures in `checkstyle.sh`.

https://issues.apache.org/jira/browse/HDDS-2205

## How was this patch tested?

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh
...
hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
 49: Unused import - org.apache.hadoop.ozone.om.OMMetadataManager.

$ cat target/checkstyle/failures
1
```