### PR TITLE
HADOOP-16605: Fix testcase testSSLChannelModeConfig

### DIFF
--- a/hadoop-tools/hadoop-azure-datalake/src/test/java/org/apache/hadoop/fs/adl/live/TestAdlSdkConfiguration.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/test/java/org/apache/hadoop/fs/adl/live/TestAdlSdkConfiguration.java
@@ -98,6 +98,7 @@ public class TestAdlSdkConfiguration {
     conf = AdlStorageConfiguration.getConfiguration();
     conf.set(ADL_SSL_CHANNEL_MODE, sslChannelModeConfigValue);
     fs = (AdlFileSystem) (AdlStorageConfiguration.createStorageConnector(conf));
+    Assume.assumeNotNull(fs);
 
     SSLChannelMode sslChannelMode = fs.getAdlClient().getSSLChannelMode();
     Assert.assertEquals(


### PR DESCRIPTION
Fixing testcase testSSLChannelModeConfig, which is supposed to be skipped when no test creds are provided. 

Without test creds set: 
INFO] Results:
[INFO] 
[WARNING] Tests run: 788, Failures: 0, Errors: 0, Skipped: 767


With test creds set:
[INFO] Results:
[INFO] 
[WARNING] Tests run: 882, Failures: 0, Errors: 0, Skipped: 3
