### PR TITLE
HDDS-2199 In SCMNodeManager dnsToUuidMap cannot track multiple DNs on the same host

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -192,11 +192,11 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   DatanodeDetails getNodeByUuid(String uuid);
 
   /**
-   * Given datanode address(Ipaddress or hostname), returns the DatanodeDetails
-   * for the node.
+   * Given datanode address(Ipaddress or hostname), returns a list of
+   * DatanodeDetails for the datanodes running at that address.
    *
    * @param address datanode address
-   * @return the given datanode, or null if not found
+   * @return the given datanode, or empty list if none found
    */
-  DatanodeDetails getNodeByAddress(String address);
+  List<DatanodeDetails> getNodesByAddress(String address);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -292,7 +292,7 @@ public class SCMNodeManager implements NodeManager {
       String dnsName, String uuid) {
     Set<String> dnList = dnsToUuidMap.get(dnsName);
     if (dnList == null) {
-      dnList = new HashSet<>();
+      dnList = ConcurrentHashMap.newKeySet();
       dnsToUuidMap.put(dnsName, dnList);
     }
     dnList.add(uuid);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
@@ -284,6 +285,9 @@ public class SCMNodeManager implements NodeManager {
    * @param dnsName String representing the hostname or IP of the node
    * @param uuid String representing the UUID of the registered node.
    */
+  @SuppressFBWarnings(value="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION",
+      justification="The method is synchronized and this is the only place "+
+          "dnsToUuidMap is modified")
   private synchronized void addEntryTodnsToUuidMap(
       String dnsName, String uuid) {
     Set<String> dnList = dnsToUuidMap.get(dnsName);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -603,7 +603,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Given datanode address(Ipaddress or hostname), return a list of
-   * DatanodeDetails for the datanodes registed on that address
+   * DatanodeDetails for the datanodes registered on that address.
    *
    * @param address datanode address
    * @return the given datanode, or empty list if none found

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -284,7 +284,8 @@ public class SCMNodeManager implements NodeManager {
    * @param dnsName String representing the hostname or IP of the node
    * @param uuid String representing the UUID of the registered node.
    */
-  private void addEntryTodnsToUuidMap(String dnsName, String uuid) {
+  private synchronized void addEntryTodnsToUuidMap(
+      String dnsName, String uuid) {
     Set<String> dnList = dnsToUuidMap.get(dnsName);
     if (dnList == null) {
       dnList = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
@@ -98,7 +100,7 @@ public class SCMNodeManager implements NodeManager {
   private final NetworkTopology clusterMap;
   private final DNSToSwitchMapping dnsToSwitchMapping;
   private final boolean useHostname;
-  private final ConcurrentHashMap<String, String> dnsToUuidMap =
+  private final ConcurrentHashMap<String, Set<String>> dnsToUuidMap =
       new ConcurrentHashMap<>();
 
   /**
@@ -260,7 +262,7 @@ public class SCMNodeManager implements NodeManager {
       }
       nodeStateManager.addNode(datanodeDetails);
       clusterMap.add(datanodeDetails);
-      dnsToUuidMap.put(dnsName, datanodeDetails.getUuidString());
+      addEntryTodnsToUuidMap(dnsName, datanodeDetails.getUuidString());
       // Updating Node Report, as registration is successful
       processNodeReport(datanodeDetails, nodeReport);
       LOG.info("Registered Data node : {}", datanodeDetails);
@@ -273,6 +275,22 @@ public class SCMNodeManager implements NodeManager {
         .setDatanode(datanodeDetails)
         .setClusterID(this.scmStorageConfig.getClusterID())
         .build();
+  }
+
+  /**
+   * Add an entry to the dnsToUuidMap, which maps hostname / IP to the DNs
+   * running on that host. As each address can have many DNs running on it,
+   * this is a one to many mapping.
+   * @param dnsName String representing the hostname or IP of the node
+   * @param uuid String representing the UUID of the registered node.
+   */
+  private void addEntryTodnsToUuidMap(String dnsName, String uuid) {
+    Set<String> dnList = dnsToUuidMap.get(dnsName);
+    if (dnList == null) {
+      dnList = new HashSet<>();
+      dnsToUuidMap.put(dnsName, dnList);
+    }
+    dnList.add(uuid);
   }
 
   /**
@@ -584,29 +602,34 @@ public class SCMNodeManager implements NodeManager {
   }
 
   /**
-   * Given datanode address(Ipaddress or hostname), returns the DatanodeDetails
-   * for the node.
+   * Given datanode address(Ipaddress or hostname), return a list of
+   * DatanodeDetails for the datanodes registed on that address
    *
    * @param address datanode address
-   * @return the given datanode, or null if not found
+   * @return the given datanode, or empty list if none found
    */
   @Override
-  public DatanodeDetails getNodeByAddress(String address) {
+  public List<DatanodeDetails> getNodesByAddress(String address) {
+    List<DatanodeDetails> results = new LinkedList<>();
     if (Strings.isNullOrEmpty(address)) {
       LOG.warn("address is null");
-      return null;
+      return results;
     }
-    String uuid = dnsToUuidMap.get(address);
-    if (uuid != null) {
+    Set<String> uuids = dnsToUuidMap.get(address);
+    if (uuids == null) {
+      LOG.warn("Cannot find node for address {}", address);
+      return results;
+    }
+
+    for (String uuid : uuids) {
       DatanodeDetails temp = DatanodeDetails.newBuilder().setUuid(uuid).build();
       try {
-        return nodeStateManager.getNode(temp);
+        results.add(nodeStateManager.getNode(temp));
       } catch (NodeNotFoundException e) {
         LOG.warn("Cannot find node for uuid {}", uuid);
       }
     }
-    LOG.warn("Cannot find node for address {}", address);
-    return null;
+    return results;
   }
 
   private String nodeResolve(String hostname) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -26,7 +26,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -26,7 +26,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.client.BlockID;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -297,14 +297,12 @@ public class SCMBlockProtocolServer implements
     boolean auditSuccess = true;
     try{
       NodeManager nodeManager = scm.getScmNodeManager();
-      Node client;
+      Node client = null;
       List<DatanodeDetails> possibleClients =
           nodeManager.getNodesByAddress(clientMachine);
       if (possibleClients.size() == 1) {
         client = possibleClients.get(0);
-      } else if (possibleClients.size() == 0) {
-        client = null;
-      } else {
+      } else if (possibleClients.size() > 1) {
         // Generally a test cluster with many DNs on the same host so check
         // if any of the passed hosts match one of the client nodes
         List<DatanodeDetails> matchedNodes = possibleClients.stream()
@@ -312,16 +310,13 @@ public class SCMBlockProtocolServer implements
             .collect(Collectors.toList());
         if (matchedNodes.size() == 0) {
           // None of the passed in nodes match a node running on the client
-          // host, so just set the client as the first one.
+          // host, so just set the client as the first one originally found as
+          // the client is part of the cluster and the nodes are sorted by
+          // distance from the client.
           client = possibleClients.get(0);
-        } else if (matchedNodes.size() == 1) {
-          // Only one of the passed nodes matches a DN on the client, so use it
-          client = matchedNodes.get(0);
         } else {
-          // Several of the passed nodes are running on the client address, so
-          // pick a random one.
-          Random rand = new Random();
-          client = matchedNodes.get(rand.nextInt(matchedNodes.size()));
+          // One or more matches the client, so just use the first one.
+          client = matchedNodes.get(0);
         }
       }
       List<Node> nodeList = new ArrayList();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -299,24 +299,8 @@ public class SCMBlockProtocolServer implements
       Node client = null;
       List<DatanodeDetails> possibleClients =
           nodeManager.getNodesByAddress(clientMachine);
-      if (possibleClients.size() == 1) {
+      if (possibleClients.size()>0){
         client = possibleClients.get(0);
-      } else if (possibleClients.size() > 1) {
-        // Generally a test cluster with many DNs on the same host so check
-        // if any of the passed hosts match one of the client nodes
-        List<DatanodeDetails> matchedNodes = possibleClients.stream()
-            .filter(nodes::contains)
-            .collect(Collectors.toList());
-        if (matchedNodes.size() == 0) {
-          // None of the passed in nodes match a node running on the client
-          // host, so just set the client as the first one originally found as
-          // the client is part of the cluster and the nodes are sorted by
-          // distance from the client.
-          client = possibleClients.get(0);
-        } else {
-          // One or more matches the client, so just use the first one.
-          client = matchedNodes.get(0);
-        }
       }
       List<Node> nodeList = new ArrayList();
       nodes.stream().forEach(uuid -> {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -53,7 +53,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -406,7 +405,8 @@ public class MockNodeManager implements NodeManager {
    * @param dnsName String representing the hostname or IP of the node
    * @param uuid String representing the UUID of the registered node.
    */
-  private synchronized void addEntryTodnsToUuidMap(String dnsName, String uuid) {
+  private synchronized void addEntryTodnsToUuidMap(
+      String dnsName, String uuid) {
     Set<String> dnList = dnsToUuidMap.get(dnsName);
     if (dnList == null) {
       dnList = ConcurrentHashMap.newKeySet();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -53,6 +53,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -88,7 +89,7 @@ public class MockNodeManager implements NodeManager {
   private final Node2PipelineMap node2PipelineMap;
   private final Node2ContainerMap node2ContainerMap;
   private NetworkTopology clusterMap;
-  private ConcurrentHashMap<String, String> dnsToUuidMap;
+  private ConcurrentHashMap<String, Set<String>> dnsToUuidMap;
 
   public MockNodeManager(boolean initializeFakeNodes, int nodeCount) {
     this.healthyNodes = new LinkedList<>();
@@ -386,7 +387,7 @@ public class MockNodeManager implements NodeManager {
     try {
       node2ContainerMap.insertNewDatanode(datanodeDetails.getUuid(),
           Collections.emptySet());
-      dnsToUuidMap.put(datanodeDetails.getIpAddress(),
+      addEntryTodnsToUuidMap(datanodeDetails.getIpAddress(),
           datanodeDetails.getUuidString());
       if (clusterMap != null) {
         datanodeDetails.setNetworkName(datanodeDetails.getUuidString());
@@ -396,6 +397,22 @@ public class MockNodeManager implements NodeManager {
       e.printStackTrace();
     }
     return null;
+  }
+
+  /**
+   * Add an entry to the dnsToUuidMap, which maps hostname / IP to the DNs
+   * running on that host. As each address can have many DNs running on it,
+   * this is a one to many mapping.
+   * @param dnsName String representing the hostname or IP of the node
+   * @param uuid String representing the UUID of the registered node.
+   */
+  private void addEntryTodnsToUuidMap(String dnsName, String uuid) {
+    Set<String> dnList = dnsToUuidMap.get(dnsName);
+    if (dnList == null) {
+      dnList = new HashSet<>();
+      dnsToUuidMap.put(dnsName, dnList);
+    }
+    dnList.add(uuid);
   }
 
   /**
@@ -484,8 +501,19 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
-  public DatanodeDetails getNodeByAddress(String address) {
-    return getNodeByUuid(dnsToUuidMap.get(address));
+  public List<DatanodeDetails> getNodesByAddress(String address) {
+    List<DatanodeDetails> results = new LinkedList<>();
+    Set<String> uuids = dnsToUuidMap.get(address);
+    if (uuids == null) {
+      return results;
+    }
+    for(String uuid : uuids) {
+      DatanodeDetails dn = getNodeByUuid(uuid);
+      if (dn != null) {
+        results.add(dn);
+      }
+    }
+    return results;
   }
 
   public void setNetworkTopology(NetworkTopology topology) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -406,10 +406,10 @@ public class MockNodeManager implements NodeManager {
    * @param dnsName String representing the hostname or IP of the node
    * @param uuid String representing the UUID of the registered node.
    */
-  private void addEntryTodnsToUuidMap(String dnsName, String uuid) {
+  private synchronized void addEntryTodnsToUuidMap(String dnsName, String uuid) {
     Set<String> dnList = dnsToUuidMap.get(dnsName);
     if (dnList == null) {
-      dnList = new HashSet<>();
+      dnList = ConcurrentHashMap.newKeySet();
       dnsToUuidMap.put(dnsName, dnList);
     }
     dnList.add(uuid);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.LinkedList;
 
 /**
  * A Node Manager to test replication.
@@ -323,7 +324,7 @@ public class ReplicationNodeManagerMock implements NodeManager {
   }
 
   @Override
-  public DatanodeDetails getNodeByAddress(String address) {
-    return null;
+  public List<DatanodeDetails> getNodesByAddress(String address) {
+    return new LinkedList<>();
   }
 }


### PR DESCRIPTION
Often in test clusters and tests, we start multiple datanodes on the same host.

In SCMNodeManager.register() there is a map of hostname -> datanode UUID called dnsToUuidMap.

If several DNs register from the same host, the entry in the map will be overwritten and the last DN to register will 'win'.

This means that the method getNodeByAddress() does not return the correct DatanodeDetails object when many hosts are registered from the same address.

This method is only used in SCMBlockProtocolServer.sortDatanodes() to allow it to see if one of the nodes matches the client, but it need to be used by the Decommission code.

Perhaps we could change the getNodeByAddress() method to returns a list of DNs? In normal production clusters, there should only be one returned, but in test clusters, there may be many. Any code looking for a specific DN entry would need to iterate the list and match on the port number too, as host:port would be the unique definition of a datanode.