### PR TITLE
HDDS-2211. Collect docker logs if env fails to start

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -29,7 +29,7 @@ rm "$ALL_RESULT_DIR/*"
 RESULT=0
 IFS=$'\n'
 # shellcheck disable=SC2044
-for test in $(find "$SCRIPT_DIR" -name test.sh); do
+for test in $(find "$SCRIPT_DIR" -name test.sh | sort); do
   echo "Executing test in $(dirname "$test")"
 
   #required to read the .env file from the right location
@@ -41,7 +41,7 @@ for test in $(find "$SCRIPT_DIR" -name test.sh); do
       echo "ERROR: Test execution of $(dirname "$test") is FAILED!!!!"
   fi
   RESULT_DIR="$(dirname "$test")/result"
-  cp "$RESULT_DIR"/robot-*.xml "$ALL_RESULT_DIR"
+  cp "$RESULT_DIR"/robot-*.xml "$RESULT_DIR"/docker-*.log "$ALL_RESULT_DIR"/
 done
 
 rebot -N "smoketests" -d "$SCRIPT_DIR/result" "$SCRIPT_DIR/result/robot-*.xml"

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -77,6 +77,7 @@ wait_for_datanodes(){
       sleep 2
    done
    echo "WARNING! Datanodes are not started successfully. Please check the docker-compose files"
+   return 1
 }
 
 ## @description  Starts a docker-compose based test environment
@@ -86,13 +87,14 @@ start_docker_env(){
 
   create_results_dir
 
-  docker-compose -f "$COMPOSE_FILE" down
-  docker-compose -f "$COMPOSE_FILE" up -d --scale datanode="${datanode_count}" \
+  docker-compose -f "$COMPOSE_FILE" --no-ansi down
+  docker-compose -f "$COMPOSE_FILE" --no-ansi up -d --scale datanode="${datanode_count}" \
     && wait_for_datanodes "$COMPOSE_FILE" "${datanode_count}" \
     && sleep 10
 
   if [[ $? -gt 0 ]]; then
-    docker-compose -f "$COMPOSE_FILE" down
+    OUTPUT_NAME="$COMPOSE_ENV_NAME"
+    stop_docker_env
     return 1
   fi
 }
@@ -136,9 +138,9 @@ execute_command_in_container(){
 
 ## @description  Stops a docker-compose based test environment (with saving the logs)
 stop_docker_env(){
-  docker-compose -f "$COMPOSE_FILE" logs > "$RESULT_DIR/docker-$OUTPUT_NAME.log"
+  docker-compose -f "$COMPOSE_FILE" --no-ansi logs > "$RESULT_DIR/docker-$OUTPUT_NAME.log"
   if [ "${KEEP_RUNNING:-false}" = false ]; then
-     docker-compose -f "$COMPOSE_FILE" down
+     docker-compose -f "$COMPOSE_FILE" --no-ansi down
   fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Collect docker logs if environment fails to start up (previously it was collected only after actual test run)
2. Copy docker logs to aggregate result directory
3. Fail fast if datanodes cannot be started
4. Avoid [ANSI codes in output](https://github.com/elek/ozone-ci-q4/blob/f700ebb2254527527960593496f15008245094d6/trunk/trunk-nightly-extra-20190930-74rp4/acceptance/output.log#L3774)
5. Sort test cases for consistent run ordering (Robot summary table is already sorted)

https://issues.apache.org/jira/browse/HDDS-2211

## How was this patch tested?

Ran `acceptance.sh` locally.  Also simulated failure during datanode startup, verified that docker log is saved.