### PR TITLE
HADOOP-16619. Upgrade jackson and jackson-databind to 2.9.10

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -69,8 +69,8 @@
 
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.9.9</jackson2.version>
-    <jackson2.databind.version>2.9.9.3</jackson2.databind.version>
+    <jackson2.version>2.9.10</jackson2.version>
+    <jackson2.databind.version>2.9.10</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.6</httpclient.version>


### PR DESCRIPTION
Compiled locally on my Mac. Confirmed that it uses 2.9.10 jars for `jackson-core`, `jackson-annotations`, `jackson-databind`, etc.:

```
$ cd hadoop-dist/target/hadoop-3.3.0-SNAPSHOT
$ find . -name "*jackson*"
./share/hadoop/yarn/lib/jackson-jaxrs-json-provider-2.9.10.jar
./share/hadoop/yarn/lib/jackson-jaxrs-base-2.9.10.jar
./share/hadoop/yarn/lib/jackson-module-jaxb-annotations-2.9.10.jar
./share/hadoop/common/lib/jackson-jaxrs-1.9.13.jar
./share/hadoop/common/lib/jackson-xc-1.9.13.jar
./share/hadoop/common/lib/jackson-core-2.9.10.jar
./share/hadoop/common/lib/jackson-core-asl-1.9.13.jar
./share/hadoop/common/lib/jackson-annotations-2.9.10.jar
./share/hadoop/common/lib/jackson-databind-2.9.10.jar
./share/hadoop/common/lib/jackson-mapper-asl-1.9.13.jar
./share/hadoop/hdfs/lib/jackson-jaxrs-1.9.13.jar
./share/hadoop/hdfs/lib/jackson-xc-1.9.13.jar
./share/hadoop/hdfs/lib/jackson-core-2.9.10.jar
./share/hadoop/hdfs/lib/jackson-core-asl-1.9.13.jar
./share/hadoop/hdfs/lib/jackson-annotations-2.9.10.jar
./share/hadoop/hdfs/lib/jackson-databind-2.9.10.jar
./share/hadoop/hdfs/lib/jackson-mapper-asl-1.9.13.jar
```