### PR TITLE
HDDS-2221. Monitor datanodes in ozoneperf compose cluster

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
    prometheus:
      image: prom/prometheus
      volumes:
-       - "../common/prometheus/prometheus.yml:/etc/prometheus.yml"
+       - "./prometheus.yml:/etc/prometheus.yml"
      command: ["--config.file","/etc/prometheus.yml"]
      ports:
         - 9090:9090

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/prometheus.yml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/prometheus.yml
@@ -23,3 +23,13 @@ scrape_configs:
      - targets:
         - "scm:9876"
         - "om:9874"
+        - "ozoneperf_datanode_1:9882"
+        - "ozoneperf_datanode_2:9882"
+        - "ozoneperf_datanode_3:9882"
+        - "ozoneperf_datanode_4:9882"
+        - "ozoneperf_datanode_5:9882"
+        - "ozoneperf_datanode_6:9882"
+        - "ozoneperf_datanode_7:9882"
+        - "ozoneperf_datanode_8:9882"
+        - "ozoneperf_datanode_9:9882"
+        - "ozoneperf_datanode_10:9882"


### PR DESCRIPTION
ozoneperf compose cluster contains a prometheus but as of now it collects the data only from scm and om.

We don't know the exact number of datanodes (can be scaled up and down) therefor it's harder to configure the datanode host names. I would suggest to configure the first 10 datanodes (which covers most of the use cases)

How to test?

```
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozoneperf
docker-compose up -d
firefox http://localhost:9090/targets
```
 