### PR TITLE
HDDS-2228. Fix NPE in OzoneDelegationTokenManager#addPersistedDelegat…

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -84,13 +84,16 @@ public class OzoneDelegationTokenSecretManager
    * milliseconds
    * @param dtRemoverScanInterval how often the tokens are scanned for expired
    * tokens in milliseconds
+   * @param certClient certificate client to SCM CA
    */
   public OzoneDelegationTokenSecretManager(OzoneConfiguration conf,
       long tokenMaxLifetime, long tokenRenewInterval,
       long dtRemoverScanInterval, Text service,
-      S3SecretManager s3SecretManager) throws IOException {
+      S3SecretManager s3SecretManager, CertificateClient certClient)
+      throws IOException {
     super(new SecurityConfig(conf), tokenMaxLifetime, tokenRenewInterval,
         service, LOG);
+    setCertClient(certClient);
     currentTokens = new ConcurrentHashMap();
     this.tokenRemoverScanInterval = dtRemoverScanInterval;
     this.s3SecretManager = (S3SecretManagerImpl) s3SecretManager;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneSecretManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneSecretManager.java
@@ -70,6 +70,7 @@ public abstract class OzoneSecretManager<T extends TokenIdentifier>
    * @param tokenRenewInterval how often the tokens must be renewed in
    * milliseconds
    * @param service name of service
+   * @param logger logger for the secret manager
    */
   public OzoneSecretManager(SecurityConfig secureConf, long tokenMaxLifetime,
       long tokenRenewInterval, Text service, Logger logger) {
@@ -246,6 +247,10 @@ public abstract class OzoneSecretManager<T extends TokenIdentifier>
 
   public CertificateClient getCertClient() {
     return certClient;
+  }
+
+  public void setCertClient(CertificateClient client) {
+    this.certClient = client;
   }
 }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneSecretManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneSecretManager.java
@@ -189,7 +189,7 @@ public abstract class OzoneSecretManager<T extends TokenIdentifier>
   public synchronized void start(CertificateClient client)
       throws IOException {
     Preconditions.checkState(!isRunning());
-    this.certClient = client;
+    setCertClient(client);
     updateCurrentKey(new KeyPair(certClient.getPublicKey(),
         certClient.getPrivateKey()));
     setIsRunning(true);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -627,7 +627,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     return new OzoneDelegationTokenSecretManager(conf, tokenMaxLifetime,
         tokenRenewInterval, tokenRemoverScanInterval, omRpcAddressTxt,
-        s3SecretManager);
+        s3SecretManager, certClient);
   }
 
   private OzoneBlockTokenSecretManager createBlockTokenSecretManager(


### PR DESCRIPTION
Fix the issue when OzoneDelegationTokenManager tries to load tokens without a valid certificate client. 
Add a unit test that repro the issue and verify the fix. 