### PR TITLE
HDDS-2226. S3 Secrets should use a strong RNG.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -73,6 +74,9 @@ import org.slf4j.LoggerFactory;
  */
 public final class OmUtils {
   public static final Logger LOG = LoggerFactory.getLogger(OmUtils.class);
+  private static final SecureRandom srand = new SecureRandom();
+  private static byte [] randomBytes = new byte[32];
+
 
   private OmUtils() {
   }
@@ -274,9 +278,9 @@ public final class OmUtils {
 
   public static byte[] getSHADigest() throws IOException {
     try {
+      srand.nextBytes(randomBytes);
       MessageDigest sha = MessageDigest.getInstance(OzoneConsts.FILE_HASH);
-      return sha.digest(RandomStringUtils.random(32)
-          .getBytes(StandardCharsets.UTF_8));
+      return sha.digest(randomBytes);
     } catch (NoSuchAlgorithmException ex) {
       throw new IOException("Error creating an instance of SHA-256 digest.\n" +
           "This could possibly indicate a faulty JRE");

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -40,7 +40,6 @@ import com.google.common.base.Strings;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.scm.HddsServerUtil;
@@ -74,9 +73,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class OmUtils {
   public static final Logger LOG = LoggerFactory.getLogger(OmUtils.class);
-  private static final SecureRandom srand = new SecureRandom();
-  private static byte [] randomBytes = new byte[32];
-
+  private static final SecureRandom SRAND = new SecureRandom();
+  private static byte[] randomBytes = new byte[32];
 
   private OmUtils() {
   }
@@ -278,7 +276,7 @@ public final class OmUtils {
 
   public static byte[] getSHADigest() throws IOException {
     try {
-      srand.nextBytes(randomBytes);
+      SRAND.nextBytes(randomBytes);
       MessageDigest sha = MessageDigest.getInstance(OzoneConsts.FILE_HASH);
       return sha.digest(randomBytes);
     } catch (NoSuchAlgorithmException ex) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2226

The S3 token generation under ozone should use a strong RNG.

I want to thank Jonathan Leitschuh, for originally noticing this issue and reporting it.

How tested: Ran Unit.sh
