### PR TITLE
HDFS-14889. Ability to check if a block has a replica on provided storage.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
@@ -182,6 +182,12 @@ public abstract class BlockInfo extends Block
   abstract boolean hasNoStorage();
 
   /**
+   * Checks whether this block has a Provided replica.
+   * @return true if this block has a replica on Provided storage.
+   */
+  abstract boolean isProvided();
+
+  /**
    * Find specified DatanodeStorageInfo.
    * @return DatanodeStorageInfo or null if not found.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoContiguous.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoContiguous.java
@@ -84,12 +84,11 @@ public class BlockInfoContiguous extends BlockInfo {
   @Override
   boolean isProvided() {
     int len = getCapacity();
-    for(int idx = 0; idx < len; idx++) {
-      DatanodeStorageInfo cur = getStorageInfo(idx);
-      if(cur != null) {
-        if (cur.getStorageType() == StorageType.PROVIDED) {
-          return true;
-        }
+    for (int idx = 0; idx < len; idx++) {
+      DatanodeStorageInfo storage = getStorageInfo(idx);
+      if (storage != null
+          && storage.getStorageType().equals(StorageType.PROVIDED)) {
+        return true;
       }
     }
     return false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoContiguous.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoContiguous.java
@@ -29,16 +29,12 @@ import org.apache.hadoop.hdfs.protocol.BlockType;
 @InterfaceAudience.Private
 public class BlockInfoContiguous extends BlockInfo {
 
-  private boolean hasProvidedStorage;
-
   public BlockInfoContiguous(short size) {
     super(size);
-    hasProvidedStorage = false;
   }
 
   public BlockInfoContiguous(Block blk, short size) {
     super(blk, size);
-    hasProvidedStorage = false;
   }
 
   /**
@@ -67,9 +63,6 @@ public class BlockInfoContiguous extends BlockInfo {
     // find the last null node
     int lastNode = ensureCapacity(1);
     setStorageInfo(lastNode, storage);
-    if (storage.getStorageType() == StorageType.PROVIDED) {
-      hasProvidedStorage = true;
-    }
     return true;
   }
 
@@ -85,19 +78,11 @@ public class BlockInfoContiguous extends BlockInfo {
     setStorageInfo(dnIndex, getStorageInfo(lastNode));
     // set the last entry to null
     setStorageInfo(lastNode, null);
-    if (storage.getStorageType() == StorageType.PROVIDED
-        && !hasProvidedStorages()) {
-      hasProvidedStorage = false;
-    }
     return true;
   }
 
   @Override
   boolean isProvided() {
-    return hasProvidedStorage;
-  }
-
-  private boolean hasProvidedStorages() {
     int len = getCapacity();
     for(int idx = 0; idx < len; idx++) {
       DatanodeStorageInfo cur = getStorageInfo(idx);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
@@ -244,6 +244,10 @@ public class BlockInfoStriped extends BlockInfo {
     return true;
   }
 
+  /**
+   * Striped blocks on Provided Storage is not supported. All blocks on
+   * Provided storage are assumed to be "contiguous".
+   */
   @Override
   boolean isProvided() {
     return false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoStriped.java
@@ -244,6 +244,11 @@ public class BlockInfoStriped extends BlockInfo {
     return true;
   }
 
+  @Override
+  boolean isProvided() {
+    return false;
+  }
+
   /**
    * This class contains datanode storage information and block index in the
    * block group.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
@@ -19,7 +19,10 @@ package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.server.namenode.INodeId.INVALID_INODE_ID;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import org.apache.hadoop.fs.StorageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdfs.DFSTestUtil;
@@ -62,6 +65,28 @@ public class TestBlockInfo {
 
     Assert.assertTrue(added);
     Assert.assertEquals(storage, blockInfo.getStorageInfo(0));
+  }
+
+  @Test
+  public void testAddProvidedStorage() throws Exception {
+    BlockInfo blockInfo = new BlockInfoContiguous((short) 3);
+
+    DatanodeStorageInfo storage = mock(DatanodeStorageInfo.class);
+    when(storage.getStorageType()).thenReturn(StorageType.PROVIDED);
+    boolean added = blockInfo.addStorage(storage, blockInfo);
+
+    Assert.assertTrue(added);
+    Assert.assertEquals(storage, blockInfo.getStorageInfo(0));
+    Assert.assertTrue(blockInfo.isProvided());
+
+    blockInfo = new BlockInfoContiguous((short) 3);
+    storage = mock(DatanodeStorageInfo.class);
+    when(storage.getStorageType()).thenReturn(StorageType.DISK);
+    added = blockInfo.addStorage(storage, blockInfo);
+
+    Assert.assertTrue(added);
+    Assert.assertEquals(storage, blockInfo.getStorageInfo(0));
+    Assert.assertFalse(blockInfo.isProvided());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
@@ -69,24 +69,35 @@ public class TestBlockInfo {
 
   @Test
   public void testAddProvidedStorage() throws Exception {
+    // block with only provided storage
     BlockInfo blockInfo = new BlockInfoContiguous((short) 3);
-
-    DatanodeStorageInfo storage = mock(DatanodeStorageInfo.class);
-    when(storage.getStorageType()).thenReturn(StorageType.PROVIDED);
-    boolean added = blockInfo.addStorage(storage, blockInfo);
-
+    DatanodeStorageInfo providedStorage = mock(DatanodeStorageInfo.class);
+    when(providedStorage.getStorageType()).thenReturn(StorageType.PROVIDED);
+    boolean added = blockInfo.addStorage(providedStorage, blockInfo);
     Assert.assertTrue(added);
-    Assert.assertEquals(storage, blockInfo.getStorageInfo(0));
+    Assert.assertEquals(providedStorage, blockInfo.getStorageInfo(0));
     Assert.assertTrue(blockInfo.isProvided());
+  }
 
-    blockInfo = new BlockInfoContiguous((short) 3);
-    storage = mock(DatanodeStorageInfo.class);
-    when(storage.getStorageType()).thenReturn(StorageType.DISK);
-    added = blockInfo.addStorage(storage, blockInfo);
-
+  @Test
+  public void testAddTwoStorageTypes() throws Exception {
+    // block with only disk storage
+    BlockInfo blockInfo = new BlockInfoContiguous((short) 3);
+    DatanodeStorageInfo diskStorage = mock(DatanodeStorageInfo.class);
+    DatanodeDescriptor mockDN = mock(DatanodeDescriptor.class);
+    when(diskStorage.getDatanodeDescriptor()).thenReturn(mockDN);
+    when(diskStorage.getStorageType()).thenReturn(StorageType.DISK);
+    boolean added = blockInfo.addStorage(diskStorage, blockInfo);
     Assert.assertTrue(added);
-    Assert.assertEquals(storage, blockInfo.getStorageInfo(0));
+    Assert.assertEquals(diskStorage, blockInfo.getStorageInfo(0));
     Assert.assertFalse(blockInfo.isProvided());
+
+    // now add provided storage
+    DatanodeStorageInfo providedStorage = mock(DatanodeStorageInfo.class);
+    when(providedStorage.getStorageType()).thenReturn(StorageType.PROVIDED);
+    added = blockInfo.addStorage(providedStorage, blockInfo);
+    Assert.assertTrue(added);
+    Assert.assertTrue(blockInfo.isProvided());
   }
 
   @Test


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/HDFS-14889.
Adding a method in `BlockInfo` to return true of the block has any replica on a Provided storage.