### PR TITLE
HDDS-2227. GDPR key generation could benefit from secureRandom.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -94,6 +94,7 @@ import javax.crypto.CipherOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.security.InvalidKeyException;
+import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -587,7 +588,7 @@ public class RpcClient implements ClientProtocol {
 
     if(Boolean.valueOf(metadata.get(OzoneConsts.GDPR_FLAG))){
       try{
-        GDPRSymmetricKey gKey = new GDPRSymmetricKey();
+        GDPRSymmetricKey gKey = new GDPRSymmetricKey(new SecureRandom());
         metadata.putAll(gKey.getKeyDetails());
       }catch (Exception e) {
         if(e instanceof InvalidKeyException &&

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/GDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/GDPRSymmetricKey.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,10 +49,11 @@ public class GDPRSymmetricKey {
    * Default constructor creates key with default values.
    * @throws Exception
    */
-  public GDPRSymmetricKey() throws Exception {
+  public GDPRSymmetricKey(SecureRandom secureRandom) throws Exception {
     algorithm = OzoneConsts.GDPR_ALGORITHM_NAME;
-    secret = RandomStringUtils
-        .randomAlphabetic(OzoneConsts.GDPR_DEFAULT_RANDOM_SECRET_LENGTH);
+    secret = RandomStringUtils.random(
+        OzoneConsts.GDPR_DEFAULT_RANDOM_SECRET_LENGTH,
+        0, 0, true, true, null, secureRandom);
     this.secretKey = new SecretKeySpec(
         secret.getBytes(OzoneConsts.GDPR_CHARSET), algorithm);
     this.cipher = Cipher.getInstance(algorithm);

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.security.SecureRandom;
+
 /**
  * Tests GDPRSymmetricKey structure.
  */
@@ -28,7 +30,7 @@ public class TestGDPRSymmetricKey {
 
   @Test
   public void testKeyGenerationWithDefaults() throws Exception {
-    GDPRSymmetricKey gkey = new GDPRSymmetricKey();
+    GDPRSymmetricKey gkey = new GDPRSymmetricKey(new SecureRandom());
 
     Assert.assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2227
The SecureRandom can be used for the symetric key for GDPR. While GDPR is not a security feature, this is a good to have optional feature.

I want to thank Jonathan Leitschuh, for originally noticing this issue and reporting it.

How tested: ran unit.sh, had one failure in TestSCMContainerPlacementRackAware