### PR TITLE
HDDS-2231. test-single.sh cannot copy results

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-single.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-single.sh
@@ -48,6 +48,8 @@ fi
 # shellcheck source=testlib.sh
 source "$COMPOSE_DIR/../testlib.sh"
 
+create_results_dir
+
 execute_robot_test "$1" "$2"
 
 generate_report


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restore pre-[HDDS-2185](https://issues.apache.org/jira/browse/HDDS-2185) behavior of `test-single.sh` by explicitly creating `result` directory.

https://issues.apache.org/jira/browse/HDDS-2231

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
$ docker-compose up -d --scale datanode=3
$ ../test-single.sh scm basic/basic.robot
$ ls result
robot-ozone-ozone-basic-scm.xml
```