### PR TITLE
HDDS-2200 : Recon does not handle the NULL snapshot from OM DB cleanly.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -185,8 +185,8 @@ public class ReconUtils {
     String lastKnownSnapshotFileName = null;
     long lastKnonwnSnapshotTs = Long.MIN_VALUE;
     if (reconDbDir != null) {
-      File[] snapshotFiles = reconDbDir.listFiles((dir, name) -> name
-          .startsWith(fileNamePrefix));
+      File[] snapshotFiles = reconDbDir.listFiles((dir, name) ->
+          name.startsWith(fileNamePrefix));
       if (snapshotFiles != null) {
         for (File snapshotFile : snapshotFiles) {
           String fileName = snapshotFile.getName();
@@ -195,7 +195,7 @@ public class ReconUtils {
             if (fileNameSplits.length <= 1) {
               continue;
             }
-            long snapshotTimestamp = Long.valueOf(fileNameSplits[1]);
+            long snapshotTimestamp = Long.parseLong(fileNameSplits[1]);
             if (lastKnonwnSnapshotTs < snapshotTimestamp) {
               lastKnonwnSnapshotTs = snapshotTimestamp;
               lastKnownSnapshotFileName = fileName;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -175,4 +175,39 @@ public class ReconUtils {
     }
   }
 
+  /**
+   * Load last known DB in Recon.
+   * @param reconDbDir
+   * @param fileNamePrefix
+   * @return
+   */
+  public File getLastKnownDB(File reconDbDir, String fileNamePrefix) {
+    String lastKnownSnapshotFileName = null;
+    long lastKnonwnSnapshotTs = Long.MIN_VALUE;
+    if (reconDbDir != null) {
+      File[] snapshotFiles = reconDbDir.listFiles((dir, name) -> name
+          .startsWith(fileNamePrefix));
+      if (snapshotFiles != null) {
+        for (File snapshotFile : snapshotFiles) {
+          String fileName = snapshotFile.getName();
+          try {
+            String[] fileNameSplits = fileName.split("_");
+            if (fileNameSplits.length <= 1) {
+              continue;
+            }
+            long snapshotTimestamp = Long.valueOf(fileNameSplits[1]);
+            if (lastKnonwnSnapshotTs < snapshotTimestamp) {
+              lastKnonwnSnapshotTs = snapshotTimestamp;
+              lastKnownSnapshotFileName = fileName;
+            }
+          } catch (NumberFormatException nfEx) {
+            LOG.warn("Unknown file found in Recon DB dir : {}", fileName);
+          }
+        }
+      }
+    }
+    return lastKnownSnapshotFileName == null ? null :
+        new File(reconDbDir.getPath(), lastKnownSnapshotFileName);
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -81,14 +81,7 @@ public class ContainerDBServiceProviderImpl
   public ContainerDBServiceProviderImpl(DBStore dbStore,
                                         Configuration sqlConfiguration) {
     globalStatsDao = new GlobalStatsDao(sqlConfiguration);
-    try {
-      this.containerKeyTable = dbStore.getTable(CONTAINER_KEY_TABLE,
-          ContainerKeyPrefix.class, Integer.class);
-      this.containerKeyCountTable = dbStore.getTable(CONTAINER_KEY_COUNT_TABLE,
-          Long.class, Long.class);
-    } catch (IOException e) {
-      LOG.error("Unable to create Container Key tables." + e);
-    }
+    initializeTables(dbStore);
   }
 
   /**
@@ -107,8 +100,9 @@ public class ContainerDBServiceProviderImpl
     File oldDBLocation = containerDbStore.getDbLocation();
     containerDbStore = ReconContainerDBProvider
         .getNewDBStore(configuration, reconUtils);
-    containerKeyTable = containerDbStore.getTable(CONTAINER_KEY_TABLE,
-        ContainerKeyPrefix.class, Integer.class);
+    LOG.info("Creating new Recon Container DB at {}",
+        containerDbStore.getDbLocation().getAbsolutePath());
+    initializeTables(containerDbStore);
 
     if (oldDBLocation.exists()) {
       LOG.info("Cleaning up old Recon Container DB at {}.",
@@ -127,6 +121,20 @@ public class ContainerDBServiceProviderImpl
     storeContainerCount(0L);
   }
 
+  /**
+   * Initialize the container DB tables.
+   * @param dbStore
+   */
+  private void initializeTables(DBStore dbStore) {
+    try {
+      this.containerKeyTable = dbStore.getTable(CONTAINER_KEY_TABLE,
+          ContainerKeyPrefix.class, Integer.class);
+      this.containerKeyCountTable = dbStore.getTable(CONTAINER_KEY_COUNT_TABLE,
+          Long.class, Long.class);
+    } catch (IOException e) {
+      LOG.error("Unable to create Container Key tables." + e);
+    }
+  }
   /**
    * Concatenate the containerID and Key Prefix using a delimiter and store the
    * count into the container DB store.

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractOMMetadataManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractOMMetadataManagerTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractOMMetadataManagerTest {
         .getAbsolutePath());
 
     ReconOMMetadataManager reconOMMetaMgr =
-        new ReconOmMetadataManagerImpl(configuration);
+        new ReconOmMetadataManagerImpl(configuration, new ReconUtils());
     reconOMMetaMgr.start(configuration);
 
     reconOMMetaMgr.updateOmDB(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -133,4 +133,35 @@ public class TestReconUtils {
     assertEquals("File 1 Contents", contents);
   }
 
+  @Test
+  public void testGetLastKnownDB() throws IOException {
+    File newDir = folder.newFolder();
+
+    File file1 = Paths.get(newDir.getAbsolutePath(), "valid_1")
+        .toFile();
+    String str = "File1 Contents";
+    BufferedWriter writer = new BufferedWriter(new FileWriter(
+        file1.getAbsolutePath()));
+    writer.write(str);
+    writer.close();
+
+    File file2 = Paths.get(newDir.getAbsolutePath(), "valid_2")
+        .toFile();
+    str = "File2 Contents";
+    writer = new BufferedWriter(new FileWriter(file2.getAbsolutePath()));
+    writer.write(str);
+    writer.close();
+
+
+    File file3 = Paths.get(newDir.getAbsolutePath(), "invalid_3")
+        .toFile();
+    str = "File3 Contents";
+    writer = new BufferedWriter(new FileWriter(file3.getAbsolutePath()));
+    writer.write(str);
+    writer.close();
+
+    ReconUtils reconUtils = new ReconUtils();
+    File latestValidFile = reconUtils.getLastKnownDB(newDir, "valid");
+    assertTrue(latestValidFile.getName().equals("valid_2"));
+  }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
@@ -22,7 +22,9 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -31,6 +33,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,8 +48,94 @@ public class TestReconOmMetadataManagerImpl {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
+  public void testStart() throws Exception {
+
+    OMMetadataManager omMetadataManager = getOMMetadataManager();
+
+    //Take checkpoint of the above OM DB.
+    DBCheckpoint checkpoint = omMetadataManager.getStore()
+        .getCheckpoint(true);
+    File snapshotFile = new File(
+        checkpoint.getCheckpointLocation().getParent() + "/" +
+            "om.snapshot.db_" + System.currentTimeMillis());
+    checkpoint.getCheckpointLocation().toFile().renameTo(snapshotFile);
+
+    //Create new Recon OM Metadata manager instance.
+    File reconOmDbDir = temporaryFolder.newFolder();
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconOmDbDir
+        .getAbsolutePath());
+    FileUtils.copyDirectory(snapshotFile.getParentFile(), reconOmDbDir);
+
+    ReconOMMetadataManager reconOMMetadataManager =
+        new ReconOmMetadataManagerImpl(configuration, new ReconUtils());
+    reconOMMetadataManager.start(configuration);
+
+    Assert.assertNotNull(reconOMMetadataManager.getBucketTable());
+    Assert.assertNotNull(reconOMMetadataManager.getVolumeTable()
+        .get("/sampleVol"));
+    Assert.assertNotNull(reconOMMetadataManager.getBucketTable()
+        .get("/sampleVol/bucketOne"));
+    Assert.assertNotNull(reconOMMetadataManager.getKeyTable()
+        .get("/sampleVol/bucketOne/key_one"));
+    Assert.assertNotNull(reconOMMetadataManager.getKeyTable()
+        .get("/sampleVol/bucketOne/key_two"));
+  }
+
+  @Test
   public void testUpdateOmDB() throws Exception {
 
+    OMMetadataManager omMetadataManager = getOMMetadataManager();
+    //Make sure OM Metadata reflects the keys that were inserted.
+    Assert.assertNotNull(omMetadataManager.getKeyTable()
+        .get("/sampleVol/bucketOne/key_one"));
+    Assert.assertNotNull(omMetadataManager.getKeyTable()
+        .get("/sampleVol/bucketOne/key_two"));
+
+    //Take checkpoint of OM DB.
+    DBCheckpoint checkpoint = omMetadataManager.getStore()
+        .getCheckpoint(true);
+    Assert.assertNotNull(checkpoint.getCheckpointLocation());
+
+    //Create new Recon OM Metadata manager instance.
+    File reconOmDbDir = temporaryFolder.newFolder();
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconOmDbDir
+        .getAbsolutePath());
+    ReconOMMetadataManager reconOMMetadataManager =
+        new ReconOmMetadataManagerImpl(configuration, new ReconUtils());
+    reconOMMetadataManager.start(configuration);
+
+    //Before accepting a snapshot, the metadata should have null tables.
+    Assert.assertNull(reconOMMetadataManager.getBucketTable());
+
+    //Update Recon OM DB with the OM DB checkpoint location.
+    reconOMMetadataManager.updateOmDB(
+        checkpoint.getCheckpointLocation().toFile());
+
+    //Now, the tables should have been initialized.
+    Assert.assertNotNull(reconOMMetadataManager.getBucketTable());
+
+    // Check volume and bucket entries.
+    Assert.assertNotNull(reconOMMetadataManager.getVolumeTable()
+        .get("/sampleVol"));
+    Assert.assertNotNull(reconOMMetadataManager.getBucketTable()
+        .get("/sampleVol/bucketOne"));
+
+    //Verify Keys inserted in OM DB are available in Recon OM DB.
+    Assert.assertNotNull(reconOMMetadataManager.getKeyTable()
+        .get("/sampleVol/bucketOne/key_one"));
+    Assert.assertNotNull(reconOMMetadataManager.getKeyTable()
+        .get("/sampleVol/bucketOne/key_two"));
+
+  }
+
+  /**
+   * Get test OM metadata manager.
+   * @return OMMetadataManager instance
+   * @throws IOException
+   */
+  private OMMetadataManager getOMMetadataManager() throws IOException {
     //Create a new OM Metadata Manager instance + DB.
     File omDbDir = temporaryFolder.newFolder();
     OzoneConfiguration omConfiguration = new OzoneConfiguration();
@@ -93,48 +182,6 @@ public class TestReconOmMetadataManagerImpl {
             .setReplicationType(HddsProtos.ReplicationType.STAND_ALONE)
             .build());
 
-    //Make sure OM Metadata reflects the keys that were inserted.
-    Assert.assertNotNull(omMetadataManager.getKeyTable()
-        .get("/sampleVol/bucketOne/key_one"));
-    Assert.assertNotNull(omMetadataManager.getKeyTable()
-        .get("/sampleVol/bucketOne/key_two"));
-
-    //Take checkpoint of OM DB.
-    DBCheckpoint checkpoint = omMetadataManager.getStore()
-        .getCheckpoint(true);
-    Assert.assertNotNull(checkpoint.getCheckpointLocation());
-
-    //Create new Recon OM Metadata manager instance.
-    File reconOmDbDir = temporaryFolder.newFolder();
-    OzoneConfiguration configuration = new OzoneConfiguration();
-    configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconOmDbDir
-        .getAbsolutePath());
-    ReconOMMetadataManager reconOMMetadataManager =
-        new ReconOmMetadataManagerImpl(configuration);
-    reconOMMetadataManager.start(configuration);
-
-    //Before accepting a snapshot, the metadata should have null tables.
-    Assert.assertNull(reconOMMetadataManager.getBucketTable());
-
-    //Update Recon OM DB with the OM DB checkpoint location.
-    reconOMMetadataManager.updateOmDB(
-        checkpoint.getCheckpointLocation().toFile());
-
-    //Now, the tables should have been initialized.
-    Assert.assertNotNull(reconOMMetadataManager.getBucketTable());
-
-    // Check volume and bucket entries.
-    Assert.assertNotNull(reconOMMetadataManager.getVolumeTable()
-        .get(volumeKey));
-    Assert.assertNotNull(reconOMMetadataManager.getBucketTable()
-        .get(bucketKey));
-
-    //Verify Keys inserted in OM DB are available in Recon OM DB.
-    Assert.assertNotNull(reconOMMetadataManager.getKeyTable()
-        .get("/sampleVol/bucketOne/key_one"));
-    Assert.assertNotNull(reconOMMetadataManager.getKeyTable()
-        .get("/sampleVol/bucketOne/key_two"));
-
+    return omMetadataManager;
   }
-
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -114,7 +114,7 @@ public class TestOzoneManagerServiceProviderImpl extends
     Assert.assertNull(reconOMMetadataManager.getKeyTable()
         .get("/sampleVol/bucketOne/key_two"));
 
-    ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot();
+    assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
 
     assertNotNull(reconOMMetadataManager.getKeyTable()
         .get("/sampleVol/bucketOne/key_one"));
@@ -241,10 +241,10 @@ public class TestOzoneManagerServiceProviderImpl extends
         .reInitializeTasks(omMetadataManager);
 
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
-        new OzoneManagerServiceProviderImpl(configuration, omMetadataManager,
+        new MockOzoneServiceProvider(configuration, omMetadataManager,
             reconTaskControllerMock, new ReconUtils(), ozoneManagerProtocol);
 
-    //Should trigger full snapshot request.
+    // Should trigger full snapshot request.
     ozoneManagerServiceProvider.syncDataFromOM();
 
     ArgumentCaptor<ReconTaskStatus> captor =
@@ -313,5 +313,26 @@ public class TestOzoneManagerServiceProviderImpl extends
         .DBUpdatesRequest.class))).thenReturn(dbUpdatesWrapper);
     return ozoneManagerProtocolMock;
   }
+}
 
+/**
+ * Mock OzoneManagerServiceProviderImpl which overrides
+ * updateReconOmDBWithNewSnapshot.
+ */
+class MockOzoneServiceProvider extends OzoneManagerServiceProviderImpl {
+
+  MockOzoneServiceProvider(OzoneConfiguration configuration,
+                           ReconOMMetadataManager omMetadataManager,
+                           ReconTaskController reconTaskController,
+                           ReconUtils reconUtils,
+                           OzoneManagerProtocol ozoneManagerClient)
+      throws IOException {
+    super(configuration, omMetadataManager, reconTaskController, reconUtils,
+        ozoneManagerClient);
+  }
+
+  @Override
+  public boolean updateReconOmDBWithNewSnapshot() {
+    return true;
+  }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerDBProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerDBProvider.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +34,6 @@ import org.junit.rules.TemporaryFolder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.ProvisionException;
 import com.google.inject.Singleton;
 
 /**
@@ -68,20 +65,10 @@ public class TestReconContainerDBProvider {
 
   @Test
   public void testGet() throws Exception {
-
     ReconContainerDBProvider reconContainerDBProvider = injector.getInstance(
         ReconContainerDBProvider.class);
     DBStore dbStore = reconContainerDBProvider.get();
     assertNotNull(dbStore);
-
-    ReconContainerDBProvider reconContainerDBProviderNew = new
-        ReconContainerDBProvider();
-    try {
-      reconContainerDBProviderNew.get();
-      fail();
-    } catch (Exception e) {
-      assertTrue(e instanceof ProvisionException);
-    }
   }
 
 }


### PR DESCRIPTION
- Fix NULL OM snapshot handling in Recon.
- Bootstrap Recon startup with last known OM snapshot DB and Recon container DB.
- Add more useful log lines. 