### PR TITLE
HDDS-2234. rat.sh fails due to ozone-recon-web/build files

### DIFF
--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -291,7 +291,7 @@
             <exclude>**/dependency-reduced-pom.xml</exclude>
             <exclude>**/node_modules/**</exclude>
             <exclude>**/yarn.lock</exclude>
-            <exclude>**/recon-web/build/**</exclude>
+            <exclude>**/ozone-recon-web/build/**</exclude>
             <exclude>src/main/license/**</exclude>
           </excludes>
         </configuration>
@@ -343,7 +343,7 @@
         <configuration>
           <excludes>
             <exclude>**/node_modules/*</exclude>
-            <exclude>**/recon-web/**</exclude>
+            <exclude>**/ozone-recon-web/**</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make RAT check ignore `ozone-recon-web/build` directory.

During `ozone-recon` to `recon` rename ([HDDS-2044](https://issues.apache.org/jira/browse/HDDS-2044)) the directory ignored by RAT was [changed to `recon-web/build`](https://github.com/apache/hadoop/blob/0e026cb0cefcadcfe404cd5d542f081f3b8ab69b/hadoop-ozone/pom.xml#L294), but the real directory is still [`ozone-recon-web`](https://github.com/apache/hadoop/tree/trunk/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web).

The mismatch is not a problem for CI because it doesn't build anything before the RAT check, so the `build` directory is not present.

https://issues.apache.org/jira/browse/HDDS-2234

## How was this patch tested?

```
$ mvn -f pom.ozone.xml -Dmaven.javadoc.skip=true -DskipTests clean package
...
[INFO] BUILD SUCCESS

$ ls hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/build
asset-manifest.json
favicon.ico
index.html
manifest.json
precache-manifest.2d16a2d17952080aea9277dca13a2b39.js
service-worker.js
static

$ hadoop-ozone/dev-support/checks/rat.sh
...
[INFO] BUILD SUCCESS

$ echo $?
0
```