### PR TITLE
HDDS-2237. KeyDeletingService throws NPE if it's started too early

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -193,7 +193,6 @@ public class KeyManagerImpl implements KeyManager {
     this.secretManager = secretManager;
     this.kmsProvider = kmsProvider;
 
-    start(conf);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
@@ -95,6 +95,7 @@ public class TestKeyDeletingService {
         new KeyManagerImpl(
             new ScmBlockLocationTestingClient(null, null, 0),
             metaMgr, conf, UUID.randomUUID().toString(), null);
+    keyManager.start(conf);
     final int keyCount = 100;
     createAndDeleteKeys(keyManager, keyCount, 1);
     KeyDeletingService keyDeletingService =
@@ -117,6 +118,7 @@ public class TestKeyDeletingService {
         new KeyManagerImpl(
             new ScmBlockLocationTestingClient(null, null, 1),
             metaMgr, conf, UUID.randomUUID().toString(), null);
+    keyManager.start(conf);
     final int keyCount = 100;
     createAndDeleteKeys(keyManager, keyCount, 1);
     KeyDeletingService keyDeletingService =
@@ -144,6 +146,7 @@ public class TestKeyDeletingService {
         new KeyManagerImpl(
             new ScmBlockLocationTestingClient(null, null, 1),
             metaMgr, conf, UUID.randomUUID().toString(), null);
+    keyManager.start(conf);
     final int keyCount = 100;
     createAndDeleteKeys(keyManager, keyCount, 0);
     KeyDeletingService keyDeletingService =


### PR DESCRIPTION
1. OzoneManager starts KeyManager

2. KeyManager starts KeyDeletingService

3. KeyDeletingService uses OzoneManager.isLeader()

4. OzoneManager.isLeader() uses omRatisServer

5. omRatisServer can be null (bumm)

 

Now the initialization order in OzoneManager:

 

new KeymanagerServer() *Includes start()!!!!*

omRatisServer initialization

start() (includes KeyManager.start())

 

The solution seems to be easy: start the key manager only from the OzoneManager.start() and not from the OzoneManager.instantiateServices()

See: https://issues.apache.org/jira/browse/HDDS-2237