### PR TITLE
HDDS-2240. Command line tool for OM HA.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.KerberosInfo;
@@ -644,5 +645,13 @@ public interface ClientProtocol {
    * @throws IOException if there is error.
    * */
   List<OzoneAcl> getAcl(OzoneObj obj) throws IOException;
+
+  /**
+   * Get a list of all OMs and their Ratis server roles.
+   *
+   * @return list of OM server roles
+   * @throws IOException
+   */
+  List<OMRoleInfo> getOMServerRoles() throws IOException;
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.GDPRSymmetricKey;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
@@ -1069,6 +1070,11 @@ public class RpcClient implements ClientProtocol {
   @Override
   public List<OzoneAcl> getAcl(OzoneObj obj) throws IOException {
     return ozoneManagerClient.getAcl(obj);
+  }
+
+  @Override
+  public List<OMRoleInfo> getOMServerRoles() throws IOException {
+    return ozoneManagerClient.getOMServerRoles();
   }
 
   private OzoneInputStream createInputStream(OmKeyInfo keyInfo)

--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -55,6 +55,7 @@ function hadoop_usage
   hadoop_add_subcommand "version" client "print the version"
   hadoop_add_subcommand "dtutil" client "operations related to delegation tokens"
   hadoop_add_subcommand "upgrade" client "HDFS to Ozone in-place upgrade tool"
+  hadoop_add_subcommand "admin" client "Ozone admin tool"
 
   hadoop_generate_usage "${HADOOP_SHELL_EXECNAME}" false
 }
@@ -206,6 +207,10 @@ function ozonecmd_case
     upgrade)
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.upgrade.InPlaceUpgrade
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-upgrade"
+    ;;
+    admin)
+      HADOOP_CLASSNAME=org.apache.hadoop.ozone.admin.OzoneAdmin
+      OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     *)
       HADOOP_CLASSNAME="${subcmd}"

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -227,6 +227,7 @@ public final class OmUtils {
     case InfoS3Bucket:
     case ListS3Buckets:
     case ServiceList:
+    case OMServerRoles:
     case ListMultiPartUploadParts:
     case GetFileStatus:
     case LookupFile:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -41,7 +41,8 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 
 import java.io.Closeable;
@@ -291,6 +292,8 @@ public interface OzoneManagerProtocol
 
   ServiceInfoEx getServiceInfo() throws IOException;
 
+  List<OMRoleInfo> getOMServerRoles() throws IOException;
+
   /*
    * S3 Specific functionality that is supported by Ozone Manager.
    */
@@ -523,8 +526,7 @@ public interface OzoneManagerProtocol
    * @return Wrapper containing the updates.
    * @throws SequenceNumberNotFoundException if db is unable to read the data.
    */
-  DBUpdatesWrapper getDBUpdates(
-      OzoneManagerProtocolProtos.DBUpdatesRequest dbUpdatesRequest)
+  DBUpdatesWrapper getDBUpdates(DBUpdatesRequest dbUpdatesRequest)
       throws IOException;
 
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -79,6 +79,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclR
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateDirectoryRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetFileStatusResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetFileStatusRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMServerRolesResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMServerRolesRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
@@ -120,6 +122,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Multipa
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadListPartsResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclResponse;
@@ -1228,6 +1231,20 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .map(ServiceInfo::getFromProtobuf)
             .collect(Collectors.toList()),
         resp.getCaCertificate());
+  }
+
+  @Override
+  public List<OMRoleInfo> getOMServerRoles() throws IOException {
+    OMServerRolesRequest req = OMServerRolesRequest.newBuilder().build();
+
+    OMRequest omRequest = createOMRequest(Type.OMServerRoles)
+        .setOmServerRolesRequest(req)
+        .build();
+
+    final OMServerRolesResponse resp = handleError(submitRequest(omRequest))
+        .getOmServerRolesResponse();
+
+    return resp.getRoleInfosList();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -73,6 +73,7 @@ enum Type {
   ListMultiPartUploadParts = 50;
 
   ServiceList = 51;
+  OMServerRoles = 52;
   DBUpdates = 53;
 
   GetDelegationToken = 61;
@@ -139,7 +140,8 @@ message OMRequest {
   optional MultipartUploadListPartsRequest  listMultipartUploadPartsRequest = 50;
 
   optional ServiceListRequest               serviceListRequest             = 51;
-  optional DBUpdatesRequest                  dbUpdatesRequest              = 53;
+  optional OMServerRolesRequest             omServerRolesRequest           = 52;
+  optional DBUpdatesRequest                 dbUpdatesRequest               = 53;
 
   optional hadoop.common.GetDelegationTokenRequestProto getDelegationTokenRequest = 61;
   optional hadoop.common.RenewDelegationTokenRequestProto renewDelegationTokenRequest= 62;
@@ -211,7 +213,8 @@ message OMResponse {
   optional MultipartUploadListPartsResponse listMultipartUploadPartsResponse = 50;
 
   optional ServiceListResponse               ServiceListResponse           = 51;
-  optional DBUpdatesResponse                 dbUpdatesResponse             = 52;
+  optional OMServerRolesResponse             omServerRolesResponse         = 52;
+  optional DBUpdatesResponse                 dbUpdatesResponse             = 53;
 
   optional GetDelegationTokenResponseProto getDelegationTokenResponse = 61;
   optional RenewDelegationTokenResponseProto renewDelegationTokenResponse = 62;
@@ -901,6 +904,18 @@ message ServicePort {
     };
     required Type type = 1;
     required uint32 value = 2;
+}
+
+message OMServerRolesRequest {
+}
+
+message OMServerRolesResponse {
+    repeated OMRoleInfo roleInfos = 1;
+}
+
+message OMRoleInfo {
+    required string nodeId = 1;
+    required string serverRole = 2;
 }
 
 message ServiceInfo {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -310,6 +310,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
             request.getServiceListRequest());
         responseBuilder.setServiceListResponse(serviceListResponse);
         break;
+      case OMServerRoles:
+        OMServerRolesResponse omServerRolesResponse = getOMServerRoles(
+            request.getOmServerRolesRequest());
+        responseBuilder.setOmServerRolesResponse(omServerRolesResponse);
+        break;
       case DBUpdates:
         DBUpdatesResponse dbUpdatesResponse = getOMDBUpdates(
             request.getDbUpdatesRequest());
@@ -770,6 +775,14 @@ public class OzoneManagerRequestHandler implements RequestHandler {
       resp.setCaCertificate(impl.getServiceInfo().getCaCertificate());
     }
     return resp.build();
+  }
+
+  private OMServerRolesResponse getOMServerRoles(OMServerRolesRequest request)
+    throws IOException {
+    OMServerRolesResponse resp = OMServerRolesResponse.newBuilder()
+        .addAllRoleInfos(impl.getOMServerRoles())
+        .build();
+    return resp;
   }
 
   private S3CreateBucketResponse createS3Bucket(S3CreateBucketRequest request)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.admin.om.OMAdmin;
+import org.apache.hadoop.util.NativeCodeLoader;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import picocli.CommandLine;
+
+/**
+ * Ozone Admin Command line tool.
+ */
+@CommandLine.Command(name = "ozone admin",
+    hidden = true,
+    description = "Developer tools for Ozone Admin operations",
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        OMAdmin.class
+    },
+    mixinStandardHelpOptions = true)
+public class OzoneAdmin extends GenericCli {
+
+    private OzoneConfiguration ozoneConf;
+
+    public OzoneConfiguration getOzoneConf() {
+        if (ozoneConf == null) {
+            ozoneConf = createOzoneConfiguration();
+        }
+        return ozoneConf;
+    }
+
+    /**
+     * Main for the Ozone Admin shell Command handling.
+     *
+     * @param argv - System Args Strings[]
+     * @throws Exception
+     */
+    public static void main(String[] argv) throws Exception {
+
+        LogManager.resetConfiguration();
+        Logger.getRootLogger().setLevel(Level.INFO);
+        Logger.getRootLogger()
+            .addAppender(new ConsoleAppender(new PatternLayout("%m%n")));
+        Logger.getLogger(NativeCodeLoader.class).setLevel(Level.ERROR);
+
+        new OzoneAdmin().run(argv);
+    }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -1,0 +1,44 @@
+package org.apache.hadoop.ozone.admin.om;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
+import picocli.CommandLine;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Handler of om get-service-roles command.
+ */
+@CommandLine.Command(
+    name = "get-service-roles",
+    description = "List all OMs and their respective Ratis server roles",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class GetServiceRolesSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(names = {"-id", "--om-service-id"},
+      description = "OM Service ID",
+      required = true)
+  private String omServiceId;
+
+  @Override
+  public Void call() throws Exception {
+    ClientProtocol client = parent.createClient(omServiceId);
+    getOmServerRoles(client.getOMServerRoles());
+    return null;
+  }
+
+  private void getOmServerRoles(List<OMRoleInfo> roleInfos) {
+    for (OMRoleInfo roleInfo : roleInfos) {
+      System.out.println(
+          roleInfo.getNodeId() + " : " + roleInfo.getServerRole());
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin.om;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.MissingSubcommandException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.cli.SCMCLI;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ozone.admin.OzoneAdmin;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.ratis.protocol.ClientId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Subcommand for admin operations related to OM.
+ */
+@CommandLine.Command(
+    name = "om",
+    description = "Ozone Manager specific admin operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        GetServiceRolesSubcommand.class
+    })
+public class OMAdmin extends GenericCli {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMAdmin.class);
+
+  @CommandLine.ParentCommand
+  private OzoneAdmin parent;
+
+  public OzoneAdmin getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    throw new MissingSubcommandException(
+        this.parent.getCmd().getSubcommands().get("om"));
+  }
+
+  public ClientProtocol createClient(String omServiceId) throws IOException {
+    OzoneConfiguration conf = parent.getOzoneConf();
+    return OzoneClientFactory.getRpcClient(omServiceId, conf).getObjectStore()
+        .getClientProxy();
+
+  }
+}


### PR DESCRIPTION
A command line tool (ozone omha) to get information related to OM HA. 
This Jira proposes to add the getServiceState option for OM HA which lists all the OMs in the service and their corresponding Ratis server roles (LEADER/ FOLLOWER). 
We can later add more options to this tool.