### PR TITLE
HDDS-2251. Add an option to customize unit.sh and integration.sh parameters

### DIFF
--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -19,7 +19,7 @@ cd "$DIR/../../.." || exit 1
 export MAVEN_OPTS="-Xmx4096m"
 mvn -B install -f pom.ozone.xml -DskipTests
 mvn -B -fn test -f pom.ozone.xml -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem,:hadoop-ozone-tools \
-  -Dtest=\!TestMiniChaosOzoneCluster
+  -Dtest=\!TestMiniChaosOzoneCluster "$@"
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/integration"}
 mkdir -p "$REPORT_DIR"

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -17,7 +17,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B -fn test -f pom.ozone.xml -pl \!:hadoop-ozone-integration-test,\!:hadoop-ozone-filesystem,\!:hadoop-ozone-tools
+mvn -B -fn test -f pom.ozone.xml -pl \!:hadoop-ozone-integration-test,\!:hadoop-ozone-filesystem,\!:hadoop-ozone-tools "$@"
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/unit"}
 mkdir -p "$REPORT_DIR"


### PR DESCRIPTION
hadoop-ozone/dev-support/checks/unit.sh (and same with integration) provides an easy entrypoint to execute all the unit/integration test. But in same cases it would be great to use the script but further specify the scope of the test.

With this simple patch it will be possible to adjust the surefire parameters.

See: https://issues.apache.org/jira/browse/HDDS-2251