### PR TITLE
HDDS-2252. Enable gdpr robot test in daily build

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -31,6 +31,8 @@ start_docker_env
 
 execute_robot_test scm basic/basic.robot
 
+execute_robot_test scm gdpr/gdpr.robot
+
 stop_docker_env
 
 generate_report


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Updated test.sh script to include gdpr.robot test so that it gets triggered as part of daily build.

**Link to Apache JIRA**
https://issues.apache.org/jira/browse/HDDS-2252

**How was this patch tested?**
Started Docker
cd ~/ozone-SNAPSHOT/compose/ozone
./test.sh