### PR TITLE
HDDS-2257. Fix checkstyle issues in ChecksumByteBuffer

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBuffer.java
@@ -47,6 +47,7 @@ public interface ChecksumByteBuffer extends Checksum {
    * An abstract class implementing {@link ChecksumByteBuffer}
    * with a 32-bit checksum and a lookup table.
    */
+  @SuppressWarnings("innerassignment")
   abstract class CrcIntTable implements ChecksumByteBuffer {
     /** Current CRC value with bit-flipped. */
     private int crc;
@@ -98,14 +99,21 @@ public interface ChecksumByteBuffer extends Checksum {
 
       // loop unroll - duff's device style
       switch (b.remaining()) {
-        case 7: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        case 6: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        case 5: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        case 4: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        case 3: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        case 2: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        case 1: crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
-        default: // noop
+      case 7:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      case 6:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      case 5:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      case 4:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      case 3:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      case 2:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      case 1:
+        crc = (crc >>> 8) ^ table[((crc ^ b.get()) & 0xff)];
+      default: // noop
       }
 
       return crc;


### PR DESCRIPTION
Fix these checkstyle issues 
```
hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBuffer.java
84: Inner assignments should be avoided.
85: Inner assignments should be avoided.
101: 'case' child has incorrect indentation level 8, expected level should be 6.
102: 'case' child has incorrect indentation level 8, expected level should be 6.
103: 'case' child has incorrect indentation level 8, expected level should be 6.
104: 'case' child has incorrect indentation level 8, expected level should be 6.
105: 'case' child has incorrect indentation level 8, expected level should be 6.
106: 'case' child has incorrect indentation level 8, expected level should be 6.
107: 'case' child has incorrect indentation level 8, expected level should be 6.
108: 'case' child has incorrect indentation level 8, expected level should be 6.
```