### PR TITLE
HDDS-2254. Fix flaky unit test TestContainerStateMachine#testRatisSnapshotRetention

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -159,12 +159,6 @@ public class TestContainerStateMachine {
   @Test
   public void testRatisSnapshotRetention() throws Exception {
 
-    ContainerStateMachine stateMachine =
-        (ContainerStateMachine) ContainerTestHelper.getStateMachine(cluster);
-    SimpleStateMachineStorage storage =
-        (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
-    Assert.assertNull(storage.findLatestSnapshot());
-
     // Write 10 keys. Num snapshots should be equal to config value.
     for (int i = 1; i <= 10; i++) {
       OzoneOutputStream key =
@@ -180,9 +174,10 @@ public class TestContainerStateMachine {
     RatisServerConfiguration ratisServerConfiguration =
         conf.getObject(RatisServerConfiguration.class);
 
-    stateMachine =
+    ContainerStateMachine stateMachine =
         (ContainerStateMachine) ContainerTestHelper.getStateMachine(cluster);
-    storage = (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
+    SimpleStateMachineStorage storage = (SimpleStateMachineStorage)
+        stateMachine.getStateMachineStorage();
     Path parentPath = storage.findLatestSnapshot().getFile().getPath();
     int numSnapshots = parentPath.getParent().toFile().listFiles().length;
     Assert.assertTrue(Math.abs(ratisServerConfiguration


### PR DESCRIPTION
## What changes were proposed in this pull request?
On locally trying out repeated runs of the unit test, the unit test failed intermittently while asserting "Null" value for CSM snapshot. This assertion is not valid when the other unit test in the class executes before and creates keys in the cluster/container. Removed the null check since it does not test the core functionality of snapshot retention.

https://issues.apache.org/jira/browse/HDDS-2254

## How was this patch tested?
Ran the unit tests a few hundred times in IDE in different order.