### PR TITLE
HDDS-2262. SLEEP_SECONDS: command not found

### DIFF
--- a/hadoop-ozone/dist/src/main/dockerbin/entrypoint.sh
+++ b/hadoop-ozone/dist/src/main/dockerbin/entrypoint.sh
@@ -63,7 +63,7 @@ if [ -n "$KERBEROS_ENABLED" ]; then
   echo "KDC ISSUER_SERVER => $ISSUER_SERVER"
 
   if [ -n "$SLEEP_SECONDS" ]; then
-    echo "Sleeping for $(SLEEP_SECONDS) seconds"
+    echo "Sleeping for ${SLEEP_SECONDS} seconds"
     sleep "$SLEEP_SECONDS"
   fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix typo in `entrypoint.sh` to avoid the following message:

```
datanode_1  | /opt/hadoop/bin/docker/entrypoint.sh: line 66: SLEEP_SECONDS: command not found
datanode_1  | Sleeping for  seconds
```

https://issues.apache.org/jira/browse/HDDS-2262

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonesecure-mr
$ docker-compose up -d
$ docker-compose logs datanode | grep -i sleep
datanode_1  | Sleeping for 5 seconds
datanode_1  | Sleeping for 5 seconds
```