### PR TITLE
HDDS-2265. integration.sh may report false negative

### DIFF
--- a/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+++ b/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
@@ -45,6 +45,11 @@ grep -A1 'Crashed tests' "${REPORT_DIR}/output.log" \
   | cut -f2- -d' ' \
   | sort -u >> "${REPORT_DIR}/summary.txt"
 
+## Check if Maven was killed
+if grep -q 'Killed.* mvn .* test ' "${REPORT_DIR}/output.log"; then
+  echo 'Maven test run was killed' >> "${REPORT_DIR}/summary.txt"
+fi
+
 #Collect of all of the report failes of FAILED tests
 while IFS= read -r -d '' dir; do
    while IFS=$'\n' read -r file; do


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check if Maven was killed during test run (observable in integration test runs).  If so, mention it in `summary.txt`.  Non-empty `summary.txt` is handled as "failure".

https://issues.apache.org/jira/browse/HDDS-2265

## How was this patch tested?

Tested both positive and negative case:

1. successful run, `summary.txt` remains empty
2. manually killed `mvn` process, verified that `summary.txt` contains the expected line