### PR TITLE
HDDS-1868. Ozone pipelines should be marked as ready only after the leader election is complete.

### DIFF
--- a/hadoop-hdds/common/src/main/proto/hdds.proto
+++ b/hadoop-hdds/common/src/main/proto/hdds.proto
@@ -67,13 +67,12 @@ enum PipelineState {
 }
 
 message Pipeline {
-    required string leaderID = 1;
-    repeated DatanodeDetailsProto members = 2;
-    // TODO: remove the state and leaderID from this class
-    optional PipelineState state = 3 [default = PIPELINE_ALLOCATED];
-    optional ReplicationType type = 4 [default = STAND_ALONE];
-    optional ReplicationFactor factor = 5 [default = ONE];
-    required PipelineID id = 6;
+    repeated DatanodeDetailsProto members = 1;
+    optional PipelineState state = 2 [default = PIPELINE_ALLOCATED];
+    optional ReplicationType type = 3 [default = STAND_ALONE];
+    optional ReplicationFactor factor = 4 [default = ONE];
+    required PipelineID id = 5;
+    optional bytes leaderID = 6;
     repeated uint32 memberOrders = 7;
 }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/PipelineReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/PipelineReportPublisher.java
@@ -33,7 +33,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
  * Publishes Pipeline which will be sent to SCM as part of heartbeat.
  * PipelineReport consist of the following information about each containers:
  *   - pipelineID
- *
+ *   - LeaderID
  */
 public class PipelineReportPublisher extends
     ReportPublisher<PipelineReportsProto> {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportManager.java
@@ -26,9 +26,7 @@ import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -102,7 +100,7 @@ public final class ReportManager {
   }
 
   /**
-   * Test friendly builder
+   * Test friendly builder.
    */
   public static Builder newBuilder(ReportPublisherFactory publisherFactory) {
     return new Builder(publisherFactory);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -486,4 +486,8 @@ public class DatanodeStateMachine implements Closeable {
   public ReplicationSupervisor getSupervisor() {
     return supervisor;
   }
+
+  public ReportManager getReportManager() {
+    return reportManager;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -872,7 +872,8 @@ public class ContainerStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public void notifyLeaderChanged(RaftGroupMemberId groupMemberId, RaftPeerId raftPeerId) {
+  public void notifyLeaderChanged(RaftGroupMemberId groupMemberId,
+                                  RaftPeerId raftPeerId) {
     ratisServer.handleLeaderChangedNotification(groupMemberId, raftPeerId);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.StateMachineException;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.impl.RaftServerProxy;
@@ -867,5 +869,10 @@ public class ContainerStateMachine extends BaseStateMachine {
     for (ExecutorService executor : executors) {
       executor.shutdown();
     }
+  }
+
+  @Override
+  public void notifyLeaderChanged(RaftGroupMemberId groupMemberId, RaftPeerId raftPeerId) {
+    ratisServer.handleLeaderChangedNotification(groupMemberId, raftPeerId);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -19,11 +19,14 @@
 package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineAction;
@@ -66,8 +69,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Collections;
 import java.util.Set;
@@ -107,6 +112,8 @@ public final class XceiverServerRatis extends XceiverServer {
   // TODO: Remove the gids set when Ratis supports an api to query active
   // pipelines
   private final Set<RaftGroupId> raftGids = new HashSet<>();
+  // pipeline leaders
+  private Map<RaftGroupId, RaftPeerId> leaderIdMap = new HashMap<>();
 
   @SuppressWarnings("parameternumber")
   private XceiverServerRatis(DatanodeDetails dd, int port,
@@ -598,6 +605,9 @@ public final class XceiverServerRatis extends XceiverServer {
       for (RaftGroupId groupId : gids) {
         reports.add(PipelineReport.newBuilder()
             .setPipelineID(PipelineID.valueOf(groupId.getUuid()).getProtobuf())
+            .setLeaderID(leaderIdMap.containsKey(groupId) ?
+                ByteString.copyFromUtf8(leaderIdMap.get(groupId).toString()) :
+                ByteString.EMPTY)
             .build());
       }
       return reports;
@@ -685,5 +695,18 @@ public final class XceiverServerRatis extends XceiverServer {
 
   void notifyGroupAdd(RaftGroupId gid) {
     raftGids.add(gid);
+  }
+
+  void handleLeaderChangedNotification(RaftGroupMemberId groupMemberId,
+                                       RaftPeerId raftPeerId) {
+    LOG.info("Leader change notification received for group: {} with new " +
+        "leaderId: {}", groupMemberId.getGroupId(), raftPeerId);
+    // Save the reported leader to be sent with the report to SCM
+    leaderIdMap.put(groupMemberId.getGroupId(), raftPeerId);
+    // Publish new reports with leaderID
+    context.getParent().getReportManager().getReportPublisher(
+        PipelineReportsProto.class).run();
+    // Trigger HB immediately
+    context.getParent().triggerHeartbeat();
   }
 }

--- a/hadoop-hdds/container-service/src/main/proto/StorageContainerDatanodeProtocol.proto
+++ b/hadoop-hdds/container-service/src/main/proto/StorageContainerDatanodeProtocol.proto
@@ -239,6 +239,7 @@ message ContainerAction {
 
 message PipelineReport {
   required PipelineID pipelineID = 1;
+  optional bytes leaderID = 2;
 }
 
 message PipelineReportsProto {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportManager.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,6 +30,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import com.google.protobuf.GeneratedMessage;
 
 /**
  * Test cases to test {@link ReportManager}.
@@ -40,13 +43,21 @@ public class TestReportManager {
     Configuration conf = new OzoneConfiguration();
     StateContext dummyContext = Mockito.mock(StateContext.class);
     ReportPublisher dummyPublisher = Mockito.mock(ReportPublisher.class);
-    ReportManager.Builder builder = ReportManager.newBuilder(conf);
+    ReportPublisherFactory publisherFactory = Mockito.mock(
+        ReportPublisherFactory.class);
+    Mockito.when(publisherFactory.getPublisherFor(any())).thenReturn(
+        dummyPublisher);
+    ReportManager.Builder builder = ReportManager.newBuilder(publisherFactory);
     builder.setStateContext(dummyContext);
-    builder.addPublisher(dummyPublisher);
+    GeneratedMessage generatedMessageMock = Mockito.mock(
+        GeneratedMessage.class, Mockito.RETURNS_DEEP_STUBS);
+    builder.addPublisherFor(generatedMessageMock.getClass());
     ReportManager reportManager = builder.build();
     reportManager.init();
     verify(dummyPublisher, times(1)).init(eq(dummyContext),
         any(ScheduledExecutorService.class));
 
   }
+
+
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportManager.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.concurrent.ScheduledExecutorService;

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -46,7 +46,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <hdds.version>0.5.0-SNAPSHOT</hdds.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-201fc85-SNAPSHOT</ratis.version>
+    <ratis.version>0.5.0-63cd2fb-SNAPSHOT</ratis.version>
 
     <bouncycastle.version>1.60</bouncycastle.version>
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -113,8 +113,7 @@ public class PipelineReportHandler implements
           reportedLeadersForPipeline.computeIfAbsent(pipelineID,
               k -> new HashMap<>());
       ids.put(dn.getUuid(), report.getLeaderID());
-      pipeline.setLeaderId(
-          RaftPeerId.valueOf(report.getLeaderID().toString()));
+      pipeline.setLeaderId(pipeline.getLeaderId());
     }
 
     if (pipeline.getPipelineState() == Pipeline.PipelineState.ALLOCATED) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -113,6 +113,8 @@ public class PipelineReportHandler implements
           reportedLeadersForPipeline.computeIfAbsent(pipelineID,
               k -> new HashMap<>());
       ids.put(dn.getUuid(), report.getLeaderID());
+      pipeline.setLeaderId(
+          RaftPeerId.valueOf(report.getLeaderID().toString()));
     }
 
     if (pipeline.getPipelineState() == Pipeline.PipelineState.ALLOCATED) {
@@ -124,8 +126,6 @@ public class PipelineReportHandler implements
           leaderIdPairs.values().stream().distinct().count() == 1) {
         // All datanodes reported same leader
         pipelineManager.openPipeline(pipelineID);
-        pipeline.setLeaderId(
-            RaftPeerId.valueOf(report.getLeaderID().toString()));
       }
     } else {
       // In OPEN state case just report the datanode

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.ratis.protocol.RaftPeerId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
@@ -32,6 +32,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.NavigableSet;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Manages the state of pipelines in SCM. All write operations like pipeline
  * creation, removal and updates should come via SCMPipelineManager.
@@ -52,9 +54,7 @@ class PipelineStateManager {
 
   void addPipeline(Pipeline pipeline) throws IOException {
     pipelineStateMap.addPipeline(pipeline);
-    if (pipeline.getPipelineState() == PipelineState.OPEN) {
-      LOG.info("Created pipeline " + pipeline);
-    }
+    LOG.info("Created pipeline " + pipeline);
   }
 
   void addContainerToPipeline(PipelineID pipelineId, ContainerID containerID)
@@ -131,8 +131,8 @@ class PipelineStateManager {
       throw new IOException("Closed pipeline can not be opened");
     }
     if (pipeline.getPipelineState() == PipelineState.ALLOCATED) {
-      pipeline = pipelineStateMap
-          .updatePipelineState(pipelineId, PipelineState.OPEN);
+      pipeline = pipelineStateMap.updatePipelineState(
+          pipelineId, PipelineState.OPEN);
       LOG.info("Pipeline {} moved to OPEN state", pipeline.toString());
     }
     return pipeline;
@@ -160,5 +160,10 @@ class PipelineStateManager {
       throws IOException {
     pipelineStateMap
         .updatePipelineState(pipelineID, PipelineState.DORMANT);
+  }
+
+  @VisibleForTesting
+  PipelineStateMap getPipelineStateMap() {
+    return pipelineStateMap;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -58,6 +58,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Implements Api for creating ratis pipelines.
  */
@@ -153,29 +155,22 @@ public class RatisPipelineProvider implements PipelineProvider {
       throw new InsufficientDatanodesException(e);
     }
 
-    Pipeline pipeline = Pipeline.newBuilder()
-        .setId(PipelineID.randomId())
-        .setState(PipelineState.OPEN)
-        .setType(ReplicationType.RATIS)
-        .setFactor(factor)
-        .setNodes(dns)
-        .build();
+    Pipeline pipeline = create(factor, dns);
     initializePipeline(pipeline);
     return pipeline;
   }
 
   @Override
   public Pipeline create(ReplicationFactor factor,
-      List<DatanodeDetails> nodes) {
+                         List<DatanodeDetails> nodes) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
-        .setState(PipelineState.OPEN)
+        .setState(PipelineState.ALLOCATED)
         .setType(ReplicationType.RATIS)
         .setFactor(factor)
         .setNodes(nodes)
         .build();
   }
-
 
   @Override
   public void shutdown() {
@@ -252,5 +247,10 @@ public class RatisPipelineProvider implements PipelineProvider {
     if (!exceptions.isEmpty()) {
       throw MultipleIOException.createIOException(exceptions);
     }
+  }
+
+  @VisibleForTesting
+  PipelineStateManager getStateManager() {
+    return stateManager;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -48,7 +47,8 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
   }
 
   @Override
-  public Pipeline create(HddsProtos.ReplicationFactor factor, List<DatanodeDetails> nodes) {
+  public Pipeline create(HddsProtos.ReplicationFactor factor,
+                         List<DatanodeDetails> nodes) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(Pipeline.PipelineState.OPEN)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -19,9 +19,13 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Mock Ratis Pipeline Provider for Mock Nodes.
@@ -41,5 +45,16 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
   @Override
   public void shutdown() {
     // Do nothing.
+  }
+
+  @Override
+  public Pipeline create(HddsProtos.ReplicationFactor factor, List<DatanodeDetails> nodes) {
+    return Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setState(Pipeline.PipelineState.OPEN)
+        .setType(HddsProtos.ReplicationType.RATIS)
+        .setFactor(factor)
+        .setNodes(nodes)
+        .build();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -355,7 +355,7 @@ public class TestSCMPipelineManager {
     List<DatanodeDetails> nodes = pipeline.getNodes();
     Assert.assertEquals(3, nodes.size());
     // Send leader for only first 2 dns
-    nodes.subList(0 ,2).forEach(dn ->
+    nodes.subList(0, 2).forEach(dn ->
         sendPipelineReport(dn, pipeline, pipelineReportHandler, true));
     sendPipelineReport(nodes.get(2), pipeline, pipelineReportHandler, false);
 

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <hdds.version>0.5.0-SNAPSHOT</hdds.version>
     <ozone.version>0.5.0-SNAPSHOT</ozone.version>
-    <ratis.version>0.5.0-201fc85-SNAPSHOT</ratis.version>
+    <ratis.version>0.5.0-63cd2fb-SNAPSHOT</ratis.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <ozone.release>Crater Lake</ozone.release>
     <declared.ozone.version>${ozone.version}</declared.ozone.version>


### PR DESCRIPTION
Ozone pipeline on restart or when first created, start in allocated state. They are moved into open state after all the pipeline have reported to it. However, this potentially can lead into an issue where the pipeline is still not ready to accept any incoming IO operations.

The pipelines should be marked as ready only after the leader election is complete and leader is ready to accept incoming IO.