### PR TITLE
HADOOP-16615.Add password check for credential provider

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialShell.java
@@ -44,7 +44,8 @@ public class CredentialShell extends CommandShell {
       "   [-help]\n" +
       "   [" + CreateCommand.USAGE + "]\n" +
       "   [" + DeleteCommand.USAGE + "]\n" +
-      "   [" + ListCommand.USAGE + "]\n";
+      "   [" + ListCommand.USAGE + "]\n" +
+      "   [" + CheckCommand.USAGE + "]\n";
   @VisibleForTesting
   public static final String NO_VALID_PROVIDERS =
       "There are no valid (non-transient) providers configured.\n" +
@@ -86,6 +87,11 @@ public class CredentialShell extends CommandShell {
           return 1;
         }
         setSubCommand(new CreateCommand(args[++i]));
+      } else if (args[i].equals("check")) {
+        if (i == args.length -1) {
+          return 1;
+        }
+        setSubCommand(new CheckCommand(args[++i]));
       } else if (args[i].equals("delete")) {
         if (i == args.length - 1) {
           return 1;
@@ -284,6 +290,83 @@ public class CredentialShell extends CommandShell {
           getOut().println("Credential " + alias + " has NOT been deleted.");
           throw e;
         }
+      }
+    }
+
+    @Override
+    public String getUsage() {
+      return USAGE + ":\n\n" + DESC;
+    }
+  }
+
+  private class CheckCommand extends Command {
+    public static final String USAGE = "check <alias> [-value alias-value] " +
+      "[-provider provider-path] [-strict]";
+    public static final String DESC =
+      "The check subcommand check a password for the name\n" +
+        "specified as the <alias> argument within the provider indicated\n" +
+        "through the -provider argument. If -strict is supplied, fail\n" +
+        "immediately if the provider requires a password and none is given.\n" +
+        "If -value is provided, use that for the value of the credential\n" +
+        "instead of prompting the user.";
+
+    private String alias = null;
+
+    public CheckCommand(String alias) {
+      this.alias = alias;
+    }
+
+    public boolean validate() {
+      if (alias == null) {
+        getOut().println("There is no alias specified. Please provide the" +
+          "mandatory <alias>. See the usage description with -help.");
+        return false;
+      }
+      if (alias.equals("-help")) {
+        return true;
+      }
+      try {
+        provider = getCredentialProvider();
+        if (provider == null) {
+          return false;
+        } else if (provider.needsPassword()) {
+          if (strict) {
+            getOut().println(provider.noPasswordError());
+            return false;
+          } else {
+            getOut().println(provider.noPasswordWarning());
+          }
+        }
+      } catch (IOException e) {
+        e.printStackTrace(getErr());
+      }
+      return true;
+    }
+
+    public void execute() throws IOException, NoSuchAlgorithmException {
+      if (alias.equals("-help")) {
+        doHelp();
+        return;
+      }
+      warnIfTransientProvider();
+      getOut().println("Checking aliases for CredentialProvider: " +
+        provider.toString());
+      try {
+        PasswordReader c = getPasswordReader();
+        if (c == null) {
+          throw new IOException("No console available for checking user.");
+        }
+
+        char[] password = c.readPassword("Enter alias password: ");
+        char[] storePassword = provider.getCredentialEntry(alias).getCredential();
+        String beMatch = Arrays.equals(storePassword, password) ? "success" : "failed";
+
+        getOut().println("Password match " + beMatch + " for " +  alias + ".");
+      } catch (IOException e) {
+        getOut().println("Cannot check aliases for CredentialProvider: " +
+          provider.toString()
+          + ": " + e.getMessage());
+        throw e;
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/TestCredShell.java
@@ -174,10 +174,19 @@ public class TestCredShell {
     assertEquals(0, rc);
     assertTrue(outContent.toString().contains("credential1 has been successfully " +
         "created."));
-    
-    String[] args2 = {"delete", "credential1", "-f", "-provider",
-        jceksProvider};
+
+    String[] args2 = {"check", "credential1", "-provider",
+      jceksProvider};
+    ArrayList<String> password = new ArrayList<String>();
+    password.add("p@ssw0rd");
+    shell.setPasswordReader(new MockPasswordReader(password));
     rc = shell.run(args2);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString().contains("Password match success for credential1."));
+
+    String[] args3 = {"delete", "credential1", "-f", "-provider",
+        jceksProvider};
+    rc = shell.run(args3);
     assertEquals(0, rc);
     assertTrue(outContent.toString().contains("credential1 has been successfully " +
         "deleted."));


### PR DESCRIPTION
When we use hadoop credential provider to store password, we can not sure if the password is the same as what we remembered.

So, I think we need a check tool.