### PR TITLE
MAPREDUCE-7240.Exception 'Invalid event: TA_TOO_MANY_FETCH_FAILURE at SUCCESS_FINISHING_CONTAINER' cause job error

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -340,12 +340,6 @@ public abstract class TaskAttemptImpl implements
          TaskAttemptStateInternal.SUCCEEDED,
          TaskAttemptEventType.TA_CONTAINER_COMPLETED,
          new ExitFinishingOnContainerCompletedTransition())
-     // Transitions from SUCCESS_FINISHING_CONTAINER state to FAILED stat
-     // When the event TA_TOO_MANY_FETCH_FAILURE received
-      .addTransition(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-         TaskAttemptStateInternal.FAILED,
-         TaskAttemptEventType.TA_TOO_MANY_FETCH_FAILURE,
-         new TooManyFetchFailureTransition())
      // Given TA notifies task T_ATTEMPT_SUCCEEDED when it transitions to
      // SUCCESS_FINISHING_CONTAINER, it is possible to receive the event
      // TA_CONTAINER_CLEANED in the following scenario.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -340,6 +340,12 @@ public abstract class TaskAttemptImpl implements
          TaskAttemptStateInternal.SUCCEEDED,
          TaskAttemptEventType.TA_CONTAINER_COMPLETED,
          new ExitFinishingOnContainerCompletedTransition())
+     // Transitions from SUCCESS_FINISHING_CONTAINER state to FAILED stat
+     // When the event TA_TOO_MANY_FETCH_FAILURE received
+      .addTransition(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+         TaskAttemptStateInternal.FAILED,
+         TaskAttemptEventType.TA_TOO_MANY_FETCH_FAILURE,
+         new TooManyFetchFailureTransition())
      // Given TA notifies task T_ATTEMPT_SUCCEEDED when it transitions to
      // SUCCESS_FINISHING_CONTAINER, it is possible to receive the event
      // TA_CONTAINER_CLEANED in the following scenario.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -1422,6 +1422,29 @@ public class TestTaskAttempt{
     assertFalse("InternalError occurred", eventHandler.internalError);
   }
 
+  @Test
+  public void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
+    MockEventHandler eventHandler = new MockEventHandler();
+    TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
+    TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
+        .getJobId(), 1, TaskType.REDUCE);
+    TaskAttemptId reduceTAId =
+        MRBuilderUtils.newTaskAttemptId(reducetaskId, 0);
+
+    taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
+        TaskAttemptEventType.TA_DONE));
+
+    assertEquals("Task attempt's internal state is not " +
+        "SUCCESS_FINISHING_CONTAINER", taImpl.getInternalState(),
+        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER);
+
+    taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
+        reduceTAId, "Host"));
+    assertEquals("Task attempt is not in FAILED state", taImpl.getState(),
+        TaskAttemptState.FAILED);
+    assertFalse("InternalError occurred", eventHandler.internalError);
+  }
+
   private void setupTaskAttemptFinishingMonitor(
       EventHandler eventHandler, JobConf jobConf, AppContext appCtx) {
     TaskAttemptFinishingMonitor taskAttemptFinishingMonitor =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -1422,29 +1422,6 @@ public class TestTaskAttempt{
     assertFalse("InternalError occurred", eventHandler.internalError);
   }
 
-  @Test
-  public void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
-    MockEventHandler eventHandler = new MockEventHandler();
-    TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
-    TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
-        .getJobId(), 1, TaskType.REDUCE);
-    TaskAttemptId reduceTAId =
-        MRBuilderUtils.newTaskAttemptId(reducetaskId, 0);
-
-    taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
-        TaskAttemptEventType.TA_DONE));
-
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER", taImpl.getInternalState(),
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER);
-
-    taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
-        reduceTAId, "Host"));
-    assertEquals("Task attempt is not in FAILED state", taImpl.getState(),
-        TaskAttemptState.FAILED);
-    assertFalse("InternalError occurred", eventHandler.internalError);
-  }
-
   private void setupTaskAttemptFinishingMonitor(
       EventHandler eventHandler, JobConf jobConf, AppContext appCtx) {
     TaskAttemptFinishingMonitor taskAttemptFinishingMonitor =


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
