### PR TITLE
HADOOP-16642. ITestDynamoDBMetadataStoreScale fails when throttled.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestDynamoDBMetadataStoreScale.java
@@ -210,11 +210,9 @@ public class ITestDynamoDBMetadataStoreScale
       // if this doesn't throttle, all is well.
       super.test_020_Moves();
     } catch (AWSServiceThrottledException ex) {
-      // if the service was throttled, we expect the exception text
-      GenericTestUtils.assertExceptionContains(
-          DynamoDBMetadataStore.HINT_DDB_IOPS_TOO_LOW,
-          ex,
-          "Expected throttling message");
+      // if the service was throttled, all is good.
+      // log and continue
+      LOG.warn("DDB connection was throttled", ex);
     } finally {
       LOG.info("Statistics {}", tracker);
     }


### PR DESCRIPTION
Change-Id: I1bbb4692c7fe345a0e5c3d3660eeb644ca9ced2d

tests against s3 ireland but its not my laptop seeing the failure -this was an in-EC2 test run. 