### PR TITLE
HADOOP-16640. WASB: Override getCanonicalServiceName() to return URI

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/NativeAzureFileSystem.java
@@ -643,6 +643,20 @@ public class NativeAzureFileSystem extends FileSystem {
     return "wasb";
   }
 
+  /**
+   * If fs.azure.override.canonical.service.name is set as true, return URI of
+   * the WASB filesystem, otherwise use the default implementation.
+   *
+   * @return a service string that uniquely identifies this file system
+   */
+  @Override
+  public String getCanonicalServiceName() {
+    if (returnUriAsCanonicalServiceName) {
+      return getUri().toString();
+    }
+    return super.getCanonicalServiceName();
+  }
+
 
   /**
    * <p>
@@ -725,6 +739,11 @@ public class NativeAzureFileSystem extends FileSystem {
    * Property to enable Append API.
    */
   public static final String APPEND_SUPPORT_ENABLE_PROPERTY_NAME = "fs.azure.enable.append.support";
+
+  /*
+   * Property to override canonical service name with filesystem's URI.
+   */
+  public static final String RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME = "fs.azure.override.canonical.service.name";
 
   /**
    * The configuration property to set number of threads to be used for rename operation.
@@ -1192,6 +1211,7 @@ public class NativeAzureFileSystem extends FileSystem {
   // A counter to create unique (within-process) names for my metrics sources.
   private static AtomicInteger metricsSourceNameCounter = new AtomicInteger();
   private boolean appendSupportEnabled = false;
+  private boolean returnUriAsCanonicalServiceName = false;
   private DelegationTokenAuthenticatedURL authURL;
   private DelegationTokenAuthenticatedURL.Token authToken = new DelegationTokenAuthenticatedURL.Token();
   private String credServiceUrl;
@@ -1389,6 +1409,8 @@ public class NativeAzureFileSystem extends FileSystem {
     if (UserGroupInformation.isSecurityEnabled() && kerberosSupportEnabled) {
       this.wasbDelegationTokenManager = new RemoteWasbDelegationTokenManager(conf);
     }
+
+    this.returnUriAsCanonicalServiceName = conf.getBoolean(RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME, false);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.azure;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.fs.azure.NativeAzureFileSystem.RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
@@ -44,7 +45,6 @@ import org.apache.hadoop.fs.AbstractFileSystem;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.CreateOptions;
 import org.apache.hadoop.test.GenericTestUtils;
 
@@ -639,5 +639,29 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
       testAccount.cleanup();
       FileSystem.closeAll();
     }
+  }
+
+  @Test
+  public void testCanonicalServiceName() throws Exception {
+    AzureBlobStorageTestAccount testAccount = AzureBlobStorageTestAccount.createMock();
+    Configuration conf = testAccount.getFileSystem().getConf();
+    String authority = testAccount.getFileSystem().getUri().getAuthority();
+    URI defaultUri = new URI("wasbs", authority, null, null, null);
+    conf.set(FS_DEFAULT_NAME_KEY, defaultUri.toString());
+
+    final FileSystem fs0 =  FileSystem.get(conf);
+    // Default getCanonicalServiceName() will try to resolve the host to IP,
+    // because the mock container does not exist, this call is expected to fail.
+    intercept(IllegalArgumentException.class,
+            "java.net.UnknownHostException",
+            ()-> {
+              fs0.getCanonicalServiceName();
+            });
+
+    // clear fs cache
+    FileSystem.closeAll();
+    conf.setBoolean(RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME, true);
+    FileSystem fs1 = FileSystem.get(conf);
+    Assert.assertEquals("getCanonicalServiceName() should return URI", fs1.getUri().toString(), fs1.getCanonicalServiceName());
   }
 }


### PR DESCRIPTION
Add a configuration to override getCanonicalServiceName() to return URI of WASB FS.
