### PR TITLE
HDDS-2267. Container metadata scanner interval mismatch

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScanner.java
@@ -94,10 +94,11 @@ public class ContainerMetadataScanner extends Thread {
           metrics.getNumScanIterations(),
           metrics.getNumContainersScanned(),
           metrics.getNumUnHealthyContainers());
-      // ensure to delay next metadata scan with respect to user config.
-      if (interval < metadataScanInterval) {
+      long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(interval);
+      long remainingSleep = metadataScanInterval - elapsedMillis;
+      if (remainingSleep > 0) {
         try {
-          Thread.sleep(metadataScanInterval - interval);
+          Thread.sleep(remainingSleep);
         } catch (InterruptedException e) {
           LOG.info("Background ContainerMetadataScanner interrupted." +
               " Going to exit");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix time unit mismatch in container metadata scanner.  Elapsed time is measured in nanoseconds, needs to be converted to milliseconds.

https://issues.apache.org/jira/browse/HDDS-2267

## How was this patch tested?

Tested on `ozone` docker-compose cluster.

```
datanode_1  | 2019-10-09 06:18:00 INFO  ContainerMetadataScanner:60 - Background ContainerMetadataScanner starting up
datanode_1  | 2019-10-09 06:18:00 INFO  ContainerMetadataScanner:88 - Completed an iteration of container metadata scrubber in 0 minutes. Number of  iterations (since the data-node restart) : 1, Number of containers scanned in this iteration : 0, Number of unhealthy containers found in this iteration : 0
datanode_1  | 2019-10-09 06:19:00 INFO  ContainerMetadataScanner:88 - Completed an iteration of container metadata scrubber in 0 minutes. Number of  iterations (since the data-node restart) : 2, Number of containers scanned in this iteration : 2, Number of unhealthy containers found in this iteration : 0
...
datanode_1  | STARTUP_MSG: Starting HddsDatanodeService
datanode_1  | 2019-10-09 06:23:52 INFO  ContainerMetadataScanner:60 - Background ContainerMetadataScanner starting up
datanode_1  | 2019-10-09 06:23:52 INFO  ContainerMetadataScanner:88 - Completed an iteration of container metadata scrubber in 0 minutes. Number of  iterations (since the data-node restart) : 1, Number of containers scanned in this iteration : 2, Number of unhealthy containers found in this iteration : 0
datanode_1  | 2019-10-09 06:24:52 INFO  ContainerMetadataScanner:88 - Completed an iteration of container metadata scrubber in 0 minutes. Number of  iterations (since the data-node restart) : 2, Number of containers scanned in this iteration : 2, Number of unhealthy containers found in this iteration : 0
```