### PR TITLE
HADOOP-16644. Do a HEAD after a PUT to get the modtime.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
@@ -41,4 +41,16 @@ public enum StatusProbeEnum {
   public static final Set<StatusProbeEnum> DIRECTORIES =
       EnumSet.of(DirMarker, List);
 
+  /** We only want the HEAD or dir marker. */
+  public static final Set<StatusProbeEnum> HEAD_OR_DIR_MARKER =
+      EnumSet.of(Head, DirMarker);
+
+  /** We only want the HEAD. */
+  public static final Set<StatusProbeEnum> HEAD_ONLY =
+      EnumSet.of(Head);
+
+  /** We only want the dir marker. */
+  public static final Set<StatusProbeEnum> DIR_MARKER_ONLY =
+      EnumSet.of(DirMarker);
+
 }


### PR DESCRIPTION
WiP: no tests. What would a test look like? best to use some mock
to fix the remote time to always be slightly different from the local.
Or we make the clock of the S3A FS patchable, which is potentially
the most flexible.

Its unfortunate we need to do this; inclusion of the result in the put response, or, if it
is there, extraction of it, is what would work best -especially as that would guarantee
consistent read on update, the way an unversioned HEAD does not

Change-Id: I2c99752647f522991b1f89dd9c43f3a2e9b98bf5
