### PR TITLE
HADOOP-16645. S3A Delegation Token extension point to use StoreContext.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -96,6 +96,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Globber;
 import org.apache.hadoop.fs.s3a.auth.SignerManager;
+import org.apache.hadoop.fs.s3a.auth.delegation.DelegationOperations;
 import org.apache.hadoop.fs.s3a.auth.delegation.DelegationTokenProvider;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ContextAccessors;
@@ -522,7 +523,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       LOG.debug("Using delegation tokens");
       S3ADelegationTokens tokens = new S3ADelegationTokens();
       this.delegationTokens = Optional.of(tokens);
-      tokens.bindToFileSystem(getCanonicalUri(), this);
+      tokens.bindToFileSystem(getCanonicalUri(),
+          createStoreContext(),
+          createDelegationOperations());
       tokens.init(conf);
       tokens.start();
       // switch to the DT provider and bypass all other configured
@@ -553,6 +556,26 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
     s3 = ReflectionUtils.newInstance(s3ClientFactoryClass, conf)
         .createS3Client(getUri(), bucket, credentials, uaSuffix);
+  }
+
+  /**
+   * Implementation of all operations used by delegation tokens.
+   */
+  private class DelegationOperationsImpl implements DelegationOperations {
+
+    @Override
+    public List<RoleModel.Statement> listAWSPolicyRules(final Set<AccessLevel> access) {
+      return S3AFileSystem.this.listAWSPolicyRules(access);
+    }
+  }
+
+  /**
+   * Create an instance of the delegation operations.
+   * @return callbacks for DT support.
+   */
+  @VisibleForTesting
+  public DelegationOperations createDelegationOperations() {
+    return new DelegationOperationsImpl();
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AMultipartUploader.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AMultipartUploader.java
@@ -189,7 +189,7 @@ public class S3AMultipartUploader extends MultipartUploader {
   }
 
   /**
-   * Parse the payload marshalled as a part handle.
+   * Parse the payload marshaled as a part handle.
    * @param data handle data
    * @return the length and etag
    * @throws IOException error reading the payload

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/TemporaryAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/TemporaryAWSCredentialsProvider.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.auth.AbstractSessionCredentialsProvider;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException;
 import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
 
@@ -91,15 +91,15 @@ public class TemporaryAWSCredentialsProvider extends
   @Override
   protected AWSCredentials createCredentials(Configuration config)
       throws IOException {
-    MarshalledCredentials creds = MarshalledCredentialBinding.fromFileSystem(
+    MarshaledCredentials creds = MarshaledCredentialBinding.fromFileSystem(
         getUri(), config);
-    MarshalledCredentials.CredentialTypeRequired sessionOnly
-        = MarshalledCredentials.CredentialTypeRequired.SessionOnly;
+    MarshaledCredentials.CredentialTypeRequired sessionOnly
+        = MarshaledCredentials.CredentialTypeRequired.SessionOnly;
     // treat only having non-session creds as empty.
     if (!creds.isValid(sessionOnly)) {
       throw new NoAwsCredentialsException(COMPONENT);
     }
-    return MarshalledCredentialBinding.toAWSCredentials(creds,
+    return MarshaledCredentialBinding.toAWSCredentials(creds,
         sessionOnly, COMPONENT);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshaledCredentialBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshaledCredentialBinding.java
@@ -50,16 +50,16 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.lookupPassword;
 
 /**
  * Class to bridge from the serializable/marshallabled
- * {@link MarshalledCredentialBinding} class to/from AWS classes.
+ * {@link MarshaledCredentialBinding} class to/from AWS classes.
  * This is to keep that class isolated and not dependent on aws-sdk JARs
  * to load.
  */
-public final class MarshalledCredentialBinding {
+public final class MarshaledCredentialBinding {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(MarshalledCredentialBinding.class);
+      LoggerFactory.getLogger(MarshaledCredentialBinding.class);
 
-  private MarshalledCredentialBinding() {
+  private MarshaledCredentialBinding() {
   }
 
   /**
@@ -69,30 +69,30 @@ public final class MarshalledCredentialBinding {
   public static final String NO_AWS_CREDENTIALS = "No AWS credentials";
 
   /**
-   * Create a set of marshalled credentials from a set of credentials
+   * Create a set of marshaled credentials from a set of credentials
    * issued by an STS call.
    * @param credentials AWS-provided session credentials
-   * @return a set of marshalled credentials.
+   * @return a set of marshaled credentials.
    */
-  public static MarshalledCredentials fromSTSCredentials(
+  public static MarshaledCredentials fromSTSCredentials(
       final Credentials credentials) {
-    MarshalledCredentials marshalled = new MarshalledCredentials(
+    MarshaledCredentials marshaled = new MarshaledCredentials(
         credentials.getAccessKeyId(),
         credentials.getSecretAccessKey(),
         credentials.getSessionToken());
     Date date = credentials.getExpiration();
-    marshalled.setExpiration(date != null ? date.getTime() : 0);
-    return marshalled;
+    marshaled.setExpiration(date != null ? date.getTime() : 0);
+    return marshaled;
   }
 
   /**
    * Create from a set of AWS credentials.
    * @param credentials source credential.
-   * @return a set of marshalled credentials.
+   * @return a set of marshaled credentials.
    */
-  public static MarshalledCredentials fromAWSCredentials(
+  public static MarshaledCredentials fromAWSCredentials(
       final AWSSessionCredentials credentials) {
-    return new MarshalledCredentials(
+    return new MarshaledCredentials(
         credentials.getAWSAccessKeyId(),
         credentials.getAWSSecretKey(),
         credentials.getSessionToken());
@@ -103,9 +103,9 @@ public final class MarshalledCredentialBinding {
    * @param env environment.
    * @return a possibly incomplete/invalid set of credentials.
    */
-  public static MarshalledCredentials fromEnvironment(
+  public static MarshaledCredentials fromEnvironment(
       final Map<String, String> env) {
-    return new MarshalledCredentials(
+    return new MarshaledCredentials(
       nullToEmptyString(env.get("AWS_ACCESS_KEY")),
       nullToEmptyString(env.get("AWS_SECRET_KEY")),
       nullToEmptyString(env.get("AWS_SESSION_TOKEN")));
@@ -129,7 +129,7 @@ public final class MarshalledCredentialBinding {
    * @return the component
    * @throws IOException on any load failure
    */
-  public static MarshalledCredentials fromFileSystem(
+  public static MarshaledCredentials fromFileSystem(
       final URI uri,
       final Configuration conf) throws IOException {
     // determine the bucket
@@ -137,19 +137,19 @@ public final class MarshalledCredentialBinding {
     final Configuration leanConf =
         ProviderUtils.excludeIncompatibleCredentialProviders(
             conf, S3AFileSystem.class);
-    return new MarshalledCredentials(
+    return new MarshaledCredentials(
         lookupPassword(bucket, leanConf, ACCESS_KEY),
         lookupPassword(bucket, leanConf, SECRET_KEY),
         lookupPassword(bucket, leanConf, SESSION_TOKEN));
   }
 
   /**
-   * Create an AWS credential set from a set of marshalled credentials.
+   * Create an AWS credential set from a set of marshaled credentials.
    *
-   * This code would seem to fit into (@link MarshalledCredentials}, and
+   * This code would seem to fit into (@link MarshaledCredentials}, and
    * while it would from a code-hygiene perspective, to keep all AWS
    * SDK references out of that class, the logic is implemented here instead,
-   * @param marshalled marshalled credentials
+   * @param marshaled marshaled credentials
    * @param typeRequired type of credentials required
    * @param component component name for exception messages.
    * @return a new set of credentials
@@ -157,24 +157,24 @@ public final class MarshalledCredentialBinding {
    * @throws NoAwsCredentialsException the credentials are actually empty.
    */
   public static AWSCredentials toAWSCredentials(
-      final MarshalledCredentials marshalled,
-      final MarshalledCredentials.CredentialTypeRequired typeRequired,
+      final MarshaledCredentials marshaled,
+      final MarshaledCredentials.CredentialTypeRequired typeRequired,
       final String component)
       throws NoAuthWithAWSException, NoAwsCredentialsException {
 
-    if (marshalled.isEmpty()) {
+    if (marshaled.isEmpty()) {
       throw new NoAwsCredentialsException(component, NO_AWS_CREDENTIALS);
     }
-    if (!marshalled.isValid(typeRequired)) {
+    if (!marshaled.isValid(typeRequired)) {
       throw new NoAuthWithAWSException(component + ":" +
-          marshalled.buildInvalidCredentialsError(typeRequired));
+          marshaled.buildInvalidCredentialsError(typeRequired));
     }
-    final String accessKey = marshalled.getAccessKey();
-    final String secretKey = marshalled.getSecretKey();
-    if (marshalled.hasSessionToken()) {
+    final String accessKey = marshaled.getAccessKey();
+    final String secretKey = marshaled.getSecretKey();
+    if (marshaled.hasSessionToken()) {
       // a session token was supplied, so return session credentials
       return new BasicSessionCredentials(accessKey, secretKey,
-          marshalled.getSessionToken());
+          marshaled.getSessionToken());
     } else {
       // these are full credentials
       return new BasicAWSCredentials(accessKey, secretKey);
@@ -193,7 +193,7 @@ public final class MarshalledCredentialBinding {
    * @throws IOException on a failure of the request
    */
   @Retries.RetryTranslated
-  public static MarshalledCredentials requestSessionCredentials(
+  public static MarshaledCredentials requestSessionCredentials(
       final AWSCredentialsProvider parentCredentials,
       final ClientConfiguration awsConf,
       final String stsEndpoint,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshaledCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshaledCredentialProvider.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.CredentialInitializationException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.toAWSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.toAWSCredentials;
 
 /**
- * AWS credential provider driven from marshalled session/full credentials
+ * AWS credential provider driven from marshaled session/full credentials
  * (full, simple session or role).
  * This is <i>not</i> intended for explicit use in job/app configurations,
  * instead it is returned by Delegation Token Bindings, as needed.
@@ -40,16 +40,16 @@ import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.toAWSCre
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-public class MarshalledCredentialProvider extends
+public class MarshaledCredentialProvider extends
     AbstractSessionCredentialsProvider {
 
   /** Name: {@value}. */
   public static final String NAME
-      = "org.apache.hadoop.fs.s3a.auth.MarshalledCredentialProvider";
+      = "org.apache.hadoop.fs.s3a.auth.MarshaledCredentialProvider";
 
-  private final MarshalledCredentials credentials;
+  private final MarshaledCredentials credentials;
 
-  private final MarshalledCredentials.CredentialTypeRequired typeRequired;
+  private final MarshaledCredentials.CredentialTypeRequired typeRequired;
 
   private final String component;
 
@@ -59,17 +59,17 @@ public class MarshalledCredentialProvider extends
    * @param component component name for exception messages.
    * @param uri filesystem URI: must not be null.
    * @param conf configuration.
-   * @param credentials marshalled credentials.
+   * @param credentials marshaled credentials.
    * @param typeRequired credential type required.
    * @throws CredentialInitializationException validation failure
    * @throws IOException failure
    */
-  public MarshalledCredentialProvider(
+  public MarshaledCredentialProvider(
       final String component,
       final URI uri,
       final Configuration conf,
-      final MarshalledCredentials credentials,
-      final MarshalledCredentials.CredentialTypeRequired typeRequired)
+      final MarshaledCredentials credentials,
+      final MarshaledCredentials.CredentialTypeRequired typeRequired)
       throws IOException {
     super(checkNotNull(uri, "No filesystem URI"), conf);
     this.component = component;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshaledCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshaledCredentials.java
@@ -46,7 +46,7 @@ import static org.apache.hadoop.fs.s3a.Constants.SESSION_TOKEN;
 
 /**
  * Stores the credentials for a session or for a full login.
- * This structure is {@link Writable}, so can be marshalled inside a
+ * This structure is {@link Writable}, so can be marshaled inside a
  * delegation token.
  *
  * The class is designed so that keys inside are kept non-null; to be
@@ -57,7 +57,7 @@ import static org.apache.hadoop.fs.s3a.Constants.SESSION_TOKEN;
  * identifier of a token type declared in this JAR is examined.</i>
  */
 @InterfaceAudience.Private
-public final class MarshalledCredentials implements Writable, Serializable {
+public final class MarshaledCredentials implements Writable, Serializable {
 
   /**
    * Error text on invalid non-empty credentials: {@value}.
@@ -106,7 +106,7 @@ public final class MarshalledCredentials implements Writable, Serializable {
   /**
    * Constructor.
    */
-  public MarshalledCredentials() {
+  public MarshaledCredentials() {
   }
 
   /**
@@ -116,7 +116,7 @@ public final class MarshalledCredentials implements Writable, Serializable {
    * @param secretKey secret key
    * @param sessionToken session token
    */
-  public MarshalledCredentials(
+  public MarshaledCredentials(
       final String accessKey,
       final String secretKey,
       final String sessionToken) {
@@ -193,7 +193,7 @@ public final class MarshalledCredentials implements Writable, Serializable {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    MarshalledCredentials that = (MarshalledCredentials) o;
+    MarshaledCredentials that = (MarshaledCredentials) o;
     return expiration == that.expiration &&
         Objects.equals(accessKey, that.accessKey) &&
         Objects.equals(secretKey, that.secretKey) &&
@@ -346,7 +346,7 @@ public final class MarshalledCredentials implements Writable, Serializable {
   public String buildInvalidCredentialsError(
       final CredentialTypeRequired typeRequired) {
     if (isEmpty()) {
-      return " " + MarshalledCredentialBinding.NO_AWS_CREDENTIALS;
+      return " " + MarshaledCredentialBinding.NO_AWS_CREDENTIALS;
     } else {
       return " " + INVALID_CREDENTIALS
           + " in " + toString() + " required: " + typeRequired;
@@ -369,11 +369,11 @@ public final class MarshalledCredentials implements Writable, Serializable {
 
   /**
    * Return a set of empty credentials.
-   * These can be marshalled, but not used for login.
+   * These can be marshaled, but not used for login.
    * @return a new set of credentials.
    */
-  public static MarshalledCredentials empty() {
-    return new MarshalledCredentials("", "", "");
+  public static MarshaledCredentials empty() {
+    return new MarshaledCredentials("", "", "");
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationTokenBinding.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.SecretManager;
@@ -55,7 +54,8 @@ import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DURAT
  *  instance which created it --which itself follows the lifecycle of the FS.
  *
  *  One big difference is that
- *  {@link #bindToFileSystem(URI, S3AFileSystem)} will be called
+ *  {@link AbstractDTService#bindToFileSystem(URI, org.apache.hadoop.fs.s3a.impl.StoreContext, DelegationOperations)}
+ *  will be called
  *  before the {@link #init(Configuration)} operation, this is where
  *  the owning FS is passed in.
  *

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationTokenBinding.java
@@ -207,7 +207,7 @@ public abstract class AbstractDelegationTokenBinding extends AbstractDTService {
   /**
    * Bind to the token identifier, returning the credential providers to use
    * for the owner to talk to S3, DDB and related AWS Services.
-   * @param retrievedIdentifier the unmarshalled data
+   * @param retrievedIdentifier the unmarshaled data
    * @return non-empty list of AWS credential providers to use for
    * authenticating this client with AWS services.
    * @throws IOException any failure.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
@@ -94,7 +94,7 @@ public abstract class AbstractS3ATokenIdentifier
   private String origin = "";
 
   /**
-   * This marshalled UUID can be used in testing to verify transmission,
+   * This marshaled UUID can be used in testing to verify transmission,
    * and reuse; as it is printed you can see what is happending too.
    */
   private String uuid = UUID.randomUUID().toString();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/DelegationOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/DelegationOperations.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.auth.delegation;
+
+/**
+ * All operations used for delegation which aren't in the store context.
+ * Initially this is just the AWS policy operations; it's
+ * here so that any future evolution isn't going to break the signatures of
+ * external DT implementations.
+ */
+public interface DelegationOperations extends AWSPolicyProvider {
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/EncryptionSecrets.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/EncryptionSecrets.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 
 /**
- * Encryption options in a form which can serialized or marshalled as a hadoop
+ * Encryption options in a form which can serialized or marshaled as a hadoop
  * Writeable.
  *
  * Maintainers: For security reasons, don't print any of this.
@@ -47,7 +47,7 @@ import org.apache.hadoop.io.Writable;
  *
  * <i>Important</i>
  * Do not import any AWS SDK classes, directly or indirectly.
- * This is to ensure that S3A Token identifiers can be unmarshalled even
+ * This is to ensure that S3A Token identifiers can be unmarshaled even
  * without that SDK.
  */
 public class EncryptionSecrets implements Writable, Serializable {
@@ -68,7 +68,7 @@ public class EncryptionSecrets implements Writable, Serializable {
   private String encryptionKey = "";
 
   /**
-   * This field isn't serialized/marshalled; it is rebuilt from the
+   * This field isn't serialized/marshaled; it is rebuilt from the
    * encryptionAlgorithm field.
    */
   private transient S3AEncryptionMethods encryptionMethod =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenBinding.java
@@ -119,7 +119,7 @@ public class FullCredentialsTokenBinding extends
         "Full Credentials Token Binding",
         new MarshalledCredentialProvider(
             FULL_TOKEN,
-            getFileSystem().getUri(),
+            getStoreContext().getFsURI(),
             getConfig(),
             awsCredentials,
             MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty));
@@ -156,9 +156,10 @@ public class FullCredentialsTokenBinding extends
         convertTokenIdentifier(retrievedIdentifier,
             FullCredentialsTokenIdentifier.class);
     return new AWSCredentialProviderList(
-        "", new MarshalledCredentialProvider(
+        "Full Credentials Token Binding",
+        new MarshalledCredentialProvider(
             FULL_TOKEN,
-            getFileSystem().getUri(),
+            getStoreContext().getFsURI(),
             getConfig(),
             tokenIdentifier.getMarshalledCredentials(),
             MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty));

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenBinding.java
@@ -25,9 +25,9 @@ import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
 import org.apache.hadoop.fs.s3a.S3AUtils;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialProvider;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialProvider;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 
@@ -53,7 +53,7 @@ public class FullCredentialsTokenBinding extends
   /**
    * Long-lived AWS credentials.
    */
-  private MarshalledCredentials awsCredentials;
+  private MarshaledCredentials awsCredentials;
 
   /**
    * Origin of credentials.
@@ -86,15 +86,15 @@ public class FullCredentialsTokenBinding extends
     // look for access keys to FS
     S3xLoginHelper.Login secrets = S3AUtils.getAWSAccessKeys(uri, conf);
     if (secrets.hasLogin()) {
-      awsCredentials = new MarshalledCredentials(
+      awsCredentials = new MarshaledCredentials(
           secrets.getUser(), secrets.getPassword(), "");
       credentialOrigin += "; source = Hadoop configuration data";
     } else {
       // if there are none, look for the environment variables.
-      awsCredentials = MarshalledCredentialBinding.fromEnvironment(
+      awsCredentials = MarshaledCredentialBinding.fromEnvironment(
           System.getenv());
       if (awsCredentials.isValid(
-          MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty)) {
+          MarshaledCredentials.CredentialTypeRequired.AnyNonEmpty)) {
         // valid tokens, so mark as origin
         credentialOrigin += "; source = Environment variables";
       } else {
@@ -103,7 +103,7 @@ public class FullCredentialsTokenBinding extends
       }
     }
     awsCredentials.validate(credentialOrigin +": ",
-        MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty);
+        MarshaledCredentials.CredentialTypeRequired.AnyNonEmpty);
   }
 
   /**
@@ -117,12 +117,12 @@ public class FullCredentialsTokenBinding extends
     requireServiceStarted();
     return new AWSCredentialProviderList(
         "Full Credentials Token Binding",
-        new MarshalledCredentialProvider(
+        new MarshaledCredentialProvider(
             FULL_TOKEN,
             getStoreContext().getFsURI(),
             getConfig(),
             awsCredentials,
-            MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty));
+            MarshaledCredentials.CredentialTypeRequired.AnyNonEmpty));
   }
 
   /**
@@ -157,12 +157,12 @@ public class FullCredentialsTokenBinding extends
             FullCredentialsTokenIdentifier.class);
     return new AWSCredentialProviderList(
         "Full Credentials Token Binding",
-        new MarshalledCredentialProvider(
+        new MarshaledCredentialProvider(
             FULL_TOKEN,
             getStoreContext().getFsURI(),
             getConfig(),
-            tokenIdentifier.getMarshalledCredentials(),
-            MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty));
+            tokenIdentifier.getMarshaledCredentials(),
+            MarshaledCredentials.CredentialTypeRequired.AnyNonEmpty));
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/FullCredentialsTokenIdentifier.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.s3a.auth.delegation;
 
 import java.net.URI;
 
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -37,13 +37,13 @@ public class FullCredentialsTokenIdentifier extends SessionTokenIdentifier {
 
   public FullCredentialsTokenIdentifier(final URI uri,
       final Text owner,
-      final MarshalledCredentials marshalledCredentials,
+      final MarshaledCredentials marshaledCredentials,
       final EncryptionSecrets encryptionSecrets,
       String origin) {
     super(DelegationConstants.FULL_TOKEN_KIND,
         owner,
         uri,
-        marshalledCredentials,
+        marshaledCredentials,
         encryptionSecrets,
         origin);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenBinding.java
@@ -109,7 +109,8 @@ public class RoleTokenBinding extends SessionTokenBinding {
     return new AWSCredentialProviderList(
         "Role Token Binding",
         new MarshalledCredentialProvider(
-            COMPONENT, getFileSystem().getUri(),
+            COMPONENT,
+            getStoreContext().getFsURI(),
             getConfig(),
             marshalledCredentials,
             MarshalledCredentials.CredentialTypeRequired.SessionOnly));

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenBinding.java
@@ -32,12 +32,12 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
 import org.apache.hadoop.fs.s3a.Retries;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialProvider;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialProvider;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.fs.s3a.auth.STSClientFactory;
 
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.fromSTSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.fromSTSCredentials;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_CREDENTIALS_PROVIDER;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_ROLE_ARN;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.E_NO_SESSION_TOKENS_FOR_ROLE_BINDING;
@@ -89,8 +89,8 @@ public class RoleTokenBinding extends SessionTokenBinding {
   }
 
   /**
-   * Returns a (wrapped) {@link MarshalledCredentialProvider} which
-   * requires the marshalled credentials to contain session secrets.
+   * Returns a (wrapped) {@link MarshaledCredentialProvider} which
+   * requires the marshaled credentials to contain session secrets.
    * @param retrievedIdentifier the incoming identifier.
    * @return the provider chain.
    * @throws IOException on failure
@@ -103,17 +103,17 @@ public class RoleTokenBinding extends SessionTokenBinding {
         convertTokenIdentifier(retrievedIdentifier,
             RoleTokenIdentifier.class);
     setTokenIdentifier(Optional.of(tokenIdentifier));
-    MarshalledCredentials marshalledCredentials
-        = tokenIdentifier.getMarshalledCredentials();
-    setExpirationDateTime(marshalledCredentials.getExpirationDateTime());
+    MarshaledCredentials marshaledCredentials
+        = tokenIdentifier.getMarshaledCredentials();
+    setExpirationDateTime(marshaledCredentials.getExpirationDateTime());
     return new AWSCredentialProviderList(
         "Role Token Binding",
-        new MarshalledCredentialProvider(
+        new MarshaledCredentialProvider(
             COMPONENT,
             getStoreContext().getFsURI(),
             getConfig(),
-            marshalledCredentials,
-            MarshalledCredentials.CredentialTypeRequired.SessionOnly));
+            marshaledCredentials,
+            MarshaledCredentials.CredentialTypeRequired.SessionOnly));
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenIdentifier.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.s3a.auth.delegation;
 
 import java.net.URI;
 
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -35,13 +35,13 @@ public class RoleTokenIdentifier extends SessionTokenIdentifier {
 
   public RoleTokenIdentifier(final URI uri,
       final Text owner,
-      final MarshalledCredentials marshalledCredentials,
+      final MarshaledCredentials marshaledCredentials,
       final EncryptionSecrets encryptionSecrets,
       final String origin) {
     super(DelegationConstants.ROLE_TOKEN_KIND,
         owner,
         uri,
-        marshalledCredentials,
+        marshaledCredentials,
         encryptionSecrets,
         origin);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/S3ADelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/S3ADelegationTokens.java
@@ -34,9 +34,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -154,11 +154,13 @@ public class S3ADelegationTokens extends AbstractDTService {
   }
 
   @Override
-  public void bindToFileSystem(final URI uri, final S3AFileSystem fs)
+  public void bindToFileSystem(final URI uri,
+      final StoreContext context,
+      final DelegationOperations delegationOperations)
       throws IOException {
-    super.bindToFileSystem(uri, fs);
+    super.bindToFileSystem(uri, context, delegationOperations);
     service = getTokenService(getCanonicalUri());
-    stats = fs.getInstrumentation().newDelegationTokenStatistics();
+    stats = context.getInstrumentation().newDelegationTokenStatistics();
   }
 
   /**
@@ -179,7 +181,9 @@ public class S3ADelegationTokens extends AbstractDTService {
         SessionTokenBinding.class,
         AbstractDelegationTokenBinding.class);
     tokenBinding = binding.newInstance();
-    tokenBinding.bindToFileSystem(getCanonicalUri(), getFileSystem());
+    tokenBinding.bindToFileSystem(getCanonicalUri(),
+        getStoreContext(),
+        getPolicyProvider());
     tokenBinding.init(conf);
     tokenBindingName = tokenBinding.getKind().toString();
     LOG.debug("Filesystem {} is using delegation tokens of kind {}",
@@ -411,7 +415,7 @@ public class S3ADelegationTokens extends AbstractDTService {
         "Null encryption secrets");
     // this isn't done in in advance as it needs S3Guard initialized in the
     // filesystem before it can generate complete policies.
-    List<RoleModel.Statement> statements = getFileSystem()
+    List<RoleModel.Statement> statements = getPolicyProvider()
         .listAWSPolicyRules(ACCESS_POLICY);
     Optional<RoleModel.Policy> rolePolicy =
         statements.isEmpty() ?

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
@@ -226,7 +226,7 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
         "Session Token Binding",
         new MarshalledCredentialProvider(
             SESSION_TOKEN,
-            getFileSystem().getUri(),
+            getStoreContext().getFsURI(),
             getConfig(),
             marshalledCredentials,
             MarshalledCredentials.CredentialTypeRequired.SessionOnly));

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
@@ -41,8 +41,8 @@ import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3ARetryPolicy;
 import org.apache.hadoop.fs.s3a.S3AUtils;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialProvider;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialProvider;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.fs.s3a.auth.STSClientFactory;
 import org.apache.hadoop.io.IOUtils;
@@ -52,8 +52,8 @@ import static org.apache.hadoop.fs.s3a.Constants.AWS_CREDENTIALS_PROVIDER;
 import static org.apache.hadoop.fs.s3a.Invoker.once;
 import static org.apache.hadoop.fs.s3a.S3AUtils.STANDARD_AWS_PROVIDERS;
 import static org.apache.hadoop.fs.s3a.S3AUtils.buildAWSProviderList;
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.fromAWSCredentials;
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.fromSTSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.fromAWSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.fromSTSCredentials;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.*;
 
 /**
@@ -207,7 +207,7 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
    * Sets the field {@link #tokenIdentifier} to the extracted/cast
    * session token identifier, and {@link #expirationDateTime} to
    * any expiration passed in.
-   * @param retrievedIdentifier the unmarshalled data
+   * @param retrievedIdentifier the unmarshaled data
    * @return the provider list
    * @throws IOException failure
    */
@@ -219,17 +219,17 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
         retrievedIdentifier,
         SessionTokenIdentifier.class);
     setTokenIdentifier(Optional.of(identifier));
-    MarshalledCredentials marshalledCredentials
-        = identifier.getMarshalledCredentials();
-    setExpirationDateTime(marshalledCredentials.getExpirationDateTime());
+    MarshaledCredentials marshaledCredentials
+        = identifier.getMarshaledCredentials();
+    setExpirationDateTime(marshaledCredentials.getExpirationDateTime());
     return new AWSCredentialProviderList(
         "Session Token Binding",
-        new MarshalledCredentialProvider(
+        new MarshaledCredentialProvider(
             SESSION_TOKEN,
             getStoreContext().getFsURI(),
             getConfig(),
-            marshalledCredentials,
-            MarshalledCredentials.CredentialTypeRequired.SessionOnly));
+            marshaledCredentials,
+            MarshaledCredentials.CredentialTypeRequired.SessionOnly));
   }
 
   @Override
@@ -356,13 +356,13 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
       final EncryptionSecrets encryptionSecrets) throws IOException {
     requireServiceStarted();
 
-    final MarshalledCredentials marshalledCredentials;
+    final MarshaledCredentials marshaledCredentials;
     String origin = AbstractS3ATokenIdentifier.createDefaultOriginMessage();
     final Optional<STSClientFactory.STSClient> client = prepareSTSClient();
 
     if (client.isPresent()) {
       // this is the normal route: ask for a new STS token
-      marshalledCredentials = fromSTSCredentials(
+      marshaledCredentials = fromSTSCredentials(
           client.get()
               .requestSessionCredentials(duration, TimeUnit.SECONDS));
     } else {
@@ -376,7 +376,7 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
       final AWSCredentials awsCredentials
           = parentAuthChain.getCredentials();
       if (awsCredentials instanceof AWSSessionCredentials) {
-        marshalledCredentials = fromAWSCredentials(
+        marshaledCredentials = fromAWSCredentials(
             (AWSSessionCredentials) awsCredentials);
       } else {
         throw new DelegationTokenIOException(
@@ -386,7 +386,7 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
     return new SessionTokenIdentifier(getKind(),
         getOwnerText(),
         getCanonicalUri(),
-        marshalledCredentials,
+        marshaledCredentials,
         encryptionSecrets,
         origin);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenIdentifier.java
@@ -23,7 +23,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
 
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.io.Text;
 
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.SESSION_TOKEN_KIND;
@@ -33,7 +33,7 @@ import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.SESSI
  * credentials which will be valid until they expire.
  *
  * <b>Note 1:</b>
- * There's a risk here that the reference to {@link MarshalledCredentials}
+ * There's a risk here that the reference to {@link MarshaledCredentials}
  * may trigger a transitive load of AWS classes, a load which will
  * fail if the aws SDK isn't on the classpath.
  *
@@ -48,8 +48,8 @@ public class SessionTokenIdentifier extends
   /**
    * Session credentials: initially empty but non-null.
    */
-  private MarshalledCredentials marshalledCredentials
-      = new MarshalledCredentials();
+  private MarshaledCredentials marshaledCredentials
+      = new MarshaledCredentials();
 
   /**
    * Constructor for service loader use.
@@ -75,7 +75,7 @@ public class SessionTokenIdentifier extends
    * @param kind token kind.
    * @param owner token owner
    * @param uri filesystem URI.
-   * @param marshalledCredentials credentials to marshall
+   * @param marshaledCredentials credentials to marshall
    * @param encryptionSecrets encryption secrets
    * @param origin origin text for diagnostics.
    */
@@ -83,11 +83,11 @@ public class SessionTokenIdentifier extends
       final Text kind,
       final Text owner,
       final URI uri,
-      final MarshalledCredentials marshalledCredentials,
+      final MarshaledCredentials marshaledCredentials,
       final EncryptionSecrets encryptionSecrets,
       final String origin) {
     super(kind, uri, owner, origin, encryptionSecrets);
-    this.marshalledCredentials = marshalledCredentials;
+    this.marshaledCredentials = marshaledCredentials;
   }
 
   /**
@@ -109,14 +109,14 @@ public class SessionTokenIdentifier extends
   @Override
   public void write(final DataOutput out) throws IOException {
     super.write(out);
-    marshalledCredentials.write(out);
+    marshaledCredentials.write(out);
   }
 
   @Override
   public void readFields(final DataInput in)
       throws IOException {
     super.readFields(in);
-    marshalledCredentials.readFields(in);
+    marshaledCredentials.readFields(in);
   }
 
   /**
@@ -125,24 +125,24 @@ public class SessionTokenIdentifier extends
    */
   @Override
   public long getExpiryTime() {
-    return marshalledCredentials.getExpiration();
+    return marshaledCredentials.getExpiration();
   }
 
   /**
-   * Get the marshalled credentials.
-   * @return marshalled AWS credentials.
+   * Get the marshaled credentials.
+   * @return marshaled AWS credentials.
    */
-  public MarshalledCredentials getMarshalledCredentials() {
-    return marshalledCredentials;
+  public MarshaledCredentials getMarshaledCredentials() {
+    return marshaledCredentials;
   }
 
   /**
-   * Add the (sanitized) marshalled credentials to the string value.
+   * Add the (sanitized) marshaled credentials to the string value.
    * @return a string value for test assertions and debugging.
    */
   @Override
   public String toString() {
     return super.toString()
-        + "; " + marshalledCredentials.toString();
+        + "; " + marshaledCredentials.toString();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/delegation_token_architecture.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/delegation_token_architecture.md
@@ -36,7 +36,7 @@ As an example, an HDFS DT can be requested by a user, included in the
 launch context of a YARN application -say DistCp, and that launched application
 can then talk to HDFS as if they were that user.
 
-### Tokens are marshalled
+### Tokens are marshaled
 
 Tokens are opaque byte arrays. They are contained within a `Token<T extends TokenIdentifier>`
  class which includes an expiry time, the service identifier, and some other details.
@@ -45,10 +45,10 @@ Tokens are opaque byte arrays. They are contained within a `Token<T extends Toke
 format. This is how they are included in YARN application and container requests,
 and elsewhere. They can even be saved to files through the `hadoop dt` command.
 
-### Tokens can be unmarshalled
+### Tokens can be unmarshaled
 
 
-At the far end, tokens can be unmarshalled and converted into instances of
+At the far end, tokens can be unmarshaled and converted into instances of
 the java classes. This assumes that all the dependent classes are on the
 classpath, obviously.
 
@@ -72,7 +72,7 @@ and data on behalf of a user.
 
 When tokens are no longer needed, the service can be told to revoke a token.
 Continuing the YARN example, after an application finishes the YARN RM
-can revoke every token marshalled into the application launch request.
+can revoke every token marshaled into the application launch request.
 At which point there's no risk associated with that token being
 compromised.
 
@@ -82,7 +82,7 @@ compromised.
 The S3A Delegation Tokens are subtly different.
 
 The S3A DTs actually include the AWS credentials within the token
-data marshalled and shared across the cluster. The credentials can be one
+data marshaled and shared across the cluster. The credentials can be one
 of:
 
 * The Full AWS (`fs.s3a.access.key`, `fs.s3a.secret.key`) login.
@@ -99,13 +99,13 @@ Again, these credentials are requested when the token is issued.
 
 When an S3A Filesystem instance is asked to issue a token it can simply package
 up the login secrets (The "Full" tokens), or talk to the AWS STS service
-to get a set of session/assumed role credentials. These are marshalled within
+to get a set of session/assumed role credentials. These are marshaled within
 the overall token, and then onwards to applications.
 
-*Tokens can be marshalled*
+*Tokens can be marshaled*
 
 The AWS secrets are held in a subclass of `org.apache.hadoop.security.token.TokenIdentifier`.
-This class gets serialized to a byte array when the whole token is marshalled, and deserialized
+This class gets serialized to a byte array when the whole token is marshaled, and deserialized
 when the token is loaded.
 
 *Tokens can be used to authenticate callers*
@@ -170,7 +170,7 @@ token binding, the "DT Binding", a class declared in the option `fs.s3a.delegati
 (the list in `fs.s3a.aws.credentials.provider` are only used if the DT binding wishes to).
 1. The DT binding scans for the current principal (`UGI.getCurrentUser()`/"the Owner") to see if they
 have any token in their credential cache whose service name matches the URI of the filesystem.
-1. If one is found, it is unmarshalled and then used to authenticate the caller via
+1. If one is found, it is unmarshaled and then used to authenticate the caller via
 some AWS Credential provider returned to the S3A FileSystem instance.
 1. If none is found, the Filesystem is considered to have been deployed "Unbonded".
 The DT binding has to return a list of the AWS credential providers to use.
@@ -179,7 +179,7 @@ When requests are made of AWS services, the created credential provider(s) are
 used to sign requests.
 
 When the filesystem is asked for a delegation token, the
-DT binding will generate a token identifier containing the marshalled tokens.
+DT binding will generate a token identifier containing the marshaled tokens.
 
 If the Filesystem was deployed with a DT, that is, it was deployed "bonded", that existing
 DT is returned.
@@ -190,7 +190,7 @@ It is up to the binding what it includes in the token identifier, and how it obt
 This new token identifier is included in a token which has a "canonical service name" of
 the URI of the filesystem (e.g "s3a://landsat-pds").
 
-The issued/reissued token identifier can be marshalled and reused.
+The issued/reissued token identifier can be marshaled and reused.
 
 
 ### class `org.apache.hadoop.fs.s3a.auth.delegation.S3ADelegationTokens`
@@ -258,7 +258,7 @@ This class contains the following fields:
   private String origin = "";
 
   /**
-   * This marshalled UUID can be used in testing to verify transmission,
+   * This marshaled UUID can be used in testing to verify transmission,
    * and reuse; as it is printed you can see what is happending too.
    */
   private String uuid = UUID.randomUUID().toString();
@@ -280,7 +280,7 @@ are included in the DT, so can be used to encrypt/decrypt data in the cluster.*
 This holds session tokens, and it also gets used as a superclass of
 the other token identifiers.
 
-It adds a set of `MarshalledCredentials` containing the session secrets.
+It adds a set of `MarshaledCredentials` containing the session secrets.
 
 Every token/token identifier must have a unique *Kind*; this is how token
 identifier deserializers are looked up. For Session Credentials, it is
@@ -310,12 +310,12 @@ token and failing meaningfully here.
 
 
 
-### class `MarshalledCredentials`
+### class `MarshaledCredentials`
 
 Can marshall a set of AWS credentials (access key, secret key, session token)
 as a Hadoop Writable.
 
-These can be given to an instance of class `MarshalledCredentialProvider`
+These can be given to an instance of class `MarshaledCredentialProvider`
 and used to sign AWS RPC/REST API calls.
 
 ## DT Binding: `AbstractDelegationTokenBinding`
@@ -371,7 +371,7 @@ the role policy.
 
 If the client is only logged in with session credentials: fail.
 
-Else: take the AWS access/secret key, store them in the MarshalledCredentials
+Else: take the AWS access/secret key, store them in the `MarshaledCredentials`
 in a new `FullCredentialsTokenIdentifier`, and return.
 
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/delegation_tokens.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/delegation_tokens.md
@@ -128,7 +128,7 @@ A Session Delegation Token is created by asking the AWS
 [Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html)
 to issue an AWS session password and identifier for a limited duration.
 These AWS session credentials are valid until the end of that time period.
-They are marshalled into the S3A Delegation Token.
+They are marshaled into the S3A Delegation Token.
 
 Other S3A connectors can extract these credentials and use them to
 talk to S3 and related services.
@@ -145,7 +145,7 @@ A Role Delegation Tokens is created by asking the AWS
 for set of "Assumed Role" credentials, with a AWS account specific role for a limited duration..
 This role is restricted to only grant access the S3 bucket, the S3Guard table
 and all KMS keys,
-They are marshalled into the S3A Delegation Token.
+They are marshaled into the S3A Delegation Token.
 
 Other S3A connectors can extract these credentials and use them to
 talk to S3 and related services.
@@ -644,8 +644,8 @@ the role of the current session (if any) is unknown.
 Concepts:
 
 1. The S3A FileSystem can create delegation tokens when requested.
-1. These can be marshalled as per other Hadoop Delegation Tokens.
-1. At the far end, they can be retrieved, unmarshalled and used to authenticate callers.
+1. These can be marshaled as per other Hadoop Delegation Tokens.
+1. At the far end, they can be retrieved, unmarshaled and used to authenticate callers.
 1. DT binding plugins can then use these directly, or, somehow,
 manage authentication and token issue through other services
 (for example: Kerberos)
@@ -666,7 +666,7 @@ authenticate the caller with AWS services used by the S3A client: AWS S3 and
 potentially AWS KMS (for SSE-KMS) and AWS DynamoDB (for S3Guard).
 
 It must have its own unique *Token Kind*, to ensure that it can be distinguished
-from the other token identifiers when tokens are being unmarshalled.
+from the other token identifiers when tokens are being unmarshaled.
 
 | Kind |  Token class |
 |------|--------------|
@@ -696,7 +696,7 @@ is needed to keep them out of logs.
   may perform to those needed to access data in the S3 bucket. This potentially
   includes a DynamoDB table, KMS access, etc.
 * Implementations need to be resistant to attacks which pass in invalid data as
-their token identifier: validate the types of the unmarshalled data; set limits
+their token identifier: validate the types of the unmarshaled data; set limits
 on the size of all strings and other arrays to read in, etc.
 
 ### <a name="resilience"></a> Resilience
@@ -742,7 +742,7 @@ Kerberos support —S3A Delegation tokens should support it.
 
 1. Come up with a token "Kind"; a unique name for the delegation token identifier.
 1. Implement a subclass of `AbstractS3ATokenIdentifier` which adds all information which
-is marshalled from client to remote services. This must subclass the `Writable` methods to read
+is marshaled from client to remote services. This must subclass the `Writable` methods to read
 and write the data to a data stream: these subclasses must call the superclass methods first.
 1. Add a resource `META-INF/services/org.apache.hadoop.security.token.TokenIdentifier`
 1. And list in it, the classname of your new identifier.
@@ -773,8 +773,8 @@ needed, failing at this point is overkill. As an example, `RoleTokenBinding` can
 DTs if it only has a set of session credentials, but it will deploy without them, so allowing
 `hadoop fs` commands to work on an EC2 VM with IAM role credentials.
 
-**Tip**: The class `org.apache.hadoop.fs.s3a.auth.MarshalledCredentials` holds a set of
-marshalled credentials and so can be used within your own Token Identifier if you want
+**Tip**: The class `org.apache.hadoop.fs.s3a.auth.MarshaledCredentials` holds a set of
+marshaled credentials and so can be used within your own Token Identifier if you want
 to include a set of full/session AWS credentials in your token identifier.
 
 ### `AWSCredentialProviderList bindToTokenIdentifier(AbstractS3ATokenIdentifier id)`

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATemporaryCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATemporaryCredentials.java
@@ -35,8 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.auth.STSClientFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.auth.delegation.SessionTokenIdentifier;
@@ -49,8 +49,8 @@ import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeSessionTestsEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.requestSessionCredentials;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.unsetHadoopCredentialProviders;
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.fromSTSCredentials;
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.toAWSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.fromSTSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.toAWSCredentials;
 import static org.apache.hadoop.fs.s3a.auth.RoleTestUtils.assertCredentialsEqual;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.*;
 import static org.apache.hadoop.fs.s3a.auth.delegation.SessionTokenBinding.CREDENTIALS_CONVERTED_TO_DELEGATION_TOKEN;
@@ -140,7 +140,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
     S3AUtils.clearBucketOption(conf2, bucket, SECRET_KEY);
     S3AUtils.clearBucketOption(conf2, bucket, SESSION_TOKEN);
 
-    MarshalledCredentials mc = fromSTSCredentials(sessionCreds);
+    MarshaledCredentials mc = fromSTSCredentials(sessionCreds);
     updateConfigWithSessionCreds(conf2, mc);
 
     conf2.set(AWS_CREDENTIALS_PROVIDER, TEMPORARY_AWS_CREDENTIALS);
@@ -190,7 +190,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
   @Test
   public void testSessionTokenPropagation() throws Exception {
     Configuration conf = new Configuration(getContract().getConf());
-    MarshalledCredentials sc = requestSessionCredentials(conf,
+    MarshaledCredentials sc = requestSessionCredentials(conf,
         getFileSystem().getBucket());
     updateConfigWithSessionCreds(conf, sc);
     conf.set(AWS_CREDENTIALS_PROVIDER, TEMPORARY_AWS_CREDENTIALS);
@@ -208,7 +208,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
       // and validate the AWS bits to make sure everything has come across.
       assertCredentialsEqual("Reissued credentials in " + ids,
           sc,
-          identifier.getMarshalledCredentials());
+          identifier.getMarshaledCredentials());
     }
   }
 
@@ -219,7 +219,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
   @Test
   public void testSessionTokenExpiry() throws Exception {
     Configuration conf = new Configuration(getContract().getConf());
-    MarshalledCredentials sc = requestSessionCredentials(conf,
+    MarshaledCredentials sc = requestSessionCredentials(conf,
         getFileSystem().getBucket());
     long permittedExpiryOffset = 60;
     OffsetDateTime expirationTimestamp = sc.getExpirationDateTime().get();
@@ -242,7 +242,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
   }
 
   protected void updateConfigWithSessionCreds(final Configuration conf,
-      final MarshalledCredentials sc) {
+      final MarshaledCredentials sc) {
     unsetHadoopCredentialProviders(conf);
     sc.setSecretsInConfiguration(conf);
   }
@@ -254,10 +254,10 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
   public void testInvalidSTSBinding() throws Exception {
     Configuration conf = new Configuration(getContract().getConf());
 
-    MarshalledCredentials sc = requestSessionCredentials(conf,
+    MarshaledCredentials sc = requestSessionCredentials(conf,
         getFileSystem().getBucket());
     toAWSCredentials(sc,
-        MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty, "");
+        MarshaledCredentials.CredentialTypeRequired.AnyNonEmpty, "");
     updateConfigWithSessionCreds(conf, sc);
 
     conf.set(AWS_CREDENTIALS_PROVIDER, TEMPORARY_AWS_CREDENTIALS);
@@ -404,13 +404,13 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
     conf.set(ACCESS_KEY, "aaa");
     conf.set(SECRET_KEY, "bbb");
     conf.set(SESSION_TOKEN, "");
-    final MarshalledCredentials sc = MarshalledCredentialBinding.fromFileSystem(
+    final MarshaledCredentials sc = MarshaledCredentialBinding.fromFileSystem(
         null, conf);
     intercept(IOException.class,
-        MarshalledCredentials.INVALID_CREDENTIALS,
+        MarshaledCredentials.INVALID_CREDENTIALS,
         () -> {
           sc.validate("",
-              MarshalledCredentials.CredentialTypeRequired.SessionOnly);
+              MarshaledCredentials.CredentialTypeRequired.SessionOnly);
           return sc.toString();
         });
   }
@@ -421,13 +421,13 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
     conf.set(ACCESS_KEY, "");
     conf.set(SECRET_KEY, "");
     conf.set(SESSION_TOKEN, "");
-    final MarshalledCredentials sc = MarshalledCredentialBinding.fromFileSystem(
+    final MarshaledCredentials sc = MarshaledCredentialBinding.fromFileSystem(
         null, conf);
     intercept(IOException.class,
-        MarshalledCredentialBinding.NO_AWS_CREDENTIALS,
+        MarshaledCredentialBinding.NO_AWS_CREDENTIALS,
         () -> {
           sc.validate("",
-              MarshalledCredentials.CredentialTypeRequired.SessionOnly);
+              MarshaledCredentials.CredentialTypeRequired.SessionOnly);
           return sc.toString();
         });
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -31,8 +31,8 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
@@ -666,7 +666,7 @@ public final class S3ATestUtils {
    * @return the credentials
    * @throws IOException on a failure
    */
-  public static MarshalledCredentials requestSessionCredentials(
+  public static MarshaledCredentials requestSessionCredentials(
       final Configuration conf,
       final String bucket)
       throws IOException {
@@ -682,13 +682,13 @@ public final class S3ATestUtils {
    * @return the credentials
    * @throws IOException on a failure
    */
-  public static MarshalledCredentials requestSessionCredentials(
+  public static MarshaledCredentials requestSessionCredentials(
       final Configuration conf,
       final String bucket,
       final int duration)
       throws IOException {
     assumeSessionTestsEnabled(conf);
-    MarshalledCredentials sc = MarshalledCredentialBinding
+    MarshaledCredentials sc = MarshaledCredentialBinding
         .requestSessionCredentials(
           buildAwsCredentialsProvider(conf),
           S3AUtils.createAwsConf(conf, bucket, AWS_SERVICE_IDENTIFIER_STS),
@@ -699,7 +699,7 @@ public final class S3ATestUtils {
           duration,
           new Invoker(new S3ARetryPolicy(conf), Invoker.LOG_EVENT));
     sc.validate("requested session credentials: ",
-        MarshalledCredentials.CredentialTypeRequired.SessionOnly);
+        MarshaledCredentials.CredentialTypeRequired.SessionOnly);
     return sc;
   }
 
@@ -708,7 +708,7 @@ public final class S3ATestUtils {
    * @param source source object
    * @param conf configuration
    * @param <T> type
-   * @return an unmarshalled instance of the type
+   * @return an unmarshaled instance of the type
    * @throws Exception on any failure.
    */
   @SuppressWarnings("unchecked")

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
@@ -216,8 +216,8 @@ public final class RoleTestUtils {
    * @param actual actual credentials.
    */
   public static void assertCredentialsEqual(final String message,
-      final MarshalledCredentials expected,
-      final MarshalledCredentials actual) {
+      final MarshaledCredentials expected,
+      final MarshaledCredentials actual) {
     // DO NOT use assertEquals() here, as that could print a secret to
     // the test report.
     assertEquals(message + ": access key",

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestMarshaledCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestMarshaledCredentials.java
@@ -34,11 +34,11 @@ import org.apache.hadoop.test.HadoopTestBase;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
- * Unit test of marshalled credential support.
+ * Unit test of marshaled credential support.
  */
-public class TestMarshalledCredentials extends HadoopTestBase {
+public class TestMarshaledCredentials extends HadoopTestBase {
 
-  private MarshalledCredentials credentials;
+  private MarshaledCredentials credentials;
 
   private int expiration;
 
@@ -47,7 +47,7 @@ public class TestMarshalledCredentials extends HadoopTestBase {
   @Before
   public void createSessionToken() throws URISyntaxException {
     bucketURI = new URI("s3a://bucket1");
-    credentials = new MarshalledCredentials("accessKey",
+    credentials = new MarshaledCredentials("accessKey",
         "secretKey", "sessionToken");
     credentials.setRoleARN("roleARN");
     expiration = 1970;
@@ -56,7 +56,7 @@ public class TestMarshalledCredentials extends HadoopTestBase {
 
   @Test
   public void testRoundTrip() throws Throwable {
-    MarshalledCredentials c2 = S3ATestUtils.roundTrip(this.credentials,
+    MarshaledCredentials c2 = S3ATestUtils.roundTrip(this.credentials,
         new Configuration());
     assertEquals(credentials, c2);
     assertEquals("accessKey", c2.getAccessKey());
@@ -68,10 +68,10 @@ public class TestMarshalledCredentials extends HadoopTestBase {
 
   @Test
   public void testRoundTripNoSessionData() throws Throwable {
-    MarshalledCredentials c = new MarshalledCredentials();
+    MarshaledCredentials c = new MarshaledCredentials();
     c.setAccessKey("A");
     c.setSecretKey("K");
-    MarshalledCredentials c2 = S3ATestUtils.roundTrip(c,
+    MarshaledCredentials c2 = S3ATestUtils.roundTrip(c,
         new Configuration());
     assertEquals(c, c2);
   }
@@ -87,13 +87,13 @@ public class TestMarshalledCredentials extends HadoopTestBase {
   }
 
   @Test
-  public void testMarshalledCredentialProviderSession() throws Throwable {
-    MarshalledCredentialProvider provider
-        = new MarshalledCredentialProvider("test",
+  public void testMarshaledCredentialProviderSession() throws Throwable {
+    MarshaledCredentialProvider provider
+        = new MarshaledCredentialProvider("test",
         bucketURI,
         new Configuration(false),
         credentials,
-        MarshalledCredentials.CredentialTypeRequired.SessionOnly);
+        MarshaledCredentials.CredentialTypeRequired.SessionOnly);
     AWSCredentials aws = provider.getCredentials();
     assertEquals(credentials.toString(),
         credentials.getAccessKey(),
@@ -111,12 +111,12 @@ public class TestMarshalledCredentials extends HadoopTestBase {
    */
   @Test
   public void testCredentialTypeMismatch() throws Throwable {
-    MarshalledCredentialProvider provider
-        = new MarshalledCredentialProvider("test",
+    MarshaledCredentialProvider provider
+        = new MarshaledCredentialProvider("test",
         bucketURI,
         new Configuration(false),
         credentials,
-        MarshalledCredentials.CredentialTypeRequired.FullOnly);
+        MarshaledCredentials.CredentialTypeRequired.FullOnly);
     // because the credentials are set to full only, creation will fail
     intercept(NoAuthWithAWSException.class, "test",
         () ->  provider.getCredentials());
@@ -129,10 +129,10 @@ public class TestMarshalledCredentials extends HadoopTestBase {
   public void testCredentialProviderNullURI() throws Throwable {
     intercept(NullPointerException.class, "",
         () ->
-            new MarshalledCredentialProvider("test",
+            new MarshaledCredentialProvider("test",
             null,
             new Configuration(false),
             credentials,
-            MarshalledCredentials.CredentialTypeRequired.FullOnly));
+            MarshaledCredentials.CredentialTypeRequired.FullOnly));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationIT.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractDelegationIT.java
@@ -203,7 +203,10 @@ public abstract class AbstractDelegationIT extends AbstractS3ATestBase {
       throws IOException {
     S3AFileSystem fs = getFileSystem();
     S3ADelegationTokens tokens = new S3ADelegationTokens();
-    tokens.bindToFileSystem(fs.getCanonicalUri(), fs);
+    tokens.bindToFileSystem(
+        fs.getCanonicalUri(),
+        fs.createStoreContext(),
+        fs.createDelegationOperations());
     tokens.init(conf);
     return tokens;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestRoleDelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestRoleDelegationTokens.java
@@ -93,7 +93,9 @@ public class ITestRoleDelegationTokens extends ITestSessionDelegationTokens {
     conf.unset(DelegationConstants.DELEGATION_TOKEN_ROLE_ARN);
     try (S3ADelegationTokens delegationTokens2 = new S3ADelegationTokens()) {
       final S3AFileSystem fs = getFileSystem();
-      delegationTokens2.bindToFileSystem(fs.getUri(), fs);
+      delegationTokens2.bindToFileSystem(fs.getUri(),
+          fs.createStoreContext(),
+          fs.createDelegationOperations());
       delegationTokens2.init(conf);
       delegationTokens2.start();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestRoleDelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestRoleDelegationTokens.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.io.Text;
 
@@ -67,7 +67,7 @@ public class ITestRoleDelegationTokens extends ITestSessionDelegationTokens {
    * so the superclass's method will fail.
    * This subclass intercepts the exception which is expected.
    * @param fs base FS to bond to.
-   * @param marshalledCredentials session credentials from first DT.
+   * @param marshaledCredentials session credentials from first DT.
    * @param conf config to use
    * @return null
    * @throws Exception failure
@@ -75,12 +75,12 @@ public class ITestRoleDelegationTokens extends ITestSessionDelegationTokens {
   @Override
   protected AbstractS3ATokenIdentifier verifyCredentialPropagation(
       final S3AFileSystem fs,
-      final MarshalledCredentials marshalledCredentials,
+      final MarshaledCredentials marshaledCredentials,
       final Configuration conf) throws Exception {
     intercept(DelegationTokenIOException.class,
         E_NO_SESSION_TOKENS_FOR_ROLE_BINDING,
         () -> super.verifyCredentialPropagation(fs,
-            marshalledCredentials, conf));
+            marshaledCredentials, conf));
     return null;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeSessionTestsEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.roundTrip;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.unsetHadoopCredentialProviders;
-import static org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding.fromAWSCredentials;
+import static org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding.fromAWSCredentials;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_CREDENTIALS_PROVIDER;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_SESSION_BINDING;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.SESSION_TOKEN_KIND;
@@ -150,7 +150,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
    * the same as the original.
    *
    * That is different from DT propagation, as here the propagation
-   * is by setting the fs.s3a session/secret/id keys from the marshalled
+   * is by setting the fs.s3a session/secret/id keys from the marshaled
    * values, and using session token auth.
    * This verifies that session token authentication can be used
    * for DT credential auth, and that new tokens aren't created.
@@ -183,7 +183,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
             () -> "no identifier in " + originalDT);
     issued.validate();
 
-    final MarshalledCredentials creds;
+    final MarshaledCredentials creds;
     try(S3ADelegationTokens dt2 = instantiateDTSupport(getConfiguration())) {
       dt2.start();
 
@@ -191,7 +191,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
       final AWSSessionCredentials awsSessionCreds
           = verifySessionCredentials(
           dt2.getCredentialProviders().getCredentials());
-      final MarshalledCredentials origCreds = fromAWSCredentials(
+      final MarshaledCredentials origCreds = fromAWSCredentials(
           awsSessionCreds);
 
       Token<AbstractS3ATokenIdentifier> boundDT =
@@ -227,7 +227,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   protected AbstractS3ATokenIdentifier verifyCredentialPropagation(
       final S3AFileSystem fs,
-      final MarshalledCredentials session,
+      final MarshaledCredentials session,
       final Configuration conf)
       throws Exception {
     describe("Verify Token Propagation");
@@ -252,7 +252,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
           = delegationTokens2.getDecodedIdentifier().get();
 
       LOG.info("Regenerated DT is {}", newDT);
-      final MarshalledCredentials creds2 = fromAWSCredentials(
+      final MarshaledCredentials creds2 = fromAWSCredentials(
           verifySessionCredentials(
               delegationTokens2.getCredentialProviders().getCredentials()));
       assertEquals("Credentials", session, creds2);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
@@ -238,7 +238,10 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
         TemporaryAWSCredentialsProvider.NAME);
     session.setSecretsInConfiguration(conf);
     try(S3ADelegationTokens delegationTokens2 = new S3ADelegationTokens()) {
-      delegationTokens2.bindToFileSystem(fs.getCanonicalUri(), fs);
+      delegationTokens2.bindToFileSystem(
+          fs.getCanonicalUri(),
+          fs.createStoreContext(),
+          fs.createDelegationOperations());
       delegationTokens2.init(conf);
       delegationTokens2.start();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
-import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentialBinding;
+import org.apache.hadoop.fs.s3a.auth.MarshaledCredentials;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
@@ -64,7 +64,7 @@ public class TestS3ADelegationTokenSupport {
         = new SessionTokenIdentifier(SESSION_TOKEN_KIND,
         alice,
         new URI("s3a://landsat-pds/"),
-        new MarshalledCredentials("a", "b", ""),
+        new MarshaledCredentials("a", "b", ""),
         new EncryptionSecrets(S3AEncryptionMethods.SSE_S3, ""),
         "origin");
     Token<AbstractS3ATokenIdentifier> t1 =
@@ -72,11 +72,11 @@ public class TestS3ADelegationTokenSupport {
             new SessionSecretManager());
     AbstractS3ATokenIdentifier decoded = t1.decodeIdentifier();
     decoded.validate();
-    MarshalledCredentials creds
-        = ((SessionTokenIdentifier) decoded).getMarshalledCredentials();
+    MarshaledCredentials creds
+        = ((SessionTokenIdentifier) decoded).getMarshaledCredentials();
     assertNotNull("credentials",
-        MarshalledCredentialBinding.toAWSCredentials(creds,
-        MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty, ""));
+        MarshaledCredentialBinding.toAWSCredentials(creds,
+        MarshaledCredentials.CredentialTypeRequired.AnyNonEmpty, ""));
     assertEquals(alice, decoded.getOwner());
     UserGroupInformation decodedUser = decoded.getUser();
     assertEquals("name of " + decodedUser,
@@ -101,15 +101,15 @@ public class TestS3ADelegationTokenSupport {
         SESSION_TOKEN_KIND,
         new Text(),
         landsatUri,
-        new MarshalledCredentials("a", "b", "c"),
+        new MarshaledCredentials("a", "b", "c"),
         new EncryptionSecrets(), "");
 
     SessionTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
     assertEquals("URI in " + ids, id.getUri(), result.getUri());
     assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
+        id.getMarshaledCredentials(),
+        result.getMarshaledCredentials());
   }
 
   @Test
@@ -117,15 +117,15 @@ public class TestS3ADelegationTokenSupport {
     RoleTokenIdentifier id = new RoleTokenIdentifier(
         landsatUri,
         new Text(),
-        new MarshalledCredentials("a", "b", "c"),
+        new MarshaledCredentials("a", "b", "c"),
         new EncryptionSecrets(), "");
 
     RoleTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
     assertEquals("URI in " + ids, id.getUri(), result.getUri());
     assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
+        id.getMarshaledCredentials(),
+        result.getMarshaledCredentials());
   }
 
   @Test
@@ -133,15 +133,15 @@ public class TestS3ADelegationTokenSupport {
     FullCredentialsTokenIdentifier id = new FullCredentialsTokenIdentifier(
         landsatUri,
         new Text(),
-        new MarshalledCredentials("a", "b", ""),
+        new MarshaledCredentials("a", "b", ""),
         new EncryptionSecrets(), "");
 
     FullCredentialsTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
     assertEquals("URI in " + ids, id.getUri(), result.getUri());
     assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
+        id.getMarshaledCredentials(),
+        result.getMarshaledCredentials());
   }
 
   /**


### PR DESCRIPTION
Adds a new interface DelegationOperations which S3A FS offers.
This just exends AWSPolicyProvider, as that is the only callback outside of
StoreContext which is currently used.

Having an explicit interface lets us add more callbacks in future, without
breaking the signature of the API -hence any external implementations

Change-Id: I412ae78d6a806bea954ec5980faf2b7f8aac7bed

