### PR TITLE
HDDS-2188 : Implement LocatedFileStatus & getFileBlockLocations to pr…

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -957,6 +957,7 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
+        .setRefreshPipeline(true)
         .build();
     return ozoneManagerClient.getFileStatus(keyArgs);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -44,8 +44,9 @@ public class OzoneFileStatus extends FileStatus {
     keyInfo = key;
   }
 
-  public OzoneFileStatus(FileStatus status) throws IOException {
+  public OzoneFileStatus(FileStatus status, OmKeyInfo key) throws IOException {
     super(status);
+    keyInfo = key;
   }
 
   // Use this constructor only for directories
@@ -54,13 +55,18 @@ public class OzoneFileStatus extends FileStatus {
   }
 
   public OzoneFileStatusProto getProtobuf() throws IOException {
-    return OzoneFileStatusProto.newBuilder().setStatus(PBHelper.convert(this))
-        .build();
+    OzoneFileStatusProto.Builder builder = OzoneFileStatusProto.newBuilder()
+        .setStatus(PBHelper.convert(this));
+    if (keyInfo != null) {
+      builder.setKeyInfo(keyInfo.getProtobuf());
+    }
+    return builder.build();
   }
 
   public static OzoneFileStatus getFromProtobuf(OzoneFileStatusProto response)
       throws IOException {
-    return new OzoneFileStatus(PBHelper.convert(response.getStatus()));
+    return new OzoneFileStatus(PBHelper.convert(response.getStatus()),
+        OmKeyInfo.getFromProtobuf(response.getKeyInfo()));
   }
 
   public static Path getPath(String keyName) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1338,6 +1338,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setVolumeName(args.getVolumeName())
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
+        .setRefreshPipeline(args.getRefreshPipeline())
         .build();
     GetFileStatusRequest req =
         GetFileStatusRequest.newBuilder()

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -650,6 +650,7 @@ message KeyArgs {
     // request type.
     optional uint64 modificationTime = 13;
     optional bool sortDatanodes = 14;
+    optional bool refreshPipeline = 15;
 }
 
 message KeyLocation {
@@ -696,6 +697,7 @@ message RepeatedKeyInfo {
 
 message OzoneFileStatusProto {
     required hadoop.fs.FileStatusProto status = 1;
+    optional KeyInfo keyInfo = 2;
 }
 
 message GetFileStatusRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -1045,6 +1045,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
+        .setRefreshPipeline(keyArgs.getRefreshPipeline())
         .build();
 
     GetFileStatusResponse.Builder rb = GetFileStatusResponse.newBuilder();

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -440,7 +440,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         status.getPermission().toShort(),
         status.getOwner(),
         status.getGroup(),
-        status.getPath()
+        status.getPath(),
+        status.getKeyInfo()
     );
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 
 /**
  * Class to hold the internal information of a FileStatus.
@@ -42,12 +43,13 @@ public final class FileStatusAdapter {
   private final String owner;
   private final String group;
   private final Path symlink;
+  private final OmKeyInfo keyInfo;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public FileStatusAdapter(long length, Path path, boolean isdir,
       short blockReplication, long blocksize, long modificationTime,
       long accessTime, short permission, String owner,
-      String group, Path symlink) {
+      String group, Path symlink, OmKeyInfo keyInfo) {
     this.length = length;
     this.path = path;
     this.isdir = isdir;
@@ -59,6 +61,7 @@ public final class FileStatusAdapter {
     this.owner = owner;
     this.group = group;
     this.symlink = symlink;
+    this.keyInfo = keyInfo;
   }
 
   public Path getPath() {
@@ -103,6 +106,10 @@ public final class FileStatusAdapter {
 
   public long getLength() {
     return length;
+  }
+
+  public OmKeyInfo getKeyInfo() {
+    return keyInfo;
   }
 
 }

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -25,12 +25,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.GlobalStorageStatistics;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -310,6 +312,25 @@ public class TestOzoneFileInterfaces {
     assertEquals(0, omStatus.getLen());
     assertTrue(omStatus.getModificationTime() >= currentTime);
     assertEquals(omStatus.getPath().getName(), o3fs.pathToKey(path));
+  }
+
+  @Test
+  public void testOzoneManagerLocatedFileStatus() throws IOException {
+    String data = RandomStringUtils.randomAlphanumeric(20);
+    String filePath = RandomStringUtils.randomAlphanumeric(5);
+    Path path = createPath("/" + filePath);
+    try (FSDataOutputStream stream = fs.create(path)) {
+      stream.writeBytes(data);
+    }
+    FileStatus status = fs.getFileStatus(path);
+    assertTrue(status instanceof LocatedFileStatus);
+    LocatedFileStatus locatedFileStatus = (LocatedFileStatus) status;
+    assertTrue(locatedFileStatus.getBlockLocations().length >= 1);
+
+    for (BlockLocation blockLocation : locatedFileStatus.getBlockLocations()) {
+      assertTrue(blockLocation.getNames().length >= 1);
+      assertTrue(blockLocation.getHosts().length >= 1);
+    }
   }
 
   @Test


### PR DESCRIPTION
…ovide node/localization information to Yarn/Mapreduce.

Note : This is a **PRELIMINARY PATCH** for getting some review comments. I am still doing some manual testing to iron out issues.

## What changes were proposed in this pull request?
For applications like Hive/MapReduce to take advantage of the data locality in Ozone, Ozone should return the location of the Ozone blocks. This is needed for better read performance for Hadoop Applications.

https://issues.apache.org/jira/browse/HDDS-2188

## How was this patch tested?
Added a few unit tests. Working on adding more.
Currently doing manual testing by running MR jobs.