### PR TITLE
HDDS-2194. Replication of Container fails with Only closed containers…

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -520,11 +520,16 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   @Override
   public void exportContainerData(OutputStream destination,
       ContainerPacker<KeyValueContainerData> packer) throws IOException {
-    if (getContainerData().getState() !=
-        ContainerProtos.ContainerDataProto.State.CLOSED) {
+    // Closed/ Quasi closed containers are considered for replication by
+    // replication manager if they are under-replicated.
+    ContainerProtos.ContainerDataProto.State state =
+        getContainerData().getState();
+    if (!(state == ContainerProtos.ContainerDataProto.State.CLOSED ||
+        state == ContainerDataProto.State.QUASI_CLOSED)) {
       throw new IllegalStateException(
-          "Only closed containers could be exported: ContainerId="
-              + getContainerData().getContainerID());
+          "Only closed/quasi closed containers could be exported: " +
+              "Where as ContainerId="
+              + getContainerData().getContainerID() + "is in state" + state);
     }
     compactDB();
     packer.pack(this, destination);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -529,7 +529,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       throw new IllegalStateException(
           "Only closed/quasi closed containers could be exported: " +
               "Where as ContainerId="
-              + getContainerData().getContainerID() + "is in state" + state);
+              + getContainerData().getContainerID() + " is in state " + state);
     }
     compactDB();
     packer.pack(this, destination);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2194

The issue is because when the Replication Manager is considering to replicate containers which are under replicated, it considers replicas in QuasiClosed/Closed. Whereas in Datanode we have a check of Closed. This has caused the issue. So, that is why we see IllegealStateException in the logs.