### PR TITLE
HDDS-2206. Separate handling for OMException and IOException in the Ozone Manager. Contributed by Supratim Deka

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1642,6 +1642,20 @@
   </property>
 
   <property>
+    <name>ozone.om.exception.stacktrace.propagate</name>
+    <value>true</value>
+    <tag>OZONE, OM, DEBUG</tag>
+    <description>
+      If true, propagate full stacktrace for system exceptions to the client.
+      If false, propagate summary message only and log stacktrace on server.
+      Full stacktrace on the client is useful for developers to debug
+      unexpected system errors encountered on the server while handling a
+      request.
+      This setting is not applicable for business exceptions.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.ratis.client.request.timeout.duration</name>
     <value>3s</value>
     <tag>OZONE, OM, RATIS, MANAGEMENT</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -151,6 +151,13 @@ public final class OMConfigKeys {
   public static final TimeDuration OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT
       = TimeDuration.valueOf(1, TimeUnit.SECONDS);
 
+  // Propagate stack trace for System Exceptions to the client.
+  public static final String OZONE_OM_PROPAGATE_SYSTEM_EXCEPTION_STACKTRACE
+      = "ozone.om.exception.stacktrace.propagate";
+  public static final boolean
+      OZONE_OM_PROPAGATE_SYSTEM_EXCEPTION_STACKTRACE_DEFAULT
+      = true;
+
   // OM Ratis client configurations
   public static final String OZONE_OM_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_KEY
       = "ozone.om.ratis.client.request.timeout.duration";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -200,15 +200,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAU
 import static org.apache.hadoop.ozone.OzoneConsts.OM_METRICS_FILE;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_METRICS_TEMP_FILE;
 import static org.apache.hadoop.ozone.OzoneConsts.RPC_PORT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_FILE_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.*;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_AUTH_METHOD;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
@@ -1193,8 +1185,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OZONE_OM_HANDLER_COUNT_DEFAULT);
     RPC.setProtocolEngine(configuration, OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
+    final boolean propagateExceptionStack =
+        conf.getBoolean(OZONE_OM_PROPAGATE_SYSTEM_EXCEPTION_STACKTRACE,
+            OZONE_OM_PROPAGATE_SYSTEM_EXCEPTION_STACKTRACE_DEFAULT);
     this.omServerProtocol = new OzoneManagerProtocolServerSideTranslatorPB(
-        this, omRatisServer, omClientProtocolMetrics, isRatisEnabled);
+        this, omRatisServer, omClientProtocolMetrics, isRatisEnabled,
+        propagateExceptionStack);
 
     BlockingService omService = newReflectiveBlockingService(omServerProtocol);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2206

Introduced a boolean config parameter to control exception propagation from OM to Clients.
If set to true, all system exceptions (IOException) are thrown as ServiceException to RPC client - this also propagates the complete server-side stack trace to the client. If false, system exception stack trace is logged locally on the server, not sent to client.
The default value is set to true for now. For Ozone GA, we can revisit this choice.

Business Exception (OMException) handling is not changed.

This change does not include propagation of exceptions from within Ratis server.