### PR TITLE
YARN-9511. [YARN] Set the default permissions of test jar file(WIP)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/JarFinder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/JarFinder.java
@@ -179,6 +179,11 @@ public class JarFinder {
     File jarFile = new File(rootDir, jarName);
     JarOutputStream jstream =
         new JarOutputStream(new FileOutputStream(jarFile));
+    jarFile.setReadable(false,false);
+    jarFile.setWritable(false,false);
+    jarFile.setExecutable(false,false);
+    jarFile.setWritable(true);
+    jarFile.setReadable(true);
     for (String clsName: clsNames) {
       String name = clsName.replace('.', '/') + ".class";
       InputStream entryInputStream = target.getResourceAsStream(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
@@ -256,6 +256,11 @@ public class TestAuxServices {
     conf.set(YarnConfiguration.NM_AUX_SERVICES_MANIFEST, manifest
         .getAbsolutePath());
     mapper.writeValue(manifest, services);
+    manifest.setReadable(false,false);
+    manifest.setWritable(false,false);
+    manifest.setExecutable(false,false);
+    manifest.setWritable(true);
+    manifest.setReadable(true);
   }
 
   @SuppressWarnings("resource")


### PR DESCRIPTION
The default permissions of created file will due to the `umask`
of system. that may cause some tests of TestAuxServices failure, because
the tests need to check the permissions. This change will do:

- Set the default permissions of test jar file to *owner read write*
- Set the default permissions of test manifest file to *owner read write*

