### PR TITLE
YARN-9881. Change Cluster_Scheduler_API's Item memory‘s datatype from int to long.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRest.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRest.md
@@ -359,7 +359,7 @@ The capacity scheduler supports hierarchical queues. This one request will print
 
 | Item | Data Type | Description |
 |:---- |:---- |:---- |
-| memory | int | The amount of memory used (in MB) |
+| memory | long | The amount of memory used (in MB) |
 | vCores | int | The number of virtual cores |
 
 ### Elements of the health object in schedulerInfo:
@@ -1162,7 +1162,7 @@ Response Body:
 
 | Item | Data Type | Description |
 |:---- |:---- |:---- |
-| memory | int | The amount of memory used (in MB) |
+| memory | long | The amount of memory used (in MB) |
 | vCores | int | The number of virtual cores |
 
 #### Response Examples


### PR DESCRIPTION
The Yarn Rest http://rm-http-address:port/ws/v1/cluster/scheduler document, In hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Scheduler_API, change Item memory‘s datatype from int to long.
1.change Capacity Scheduler API's item [memory]'s dataType from int to long.
2. change Fair Scheduler API's item [memory]'s dataType from int to long.