### PR TITLE
YARN-9880. In YARN ui2 attempts tab, The running Application Attempt's ElapsedTime is incorrect.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/AppAttemptInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/dao/AppAttemptInfo.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptReport;
 import org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState;
+import org.apache.hadoop.yarn.util.Times;
 
 @Public
 @Evolving
@@ -44,6 +45,7 @@ public class AppAttemptInfo {
   protected String amContainerId;
   protected long startedTime;
   protected long finishedTime;
+  protected long elapsedTime;
 
   public AppAttemptInfo() {
     // JAXB needs this
@@ -62,6 +64,7 @@ public class AppAttemptInfo {
     }
     startedTime = appAttempt.getStartTime();
     finishedTime = appAttempt.getFinishTime();
+    elapsedTime = Times.elapsed(startedTime, finishedTime);
   }
 
   public String getAppAttemptId() {
@@ -102,6 +105,10 @@ public class AppAttemptInfo {
 
   public long getFinishedTime() {
     return finishedTime;
+  }
+
+  public long getElapsedTime() {
+    return elapsedTime;
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AppAttemptInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AppAttemptInfo.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplicationAttempt;
+import org.apache.hadoop.yarn.util.Times;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 
 @XmlRootElement(name = "appAttempt")
@@ -37,6 +38,7 @@ public class AppAttemptInfo {
   protected int id;
   protected long startTime;
   protected long finishedTime;
+  protected long elapsedTime;
   protected String containerId;
   protected String nodeHttpAddress;
   protected String nodeId;
@@ -62,6 +64,8 @@ public class AppAttemptInfo {
       this.id = attempt.getAppAttemptId().getAttemptId();
       this.startTime = attempt.getStartTime();
       this.finishedTime = attempt.getFinishTime();
+      this.elapsedTime =
+          Times.elapsed(attempt.getStartTime(), attempt.getFinishTime());
       Container masterContainer = attempt.getMasterContainer();
       if (masterContainer != null) {
         this.containerId = masterContainer.getId().toString();
@@ -102,6 +106,10 @@ public class AppAttemptInfo {
 
   public long getFinishedTime() {
     return this.finishedTime;
+  }
+
+  public long getElapsedTime() {
+    return this.elapsedTime;
   }
 
   public String getNodeHttpAddress() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-app-attempt.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-app-attempt.js
@@ -24,6 +24,7 @@ export default DS.Model.extend({
   startTime: DS.attr('string'),
   startedTime: DS.attr('string'),
   finishedTime: DS.attr('string'),
+  elapsedTimeMs: DS.attr('string'),
   containerId: DS.attr('string'),
   amContainerId: DS.attr('string'),
   nodeHttpAddress: DS.attr('string'),
@@ -117,11 +118,7 @@ export default DS.Model.extend({
   }.property("logsLink"),
 
   elapsedTime: function() {
-    var elapsedMs = this.get("finishedTs") - this.get("startTs");
-    if (elapsedMs <= 0) {
-      elapsedMs = Date.now() - this.get("startTs");
-    }
-    return Converter.msToElapsedTimeUnit(elapsedMs);
+    return Converter.msToElapsedTimeUnit(this.get("elapsedTimeMs"));
   }.property(),
 
   tooltipLabel: function() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/serializers/yarn-app-attempt.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/serializers/yarn-app-attempt.js
@@ -33,6 +33,7 @@ export default DS.JSONAPISerializer.extend({
           startTime: Converter.timeStampToDate(payload.startTime),
           startedTime: Converter.timeStampToDate(payload.startedTime),
           finishedTime: Converter.timeStampToDate(payload.finishedTime),
+          elapsedTimeMs: payload.elapsedTime,
           containerId: payload.containerId,
           amContainerId: payload.amContainerId,
           nodeHttpAddress: payload.nodeHttpAddress,


### PR DESCRIPTION
I found this problem where hadoop3.1.1 was used, want to upgrade to the latest version of hadoop, but found the running Application Attempt's ElapsedTime is also incorrect.

In UI1, get ElapsedTime from yarn server. In UI2, get currentTime from brower. Therefore, when the brower and the yarn server are not in the same time zones, the ElapsedTime is incorrect. While the Application‘s ElapsedTime is 29 Secs, the Application Attempt's ElapsedTime is 10 Hrs : 49 Mins : 55 Secs.

I think, in UI2, ElapsedTime should also come from the yarn server too.