### PR TITLE
HDDS-2220. HddsVolume needs a toString method.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -452,4 +452,12 @@ public class HddsVolume
       volumeInfo.setScmUsageForTesting(scmUsageForTest);
     }
   }
+
+  /**
+   * Override toSting() to show the path of HddsVolume.
+   */
+  @Override
+  public String toString() {
+    return getHddsRootDir().toString();
+  }
 }


### PR DESCRIPTION
Override toString to show the path of HddsVolume.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
