### PR TITLE
HADOOP-16653. S3Guard DDB overreacts to no tag access.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/RolePolicies.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/RolePolicies.java
@@ -331,6 +331,16 @@ public final class RolePolicies {
   public static final String DDB_BATCH_WRITE_ITEM = "dynamodb:BatchWriteItem";
 
   /**
+   * Read tags of a table: {@value}.
+   */
+  public static final String DDB_TAGS_LIST = "dynamodb:ListTagsOfResource";
+
+  /**
+   * Write- tags of a table: {@value}.
+   */
+  public static final String DDB_TAGS_WRITE = "dynamodb:TagResource";
+
+  /**
    * All DynamoDB tables: {@value}.
    */
   public static final String ALL_DDB_TABLES = "arn:aws:dynamodb:*";

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -722,4 +722,25 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
         roleFS.delete(pathWhichDoesntExist, true));
   }
 
+  /**
+   * Turn off access to dynamo DB Tags and see how DDB table init copes.
+   */
+  @Test
+  public void testRestrictDDBTagAccess() throws Throwable {
+
+    describe("extra policies in assumed roles need;"
+        + " all required policies stated");
+    Configuration conf = createAssumedRoleConfig();
+
+    bindRolePolicyStatements(conf,
+        STATEMENT_S3GUARD_CLIENT,
+        STATEMENT_ALLOW_SSE_KMS_RW,
+        STATEMENT_ALL_S3,
+        new Statement(Effects.Deny)
+            .addActions(S3_PATH_RW_OPERATIONS)
+            .addResources(ALL_DDB_TABLES));
+    Path path = path("testRestrictDDBTagAccess");
+    roleFS = (S3AFileSystem) path.getFileSystem(conf);
+  }
+
 }


### PR DESCRIPTION
Initial PR just creates the test to demonstrate the issue.

Change-Id: I8ab98acbdf3d854491571ee98627f96a98cbde48

