### PR TITLE
HADOOP-16629: support copyFile in s3afilesystem

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonPathCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonPathCapabilities.java
@@ -54,6 +54,13 @@ public final class CommonPathCapabilities {
   public static final String FS_CONCAT = "fs.capability.paths.concat";
 
   /**
+   * Does the store support native file copy.
+   * {@code FileSystem.copyFile(URI, URI)}
+   * Value: {@value}.
+   */
+  public static final String FS_NATIVE_COPY = "fs.capability.paths.native.copy";
+
+  /**
    * Does the store support {@code FileSystem.listCorruptFileBlocks(Path)} ()}?
    * Value: {@value}.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -1601,6 +1601,29 @@ public abstract class FileSystem extends Configured
   }
 
   /**
+   * Copy a file from one location to another location.
+   *
+   * <ul>
+   *   <li>Fails if source file is absent.</li>
+   *   <li>Fails if destination folder does not exist.</li>
+   *   <li>Overwrites if destination file exists.</li>
+   *   <li>Fails if source is a directory.</li>
+   * </ul>
+   *
+   * @param srcFile URI to be copied
+   * @param dstFile copied file
+   *
+   * @return a future indicating completion of copy operation
+   * @throws IOException IO failure
+   */
+  @InterfaceStability.Unstable
+  public CompletableFuture<Void> copyFile(URI srcFile, URI dstFile)
+      throws IOException {
+    throw new UnsupportedOperationException("Not implemented by the " +
+        getClass().getSimpleName() + " FileSystem implementation");
+  }
+
+  /**
    * Delete a file/directory.
    * @deprecated Use {@link #delete(Path, boolean)} instead.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StorageStatistics.java
@@ -50,6 +50,7 @@ public abstract class StorageStatistics {
     String OP_APPEND = "op_append";
     String OP_COPY_FROM_LOCAL_FILE = "op_copy_from_local_file";
     String OP_CREATE = "op_create";
+    String OP_COPY = "op_copy";
     String OP_CREATE_NON_RECURSIVE = "op_create_non_recursive";
     String OP_DELETE = "op_delete";
     String OP_EXISTS = "op_exists";

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -905,6 +905,28 @@ the file, then verify the invariants in the `PathHandle` using
 `getFileStatus(Path)` to implement `CONTENT`. This could yield false
 positives and it requires additional RPC traffic.
 
+
+### `copyFile(URI srcFile, URI dstFile)`
+
+Copies a file `srcFile` to another file `dstFile`.
+
+Implementations without a compliant call MUST throw
+`UnsupportedOperationException`.
+
+#### Preconditions
+
+    if not exists(FS, srcFile) : raise FileNotFoundException
+
+    if not exists(parentFolder(dstFile)) : raise [IllegalArguementException]
+
+    if isDirectory(srcFile) : raise [IllegalArguementException]
+
+
+#### Postconditions
+
+`dstFile` is available in the filesystem. `dstFile` matches that of `srcFile`.
+Overwrites `dstFile` if already present.
+
 ### `boolean delete(Path p, boolean recursive)`
 
 Delete a path, be it a file, symbolic link or directory. The

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCopyTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractCopyTest.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.contract;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+
+import static org.apache.hadoop.fs.CommonPathCapabilities.FS_NATIVE_COPY;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.verifyFileContents;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.apache.hadoop.test.LambdaTestUtils.interceptFuture;
+
+/**
+ * Test native copy - if supported.
+ */
+public abstract class AbstractContractCopyTest extends
+    AbstractFSContractTestBase {
+
+  protected Path srcDir;
+  protected Path srcFile;
+  protected Path zeroByteFile;
+  protected Path dstDir;
+  protected Path dstFile;
+  protected FileSystem fs;
+
+  protected byte[] srcData;
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    skipIfUnsupported(SUPPORTS_NATIVE_COPY);
+
+    srcDir = absolutepath("source");
+    dstDir = absolutepath("target");
+
+    srcFile = new Path(srcDir, "source.txt");
+    dstFile = new Path(dstDir, "dst.txt");
+    zeroByteFile = new Path(srcDir, "zero.txt");
+
+    srcData = dataset(TEST_FILE_LEN, 0, 255);
+    createFile(getFileSystem(), srcFile, true, srcData);
+    touch(getFileSystem(), zeroByteFile);
+
+    fs = getFileSystem();
+  }
+
+  @Override
+  public void teardown() throws Exception {
+    describe("\nTeardown\n");
+    super.teardown();
+  }
+
+
+  @Test
+  public void testBasicCopy() throws Throwable {
+    describe("Checks whether S3A FS supports native copy"
+        + " and copies a file from one location to another."
+        + " File deletion taken care in teardown.");
+
+    assertPathExists(srcFile + " does not exist", srcFile);
+
+    fs.delete(dstFile, false);
+    // initiate copy
+    fs.copyFile(srcFile.toUri(), dstFile.toUri()).get();
+
+    // Check if file is available and verify its contents
+    assertIsFile(srcFile);
+    assertIsFile(dstFile);
+    verifyFileContents(fs, dstFile, srcData);
+  }
+
+  @Test
+  public void testZeroByteFile() throws Throwable {
+    describe("Copy 0 byte file.");
+
+    assertPathExists(zeroByteFile + " does not exist", zeroByteFile);
+
+    fs.delete(dstFile, false);
+    // initiate copy
+    fs.copyFile(zeroByteFile.toUri(), dstFile.toUri()).get();
+    // Check if file is available
+    assertIsFile(zeroByteFile);
+  }
+
+  @Test
+  public void testFolderCopy() throws Throwable {
+    describe("Test folder copy. Recursive copy is not supported yet.");
+    // initiate copy
+    handleExpectedException(intercept(Exception.class,
+        () -> fs.copyFile(srcDir.toUri(), dstDir.toUri()).get()));
+  }
+
+  @Test
+  public void testOverwrite() throws Throwable {
+    describe("Test copying a file which is already present");
+
+    fs.delete(dstFile, false);
+    // initiate copy
+    fs.copyFile(srcFile.toUri(), dstFile.toUri()).get();
+
+    // Recopy, this would overwrite the contents
+    fs.copyFile(srcFile.toUri(), dstFile.toUri()).get();
+
+    // Check if file is available and verify its contents
+    assertIsFile(srcFile);
+    assertIsFile(dstFile);
+    verifyFileContents(fs, dstFile, srcData);
+  }
+
+  @Test
+  public void testNonExistingParentFolder() throws Throwable {
+    describe("Test copying a file to destination folder "
+        + "which is not present");
+
+    Path nonExistingFolder = new Path(dstDir.getParent(),
+        Long.toString(System.currentTimeMillis()));
+    Path dFile = new Path(nonExistingFolder, "testfile");
+
+    handleExpectedException(interceptFuture(Exception.class, "",
+        fs.copyFile(zeroByteFile.toUri(), dFile.toUri())));
+  }
+
+  @Test
+  public void testNonExistingFileCopy() throws Throwable {
+    describe("Test copying a non-existing file to destination folder");
+
+    Path srcFilePath = new Path(srcDir, "non-existing-file.txt");
+    handleExpectedException(intercept(Exception.class,
+        () -> fs.copyFile(srcFilePath.toUri(), dstDir.toUri()).get()));
+  }
+
+  @Test
+  public void testNativeCopyCapability() throws Throwable {
+    describe("Test native copy capability");
+
+    // Check for native copy support
+    boolean nativeCopySupported = fs.hasPathCapability(srcFile, FS_NATIVE_COPY);
+    assertFalse("FileSystem does not have support for native file copy",
+        nativeCopySupported);
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractOptions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractOptions.java
@@ -207,6 +207,11 @@ public interface ContractOptions {
   String SUPPORTS_UNBUFFER = "supports-unbuffer";
 
   /**
+   * Indicates that FS supports native copy.
+   */
+  String SUPPORTS_NATIVE_COPY = "supports-native-copy";
+
+  /**
    * Maximum path length
    * {@value}
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -53,6 +53,8 @@ public enum Statistic {
       "Calls of copyFromLocalFile()"),
   INVOCATION_CREATE(CommonStatisticNames.OP_CREATE,
       "Calls of create()"),
+  INVOCATION_COPY(CommonStatisticNames.OP_COPY,
+      "Calls of copy()"),
   INVOCATION_CREATE_NON_RECURSIVE(CommonStatisticNames.OP_CREATE_NON_RECURSIVE,
       "Calls of createNonRecursive()"),
   INVOCATION_DELETE(CommonStatisticNames.OP_DELETE,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyOperation.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.Retries;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
+import org.apache.hadoop.fs.s3a.S3AReadOpContext;
+import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.util.DurationInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Note that this is used for copying single file from source to destination.
+ * It can copy across buckets provided relevant permissions are available.
+ * This can be enhanced later to support directory level copy with
+ * multiple threads.
+ */
+public class CopyOperation extends ExecutingStoreOperation<Long> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      CopyOperation.class);
+
+  private S3AFileStatus srcStatus;
+
+  private final URI dstURI;
+  private final URI srcURI;
+
+  private OperationCallbacks callbacks;
+
+  /**
+   * Copy operation constructor.
+   *
+   * @param context store context
+   * @param srcStatus pre-fetched source status
+   * @param srcURI destination file location
+   * @param dstURI destination file location
+   * @param callbacks callback provider
+   */
+  public CopyOperation(final StoreContext context,
+      final S3AFileStatus srcStatus,
+      final URI srcURI,
+      final URI dstURI,
+      final OperationCallbacks callbacks) {
+
+    super(context);
+    this.srcStatus = srcStatus;
+    this.srcURI = srcURI;
+    this.dstURI = dstURI;
+    this.callbacks = callbacks;
+  }
+
+  /**
+   * Validations for copying file from source to destination.
+   *
+   * @throws IllegalArgumentException path validation
+   * @throws IOException any other S3 issue
+   */
+  private void verifyCopyConditions()
+      throws IllegalArgumentException, IOException {
+
+    // Source should not be a directory
+    if (srcStatus.isDirectory()) {
+      throw new IllegalArgumentException(
+          srcStatus.getPath().toUri() + " can not be a directory");
+    }
+
+    // Destination should have its parent directory
+    Path dstPath = new Path(dstURI);
+    FileSystem dstFS =
+        dstPath.getFileSystem(getStoreContext().getConfiguration());
+    if (!dstFS.exists(dstPath.getParent())) {
+      throw new IllegalArgumentException(dstPath.getParent() + " not present");
+    }
+    try {
+      FileStatus dstStatus = dstFS.getFileStatus(dstPath);
+      if (dstStatus.isDirectory()) {
+        throw new IllegalArgumentException(
+            dstURI + " does not contain filename");
+      }
+    } catch (FileNotFoundException fnfe) {
+      // destination file is not present. Ok to write.
+    }
+
+  }
+
+  @Retries.RetryTranslated
+  public Long execute() throws IOException {
+    executeOnlyOnce();
+    copyFile();
+    return srcStatus.getLen();
+  }
+
+  /**
+   * Copy a file to destination
+   *
+   * @throws IOException failure
+   */
+  protected void copyFile() throws IOException {
+    verifyCopyConditions();
+    S3ObjectAttributes sourceAttributes =
+        callbacks.createObjectAttributes(srcStatus);
+    S3AReadOpContext readContext = callbacks.createReadContext(srcStatus);
+    LOG.debug("copy: copying file {} to {}", srcStatus.getPath().toUri(),
+        dstURI);
+    // copy
+    try (DurationInfo ignored = new DurationInfo(LOG, false,
+        "Copy file from %s to %s (length=%d)", srcURI, dstURI.toString(),
+        srcStatus.getLen())) {
+      callbacks.copyFile(srcURI, dstURI, sourceAttributes, readContext);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OperationCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OperationCallbacks.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a.impl;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.URI;
 import java.util.List;
 
 import com.amazonaws.AmazonClientException;
@@ -135,6 +136,25 @@ public interface OperationCallbacks {
   @Retries.RetryTranslated
   CopyResult copyFile(String srcKey,
       String destKey,
+      S3ObjectAttributes srcAttributes,
+      S3AReadOpContext readContext)
+      throws IOException;
+
+  /**
+   * Copy a single object in the bucket via a COPY operation.
+   * There's no update of metadata, directory markers, etc.
+   * Callers must implement.
+   * @param src source path
+   * @param dst destination path
+   * @param srcAttributes S3 attributes of the source object
+   * @param readContext the read context
+   * @return the result of the copy
+   * @throws InterruptedIOException the operation was interrupted
+   * @throws IOException Other IO problems
+   */
+  @Retries.RetryTranslated
+  CopyResult copyFile(URI src,
+      URI dst,
       S3ObjectAttributes srcAttributes,
       S3AReadOpContext readContext)
       throws IOException;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCopy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCopy.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.contract.s3a;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractCopyTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+import static org.apache.hadoop.fs.CommonPathCapabilities.FS_NATIVE_COPY;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.S3A_TEST_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeEnableS3Guard;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * S3a contract test covering copy tests.
+ */
+public class ITestS3AContractCopy extends AbstractContractCopyTest {
+
+  public static final Logger LOG = LoggerFactory.getLogger(
+      ITestS3AContractRename.class);
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+  }
+
+  @Override
+  protected int getTestTimeoutMillis() {
+    return S3A_TEST_TIMEOUT;
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new S3AContract(conf);
+  }
+
+  /**
+   * Create a configuration, possibly patching in S3Guard options.
+   *
+   * @return a configuration
+   */
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    maybeEnableS3Guard(conf);
+    return conf;
+  }
+
+  @Test
+  public void testNativeCopyCapability() throws Throwable {
+    describe("Test native copy capability");
+
+    // Check for native copy support
+    boolean nativeCopySupported = fs.hasPathCapability(srcFile, FS_NATIVE_COPY);
+    assertTrue("s3a has to support native file copy",
+        nativeCopySupported);
+  }
+
+  @Test
+  public void testCopyAcrossSchemes() throws Throwable {
+    describe("Test native file copy with different schemes");
+
+    URI src = URI.create("s3a://testbucket/sample.txt");
+    URI dst = URI.create("hdfs://testhdfs/sample.txt");
+
+    handleExpectedException(intercept(IllegalArgumentException.class,
+        () -> fs.copyFile(src, dst).get()));
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/resources/contract/s3a.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/contract/s3a.xml
@@ -127,4 +127,9 @@
     <value>true</value>
   </property>
 
+  <property>
+    <name>fs.contract.supports-native-copy</name>
+    <value>true</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
This is subtask of HADOOP-16604 which aims to provide copy functionality for cloud native applications. Intent of this PR is to provide copyFile(URI src, URI dst) functionality for S3AFileSystem (HADOOP-16629).

Creating new PR due to a merge mess up in https://github.com/apache/hadoop/pull/1591.

Changes w.r.t PR:1591:

1. Fixed doc (filesystem.md)
2. Fixed AbstractContractCopyTest.
3. If file already exists in destination, it would overwrite dest file.
4. Added CompletableFuture support. `public CompletableFuture<Void> copyFile(URI srcFile, URI dstFile)`

CompletableFuture makes the API nicer. However, `CompletableFuture::get --> waitingAndGet` invokes `Runtime.getAvailableProcessors` frequently. This can turn out
to be expensive native call depending on workload. We can optimise this later, if it turns out to be an issue.

If the destination bucket is different, relevant persmissions/policies have to be already setup, without which it would throw exceptions. Providing URI instead of path, makes it easier to mention different buckets on need basis. Since this is yet to stabilize in implemetation, we can make relevant changes in the store. 

Testing was done in region=us-west-2 on my local laptop. Contract tests and huge file tests passed . Other tests are still running and I will post the results. (ITestS3AContractRename failed, but not related to this patch)