### PR TITLE
YARN-9913. In YARN ui2 attempt container tab, The Container's ElapsedTime of  running Application is incorrect when the browser and the yarn server are in different timezons.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/components/timeline-view.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/components/timeline-view.js
@@ -455,7 +455,7 @@ export default Ember.Component.extend({
     }, {
       id: 'elapsedTime',
       headerTitle: 'Elapsed Time',
-      contentPath: 'elapsedTime'
+      contentPath: 'formattedElapsedTime'
     }, {
       id: 'priority',
       headerTitle: 'Priority',

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-container.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/models/yarn-container.js
@@ -26,6 +26,7 @@ export default DS.Model.extend({
   priority: DS.attr('number'),
   startedTime: DS.attr('number'),
   finishedTime: DS.attr('number'),
+  elapsedTime: DS.attr('number'),
   logUrl: DS.attr('string'),
   containerExitStatus: DS.attr('number'),
   containerState: DS.attr('string'),
@@ -49,18 +50,14 @@ export default DS.Model.extend({
     return this.get("finishedTime");
   }.property("finishedTime"),
 
-  elapsedTime: function() {
-    var elapsedMs = this.get("finishedTs") - this.get("startTs");
-    if (elapsedMs <= 0) {
-      elapsedMs = Date.now() - this.get("startTs");
-    }
-    return Converter.msToElapsedTimeUnit(elapsedMs);
-  }.property(),
+  formattedElapsedTime: function() {
+    return Converter.msToElapsedTimeUnit(this.get("elapsedTime"));
+  }.property("elapsedTime"),
 
   tooltipLabel: function() {
     return "<p>Id:" + this.get("id") +
            "</p><p>ElapsedTime:" +
-           String(this.get("elapsedTime")) + "</p>";
+           String(this.get("formattedElapsedTime")) + "</p>";
   }.property(),
 
   masterNodeURL: function() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/components/container-table.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/components/container-table.hbs
@@ -30,7 +30,7 @@
     {{/if}}
     <tr>
       <td>Elapsed Time</td>
-      <td>{{container.elapsedTime}}</td>
+      <td>{{container.formattedElapsedTime}}</td>
     </tr>
     <tr>
       <td>Priority</td>


### PR DESCRIPTION
### what is the problem
In YARN ui2 attempt container tab, The Container's ElapsedTime of running Application is incorrect when the browser and the yarn server are in different timezons.

### how to fix
Use the RestAPI's returnValue ElapsedTime as the container‘s ElapsedTime. ( Instead of using Date.now() of the browser)