### PR TITLE
MAPREDUCE-7240.Exception 'Invalid event: TA_TOO_MANY_FETCH_FAILURE at…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -391,6 +391,12 @@ public abstract class TaskAttemptImpl implements
              TaskAttemptEventType.TA_FAILMSG,
              TaskAttemptEventType.TA_FAILMSG_BY_CLIENT))
 
+     // Transitions from SUCCESS_FINISHING_CONTAINER state to FAILED stat
+     // When the event TA_TOO_MANY_FETCH_FAILURE received
+    .addTransition(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        TaskAttemptStateInternal.FAILED,
+        TaskAttemptEventType.TA_TOO_MANY_FETCH_FAILURE,
+        new TooManyFetchFailureTransition())
      // Transitions from FAIL_FINISHING_CONTAINER state
      // When the container exits by itself, the notification of container
      // completed event will be routed via NM -> RM -> AM.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -1883,7 +1883,7 @@ public class TestTaskAttempt{
         TaskAttemptEventType.TA_DONE));
 
     assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER", 
+        "SUCCESS_FINISHING_CONTAINER",
         TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
         taImpl.getInternalState());
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -1870,6 +1870,31 @@ public class TestTaskAttempt{
             .build());
   }
 
+  @Test
+  public void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
+    MockEventHandler eventHandler = new MockEventHandler();
+    TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
+    TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
+        .getJobId(), 1, TaskType.REDUCE);
+    TaskAttemptId reduceTAId =
+        MRBuilderUtils.newTaskAttemptId(reducetaskId, 0);
+
+    taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
+        TaskAttemptEventType.TA_DONE));
+
+    assertEquals("Task attempt's internal state is not " +
+        "SUCCESS_FINISHING_CONTAINER", 
+        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState());
+
+    taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
+        reduceTAId, "Host"));
+    assertEquals("Task attempt is not in FAILED state",
+        TaskAttemptState.FAILED,
+        taImpl.getState());
+    assertFalse("InternalError occurred", eventHandler.internalError);
+  }
+
   private void setupTaskAttemptFinishingMonitor(
       EventHandler eventHandler, JobConf jobConf, AppContext appCtx) {
     TaskAttemptFinishingMonitor taskAttemptFinishingMonitor =


### PR DESCRIPTION
… SUCCESS_FINISHING_CONTAINER' cause job error

https://github.com/apache/hadoop/pull/1618
PR for trunk