### PR TITLE
HADOOP-16669. TestRawLocalFileSystemContract.testPermission fails if no native library

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestRawLocalFileSystemContract.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestRawLocalFileSystemContract.java
@@ -24,13 +24,14 @@ import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.StatUtils;
+import org.apache.hadoop.util.NativeCodeLoader;
 import org.apache.hadoop.util.Shell;
 
-import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,6 +129,8 @@ public class TestRawLocalFileSystemContract extends FileSystemContractBaseTest {
   @Test
   @SuppressWarnings("deprecation")
   public void testPermission() throws Exception {
+    assumeTrue("No native library",
+        NativeCodeLoader.isNativeCodeLoaded());
     Path testDir = getTestBaseDir();
     String testFilename = "teststat2File";
     Path path = new Path(testDir, testFilename);
@@ -146,11 +149,7 @@ public class TestRawLocalFileSystemContract extends FileSystemContractBaseTest {
     RawLocalFileSystem.DeprecatedRawLocalFileStatus fsNIO =
         new RawLocalFileSystem.DeprecatedRawLocalFileStatus(
             file, defaultBlockSize, rfs);
-    try {
-      fsNIO.loadPermissionInfoByNativeIO();
-    } catch (UnsatisfiedLinkError e) {
-      throw new AssumptionViolatedException("No native library", e);
-    }
+    fsNIO.loadPermissionInfoByNativeIO();
     RawLocalFileSystem.DeprecatedRawLocalFileStatus fsnonNIO =
         new RawLocalFileSystem.DeprecatedRawLocalFileStatus(
             file, defaultBlockSize, rfs);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestRawLocalFileSystemContract.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestRawLocalFileSystemContract.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.StatUtils;
 import org.apache.hadoop.util.Shell;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -145,7 +146,11 @@ public class TestRawLocalFileSystemContract extends FileSystemContractBaseTest {
     RawLocalFileSystem.DeprecatedRawLocalFileStatus fsNIO =
         new RawLocalFileSystem.DeprecatedRawLocalFileStatus(
             file, defaultBlockSize, rfs);
-    fsNIO.loadPermissionInfoByNativeIO();
+    try {
+      fsNIO.loadPermissionInfoByNativeIO();
+    } catch (UnsatisfiedLinkError e) {
+      throw new AssumptionViolatedException("No native library", e);
+    }
     RawLocalFileSystem.DeprecatedRawLocalFileStatus fsnonNIO =
         new RawLocalFileSystem.DeprecatedRawLocalFileStatus(
             file, defaultBlockSize, rfs);


### PR DESCRIPTION


Catches the first error and converts to a skip;
stack traces retained for the curious.

Change-Id: Id2fed3cde6fa86acf36f0e78766f707b2b3c2c5b

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
