### PR TITLE
YARN-9934. avoid submitting aggregator when app dir creation fail

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
@@ -288,6 +288,11 @@ public class LogAggregationService extends AbstractService implements
     // TODO Get the user configuration for the list of containers that need log
     // aggregation.
 
+    // avoid submitting aggregator when app dir creation fail
+    if (appDirException != null) {
+      throw appDirException;
+    }
+
     // Schedule the aggregator.
     Runnable aggregatorWrapper = new Runnable() {
       public void run() {
@@ -300,10 +305,6 @@ public class LogAggregationService extends AbstractService implements
       }
     };
     this.threadPool.execute(aggregatorWrapper);
-
-    if (appDirException != null) {
-      throw appDirException;
-    }
   }
 
   protected void closeFileSystems(final UserGroupInformation userUgi) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/LogAggregationService.java
@@ -290,6 +290,10 @@ public class LogAggregationService extends AbstractService implements
 
     // avoid submitting aggregator when app dir creation fail
     if (appDirException != null) {
+      // cleanup resources
+      appLogAggregators.remove(appId);
+      closeFileSystems(userUgi);
+
       throw appDirException;
     }
 


### PR DESCRIPTION
Before submiting a log aggreation runnable, LogAggregationService  will try to create the aggreated log dir.

In some case, it may fail(e.g dir num exceed max limit)


When it did failed and submitted to LogAggregationService, the runnable may run forever if some app statue flip misbehavior(e.g not handling application complete event rightfully,thus keeping appFinishing of AppLogAggregatorImpl be always true).

 
In our production(Version 2.7.3), this cause huge number of dangling aggregator(~400+ LogAggregationService threads alive for some node, in which nodemanager configured only 50+ vCPUs).


The patch try to early throw the creation exception, avoiding starting unnecessary log polling. 

Jira:[YARN-9934](https://issues.apache.org/jira/browse/YARN-9934)