### PR TITLE
MAPREDUCE-7247. Change the job attempt id‘s datatype from string to int in HistoryServerRest.html

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/site/markdown/HistoryServerRest.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/site/markdown/HistoryServerRest.md
@@ -432,7 +432,7 @@ jobAttempts:
 
 | Item | Data Type | Description |
 |:---- |:---- |:---- |
-| id | string | The job attempt id |
+| id | int | The job attempt id |
 | nodeId | string | The node id of the node the attempt ran on |
 | nodeHttpAddress | string | The node http address of the node the attempt ran on |
 | logsLink | string | The http link to the job attempt logs |


### PR DESCRIPTION
The Job Attempts API http://history-server-http-address:port/ws/v1/history/mapreduce/jobs/{jobid}/jobattempts document, In http://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/HistoryServerRest.html#Job_Attempts_API, change The job attempt id‘s datatype from string to int.