### PR TITLE
HADOOP-16742. Possible NPE in S3A MultiObjectDeleteSupport error handling.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/MultiObjectDeleteSupport.java
@@ -93,7 +93,7 @@ public final class MultiObjectDeleteSupport extends AbstractStoreOperation {
       String code = error.getCode();
       result.append(String.format("%s: %s: %s%n", code, error.getKey(),
           error.getMessage()));
-      if (exitCode.isEmpty() || ACCESS_DENIED.equals(code)) {
+      if (exitCode == null || exitCode.isEmpty() || ACCESS_DENIED.equals(code)) {
         exitCode = code;
       }
     }


### PR DESCRIPTION
I've hit an issue where a DeleteObjects request using LocalStack causes a NullPointerException in the translateDeleteException function. `error.getCode()` can return `null`, and if there is more than one error returned by `deleteException.getErrors()`, this will cause the NPE.