### PR TITLE
HADOOP-16685: FileSystem#listStatusIterator does not check if given path exists

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -2160,24 +2160,19 @@ public abstract class FileSystem extends Configured
     private DirectoryEntries entries;
     private int i = 0;
 
-    DirListingIterator(Path path) {
+    DirListingIterator(Path path) throws IOException {
       this.path = path;
+      this.entries = listStatusBatch(path, null);
     }
 
     @Override
     public boolean hasNext() throws IOException {
-      if (entries == null) {
-        fetchMore();
-      }
       return i < entries.getEntries().length ||
           entries.hasMore();
     }
 
     private void fetchMore() throws IOException {
-      byte[] token = null;
-      if (entries != null) {
-        token = entries.getToken();
-      }
+      byte[] token = entries.getToken();
       entries = listStatusBatch(path, token);
       i = 0;
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
@@ -280,6 +280,14 @@ public abstract class AbstractContractGetFileStatusTest extends
   }
 
   @Test
+  public void testListStatusIteratorNoDir() throws Throwable {
+    describe("test the listStatusIterator call on a path which is not " +
+        "present");
+    intercept(FileNotFoundException.class,
+        () -> getFileSystem().listStatusIterator(path("missing")));
+  }
+
+  @Test
   public void testLocatedStatusNoDir() throws Throwable {
     describe("test the LocatedStatus call on a path which is not present");
     intercept(FileNotFoundException.class,


### PR DESCRIPTION
[HADOOP-16685](https://issues.apache.org/jira/browse/HADOOP-16685): FileSystem#listStatusIterator does not check if given path exists

Changed `DirListingIterator` so that the constructor makes the first call to `listStatusBatch`. This is similar to what `FileSystem#listFiles` does. Added a contract test in `AbstractContractGetFileStatusTest.java` to validate that `listStatusIterator` throws a FNF exception if the given `Path` does not exist.