### PR TITLE
HADOOP-16684. Bucket info to add more on authoritative mode

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -1246,12 +1246,13 @@ public abstract class S3GuardTool extends Configured implements Tool {
               AUTHORITATIVE_PATH, "");
         final Collection<String> authoritativePaths
             = S3Guard.getAuthoritativePaths(fs);
-        if (!authoritativePaths.isEmpty())
+        if (!authoritativePaths.isEmpty()) {
           println(out, "Qualified Authoritative Paths:");
-        for (String path : authoritativePaths) {
-          println(out, "\t%s", path);
+          for (String path : authoritativePaths) {
+            println(out, "\t%s", path);
+          }
+          println(out, "");
         }
-        println(out, "");
         authMode = conf.getBoolean(METADATASTORE_AUTHORITATIVE, false);
         final long ttl = conf.getTimeDuration(METADATASTORE_METADATA_TTL,
             DEFAULT_METADATASTORE_METADATA_TTL, TimeUnit.MILLISECONDS);
@@ -1296,8 +1297,8 @@ public abstract class S3GuardTool extends Configured implements Tool {
             + " -this is slow and potentially unsafe");
         break;
       case InternalCommitterConstants.COMMITTER_NAME_STAGING:
-        println(out,
-            "The 'staging' committer is used -prefer the 'directory' committer");
+        println(out, "The 'staging' committer is used "
+            + "-prefer the 'directory' committer");
         // fall through
       case COMMITTER_NAME_DIRECTORY:
         // fall through

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -1255,7 +1255,7 @@ public abstract class S3GuardTool extends Configured implements Tool {
         authMode = conf.getBoolean(METADATASTORE_AUTHORITATIVE, false);
         final long ttl = conf.getTimeDuration(METADATASTORE_METADATA_TTL,
             DEFAULT_METADATASTORE_METADATA_TTL, TimeUnit.MILLISECONDS);
-        println(out, "\t%s: %s=%s milliseconds", METADATASTORE_METADATA_TTL,
+        println(out, "\tMetadata time to live: %s=%s milliseconds",
             METADATASTORE_METADATA_TTL, ttl);
         printStoreDiagnostics(out, store);
       } else {


### PR DESCRIPTION
-it also adds a lot on committers based on the chosen committer.
-layout tuning

```
Location: eu-west-1
Filesystem s3a://hwdev-steve-ireland-new is using S3Guard with store DynamoDBMetadataStore{region=eu-west-1, tableName=hwdev-steve-ireland-new, tableArn=arn:aws:dynamodb:eu-west-1:980678866538:table/hwdev-steve-ireland-new}
Authoritative Metadata Store: fs.s3a.metadatastore.authoritative=false
Authoritative Path: fs.s3a.authoritative.path=/tables
Qualified Authoritative Paths:
	s3a://hwdev-steve-ireland-new/tables/

	Metadata time to live: fs.s3a.metadatastore.metadata.ttl=900000 milliseconds
Metadata Store Diagnostics:
	ARN=arn:aws:dynamodb:eu-west-1:980678866538:table/hwdev-steve-ireland-new
	billing-mode=per-request
	description=S3Guard metadata store in DynamoDB
	name=hwdev-steve-ireland-new
	persist.authoritative.bit=true
	read-capacity=0
	region=eu-west-1
	retryPolicy=ExponentialBackoffRetry(maxRetries=9, sleepTime=250 MILLISECONDS)
	size=32261
	status=ACTIVE
	table={AttributeDefinitions: [{AttributeName: child,AttributeType: S}, {AttributeName: parent,AttributeType: S}],TableName: hwdev-steve-ireland-new,KeySchema: [{AttributeName: parent,KeyType: HASH}, {AttributeName: child,KeyType: RANGE}],TableStatus: ACTIVE,CreationDateTime: Wed Oct 02 18:51:07 BST 2019,ProvisionedThroughput: {NumberOfDecreasesToday: 0,ReadCapacityUnits: 0,WriteCapacityUnits: 0},TableSizeBytes: 32261,ItemCount: 219,TableArn: arn:aws:dynamodb:eu-west-1:980678866538:table/hwdev-steve-ireland-new,TableId: 9b81d364-bef0-4ce0-afb8-c8115c473903,BillingModeSummary: {BillingMode: PAY_PER_REQUEST,LastUpdateToPayPerRequestDateTime: Wed Oct 02 18:51:07 BST 2019},}
	write-capacity=0

S3A Client
	Signing Algorithm: fs.s3a.signing-algorithm=(unset)
	Endpoint: fs.s3a.endpoint=s3-eu-west-1.amazonaws.com
	Encryption: fs.s3a.server-side-encryption-algorithm=SSE-KMS
	Input seek policy: fs.s3a.experimental.input.fadvise=normal
	Change Detection Source: fs.s3a.change.detection.source=etag
	Change Detection Mode: fs.s3a.change.detection.mode=server

S3A Committers
	The "magic" committer is supported in the filesystem
	S3A Committer factory class: mapreduce.outputcommitter.factory.scheme.s3a=org.apache.hadoop.fs.s3a.commit.S3ACommitterFactory
	S3A Committer name: fs.s3a.committer.name=directory
	Cluster filesystem staging directory: fs.s3a.committer.staging.tmp.path=tmp/staging
	Local filesystem buffer directory: fs.s3a.buffer.dir=/tmp/hadoop-stevel/s3a
	File conflict resolution: fs.s3a.committer.staging.conflict-mode=append

Security
	Delegation Support enabled: token kind = S3ADelegationToken/Session
	Hadoop security mode: SIMPLE
```
