### PR TITLE
Hadoop 16687: Fix testcase added for HADOOP-16138 for namespace enabled account

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -56,8 +56,7 @@ public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
     FsShell fsShell = new FsShell(rawConf);
 
     int result = fsShell.run(new String[] {"-mkdir",
-        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account
-            + "/testDirOnRoot"});
+        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account + "/"});
 
     assertEquals(1, result);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -49,20 +49,15 @@ public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
   @Test
   public void testMkdirRootNonExistentContainer() throws Exception {
     final Configuration rawConf = getRawConfiguration();
-    FsShell fsShell = new FsShell(rawConf);
-    final String account =
-        rawConf.get(FS_AZURE_ABFS_ACCOUNT_NAME, null);
-
-    String nonExistentContainer = "nonexistent-" + UUID.randomUUID();
-
-    // Disable creation of new filesystem
-    final AbfsConfiguration conf = getConfiguration();
-    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION,
+    final String account = rawConf.get(FS_AZURE_ABFS_ACCOUNT_NAME, null);
+    rawConf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION,
         false);
+    String nonExistentContainer = "nonexistent-" + UUID.randomUUID();
+    FsShell fsShell = new FsShell(rawConf);
 
-    int result = fsShell.run(new String[] { "-mkdir",
-        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account +
-            "/testDirOnRoot" });
+    int result = fsShell.run(new String[] {"-mkdir",
+        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account
+            + "/testDirOnRoot"});
 
     assertEquals(1, result);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -22,12 +22,11 @@ import java.util.UUID;
 
 import org.junit.Test;
 
-import org.apache.hadoop.fs.FsShell;
 import org.apache.hadoop.conf.Configuration;
-
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_SCHEME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
+import org.apache.hadoop.fs.FsShell;
 
 /**
  * Tests for Azure Blob FileSystem CLI.
@@ -36,8 +35,6 @@ public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
 
   public  ITestAzureBlobFileSystemCLI() throws Exception {
     super();
-    final AbfsConfiguration conf = getConfiguration();
-    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION, false);
   }
 
   /**
@@ -57,8 +54,14 @@ public class ITestAzureBlobFileSystemCLI extends AbstractAbfsIntegrationTest {
 
     String nonExistentContainer = "nonexistent-" + UUID.randomUUID();
 
+    // Disable creation of new filesystem
+    final AbfsConfiguration conf = getConfiguration();
+    conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION,
+        false);
+
     int result = fsShell.run(new String[] { "-mkdir",
-        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account + "/" });
+        ABFS_SCHEME + "://" + nonExistentContainer + "@" + account +
+            "/testDirOnRoot" });
 
     assertEquals(1, result);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCLI.java
@@ -23,10 +23,11 @@ import java.util.UUID;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FsShell;
+
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_SCHEME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
-import org.apache.hadoop.fs.FsShell;
 
 /**
  * Tests for Azure Blob FileSystem CLI.


### PR DESCRIPTION
Fixing the testcase by allowing the setup and teardown to handle creation and deletion of filesystems as expected. Moving the config to prevent filesystem creation inside the testcase which issues request to a non-existing filesystem. 