### PR TITLE
YARN-9958. Remove the invalid lock in ContainerExecutor

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/ContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/ContainerExecutor.java
@@ -34,8 +34,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.apache.hadoop.hdfs.protocol.datatransfer.IOStreamPair;
 import org.slf4j.Logger;
@@ -100,8 +98,6 @@ public abstract class ContainerExecutor implements Configurable {
   private final ConcurrentMap<ContainerId, Path> pidFiles =
       new ConcurrentHashMap<>();
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-  private final ReadLock readLock = lock.readLock();
-  private final WriteLock writeLock = lock.writeLock();
   private String[] whitelistVars;
 
   @Override
@@ -559,12 +555,7 @@ public abstract class ContainerExecutor implements Configurable {
    * @return the path of the pid-file for the given containerId.
    */
   protected Path getPidFilePath(ContainerId containerId) {
-    readLock.lock();
-    try {
-      return (this.pidFiles.get(containerId));
-    } finally {
-      readLock.unlock();
-    }
+    return this.pidFiles.get(containerId);
   }
 
   /**
@@ -710,12 +701,7 @@ public abstract class ContainerExecutor implements Configurable {
    * @return true if the container is active
    */
   protected boolean isContainerActive(ContainerId containerId) {
-    readLock.lock();
-    try {
-      return (this.pidFiles.containsKey(containerId));
-    } finally {
-      readLock.unlock();
-    }
+    return this.pidFiles.containsKey(containerId);
   }
 
   @VisibleForTesting
@@ -731,12 +717,7 @@ public abstract class ContainerExecutor implements Configurable {
    * of the launched process
    */
   public void activateContainer(ContainerId containerId, Path pidFilePath) {
-    writeLock.lock();
-    try {
-      this.pidFiles.put(containerId, pidFilePath);
-    } finally {
-      writeLock.unlock();
-    }
+    this.pidFiles.put(containerId, pidFilePath);
   }
 
   // LinuxContainerExecutor overrides this method and behaves differently.
@@ -767,12 +748,7 @@ public abstract class ContainerExecutor implements Configurable {
    * @param containerId the container ID
    */
   public void deactivateContainer(ContainerId containerId) {
-    writeLock.lock();
-    try {
-      this.pidFiles.remove(containerId);
-    } finally {
-      writeLock.unlock();
-    }
+    this.pidFiles.remove(containerId);
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-9958

ContainerExecutor has ReadLock and WriteLock. These used to call get/put method of ConcurrentMap. Due to the ConcurrentMap providing thread safety and atomicity guarantees, so we can remove the lock.