### PR TITLE
YARN-9973: Make history file cleaner robust

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
@@ -192,6 +192,8 @@ public class JobHistory extends AbstractService implements HistoryContext {
         hsManager.scanIntermediateDirectory();
       } catch (IOException e) {
         LOG.error("Error while scanning intermediate done dir ", e);
+      } catch (RuntimeException e) {
+        LOG.error("Error while scanning intermediate done dir ", e);
       }
     }
   }
@@ -202,6 +204,8 @@ public class JobHistory extends AbstractService implements HistoryContext {
       try {
         hsManager.clean();
       } catch (IOException e) {
+        LOG.warn("Error trying to clean up ", e);
+      } catch (RuntimeException e) {
         LOG.warn("Error trying to clean up ", e);
       }
       LOG.info("History Cleaner complete");


### PR DESCRIPTION
When we got exception below the thread in job historyserver will exit, we should catch runtime exception.
`xxx 2019-06-30,17:45:52,386 ERROR org.apache.hadoop.hdfs.server.namenode.ha.ZkConfiguredFailoverProxyProvider: Fail to get initial active Namenode informationjava.lang.RuntimeException: Fail to get active namenode from zookeeper
        at org.apache.hadoop.hdfs.server.namenode.ha.ZkConfiguredFailoverProxyProvider.getActiveNNIndex(ZkConfiguredFailoverProxyProvider.java:149)
        at org.apache.hadoop.hdfs.server.namenode.ha.ZkConfiguredFailoverProxyProvider.performFailover(ZkConfiguredFailoverProxyProvider.java:176)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:159)
        at $Proxy15.getListing(Unknown Source)
        at org.apache.hadoop.hdfs.DFSClient.listPaths(DFSClient.java:1996)
        at org.apache.hadoop.fs.Hdfs$DirListingIterator.<init>(Hdfs.java:211)
        at org.apache.hadoop.fs.Hdfs$DirListingIterator.<init>(Hdfs.java:198)
        at org.apache.hadoop.fs.Hdfs$2.<init>(Hdfs.java:180)
        at org.apache.hadoop.fs.Hdfs.listStatusIterator(Hdfs.java:180)
        at org.apache.hadoop.fs.FileContext$21.next(FileContext.java:1445)
        at org.apache.hadoop.fs.FileContext$21.next(FileContext.java:1440)
        at org.apache.hadoop.fs.FSLinkResolver.resolve(FSLinkResolver.java:90)
        at org.apache.hadoop.fs.FileContext.listStatus(FileContext.java:1440)
        at org.apache.hadoop.mapreduce.v2.hs.HistoryFileManager.scanDirectory(HistoryFileManager.java:739)
        at org.apache.hadoop.mapreduce.v2.hs.HistoryFileManager.scanDirectoryForHistoryFiles(HistoryFileManager.java:752)
        at org.apache.hadoop.mapreduce.v2.hs.HistoryFileManager.scanIntermediateDirectory(HistoryFileManager.java:806)
        at org.apache.hadoop.mapreduce.v2.hs.HistoryFileManager.access$200(HistoryFileManager.java:82)
        at org.apache.hadoop.mapreduce.v2.hs.HistoryFileManager$UserLogDir.scanIfNeeded(HistoryFileManager.java:280)
        at org.apache.hadoop.mapreduce.v2.hs.HistoryFileManager.scanIntermediateDirectory(HistoryFileManager.java:792)`