### PR TITLE
HADOOP-16728. Avoid removing all the channels from connectionInfo when borrowing from the pool

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/sftp/SFTPConnectionPool.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/sftp/SFTPConnectionPool.java
@@ -18,10 +18,7 @@
 package org.apache.hadoop.fs.sftp;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.hadoop.util.StringUtils;
 
@@ -45,7 +42,7 @@ class SFTPConnectionPool {
   private int liveConnectionCount = 0;
   private HashMap<ConnectionInfo, HashSet<ChannelSftp>> idleConnections =
       new HashMap<ConnectionInfo, HashSet<ChannelSftp>>();
-  private HashMap<ChannelSftp, ConnectionInfo> con2infoMap =
+  protected HashMap<ChannelSftp, ConnectionInfo> con2infoMap =
       new HashMap<ChannelSftp, ConnectionInfo>();
 
   SFTPConnectionPool(int maxConnection) {
@@ -60,7 +57,7 @@ class SFTPConnectionPool {
       Iterator<ChannelSftp> it = cons.iterator();
       if (it.hasNext()) {
         channel = it.next();
-        idleConnections.remove(info);
+        it.remove();
         return channel;
       } else {
         throw new IOException("Connection pool error.");
@@ -211,7 +208,13 @@ class SFTPConnectionPool {
   }
 
   public int getIdleCount() {
-    return this.idleConnections.size();
+    int c = 0;
+    for (Map.Entry<ConnectionInfo, HashSet<ChannelSftp>> entry : this.idleConnections.entrySet()) {
+      if (entry.getValue() != null) {
+        c += entry.getValue().size();
+      }
+    }
+    return c;
   }
 
   public int getLiveConnCount() {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/sftp/SFTPConnectionPool.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/sftp/SFTPConnectionPool.java
@@ -70,14 +70,17 @@ class SFTPConnectionPool {
    * @param channel
    */
   synchronized void returnToPool(ChannelSftp channel) {
-    ConnectionInfo info = con2infoMap.get(channel);
-    HashSet<ChannelSftp> cons = idleConnections.get(info);
-    if (cons == null) {
-      cons = new HashSet<ChannelSftp>();
-      idleConnections.put(info, cons);
-    }
-    cons.add(channel);
 
+    // do not return closed channels into the pool.
+    if (!channel.isClosed()) {
+      ConnectionInfo info = con2infoMap.get(channel);
+      HashSet<ChannelSftp> cons = idleConnections.get(info);
+      if (cons == null) {
+        cons = new HashSet<ChannelSftp>();
+        idleConnections.put(info, cons);
+      }
+      cons.add(channel);
+    }
   }
 
   /** Shutdown the connection pool and close all open connections. */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/sftp/SFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/sftp/SFTPFileSystem.java
@@ -158,7 +158,7 @@ public class SFTPFileSystem extends FileSystem {
    * @param client
    * @throws IOException
    */
-  private void disconnect(ChannelSftp channel) throws IOException {
+  void disconnect(ChannelSftp channel) throws IOException {
     connectionPool.disconnect(channel);
   }
 
@@ -507,6 +507,7 @@ public class SFTPFileSystem extends FileSystem {
     try {
       workDir = new Path(channel.pwd());
     } catch (SftpException e) {
+      disconnect(channel);
       throw new IOException(e);
     }
     Path absolute = makeAbsolute(workDir, f);
@@ -522,11 +523,12 @@ public class SFTPFileSystem extends FileSystem {
 
       is = channel.get(absolute.toUri().getPath());
     } catch (SftpException e) {
+      disconnect(channel);
       throw new IOException(e);
     }
 
     FSDataInputStream fis =
-        new FSDataInputStream(new SFTPInputStream(is, channel, statistics));
+        new FSDataInputStream(new SFTPInputStream(is, channel, this, statistics));
     return fis;
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/sftp/TestSFTPConnectionPool.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/sftp/TestSFTPConnectionPool.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.fs.sftp;
+
+import com.jcraft.jsch.ChannelSftp;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
+import static org.junit.Assert.*;
+
+public class TestSFTPConnectionPool {
+
+  @Rule public TestName name = new TestName();
+
+
+  @Test
+  public void testConnectionPool() throws Exception {
+
+    MockSFTPConnectionPool pool = new MockSFTPConnectionPool(2);
+    SFTPConnectionPool.ConnectionInfo info = new SFTPConnectionPool.ConnectionInfo("localhost", 1234, "user");
+    pool.manualAddToPool(new MockChannelSFTP(), info);
+    pool.manualAddToPool(new MockChannelSFTP(), info);
+
+    assertEquals(2, pool.getIdleCount());
+
+    ChannelSftp channel1FromPool = pool.getFromPool(info);
+    assertNotNull(channel1FromPool);
+
+    assertEquals(1, pool.getIdleCount());
+
+    ChannelSftp channel2FromPool = pool.getFromPool(info);
+    assertNotNull(channel2FromPool);
+
+    assertEquals(0, pool.getIdleCount());
+
+    ChannelSftp channel3FromPool = pool.getFromPool(info);
+    assertNull(channel3FromPool);
+
+  }
+
+  public static class MockSFTPConnectionPool extends SFTPConnectionPool {
+
+    MockSFTPConnectionPool(int maxConnection) {
+      super(maxConnection);
+    }
+
+    public void manualAddToPool(MockChannelSFTP channel, SFTPConnectionPool.ConnectionInfo info) {
+      this.con2infoMap.put(channel, info);
+      this.returnToPool(channel);
+    }
+  }
+  public static class MockChannelSFTP extends ChannelSftp {
+
+    @Override
+    public boolean isConnected() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
Please have a look at this bug. I added a test case to demonstrated the issue. Thanks