### PR TITLE
YARN-10020. Fix build instruction of hadoop-yarn-ui.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
@@ -21,7 +21,12 @@ The YARN UI is an Ember based web-app that provides visualization of the applica
 
 ## Configurations
 
-* You can point the UI to custom locations by setting the environment variables in `src/main/webapp/config/configs.env`
+You can point the UI to custom locations by setting the environment variables in `src/main/webapp/config/configs.env`.
+
+In order to access RM from UI started by `yarn start`,
+you need to enbale CORS by setting `hadoop.http.cross-origin.enabled` to true
+and adding `org.apache.hadoop.security.HttpCrossOriginFilterInitializer`
+to `hadoop.http.filter.initializers` in core-site.xml.
 
 ## Development
 
@@ -32,8 +37,21 @@ All the following commands must be run inside `src/main/webapp`.
 You will need the following things properly installed on your computer.
 
 * Install [Yarn](https://yarnpkg.com) v0.21.3
-* Install [Bower](http://bower.io/) v1.7.7
+* Install [Bower](http://bower.io/) v1.8.8
 * Install all dependencies by running `yarn install` & `bower install`
+
+Instead of manual installation, you can reuse locally installed Node.js,
+Yarn and Bower after building by maven with `-Pyarn-ui` in this directory.
+
+```
+$ mvn package -Pyarn-ui
+$ export PATH=$PWD/target/webapp/node:$PATH
+$ export YARNJS=$PWD/target/webapp/node/yarn/dist/bin/yarn.js
+$ cd src/main/webapp/
+$ node $YARNJS install
+$ node node_modules/.bin/bower install
+$ node $YARNJS start
+```
 
 ### Running UI
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
@@ -40,19 +40,6 @@ You will need the following things properly installed on your computer.
 * Install [Bower](http://bower.io/) v1.8.8
 * Install all dependencies by running `yarn install` & `bower install`
 
-Instead of manual installation, you can reuse locally installed Node.js,
-Yarn and Bower after building by maven with `-Pyarn-ui` in this directory.
-
-```
-$ mvn package -Pyarn-ui
-$ export PATH=$PWD/target/webapp/node:$PATH
-$ export YARNJS=$PWD/target/webapp/node/yarn/dist/bin/yarn.js
-$ cd src/main/webapp/
-$ node $YARNJS install
-$ node node_modules/.bin/bower install
-$ node $YARNJS start
-```
-
 ### Running UI
 
 * `yarn start`
@@ -80,3 +67,20 @@ YARN UI has replaced NPM with Yarn package manager. And hence Yarn would be used
 ### Adding new routes (pages), controllers, components etc.
 
 * Use ember-cli blueprint generator - [Ember CLI](http://ember-cli.com/extending/#generators-and-blueprints)
+
+### Building with Maven
+
+YARN-6278 added build profile using rontend-maven-plugin which
+automatically installs Node.js and Yarn locally under target/webapp directory.
+After building yarn-ui by `mvn package -Pyarn-ui`, you can reuse
+locally installed Node.js and Yarn instead of manually installing them.
+
+```
+$ mvn package -Pyarn-ui
+$ export PATH=$PWD/target/webapp/node:$PATH
+$ export YARNJS=$PWD/target/webapp/node/yarn/dist/bin/yarn.js
+$ cd src/main/webapp/
+$ node $YARNJS install
+$ node node_modules/.bin/bower install
+$ node $YARNJS start
+```

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
@@ -70,7 +70,8 @@ YARN UI has replaced NPM with Yarn package manager. And hence Yarn would be used
 
 ### Building with Maven
 
-YARN-6278 added build profile using rontend-maven-plugin which
+[YARN-6278](https://issues.apache.org/jira/browse/YARN-6278)
+added build profile using rontend-maven-plugin which
 automatically installs Node.js and Yarn locally under target/webapp directory.
 After building yarn-ui by `mvn package -Pyarn-ui`, you can reuse
 locally installed Node.js and Yarn instead of manually installing them.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
@@ -71,7 +71,7 @@ YARN UI has replaced NPM with Yarn package manager. And hence Yarn would be used
 ### Building with Maven
 
 [YARN-6278](https://issues.apache.org/jira/browse/YARN-6278)
-added build profile using rontend-maven-plugin which
+added build profile using frontend-maven-plugin which
 automatically installs Node.js and Yarn locally under target/webapp directory.
 After building yarn-ui by `mvn package -Pyarn-ui`, you can reuse
 locally installed Node.js and Yarn instead of manually installing them.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/README.md
@@ -23,10 +23,11 @@ The YARN UI is an Ember based web-app that provides visualization of the applica
 
 You can point the UI to custom locations by setting the environment variables in `src/main/webapp/config/configs.env`.
 
-In order to access RM from UI started by `yarn start`,
-you need to enbale CORS by setting `hadoop.http.cross-origin.enabled` to true
+In order to make the UI running on Ember server (started by `yarn start`)
+work with independently running ResouceManager,
+you need to enable CORS by setting `hadoop.http.cross-origin.enabled` to true
 and adding `org.apache.hadoop.security.HttpCrossOriginFilterInitializer`
-to `hadoop.http.filter.initializers` in core-site.xml.
+to `hadoop.http.filter.initializers` in core-site.xml of the ResourceManager.
 
 ## Development
 
@@ -71,10 +72,11 @@ YARN UI has replaced NPM with Yarn package manager. And hence Yarn would be used
 ### Building with Maven
 
 [YARN-6278](https://issues.apache.org/jira/browse/YARN-6278)
-added build profile using frontend-maven-plugin which
+added `yarn-ui` profile to pom.xml leveraging
+[frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin) which
 automatically installs Node.js and Yarn locally under target/webapp directory.
 After building yarn-ui by `mvn package -Pyarn-ui`, you can reuse
-locally installed Node.js and Yarn instead of manually installing them.
+the locally installed Node.js and Yarn instead of manually installing them.
 
 ```
 $ mvn package -Pyarn-ui


### PR DESCRIPTION
We don't need to manually install package managers such as yarn and bower as described in README.md since frontend-maven-plugin was introduced by YARN-6278.

https://issues.apache.org/jira/browse/YARN-10020