### PR TITLE
HDFS-15058. Enlarge the sleep time of Fsck tests for checking corrupt files

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
@@ -1157,7 +1157,7 @@ public class TestFsck {
         .listCorruptFileBlocks("/corruptData", null);
     int numCorrupt = corruptFileBlocks.getFiles().length;
     while (numCorrupt == 0) {
-      Thread.sleep(1000);
+      Thread.sleep(5000);
       corruptFileBlocks = namenode
           .listCorruptFileBlocks("/corruptData", null);
       numCorrupt = corruptFileBlocks.getFiles().length;
@@ -2154,7 +2154,7 @@ public class TestFsck {
         .listCorruptFileBlocks("/corruptData", null);
     int numCorrupt = corruptFileBlocks.getFiles().length;
     while (numCorrupt == 0) {
-      Thread.sleep(1000);
+      Thread.sleep(5000);
       corruptFileBlocks = namenode
           .listCorruptFileBlocks("/corruptData", null);
       numCorrupt = corruptFileBlocks.getFiles().length;


### PR DESCRIPTION
The testFsckListCorruptFilesBlocks and testFsckListCorruptSnapshotFiles
tests are easy to fail, because it will check the number of corrupt files
which is unequal to expected sometimes. It is mainly because the waiting
time before checking the corrupt files is too short.
