### PR TITLE
HADOOP-16767 Handle non-IO exceptions in reopen()

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -576,7 +576,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
           // and an abort is triggered, the initial attempt's statistics
           // aren't collected.
           streamStatistics.streamClose(false, drained);
-        } catch (IOException e) {
+        } catch (Exception e) {
           // exception escalates to an abort
           LOG.debug("When closing {} stream for {}", uri, reason, e);
           shouldAbort = true;


### PR DESCRIPTION
Catch Exception instead of IOException in closeStream() to handle exceptions such as SdkClientException properly.

Jira Issue: https://issues.apache.org/jira/browse/HADOOP-16767