### PR TITLE
YARN-10041. Create tmp socket file under /tmp for CSI tests

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.csi.client;
 
 import csi.v0.Csi;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -39,20 +40,15 @@ public class TestCsiClient {
   private static FakeCsiDriver driver = null;
 
   @BeforeClass
-  public static void setUp() throws IOException {
+  public static void setUp() {
     socketFile = new File("/tmp", "yarn-csi-test.sock");
     domainSocket = "unix://" + socketFile.getAbsolutePath();
     driver = new FakeCsiDriver(domainSocket);
   }
 
   @AfterClass
-  public static void tearDown() throws IOException {
-    if (socketFile != null && socketFile.exists()) {
-      if (!socketFile.delete()) {
-        String message = "Unable to delete file " + socketFile + ".";
-        throw new IOException(message);
-      }
-    }
+  public static void tearDown() throws IOException{
+    FileUtils.forceDelete(socketFile);
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.csi.client;
 
 import csi.v0.Csi;
 import org.apache.commons.io.FileUtils;
-import org.apache.curator.shaded.com.google.common.io.Files;
+import com.google.common.io.Files;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.csi.client;
 
 import csi.v0.Csi;
 import org.apache.commons.io.FileUtils;
+import org.apache.curator.shaded.com.google.common.io.Files;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -35,20 +36,24 @@ import java.io.IOException;
  */
 public class TestCsiClient {
 
-  private static File socketFile = null;
+  private static File testRoot = null;
   private static String domainSocket = null;
   private static FakeCsiDriver driver = null;
 
   @BeforeClass
-  public static void setUp() {
-    socketFile = new File("/tmp", "yarn-csi-test.sock");
-    domainSocket = "unix://" + socketFile.getAbsolutePath();
+  public static void setUp() throws IOException {
+    testRoot = Files.createTempDir();
+    File socketPath = new File(testRoot, "csi.sock");
+    FileUtils.forceMkdirParent(socketPath);
+    domainSocket = "unix://" + socketPath.getAbsolutePath();
     driver = new FakeCsiDriver(domainSocket);
   }
 
   @AfterClass
-  public static void tearDown() throws IOException{
-    FileUtils.forceDelete(socketFile);
+  public static void tearDown() throws IOException {
+    if (testRoot != null) {
+      FileUtils.deleteDirectory(testRoot);
+    }
   }
 
   @Before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.yarn.csi.client;
 
 import csi.v0.Csi;
-import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -36,7 +34,6 @@ import java.io.IOException;
  */
 public class TestCsiClient {
 
-  private static File testRoot = null;
   private static File socketFile = null;
   private static String domainSocket = null;
   private static FakeCsiDriver driver = null;
@@ -50,8 +47,11 @@ public class TestCsiClient {
 
   @AfterClass
   public static void tearDown() throws IOException {
-    if (testRoot != null) {
-      FileUtils.deleteDirectory(testRoot);
+    if (socketFile != null && socketFile.exists()) {
+      if (!socketFile.delete()) {
+        String message = "Unable to delete file " + socketFile + ".";
+        throw new IOException(message);
+      }
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -37,15 +37,14 @@ import java.io.IOException;
 public class TestCsiClient {
 
   private static File testRoot = null;
+  private static File socketFile = null;
   private static String domainSocket = null;
   private static FakeCsiDriver driver = null;
 
   @BeforeClass
   public static void setUp() throws IOException {
-    testRoot = GenericTestUtils.getTestDir("csi-test");
-    File socketPath = new File(testRoot, "csi.sock");
-    FileUtils.forceMkdirParent(socketPath);
-    domainSocket = "unix://" + socketPath.getAbsolutePath();
+    socketFile = new File("/tmp", "yarn-csi-test.sock");
+    domainSocket = "unix://" + socketFile.getAbsolutePath();
     driver = new FakeCsiDriver(domainSocket);
   }
 


### PR DESCRIPTION
As the issue described, it is easy to exceed the UNIX_PATH_MAX limit if
we create the CSI test socket file under the test code dicrectory.

