### PR TITLE
HADOOP-16826. ABFS: update abfs.md to include config keys for identity transformation

### DIFF
--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -859,9 +859,9 @@ signon page for humans, even though it is a machine calling.
 
 ### `java.io.IOException: The ownership on the staging directory /tmp/hadoop-yarn/staging/user1/.staging is not as expected. It is owned by <principal_id>. The directory must be owned by the submitter user1 or user1`
 
-When using [Azure Managed Identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), the files/directories in ADLS Gen2 are by default owned by the service principal object id i.e. principal ID & submitting jobs as the local OS user 'user1' results in the above exception. 
+When using [Azure Managed Identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), the files/directories in ADLS Gen2 are by default owned by the service principal object id i.e. principal ID & submitting jobs as the local OS user 'user1' results in the above exception.
 
-The following configurations have to be added to core-site.xml to resolve this issue   
+The following configurations have to be added to core-site.xml to resolve this issue
 
 ```
 <property>

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -863,36 +863,34 @@ When using [Azure Managed Identities](https://docs.microsoft.com/en-us/azure/act
 
 The following configurations have to be added to core-site.xml to resolve this issue
 
-```
+```xml
 <property>
   <name>fs.azure.identity.transformer.service.principal.id</name>
   <value>service principal object id</value>
   <description>
-    An Azure Active Directory object ID (oid) used as the replacement for names contained
-    in the list specified by “fs.azure.identity.transformer.service.principal.substitution.list”.
-    Notice that instead of setting oid, you can also set $superuser here.
+  An Azure Active Directory object ID (oid) used as the replacement for names contained
+  in the list specified by “fs.azure.identity.transformer.service.principal.substitution.list”.
+  Notice that instead of setting oid, you can also set $superuser here.
   </description>
 </property>
-
 <property>
   <name>fs.azure.identity.transformer.service.principal.substitution.list</name>
   <value>user1</value>
   <description>
-    A comma separated list of names to be replaced with the service principal ID specified by
-    “fs.azure.identity.transformer.service.principal.id”.  This substitution occurs
-    when setOwner, setAcl, modifyAclEntries, or removeAclEntries are invoked with identities
-    contained in the substitution list. Notice that when in non-secure cluster, asterisk symbol *
-    can be used to match all user/group.
+  A comma separated list of names to be replaced with the service principal ID specified by
+  “fs.azure.identity.transformer.service.principal.id”.  This substitution occurs
+  when setOwner, setAcl, modifyAclEntries, or removeAclEntries are invoked with identities
+  contained in the substitution list. Notice that when in non-secure cluster, asterisk symbol *
+  can be used to match all user/group.
   </description>
 </property>
-
 <property>
   <name>fs.azure.use.upn</name>
   <value>true</value>
   <description>
-    User principal names (UPNs) have the format “{alias}@{domain}”. If true,
-    only {alias} is included when a UPN would otherwise appear in the output
-    of APIs like getFileStatus, getOwner, getAclStatus, etc. Default is false.
+  User principal names (UPNs) have the format “{alias}@{domain}”. If true,
+  only {alias} is included when a UPN would otherwise appear in the output
+  of APIs like getFileStatus, getOwner, getAclStatus, etc. Default is false.
   </description>
 </property>
 ```

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -859,9 +859,9 @@ signon page for humans, even though it is a machine calling.
 
 ### `java.io.IOException: The ownership on the staging directory /tmp/hadoop-yarn/staging/user1/.staging is not as expected. It is owned by <principal_id>. The directory must be owned by the submitter user1 or user1`
 
-When using [Azure Managed Identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), the files/directories in ADLS Gen2 are by default owned by the service principal object id i.e. principal ID & submitting jobs as the local OS user 'user1' results in the above exception.
+When using [Azure Managed Identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), the files/directories in ADLS Gen2 by default will be owned by the service principal object id i.e. principal ID & submitting jobs as the local OS user 'user1' results in the above exception.
 
-The following configurations have to be added to core-site.xml to resolve this issue
+The fix is to mimic the ownership to the local OS user, by adding the below properties to`core-site.xml`.
 
 ```xml
 <property>
@@ -882,15 +882,6 @@ The following configurations have to be added to core-site.xml to resolve this i
   when setOwner, setAcl, modifyAclEntries, or removeAclEntries are invoked with identities
   contained in the substitution list. Notice that when in non-secure cluster, asterisk symbol *
   can be used to match all user/group.
-  </description>
-</property>
-<property>
-  <name>fs.azure.use.upn</name>
-  <value>true</value>
-  <description>
-  User principal names (UPNs) have the format “{alias}@{domain}”. If true,
-  only {alias} is included when a UPN would otherwise appear in the output
-  of APIs like getFileStatus, getOwner, getAclStatus, etc. Default is false.
   </description>
 </property>
 ```

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -857,6 +857,48 @@ signon page for humans, even though it is a machine calling.
 1. The URL is wrong —it is pointing at a web page unrelated to OAuth2.0
 1. There's a proxy server in the way trying to return helpful instructions.
 
+### `java.io.IOException: The ownership on the staging directory /tmp/hadoop-yarn/staging/user1/.staging is not as expected. It is owned by <principal_id>. The directory must be owned by the submitter user1 or user1`
+
+When using [Azure Managed Identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), the files/directories in ADLS Gen2 are by default owned by the service principal object id i.e. principal ID & submitting jobs as the local OS user 'user1' results in the above exception. 
+
+The following configurations have to be added to core-site.xml to resolve this issue   
+
+```
+<property>
+  <name>fs.azure.identity.transformer.service.principal.id</name>
+  <value>service principal object id</value>
+  <description>
+    An Azure Active Directory object ID (oid) used as the replacement for names contained
+    in the list specified by “fs.azure.identity.transformer.service.principal.substitution.list”.
+    Notice that instead of setting oid, you can also set $superuser here.
+  </description>
+</property>
+
+<property>
+  <name>fs.azure.identity.transformer.service.principal.substitution.list</name>
+  <value>user1</value>
+  <description>
+    A comma separated list of names to be replaced with the service principal ID specified by
+    “fs.azure.identity.transformer.service.principal.id”.  This substitution occurs
+    when setOwner, setAcl, modifyAclEntries, or removeAclEntries are invoked with identities
+    contained in the substitution list. Notice that when in non-secure cluster, asterisk symbol *
+    can be used to match all user/group.
+  </description>
+</property>
+
+<property>
+  <name>fs.azure.use.upn</name>
+  <value>true</value>
+  <description>
+    User principal names (UPNs) have the format “{alias}@{domain}”. If true,
+    only {alias} is included when a UPN would otherwise appear in the output
+    of APIs like getFileStatus, getOwner, getAclStatus, etc. Default is false.
+  </description>
+</property>
+```
+
+Once the above properties are configured, `hdfs dfs -ls abfs://container1@abfswales1.dfs.core.windows.net/` shows the ADLS Gen2 files/directories are now owned by 'user1'.
+
 ## <a name="testing"></a> Testing ABFS
 
 See the relevant section in [Testing Azure](testing_azure.html).


### PR DESCRIPTION
In this PR, I have updated the `abfs.md` to include some key configurations required when submitting jobs to YARN using hadoop-azure module. Currently, these properties aren't documented anywhere in Apache Hadoop. I have them included under 'Troubleshooting' section of `abfs.md`, please review and also let me know if you think they need to be documented elsewhere?  
As the PR is only an update to the existing doc I have not opened any JIRA ticket, let me know if you think a JIRA is still required? 

Many thanks!

