### PR TITLE
MAPREDUCE-7255: fix typo in MapReduce documentaion example

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/MapReduceTutorial.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/MapReduceTutorial.md
@@ -1097,7 +1097,7 @@ Sure enough, the output:
     goodbye 1
     hadoop 2
     hello 2
-    horld 2
+    world 2
 
 #### Highlights
 


### PR DESCRIPTION
Fix for typo in MapReduce documentation example (https://issues.apache.org/jira/browse/MAPREDUCE-7255)

<img width="353" alt="68159611-c93f0200-ff5a-11e9-9fe2-efa3e786fb22" src="https://user-images.githubusercontent.com/10631410/71770964-7f639f80-2f3c-11ea-920d-2792297860b8.png">
