### PR TITLE
HADOOP-15887: Add an option to avoid writing data locally in Distcp

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -128,6 +128,10 @@ public final class DistCpConstants {
   public static final String CONF_LABEL_BLOCKS_PER_CHUNK =
       "distcp.blocks.per.chunk";
 
+  /** Whether DistCp Copy should avoid write on local datanode. */
+  public static final String CONF_LABEL_NO_LOCAL_WRITE =
+      "distcp.no.local.write";
+
   /**
    * Constants for DistCp return code to shell / consumer of ToolRunner's run
    */

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
@@ -178,6 +178,10 @@ public enum DistCpOptionSwitch {
       "Use target snapshot diff report to identify changes made on target"),
       2),
 
+  NO_LOCAL_WRITE(DistCpConstants.CONF_LABEL_NO_LOCAL_WRITE,
+      new Option("noLocalWrite", false,
+          "Avoid writing blocks on local Datanode.")),
+
   /**
    * Should DisctpExecution be blocking
    */

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
@@ -158,6 +158,9 @@ public final class DistCpOptions {
   /** Whether data should be written directly to the target paths. */
   private final boolean directWrite;
 
+  /** Whether DistCp Copy should avoid write on local datanode. */
+  private final boolean noLocalWrite;
+
   /**
    * File attributes for preserve.
    *
@@ -221,6 +224,7 @@ public final class DistCpOptions {
     this.trackPath = builder.trackPath;
 
     this.directWrite = builder.directWrite;
+    this.noLocalWrite = builder.noLocalWrite;
   }
 
   public Path getSourceFileListing() {
@@ -352,6 +356,10 @@ public final class DistCpOptions {
     return directWrite;
   }
 
+  public boolean shouldNoLocalWrite() {
+    return noLocalWrite;
+  }
+
   /**
    * Add options to configuration. These will be used in the Mapper/committer
    *
@@ -402,6 +410,8 @@ public final class DistCpOptions {
     }
     DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.DIRECT_WRITE,
             String.valueOf(directWrite));
+    DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.NO_LOCAL_WRITE,
+            String.valueOf(noLocalWrite));
   }
 
   /**
@@ -439,6 +449,7 @@ public final class DistCpOptions {
         ", copyBufferSize=" + copyBufferSize +
         ", verboseLog=" + verboseLog +
         ", directWrite=" + directWrite +
+        ", noLocalWrite=" + noLocalWrite +
         '}';
   }
 
@@ -489,6 +500,7 @@ public final class DistCpOptions {
             DistCpConstants.COPY_BUFFER_SIZE_DEFAULT;
 
     private boolean directWrite = false;
+    private boolean noLocalWrite = false;
 
     public Builder(List<Path> sourcePaths, Path targetPath) {
       Preconditions.checkArgument(sourcePaths != null && !sourcePaths.isEmpty(),
@@ -745,6 +757,11 @@ public final class DistCpOptions {
 
     public Builder withDirectWrite(boolean newDirectWrite) {
       this.directWrite = newDirectWrite;
+      return this;
+    }
+
+    public Builder withNoLocalWrite(boolean newNoLocalWrite) {
+      this.noLocalWrite = newNoLocalWrite;
       return this;
     }
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
@@ -115,7 +115,9 @@ public class OptionsParser {
         .withVerboseLog(
             command.hasOption(DistCpOptionSwitch.VERBOSE_LOG.getSwitch()))
         .withDirectWrite(
-            command.hasOption(DistCpOptionSwitch.DIRECT_WRITE.getSwitch()));
+            command.hasOption(DistCpOptionSwitch.DIRECT_WRITE.getSwitch()))
+        .withNoLocalWrite(
+            command.hasOption(DistCpOptionSwitch.NO_LOCAL_WRITE.getSwitch()));
 
     if (command.hasOption(DistCpOptionSwitch.DIFF.getSwitch())) {
       String[] snapshots = getVals(command,

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyMapper.java
@@ -85,6 +85,7 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
   private boolean append = false;
   private boolean verboseLog = false;
   private boolean directWrite = false;
+  private boolean noLocalWrite = false;
   private EnumSet<FileAttribute> preserve = EnumSet.noneOf(FileAttribute.class);
 
   private FileSystem targetFS = null;
@@ -114,7 +115,8 @@ public class CopyMapper extends Mapper<Text, CopyListingFileStatus, Text, Text> 
         PRESERVE_STATUS.getConfigLabel()));
     directWrite = conf.getBoolean(
         DistCpOptionSwitch.DIRECT_WRITE.getConfigLabel(), false);
-
+    noLocalWrite = conf.getBoolean(
+        DistCpOptionSwitch.NO_LOCAL_WRITE.getConfigLabel(), false);
     targetWorkPath = new Path(conf.get(DistCpConstants.CONF_LABEL_TARGET_WORK_PATH));
     Path targetFinalPath = new Path(conf.get(
             DistCpConstants.CONF_LABEL_TARGET_FINAL_PATH));

--- a/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
+++ b/hadoop-tools/hadoop-distcp/src/site/markdown/DistCp.md.vm
@@ -362,6 +362,7 @@ Command Line Options
 | `-copybuffersize <copybuffersize>` | Size of the copy buffer to use. By default, `<copybuffersize>` is set to 8192B | |
 | `-xtrack <path>` | Save information about missing source files to the specified path. | This option is only valid with `-update` option. This is an experimental property and it cannot be used with `-atomic` option. |
 | `-direct` | Write directly to destination paths | Useful for avoiding potentially very expensive temporary file rename operations when the destination is an object store |
+| `-noLocalWrite` | Write data to target cluster with data locality disabled. | If this option is set, the distcp task will not write data replication to local datanode to avoid datanode being imbalanced. This option is suggested to be specified when the data to copy is very large and the DistCp job runs on the target cluster. |
 
 Architecture of DistCp
 ----------------------

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
@@ -289,7 +289,7 @@ public class TestDistCpOptions {
         "atomicWorkPath=null, logPath=null, sourceFileListing=abc, " +
         "sourcePaths=null, targetPath=xyz, filtersFile='null', " +
         "blocksPerChunk=0, copyBufferSize=8192, verboseLog=false, " +
-        "directWrite=false}";
+        "directWrite=false, noLocalWrite=false}";
     String optionString = option.toString();
     Assert.assertEquals(val, optionString);
     Assert.assertNotSame(DistCpOptionSwitch.ATOMIC_COMMIT.toString(),

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestIntegration.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestIntegration.java
@@ -21,12 +21,18 @@ package org.apache.hadoop.tools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.Cluster;
 import org.apache.hadoop.mapreduce.JobSubmissionFiles;
 import org.apache.hadoop.tools.util.TestDistCpUtils;
+import org.apache.hadoop.util.Progressable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -39,6 +45,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 
 @RunWith(value = Parameterized.class)
@@ -511,7 +518,27 @@ public class TestIntegration {
       Assert.fail("testCleanup failed " + e.getMessage());
     }
   }
-  
+
+  @Test(timeout=100000)
+  public void testNoLocalWrite() {
+    try {
+      addEntries(listFile, "singlefile1/file1");
+      createFiles("singlefile1/file1", "target");
+
+      Configuration conf = new Configuration(getConf());
+      conf.set("fs.file.impl", MockFileSystem.class.getName());
+      conf.setBoolean("fs.file.impl.disable.cache", true);
+      runTest(listFile, target, false, false, false, false, true, conf);
+
+      checkResult(target, 1);
+    } catch (IOException e) {
+      LOG.error("Exception encountered while testing distcp", e);
+      Assert.fail("distcp failure");
+    } finally {
+      TestDistCpUtils.delete(fs, root);
+    }
+  }
+
   private void addEntries(Path listFile, String... entries) throws IOException {
     OutputStream out = fs.create(listFile);
     try {
@@ -556,15 +583,23 @@ public class TestIntegration {
     runTest(listFile, target, targetExists, sync, false, false);
   }
   
-  private void runTest(Path listFile, Path target, boolean targetExists, 
-      boolean sync, boolean delete,
-      boolean overwrite) throws IOException {
-    final DistCpOptions options = new DistCpOptions.Builder(listFile, target)
+  private void runTest(Path innerListFile, Path innerTarget,
+      boolean targetExists, boolean sync, boolean delete, boolean overwrite)
+      throws IOException {
+    runTest(innerListFile, innerTarget, targetExists, sync, delete, overwrite,
+        false, getConf());
+  }
+
+  private void runTest(Path innerListFile, Path innerTarget,
+      boolean targetExists, boolean sync, boolean delete, boolean overwrite,
+      boolean noLocalWrite, Configuration conf) throws IOException {
+    final DistCpOptions options =
+        new DistCpOptions.Builder(innerListFile, innerTarget)
         .withSyncFolder(sync)
         .withDeleteMissing(delete)
         .withOverwrite(overwrite)
         .withNumListstatusThreads(numListstatusThreads)
-        .build();
+        .withNoLocalWrite(noLocalWrite).build();
     try {
       final DistCp distCp = new DistCp(getConf(), options);
       distCp.context.setTargetPathExists(targetExists);
@@ -586,4 +621,21 @@ public class TestIntegration {
     }
   }
 
+  static class MockFileSystem extends LocalFileSystem {
+    MockFileSystem() {
+      super();
+    }
+
+    @Override
+    public FSDataOutputStream create(Path f, FsPermission permission,
+        EnumSet<CreateFlag> flags, int bufferSize, short replication,
+        long blockSize, Progressable progress, ChecksumOpt checksumOpt)
+        throws IOException {
+      // check flags in create-op should contain NO_LOCAL_WRITE
+      Assert.assertTrue(flags.contains(CreateFlag.NO_LOCAL_WRITE));
+      return super.create(f, permission, flags, bufferSize, replication,
+          blockSize, progress, checksumOpt);
+
+    }
+  }
 }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestOptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestOptionsParser.java
@@ -804,4 +804,18 @@ public class TestOptionsParser {
         "hdfs://localhost:8020/target/"});
     assertThat(options.getFiltersFile()).isEqualTo("/tmp/filters.txt");
   }
+
+  @Test
+  public void testParseNoLocalWrite() {
+    DistCpOptions options = OptionsParser.parse(new String[] {
+        "hdfs://localhost:8020/source/first",
+        "hdfs://localhost:8020/target/"});
+    Assert.assertEquals(options.shouldNoLocalWrite(), false);
+
+    options = OptionsParser.parse(new String[] {
+        "-noLocalWrite",
+        "hdfs://localhost:8020/source/first",
+        "hdfs://localhost:8020/target/"});
+    Assert.assertEquals(options.shouldNoLocalWrite(), true);
+  }
 }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/contract/AbstractContractDistCpTest.java
@@ -650,4 +650,22 @@ public abstract class AbstractContractDistCpTest
                     Collections.singletonList(srcDir), destDir)
                     .withDirectWrite(true)));
   }
+
+  @Test
+  public void testDistCpWithNoLocalWrite() throws Exception {
+    describe("test dictcp job compatibility with option: noLocalWrite");
+    Path target = distCpDeepDirectoryStructure(localFS, localDir, remoteFS,
+        remoteDir);
+    lsR("Local to update", localFS, localDir);
+    lsR("Remote before update", remoteFS, target);
+    Job job = runDistCp(buildWithStandardOptions(
+        new DistCpOptions.Builder(
+            Collections.singletonList(localDir), target)
+            .withDeleteMissing(true)
+            .withSyncFolder(true)
+            .withCRC(true)
+            .withOverwrite(false)
+            .withNoLocalWrite(true)));
+    assertTrue(job.isSuccessful());
+  }
 }


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/HDFS-3702 we add a flag in DFSClient to avoid replicating to the local datanode.  We can make use of this flag in Distcp.