### PR TITLE
HADOOP-16751. Followup: move java import.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DurationInfo.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DurationInfo.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.util;
 
+import java.util.function.Supplier;
+
 import org.slf4j.Logger;
 
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
-
-import java.util.function.Supplier;
 
 /**
  * A duration with logging of final state at info or debug


### PR DESCRIPTION
This moves the import of a java module to the preferred place in the import ordering.

I know this is minor but it's good to at least try to keep imports under control. If I'd noticed the problem earlier I'd have done the reordering during the commit process.

Change-Id: I1a594e3d954554a72c2b71c954eda0ae940a8f70
