### PR TITLE
HADOOP-16785. abfs close()

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.util.EnumSet;
 
@@ -155,4 +156,22 @@ public class ITestAzureBlobFileSystemCreate extends
       GenericTestUtils.assertExceptionContains(fnfe.getMessage(), inner);
     }
   }
+
+  /**
+   * Attempts to write to the azure stream after it is closed will raise
+   * an IOException.
+   */
+  @Test
+  public void testFilterFSWriteAfterClose() throws Throwable {
+    final AzureBlobFileSystem fs = getFileSystem();
+    Path testPath = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    FSDataOutputStream out = fs.create(testPath);
+    intercept(FileNotFoundException.class,
+        () -> {
+          try (FilterOutputStream fos = new FilterOutputStream(out)) {
+            fs.delete(testPath, false);
+          }
+        });
+  }
+
 }


### PR DESCRIPTION
Followup to #1791 

Add an extra test to verify FilterOutputStream close in try-with-resources

All seems good -tested azure cardiff

Change-Id: Iaa9c5f9602d7a4f0b8c9d8bd71f308c87e4d525a

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
