### PR TITLE
HADOOP-16823. Manage S3 Throttling exclusively in S3A client.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1698,7 +1698,7 @@
 
 <property>
   <name>fs.s3a.retry.throttle.limit</name>
-  <value>${fs.s3a.attempts.maximum}</value>
+  <value>20</value>
   <description>
     Number of times to retry any throttled request.
   </description>
@@ -1706,9 +1706,13 @@
 
 <property>
   <name>fs.s3a.retry.throttle.interval</name>
-  <value>1000ms</value>
+  <value>5000s</value>
   <description>
-    Interval between retry attempts on throttled requests.
+    Initial between retry attempts on throttled requests, +/- 50%. chosen at random.
+    i.e. for an intial value of 3000ms, the initial delay would be in the range 1500ms to 4500ms.
+    Backoffs are exponential; again randomness is used to avoid the thundering heard problem.
+    Given that throttling in S3 is per-second, very short delays will not initial spread
+    out work and so continue to create the problem.
   </description>
 </property>
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -733,8 +733,7 @@ public final class Constants {
   /**
    * Default throttled retry limit: {@value}.
    */
-  public static final int RETRY_THROTTLE_LIMIT_DEFAULT =
-      DEFAULT_MAX_ERROR_RETRIES;
+  public static final int RETRY_THROTTLE_LIMIT_DEFAULT = 20;
 
   /**
    * Interval between retry attempts on throttled requests: {@value}.
@@ -745,7 +744,7 @@ public final class Constants {
   /**
    * Default throttled retry interval: {@value}.
    */
-  public static final String RETRY_THROTTLE_INTERVAL_DEFAULT = "500ms";
+  public static final String RETRY_THROTTLE_INTERVAL_DEFAULT = "5000ms";
 
   /**
    * Should etags be exposed as checksums?

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -57,6 +57,11 @@ public class DefaultS3ClientFactory extends Configured
     Configuration conf = getConf();
     final ClientConfiguration awsConf = S3AUtils
         .createAwsConf(getConf(), bucket, Constants.AWS_SERVICE_IDENTIFIER_S3);
+
+    // throttling is explicitly disabled on the S3 client so that
+    // all failures are collected
+    awsConf.setUseThrottleRetries(false);
+
     if (!StringUtils.isEmpty(userAgentSuffix)) {
       awsConf.setUserAgentSuffix(userAgentSuffix);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -123,6 +123,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
   private final MutableCounterLong ignoredErrors;
   private final MutableQuantiles putLatencyQuantile;
   private final MutableQuantiles throttleRateQuantile;
+  private final MutableQuantiles s3GuardThrottleRateQuantile;
   private final MutableCounterLong numberOfFilesCreated;
   private final MutableCounterLong numberOfFilesCopied;
   private final MutableCounterLong bytesOfFilesCopied;
@@ -248,7 +249,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     int interval = 1;
     putLatencyQuantile = quantiles(S3GUARD_METADATASTORE_PUT_PATH_LATENCY,
         "ops", "latency", interval);
-    throttleRateQuantile = quantiles(S3GUARD_METADATASTORE_THROTTLE_RATE,
+    s3GuardThrottleRateQuantile = quantiles(S3GUARD_METADATASTORE_THROTTLE_RATE,
+        "events", "frequency (Hz)", interval);
+    throttleRateQuantile = quantiles(STORE_IO_THROTTLE_RATE,
         "events", "frequency (Hz)", interval);
 
     registerAsMetricsSource(name);
@@ -617,6 +620,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       // task in a shared thread pool.
       putLatencyQuantile.stop();
       throttleRateQuantile.stop();
+      s3GuardThrottleRateQuantile.stop();
       metricsSystem.unregisterSource(metricsSourceName);
       int activeSources = --metricsSourceActiveCounter;
       if (activeSources == 0) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1234,7 +1234,6 @@ public final class S3AUtils {
     initConnectionSettings(conf, awsConf);
     initProxySupport(conf, bucket, awsConf);
     initUserAgent(conf, awsConf);
-    awsConf.setUseThrottleRetries(false);
     if (StringUtils.isNotEmpty(awsServiceIdentifier)) {
       String configKey = null;
       switch (awsServiceIdentifier) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1234,6 +1234,7 @@ public final class S3AUtils {
     initConnectionSettings(conf, awsConf);
     initProxySupport(conf, bucket, awsConf);
     initUserAgent(conf, awsConf);
+    awsConf.setUseThrottleRetries(false);
     if (StringUtils.isNotEmpty(awsServiceIdentifier)) {
       String configKey = null;
       switch (awsServiceIdentifier) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -230,6 +230,7 @@ public enum Statistic {
       "S3Guard metadata store authoritative directories updated from S3"),
 
   STORE_IO_THROTTLED("store_io_throttled", "Requests throttled and retried"),
+  STORE_IO_THROTTLE_RATE("store_io_throttle_rate", "Rate of S3 request throttling"),
 
   DELEGATION_TOKENS_ISSUED("delegation_tokens_issued",
       "Number of delegation tokens issued");

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -230,7 +230,8 @@ public enum Statistic {
       "S3Guard metadata store authoritative directories updated from S3"),
 
   STORE_IO_THROTTLED("store_io_throttled", "Requests throttled and retried"),
-  STORE_IO_THROTTLE_RATE("store_io_throttle_rate", "Rate of S3 request throttling"),
+  STORE_IO_THROTTLE_RATE("store_io_throttle_rate",
+      "Rate of S3 request throttling"),
 
   DELEGATION_TOKENS_ISSUED("delegation_tokens_issued",
       "Number of delegation tokens issued");

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DumpS3GuardDynamoTable.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DumpS3GuardDynamoTable.java
@@ -439,8 +439,8 @@ public class DumpS3GuardDynamoTable extends AbstractS3GuardDynamoDBDiagnostic {
   private Pair<Long, Long> scanMetastore(CsvFile csv) {
     S3GuardTableAccess tableAccess = new S3GuardTableAccess(getStore());
     ExpressionSpecBuilder builder = new ExpressionSpecBuilder();
-    Iterable<DDBPathMetadata> results = tableAccess.scanMetadata(
-        builder);
+    Iterable<DDBPathMetadata> results =
+        getStore().wrapWithRetries(tableAccess.scanMetadata(builder));
     long live = 0;
     long tombstone = 0;
     for (DDBPathMetadata md : results) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PurgeS3GuardDynamoTable.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/PurgeS3GuardDynamoTable.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.s3a.s3guard;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -128,9 +129,10 @@ public class PurgeS3GuardDynamoTable
    * delete all entries from that bucket.
    * @return the exit code.
    * @throws ServiceLaunchException on failure.
+   * @throws IOException IO failure.
    */
   @Override
-  public int execute() throws ServiceLaunchException {
+  public int execute() throws ServiceLaunchException, IOException {
 
     URI uri = getUri();
     String host = uri.getHost();
@@ -144,7 +146,8 @@ public class PurgeS3GuardDynamoTable
     LOG.info("Scanning for entries with prefix {} to delete from {}",
         prefix, ddbms);
 
-    Iterable<DDBPathMetadata> entries = tableAccess.scanMetadata(builder);
+    Iterable<DDBPathMetadata> entries =
+        ddbms.wrapWithRetries(tableAccess.scanMetadata(builder));
     List<Path> list = new ArrayList<>();
     entries.iterator().forEachRemaining(e -> {
       if (!(e instanceof S3GuardTableAccess.VersionMarker)) {
@@ -169,7 +172,12 @@ public class PurgeS3GuardDynamoTable
             new DurationInfo(LOG,
                 "deleting %s entries from %s",
                 count, ddbms.toString());
-        tableAccess.delete(list);
+        ddbms.getWriteOperationInvoker()
+            .retry("delete",
+                prefix,
+                true,
+                () -> tableAccess.delete(list));
+
         duration.close();
         long durationMillis = duration.value();
         long timePerEntry = durationMillis / count;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTableAccess.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTableAccess.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -70,6 +71,7 @@ import static org.apache.hadoop.fs.s3a.s3guard.PathMetadataDynamoDBTranslation.i
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
+@Retries.OnceRaw
 class S3GuardTableAccess {
 
   private static final Logger LOG =
@@ -107,6 +109,7 @@ class S3GuardTableAccess {
    * @param spec query spec.
    * @return the outcome.
    */
+  @Retries.OnceRaw
   ItemCollection<QueryOutcome> query(QuerySpec spec) {
     return table.query(spec);
   }
@@ -118,18 +121,22 @@ class S3GuardTableAccess {
    * @param spec query spec.
    * @return an iterator over path entries.
    */
+  @Retries.OnceRaw
   Iterable<DDBPathMetadata> queryMetadata(QuerySpec spec) {
     return new DDBPathMetadataCollection<>(query(spec));
   }
 
+  @Retries.OnceRaw
   ItemCollection<ScanOutcome> scan(ExpressionSpecBuilder spec) {
     return table.scan(spec.buildForScan());
   }
 
+  @Retries.OnceRaw
   Iterable<DDBPathMetadata> scanMetadata(ExpressionSpecBuilder spec) {
     return new DDBPathMetadataCollection<>(scan(spec));
   }
 
+  @Retries.OnceRaw
   void delete(Collection<Path> paths) {
     paths.stream()
         .map(PathMetadataDynamoDBTranslation::pathToKey)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ThrottleTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ThrottleTracker.java
@@ -42,11 +42,15 @@ class ThrottleTracker {
 
   private long batchWriteThrottleCountOrig = 0;
 
+  private long scanThrottleCountOrig;
+
   private long readThrottles;
 
   private long writeThrottles;
 
   private long batchThrottles;
+
+  private long scanThrottles;
 
   ThrottleTracker(final DynamoDBMetadataStore ddbms) {
     this.ddbms = ddbms;
@@ -65,6 +69,9 @@ class ThrottleTracker {
 
     batchWriteThrottleCountOrig
         = ddbms.getBatchWriteCapacityExceededCount();
+
+    scanThrottleCountOrig
+        = ddbms.getScanThrottleEventCount();
   }
 
   /**
@@ -78,6 +85,8 @@ class ThrottleTracker {
         - writeThrottleEventOrig);
     setBatchThrottles(ddbms.getBatchWriteCapacityExceededCount()
         - batchWriteThrottleCountOrig);
+    setScanThrottles(ddbms.getScanThrottleEventCount()
+        - scanThrottleCountOrig);
     return isThrottlingDetected();
   }
 
@@ -85,9 +94,11 @@ class ThrottleTracker {
   public String toString() {
     return String.format(
         "Tracker with read throttle events = %d;"
-            + " write events = %d;"
-            + " batch throttles = %d",
-        getReadThrottles(), getWriteThrottles(), getBatchThrottles());
+            + " write throttles = %d;"
+            + " batch throttles = %d;"
+            + " scan throttles = %d",
+        getReadThrottles(), getWriteThrottles(), getBatchThrottles(),
+        getScanThrottles());
   }
 
   /**
@@ -101,11 +112,13 @@ class ThrottleTracker {
 
   /**
    * Has there been any throttling on an operation?
-   * @return true iff read, write or batch operations were throttled.
+   * @return true if any operations were throttled.
    */
   public boolean isThrottlingDetected() {
-    return getReadThrottles() > 0 || getWriteThrottles()
-        > 0 || getBatchThrottles() > 0;
+    return getReadThrottles() > 0
+        || getWriteThrottles() > 0
+        || getBatchThrottles() > 0
+        || getScanThrottles() > 0;
   }
 
   public long getReadThrottles() {
@@ -130,5 +143,13 @@ class ThrottleTracker {
 
   public void setBatchThrottles(long batchThrottles) {
     this.batchThrottles = batchThrottles;
+  }
+
+  public long getScanThrottles() {
+    return scanThrottles;
+  }
+
+  public void setScanThrottles(final long scanThrottles) {
+    this.scanThrottles = scanThrottles;
   }
 }


### PR DESCRIPTION
Currently AWS S3 throttling is initially handled in the AWS SDK, only reaching the S3 client code after it has given up.

This means we don't always directly observe when throttling is taking place.

Proposed:

* disable throttling retries in the AWS client Library
* add a quantile for the S3 throttle events, as DDB has
* isolate counters of s3 and DDB throttle events to classify issues better

Because we are taking over the AWS retries, we will need to expand the initial delay en retries and the number of retries we should support before giving up.

Also: should we log throttling events? It could be useful but there is a risk of logs overloading especially if many threads in the same process were triggering the problem.

Change-Id: I386928cd478a6a9fbb91f15b9185a1ea91878680

