### PR TITLE
HADOOP-16827. TestHarFileSystem.testInheritedMethodsImplemented broken.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHarFileSystem.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.impl.OpenFileParameters;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -246,15 +247,11 @@ public class TestHarFileSystem {
 
     CompletableFuture<FSDataInputStream> openFileWithOptions(
         PathHandle pathHandle,
-        Set<String> mandatoryKeys,
-        Configuration options,
-        int bufferSize) throws IOException;
+        OpenFileParameters parameters) throws IOException;
 
     CompletableFuture<FSDataInputStream> openFileWithOptions(
         Path path,
-        Set<String> mandatoryKeys,
-        Configuration options,
-        int bufferSize) throws IOException;
+        OpenFileParameters parameters) throws IOException;
   }
 
   @Test


### PR DESCRIPTION

This is a regression caused by HADOOP-16759.

The test TestHarFileSystem uses introspection to verify that HarFileSystem
Does not implement methods to which there is a suitable implementation in
the base FileSystem class. Because of the way it checks this, refactoring
(protected) FileSystem methods in an IDE do not automatically change
the probes in TestHarFileSystem.

The changes in HADOOP-16759 did exactly that, and somehow managed
to get through the build/test process without this being noticed.

This patch fixes that failure.

Caused by and fixed by Steve Loughran.
