### PR TITLE
HDFS-14989. Add a 'swapBlockList' operation to Namenode.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
@@ -518,4 +518,27 @@ public final class Options {
     MD5MD5CRC,  // MD5 of block checksums, which are MD5 over chunk CRCs
     COMPOSITE_CRC  // Block/chunk-independent composite CRC
   }
+
+  /**
+   * Enum to support the varargs for swapBlockList() options
+   */
+  public enum SwapBlockList {
+    NONE((byte) 0), // No options, swap the block list.
+    ONE_WAY_BLOCK_SWAP((byte) 1), // Skip replacing source with dst info.
+    EXCLUDE_BLOCK_LAYOUT_HEADER_SWAP((byte) 2); // Exclude block layout header swap
+
+    private final byte code;
+
+    private SwapBlockList(byte code) {
+      this.code = code;
+    }
+
+    public static SwapBlockList valueOf(byte code) {
+      return code < 0 || code >= values().length ? null : values()[code];
+    }
+
+    public byte value() {
+      return code;
+    }
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
@@ -520,16 +520,17 @@ public final class Options {
   }
 
   /**
-   * Enum to support the varargs for swapBlockList() options
+   * Enum to support the varargs for swapBlockList() options.
    */
   public enum SwapBlockList {
     NONE((byte) 0), // No options, swap the block list.
     ONE_WAY_BLOCK_SWAP((byte) 1), // Skip replacing source with dst info.
-    EXCLUDE_BLOCK_LAYOUT_HEADER_SWAP((byte) 2); // Exclude block layout header swap
+    EXCLUDE_BLOCK_LAYOUT_HEADER_SWAP((byte) 2);
+    // Exclude block layout header swap
 
     private final byte code;
 
-    private SwapBlockList(byte code) {
+    SwapBlockList(byte code) {
       this.code = code;
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
@@ -518,28 +518,4 @@ public final class Options {
     MD5MD5CRC,  // MD5 of block checksums, which are MD5 over chunk CRCs
     COMPOSITE_CRC  // Block/chunk-independent composite CRC
   }
-
-  /**
-   * Enum to support the varargs for swapBlockList() options.
-   */
-  public enum SwapBlockList {
-    NONE((byte) 0), // No options, swap the block list.
-    ONE_WAY_BLOCK_SWAP((byte) 1), // Skip replacing source with dst info.
-    EXCLUDE_BLOCK_LAYOUT_HEADER_SWAP((byte) 2);
-    // Exclude block layout header swap
-
-    private final byte code;
-
-    SwapBlockList(byte code) {
-      this.code = code;
-    }
-
-    public static SwapBlockList valueOf(byte code) {
-      return code < 0 || code >= values().length ? null : values()[code];
-    }
-
-    public byte value() {
-      return code;
-    }
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -8507,8 +8507,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    * @param dst destination file.
    * @throws IOException on Error.
    */
-  boolean swapBlockList(final String src, final String dst,
-                        Options.SwapBlockList... options)
+  boolean swapBlockList(final String src, final String dst)
       throws IOException {
     final String operationName = "swapBlockList";
     checkOperation(OperationCategory.WRITE);
@@ -8519,7 +8518,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       try {
         checkOperation(OperationCategory.WRITE);
         checkNameNodeSafeMode("Cannot swap block list." + src + ", " + dst);
-        res = SwapBlockListOp.swapBlocks(dir, pc, src, dst, options);
+        res = SwapBlockListOp.swapBlocks(dir, pc, src, dst);
       } finally {
         writeUnlock(operationName);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -8507,7 +8507,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    * @param dst destination file.
    * @throws IOException on Error.
    */
-  boolean swapBlockList(final String src, final String dst)
+  boolean swapBlockList(final String src, final String dst, long genTimestamp)
       throws IOException {
     final String operationName = "swapBlockList";
     checkOperation(OperationCategory.WRITE);
@@ -8518,7 +8518,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       try {
         checkOperation(OperationCategory.WRITE);
         checkNameNodeSafeMode("Cannot swap block list." + src + ", " + dst);
-        res = SwapBlockListOp.swapBlocks(dir, pc, src, dst);
+        res = SwapBlockListOp.swapBlocks(dir, pc, src, dst, genTimestamp);
       } finally {
         writeUnlock(operationName);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -8527,8 +8527,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       logAuditEvent(false, operationName, src, dst, null);
       throw e;
     }
-    logAuditEvent(true, operationName, src, dst, res.dstFileAuditStat);
-    return res.success;
+    logAuditEvent(true, operationName, src, dst, res.getDstFileAuditStat());
+    return res.isSuccess();
   }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -112,6 +112,7 @@ import org.apache.hadoop.hdfs.protocol.ZoneReencryptionStatus;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReportListing;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.hdfs.server.common.ECTopologyVerifier;
+import org.apache.hadoop.hdfs.server.namenode.SwapBlockListOp.SwapBlockListResult;
 import org.apache.hadoop.hdfs.server.namenode.metrics.ReplicatedBlocksMBean;
 import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
 import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
@@ -8497,6 +8498,37 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         getEffectiveLayoutVersion())) {
       throw new UnsupportedActionException(operationName + " not supported.");
     }
+  }
+
+  /**
+   * Namesystem API to swap block list between source and destination files.
+   *
+   * @param src source file.
+   * @param dst destination file.
+   * @throws IOException on Error.
+   */
+  boolean swapBlockList(final String src, final String dst,
+                        Options.SwapBlockList... options)
+      throws IOException {
+    final String operationName = "swapBlockList";
+    checkOperation(OperationCategory.WRITE);
+    final FSPermissionChecker pc = getPermissionChecker();
+    SwapBlockListResult res = null;
+    try {
+      writeLock();
+      try {
+        checkOperation(OperationCategory.WRITE);
+        checkNameNodeSafeMode("Cannot swap block list." + src + ", " + dst);
+        res = SwapBlockListOp.swapBlocks(dir, pc, src, dst, options);
+      } finally {
+        writeUnlock(operationName);
+      }
+    } catch (AccessControlException e) {
+      logAuditEvent(false, operationName, src, dst, null);
+      throw e;
+    }
+    logAuditEvent(true, operationName, src, dst, res.dstFileAuditStat);
+    return res.success;
   }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -733,12 +733,15 @@ public class INodeFile extends INodeWithAdditionalFields
   }
 
   /**
-   * This method replaces blocks in a file with the supplied blocks. Make sure
-   * you know what you are doing when you are calling this!
+   * This method replaces blocks in a file with the supplied blocks.
    * @param newBlocks List of new blocks.
+   * @param newId new block collection id.
    */
   void replaceBlocks(BlockInfo[] newBlocks) {
     this.blocks = Arrays.copyOf(newBlocks, newBlocks.length);
+    for (BlockInfo block : blocks) {
+      block.setBlockCollectionId(getId());
+    }
   }
 
   private void updateRemovedUnderConstructionFiles(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -735,7 +735,6 @@ public class INodeFile extends INodeWithAdditionalFields
   /**
    * This method replaces blocks in a file with the supplied blocks.
    * @param newBlocks List of new blocks.
-   * @param newId new block collection id.
    */
   void replaceBlocks(BlockInfo[] newBlocks) {
     this.blocks = Arrays.copyOf(newBlocks, newBlocks.length);
@@ -1277,11 +1276,13 @@ public class INodeFile extends INodeWithAdditionalFields
   /**
    * Update Header with new Block Layout and Redundancy bits.
    * @param newBlockLayoutPolicy new block layout policy.
+   * @param newStoragePolicy new storage policy ID.
    */
-  void updateHeaderWithNewBlockLayoutPolicy(byte newBlockLayoutPolicy) {
+  void updateHeaderWithNewPolicy(byte newBlockLayoutPolicy,
+                                 byte newStoragePolicy) {
     this.header = HeaderFormat.toLong(
         HeaderFormat.getPreferredBlockSize(header),
         newBlockLayoutPolicy,
-        HeaderFormat.getStoragePolicyID(header));
+        newStoragePolicy);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -163,6 +163,10 @@ public class INodeFile extends INodeWithAdditionalFields
       return (byte)STORAGE_POLICY_ID.BITS.retrieve(header);
     }
 
+    static byte getBlockLayoutPolicy(long header) {
+      return (byte)BLOCK_LAYOUT_AND_REDUNDANCY.BITS.retrieve(header);
+    }
+
     // Union of all the block type masks. Currently there is only
     // BLOCK_TYPE_MASK_STRIPED
     static final long BLOCK_TYPE_MASK = 1 << 11;
@@ -728,6 +732,15 @@ public class INodeFile extends INodeWithAdditionalFields
     this.blocks = BlockInfo.EMPTY_ARRAY;
   }
 
+  /**
+   * This method replaces blocks in a file with the supplied blocks. Make sure
+   * you know what you are doing when you are calling this!
+   * @param newBlocks List of new blocks.
+   */
+  void replaceBlocks(BlockInfo[] newBlocks) {
+    this.blocks = Arrays.copyOf(newBlocks, newBlocks.length);
+  }
+
   private void updateRemovedUnderConstructionFiles(
       ReclaimContext reclaimContext) {
     if (isUnderConstruction() && reclaimContext.removedUCFiles != null) {
@@ -1256,5 +1269,16 @@ public class INodeFile extends INodeWithAdditionalFields
         .findEarlierSnapshotBlocks(getDiffs().getLastSnapshotId());
     return snapshotBlocks != null &&
         Arrays.asList(snapshotBlocks).contains(block);
+  }
+
+  /**
+   * Update Header with new Block Layout and Redundancy bits.
+   * @param newBlockLayoutPolicy new block layout policy.
+   */
+  void updateHeaderWithNewBlockLayoutPolicy(byte newBlockLayoutPolicy) {
+    this.header = HeaderFormat.toLong(
+        HeaderFormat.getPreferredBlockSize(header),
+        newBlockLayoutPolicy,
+        HeaderFormat.getStoragePolicyID(header));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -2674,7 +2674,6 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     if (stateChangeLog.isDebugEnabled()) {
       stateChangeLog.debug("*DIR* NameNode.swapBlockList: {} and {}", src, dst);
     }
-    namesystem.checkOperation(OperationCategory.WRITE);
     return namesystem.swapBlockList(src, dst, maxTimestamp);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -2668,14 +2668,14 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     return namesystem.getBlockManager().getSPSManager().getNextPathId();
   }
 
-  public boolean swapBlockList(String src, String dst)
+  public boolean swapBlockList(String src, String dst, long maxTimestamp)
       throws IOException {
     checkNNStartup();
     if (stateChangeLog.isDebugEnabled()) {
       stateChangeLog.debug("*DIR* NameNode.swapBlockList: {} and {}", src, dst);
     }
     namesystem.checkOperation(OperationCategory.WRITE);
-    return namesystem.swapBlockList(src, dst);
+    return namesystem.swapBlockList(src, dst, maxTimestamp);
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -2668,8 +2668,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     return namesystem.getBlockManager().getSPSManager().getNextPathId();
   }
 
-  public boolean swapBlockList(String src, String dst,
-                               Options.SwapBlockList... options)
+  public boolean swapBlockList(String src, String dst)
       throws IOException {
     checkNNStartup();
     if (stateChangeLog.isDebugEnabled()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -2667,4 +2667,16 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     }
     return namesystem.getBlockManager().getSPSManager().getNextPathId();
   }
+
+  public boolean swapBlockList(String src, String dst,
+                               Options.SwapBlockList... options)
+      throws IOException {
+    checkNNStartup();
+    if (stateChangeLog.isDebugEnabled()) {
+      stateChangeLog.debug("*DIR* NameNode.swapBlockList: {} and {}", src, dst);
+    }
+    namesystem.checkOperation(OperationCategory.WRITE);
+    return namesystem.swapBlockList(src, dst);
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
@@ -38,7 +38,10 @@ import org.apache.hadoop.util.Time;
  * of a file header, which is useful for client operations like converting
  * replicated to EC file.
  */
-public class SwapBlockListOp {
+public final class SwapBlockListOp {
+
+  private SwapBlockListOp() {
+  }
 
   static SwapBlockListResult swapBlocks(FSDirectory fsd, FSPermissionChecker pc,
                           String src, String dst,
@@ -161,9 +164,9 @@ public class SwapBlockListOp {
   }
 
   static class SwapBlockListResult {
-    final boolean success;
-    final FileStatus srcFileAuditStat;
-    final FileStatus dstFileAuditStat;
+    private final boolean success;
+    private final FileStatus srcFileAuditStat;
+    private final FileStatus dstFileAuditStat;
 
     SwapBlockListResult(boolean success,
                         FileStatus srcFileAuditStat,
@@ -171,6 +174,18 @@ public class SwapBlockListOp {
       this.success = success;
       this.srcFileAuditStat = srcFileAuditStat;
       this.dstFileAuditStat = dstFileAuditStat;
+    }
+
+    public boolean isSuccess() {
+      return success;
+    }
+
+    public FileStatus getDstFileAuditStat() {
+      return dstFileAuditStat;
+    }
+
+    public FileStatus getSrcFileAuditStat() {
+      return srcFileAuditStat;
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
@@ -130,9 +130,8 @@ public final class SwapBlockListOp {
     String errorPrefix = "DIR* FSDirectory.swapBlockList: ";
     String error = "Swap Block List input ";
 
-    FSDirectory.resolveLastINode(srcIIP);
+    INode srcInode = FSDirectory.resolveLastINode(srcIIP);
 
-    final INode srcInode = srcIIP.getLastINode();
     // Check if INode is a file and NOT a directory.
     if (!srcInode.isFile()) {
       error  += srcIIP.getPath() + " is not a file.";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.namenode;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
+import org.apache.hadoop.hdfs.server.namenode.FSDirectory.DirOp;
+import org.apache.hadoop.hdfs.server.namenode.INodeFile.HeaderFormat;
+import org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot;
+import org.apache.hadoop.util.Time;
+
+/**
+ * Class to carry out the operation of swapping blocks from one file to another.
+ * Along with swapping blocks, we can also optionally swap the block layout
+ * of a file header, which is useful for client operations like converting
+ * replicated to EC file.
+ */
+public class SwapBlockListOp {
+
+  static SwapBlockListResult swapBlocks(FSDirectory fsd, FSPermissionChecker pc,
+                          String src, String dst,
+                          Options.SwapBlockList... options) throws IOException {
+
+    final INodesInPath srcIIP = fsd.resolvePath(pc, src, DirOp.WRITE);
+    final INodesInPath dstIIP = fsd.resolvePath(pc, dst, DirOp.WRITE);
+    if (fsd.isPermissionEnabled()) {
+      fsd.checkAncestorAccess(pc, srcIIP, FsAction.WRITE);
+      fsd.checkAncestorAccess(pc, dstIIP, FsAction.WRITE);
+    }
+    if (NameNode.stateChangeLog.isDebugEnabled()) {
+      NameNode.stateChangeLog.debug("DIR* FSDirectory.swapBlockList: "
+          + srcIIP.getPath() + " and " + dstIIP.getPath());
+    }
+    SwapBlockListResult result = null;
+    fsd.writeLock();
+    try {
+      result = swapBlockList(fsd, srcIIP, dstIIP, options);
+    } finally {
+      fsd.writeUnlock();
+    }
+    return result;
+  }
+
+  private static SwapBlockListResult swapBlockList(FSDirectory fsd,
+                                    final INodesInPath srcIIP,
+                                    final INodesInPath dstIIP,
+                                    Options.SwapBlockList... options)
+      throws IOException {
+
+    assert fsd.hasWriteLock();
+    validateInode(fsd, srcIIP);
+    validateInode(fsd, dstIIP);
+    fsd.ezManager.checkMoveValidity(srcIIP, dstIIP);
+
+    final String src = srcIIP.getPath();
+    final String dst = dstIIP.getPath();
+    if (dst.equals(src)) {
+      throw new FileAlreadyExistsException("The source " + src +
+          " and destination " + dst + " are the same");
+    }
+
+    INodeFile srcINodeFile = (INodeFile) srcIIP.getLastINode();
+    INodeFile dstINodeFile = (INodeFile) dstIIP.getLastINode();
+
+    long mtime = Time.now();
+    BlockInfo[] dstINodeFileBlocks = dstINodeFile.getBlocks();
+    dstINodeFile.replaceBlocks(srcINodeFile.getBlocks());
+
+    boolean overwrite = options != null
+        && Arrays.asList(options).contains(
+            Options.SwapBlockList.ONE_WAY_BLOCK_SWAP);
+    if (!overwrite) {
+      srcINodeFile.replaceBlocks(dstINodeFileBlocks);
+    }
+
+    boolean excludeHeader = options != null &&
+        Arrays.asList(options).contains(
+            Options.SwapBlockList.EXCLUDE_BLOCK_LAYOUT_HEADER_SWAP);
+    if (!excludeHeader) {
+      long srcHeader = srcINodeFile.getHeaderLong();
+      long dstHeader = dstINodeFile.getHeaderLong();
+
+      byte srcBlockLayoutPolicy =
+          HeaderFormat.getBlockLayoutPolicy(srcHeader);
+      dstINodeFile.updateHeaderWithNewBlockLayoutPolicy(srcBlockLayoutPolicy);
+
+      if (!overwrite) {
+        byte dstBlockLayoutPolicy =
+            HeaderFormat.getBlockLayoutPolicy(dstHeader);
+        srcINodeFile.updateHeaderWithNewBlockLayoutPolicy(dstBlockLayoutPolicy);
+        srcINodeFile.setModificationTime(mtime);
+      }
+    }
+    // Update modification time.
+    dstINodeFile.setModificationTime(mtime);
+
+    return new SwapBlockListResult(true,
+        fsd.getAuditFileInfo(srcIIP),
+        fsd.getAuditFileInfo(dstIIP));
+  }
+
+  private static void validateInode(FSDirectory fsd, INodesInPath srcIIP)
+      throws IOException {
+
+    String errorPrefix = "DIR* FSDirectory.swapBlockList: ";
+    String error = "Swap Block List input ";
+    final INode srcInode = srcIIP.getLastINode();
+
+    // Check if INode is null.
+    if (srcInode == null) {
+      error  += srcIIP.getPath() + " is not found.";
+      NameNode.stateChangeLog.warn(errorPrefix + error);
+      throw new FileNotFoundException(error);
+    }
+
+    // Check if INode is a file and NOT a directory.
+    if (!srcInode.isFile()) {
+      error  += srcIIP.getPath() + " is not a file.";
+      NameNode.stateChangeLog.warn(errorPrefix + error);
+      throw new IOException(error);
+    }
+
+    // Check if file is under construction.
+    INodeFile iNodeFile = (INodeFile) srcIIP.getLastINode();
+    if (iNodeFile.isUnderConstruction()) {
+      error  += srcIIP.getPath() + " is under construction.";
+      NameNode.stateChangeLog.warn(errorPrefix + error);
+      throw new IOException(error);
+    }
+
+    // Check if any parent directory is in a snapshot.
+    if (srcIIP.getLatestSnapshotId() != Snapshot.CURRENT_STATE_ID) {
+      error  += srcIIP.getPath() + " is in a snapshot directory.";
+      NameNode.stateChangeLog.warn(errorPrefix + error);
+      throw new IOException(error);
+    }
+
+  }
+
+  static class SwapBlockListResult {
+    final boolean success;
+    final FileStatus srcFileAuditStat;
+    final FileStatus dstFileAuditStat;
+
+    SwapBlockListResult(boolean success,
+                        FileStatus srcFileAuditStat,
+                        FileStatus dstFileAuditStat) {
+      this.success = success;
+      this.srcFileAuditStat = srcFileAuditStat;
+      this.dstFileAuditStat = dstFileAuditStat;
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SwapBlockListOp.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hdfs.server.namenode;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -55,7 +54,7 @@ public final class SwapBlockListOp {
       NameNode.stateChangeLog.debug("DIR* FSDirectory.swapBlockList: "
           + srcIIP.getPath() + " and " + dstIIP.getPath());
     }
-    SwapBlockListResult result = null;
+    SwapBlockListResult result;
     fsd.writeLock();
     try {
       result = swapBlockList(fsd, srcIIP, dstIIP, genTimestamp);
@@ -83,8 +82,8 @@ public final class SwapBlockListOp {
           " and destination " + dst + " are the same");
     }
 
-    INodeFile srcINodeFile = (INodeFile) srcIIP.getLastINode();
-    INodeFile dstINodeFile = (INodeFile) dstIIP.getLastINode();
+    INodeFile srcINodeFile = srcIIP.getLastINode().asFile();
+    INodeFile dstINodeFile = dstIIP.getLastINode().asFile();
 
     String errorPrefix = "DIR* FSDirectory.swapBlockList: ";
     String error = "Swap Block List destination file ";
@@ -130,15 +129,10 @@ public final class SwapBlockListOp {
 
     String errorPrefix = "DIR* FSDirectory.swapBlockList: ";
     String error = "Swap Block List input ";
+
+    FSDirectory.resolveLastINode(srcIIP);
+
     final INode srcInode = srcIIP.getLastINode();
-
-    // Check if INode is null.
-    if (srcInode == null) {
-      error  += srcIIP.getPath() + " is not found.";
-      NameNode.stateChangeLog.warn(errorPrefix + error);
-      throw new FileNotFoundException(error);
-    }
-
     // Check if INode is a file and NOT a directory.
     if (!srcInode.isFile()) {
       error  += srcIIP.getPath() + " is not a file.";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
@@ -18,11 +18,12 @@
 
 package org.apache.hadoop.hdfs.server.namenode;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
@@ -176,43 +177,14 @@ public class TestSwapBlockList {
 
     fsn.swapBlockList(sourceFile, dstFile);
     assertBlockListEquality(dstBlockLocationsBeforeSwap,
-        srcInodeFile.getBlocks());
+        srcInodeFile.getBlocks(), srcInodeFile.getId());
     assertBlockListEquality(srcBlockLocationsBeforeSwap,
-        dstInodeFile.getBlocks());
+        dstInodeFile.getBlocks(), dstInodeFile.getId());
 
     // Assert Block Layout
-    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+    assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
         HeaderFormat.getBlockLayoutPolicy(dstInodeFile.getHeaderLong()));
-    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(dstHeader),
-        HeaderFormat.getBlockLayoutPolicy(srcInodeFile.getHeaderLong()));
-  }
-
-  @Test
-  public void testSwapBlockListOpOneWay() throws Exception {
-    String sourceFile = "/TestSwapBlockList/dir1/file1";
-    String dstFile = "/TestSwapBlockList/dir1/dir11/file3";
-
-    INodeFile srcInodeFile =
-        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
-            sourceFile, FSDirectory.DirOp.WRITE).getLastINode();
-    INodeFile dstInodeFile =
-        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
-            dstFile, FSDirectory.DirOp.WRITE).getLastINode();
-
-    BlockInfo[] srcBlockLocationsBeforeSwap = srcInodeFile.getBlocks();
-    long srcHeader = srcInodeFile.getHeaderLong();
-
-    fsn.swapBlockList(sourceFile, dstFile,
-        Options.SwapBlockList.ONE_WAY_BLOCK_SWAP);
-    assertBlockListEquality(srcBlockLocationsBeforeSwap,
-        dstInodeFile.getBlocks());
-    assertBlockListEquality(srcBlockLocationsBeforeSwap,
-        srcInodeFile.getBlocks());
-
-    // Assert Block Layout
-    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
-        HeaderFormat.getBlockLayoutPolicy(dstInodeFile.getHeaderLong()));
-    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+    assertEquals(HeaderFormat.getBlockLayoutPolicy(dstHeader),
         HeaderFormat.getBlockLayoutPolicy(srcInodeFile.getHeaderLong()));
   }
 
@@ -240,22 +212,24 @@ public class TestSwapBlockList {
     testSwapBlockListOp();
 
     assertBlockListEquality(dstBlockLocationsBeforeSwap,
-        dstInodeFile.getBlocks());
+        dstInodeFile.getBlocks(), dstInodeFile.getId());
     assertBlockListEquality(srcBlockLocationsBeforeSwap,
-        srcInodeFile.getBlocks());
+        srcInodeFile.getBlocks(), srcInodeFile.getId());
 
     // Assert Block Layout
-    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+    assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
         HeaderFormat.getBlockLayoutPolicy(srcInodeFile.getHeaderLong()));
-    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(dstHeader),
+    assertEquals(HeaderFormat.getBlockLayoutPolicy(dstHeader),
         HeaderFormat.getBlockLayoutPolicy(dstInodeFile.getHeaderLong()));
   }
 
   private void assertBlockListEquality(BlockInfo[] expected,
-                                       BlockInfo[] actual) {
-    Assert.assertEquals(expected.length, actual.length);
+                                       BlockInfo[] actual,
+                                       long expectedId) {
+    assertEquals(expected.length, actual.length);
     for (int i = 0; i < expected.length; i++) {
-      Assert.assertEquals(expected[i].getBlockId(), actual[i].getBlockId());
+      assertEquals(expected[i].getBlockId(), actual[i].getBlockId());
+      assertEquals(expectedId, actual[i].getBlockCollectionId());
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
@@ -1,0 +1,258 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.namenode;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
+import org.apache.hadoop.hdfs.server.namenode.INodeFile.HeaderFormat;
+import org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotTestHelper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSwapBlockList {
+
+  private static final short REPLICATION = 3;
+
+  private static final long seed = 0;
+  private final Path rootDir = new Path("/" + getClass().getSimpleName());
+
+  private final Path subDir1 = new Path(rootDir, "dir1");
+  private final Path file1 = new Path(subDir1, "file1");
+  private final Path file2 = new Path(subDir1, "file2");
+
+  private final Path subDir11 = new Path(subDir1, "dir11");
+  private final Path file3 = new Path(subDir11, "file3");
+
+  private final Path subDir2 = new Path(rootDir, "dir2");
+  private final Path file4 = new Path(subDir2, "file4");
+
+  private Configuration conf;
+  private MiniDFSCluster cluster;
+  private FSNamesystem fsn;
+  private FSDirectory fsdir;
+
+  private DistributedFileSystem hdfs;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = new Configuration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_MAX_XATTRS_PER_INODE_KEY, 2);
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(REPLICATION)
+        .build();
+    cluster.waitActive();
+
+    fsn = cluster.getNamesystem();
+    fsdir = fsn.getFSDirectory();
+
+    hdfs = cluster.getFileSystem();
+
+    hdfs.mkdirs(subDir2);
+
+    DFSTestUtil.createFile(hdfs, file1, 1024, REPLICATION, seed);
+    DFSTestUtil.createFile(hdfs, file2, 1024, REPLICATION, seed);
+    DFSTestUtil.createFile(hdfs, file3, 1024, REPLICATION, seed);
+    DFSTestUtil.createFile(hdfs, file4, 1024, REPLICATION, seed);
+
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testInputValidation() throws Exception {
+
+    // Source file not found.
+    try {
+      fsn.swapBlockList("/TestSwapBlockList/dir1/fileXYZ",
+          "/TestSwapBlockList/dir1/dir11/file3");
+      Assert.fail();
+    } catch (IOException ioEx) {
+      Assert.assertTrue(ioEx instanceof FileNotFoundException);
+      Assert.assertTrue(
+          ioEx.getMessage().contains("/TestSwapBlockList/dir1/fileXYZ"));
+    }
+
+    // Destination file not found.
+    try {
+      fsn.swapBlockList("/TestSwapBlockList/dir1/file1",
+          "/TestSwapBlockList/dir1/dir11/fileXYZ");
+      Assert.fail();
+    } catch (IOException ioEx) {
+      Assert.assertTrue(ioEx instanceof FileNotFoundException);
+      Assert.assertTrue(
+          ioEx.getMessage().contains("/TestSwapBlockList/dir1/dir11/fileXYZ"));
+    }
+
+    // Source is Directory, not a file.
+    try {
+      fsn.swapBlockList("/TestSwapBlockList/dir1",
+          "/TestSwapBlockList/dir1/dir11/file3");
+      Assert.fail();
+    } catch (IOException ioEx) {
+      Assert.assertTrue(
+          ioEx.getMessage().contains("/TestSwapBlockList/dir1 is not a file."));
+    }
+
+    String sourceFile = "/TestSwapBlockList/dir1/file1";
+    String dstFile = "/TestSwapBlockList/dir1/dir11/file3";
+
+    // Destination file is under construction.
+    INodeFile dstInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+        dstFile, FSDirectory.DirOp.WRITE).getLastINode();
+    dstInodeFile.toUnderConstruction("TestClient", "TestClientMachine");
+    try {
+      fsn.swapBlockList(sourceFile, dstFile);
+      Assert.fail();
+    } catch (IOException ioEx) {
+      Assert.assertTrue(
+          ioEx.getMessage().contains(dstFile + " is under construction."));
+    }
+
+    // Check if parent directory is in snapshot.
+    SnapshotTestHelper.createSnapshot(hdfs, subDir2, "s0");
+    dstFile = "/TestSwapBlockList/dir2/file4";
+    try {
+      fsn.swapBlockList(sourceFile, dstFile);
+      Assert.fail();
+    } catch (IOException ioEx) {
+      Assert.assertTrue(
+          ioEx.getMessage().contains(dstFile + " is in a snapshot directory."));
+    }
+  }
+
+  @Test
+  public void testSwapBlockListOp() throws Exception {
+    String sourceFile = "/TestSwapBlockList/dir1/file1";
+    String dstFile = "/TestSwapBlockList/dir1/dir11/file3";
+
+    INodeFile srcInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+            sourceFile, FSDirectory.DirOp.WRITE).getLastINode();
+    INodeFile dstInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+            dstFile, FSDirectory.DirOp.WRITE).getLastINode();
+
+    BlockInfo[] srcBlockLocationsBeforeSwap = srcInodeFile.getBlocks();
+    long srcHeader = srcInodeFile.getHeaderLong();
+
+    BlockInfo[] dstBlockLocationsBeforeSwap = dstInodeFile.getBlocks();
+    long dstHeader = dstInodeFile.getHeaderLong();
+
+    fsn.swapBlockList(sourceFile, dstFile);
+    assertBlockListEquality(dstBlockLocationsBeforeSwap,
+        srcInodeFile.getBlocks());
+    assertBlockListEquality(srcBlockLocationsBeforeSwap,
+        dstInodeFile.getBlocks());
+
+    // Assert Block Layout
+    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+        HeaderFormat.getBlockLayoutPolicy(dstInodeFile.getHeaderLong()));
+    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(dstHeader),
+        HeaderFormat.getBlockLayoutPolicy(srcInodeFile.getHeaderLong()));
+  }
+
+  @Test
+  public void testSwapBlockListOpOneWay() throws Exception {
+    String sourceFile = "/TestSwapBlockList/dir1/file1";
+    String dstFile = "/TestSwapBlockList/dir1/dir11/file3";
+
+    INodeFile srcInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+            sourceFile, FSDirectory.DirOp.WRITE).getLastINode();
+    INodeFile dstInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+            dstFile, FSDirectory.DirOp.WRITE).getLastINode();
+
+    BlockInfo[] srcBlockLocationsBeforeSwap = srcInodeFile.getBlocks();
+    long srcHeader = srcInodeFile.getHeaderLong();
+
+    fsn.swapBlockList(sourceFile, dstFile,
+        Options.SwapBlockList.ONE_WAY_BLOCK_SWAP);
+    assertBlockListEquality(srcBlockLocationsBeforeSwap,
+        dstInodeFile.getBlocks());
+    assertBlockListEquality(srcBlockLocationsBeforeSwap,
+        srcInodeFile.getBlocks());
+
+    // Assert Block Layout
+    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+        HeaderFormat.getBlockLayoutPolicy(dstInodeFile.getHeaderLong()));
+    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+        HeaderFormat.getBlockLayoutPolicy(srcInodeFile.getHeaderLong()));
+  }
+
+  @Test
+  public void testSwapBlockListOpRollback() throws Exception {
+    // Invoke swap twice and make sure the blocks are back to their original
+    // file.
+    String sourceFile = "/TestSwapBlockList/dir1/file1";
+    String dstFile = "/TestSwapBlockList/dir1/dir11/file3";
+
+    INodeFile srcInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+            sourceFile, FSDirectory.DirOp.WRITE).getLastINode();
+    INodeFile dstInodeFile =
+        (INodeFile) fsdir.resolvePath(fsdir.getPermissionChecker(),
+            dstFile, FSDirectory.DirOp.WRITE).getLastINode();
+
+    BlockInfo[] srcBlockLocationsBeforeSwap = srcInodeFile.getBlocks();
+    long srcHeader = srcInodeFile.getHeaderLong();
+
+    BlockInfo[] dstBlockLocationsBeforeSwap = dstInodeFile.getBlocks();
+    long dstHeader = dstInodeFile.getHeaderLong();
+
+    testSwapBlockListOp();
+    testSwapBlockListOp();
+
+    assertBlockListEquality(dstBlockLocationsBeforeSwap,
+        dstInodeFile.getBlocks());
+    assertBlockListEquality(srcBlockLocationsBeforeSwap,
+        srcInodeFile.getBlocks());
+
+    // Assert Block Layout
+    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(srcHeader),
+        HeaderFormat.getBlockLayoutPolicy(srcInodeFile.getHeaderLong()));
+    Assert.assertEquals(HeaderFormat.getBlockLayoutPolicy(dstHeader),
+        HeaderFormat.getBlockLayoutPolicy(dstInodeFile.getHeaderLong()));
+  }
+
+  private void assertBlockListEquality(BlockInfo[] expected,
+                                       BlockInfo[] actual) {
+    Assert.assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      Assert.assertEquals(expected[i].getBlockId(), actual[i].getBlockId());
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
@@ -36,11 +36,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * Test SwapBlockListOp working.
+ */
 public class TestSwapBlockList {
 
   private static final short REPLICATION = 3;
 
-  private static final long seed = 0;
+  private static final long SEED = 0;
   private final Path rootDir = new Path("/" + getClass().getSimpleName());
 
   private final Path subDir1 = new Path(rootDir, "dir1");
@@ -76,10 +79,10 @@ public class TestSwapBlockList {
 
     hdfs.mkdirs(subDir2);
 
-    DFSTestUtil.createFile(hdfs, file1, 1024, REPLICATION, seed);
-    DFSTestUtil.createFile(hdfs, file2, 1024, REPLICATION, seed);
-    DFSTestUtil.createFile(hdfs, file3, 1024, REPLICATION, seed);
-    DFSTestUtil.createFile(hdfs, file4, 1024, REPLICATION, seed);
+    DFSTestUtil.createFile(hdfs, file1, 1024, REPLICATION, SEED);
+    DFSTestUtil.createFile(hdfs, file2, 1024, REPLICATION, SEED);
+    DFSTestUtil.createFile(hdfs, file3, 1024, REPLICATION, SEED);
+    DFSTestUtil.createFile(hdfs, file4, 1024, REPLICATION, SEED);
 
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSwapBlockList.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
-import org.apache.hadoop.hdfs.server.namenode.INode.BlocksMapUpdateInfo;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile.HeaderFormat;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotTestHelper;
 import org.junit.After;


### PR DESCRIPTION
This is the first patch HDFS-14989 for the In Place Erasure Coding Feature HDFS-14978.

Work Done
The swapBlockList takes two parameters, a source file and a destination file. This operation swaps the blocks belonging to the source and the destination atomically.

The namespace metadata of interest is the INodeFile class. A file (INodeFile) contains a header composed of PREFERRED_BLOCK_SIZE, BLOCK_LAYOUT_AND_REDUNDANCY and STORAGE_POLICY_ID. In addition, an INodeFile contains a list of blocks (BlockInfo[]). The operation will swap BLOCK_LAYOUT_AND_REDUNDANCY header bits and the block lists. But it will not touch other fields. To avoid complication, this operation will abort if either file is open (isUnderConstruction() == true)

Note : This patch is intentionally not exposing the client side API to use this operation. That will be handled in a separate JIRA where the client side API will involve using this operation to carry out EC conversion.

Added unit tests for the operation as well.