### PR TITLE
HADOOP-16794 S3 Encryption keys not propagating correctly during copy operation

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -45,7 +45,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
@@ -3511,20 +3510,20 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     kmsParams.ifPresent(
             copyObjectRequest::setSSEAwsKeyManagementParams);
     switch(encryptionSecrets.getEncryptionMethod()) {
-      /**
-       * Overriding with client encryption settings.
-       */
-      case SSE_C:
-        generateSSECustomerKey().ifPresent(customerKey -> {
-          copyObjectRequest.setSourceSSECustomerKey(customerKey);
-          copyObjectRequest.setDestinationSSECustomerKey(customerKey);
-        });
-        break;
-      case SSE_KMS:
-        generateSSEAwsKeyParams().ifPresent(
-                copyObjectRequest::setSSEAwsKeyManagementParams);
-        break;
-      default:
+    /**
+     * Overriding with client encryption settings.
+     */
+    case SSE_C:
+      generateSSECustomerKey().ifPresent(customerKey -> {
+        copyObjectRequest.setSourceSSECustomerKey(customerKey);
+        copyObjectRequest.setDestinationSSECustomerKey(customerKey);
+      });
+      break;
+    case SSE_KMS:
+      generateSSEAwsKeyParams().ifPresent(
+              copyObjectRequest::setSSEAwsKeyManagementParams);
+      break;
+    default:
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3794,9 +3794,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     if (source.getRestoreExpirationTime() != null) {
       ret.setRestoreExpirationTime(source.getRestoreExpirationTime());
     }
-    if (source.getSSEAlgorithm() != null) {
-      ret.setSSEAlgorithm(source.getSSEAlgorithm());
-    }
     if (source.getSSECustomerAlgorithm() != null) {
       ret.setSSECustomerAlgorithm(source.getSSECustomerAlgorithm());
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3464,8 +3464,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           copyObjectRequest.setNewObjectMetadata(dstom);
           Optional.ofNullable(srcom.getStorageClass())
               .ifPresent(copyObjectRequest::setStorageClass);
-
-
           Copy copy = transfers.copy(copyObjectRequest);
           copy.addProgressListener(progressListener);
           CopyOutcome copyOutcome = CopyOutcome.waitForCopy(copy);
@@ -3497,8 +3495,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @param srcom source object meta.
    * @param copyObjectRequest copy object request body.
    */
-  private void setOptionalCopyObjectRequestParameters(ObjectMetadata srcom,
-                                                      CopyObjectRequest copyObjectRequest) {
+  private void setOptionalCopyObjectRequestParameters(
+          ObjectMetadata srcom,
+          CopyObjectRequest copyObjectRequest) {
     String sourceKMSId = srcom.getSSEAwsKmsKeyId();
     if (isNotEmpty(sourceKMSId)) {
       // source KMS ID is propagated

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3464,6 +3464,28 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           copyObjectRequest.setNewObjectMetadata(dstom);
           Optional.ofNullable(srcom.getStorageClass())
               .ifPresent(copyObjectRequest::setStorageClass);
+          // KMS key patch
+          SSEAwsKeyManagementParams kmsParams = null;
+          String sourceKMSId = srcom.getSSEAwsKmsKeyId();
+          if (isNotEmpty(sourceKMSId)) {
+            // source KMS ID is propagated
+            LOG.debug("Propagating SSE-KMS settings from source {}",
+                sourceKMSId);
+            kmsParams = new SSEAwsKeyManagementParams(sourceKMSId);
+          }
+          if (S3AEncryptionMethods.SSE_KMS.equals(
+              encryptionSecrets.getEncryptionMethod())
+              && isNotEmpty(encryptionSecrets.getEncryptionKey())) {
+            // client has KMS encryption settings.
+            // and explicitly defines a key
+            // these override any of the source file
+            kmsParams = new SSEAwsKeyManagementParams(
+                encryptionSecrets.getEncryptionKey());
+          }
+          if (kmsParams != null) {
+            copyObjectRequest.setSSEAwsKeyManagementParams(
+                kmsParams);
+          }
           Copy copy = transfers.copy(copyObjectRequest);
           copy.addProgressListener(progressListener);
           CopyOutcome copyOutcome = CopyOutcome.waitForCopy(copy);
@@ -3793,6 +3815,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
     if (source.getRestoreExpirationTime() != null) {
       ret.setRestoreExpirationTime(source.getRestoreExpirationTime());
+    }
+    if (source.getSSEAlgorithm() != null) {
+      ret.setSSEAlgorithm(source.getSSEAlgorithm());
     }
     if (source.getSSECustomerAlgorithm() != null) {
       ret.setSSECustomerAlgorithm(source.getSSECustomerAlgorithm());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -145,17 +145,4 @@ public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
   protected String getTestTableName(String suffix) {
     return getTestDynamoTablePrefix(getConfiguration()) + suffix;
   }
-
-  /**
-   * Assert that an exception failed with a specific status code.
-   * @param e exception
-   * @param code expected status code
-   * @throws AWSServiceIOException rethrown if the status code does not match.
-   */
-  protected void assertStatusCode(AWSServiceIOException e, int code)
-      throws AWSServiceIOException {
-    if (e.getStatusCode() != code) {
-      throw e;
-    }
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -187,26 +187,26 @@ public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
             md.getSSEAlgorithm(),
             md.getSSEAwsKmsKeyId());
     switch(algorithm) {
-      case SSE_C:
-        assertNull("Metadata algorithm should have been null in "
-                        + details,
-                md.getSSEAlgorithm());
-        assertEquals("Wrong SSE-C algorithm in "
-                        + details,
-                SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
-        String md5Key = convertKeyToMd5();
-        assertEquals("getSSECustomerKeyMd5() wrong in " + details,
-                md5Key, md.getSSECustomerKeyMd5());
-        break;
-      case SSE_KMS:
-        assertEquals("Wrong algorithm in " + details,
-                AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
-        assertEquals("Wrong KMS key in " + details,
-                kmsKeyArn,
-                md.getSSEAwsKmsKeyId());
-        break;
-      default:
-        assertEquals("AES256", md.getSSEAlgorithm());
+    case SSE_C:
+      assertNull("Metadata algorithm should have been null in "
+                      + details,
+              md.getSSEAlgorithm());
+      assertEquals("Wrong SSE-C algorithm in "
+                      + details,
+              SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
+      String md5Key = convertKeyToMd5();
+      assertEquals("getSSECustomerKeyMd5() wrong in " + details,
+              md5Key, md.getSSECustomerKeyMd5());
+      break;
+    case SSE_KMS:
+      assertEquals("Wrong algorithm in " + details,
+              AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
+      assertEquals("Wrong KMS key in " + details,
+              kmsKeyArn,
+              md.getSSEAwsKmsKeyId());
+      break;
+    default:
+      assertEquals("AES256", md.getSSEAlgorithm());
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.net.util.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -32,8 +34,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestDynamoTablePrefix;
 
 /**
@@ -41,6 +46,10 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestDynamoTablePrefix;
  */
 public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
     implements S3ATestConstants {
+
+  protected static final String AWS_KMS_SSE_ALGORITHM = "aws:kms";
+
+  protected static final String SSE_C_ALGORITHM = "AES256";
 
   protected static final Logger LOG =
       LoggerFactory.getLogger(AbstractS3ATestBase.class);
@@ -159,4 +168,63 @@ public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
       throw e;
     }
   }
+
+  /**
+   * Assert that a path is encrypted with right encryption settings.
+   * @param path file path.
+   * @param algorithm encryption algorithm.
+   * @param kmsKeyArn
+   * @throws IOException
+   */
+  protected void assertEncrypted(final Path path,
+                                 final S3AEncryptionMethods algorithm,
+                                 final String kmsKeyArn)
+          throws IOException {
+    ObjectMetadata md = getFileSystem().getObjectMetadata(path);
+    String details = String.format(
+            "file %s with encryption algorthm %s and key %s",
+            path,
+            md.getSSEAlgorithm(),
+            md.getSSEAwsKmsKeyId());
+    switch(algorithm) {
+      case SSE_C:
+        assertNull("Metadata algorithm should have been null in "
+                        + details,
+                md.getSSEAlgorithm());
+        assertEquals("Wrong SSE-C algorithm in "
+                        + details,
+                SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
+        String md5Key = convertKeyToMd5();
+        assertEquals("getSSECustomerKeyMd5() wrong in " + details,
+                md5Key, md.getSSECustomerKeyMd5());
+        break;
+      case SSE_KMS:
+        assertEquals("Wrong algorithm in " + details,
+                AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
+        assertEquals("Wrong KMS key in " + details,
+                kmsKeyArn,
+                md.getSSEAwsKmsKeyId());
+        break;
+      default:
+        assertEquals("AES256", md.getSSEAlgorithm());
+    }
+  }
+
+  /**
+   * Decodes the SERVER_SIDE_ENCRYPTION_KEY from base64 into an AES key, then
+   * gets the md5 of it, then encodes it in base64 so it will match the version
+   * that AWS returns to us.
+   *
+   * @return md5'd base64 encoded representation of the server side encryption
+   * key
+   */
+  private String convertKeyToMd5() {
+    String base64Key = getFileSystem().getConf().getTrimmed(
+            SERVER_SIDE_ENCRYPTION_KEY
+    );
+    byte[] key = Base64.decodeBase64(base64Key);
+    byte[] md5 =  DigestUtils.md5(key);
+    return Base64.encodeBase64String(md5).trim();
+  }
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -161,7 +161,7 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     String kmsKeyArn = this.getConfiguration().
         getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
     S3AEncryptionMethods algorithm = getSSEAlgorithm();
-    assertEncrypted(path, algorithm, kmsKeyArn);
+    EncryptionTestUtils.assertEncrypted(getFileSystem(), path, algorithm, kmsKeyArn);
   }
 
   protected abstract S3AEncryptionMethods getSSEAlgorithm();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -161,7 +161,10 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     String kmsKeyArn = this.getConfiguration().
         getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
     S3AEncryptionMethods algorithm = getSSEAlgorithm();
-    EncryptionTestUtils.assertEncrypted(getFileSystem(), path, algorithm, kmsKeyArn);
+    EncryptionTestUtils.assertEncrypted(getFileSystem(),
+            path,
+            algorithm,
+            kmsKeyArn);
   }
 
   protected abstract S3AEncryptionMethods getSSEAlgorithm();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -107,10 +107,7 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     writeDataset(fs, src, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, src, data);
     Path targetDir = path("target");
-    Path dest = new Path(targetDir, src.getName() + "-another");
-    byte[] dataTarget = dataset(1024, 'A', 'Z');
-    writeDataset(fs, dest, dataTarget, dataTarget.length, 1024*1024, true);
-    ContractTestUtils.verifyFileContents(fs, dest, dataTarget);
+    mkdirs(targetDir);
     fs.rename(src, targetDir);
     Path renamedFile = new Path(targetDir, src.getName());
     ContractTestUtils.verifyFileContents(fs, renamedFile, data);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionTestsDisabled;
 import static org.apache.hadoop.fs.s3a.S3AUtils.getEncryptionAlgorithm;
@@ -107,10 +106,15 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     validateEncrytionSecrets(secrets);
     writeDataset(fs, src, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, src, data);
-    Path dest = path(src.getName() + "-copy");
-    fs.rename(src, dest);
-    ContractTestUtils.verifyFileContents(fs, dest, data);
-    assertEncrypted(dest);
+    Path targetDir = path("target");
+    Path dest = new Path(targetDir, src.getName() + "-another");
+    byte[] dataTarget = dataset(1024, 'A', 'Z');
+    writeDataset(fs, dest, dataTarget, dataTarget.length, 1024*1024, true);
+    ContractTestUtils.verifyFileContents(fs, dest, dataTarget);
+    fs.rename(src, targetDir);
+    Path renamedFile = new Path(targetDir, src.getName());
+    ContractTestUtils.verifyFileContents(fs, renamedFile, data);
+    assertEncrypted(renamedFile);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.net.util.Base64;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class EncryptionTestUtils {
+
+  /** Private constructor */
+  private EncryptionTestUtils() {
+  }
+
+  public static final String AWS_KMS_SSE_ALGORITHM = "aws:kms";
+
+  public static final String SSE_C_ALGORITHM = "AES256";
+
+  /**
+   * Decodes the SERVER_SIDE_ENCRYPTION_KEY from base64 into an AES key, then
+   * gets the md5 of it, then encodes it in base64 so it will match the version
+   * that AWS returns to us.
+   *
+   * @return md5'd base64 encoded representation of the server side encryption
+   * key
+   */
+  public static String convertKeyToMd5(FileSystem fs) {
+    String base64Key = fs.getConf().getTrimmed(
+            SERVER_SIDE_ENCRYPTION_KEY
+    );
+    byte[] key = Base64.decodeBase64(base64Key);
+    byte[] md5 =  DigestUtils.md5(key);
+    return Base64.encodeBase64String(md5).trim();
+  }
+
+  /**
+   * Assert that a path is encrypted with right encryption settings.
+   * @param path file path.
+   * @param algorithm encryption algorithm.
+   * @param kmsKeyArn full kms key.
+   */
+  public static void assertEncrypted(S3AFileSystem fs,
+                                     final Path path,
+                                     final S3AEncryptionMethods algorithm,
+                                     final String kmsKeyArn)
+          throws IOException {
+    ObjectMetadata md = fs.getObjectMetadata(path);
+    String details = String.format(
+            "file %s with encryption algorithm %s and key %s",
+            path,
+            md.getSSEAlgorithm(),
+            md.getSSEAwsKmsKeyId());
+    switch(algorithm) {
+      case SSE_C:
+        assertNull("Metadata algorithm should have been null in "
+                        + details,
+                md.getSSEAlgorithm());
+        assertEquals("Wrong SSE-C algorithm in "
+                        + details,
+                SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
+        String md5Key = convertKeyToMd5(fs);
+        assertEquals("getSSECustomerKeyMd5() wrong in " + details,
+                md5Key, md.getSSECustomerKeyMd5());
+        break;
+      case SSE_KMS:
+        assertEquals("Wrong algorithm in " + details,
+                AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
+        assertEquals("Wrong KMS key in " + details,
+                kmsKeyArn,
+                md.getSSEAwsKmsKeyId());
+        break;
+      default:
+        assertEquals("AES256", md.getSSEAlgorithm());
+    }
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/EncryptionTestUtils.java
@@ -31,7 +31,7 @@ import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class EncryptionTestUtils {
+public final class EncryptionTestUtils {
 
   /** Private constructor */
   private EncryptionTestUtils() {
@@ -76,26 +76,26 @@ public class EncryptionTestUtils {
             md.getSSEAlgorithm(),
             md.getSSEAwsKmsKeyId());
     switch(algorithm) {
-      case SSE_C:
-        assertNull("Metadata algorithm should have been null in "
-                        + details,
-                md.getSSEAlgorithm());
-        assertEquals("Wrong SSE-C algorithm in "
-                        + details,
-                SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
-        String md5Key = convertKeyToMd5(fs);
-        assertEquals("getSSECustomerKeyMd5() wrong in " + details,
-                md5Key, md.getSSECustomerKeyMd5());
-        break;
-      case SSE_KMS:
-        assertEquals("Wrong algorithm in " + details,
-                AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
-        assertEquals("Wrong KMS key in " + details,
-                kmsKeyArn,
-                md.getSSEAwsKmsKeyId());
-        break;
-      default:
-        assertEquals("AES256", md.getSSEAlgorithm());
+    case SSE_C:
+      assertNull("Metadata algorithm should have been null in "
+                      + details,
+              md.getSSEAlgorithm());
+      assertEquals("Wrong SSE-C algorithm in "
+                      + details,
+              SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
+      String md5Key = convertKeyToMd5(fs);
+      assertEquals("getSSECustomerKeyMd5() wrong in " + details,
+              md5Key, md.getSSECustomerKeyMd5());
+      break;
+    case SSE_KMS:
+      assertEquals("Wrong algorithm in " + details,
+              AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
+      assertEquals("Wrong KMS key in " + details,
+              kmsKeyArn,
+              md.getSSEAwsKmsKeyId());
+      break;
+    default:
+      assertEquals("AES256", md.getSSEAlgorithm());
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSDefaultKey.java
@@ -52,7 +52,8 @@ public class ITestS3AEncryptionSSEKMSDefaultKey
   @Override
   protected void assertEncrypted(Path path) throws IOException {
     ObjectMetadata md = getFileSystem().getObjectMetadata(path);
-    assertEquals("SSE Algorithm", AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
+    assertEquals("SSE Algorithm", EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM,
+            md.getSSEAlgorithm());
     assertThat(md.getSSEAwsKmsKeyId(), containsString("arn:aws:kms:"));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -93,22 +93,6 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
     Configuration c = fs.getConf();
     String kmsKey = c.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
     assertEncrypted(path, SSE_KMS, kmsKey);
-/*
-    ObjectMetadata objectMetadata = fs.getObjectMetadata(path);
-    String details = String.format(
-        "copied file %s with encryption algorthm %s and key %s",
-        path,
-        objectMetadata.getSSEAlgorithm(),
-        objectMetadata.getSSEAwsKmsKeyId());
-    // algorithm must be SSE-KMS, regardless of the default bucket settings
-    Assertions.assertThat(objectMetadata.getSSEAlgorithm())
-        .describedAs("SSE algorithm in %s", details)
-        .isEqualTo(getSSEAlgorithm().getMethod());
-    // and the key must be ours.
-    Assertions.assertThat(objectMetadata.getSSEAwsKmsKeyId())
-        .describedAs("SSE KMS key ID in %s", details)
-        .isEqualTo(kmsKey);
-*/
   }
 
   @Override
@@ -150,18 +134,6 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
       // we assert that the renamed file has picked up the KMS key of our FS
       assertEncrypted(renamedFile, SSE_KMS, kmsKey);
     }
-
-
-/*
-    Path targetDir = path("target");
-    Path dest = new Path(targetDir, src.getName() + "-another");
-    byte[] dataTarget = dataset(1024, 'A', 'Z');
-    writeDataset(fs, dest, dataTarget, dataTarget.length, 1024 * 1024, true);
-    ContractTestUtils.verifyFileContents(fs, dest, dataTarget);
-    fs.rename(src, targetDir);
-    Path renamedFile = new Path(targetDir, src.getName());
-    ContractTestUtils.verifyFileContents(fs, renamedFile, data);
-    assertEncrypted(renamedFile);*/
   }
 
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -20,17 +20,23 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 
 /**
  * Concrete class that extends {@link AbstractTestS3AEncryption}
@@ -38,39 +44,71 @@ import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
  * This requires the SERVER_SIDE_ENCRYPTION_KEY
  * to be set in auth-keys.xml for it to run. The value should match with the
  * kms key set for the bucket.
+ * See HADOOP-16794.
  */
 public class ITestS3AEncryptionWithDefaultS3Settings extends
         AbstractTestS3AEncryption {
 
   @Override
-  protected Configuration getConfiguration() {
+  public void setup() throws Exception {
+    super.setup();
     // get the KMS key for this test.
-    Configuration c = new Configuration();
+    S3AFileSystem fs = getFileSystem();
+    Configuration c = fs.getConf();
     String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
     if (StringUtils.isBlank(kmsKey)) {
       skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
-              SSE_KMS.getMethod());
+          SSE_KMS.getMethod());
     }
-    return super.createConfiguration();
+  }
+
+  @Override
+  protected void patchConfigurationEncryptionSettings(
+      final Configuration conf) {
+    removeBaseAndBucketOverrides(conf,
+        SERVER_SIDE_ENCRYPTION_ALGORITHM);
+    conf.set(SERVER_SIDE_ENCRYPTION_ALGORITHM,
+            getSSEAlgorithm().getMethod());
   }
 
   /**
    * Setting this to NONE as we don't want to overwrite
    * already configured encryption settings.
-   * @return
+   * @return the algorithm
    */
   @Override
   protected S3AEncryptionMethods getSSEAlgorithm() {
     return S3AEncryptionMethods.NONE;
   }
 
+  /**
+   * The check here is that the object is encrypted
+   * <i>and</i> that the encryption key is the KMS key
+   * provided, not any default key.
+   * @param path path
+   */
   @Override
   protected void assertEncrypted(Path path) throws IOException {
-    Configuration c = new Configuration();
-    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
-    ObjectMetadata objectMetadata = getFileSystem().getObjectMetadata(path);
-    assertEquals("SSE KMS key id should match", kmsKey,
-            objectMetadata.getSSEAwsKmsKeyId());
+    S3AFileSystem fs = getFileSystem();
+    Configuration c = fs.getConf();
+    String kmsKey = c.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
+    assertEncrypted(path, SSE_KMS, kmsKey);
+/*
+    ObjectMetadata objectMetadata = fs.getObjectMetadata(path);
+    String details = String.format(
+        "copied file %s with encryption algorthm %s and key %s",
+        path,
+        objectMetadata.getSSEAlgorithm(),
+        objectMetadata.getSSEAwsKmsKeyId());
+    // algorithm must be SSE-KMS, regardless of the default bucket settings
+    Assertions.assertThat(objectMetadata.getSSEAlgorithm())
+        .describedAs("SSE algorithm in %s", details)
+        .isEqualTo(getSSEAlgorithm().getMethod());
+    // and the key must be ours.
+    Assertions.assertThat(objectMetadata.getSSEAwsKmsKeyId())
+        .describedAs("SSE KMS key ID in %s", details)
+        .isEqualTo(kmsKey);
+*/
   }
 
   @Override
@@ -84,4 +122,47 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
   @Test
   public void testEncryption() throws Throwable {
   }
+
+  @Test
+  public void testEncryptionOverRename2() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+
+    // write the file with the unencrypted FS.
+    // this will pick up whatever defaults we have.
+    Path src = path(createFilename(1024));
+    byte[] data = dataset(1024, 'a', 'z');
+    EncryptionSecrets secrets = fs.getEncryptionSecrets();
+    validateEncrytionSecrets(secrets);
+    writeDataset(fs, src, data, data.length, 1024 * 1024, true);
+    ContractTestUtils.verifyFileContents(fs, src, data);
+
+    // fs2 conf will always use SSE-KMS
+    Configuration fs2Conf = new Configuration(fs.getConf());
+    fs2Conf.set(SERVER_SIDE_ENCRYPTION_ALGORITHM,
+        S3AEncryptionMethods.SSE_KMS.getMethod());
+    try (FileSystem kmsFS = FileSystem.newInstance(fs.getUri(), fs2Conf)) {
+      Path targetDir = path("target");
+      kmsFS.mkdirs(targetDir);
+      ContractTestUtils.rename(kmsFS, src, targetDir);
+      Path renamedFile = new Path(targetDir, src.getName());
+      ContractTestUtils.verifyFileContents(fs, renamedFile, data);
+      String kmsKey = fs2Conf.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
+      // we assert that the renamed file has picked up the KMS key of our FS
+      assertEncrypted(renamedFile, SSE_KMS, kmsKey);
+    }
+
+
+/*
+    Path targetDir = path("target");
+    Path dest = new Path(targetDir, src.getName() + "-another");
+    byte[] dataTarget = dataset(1024, 'A', 'Z');
+    writeDataset(fs, dest, dataTarget, dataTarget.length, 1024 * 1024, true);
+    ContractTestUtils.verifyFileContents(fs, dest, dataTarget);
+    fs.rename(src, targetDir);
+    Path renamedFile = new Path(targetDir, src.getName());
+    ContractTestUtils.verifyFileContents(fs, renamedFile, data);
+    assertEncrypted(renamedFile);*/
+  }
+
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -92,7 +92,7 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
     S3AFileSystem fs = getFileSystem();
     Configuration c = fs.getConf();
     String kmsKey = c.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
-    assertEncrypted(path, SSE_KMS, kmsKey);
+    EncryptionTestUtils.assertEncrypted(fs, path, SSE_KMS, kmsKey);
   }
 
   @Override
@@ -132,9 +132,7 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
       ContractTestUtils.verifyFileContents(fs, renamedFile, data);
       String kmsKey = fs2Conf.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
       // we assert that the renamed file has picked up the KMS key of our FS
-      assertEncrypted(renamedFile, SSE_KMS, kmsKey);
+      EncryptionTestUtils.assertEncrypted(fs, renamedFile, SSE_KMS, kmsKey);
     }
   }
-
-
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
+import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
+
+/**
+ * Concrete class that extends {@link AbstractTestS3AEncryption}
+ * and tests already configured bucket level encryption using s3 console.
+ * This requires the SERVER_SIDE_ENCRYPTION_KEY
+ * to be set in auth-keys.xml for it to run. The value should match with the
+ * kms key set for the bucket.
+ */
+public class ITestS3AEncryptionWithDefaultS3Settings extends
+        AbstractTestS3AEncryption {
+
+  @Override
+  protected Configuration getConfiguration() {
+    // get the KMS key for this test.
+    Configuration c = new Configuration();
+    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
+    if (StringUtils.isBlank(kmsKey)) {
+      skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
+              SSE_KMS.getMethod());
+    }
+    return super.createConfiguration();
+  }
+
+  /**
+   * Setting this to NONE as we don't want to overwrite
+   * already configured encryption settings.
+   * @return
+   */
+  @Override
+  protected S3AEncryptionMethods getSSEAlgorithm() {
+    return S3AEncryptionMethods.NONE;
+  }
+
+  @Override
+  protected void assertEncrypted(Path path) throws IOException {
+    Configuration c = new Configuration();
+    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
+    ObjectMetadata objectMetadata = getFileSystem().getObjectMetadata(path);
+    assertEquals("SSE KMS key id should match", kmsKey,
+            objectMetadata.getSSEAwsKmsKeyId());
+  }
+
+  @Override
+  @Ignore
+  @Test
+  public void testEncryptionSettingPropagation() throws Throwable {
+  }
+
+  @Override
+  @Ignore
+  @Test
+  public void testEncryption() throws Throwable {
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.event.ProgressListener;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.junit.FixMethodOrder;
@@ -457,6 +459,30 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     logFSState();
   }
 
+  /**
+   * Test to verify source file encryption key.
+   * @throws IOException
+   */
+  @Test
+  public void test_090_verifyRenameSourceEncryption() throws IOException {
+    if(isEncrypted(getFileSystem())) {
+      assertEncrypted(getHugefile());
+    }
+  }
+
+  protected void assertEncrypted(Path hugeFile) throws IOException {
+    //Concrete classes will have implementation.
+  }
+
+  /**
+   * Checks if the encryption is enabled for the file system.
+   * @param fileSystem
+   * @return
+   */
+  protected boolean isEncrypted(S3AFileSystem fileSystem) {
+    return false;
+  }
+
   @Test
   public void test_100_renameHugeFile() throws Throwable {
     assumeHugeFileExists();
@@ -485,6 +511,20 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     bandwidth(timer2, size);
   }
 
+  /**
+   * Test to verify target file encryption key.
+   * @throws IOException
+   */
+  @Test
+  public void test_110_verifyRenameDestEncryption() throws IOException {
+    if(isEncrypted(getFileSystem())) {
+      /**
+       * Using hugeFile again as hugeFileRenamed is renamed back
+       * to hugeFile.
+       */
+      assertEncrypted(hugefile);
+    }
+  }
   /**
    * Cleanup: delete the files.
    */

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.event.ProgressListener;
-
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.junit.FixMethodOrder;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.event.ProgressListener;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.scale;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
+import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
+
+/**
+ * Class to test SSE_KMS encryption settings for huge files.
+ * Tests will only run if value of {@link Constants#SERVER_SIDE_ENCRYPTION_KEY}
+ * is set in the configuration. The testing bucket must be configured with this
+ * same key else test might fail.
+ */
+public class ITestS3AHugeFilesEncryption extends AbstractSTestS3AHugeFiles {
+
+  @Override
+  public void setup() throws Exception {
+    Configuration c = new Configuration();
+    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
+    if (StringUtils.isBlank(kmsKey)) {
+      skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
+              SSE_KMS.getMethod());
+    }
+    super.setup();
+  }
+
+  @Override
+  protected String getBlockOutputBufferName() {
+    return Constants.FAST_UPLOAD_BUFFER_ARRAY;
+  }
+
+  /**
+   * @param fileSystem
+   * @return true if {@link Constants#SERVER_SIDE_ENCRYPTION_KEY} is set
+   * in the config.
+   */
+  @Override
+  protected boolean isEncrypted(S3AFileSystem fileSystem) {
+    Configuration c = new Configuration();
+    return c.get(SERVER_SIDE_ENCRYPTION_KEY) != null;
+  }
+  
+  @Override
+  protected void assertEncrypted(Path hugeFile) throws IOException {
+    Configuration c = new Configuration();
+    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
+    assertEncrypted(hugeFile, SSE_KMS, kmsKey);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.EncryptionTestUtils;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
@@ -69,6 +70,7 @@ public class ITestS3AHugeFilesEncryption extends AbstractSTestS3AHugeFiles {
   protected void assertEncrypted(Path hugeFile) throws IOException {
     Configuration c = new Configuration();
     String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
-    assertEncrypted(hugeFile, SSE_KMS, kmsKey);
+    EncryptionTestUtils.assertEncrypted(getFileSystem(), hugeFile,
+            SSE_KMS, kmsKey);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
@@ -65,7 +65,7 @@ public class ITestS3AHugeFilesEncryption extends AbstractSTestS3AHugeFiles {
     Configuration c = new Configuration();
     return c.get(SERVER_SIDE_ENCRYPTION_KEY) != null;
   }
-  
+
   @Override
   protected void assertEncrypted(Path hugeFile) throws IOException {
     Configuration c = new Configuration();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/ExtraAssertions.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/ExtraAssertions.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.AWSServiceIOException;
 import org.apache.hadoop.util.DurationInfo;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.applyLocatedFiles;
@@ -134,5 +135,18 @@ public final class ExtraAssertions {
         "Inner cause is of wrong type : expected " + expected,
         thrown);
     return (T)cause;
+  }
+
+  /**
+   * Assert that an exception failed with a specific status code.
+   * @param e exception
+   * @param code expected status code
+   * @throws AWSServiceIOException rethrown if the status code does not match.
+   */
+  protected void assertStatusCode(AWSServiceIOException e, int code)
+          throws AWSServiceIOException {
+    if (e.getStatusCode() != code) {
+      throw e;
+    }
   }
 }


### PR DESCRIPTION
Debugging details:
When a put operation is performed without -d parameter is used, it happens in two steps. First is copying to a temporary file and then copying the temp file to the right location. The is issue is durning the copy step as an extra header "x-amz-server-side-encryption: aws:kms" is set. 
When -d parameter is used, the file is uploaded directly and in that api call this kms header is not set. 

Solution: Removing the kms header from the ClonedObjectMetatData.

Testing: Tested by compiling the complete hadoop distribution and invoking the hadoop shell command locally. 
Bucket used : https://mthakur-data.s3.ap-south-1.amazonaws.com/file2

Please suggest how to write testcases for this. Thanks