### PR TITLE
Hadoop 16845: ITestAbfsClient.testContinuationTokenHavingEqualSign failing

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -43,6 +43,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     super();
   }
 
+  @Ignore("HADOOP-16845: ITestAbfsClient.testContinuationTokenHavingEqualSign failing")
   @Test
   public void testContinuationTokenHavingEqualSign() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -43,8 +43,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     super();
   }
 
-  @Ignore("HADOOP-16845: Server side raw query consumption will lead to "
-      + "ignoring invalid continuation token.")
+  @Ignore("HADOOP-16845: Invalid continuation tokens are ignored by the ADLS "
+      + "Gen2 service, so we are disabling this test until the service is fixed.")
   @Test
   public void testContinuationTokenHavingEqualSign() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -43,7 +43,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     super();
   }
 
-  @Ignore("HADOOP-16845: ITestAbfsClient.testContinuationTokenHavingEqualSign failing")
+  @Ignore("HADOOP-16845: Server side raw query consumption will lead to "
+      + "ignoring invalid continuation token.")
   @Test
   public void testContinuationTokenHavingEqualSign() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();


### PR DESCRIPTION
Ignoring the test case as there is a change of behaviour on server side continuation token query handling.