### PR TITLE
HADOOP-16848. Experimental directory marker optimization.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -210,6 +210,20 @@ public final class Constants {
   public static final boolean EXPERIMENTAL_AWS_INTERNAL_THROTTLING_DEFAULT =
       true;
 
+  /**
+   * Experimental/Unstable feature: should empty directory marker
+   * operations be optimized? Value {@value}.
+   * Default: false.
+   *
+   * This is an experimental feature for reducing operations related
+   * to looking for/deleting fake directory markers.
+   * The goals are better performance as well as fewer tombstone markers
+   * being created on versioned buckets.
+   */
+  @InterfaceStability.Unstable
+  public static final String EXPERIMENTAL_OPTIMIZED_DIRECTORY_OPERATIONS =
+      "fs.s3a.experimental.optimized.directory.operations";
+
   // seconds until we give up trying to establish a connection to s3
   public static final String ESTABLISH_TIMEOUT =
       "fs.s3a.connection.establish.timeout";


### PR DESCRIPTION
# Optimizes directory marker operations through:-

* Async create/clear
* An option "fs.s3a.experimental.optimized.directory.operations"

That performs whatever optimisations to directory marker IO are considered
effective to reduce that I while still avoiding problems with missing markers
and/or markers not deleted.

# Important 
1. Work in progress
2. Experimental: use at own risk
3. Not for use against buckets whether other S3A releases are active
4. And not for use with data you value.

View it as a Proof of Concept to explore what we can do here.

