### PR TITLE
HADOOP-16847. Test can fail if HashSet iterates in a different order

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -66,7 +67,7 @@ public class TestGroupsCaching {
 
   public static class FakeGroupMapping extends ShellBasedUnixGroupsMapping {
     // any to n mapping
-    private static Set<String> allGroups = new HashSet<String>();
+    private static Set<String> allGroups = new LinkedHashSet<String>();
     private static Set<String> blackList = new HashSet<String>();
     private static int requestCount = 0;
     private static long getGroupsDelayMs = 0;


### PR DESCRIPTION
The test `testNegativeGroupCaching` can fail if the iteration order of HashSet changes. In detail, the method `assertEquals` (line 331) compares `groups.getGroups(user)` with an ArrayList `myGroups`. The method `getGroups` converts `allGroups` (a HashSet) to a list and it calls iterator in HashSet. However, the iteration is non-deterministic.
This PR proposes to modify HashSet to LinkedHashSet for a deterministic order.