### PR TITLE
HADOOP-16794. encryption over rename/copy

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3682,9 +3682,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     if (source.getRestoreExpirationTime() != null) {
       ret.setRestoreExpirationTime(source.getRestoreExpirationTime());
     }
-    if (source.getSSEAlgorithm() != null) {
-      ret.setSSEAlgorithm(source.getSSEAlgorithm());
-    }
     if (source.getSSECustomerAlgorithm() != null) {
       ret.setSSECustomerAlgorithm(source.getSSECustomerAlgorithm());
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -52,12 +52,25 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     S3ATestUtils.disableFilesystemCaching(conf);
+    patchConfigurationEncryptionSettings(conf);
+    return conf;
+  }
+
+  /**
+   * This removes the encryption settings from the
+   * configuration and then sets the
+   * fs.s3a.server-side-encryption-algorithm value to
+   * be that of {@code getSSEAlgorithm()}.
+   * Called in {@code createConfiguration()}.
+   * @param conf configuration to patch.
+   */
+  protected void patchConfigurationEncryptionSettings(
+      final Configuration conf) {
     removeBaseAndBucketOverrides(conf,
         SERVER_SIDE_ENCRYPTION_ALGORITHM,
         SERVER_SIDE_ENCRYPTION_KEY);
     conf.set(SERVER_SIDE_ENCRYPTION_ALGORITHM,
             getSSEAlgorithm().getMethod());
-    return conf;
   }
 
   private static final int[] SIZES = {
@@ -106,6 +119,9 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     validateEncrytionSecrets(secrets);
     writeDataset(fs, src, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, src, data);
+    // this file will be encrypted
+    assertEncrypted(src);
+
     Path targetDir = path("target");
     Path dest = new Path(targetDir, src.getName() + "-another");
     byte[] dataTarget = dataset(1024, 'A', 'Z');
@@ -151,20 +167,40 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
    * @throws IOException on a failure
    */
   protected void assertEncrypted(Path path) throws IOException {
+    //S3 will return full arn of the key, so specify global arn in properties
+    String kmsKeyArn = this.getConfiguration().
+        getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
+    S3AEncryptionMethods algorithm = getSSEAlgorithm();
+    assertEncrypted(path, algorithm, kmsKeyArn);
+  }
+
+  public void assertEncrypted(final Path path,
+      final S3AEncryptionMethods algorithm,
+      final String kmsKeyArn)
+      throws IOException {
     ObjectMetadata md = getFileSystem().getObjectMetadata(path);
-    switch(getSSEAlgorithm()) {
+    String details = String.format(
+        "file %s with encryption algorthm %s and key %s",
+        path,
+        md.getSSEAlgorithm(),
+        md.getSSEAwsKmsKeyId());
+    switch(algorithm) {
     case SSE_C:
-      assertNull("Metadata algorithm should have been null",
+      assertNull("Metadata algorithm should have been null in "
+          + details,
           md.getSSEAlgorithm());
-      assertEquals("Wrong SSE-C algorithm", SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
+      assertEquals("Wrong SSE-C algorithm in "
+          + details,
+          SSE_C_ALGORITHM, md.getSSECustomerAlgorithm());
       String md5Key = convertKeyToMd5();
-      assertEquals("getSSECustomerKeyMd5() wrong", md5Key, md.getSSECustomerKeyMd5());
+      assertEquals("getSSECustomerKeyMd5() wrong in " + details,
+          md5Key, md.getSSECustomerKeyMd5());
       break;
     case SSE_KMS:
-      assertEquals(AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
-      //S3 will return full arn of the key, so specify global arn in properties
-      assertEquals(this.getConfiguration().
-          getTrimmed(SERVER_SIDE_ENCRYPTION_KEY),
+      assertEquals("Wrong algorithm in " + details,
+          AWS_KMS_SSE_ALGORITHM, md.getSSEAlgorithm());
+      assertEquals("Wrong KMS key in " + details,
+          kmsKeyArn,
           md.getSSEAwsKmsKeyId());
       break;
     default:

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionTestsDisabled;
 import static org.apache.hadoop.fs.s3a.S3AUtils.getEncryptionAlgorithm;
@@ -107,10 +106,15 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     validateEncrytionSecrets(secrets);
     writeDataset(fs, src, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, src, data);
-    Path dest = path(src.getName() + "-copy");
-    fs.rename(src, dest);
-    ContractTestUtils.verifyFileContents(fs, dest, data);
-    assertEncrypted(dest);
+    Path targetDir = path("target");
+    Path dest = new Path(targetDir, src.getName() + "-another");
+    byte[] dataTarget = dataset(1024, 'A', 'Z');
+    writeDataset(fs, dest, dataTarget, dataTarget.length, 1024*1024, true);
+    ContractTestUtils.verifyFileContents(fs, dest, dataTarget);
+    fs.rename(src, targetDir);
+    Path renamedFile = new Path(targetDir, src.getName());
+    ContractTestUtils.verifyFileContents(fs, renamedFile, data);
+    assertEncrypted(renamedFile);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -20,17 +20,23 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 
 /**
  * Concrete class that extends {@link AbstractTestS3AEncryption}
@@ -38,39 +44,71 @@ import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
  * This requires the SERVER_SIDE_ENCRYPTION_KEY
  * to be set in auth-keys.xml for it to run. The value should match with the
  * kms key set for the bucket.
+ * See HADOOP-16794.
  */
 public class ITestS3AEncryptionWithDefaultS3Settings extends
         AbstractTestS3AEncryption {
 
   @Override
-  protected Configuration getConfiguration() {
+  public void setup() throws Exception {
+    super.setup();
     // get the KMS key for this test.
-    Configuration c = new Configuration();
+    S3AFileSystem fs = getFileSystem();
+    Configuration c = fs.getConf();
     String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
     if (StringUtils.isBlank(kmsKey)) {
       skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
-              SSE_KMS.getMethod());
+          SSE_KMS.getMethod());
     }
-    return super.createConfiguration();
+  }
+
+  @Override
+  protected void patchConfigurationEncryptionSettings(
+      final Configuration conf) {
+    removeBaseAndBucketOverrides(conf,
+        SERVER_SIDE_ENCRYPTION_ALGORITHM);
+    conf.set(SERVER_SIDE_ENCRYPTION_ALGORITHM,
+            getSSEAlgorithm().getMethod());
   }
 
   /**
    * Setting this to NONE as we don't want to overwrite
    * already configured encryption settings.
-   * @return
+   * @return the algorithm
    */
   @Override
   protected S3AEncryptionMethods getSSEAlgorithm() {
     return S3AEncryptionMethods.NONE;
   }
 
+  /**
+   * The check here is that the object is encrypted
+   * <i>and</i> that the encryption key is the KMS key
+   * provided, not any default key.
+   * @param path path
+   */
   @Override
   protected void assertEncrypted(Path path) throws IOException {
-    Configuration c = new Configuration();
-    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
-    ObjectMetadata objectMetadata = getFileSystem().getObjectMetadata(path);
-    assertEquals("SSE KMS key id should match", kmsKey,
-            objectMetadata.getSSEAwsKmsKeyId());
+    S3AFileSystem fs = getFileSystem();
+    Configuration c = fs.getConf();
+    String kmsKey = c.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
+    assertEncrypted(path, SSE_KMS, kmsKey);
+/*
+    ObjectMetadata objectMetadata = fs.getObjectMetadata(path);
+    String details = String.format(
+        "copied file %s with encryption algorthm %s and key %s",
+        path,
+        objectMetadata.getSSEAlgorithm(),
+        objectMetadata.getSSEAwsKmsKeyId());
+    // algorithm must be SSE-KMS, regardless of the default bucket settings
+    Assertions.assertThat(objectMetadata.getSSEAlgorithm())
+        .describedAs("SSE algorithm in %s", details)
+        .isEqualTo(getSSEAlgorithm().getMethod());
+    // and the key must be ours.
+    Assertions.assertThat(objectMetadata.getSSEAwsKmsKeyId())
+        .describedAs("SSE KMS key ID in %s", details)
+        .isEqualTo(kmsKey);
+*/
   }
 
   @Override
@@ -84,4 +122,47 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
   @Test
   public void testEncryption() throws Throwable {
   }
+
+  @Test
+  public void testEncryptionOverRename2() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+
+    // write the file with the unencrypted FS.
+    // this will pick up whatever defaults we have.
+    Path src = path(createFilename(1024));
+    byte[] data = dataset(1024, 'a', 'z');
+    EncryptionSecrets secrets = fs.getEncryptionSecrets();
+    validateEncrytionSecrets(secrets);
+    writeDataset(fs, src, data, data.length, 1024 * 1024, true);
+    ContractTestUtils.verifyFileContents(fs, src, data);
+
+    // fs2 conf will always use SSE-KMS
+    Configuration fs2Conf = new Configuration(fs.getConf());
+    fs2Conf.set(SERVER_SIDE_ENCRYPTION_ALGORITHM,
+        S3AEncryptionMethods.SSE_KMS.getMethod());
+    try (FileSystem kmsFS = FileSystem.newInstance(fs.getUri(), fs2Conf)) {
+      Path targetDir = path("target");
+      kmsFS.mkdirs(targetDir);
+      ContractTestUtils.rename(kmsFS, src, targetDir);
+      Path renamedFile = new Path(targetDir, src.getName());
+      ContractTestUtils.verifyFileContents(fs, renamedFile, data);
+      String kmsKey = fs2Conf.getTrimmed(SERVER_SIDE_ENCRYPTION_KEY);
+      // we assert that the renamed file has picked up the KMS key of our FS
+      assertEncrypted(renamedFile, SSE_KMS, kmsKey);
+    }
+
+
+/*
+    Path targetDir = path("target");
+    Path dest = new Path(targetDir, src.getName() + "-another");
+    byte[] dataTarget = dataset(1024, 'A', 'Z');
+    writeDataset(fs, dest, dataTarget, dataTarget.length, 1024 * 1024, true);
+    ContractTestUtils.verifyFileContents(fs, dest, dataTarget);
+    fs.rename(src, targetDir);
+    Path renamedFile = new Path(targetDir, src.getName());
+    ContractTestUtils.verifyFileContents(fs, renamedFile, data);
+    assertEncrypted(renamedFile);*/
+  }
+
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
+import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
+
+/**
+ * Concrete class that extends {@link AbstractTestS3AEncryption}
+ * and tests already configured bucket level encryption using s3 console.
+ * This requires the SERVER_SIDE_ENCRYPTION_KEY
+ * to be set in auth-keys.xml for it to run. The value should match with the
+ * kms key set for the bucket.
+ */
+public class ITestS3AEncryptionWithDefaultS3Settings extends
+        AbstractTestS3AEncryption {
+
+  @Override
+  protected Configuration getConfiguration() {
+    // get the KMS key for this test.
+    Configuration c = new Configuration();
+    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
+    if (StringUtils.isBlank(kmsKey)) {
+      skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
+              SSE_KMS.getMethod());
+    }
+    return super.createConfiguration();
+  }
+
+  /**
+   * Setting this to NONE as we don't want to overwrite
+   * already configured encryption settings.
+   * @return
+   */
+  @Override
+  protected S3AEncryptionMethods getSSEAlgorithm() {
+    return S3AEncryptionMethods.NONE;
+  }
+
+  @Override
+  protected void assertEncrypted(Path path) throws IOException {
+    Configuration c = new Configuration();
+    String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
+    ObjectMetadata objectMetadata = getFileSystem().getObjectMetadata(path);
+    assertEquals("SSE KMS key id should match", kmsKey,
+            objectMetadata.getSSEAwsKmsKeyId());
+  }
+
+  @Override
+  @Ignore
+  @Test
+  public void testEncryptionSettingPropagation() throws Throwable {
+  }
+
+  @Override
+  @Ignore
+  @Test
+  public void testEncryption() throws Throwable {
+  }
+}


### PR DESCRIPTION
Patch atop Mukund's #1823 patch

returns to copying sse algorithm header, but then

* extracts full KMS settings from src and sets on request
* overriding with S3A KMS client settings.
* tries to test it better

This is still not ready to go in.

I think we should have a consistent policy here of

1. if the client has any encryption settings, including explicit AES256, KMS+default key, KMS+custom key, then they will set the encryption options on the copy.
2. else the encryption settings of the source file are retained.

This is nice and memorable. It needs to apply for all s3a encryption settings; this patch only does it for SSE-KMS.


