### PR TITLE
HADOOP-16859: ABFS: Add unbuffer support to ABFS connector

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsContractUnbuffer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsContractUnbuffer.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contract;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.contract.AbstractContractUnbufferTest;
+
+/**
+ * Contract test for unbuffer operation.
+ */
+public class ITestAbfsContractUnbuffer extends AbstractContractUnbufferTest {
+  private final boolean isSecure;
+  private final ABFSContractTestBinding binding;
+
+  public ITestAbfsContractUnbuffer() throws Exception {
+    binding = new ABFSContractTestBinding();
+    this.isSecure = binding.isSecureMode();
+  }
+
+  @Override
+  public void setup() throws Exception {
+    binding.setup();
+    super.setup();
+  }
+
+  @Override
+  protected Configuration createConfiguration() {
+    return binding.getRawConfiguration();
+  }
+
+  @Override
+  protected AbfsFileSystemContract createContract(Configuration conf) {
+    return new AbfsFileSystemContract(conf, isSecure);
+  }
+
+  /**
+   * {@link org.apache.hadoop.fs.azurebfs.services.AbfsInputStream} does not
+   * allow calling {@link org.apache.hadoop.fs.Seekable#getPos()} on a closed
+   * stream, so this test needs to be overridden so that it does not call
+   * getPos() after the stream has been closed.
+   */
+  @Override
+  public void testUnbufferOnClosedFile() throws IOException {
+    describe("unbuffer a file before a read");
+    FSDataInputStream stream = null;
+    try {
+      stream = getFileSystem().open(getFile());
+      validateFullFileContents(stream);
+    } finally {
+      if (stream != null) {
+        stream.close();
+      }
+    }
+    if (stream != null) {
+      stream.unbuffer();
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsUnbuffer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsUnbuffer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+
+/**
+ * Integration test for calling
+ * {@link org.apache.hadoop.fs.CanUnbuffer#unbuffer} on {@link AbfsInputStream}.
+ * Validates that the underlying stream's buffer is null.
+ */
+public class ITestAbfsUnbuffer extends AbstractAbfsIntegrationTest {
+
+  private Path dest;
+
+  public ITestAbfsUnbuffer() throws Exception {
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    dest = path("ITestAbfsUnbuffer");
+
+    byte[] data = ContractTestUtils.dataset(16, 'a', 26);
+    ContractTestUtils.writeDataset(getFileSystem(), dest, data, data.length,
+            16, true);
+  }
+
+  @Test
+  public void testUnbuffer() throws IOException {
+    // Open file, read half the data, and then call unbuffer
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      assertTrue("unexpected stream type "
+              + inputStream.getWrappedStream().getClass().getSimpleName(),
+              inputStream.getWrappedStream() instanceof AbfsInputStream);
+      readAndAssertBytesRead(inputStream, 8);
+      assertFalse("AbfsInputStream buffer should not be null",
+              isBufferNull(inputStream));
+      inputStream.unbuffer();
+
+      // Check the the underlying buffer is null
+      assertTrue("AbfsInputStream buffer should be null",
+              isBufferNull(inputStream));
+    }
+  }
+
+  private boolean isBufferNull(FSDataInputStream inputStream) {
+    return ((AbfsInputStream) inputStream.getWrappedStream()).getBuffer() == null;
+  }
+
+  /**
+   * Read the specified number of bytes from the given
+   * {@link FSDataInputStream} and assert that
+   * {@link FSDataInputStream#read(byte[])} read the specified number of bytes.
+   */
+  private static void readAndAssertBytesRead(FSDataInputStream inputStream,
+                                             int bytesToRead) throws IOException {
+    assertEquals("AbfsInputStream#read did not read the correct number of "
+            + "bytes", bytesToRead, inputStream.read(new byte[bytesToRead]));
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/resources/abfs.xml
+++ b/hadoop-tools/hadoop-azure/src/test/resources/abfs.xml
@@ -61,4 +61,9 @@
         <name>fs.contract.supports-getfilestatus</name>
         <value>true</value>
     </property>
+
+    <property>
+        <name>fs.contract.supports-unbuffer</name>
+        <value>true</value>
+    </property>
 </configuration>


### PR DESCRIPTION
Added two unit tests: `ITestAbfsUnbuffer` and `ITestS3AContractUnbuffer`

Ran ABFS tests against "East US 2"; the following tests failed:

```
ITestGetNameSpaceEnabled.testNonXNSAccount
ITestAbfsRestOperationException.testRequestRetryConfig
ITestAzureBlobFileSystemAuthorization.testSetOwnerAuthorized
ITestAzureBlobFilesystemAcl.testEnsureAclOperationWorksForRoot
```

I've seen most of these failures before and they all seem to be account related issues. I haven't seen `ITestAbfsRestOperationException#testRequestRetryConfig` before, but it looks like it was recently added and uses a custom token provider, so my guess is the failure is account related as well.