### PR TITLE
HADOOP-16873 - Upgrade to Apache ZooKeeper 3.5.7

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -95,7 +95,7 @@
     <hadoop-thirdparty-shaded-prefix>org.apache.hadoop.thirdparty</hadoop-thirdparty-shaded-prefix>
     <hadoop-thirdparty-shaded-protobuf-prefix>${hadoop-thirdparty-shaded-prefix}.protobuf</hadoop-thirdparty-shaded-protobuf-prefix>
 
-    <zookeeper.version>3.5.6</zookeeper.version>
+    <zookeeper.version>3.5.7</zookeeper.version>
     <curator.version>4.2.0</curator.version>
     <findbugs.version>3.0.0</findbugs.version>
     <spotbugs.version>3.1.0-RC1</spotbugs.version>


### PR DESCRIPTION
Apache ZooKeeper 3.5.7 has been released, which contains some important fixes including third party CVE, possible split brain and data loss in some very rare but plausible scenarios etc.
the release has been tested by the curator team to be compatible with 4.2.0
Release notes: https://zookeeper.apache.org/doc/r3.5.7/releasenotes.html

Change-Id: Ia7dae5e7e3ee5e7f7f92734e74722da7fedaa063

