### PR TITLE
HADOOP-16878. FileUtil.copy() to throw IOException if the source and destination are the same

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -398,6 +398,12 @@ public class FileUtil {
                              Configuration conf) throws IOException {
     Path src = srcStatus.getPath();
     dst = checkDest(src.getName(), dstFS, dst, overwrite);
+
+    if (src.toUri().equals(dst.toUri())) {
+      throw new PathOperationException("Source (" + src + ") and destination " +
+          "(" + dst + ") are equal in the copy command.");
+    }
+
     if (srcStatus.isDirectory()) {
       checkDependencies(srcFS, src, dstFS, dst);
       if (!dstFS.mkdirs(dst)) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -399,7 +399,8 @@ public class FileUtil {
     Path src = srcStatus.getPath();
     dst = checkDest(src.getName(), dstFS, dst, overwrite);
 
-    if (src.toUri().equals(dst.toUri())) {
+    if (dst != null && src != null &&
+        src.toUri().equals(dst.toUri())) {
       throw new PathOperationException("Source (" + src + ") and destination " +
           "(" + dst + ") are equal in the copy command.");
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -399,8 +399,7 @@ public class FileUtil {
     Path src = srcStatus.getPath();
     dst = checkDest(src.getName(), dstFS, dst, overwrite);
 
-    if (dst != null && src != null &&
-        src.toUri().equals(dst.toUri())) {
+    if (srcFS.makeQualified(src).equals(dstFS.makeQualified(dst))) {
       throw new PathOperationException("Source (" + src + ") and destination " +
           "(" + dst + ") are equal in the copy command.");
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
@@ -34,6 +34,7 @@ import java.io.PrintStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -175,7 +176,20 @@ public class TestFsShellCopy {
     checkPut(dirPath, targetDir, true);
   }
 
-  
+  @Test
+  public void testCopyBetweenFsEqualPath() throws Exception {
+    Path testRoot = new Path(testRootDir, "testPutFile");
+    lfs.delete(testRoot, true);
+    lfs.mkdirs(testRoot);
+
+    Path filePath = new Path(testRoot, "sameSourceTarget");
+    lfs.create(filePath).close();
+    final FileStatus status = lfs.getFileStatus(filePath);
+    LambdaTestUtils.intercept(PathOperationException.class, () ->
+        FileUtil.copy(lfs, status, lfs, filePath, false, true, conf)
+    );
+  }
+
   private void checkPut(Path srcPath, Path targetDir, boolean useWindowsPath)
   throws Exception {
     lfs.delete(targetDir, true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem.Statistics.StatisticsData;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.FsServerDefaults;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
@@ -78,6 +79,7 @@ import org.apache.hadoop.fs.MD5MD5CRC32FileChecksum;
 import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
+import org.apache.hadoop.fs.PathOperationException;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.StorageStatistics.LongStatistic;
 import org.apache.hadoop.fs.StorageType;
@@ -2495,6 +2497,20 @@ public class TestDistributedFileSystem {
       if (cluster != null) {
         cluster.shutdown();
       }
+    }
+  }
+
+  @Test
+  public void testCopyBetweenFsEqualPath() throws Exception {
+    Configuration conf = getTestConfiguration();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build()) {
+      cluster.waitActive();
+      final DistributedFileSystem dfs = cluster.getFileSystem();
+      Path filePath = new Path("/dir/file");
+      dfs.create(filePath).close();
+      FileStatus fstatus = dfs.getFileStatus(filePath);
+      LambdaTestUtils.intercept(PathOperationException.class,
+          () -> FileUtil.copy(dfs, fstatus, dfs, filePath, false, true, conf));
     }
   }
 }


### PR DESCRIPTION
Change-Id: Ibaa6e8a23ba575d0092b6d67989dc58c93a3a2d7
