### PR TITLE
HADOOP-13230. Optionally retain directory markers

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/AssertExtensions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/AssertExtensions.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.test;
+
+import java.util.concurrent.Callable;
+
+import org.assertj.core.description.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extra classes to work with AssertJ.
+ * These are kept separate from {@link LambdaTestUtils} so there's
+ * no requirement for AssertJ to be on the classpath in that broadly
+ * used class.
+ */
+public final class AssertExtensions {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(AssertExtensions.class);
+
+  private AssertExtensions() {
+  }
+
+  /**
+   * A description for AssertJ "describedAs" clauses which evaluates the
+   * lambda-expression only on failure. That must return a string
+   * or null/"" to be skipped.
+   * @param eval lambda expression to invoke
+   * @return a description for AssertJ
+   */
+  public static Description dynamicDescription(Callable<String> eval) {
+    return new DynamicDescription(eval);
+  }
+
+  private static final class DynamicDescription extends Description {
+    private final Callable<String> eval;
+
+    private DynamicDescription(final Callable<String> eval) {
+      this.eval = eval;
+    }
+
+    @Override
+    public String value() {
+      try {
+        return eval.call();
+      } catch (Exception e) {
+        LOG.warn("Failed to evaluate description: " + e);
+        LOG.debug("Evaluation failure", e);
+        // return null so that the description evaluation chain
+        // will skip this one
+        return null;
+      }
+    }
+  }
+
+
+}

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -51,6 +51,7 @@
     <!-- Set a longer timeout for integration test (in milliseconds) -->
     <test.integration.timeout>200000</test.integration.timeout>
 
+    <fs.s3a.directory.marker></fs.s3a.directory.marker>
   </properties>
 
   <profiles>
@@ -122,6 +123,7 @@
                 <fs.s3a.scale.test.huge.filesize>${fs.s3a.scale.test.huge.filesize}</fs.s3a.scale.test.huge.filesize>
                 <fs.s3a.scale.test.huge.huge.partitionsize>${fs.s3a.scale.test.huge.partitionsize}</fs.s3a.scale.test.huge.huge.partitionsize>
                 <fs.s3a.scale.test.timeout>${fs.s3a.scale.test.timeout}</fs.s3a.scale.test.timeout>
+                <fs.s3a.directory.marker>${fs.s3a.directory.marker}</fs.s3a.directory.marker>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -162,6 +164,7 @@
                     <fs.s3a.s3guard.test.enabled>${fs.s3a.s3guard.test.enabled}</fs.s3a.s3guard.test.enabled>
                     <fs.s3a.s3guard.test.authoritative>${fs.s3a.s3guard.test.authoritative}</fs.s3a.s3guard.test.authoritative>
                     <fs.s3a.s3guard.test.implementation>${fs.s3a.s3guard.test.implementation}</fs.s3a.s3guard.test.implementation>
+                    <fs.s3a.directory.marker>${fs.s3a.directory.marker}</fs.s3a.directory.marker>
 
                     <test.default.timeout>${test.integration.timeout}</test.default.timeout>
                   </systemPropertyVariables>
@@ -214,6 +217,7 @@
                     <fs.s3a.s3guard.test.enabled>${fs.s3a.s3guard.test.enabled}</fs.s3a.s3guard.test.enabled>
                     <fs.s3a.s3guard.test.implementation>${fs.s3a.s3guard.test.implementation}</fs.s3a.s3guard.test.implementation>
                     <fs.s3a.s3guard.test.authoritative>${fs.s3a.s3guard.test.authoritative}</fs.s3a.s3guard.test.authoritative>
+                    <fs.s3a.directory.marker>${fs.s3a.directory.marker}</fs.s3a.directory.marker>
                   </systemPropertyVariables>
                   <!-- Do a sequential run for tests that cannot handle -->
                   <!-- parallel execution. -->
@@ -268,6 +272,7 @@
                     <fs.s3a.s3guard.test.enabled>${fs.s3a.s3guard.test.enabled}</fs.s3a.s3guard.test.enabled>
                     <fs.s3a.s3guard.test.implementation>${fs.s3a.s3guard.test.implementation}</fs.s3a.s3guard.test.implementation>
                     <fs.s3a.s3guard.test.authoritative>${fs.s3a.s3guard.test.authoritative}</fs.s3a.s3guard.test.authoritative>
+                    <fs.s3a.directory.marker>${fs.s3a.directory.marker}</fs.s3a.directory.marker>
                   </systemPropertyVariables>
                   <forkedProcessTimeoutInSeconds>${fs.s3a.scale.test.timeout}</forkedProcessTimeoutInSeconds>
                 </configuration>
@@ -328,6 +333,44 @@
       </activation>
       <properties >
         <fs.s3a.s3guard.test.authoritative>true</fs.s3a.s3guard.test.authoritative>
+      </properties>
+    </profile>
+
+    <!-- Directory marker retention options, all from the -Dmarkers value-->
+    <profile>
+      <id>keep-markers</id>
+      <activation>
+        <property>
+          <name>markers</name>
+          <value>keep</value>
+        </property>
+      </activation>
+      <properties >
+        <fs.s3a.directory.marker>keep</fs.s3a.directory.marker>
+      </properties>
+    </profile>
+    <profile>
+      <id>delete-markers</id>
+      <activation>
+        <property>
+          <name>markers</name>
+          <value>delete</value>
+        </property>
+      </activation>
+      <properties >
+        <fs.s3a.directory.marker>delete</fs.s3a.directory.marker>
+      </properties>
+    </profile>
+    <profile>
+      <id>auth-markers</id>
+      <activation>
+        <property>
+          <name>markers</name>
+          <value>authoritative</value>
+        </property>
+      </activation>
+      <properties >
+        <fs.s3a.directory.marker>authoritative</fs.s3a.directory.marker>
       </properties>
     </profile>
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -953,4 +953,40 @@ public final class Constants {
    * Value: {@value} seconds.
    */
   public static final int THREAD_POOL_SHUTDOWN_DELAY_SECONDS = 30;
+
+  /**
+   * Policy for directory markers.
+   * This is a new feature of HADOOP-13230 which addresses
+   * some scale, performance and permissions issues -but
+   * at the risk of backwards compatibility.
+   */
+  public static final String DIRECTORY_MARKER_POLICY =
+      "fs.s3a.directory.markers";
+
+  /**
+   * Retain directory markers.
+   * Value: {@value}.
+   */
+  public static final String DIRECTORY_MARKER_POLICY_KEEP =
+      "keep";
+
+  /**
+   * Delete directory markers. This is the backwards compatible option.
+   * Value: {@value}.
+   */
+  public static final String DIRECTORY_MARKER_POLICY_DELETE =
+      "delete";
+
+  /**
+   * Retain directory markers in authoritative directory trees only.
+   * Value: {@value}.
+   */
+  public static final String DIRECTORY_MARKER_POLICY_AUTHORITATIVE =
+      "authoritative";
+
+  /**
+   * Default retention policy.
+   */
+  public static final String DEFAULT_DIRECTORY_MARKER_POLICY =
+      DIRECTORY_MARKER_POLICY_DELETE;
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
@@ -125,10 +125,25 @@ public class Listing {
       Listing.FileStatusAcceptor acceptor,
       RemoteIterator<S3AFileStatus> providedStatus) throws IOException {
     return new FileStatusListingIterator(
-        new ObjectListingIterator(listPath, request),
+        createObjectListingIterator(listPath, request),
         filter,
         acceptor,
         providedStatus);
+  }
+
+  /**
+   * Create an object listing iterator against a path, with a given
+   * list object request.
+   * @param listPath path of the listing
+   * @param request initial request to make
+   * @return the iterator
+   * @throws IOException IO Problems
+   */
+  @Retries.RetryRaw
+  public ObjectListingIterator createObjectListingIterator(
+      final Path listPath,
+      final S3ListRequest request) throws IOException {
+    return new ObjectListingIterator(listPath, request);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -4843,6 +4843,15 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   }
 
   /**
+   * Get the operation callbacks for this FS.
+   * @return callbacks for operations.
+   */
+  @InterfaceAudience.Private
+  public OperationCallbacks getOperationCallbacks() {
+    return operationCallbacks;
+  }
+
+  /**
    * The implementation of context accessors.
    */
   private class ContextAccessorsImpl implements ContextAccessors {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3036,7 +3036,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       final Set<StatusProbeEnum> probes,
       @Nullable final Set<Path> tombstones,
       final boolean needEmptyDirectoryFlag) throws IOException {
-    LOG.debug("S3GetFileStatus");
+    LOG.debug("S3GetFileStatus {}", path);
     Preconditions.checkArgument(!needEmptyDirectoryFlag
         || probes.contains(StatusProbeEnum.List),
         "s3GetFileStatus(%s) wants to know if a directory is empty but"

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1449,11 +1449,12 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       LOG.debug("rename: destination path {} not found", dst);
       // Parent must exist
       Path parent = dst.getParent();
-      if (!pathToKey(parent).isEmpty()) {
+      if (!pathToKey(parent).isEmpty()
+          && !parent.equals(src.getParent()) ) {
         try {
           // only look against S3 for directories; saves
           // a HEAD request on all normal operations.
-          S3AFileStatus dstParentStatus = innerGetFileStatus(dst.getParent(),
+          S3AFileStatus dstParentStatus = innerGetFileStatus(parent,
               false, StatusProbeEnum.DIRECTORIES);
           if (!dstParentStatus.isDirectory()) {
             throw new RenameFailedException(src, dst,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ListRequest.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ListRequest.java
@@ -24,11 +24,15 @@ import com.amazonaws.services.s3.model.ListObjectsV2Request;
 /**
  * API version-independent container for S3 List requests.
  */
-public class S3ListRequest {
-  private ListObjectsRequest v1Request;
-  private ListObjectsV2Request v2Request;
+public final class S3ListRequest {
 
-  protected S3ListRequest(ListObjectsRequest v1, ListObjectsV2Request v2) {
+  private static final String DESCRIPTION
+      = "List %s:/%s delimiter=%s keys=%d requester pays=%s";
+
+  private final ListObjectsRequest v1Request;
+  private final ListObjectsV2Request v2Request;
+
+  private S3ListRequest(ListObjectsRequest v1, ListObjectsV2Request v2) {
     v1Request = v1;
     v2Request = v2;
   }
@@ -70,11 +74,15 @@ public class S3ListRequest {
   @Override
   public String toString() {
     if (isV1()) {
-      return String.format("List %s:/%s",
-          v1Request.getBucketName(), v1Request.getPrefix());
+      return String.format(DESCRIPTION,
+          v1Request.getBucketName(), v1Request.getPrefix(),
+          v1Request.getDelimiter(), v1Request.getMaxKeys(),
+          v1Request.isRequesterPays());
     } else {
-      return String.format("List %s:/%s",
-          v2Request.getBucketName(), v2Request.getPrefix());
+      return String.format(DESCRIPTION,
+          v2Request.getBucketName(), v2Request.getPrefix(),
+          v2Request.getDelimiter(), v2Request.getMaxKeys(),
+          v2Request.isRequesterPays());
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ListResult.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ListResult.java
@@ -18,11 +18,18 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.slf4j.Logger;
 
-import java.util.List;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.impl.ContextAccessors;
 
 /**
  * API version-independent container for S3 List responses.
@@ -92,6 +99,109 @@ public class S3ListResult {
     } else {
       return v2Result.getCommonPrefixes();
     }
+  }
 
+  /**
+   * Is the list of object summaries empty
+   * after accounting for tombstone markers (if provided)?
+   * @param accessors callback for key to path mapping.
+   * @param tombstones Set of tombstone markers, or null if not applicable.
+   * @return false if summaries contains objects not accounted for by
+   * tombstones.
+   */
+  public boolean isEmptyOfObjects(
+      final ContextAccessors accessors,
+      final Set<Path> tombstones) {
+    if (tombstones == null) {
+      return getObjectSummaries().isEmpty();
+    }
+    return isEmptyOfKeys(accessors,
+        objectSummaryKeys(),
+        tombstones);
+  }
+
+  /**
+   * Get the list of keys in the object summary.
+   * @return a possibly empty list
+   */
+  private List<String> objectSummaryKeys() {
+    return getObjectSummaries().stream()
+        .map(S3ObjectSummary::getKey)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Does this listing have prefixes or objects?
+   * @param accessors callback for key to path mapping.
+   * @param tombstones Set of tombstone markers, or null if not applicable.
+   * @return true if the reconciled list is non-empty
+   */
+  public boolean hasPrefixesOrObjects(
+      final ContextAccessors accessors,
+      final Set<Path> tombstones) {
+
+    return !isEmptyOfKeys(accessors, getCommonPrefixes(), tombstones)
+        || !isEmptyOfObjects(accessors, tombstones);
+  }
+
+  /**
+   * Helper function to determine if a collection of keys is empty
+   * after accounting for tombstone markers (if provided).
+   * @param accessors callback for key to path mapping.
+   * @param keys Collection of path (prefixes / directories or keys).
+   * @param tombstones Set of tombstone markers, or null if not applicable.
+   * @return true if the list is considered empty.
+   */
+  public boolean isEmptyOfKeys(
+      final ContextAccessors accessors,
+      final Collection<String> keys,
+      final Set<Path> tombstones) {
+    if (tombstones == null) {
+      return keys.isEmpty();
+    }
+    for (String key : keys) {
+      Path qualified = accessors.keyToPath(key);
+      if (!tombstones.contains(qualified)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Does this listing represent an empty directory?
+   * @param contextAccessors callback for key to path mapping.
+   * @param dirKey directory key
+   * @param tombstones Set of tombstone markers, or null if not applicable.
+   * @return true if the list is considered empty.
+   */
+  public boolean representsEmptyDirectory(
+      final ContextAccessors contextAccessors,
+      final String dirKey,
+      final Set<Path> tombstones) {
+    // If looking for an empty directory, the marker must exist but
+    // no children.
+    // So the listing must contain the marker entry only as an object,
+    // and prefixes is null
+    List<String> keys = objectSummaryKeys();
+    return keys.size() == 1 && keys.contains(dirKey)
+        && getCommonPrefixes().isEmpty();
+  }
+
+  /**
+   * dump the result at debug level only.
+   * @param log log to use
+   */
+  public void logAtDebug(Logger log) {
+    Collection<String> prefixes = getCommonPrefixes();
+    Collection<S3ObjectSummary> summaries = getObjectSummaries();
+    log.debug("Prefix count = {}; object count={}",
+        prefixes.size(), summaries.size());
+    for (S3ObjectSummary summary : summaries) {
+      log.debug("Summary: {} {}", summary.getKey(), summary.getSize());
+    }
+    for (String prefix : prefixes) {
+      log.debug("Prefix: {}", prefix);
+    }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DirMarkerTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DirMarkerTracker.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
+
+/**
+ * Tracks directory markers which have been reported in object listings.
+ * This is needed for auditing and cleanup, including during rename
+ * operations.
+ * <p></p>
+ * Designed to be used while scanning through the results of listObject
+ * calls, where are we assume the results come in alphanumeric sort order
+ * and parent entries before children.
+ * <p></p>
+ * This lets as assume that we can identify all leaf markers as those
+ * markers which were added to set of leaf markers and not subsequently
+ * removed as a child entries were discovered.
+ * <p></p>
+ * To avoid scanning datastructures excessively, the path of the parent
+ * directory of the last file added is cached. This allows for a
+ * quick bailout when many children of the same directory are
+ * returned in a listing.
+ */
+public class DirMarkerTracker {
+
+  private final Map<Path, Pair<String, S3ALocatedFileStatus>> leafMarkers
+      = new TreeMap<>();
+
+  private final Map<Path, Pair<String, S3ALocatedFileStatus>> surplusMarkers
+      = new TreeMap<>();
+
+  private Path lastDirChecked;
+
+  public int markerFound(Path path,
+      final String key,
+      final S3ALocatedFileStatus source) {
+    leafMarkers.put(path, Pair.of(key, source));
+    return fileFound(path, key, source);
+  }
+
+  public int fileFound(Path path,
+      final String key,
+      final S3ALocatedFileStatus source) {
+    // all parent entries are superfluous
+    final Path parent = path.getParent();
+    if (parent == null || parent.equals(lastDirChecked)) {
+      // short cut exit
+      return 0;
+    }
+    final int markers = removeParentMarkers(parent);
+    lastDirChecked = parent;
+    return markers;
+  }
+
+  /**
+   * Remove all markers from the path and its parents.
+   * @param path path to start at
+   * @return number of markers removed.
+   */
+  private int removeParentMarkers(final Path path) {
+    if (path == null || path.isRoot()) {
+      return 0;
+    }
+    int parents = removeParentMarkers(path.getParent());
+    final Pair<String, S3ALocatedFileStatus> value = leafMarkers.remove(path);
+    if (value != null) {
+      // marker is surplus
+      surplusMarkers.put(path, value);
+      parents++;
+    }
+    return parents;
+  }
+
+  public Map<Path, Pair<String, S3ALocatedFileStatus>> getLeafMarkers() {
+    return leafMarkers;
+  }
+
+  public Map<Path, Pair<String, S3ALocatedFileStatus>> getSurplusMarkers() {
+    return surplusMarkers;
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DirectoryPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DirectoryPolicy.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import org.apache.hadoop.fs.Path;
+
+public interface DirectoryPolicy {
+
+  /**
+   * Should a directory marker be retained?
+   * @param path path a file/directory is being created with.
+   * @return true if the marker MAY be kept, false if it MUST be deleted.
+   */
+  boolean keepDirectoryMarkers(Path path);
+
+  /**
+   * Supported retention policies.
+   */
+  enum MarkerPolicy {
+    /**
+     * Keep markers.
+     * This is <i>Not backwards compatible</i>.
+     */
+    Keep,
+
+    /**
+     * Delete markers.
+     * This is what has been done since S3A was released. */
+    Delete,
+
+    /**
+     * Keep markers in authoritative paths only.
+     * This is <i>Not backwards compatible</i> within the
+     * auth paths, but is outside these.
+     */
+    Authoritative
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DirectoryPolicyImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/DirectoryPolicyImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+
+import java.util.Locale;
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_DIRECTORY_MARKER_POLICY;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_AUTHORITATIVE;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_DELETE;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_KEEP;
+
+/**
+ * Implementation of directory policy.
+ */
+public final class DirectoryPolicyImpl
+    implements DirectoryPolicy {
+
+  public static final String UNKNOWN_MARKER_POLICY = "Unknown value of "
+      + DIRECTORY_MARKER_POLICY + ": ";
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      DirectoryPolicyImpl.class);
+
+  private final MarkerPolicy markerPolicy;
+
+  private final Predicate<Path> authoritativenes;
+
+  public DirectoryPolicyImpl(
+      final Configuration conf,
+      final Predicate<Path> authoritativenes) {
+    this.authoritativenes = authoritativenes;
+    String option = conf.getTrimmed(DIRECTORY_MARKER_POLICY,
+        DEFAULT_DIRECTORY_MARKER_POLICY);
+    MarkerPolicy p;
+    switch (option.toLowerCase(Locale.ENGLISH)) {
+
+    case DIRECTORY_MARKER_POLICY_KEEP:
+      p = MarkerPolicy.Keep;
+      LOG.info("Directory markers will be deleted");
+      break;
+    case DIRECTORY_MARKER_POLICY_AUTHORITATIVE:
+      p = MarkerPolicy.Authoritative;
+      LOG.info("Directory markers will be deleted on authoritative"
+          + " paths");
+      break;
+    case DIRECTORY_MARKER_POLICY_DELETE:
+      p = MarkerPolicy.Delete;
+      break;
+    default:
+      throw new IllegalArgumentException(UNKNOWN_MARKER_POLICY + option);
+    }
+    this.markerPolicy = p;
+  }
+
+  @Override
+  public boolean keepDirectoryMarkers(final Path path) {
+    switch (markerPolicy) {
+    case Keep:
+      return true;
+    case Authoritative:
+      return authoritativenes.test(path);
+    case Delete:
+    default:   // which cannot happen
+      return false;
+    }
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(
+        "DirectoryMarkerRetention{");
+    sb.append("policy='").append(markerPolicy).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OperationCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OperationCallbacks.java
@@ -105,6 +105,24 @@ public interface OperationCallbacks {
       throws IOException;
 
   /**
+   * Delete a directory marker also updating the metastore.
+   * If the marker retention policy is to keep markers under this
+   * path, the marker is not deleted.
+   * This call does <i>not</i> create any mock parent entries.
+   * Retry policy: retry untranslated; delete considered idempotent.
+   * @param path path to delete
+   * @param key key of entry
+   * @param operationState (nullable) operational state for a bulk update
+   * @throws AmazonClientException problems working with S3
+   * @throws IOException IO failure in the metastore
+   */
+  @Retries.RetryTranslated
+  void deleteDirectoryMarkers(final Path path,
+      final String key,
+      final BulkOperationState operationState)
+      throws IOException;
+
+  /**
    * Recursive list of files and empty directories.
    *
    * @param path path to list from

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
@@ -325,6 +325,7 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
       // marker.
       LOG.debug("Deleting fake directory marker at destination {}",
           destStatus.getPath());
+      // TODO: dir marker policy doesn't always need to do this.
       callbacks.deleteObjectAtPath(destStatus.getPath(), dstKey, false, null);
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
@@ -391,7 +391,6 @@ Are   * @throws IOException failure
       Path source = entry.getKey();
       String key = entry.getValue().getLeft();
       S3ALocatedFileStatus stat = entry.getValue().getRight();
-      queueToDelete(source, key);
       String newDestKey =
           dstKey + key.substring(srcKey.length());
       Path childDestPath = storeContext.keyToPath(newDestKey);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
@@ -34,8 +34,18 @@ public enum StatusProbeEnum {
   List;
 
   /** All probes. */
-  public static final Set<StatusProbeEnum> ALL = EnumSet.allOf(
+  public static final Set<StatusProbeEnum> REALLY_ALL = EnumSet.allOf(
       StatusProbeEnum.class);
+
+  /** Look for files and directories. */
+  public static final Set<StatusProbeEnum> FILES_AND_DIRECTORIES =
+      EnumSet.of(Head, List);
+
+  /**
+   * This used to mean "all probes", now it means "all file type.
+   * @deprecated use {@link #FILES_AND_DIRECTORIES}
+   */
+  public static final Set<StatusProbeEnum> ALL = FILES_AND_DIRECTORIES;
 
   /** Skip the HEAD and only look for directories. */
   public static final Set<StatusProbeEnum> DIRECTORIES =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
@@ -33,17 +33,12 @@ public enum StatusProbeEnum {
   /** LIST under the path. */
   List;
 
-  /** All probes. */
-  public static final Set<StatusProbeEnum> REALLY_ALL = EnumSet.allOf(
-      StatusProbeEnum.class);
-
   /** Look for files and directories. */
   public static final Set<StatusProbeEnum> FILES_AND_DIRECTORIES =
       EnumSet.of(Head, List);
 
   /**
    * This used to mean "all probes", now it means "all file type.
-   * @deprecated use {@link #FILES_AND_DIRECTORIES}
    */
   public static final Set<StatusProbeEnum> ALL = FILES_AND_DIRECTORIES;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
@@ -34,32 +34,24 @@ public enum StatusProbeEnum {
   List;
 
   /** Look for files and directories. */
-  public static final Set<StatusProbeEnum> FILES_AND_DIRECTORIES =
+  public static final Set<StatusProbeEnum> ALL =
       EnumSet.of(Head, List);
-
-  /**
-   * This used to mean "all probes", now it means "all file type.
-   */
-  public static final Set<StatusProbeEnum> ALL = FILES_AND_DIRECTORIES;
-
-  /** Skip the HEAD and only look for directories. */
-  public static final Set<StatusProbeEnum> DIRECTORIES =
-      EnumSet.of(DirMarker, List);
-
-  /** We only want the HEAD or dir marker. */
-  public static final Set<StatusProbeEnum> HEAD_OR_DIR_MARKER =
-      EnumSet.of(Head, DirMarker);
 
   /** We only want the HEAD. */
   public static final Set<StatusProbeEnum> HEAD_ONLY =
       EnumSet.of(Head);
 
-  /** We only want the dir marker. */
-  public static final Set<StatusProbeEnum> DIR_MARKER_ONLY =
-      EnumSet.of(DirMarker);
-
-  /** We only want the dir marker. */
+  /** List operation only. */
   public static final Set<StatusProbeEnum> LIST_ONLY =
       EnumSet.of(List);
+
+  /** Look for files and directories. */
+  public static final Set<StatusProbeEnum> FILE =
+      HEAD_ONLY;
+
+  /** Skip the HEAD and only look for directories. */
+  public static final Set<StatusProbeEnum> DIRECTORIES =
+      LIST_ONLY;
+
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/ITtlTimeProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/ITtlTimeProvider.java
@@ -29,6 +29,19 @@ package org.apache.hadoop.fs.s3a.s3guard;
  * Time is measured in milliseconds,
  */
 public interface ITtlTimeProvider {
+
+  /**
+   * The current time in milliseconds.
+   * Assuming this calls System.currentTimeMillis(), this is a native iO call
+   * and so should be invoked sparingly (i.e. evaluate before any loop, rather
+   * than inside).
+   * @return the current time.
+   */
   long getNow();
+
+  /**
+   * The TTL of the metadata.
+   * @return time in millis after which metadata is considered out of date.
+   */
   long getMetadataTtl();
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.fs.s3a.auth.delegation.S3ADelegationTokens;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 import org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants;
 import org.apache.hadoop.fs.s3a.select.SelectTool;
+import org.apache.hadoop.fs.s3a.tools.MarkerTool;
 import org.apache.hadoop.fs.shell.CommandFormat;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -98,6 +99,7 @@ public abstract class S3GuardTool extends Configured implements Tool,
       "Commands: \n" +
       "\t" + Init.NAME + " - " + Init.PURPOSE + "\n" +
       "\t" + Destroy.NAME + " - " + Destroy.PURPOSE + "\n" +
+      "\t" + MarkerTool.NAME + " - " + MarkerTool.PURPOSE + "\n" +
       "\t" + Import.NAME + " - " + Import.PURPOSE + "\n" +
       "\t" + BucketInfo.NAME + " - " + BucketInfo.PURPOSE + "\n" +
       "\t" + Uploads.NAME + " - " + Uploads.PURPOSE + "\n" +
@@ -106,7 +108,8 @@ public abstract class S3GuardTool extends Configured implements Tool,
       "\t" + SetCapacity.NAME + " - " + SetCapacity.PURPOSE + "\n" +
       "\t" + SelectTool.NAME + " - " + SelectTool.PURPOSE + "\n" +
       "\t" + Fsck.NAME + " - " + Fsck.PURPOSE + "\n" +
-      "\t" + Authoritative.NAME + " - " + Authoritative.PURPOSE + "\n";
+      "\t" + Authoritative.NAME + " - " + Authoritative.PURPOSE + "\n"
+      ;
   private static final String DATA_IN_S3_IS_PRESERVED
       = "(all data in S3 is preserved)";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -99,16 +99,16 @@ public abstract class S3GuardTool extends Configured implements Tool,
       "Commands: \n" +
       "\t" + Init.NAME + " - " + Init.PURPOSE + "\n" +
       "\t" + Destroy.NAME + " - " + Destroy.PURPOSE + "\n" +
-      "\t" + MarkerTool.NAME + " - " + MarkerTool.PURPOSE + "\n" +
-      "\t" + Import.NAME + " - " + Import.PURPOSE + "\n" +
+      "\t" + Authoritative.NAME + " - " + Authoritative.PURPOSE + "\n" +
       "\t" + BucketInfo.NAME + " - " + BucketInfo.PURPOSE + "\n" +
-      "\t" + Uploads.NAME + " - " + Uploads.PURPOSE + "\n" +
       "\t" + Diff.NAME + " - " + Diff.PURPOSE + "\n" +
+      "\t" + Fsck.NAME + " - " + Fsck.PURPOSE + "\n" +
+      "\t" + Import.NAME + " - " + Import.PURPOSE + "\n" +
+      "\t" + MarkerTool.NAME + " - " + MarkerTool.PURPOSE + "\n" +
       "\t" + Prune.NAME + " - " + Prune.PURPOSE + "\n" +
       "\t" + SetCapacity.NAME + " - " + SetCapacity.PURPOSE + "\n" +
       "\t" + SelectTool.NAME + " - " + SelectTool.PURPOSE + "\n" +
-      "\t" + Fsck.NAME + " - " + Fsck.PURPOSE + "\n" +
-      "\t" + Authoritative.NAME + " - " + Authoritative.PURPOSE + "\n"
+      "\t" + Uploads.NAME + " - " + Uploads.PURPOSE + "\n"
       ;
   private static final String DATA_IN_S3_IS_PRESERVED
       = "(all data in S3 is preserved)";
@@ -1993,6 +1993,9 @@ public abstract class S3GuardTool extends Configured implements Tool,
       break;
     case Diff.NAME:
       command = new Diff(conf);
+      break;
+    case MarkerTool.NAME:
+      command = new MarkerTool(conf);
       break;
     case Prune.NAME:
       command = new Prune(conf);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.tools;
+
+import java.io.PrintStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.s3a.s3guard.S3GuardTool;
+import org.apache.hadoop.util.ExitUtil;
+
+/**
+ * Handle directory-related command-line options in the
+ * s3guard tool.
+ * <pre>
+ *   scan: scan for markers
+ *   clean: clean up marker entries. This will include empty directories
+ *   created with -mkdir
+ * </pre>
+ * This tool does not go anywhere near S3Guard.
+ */
+public class MarkerTool extends S3GuardTool {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MarkerTool.class);
+
+  public static final String NAME = "markers";
+
+  public static final String PURPOSE =
+      "view and manipulate S3 directory markers";
+
+  private static final String USAGE = NAME
+      + " [OPTIONS]"
+      + " [-scan]"
+      + " [-clean]"
+      + " [-out <path>]"
+      + " [-" + VERBOSE + "]"
+      + " <PATH>\n"
+      + "\t" + PURPOSE + "\n\n";
+
+  public static final String OPT_EXPECTED = "expected";
+
+  public static final String OPT_OUTPUT = "out";
+
+  public MarkerTool(final Configuration conf,
+      final String... opts) {
+    super(conf, opts);
+  }
+
+  @Override
+  public String getUsage() {
+    return USAGE;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int run(final String[] args, final PrintStream out)
+      throws Exception, ExitUtil.ExitException {
+    return 0;
+  }
+
+  static interface MarkerOperationCallbacks {
+
+  }
+
+  /**
+   * Maintenance operations isolated from command line for ease of testing.
+   */
+  static final class MarkerMaintenance {
+    private final StoreContext store;
+    private final MarkerOperationCallbacks operationCallbacks;
+
+    MarkerMaintenance(final StoreContext store,
+        final MarkerOperationCallbacks operationCallbacks) {
+      this.store = store;
+      this.operationCallbacks = operationCallbacks;
+    }
+
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
@@ -18,27 +18,49 @@
 
 package org.apache.hadoop.fs.s3a.tools;
 
+import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.fs.s3a.S3AFileStatus;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
+import org.apache.hadoop.fs.s3a.impl.DirMarkerTracker;
+import org.apache.hadoop.fs.s3a.impl.OperationCallbacks;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 import org.apache.hadoop.fs.s3a.s3guard.S3GuardTool;
+import org.apache.hadoop.fs.shell.CommandFormat;
+import org.apache.hadoop.util.DurationInfo;
 import org.apache.hadoop.util.ExitUtil;
+
+import static org.apache.hadoop.fs.s3a.Invoker.once;
+import static org.apache.hadoop.service.launcher.LauncherExitCodes.EXIT_NOT_ACCEPTABLE;
+import static org.apache.hadoop.service.launcher.LauncherExitCodes.EXIT_SUCCESS;
+import static org.apache.hadoop.service.launcher.LauncherExitCodes.EXIT_USAGE;
 
 /**
  * Handle directory-related command-line options in the
  * s3guard tool.
  * <pre>
  *   scan: scan for markers
- *   clean: clean up marker entries. This will include empty directories
- *   created with -mkdir
+ *   clean: clean up marker entries.
  * </pre>
- * This tool does not go anywhere near S3Guard.
+ * This tool does not go anywhere near S3Guard; its scan bypasses any
+ * metastore as we are explicitly looking for marker objects.
+ *
  */
-public class MarkerTool extends S3GuardTool {
+public final class MarkerTool extends S3GuardTool {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(MarkerTool.class);
@@ -50,20 +72,32 @@ public class MarkerTool extends S3GuardTool {
 
   private static final String USAGE = NAME
       + " [OPTIONS]"
-      + " [-scan]"
-      + " [-clean]"
-      + " [-out <path>]"
+      + " (audit || report || clean)"
+//      + " [-out <path>]"
       + " [-" + VERBOSE + "]"
       + " <PATH>\n"
       + "\t" + PURPOSE + "\n\n";
 
   public static final String OPT_EXPECTED = "expected";
 
-  public static final String OPT_OUTPUT = "out";
+  public static final String OPT_AUDIT = "audit";
 
-  public MarkerTool(final Configuration conf,
-      final String... opts) {
-    super(conf, opts);
+  public static final String OPT_CLEAN = "clean";
+
+  public static final String OPT_REPORT = "report";
+
+  public static final String OPT_OUTPUT = "output";
+
+  public static final String OPT_VERBOSE = "verbose";
+
+  static final String TOO_FEW_ARGUMENTS = "Too few arguments";
+
+  private PrintStream out;
+
+  public MarkerTool(final Configuration conf) {
+    super(conf, OPT_VERBOSE);
+    getCommandFormat().addOptionWithValue(OPT_EXPECTED);
+//    getCommandFormat().addOptionWithValue(OPT_OUTPUT);
   }
 
   @Override
@@ -77,27 +111,151 @@ public class MarkerTool extends S3GuardTool {
   }
 
   @Override
-  public int run(final String[] args, final PrintStream out)
-      throws Exception, ExitUtil.ExitException {
-    return 0;
+  public int run(final String[] args, final PrintStream stream)
+      throws ExitUtil.ExitException, Exception {
+    this.out = stream;
+    final List<String> parsedArgs;
+    try {
+      parsedArgs = parseArgs(args);
+    } catch (CommandFormat.UnknownOptionException e) {
+      errorln(getUsage());
+      throw new ExitUtil.ExitException(EXIT_USAGE, e.getMessage(), e);
+    }
+    if (parsedArgs.size() < 2) {
+      errorln(getUsage());
+      throw new ExitUtil.ExitException(EXIT_USAGE, TOO_FEW_ARGUMENTS);
+    }
+    // read arguments
+    CommandFormat commandFormat = getCommandFormat();
+    boolean verbose = commandFormat.getOpt(VERBOSE);
+
+    boolean purge = false;
+    int expected = 0;
+    String action = parsedArgs.get(0);
+    switch (action) {
+    case OPT_AUDIT:
+      purge = false;
+      expected = 0;
+      break;
+    case OPT_CLEAN:
+      purge = true;
+      expected = -1;
+      break;
+    case OPT_REPORT:
+      purge = false;
+      expected = -1;
+      break;
+    default:
+      errorln(getUsage());
+      throw new ExitUtil.ExitException(EXIT_USAGE, "Unknown action: " + action);
+    }
+
+    final String file = parsedArgs.get(1);
+    final Path path = new Path(file);
+    S3AFileSystem fs = bindFilesystem(path.getFileSystem(getConf()));
+    final StoreContext context = fs.createStoreContext();
+    final OperationCallbacks operations = fs.getOperationCallbacks();
+
+
+    boolean finalPurge = purge;
+    int finalExpected = expected;
+    int result = once("action", path.toString(),
+        () -> scan(path, finalPurge, finalExpected, verbose, context,
+            operations));
+    if (verbose) {
+      dumpFileSystemStatistics(fs);
+    }
+    return result;
   }
 
-  static interface MarkerOperationCallbacks {
+  private int scan(final Path path,
+      final boolean purge,
+      final int expected,
+      final boolean verbose,
+      final StoreContext context,
+      final OperationCallbacks operations)
+      throws IOException, ExitUtil.ExitException {
+    DirMarkerTracker tracker = new DirMarkerTracker();
+    try (DurationInfo ignored =
+             new DurationInfo(LOG, "marker scan %s", path)) {
+      scanDirectoryTree(path, expected, context, operations, tracker);
+    }
+    // scan done. what have we got?
+    Map<Path, Pair<String, S3ALocatedFileStatus>> surplusMarkers
+        = tracker.getSurplusMarkers();
+    Map<Path, Pair<String, S3ALocatedFileStatus>> leafMarkers
+        = tracker.getLeafMarkers();
+    int size = surplusMarkers.size();
+    if (size == 0) {
+      println(out, "No surplus directory markers were found under %s", path);
+    } else {
+      println(out, "Found %d surplus directory marker%s under %s",
+          size,
+          suffix(size),
+          path);
 
+      for (Path markers : surplusMarkers.keySet()) {
+        println(out, "    %s", markers);
+      }
+
+      if (size > expected) {
+        // failure
+        println(out, "Expected %d marker%s", expected, suffix(size));
+        return EXIT_NOT_ACCEPTABLE;
+      }
+
+    }
+    return EXIT_SUCCESS;
+  }
+
+  private String suffix(final int size) {
+    return size == 1 ? "" : "s";
+  }
+
+  private void scanDirectoryTree(final Path path,
+      final int expected,
+      final StoreContext context,
+      final OperationCallbacks operations,
+      final DirMarkerTracker tracker) throws IOException {
+    RemoteIterator<S3AFileStatus> listing = operations
+        .listObjects(path,
+            context.pathToKey(path));
+    while (listing.hasNext()) {
+      S3AFileStatus status = listing.next();
+      Path p = status.getPath();
+      S3ALocatedFileStatus lfs = new S3ALocatedFileStatus(
+          status, null);
+      String key = context.pathToKey(p);
+      if (status.isDirectory()) {
+        LOG.info("{}", key);
+        tracker.markerFound(p,
+            key + "/",
+            lfs);
+      } else {
+        tracker.fileFound(p,
+            key,
+            lfs);
+      }
+
+
+    }
   }
 
   /**
-   * Maintenance operations isolated from command line for ease of testing.
+   * Dump the filesystem Storage Statistics.
+   * @param fs filesystem; can be null
    */
-  static final class MarkerMaintenance {
-    private final StoreContext store;
-    private final MarkerOperationCallbacks operationCallbacks;
-
-    MarkerMaintenance(final StoreContext store,
-        final MarkerOperationCallbacks operationCallbacks) {
-      this.store = store;
-      this.operationCallbacks = operationCallbacks;
+  private void dumpFileSystemStatistics(FileSystem fs) {
+    if (fs == null) {
+      return;
     }
-
+    println(out, "Storage Statistics");
+    StorageStatistics st = fs.getStorageStatistics();
+    Iterator<StorageStatistics.LongStatistic> it
+        = st.getLongStatistics();
+    while (it.hasNext()) {
+      StorageStatistics.LongStatistic next = it.next();
+      println(out, "%s\t%s", next.getName(), next.getValue());
+    }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/package-info.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Command line tools.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.s3a.tools;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABucketExistence.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABucketExistence.java
@@ -75,7 +75,10 @@ public class ITestS3ABucketExistence extends AbstractS3ATestBase {
 
     // the exception must not be caught and marked down to an FNFE
     expectUnknownStore(() -> fs.exists(src));
-    expectUnknownStore(() -> fs.isFile(src));
+    // now that isFile() only does a HEAD, it will get a 404 without
+    // the no-such-bucket error (really)
+    assertFalse("isFile(" + src + " was expected to complete by returning false",
+        fs.isFile(src));
     expectUnknownStore(() -> fs.isDirectory(src));
     expectUnknownStore(() -> fs.mkdirs(src));
     expectUnknownStore(() -> fs.delete(src));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEmptyDirectory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEmptyDirectory.java
@@ -80,7 +80,7 @@ public class ITestS3AEmptyDirectory extends AbstractS3ATestBase {
   private S3AFileStatus getS3AFileStatus(S3AFileSystem fs, Path p) throws
       IOException {
     return fs.innerGetFileStatus(p, true,
-        StatusProbeEnum.ALL);
+        StatusProbeEnum.FILES_AND_DIRECTORIES);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEmptyDirectory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEmptyDirectory.java
@@ -80,7 +80,7 @@ public class ITestS3AEmptyDirectory extends AbstractS3ATestBase {
   private S3AFileStatus getS3AFileStatus(S3AFileSystem fs, Path p) throws
       IOException {
     return fs.innerGetFileStatus(p, true,
-        StatusProbeEnum.FILES_AND_DIRECTORIES);
+        StatusProbeEnum.ALL);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
@@ -20,8 +20,13 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
+import java.util.Arrays;
+import java.util.Collection;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -31,13 +36,26 @@ import org.apache.hadoop.fs.contract.s3a.S3AContract;
 import org.apache.hadoop.io.IOUtils;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_DELETE;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_KEEP;
+import static org.apache.hadoop.fs.s3a.Constants.ETAG_CHECKSUM_ENABLED;
+import static org.apache.hadoop.fs.s3a.Constants.S3_METADATA_STORE_IMPL;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
+import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
  * Concrete class that extends {@link AbstractTestS3AEncryption}
  * and tests SSE-C encryption.
+ * HEAD requests against SSE-C-encrypted data will fail if the wrong key
+ * is presented, so the tests are very brittle to S3Guard being on vs. off.
+ * Equally "vexing" has been the optimizations of getFileStatus(), wherein
+ * LIST comes before HEAD path + /
  */
+@RunWith(Parameterized.class)
 public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
 
   private static final String SERVICE_AMAZON_S3_STATUS_CODE_403
@@ -53,17 +71,66 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
   private static final int TEST_FILE_LEN = 2048;
 
   /**
+   * Parameterization.
+   */
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {"raw-keep-markers", false, true},
+        {"raw-delete-markers", false, false},
+        {"guarded-keep-markers", true, true},
+        {"guarded-delete-markers", true, false}
+    });
+  }
+
+  /**
+   * Parameter: should the stores be guarded?
+   */
+  private final boolean s3guard;
+
+  /**
+   * Parameter: should directory markers be retained?
+   */
+  private final boolean keepMarkers;
+
+  /**
    * Filesystem created with a different key.
    */
-  private FileSystem fsKeyB;
+  private S3AFileSystem fsKeyB;
+
+  public ITestS3AEncryptionSSEC(final String name,
+      final boolean s3guard,
+      final boolean keepMarkers) {
+    this.s3guard = s3guard;
+    this.keepMarkers = keepMarkers;
+  }
 
   @Override
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     disableFilesystemCaching(conf);
-    conf.set(Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM,
+    String bucketName = getTestBucketName(conf);
+    removeBucketOverrides(bucketName, conf,
+        S3_METADATA_STORE_IMPL);
+    if (!s3guard) {
+      // in a raw run remove all s3guard settings
+      removeBaseAndBucketOverrides(bucketName, conf,
+          S3_METADATA_STORE_IMPL);
+    }
+    // directory marker options
+    removeBaseAndBucketOverrides(bucketName, conf,
+        DIRECTORY_MARKER_POLICY,
+        ETAG_CHECKSUM_ENABLED,
+        SERVER_SIDE_ENCRYPTION_ALGORITHM,
+        SERVER_SIDE_ENCRYPTION_KEY);
+    conf.set(DIRECTORY_MARKER_POLICY,
+        keepMarkers
+            ? DIRECTORY_MARKER_POLICY_KEEP
+            : DIRECTORY_MARKER_POLICY_DELETE);
+    conf.set(SERVER_SIDE_ENCRYPTION_ALGORITHM,
         getSSEAlgorithm().getMethod());
-    conf.set(Constants.SERVER_SIDE_ENCRYPTION_KEY, KEY_1);
+    conf.set(SERVER_SIDE_ENCRYPTION_KEY, KEY_1);
+    conf.setBoolean(ETAG_CHECKSUM_ENABLED, true);
     return conf;
   }
 
@@ -109,31 +176,19 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
   }
 
   /**
-   * While each object has its own key and should be distinct, this verifies
-   * that hadoop treats object keys as a filesystem path.  So if a top level
-   * dir is encrypted with keyA, a sublevel dir cannot be accessed with a
-   * different keyB.
    *
-   * This is expected AWS S3 SSE-C behavior.
-   *
+   * You can use a different key under a sub directory, even if you
+   * do not have permissions to read the marker.
    * @throws Exception
    */
   @Test
   public void testCreateSubdirWithDifferentKey() throws Exception {
-    requireUnguardedFilesystem();
-
-    intercept(AccessDeniedException.class,
-        SERVICE_AMAZON_S3_STATUS_CODE_403,
-        () -> {
-          Path base = path("testCreateSubdirWithDifferentKey");
-          Path nestedDirectory = new Path(base, "nestedDir");
-          fsKeyB = createNewFileSystemWithSSECKey(
-              KEY_2);
-          getFileSystem().mkdirs(base);
-          fsKeyB.mkdirs(nestedDirectory);
-          // expected to fail
-          return fsKeyB.getFileStatus(nestedDirectory);
-        });
+    Path base = path("testCreateSubdirWithDifferentKey");
+    Path nestedDirectory = new Path(base, "nestedDir");
+    fsKeyB = createNewFileSystemWithSSECKey(
+        KEY_2);
+    getFileSystem().mkdirs(base);
+    fsKeyB.mkdirs(nestedDirectory);
   }
 
   /**
@@ -176,14 +231,11 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
   }
 
   /**
-   * It is possible to list the contents of a directory up to the actual
-   * end of the nested directories.  This is due to how S3A mocks the
-   * directories and how prefixes work in S3.
+   * Directory listings always work.
    * @throws Exception
    */
   @Test
   public void testListEncryptedDir() throws Exception {
-    requireUnguardedFilesystem();
 
     Path pathABC = path("testListEncryptedDir/a/b/c/");
     Path pathAB = pathABC.getParent();
@@ -196,17 +248,11 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
 
     fsKeyB.listFiles(pathA, true);
     fsKeyB.listFiles(pathAB, true);
-
-    //Until this point, no exception is thrown about access
-    intercept(AccessDeniedException.class,
-        SERVICE_AMAZON_S3_STATUS_CODE_403,
-        () -> {
-          fsKeyB.listFiles(pathABC, false);
-        });
+    fsKeyB.listFiles(pathABC, false);
 
     Configuration conf = this.createConfiguration();
-    conf.unset(Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM);
-    conf.unset(Constants.SERVER_SIDE_ENCRYPTION_KEY);
+    conf.unset(SERVER_SIDE_ENCRYPTION_ALGORITHM);
+    conf.unset(SERVER_SIDE_ENCRYPTION_KEY);
 
     S3AContract contract = (S3AContract) createContract(conf);
     contract.init();
@@ -215,20 +261,14 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     //unencrypted can access until the final directory
     unencryptedFileSystem.listFiles(pathA, true);
     unencryptedFileSystem.listFiles(pathAB, true);
-    AWSBadRequestException ex = intercept(AWSBadRequestException.class,
-        () -> {
-          unencryptedFileSystem.listFiles(pathABC, false);
-        });
+    unencryptedFileSystem.listFiles(pathABC, false);
   }
 
   /**
-   * Much like the above list encrypted directory test, you cannot get the
-   * metadata of an object without the correct encryption key.
-   * @throws Exception
+   * listStatus also works with encrypted directories and key mismatch.
    */
   @Test
   public void testListStatusEncryptedDir() throws Exception {
-    requireUnguardedFilesystem();
 
     Path pathABC = path("testListStatusEncryptedDir/a/b/c/");
     Path pathAB = pathABC.getParent();
@@ -240,17 +280,14 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     fsKeyB.listStatus(pathA);
     fsKeyB.listStatus(pathAB);
 
-    //Until this point, no exception is thrown about access
-    intercept(AccessDeniedException.class,
-        SERVICE_AMAZON_S3_STATUS_CODE_403,
-        () -> {
-          fsKeyB.listStatus(pathABC);
-        });
+    // this used to raise 403, but with LIST before HEAD,
+    // no longer true.
+    fsKeyB.listStatus(pathABC);
 
     //Now try it with an unencrypted filesystem.
     Configuration conf = createConfiguration();
-    conf.unset(Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM);
-    conf.unset(Constants.SERVER_SIDE_ENCRYPTION_KEY);
+    conf.unset(SERVER_SIDE_ENCRYPTION_ALGORITHM);
+    conf.unset(SERVER_SIDE_ENCRYPTION_KEY);
 
     S3AContract contract = (S3AContract) createContract(conf);
     contract.init();
@@ -259,21 +296,15 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     //unencrypted can access until the final directory
     unencryptedFileSystem.listStatus(pathA);
     unencryptedFileSystem.listStatus(pathAB);
-
-    intercept(AWSBadRequestException.class,
-        () -> {
-          unencryptedFileSystem.listStatus(pathABC);
-        });
+    unencryptedFileSystem.listStatus(pathABC);
   }
 
   /**
-   * Much like trying to access a encrypted directory, an encrypted file cannot
-   * have its metadata read, since both are technically an object.
+   * An encrypted file cannot have its metadata read.
    * @throws Exception
    */
   @Test
   public void testListStatusEncryptedFile() throws Exception {
-    requireUnguardedFilesystem();
     Path pathABC = path("testListStatusEncryptedFile/a/b/c/");
     assertTrue("mkdirs failed", getFileSystem().mkdirs(pathABC));
 
@@ -283,22 +314,14 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     fsKeyB = createNewFileSystemWithSSECKey(KEY_4);
 
     //Until this point, no exception is thrown about access
-    intercept(AccessDeniedException.class,
-        SERVICE_AMAZON_S3_STATUS_CODE_403,
-        () -> {
-          fsKeyB.listStatus(fileToStat);
-        });
+    if (!fsKeyB.hasMetadataStore()) {
+      intercept(AccessDeniedException.class,
+          SERVICE_AMAZON_S3_STATUS_CODE_403,
+          () -> fsKeyB.listStatus(fileToStat));
+    } else {
+      fsKeyB.listStatus(fileToStat);
+    }
   }
-
-  /**
-   * Skip the test case if S3Guard is enabled; generally this is because
-   * list and GetFileStatus calls can succeed even with different keys.
-   */
-  protected void requireUnguardedFilesystem() {
-    assume("Filesystem has a metastore",
-        !getFileSystem().hasMetadataStore());
-  }
-
 
   /**
    * It is possible to delete directories without the proper encryption key and
@@ -308,7 +331,7 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
    */
   @Test
   public void testDeleteEncryptedObjectWithDifferentKey() throws Exception {
-    requireUnguardedFilesystem();
+    //requireUnguardedFilesystem();
     Path pathABC = path("testDeleteEncryptedObjectWithDifferentKey/a/b/c/");
 
     Path pathAB = pathABC.getParent();
@@ -317,12 +340,13 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     Path fileToDelete = new Path(pathABC, "filetobedeleted.txt");
     writeThenReadFile(fileToDelete, TEST_FILE_LEN);
     fsKeyB = createNewFileSystemWithSSECKey(KEY_4);
-    intercept(AccessDeniedException.class,
-        SERVICE_AMAZON_S3_STATUS_CODE_403,
-        () -> {
-          fsKeyB.delete(fileToDelete, false);
-        });
-
+    if (!fsKeyB.hasMetadataStore()) {
+      intercept(AccessDeniedException.class,
+          SERVICE_AMAZON_S3_STATUS_CODE_403,
+          () -> fsKeyB.delete(fileToDelete, false));
+    } else {
+      fsKeyB.delete(fileToDelete, false);
+    }
     //This is possible
     fsKeyB.delete(pathABC, true);
     fsKeyB.delete(pathAB, true);
@@ -330,15 +354,33 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     assertPathDoesNotExist("expected recursive delete", fileToDelete);
   }
 
-  private FileSystem createNewFileSystemWithSSECKey(String sseCKey) throws
+  /**
+   * getFileChecksum always goes to S3, so when
+   * the caller lacks permissions, it fails irrespective
+   * of guard.
+   */
+  @Test
+  public void testChecksumRequiresReadAccess() throws Throwable {
+    Path path = path("tagged-file");
+    S3AFileSystem fs = getFileSystem();
+    touch(fs, path);
+    Assertions.assertThat(fs.getFileChecksum(path))
+        .isNotNull();
+    fsKeyB = createNewFileSystemWithSSECKey(KEY_4);
+    intercept(AccessDeniedException.class,
+        SERVICE_AMAZON_S3_STATUS_CODE_403,
+        () -> fsKeyB.getFileChecksum(path));
+  }
+
+  private S3AFileSystem createNewFileSystemWithSSECKey(String sseCKey) throws
       IOException {
     Configuration conf = this.createConfiguration();
-    conf.set(Constants.SERVER_SIDE_ENCRYPTION_KEY, sseCKey);
+    conf.set(SERVER_SIDE_ENCRYPTION_KEY, sseCKey);
 
     S3AContract contract = (S3AContract) createContract(conf);
     contract.init();
     FileSystem fileSystem = contract.getTestFileSystem();
-    return fileSystem;
+    return (S3AFileSystem) fileSystem;
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
@@ -44,9 +43,9 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
-import static org.apache.hadoop.fs.s3a.Constants.AUTHORITATIVE_PATH;
 import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY;
 import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_DELETE;
 import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_KEEP;
@@ -69,18 +68,72 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3AFileOperationCost.class);
 
-  // source, dest, copy metadata
-  public static final int HEAD_REQUESTS_SINGLE_FILE_RENAME = 3;
-  // yes, that's a lot
-  public static final int LIST_REQUESTS_SINGLE_FILE_RENAME_DIFFERENT_DIR = 3;
+  /*
+   * constants declaring operation costs in HEAD and LIST.
+   */
 
-  private MetricDiff metadataRequests;
-  private MetricDiff listRequests;
+
+  /* getFileStatus() directory probe only. */
+  public static final int GFS_DIR_PROBE_H = 0;
+
+  public static final int GFS_DIR_PROBE_L = 1;
+
+  /* getFileStatus() file probe only. */
+  public static final int GFS_FILE_PROBE_H = 1;
+
+  public static final int GFS_FILE_PROBE_L = 0;
+
+  /* getFileStatus() on a file which exists. */
+  public static final int GFS_SINGLE_FILE_H = GFS_FILE_PROBE_H;
+  public static final int GFS_SINGLE_FILE_L = 0;
+
+  /* getFileStatus() directory marker which exists. */
+  public static final int GFS_MARKER_H = GFS_FILE_PROBE_H;
+  public static final int GFS_MARKER_L = GFS_DIR_PROBE_L;
+
+  /* getFileStatus() directory which is non-empty. */
+  public static final int GFS_DIR_H = GFS_FILE_PROBE_H;
+  public static final int GFS_DIR_L = GFS_DIR_PROBE_L;
+
+  /* getFileStatus() no file or dir. */
+  public static final int GFS_FNFE_H = GFS_FILE_PROBE_H;
+  public static final int GFS_FNFE_L = GFS_DIR_PROBE_L;
+
+  public static final int DELETE_OBJECT_REQUEST = 1;
+  public static final int DELETE_MARKER_REQUEST = 1;
+
+  /** listLocatedStatus always does a list. */
+  public static final int LLS_ALWAYS_L = 1;
+
+  /** source is found, dest not found, copy metadataRequests */
+  public static final int RENAME_SINGLE_FILE_RENAME_H =
+      GFS_FILE_PROBE_H + GFS_FNFE_H + 1;
+
+  /**
+   * LIST on dest not found, look for dest dir, and then, at
+   * end of rename, whether a parent dir needs to be created.
+   */
+  public static final int RENAME_SINGLE_FILE_RENAME_DIFFERENT_DIR_L =
+      GFS_FNFE_L + GFS_DIR_L * 2;
+
+  /* All the metrics which can be used in assertions */
+
+  private MetricDiff copyLocalOps;
+  private MetricDiff copyRequests;
   private MetricDiff deleteRequests;
+  private MetricDiff directoriesCreated;
   private MetricDiff directoriesDeleted;
   private MetricDiff fakeDirectoriesDeleted;
-  private MetricDiff directoriesCreated;
+  private MetricDiff filesDeleted;
+  private MetricDiff listRequests;
+  private MetricDiff metadataRequests;
+  private MetricDiff putBytes;
+  private MetricDiff putRequests;
 
+  /**
+   * Array of all metrics built up in setup.
+   */
+  private MetricDiff[] allMetrics;
 
   /**
    * Parameterization.
@@ -88,12 +141,10 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> params() {
     return Arrays.asList(new Object[][]{
-        {"raw-keep-markers",            false,  true,   false},
-        {"raw-delete-markers",          false,  false,  false},
-        {"guarded-keep-markers",        true,   true,   false},
-        {"guarded-delete-markers",      true,   false,  false},
-        {"guarded-auth-keep-markers",   true,   true,   true},
-        {"guarded-auth-delete-markers", true,   false,  true},
+        {"raw-keep-markers", false, true},
+        {"raw-delete-markers", false, false},
+        {"guarded-keep-markers", true, true},
+        {"guarded-delete-markers", true, false}
     });
   }
 
@@ -107,15 +158,16 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
    */
   private final boolean keepMarkers;
 
-  private final boolean authoritative;
+  /**
+   * Is this an auth mode test run?
+   */
+  private boolean authoritative;
 
   public ITestS3AFileOperationCost(final String name,
       final boolean s3guard,
-      final boolean keepMarkers,
-      final boolean authoritative) {
+      final boolean keepMarkers) {
     this.s3guard = s3guard;
     this.keepMarkers = keepMarkers;
-    this.authoritative = authoritative;
   }
 
   @Override
@@ -123,9 +175,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     Configuration conf = super.createConfiguration();
     String bucketName = getTestBucketName(conf);
     removeBucketOverrides(bucketName, conf,
-        S3_METADATA_STORE_IMPL,
-        AUTHORITATIVE_PATH,
-        METADATASTORE_AUTHORITATIVE);
+        S3_METADATA_STORE_IMPL);
     if (!isGuarded()) {
       // in a raw run remove all s3guard settings
       removeBaseAndBucketOverrides(bucketName, conf,
@@ -153,14 +203,37 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     }
     S3AFileSystem fs = getFileSystem();
     skipDuringFaultInjection(fs);
-    metadataRequests = new MetricDiff(fs, OBJECT_METADATA_REQUESTS);
-    listRequests = new MetricDiff(fs, OBJECT_LIST_REQUESTS);
-    deleteRequests = new MetricDiff(fs, Statistic.OBJECT_DELETE_REQUESTS);
-    directoriesDeleted =
-        new MetricDiff(fs, Statistic.DIRECTORIES_DELETED);
-    fakeDirectoriesDeleted =
-        new MetricDiff(fs, Statistic.FAKE_DIRECTORIES_DELETED);
-    directoriesCreated = new MetricDiff(fs, Statistic.DIRECTORIES_CREATED);
+    authoritative = fs.allowAuthoritative(new Path("/"));
+
+    copyLocalOps = mkdiff(INVOCATION_COPY_FROM_LOCAL_FILE);
+    copyRequests = mkdiff(OBJECT_COPY_REQUESTS);
+    deleteRequests = mkdiff(OBJECT_DELETE_REQUESTS);
+    directoriesCreated = mkdiff(DIRECTORIES_CREATED);
+    directoriesDeleted = mkdiff(DIRECTORIES_DELETED);
+    fakeDirectoriesDeleted = mkdiff(FAKE_DIRECTORIES_DELETED);
+    filesDeleted = mkdiff(FILES_DELETED);
+    listRequests = mkdiff(OBJECT_LIST_REQUESTS);
+    metadataRequests = mkdiff(OBJECT_METADATA_REQUESTS);
+    putBytes = mkdiff(OBJECT_PUT_BYTES);
+    putRequests = mkdiff(OBJECT_PUT_REQUESTS);
+    allMetrics = new MetricDiff[]{
+        copyLocalOps,
+        copyRequests,
+        deleteRequests,
+        directoriesCreated,
+        directoriesDeleted,
+        fakeDirectoriesDeleted,
+        filesDeleted,
+        listRequests,
+        metadataRequests,
+        putBytes,
+        putRequests
+    };
+
+  }
+
+  public MetricDiff mkdiff(final Statistic statistic) {
+    return new MetricDiff(getFileSystem(), statistic);
   }
 
   public void assumeUnguarded() {
@@ -185,8 +258,9 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     Path file = file(methodPath());
     S3AFileSystem fs = getFileSystem();
     verifyMetrics(() -> fs.listLocatedStatus(file),
-        always(listRequests, 1),
-        raw(metadataRequests, 1));
+        raw(listRequests, LLS_ALWAYS_L),
+        nonauth(listRequests, LLS_ALWAYS_L),
+        raw(metadataRequests, GFS_FILE_PROBE_H));
   }
 
   @Test
@@ -196,11 +270,11 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     S3AFileSystem fs = getFileSystem();
     verifyMetrics(() ->
             fs.listLocatedStatus(dir),
-        raw(metadataRequests, 1),
-        raw(listRequests, 2),
+        raw(metadataRequests, GFS_FILE_PROBE_H),
+        raw(listRequests, LLS_ALWAYS_L + GFS_DIR_L),
         guarded(metadataRequests, 0),
         authoritative(listRequests, 0),
-        nonauth(listRequests, 1));
+        nonauth(listRequests, LLS_ALWAYS_L));
   }
 
   @Test
@@ -212,9 +286,9 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     verifyMetrics(() ->
           fs.listLocatedStatus(dir),
         always(metadataRequests, 0),
-        raw(listRequests, 1),
+        raw(listRequests, LLS_ALWAYS_L),
         authoritative(listRequests, 0),
-        nonauth(listRequests, 1));
+        nonauth(listRequests, LLS_ALWAYS_L));
   }
 
   @Test
@@ -222,137 +296,53 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     describe("performing getFileStatus on a file");
     Path simpleFile = file(methodPath());
     S3AFileSystem fs = getFileSystem();
-    verifyMetrics(() -> {
-      FileStatus status = fs.getFileStatus(simpleFile);
-      assertTrue("not a file: " + status, status.isFile());
-      return "After getFileStatus(" + simpleFile + ")";
-      },
-        always(listRequests, 0),
-        raw(metadataRequests, 1));
-  }
-
-  /**
-   * Reset all the metrics being tracked.
-   */
-  private void resetMetricDiffs() {
-    reset(deleteRequests,
-        directoriesCreated,
-        directoriesDeleted,
-        fakeDirectoriesDeleted,
-        listRequests,
-        metadataRequests);
-  }
-
-  /**
-   * Verify that the head and list calls match expectations
-   * against unguarded stores.
-   * then reset the counters ready for the next operation.
-   * @param head expected HEAD count
-   * @param list expected LIST count
-   */
-  private void verifyOperationCount(int head, int list) {
-    if (!isGuarded()) {
-      metadataRequests.assertDiffEquals(head);
-      listRequests.assertDiffEquals(list);
-    }
-    metadataRequests.reset();
-    listRequests.reset();
+    S3AFileStatus status = verifyRawGetFileStatus(simpleFile, true,
+        StatusProbeEnum.ALL, GFS_SINGLE_FILE_H, GFS_SINGLE_FILE_L);
+    assertTrue("not a file: " + status, status.isFile());
   }
 
   @Test
   public void testCostOfGetFileStatusOnEmptyDir() throws Throwable {
     describe("performing getFileStatus on an empty directory");
-    S3AFileSystem fs = getFileSystem();
     Path dir = dir(methodPath());
     S3AFileStatus status = verifyRawGetFileStatus(dir, true,
-            StatusProbeEnum.FILES_AND_DIRECTORIES, 1, 1);
+            StatusProbeEnum.ALL, GFS_MARKER_H, GFS_MARKER_L);
     assertSame("not empty: " + status, Tristate.TRUE,
         status.isEmptyDirectory());
     // but now only ask for the directories and the file check is skipped.
     verifyRawGetFileStatus(dir, false,
-        StatusProbeEnum.DIRECTORIES,0, 1);
+        StatusProbeEnum.DIRECTORIES, GFS_DIR_PROBE_H, GFS_MARKER_L);
 
     // now look at isFile/isDir against the same entry
-    isDir(dir, true, 0, 1);
-    isFile(dir, false, 1, 0 );
-  }
-
-  /**
-   * Probe for a path being a directory.
-   * Metrics are only checked on unguarded stores.
-   * @param path path
-   * @param expected expected outcome
-   * @param head head count (unguarded)
-   * @param list listCount (unguarded)
-   */
-  private void isDir(Path path, boolean expected,
-      int head, int list) throws Exception {
-    boolean b = verifyRawHeadList(head, list, () ->
-        getFileSystem().isDirectory(path));
-    Assertions.assertThat(b)
-        .describedAs("isDirectory(%s)", path)
-        .isEqualTo(expected);
-  }
-
-  /**
-   * Probe for a path being a file.
-   * Metrics are only checked on unguarded stores.
-   * @param path path
-   * @param expected expected outcome
-   * @param head head count (unguarded)
-   * @param list listCount (unguarded)
-   */
-  private void isFile(Path path, boolean expected,
-      int head, int list) throws Exception {
-    boolean b = verifyRawHeadList(head, list, () ->
-        getFileSystem().isFile(path));
-    Assertions.assertThat(b)
-        .describedAs("isFile(%s)", path)
-        .isEqualTo(expected);
+    isDir(dir, true, 0, GFS_MARKER_L);
+    isFile(dir, false, GFS_SINGLE_FILE_H, GFS_SINGLE_FILE_L);
   }
 
   @Test
   public void testCostOfGetFileStatusOnMissingFile() throws Throwable {
     describe("performing getFileStatus on a missing file");
-    S3AFileSystem fs = getFileSystem();
-    Path path = path("missing");
-    verifyRawHeadListIntercepting(FileNotFoundException.class,
-        "getFileStatus",1, 1,
-        () -> fs.getFileStatus(path));
+    verifyRawGetFileStatusFNFE(methodPath(), false,
+        StatusProbeEnum.ALL,
+        GFS_FNFE_H, GFS_FNFE_L);
   }
 
   @Test
   public void testIsDirIsFileMissingPath() throws Throwable {
-    describe("performing getFileStatus on a missing file");
+    describe("performing isDir and isFile on a missing file");
     Path path = methodPath();
     // now look at isFile/isDir against the same entry
-    isDir(path, false, 0, 1);
-    isFile(path, false, 1, 0);
-  }
-
-  @Test
-  public void testCostOfGetFileStatusOnMissingSubPath() throws Throwable {
-    describe("performing getFileStatus on a missing subpath");
-    S3AFileSystem fs = getFileSystem();
-    Path path = path("missingdir/missingpath");
-    verifyRawHeadListIntercepting(FileNotFoundException.class,
-        "getFileStatus", 1, 1,
-        () -> fs.getFileStatus(path));
+    isDir(path, false, GFS_DIR_PROBE_H, GFS_DIR_PROBE_L);
+    isFile(path, false, GFS_FILE_PROBE_H, GFS_FILE_PROBE_L);
   }
 
   @Test
   public void testCostOfGetFileStatusOnNonEmptyDir() throws Throwable {
     describe("performing getFileStatus on a non-empty directory");
-    S3AFileSystem fs = getFileSystem();
     Path dir = dir(methodPath());
     Path simpleFile = file(new Path(dir, "simple.txt"));
     S3AFileStatus status = verifyRawGetFileStatus(dir, true,
-            StatusProbeEnum.FILES_AND_DIRECTORIES, 1, 1);
-    Assertions.assertThat(status.isEmptyDirectory())
-        .describedAs(dynamicDescription(() ->
-            "FileStatus says directory is empty: " + status
-                + "\n" + ContractTestUtils.ls(fs, dir)))
-        .isNotEqualTo(Tristate.TRUE);
+            StatusProbeEnum.ALL, GFS_DIR_H, GFS_DIR_L);
+    assertEmptyDirStatus(status, Tristate.FALSE);
   }
 
   /**
@@ -360,26 +350,38 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
    * The parent dir must be found and declared as empty.
    */
   @Test
-  public void testDirGetFileStatusAfterChildDeleted() throws Throwable {
+  public void testDeleteFile() throws Throwable {
     describe("performing getFileStatus on newly emptied directory");
     S3AFileSystem fs = getFileSystem();
+    // creates the marker
     Path dir = dir(methodPath());
+    // file creation may have deleted that marker, but it may
+    // still be there
     Path simpleFile = file(new Path(dir, "simple.txt"));
 
     verifyMetrics(() -> {
           fs.delete(simpleFile, false);
           return "after fs.delete(simpleFile) " + metricSummary;
         },
+        // delete file then look for parent
+        raw(metadataRequests, GFS_FILE_PROBE_H +
+            (isKeepingMarkers()? 0: GFS_DIR_PROBE_H)),
+        raw(listRequests, GFS_FILE_PROBE_L + GFS_DIR_PROBE_L),
         always(directoriesDeleted, 0),
-        keeping(directoriesCreated, 0),
-        keeping(deleteRequests, 1),
-        deleting(directoriesCreated, 1),
-        deleting(deleteRequests, 1 + 1)
-    );
-    // delete a child may create a parent if there wasn't one
+        always(filesDeleted, 1),
 
+        // keeping: create no parent dirs or delete parents
+        keeping(directoriesCreated, 0),
+        keeping(deleteRequests, DELETE_OBJECT_REQUEST),
+
+        // deleting: create a parent and delete any of its parents
+        deleting(directoriesCreated, 1),
+        deleting(deleteRequests,
+            DELETE_OBJECT_REQUEST + DELETE_MARKER_REQUEST)
+    );
+    // there is an empty dir for a parent
     S3AFileStatus status = verifyRawGetFileStatus(dir, true,
-        StatusProbeEnum.FILES_AND_DIRECTORIES, 1, 1);
+        StatusProbeEnum.ALL, GFS_DIR_H, GFS_DIR_L);
     assertEmptyDirStatus(status, Tristate.TRUE);
   }
 
@@ -400,12 +402,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
       byte[] data = dataset(len, 'A', 'Z');
       writeDataset(localFS, localPath, data, len, 1024, true);
       S3AFileSystem s3a = getFileSystem();
-      MetricDiff copyLocalOps = new MetricDiff(s3a,
-          INVOCATION_COPY_FROM_LOCAL_FILE);
-      MetricDiff putRequests = new MetricDiff(s3a,
-          OBJECT_PUT_REQUESTS);
-      MetricDiff putBytes = new MetricDiff(s3a,
-          OBJECT_PUT_BYTES);
+
 
       Path remotePath = methodPath();
 
@@ -424,71 +421,48 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     }
   }
 
-  private boolean reset(MetricDiff... diffs) {
-    for (MetricDiff diff : diffs) {
-      diff.reset();
-    }
-    return true;
-  }
+  @Test
+  public void testDirMarkersSubdir() throws Throwable {
+    describe("verify cost of deep subdir creation");
 
-  /**
-   * How many marker delete requests are issued?
-   * This is dependent on the keep marker policy
-   * @param requests expected value if markers are not kept
-   * @return the number to use in assertions.
-   */
-  private int markerDeleteRequests(int requests) {
-    return isKeepingMarkers() ? 0: requests;
-  }
-
-  private int markerCreateRequests(int requests) {
-    return isKeepingMarkers() ? 0: requests;
-  }
-
-  /**
-   * How many markers will be deleted?
-   * This is dependent on the keep marker policy
-   * @param deleted expected value if markers are not kept
-   * @return the number to use in assertions.
-   */
-  private int markerDeletes(int deleted) {
-    return isKeepingMarkers() ? 0: deleted;
+    Path subDir = new Path(methodPath(), "1/2/3/4/5/6");
+    // one dir created, possibly a parent removed
+    verifyMetrics(() -> {
+          mkdirs(subDir);
+          return "after mkdir(subDir) " + metricSummary;
+        },
+        always(directoriesCreated, 1),
+        always(directoriesDeleted, 0),
+        keeping(deleteRequests, 0),
+        keeping(fakeDirectoriesDeleted, 0),
+        deleting(deleteRequests, DELETE_MARKER_REQUEST),
+        // delete all possible fake dirs above the subdirectory
+        deleting(fakeDirectoriesDeleted, directoriesInPath(subDir) - 1));
   }
 
   @Test
   public void testDirMarkersFileCreation() throws Throwable {
     describe("verify cost of file creation");
-    S3AFileSystem fs = getFileSystem();
 
     Path srcBaseDir = dir(methodPath());
 
-    // when you call toString() on this, you get the stats
-    // so it gets auto-evaluated in log calls.
-
-    Path srcDir = new Path(srcBaseDir, "1/2/3/4/5/6");
-    int srcDirDepth = directoriesInPath(srcDir);
-    // one dir created, possibly a parent removed
-    verifyMetrics(() -> {
-          mkdirs(srcDir);
-          return "after mkdir(srcDir) " + metricSummary;
-        },
-        always(directoriesCreated, 1),
-        always(directoriesDeleted, 0),
-        always(deleteRequests, markerDeleteRequests(1)),
-        always(fakeDirectoriesDeleted, markerDeleteRequests(srcDirDepth - 1)));
+    Path srcDir = dir(new Path(srcBaseDir, "1/2/3/4/5/6"));
 
     // creating a file should trigger demise of the src dir marker
     // unless markers are being kept
-    final Path srcFilePath = new Path(srcDir, "source.txt");
 
     verifyMetrics(() -> {
-          touch(fs, srcFilePath);
+          file(new Path(srcDir, "source.txt"));
           return "after touch(fs, srcFilePath) " + metricSummary;
         },
         always(directoriesCreated, 0),
         always(directoriesDeleted, 0),
-        always(deleteRequests, markerDeleteRequests(1)),
-        always(fakeDirectoriesDeleted, markerDeleteRequests(srcDirDepth)));
+        // keeping: no delete operations.
+        keeping(deleteRequests, 0),
+        keeping(fakeDirectoriesDeleted, 0),
+        // delete all possible fake dirs above the file
+        deleting(deleteRequests, 1),
+        deleting(fakeDirectoriesDeleted, directoriesInPath(srcDir)));
   }
 
   @Test
@@ -518,45 +492,34 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     Path destBaseDir = new Path(baseDir, "dest");
     Path destDir = dir(new Path(destBaseDir, "a/b/c/d"));
     Path destFilePath = new Path(destDir, "dest.txt");
-    int destDirDepth = directoriesInPath(destDir);
 
     // rename the source file to the destination file.
     // this tests file rename, not dir rename
     // as srcFile2 exists, the parent dir of srcFilePath must not be created.
-    verifyMetrics(() -> {
-      fs.rename(srcFilePath, destFilePath);
-      return String.format("after rename(%s, %s)"
-              + " %s dest dir depth=%d",
-          srcFilePath, destFilePath,
-          metricSummary,
-          destDirDepth);
-      },
-        raw(metadataRequests, HEAD_REQUESTS_SINGLE_FILE_RENAME),
-        raw(listRequests, LIST_REQUESTS_SINGLE_FILE_RENAME_DIFFERENT_DIR),
+    verifyMetrics(() ->
+      execRename(srcFilePath, destFilePath),
+        raw(metadataRequests, RENAME_SINGLE_FILE_RENAME_H),
+        raw(listRequests, RENAME_SINGLE_FILE_RENAME_DIFFERENT_DIR_L),
         always(directoriesCreated, 0),
         always(directoriesDeleted, 0),
-        always(deleteRequests, 1 + markerDeleteRequests(1)),
-        always(fakeDirectoriesDeleted, markerDeleteRequests(destDirDepth)));
+        // keeping: only the core delete operation is issued.
+        keeping(deleteRequests, DELETE_OBJECT_REQUEST),
+        keeping(fakeDirectoriesDeleted, 0),
+        // deleting: delete any fake marker above the destination.
+        deleting(deleteRequests,
+            DELETE_OBJECT_REQUEST + DELETE_MARKER_REQUEST),
+        deleting(fakeDirectoriesDeleted, directoriesInPath(destDir)));
 
     assertIsFile(destFilePath);
     assertIsDirectory(srcDir);
     assertPathDoesNotExist("should have gone in the rename", srcFilePath);
-
-    // rename the source file2 to the (no longer existing) srcFilePath
-    // in the same directory
-/*    verifyMetrics(() -> {
-      fs.rename(srcFile2, srcFilePath);
-      return String.format("after rename(%s, %s) %s dest dir depth=%d",
-          srcFile2, srcFilePath,
-          metricSummary,
-          destDirDepth);
-      },
-        always(directoriesCreated, 0),
-        always(directoriesDeleted, 0),
-        always(deleteRequests, 1),
-        always(fakeDirectoriesDeleted, 0));*/
   }
 
+  /**
+   * Same directory rename is lower cost as there's no need to
+   * look for the parent dir of the dest path or worry about
+   * deleting markers.
+   */
   @Test
   public void testRenameSameDirectory() throws Throwable {
     describe("rename a file to a different directory, "
@@ -570,21 +533,15 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     // are different object instances and so equals() rather than ==
     // is
     Path parent2 = sourceFile.getParent();
-    Path destFile = file(new Path(parent2, "dest"));
+    Path destFile = new Path(parent2, "dest");
     verifyMetrics(() ->
             execRename(sourceFile, destFile),
-        raw(metadataRequests, HEAD_REQUESTS_SINGLE_FILE_RENAME - 1),
-        raw(listRequests, LIST_REQUESTS_SINGLE_FILE_RENAME_DIFFERENT_DIR),
+        raw(metadataRequests, RENAME_SINGLE_FILE_RENAME_H),
+        raw(listRequests, GFS_FNFE_L),
+        always(copyRequests, 1),
         always(directoriesCreated, 0),
-        always(deleteRequests, 0),
+        always(deleteRequests, DELETE_OBJECT_REQUEST),
         always(fakeDirectoriesDeleted, 0));
-  }
-
-  public String execRename(final Path source,
-      final Path dest) throws IOException {
-    getFileSystem().rename(source, dest);
-    return String.format("rename(%s, %s)",
-        dest, source);
   }
 
   @Test
@@ -604,16 +561,17 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
         return "after fs.rename(/src,/dest) " + metricSummary;
         },
           // TWO HEAD for exists, one for source MD in copy
-          raw(metadataRequests, HEAD_REQUESTS_SINGLE_FILE_RENAME),
-          raw(listRequests, 1),
+          raw(metadataRequests, RENAME_SINGLE_FILE_RENAME_H),
+          raw(listRequests, GFS_FNFE_L),
           // here we expect there to be no fake directories
           always(directoriesCreated, 0),
           // one for the renamed file only
-          always(deleteRequests, 1),
+          always(deleteRequests, DELETE_OBJECT_REQUEST),
           // no directories are deleted: This is root
           always(directoriesDeleted, 0),
           // no fake directories are deleted: This is root
-          always(fakeDirectoriesDeleted, 0));
+          always(fakeDirectoriesDeleted, 0),
+          always(filesDeleted, 1));
 
       // delete that destination file, assert only the file delete was issued
       verifyMetrics(() -> {
@@ -623,7 +581,9 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
           always(directoriesCreated, 0),
           always(directoriesDeleted, 0),
           always(fakeDirectoriesDeleted, 0),
-          always(deleteRequests, 1),
+          always(filesDeleted, 1),
+          always(deleteRequests, DELETE_OBJECT_REQUEST),
+          raw(metadataRequests, GFS_FILE_PROBE_H),
           raw(listRequests, 0)   /* no need to look at parent. */
           );
 
@@ -641,23 +601,19 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     // Create the empty directory.
     Path emptydir = dir(methodPath());
 
-    // metrics and assertions.
-    verifyRawHeadListIntercepting(FileNotFoundException.class, "",
-        1, 0, () ->
-        fs.innerGetFileStatus(emptydir, false,
-            StatusProbeEnum.HEAD_ONLY));
+    // head probe fails
+    verifyRawGetFileStatusFNFE(emptydir, false, StatusProbeEnum.HEAD_ONLY,
+        GFS_FILE_PROBE_H, GFS_FILE_PROBE_L);
 
     // a LIST will find it and declare as empty
     S3AFileStatus status = verifyRawGetFileStatus(emptydir, true,
-        StatusProbeEnum.LIST_ONLY, 0, 1);
+        StatusProbeEnum.LIST_ONLY, 0, GFS_MARKER_L);
     assertEmptyDirStatus(status, Tristate.TRUE);
 
-    // finally, skip all probes and expect no operations to
-    // take place
-    verifyRawHeadListIntercepting(FileNotFoundException.class, "",
-        0, 0, () ->
-        fs.innerGetFileStatus(emptydir, false,
-            EnumSet.noneOf(StatusProbeEnum.class)));
+    // skip all probes and expect no operations to take place
+    verifyRawGetFileStatusFNFE(emptydir, false,
+        EnumSet.noneOf(StatusProbeEnum.class),
+        0, 0);
 
     // now add a trailing slash to the key and use the
     // deep internal s3GetFileStatus method call.
@@ -670,39 +626,28 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
             StatusProbeEnum.HEAD_ONLY, null, false));
 
     // but ask for a directory marker and you get the entry
-    status = verifyRawHeadList(0, 1, () ->
+    status = verifyRawHeadList(0, GFS_MARKER_L, () ->
         fs.s3GetFileStatus(emptydir,
-        emptyDirTrailingSlash,
-        StatusProbeEnum.LIST_ONLY, null, true));
+            emptyDirTrailingSlash,
+            StatusProbeEnum.LIST_ONLY,
+            null,
+            true));
     assertEquals(emptydir, status.getPath());
     assertEmptyDirStatus(status, Tristate.TRUE);
-    if (!dirMarkerProbesEnabled()) {
-      verifyRawHeadListIntercepting(FileNotFoundException.class, "",
-          0, 0, () ->
-          fs.s3GetFileStatus(emptydir,
-              emptyDirTrailingSlash,
-              StatusProbeEnum.DIR_MARKER_ONLY,
-              null,
-              false));
-    } else {
-      status = verifyRawHeadList(probeHeadCost(StatusProbeEnum.DIR_MARKER_ONLY),
-          0, () ->
-          fs.s3GetFileStatus(emptydir,
-          emptyDirTrailingSlash,
-          StatusProbeEnum.DIR_MARKER_ONLY,
-          null,
-          false));
-      assertEmptyDirStatus(status, Tristate.FALSE);
-    }
   }
 
+  /**
+   * Assert the empty directory status of a file is as expected.
+   * @param status status to probe.
+   * @param expected expected value
+   */
   protected void assertEmptyDirStatus(final S3AFileStatus status,
       final Tristate expected) {
     Assertions.assertThat(status.isEmptyDirectory())
         .describedAs(dynamicDescription(() ->
             "FileStatus says directory is not empty: " + status
                 + "\n" + ContractTestUtils.ls(getFileSystem(), status.getPath())))
-        .isEqualTo(Tristate.TRUE);
+        .isEqualTo(expected);
   }
 
   @Test
@@ -711,14 +656,9 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     assumeUnguarded();
     Path testFile = methodPath();
     // when overwrite is false, the path is checked for existence.
-    create(testFile, false, 1, 1);
+    create(testFile, false, GFS_FNFE_H, GFS_FNFE_L);
     // but when true: only the directory checks take place.
-    create(testFile, true, 0, 1);
-
-    // now there is a file there, an attempt with overwrite == false will
-    // fail on the first HEAD.
-    verifyRawHeadListIntercepting(FileAlreadyExistsException.class, "",
-        1, 0, () -> file(testFile, false));
+    create(testFile, true, 0, GFS_FNFE_L);
   }
 
   @Test
@@ -730,7 +670,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     // now there is a file there, an attempt with overwrite == false will
     // fail on the first HEAD.
     verifyRawHeadListIntercepting(FileAlreadyExistsException.class, "",
-        1, 0,
+        GFS_FILE_PROBE_H, 0,
         () -> file(testFile, false));
   }
 
@@ -743,7 +683,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     // now there is a file there, an attempt with overwrite == false will
     // fail on the first HEAD.
     verifyRawHeadListIntercepting(FileAlreadyExistsException.class, "",
-        1, 1,
+        GFS_MARKER_H, GFS_MARKER_L,
         () -> file(testFile, false));
   }
 
@@ -752,24 +692,25 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
    * This always looks for a parent unless the caller says otherwise.
    */
   @Test
-  public void testCreateBuilderCost() throws Throwable {
+  public void testCreateBuilder() throws Throwable {
     describe("Test builder file creation cost -raw only");
     assumeUnguarded();
     Path testFile = methodPath();
     dir(testFile.getParent());
 
     // builder defaults to looking for parent existence (non-recursive)
-    buildFile(testFile, false,  false, 1, 2);
+    buildFile(testFile, false,  false,
+        GFS_FILE_PROBE_H,   // destination file
+        GFS_DIR_PROBE_L * 2);    // destination file and parent dir
     // recursive = false and overwrite=true:
     // only make sure the dest path isn't a directory.
-    buildFile(testFile, true, true,0, 1);
+    buildFile(testFile, true, true, GFS_DIR_PROBE_H, GFS_DIR_PROBE_L);
 
     // now there is a file there, an attempt with overwrite == false will
     // fail on the first HEAD.
     verifyRawHeadListIntercepting(FileAlreadyExistsException.class, "",
-        1, 0, () ->
-            buildFile(testFile, false, true, 0, 0));
-
+        GFS_FILE_PROBE_H, 0, () ->
+            buildFile(testFile, false, true, GFS_FILE_PROBE_H, 0));
   }
 
   /**
@@ -843,43 +784,62 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   }
 
 
+  /**
+   * Execute rename, returning the current metrics.
+   * For use in l-expressions.
+   * @param source source path.
+   * @param dest dest path
+   * @return a string for exceptions.
+   */
+  public String execRename(final Path source,
+      final Path dest) throws IOException {
+    getFileSystem().rename(source, dest);
+    return String.format("rename(%s, %s): %s", dest, source, metricSummary);
+  }
+
+  /**
+   * How many directories are in a path?
+   * @param path path to probe.
+   * @return the number of entries below root this path is
+   */
   private int directoriesInPath(Path path) {
     return path.isRoot() ? 0 : 1 + directoriesInPath(path.getParent());
   }
-  /**
-   * This lets us control whether dir marker HEAD +/ probes are being
-   * used at all.
-   */
-  private boolean dirMarkerProbesEnabled() {
-    return false;
-  }
 
-  /**
-   * How many HEAD requests will this probe set make.
-   * It's a method to allow for dynamicness/ease
-   * of re-organizing and disabling the s3GetFileStatus
-   * code.
-   * @param probes probes to run.
-   * @return how many head requests.
-   */
-
-  private int probeHeadCost(Set<StatusProbeEnum> probes) {
-    int total = 0;
-    for (StatusProbeEnum probe : probes) {
-      if (probe == StatusProbeEnum.Head) {
-        total ++;
-      }
+  private boolean reset(MetricDiff... diffs) {
+    for (MetricDiff diff : diffs) {
+      diff.reset();
     }
-    return total;
+    return true;
   }
 
+  /**
+   * Reset all the metrics being tracked.
+   */
+  private void resetMetricDiffs() {
+    reset(allMetrics);
+  }
+
+  /**
+   * Verify that the head and list calls match expectations
+   * against unguarded stores.
+   * then reset the counters ready for the next operation.
+   * @param head expected HEAD count
+   * @param list expected LIST count
+   */
+  private void verifyOperationCount(int head, int list) {
+    if (!isGuarded()) {
+      metadataRequests.assertDiffEquals(head);
+      listRequests.assertDiffEquals(list);
+    }
+    resetMetricDiffs();
+  }
   /**
    * Execute a closure and verify the metrics.
    * @param eval closure to evaluate
    * @param expected varargs list of expected diffs
    * @param <T> return type.
    * @return the result of the evaluation
-   * @throws Exception
    */
   private <T> T verifyMetrics(
       Callable<T> eval,
@@ -970,6 +930,53 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     return verifyRawHeadList(head, list, () ->
         getFileSystem().innerGetFileStatus(path, needEmptyDirectoryFlag,
             probes));
+  }
+
+  /**
+   * Execute innerGetFileStatus for the given probes and expect failure
+   * and expect in raw FS to have the specific HEAD/LIST count.
+   */
+  public void verifyRawGetFileStatusFNFE(final Path path,
+      boolean needEmptyDirectoryFlag,
+      Set<StatusProbeEnum> probes, int head, int list) throws Exception {
+    verifyRawHeadListIntercepting(FileNotFoundException.class, "",
+        head, list, () ->
+            getFileSystem().innerGetFileStatus(path, needEmptyDirectoryFlag,
+                probes));
+  }
+
+  /**
+   * Probe for a path being a directory.
+   * Metrics are only checked on unguarded stores.
+   * @param path path
+   * @param expected expected outcome
+   * @param head head count (unguarded)
+   * @param list listCount (unguarded)
+   */
+  private void isDir(Path path, boolean expected,
+      int head, int list) throws Exception {
+    boolean b = verifyRawHeadList(head, list, () ->
+        getFileSystem().isDirectory(path));
+    Assertions.assertThat(b)
+        .describedAs("isDirectory(%s)", path)
+        .isEqualTo(expected);
+  }
+
+  /**
+   * Probe for a path being a file.
+   * Metrics are only checked on unguarded stores.
+   * @param path path
+   * @param expected expected outcome
+   * @param head head count (unguarded)
+   * @param list listCount (unguarded)
+   */
+  private void isFile(Path path, boolean expected,
+      int head, int list) throws Exception {
+    boolean b = verifyRawHeadList(head, list, () ->
+        getFileSystem().isFile(path));
+    Assertions.assertThat(b)
+        .describedAs("isFile(%s)", path)
+        .isEqualTo(expected);
   }
 
   /**
@@ -1136,14 +1143,9 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   private final Object metricSummary = new Object() {
     @Override
     public String toString() {
-      return String.format("[%s, %s, %s, %s, %s, %s]",
-          deleteRequests,
-          directoriesCreated,
-          directoriesDeleted,
-          fakeDirectoriesDeleted,
-          listRequests,
-          metadataRequests
-      );
+      return Arrays.stream(allMetrics)
+          .map(MetricDiff::toString)
+          .collect(Collectors.joining(", "));
     }
   };
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.fs.s3a;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -35,33 +37,48 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_DELETE;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_KEEP;
 import static org.apache.hadoop.fs.s3a.Constants.S3_METADATA_STORE_IMPL;
 import static org.apache.hadoop.fs.s3a.Statistic.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
+import static org.apache.hadoop.test.AssertExtensions.dynamicDescription;
 import static org.apache.hadoop.test.GenericTestUtils.getTestDir;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
  * Use metrics to assert about the cost of file status queries.
  * {@link S3AFileSystem#getFileStatus(Path)}.
- * Parameterized on guarded vs raw.
+ * Parameterized on guarded vs raw. and directory marker keep vs delete
  */
 @RunWith(Parameterized.class)
 public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
 
-  private MetricDiff metadataRequests;
-  private MetricDiff listRequests;
-
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3AFileOperationCost.class);
+
+  // source, dest, copy metadata
+  public static final int HEAD_REQUESTS_SINGLE_FILE_RENAME = 3;
+  // yes, that's a lot
+  public static final int LIST_REQUESTS_SINGLE_FILE_RENAME = 3;
+
+  private MetricDiff metadataRequests;
+  private MetricDiff listRequests;
+  private MetricDiff deleteRequests;
+  private MetricDiff directoriesDeleted;
+  private MetricDiff fakeDirectoriesDeleted;
+  private MetricDiff directoriesCreated;
 
   /**
    * Parameterization.
@@ -69,18 +86,28 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> params() {
     return Arrays.asList(new Object[][]{
-        {"raw", false},
-        {"guarded", true}
+        {"raw-keep-markers", false, true},
+        {"raw-delete-markers", false, false},
+        {"guarded-keep-markers", true, true},
+        {"guarded-delete-markers", true, false}
     });
   }
 
-  private final String name;
-
+  /**
+   * Parameter: should the stores be guarded?
+   */
   private final boolean s3guard;
 
-  public ITestS3AFileOperationCost(final String name, final boolean s3guard) {
-    this.name = name;
+  /**
+   * Parameter: should directory markers be retained?
+   */
+  private final boolean keepMarkers;
+
+  public ITestS3AFileOperationCost(final String name,
+      final boolean s3guard,
+      final boolean keepMarkers) {
     this.s3guard = s3guard;
+    this.keepMarkers = keepMarkers;
   }
 
   @Override
@@ -94,6 +121,13 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
       removeBaseAndBucketOverrides(bucketName, conf,
           S3_METADATA_STORE_IMPL);
     }
+    // directory marker options
+    removeBaseAndBucketOverrides(bucketName, conf,
+        DIRECTORY_MARKER_POLICY);
+    conf.set(DIRECTORY_MARKER_POLICY,
+        keepMarkers
+            ? DIRECTORY_MARKER_POLICY_KEEP
+            : DIRECTORY_MARKER_POLICY_DELETE);
     disableFilesystemCaching(conf);
     return conf;
   }
@@ -106,9 +140,15 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
       assumeS3GuardState(true, getConfiguration());
     }
     S3AFileSystem fs = getFileSystem();
+    skipDuringFaultInjection(fs);
     metadataRequests = new MetricDiff(fs, OBJECT_METADATA_REQUESTS);
     listRequests = new MetricDiff(fs, OBJECT_LIST_REQUESTS);
-    skipDuringFaultInjection(fs);
+    deleteRequests = new MetricDiff(fs, Statistic.OBJECT_DELETE_REQUESTS);
+    directoriesDeleted =
+        new MetricDiff(fs, Statistic.DIRECTORIES_DELETED);
+    fakeDirectoriesDeleted =
+        new MetricDiff(fs, Statistic.FAKE_DIRECTORIES_DELETED);
+    directoriesCreated = new MetricDiff(fs, Statistic.DIRECTORIES_CREATED);
   }
 
   @Test
@@ -132,18 +172,13 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     Path dir = path(getMethodName());
     S3AFileSystem fs = getFileSystem();
     fs.mkdirs(dir);
-    resetMetricDiffs();
-    fs.listLocatedStatus(dir);
-    if (!fs.hasMetadataStore()) {
-      // Unguarded FS.
-      verifyOperationCount(2, 1);
-    } else {
-      if (fs.allowAuthoritative(dir)) {
-        verifyOperationCount(0, 0);
-      } else {
-        verifyOperationCount(0, 1);
-      }
-    }
+    verifyMetrics(() ->
+            fs.listLocatedStatus(dir),
+        raw(metadataRequests, 1),
+        raw(listRequests, 2),
+        guarded(metadataRequests, 0),
+        guarded(listRequests,
+            fs.allowAuthoritative(dir) ? 0 : 1));
   }
 
   @Test
@@ -154,18 +189,12 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     fs.mkdirs(dir);
     Path file = new Path(dir, "file.txt");
     touch(fs, file);
-    resetMetricDiffs();
-    fs.listLocatedStatus(dir);
-    if (!fs.hasMetadataStore()) {
-      // Unguarded FS.
-      verifyOperationCount(0, 1);
-    } else {
-      if(fs.allowAuthoritative(dir)) {
-        verifyOperationCount(0, 0);
-      } else {
-        verifyOperationCount(0, 1);
-      }
-    }
+    verifyMetrics(() ->
+          fs.listLocatedStatus(dir),
+        always(metadataRequests, 0),
+        raw(listRequests, 1),
+        guarded(listRequests,
+            fs.allowAuthoritative(dir) ? 0 : 1));
   }
 
   @Test
@@ -174,28 +203,39 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     Path simpleFile = path("simple.txt");
     S3AFileSystem fs = getFileSystem();
     touch(fs, simpleFile);
-    resetMetricDiffs();
-    FileStatus status = fs.getFileStatus(simpleFile);
-    assertTrue("not a file: " + status, status.isFile());
-    if (!fs.hasMetadataStore()) {
-      metadataRequests.assertDiffEquals(1);
-    }
-    listRequests.assertDiffEquals(0);
-  }
-
-  private void resetMetricDiffs() {
-    reset(metadataRequests, listRequests);
+    verifyMetrics(() -> {
+      FileStatus status = fs.getFileStatus(simpleFile);
+      assertTrue("not a file: " + status, status.isFile());
+      return "After getFileStatus(" + simpleFile + ")";
+      },
+        always(listRequests, 0),
+        raw(metadataRequests, 1));
   }
 
   /**
-   * Verify that the head and list calls match expectations,
+   * Reset all the metrics being tracked.
+   */
+  private void resetMetricDiffs() {
+    reset(deleteRequests,
+        directoriesCreated,
+        directoriesDeleted,
+        fakeDirectoriesDeleted,
+        listRequests,
+        metadataRequests);
+  }
+
+  /**
+   * Verify that the head and list calls match expectations
+   * against unguarded stores.
    * then reset the counters ready for the next operation.
    * @param head expected HEAD count
    * @param list expected LIST count
    */
-  private void verifyOperationCount(int head, int list) {
-    metadataRequests.assertDiffEquals(head);
-    listRequests.assertDiffEquals(list);
+  private void verifyUnguardedOperationCount(int head, int list) {
+    if (!guardedFs()) {
+      metadataRequests.assertDiffEquals(head);
+      listRequests.assertDiffEquals(list);
+    }
     metadataRequests.reset();
     listRequests.reset();
   }
@@ -207,23 +247,59 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     Path dir = path("empty");
     fs.mkdirs(dir);
     resetMetricDiffs();
-    S3AFileStatus status = fs.innerGetFileStatus(dir, true,
-        StatusProbeEnum.ALL);
+    S3AFileStatus status = execFileStatus(dir, true,
+            StatusProbeEnum.FILES_AND_DIRECTORIES, 1, 1);
     assertSame("not empty: " + status, Tristate.TRUE,
         status.isEmptyDirectory());
-
-    if (!fs.hasMetadataStore()) {
-      metadataRequests.assertDiffEquals(2);
-    }
-    listRequests.assertDiffEquals(0);
-
     // but now only ask for the directories and the file check is skipped.
-    resetMetricDiffs();
-    fs.innerGetFileStatus(dir, false,
-        StatusProbeEnum.DIRECTORIES);
-    if (!fs.hasMetadataStore()) {
-      metadataRequests.assertDiffEquals(1);
-    }
+    execFileStatus(dir, false,
+        StatusProbeEnum.DIRECTORIES,0, 1);
+
+    // now look at isFile/isDir against the same entry
+    isDir(dir, true, 0, 1);
+    isFile(dir, false, 1, 0 );
+  }
+
+  /**
+   * Is the FS guarded?
+   * @return true if there is a metastore.
+   */
+  protected boolean guardedFs() {
+    return getFileSystem().hasMetadataStore();
+  }
+
+  /**
+   * Probe for a path being a directory.
+   * Metrics are only checked on unguarded stores.
+   * @param path path
+   * @param expected expected outcome
+   * @param head head count (unguarded)
+   * @param list listCount (unguarded)
+   */
+  private void isDir(Path path, boolean expected,
+      int head, int list) throws Exception {
+    boolean b = verifyRawHeadList(head, list, () ->
+        getFileSystem().isDirectory(path));
+    Assertions.assertThat(b)
+        .describedAs("isDirectory(%s)", path)
+        .isEqualTo(expected);
+  }
+
+  /**
+   * Probe for a path being a file.
+   * Metrics are only checked on unguarded stores.
+   * @param path path
+   * @param expected expected outcome
+   * @param head head count (unguarded)
+   * @param list listCount (unguarded)
+   */
+  private void isFile(Path path, boolean expected,
+      int head, int list) throws Exception {
+    boolean b = verifyRawHeadList(head, list, () ->
+        getFileSystem().isFile(path));
+    Assertions.assertThat(b)
+        .describedAs("isFile(%s)", path)
+        .isEqualTo(expected);
   }
 
   @Test
@@ -231,47 +307,77 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     describe("performing getFileStatus on a missing file");
     S3AFileSystem fs = getFileSystem();
     Path path = path("missing");
-    resetMetricDiffs();
-    intercept(FileNotFoundException.class,
+    verifyRawHeadListIntercepting(FileNotFoundException.class,
+        "getFileStatus",1, 1,
         () -> fs.getFileStatus(path));
-    metadataRequests.assertDiffEquals(2);
-    listRequests.assertDiffEquals(1);
+  }
+
+  @Test
+  public void testIsDirIsFileMissingPath() throws Throwable {
+    describe("performing getFileStatus on a missing file");
+    Path path = methodPath();
+    // now look at isFile/isDir against the same entry
+    isDir(path, false, 0, 1);
+    isFile(path, false, 1, 0);
   }
 
   @Test
   public void testCostOfGetFileStatusOnMissingSubPath() throws Throwable {
-    describe("performing getFileStatus on a missing file");
+    describe("performing getFileStatus on a missing subpath");
     S3AFileSystem fs = getFileSystem();
     Path path = path("missingdir/missingpath");
-    resetMetricDiffs();
-    intercept(FileNotFoundException.class,
+    verifyRawHeadListIntercepting(FileNotFoundException.class,
+        "getFileStatus", 1, 1,
         () -> fs.getFileStatus(path));
-    metadataRequests.assertDiffEquals(2);
-    listRequests.assertDiffEquals(1);
   }
 
   @Test
   public void testCostOfGetFileStatusOnNonEmptyDir() throws Throwable {
     describe("performing getFileStatus on a non-empty directory");
     S3AFileSystem fs = getFileSystem();
-    Path dir = path("empty");
+    Path dir = methodPath();
     fs.mkdirs(dir);
     Path simpleFile = new Path(dir, "simple.txt");
     touch(fs, simpleFile);
     resetMetricDiffs();
-    S3AFileStatus status = fs.innerGetFileStatus(dir, true,
-        StatusProbeEnum.ALL);
-    if (status.isEmptyDirectory() == Tristate.TRUE) {
-      // erroneous state
-      String fsState = fs.toString();
-      fail("FileStatus says directory isempty: " + status
-          + "\n" + ContractTestUtils.ls(fs, dir)
-          + "\n" + fsState);
-    }
-    if (!fs.hasMetadataStore()) {
-      metadataRequests.assertDiffEquals(2);
-      listRequests.assertDiffEquals(1);
-    }
+    S3AFileStatus status = execFileStatus(dir, true,
+            StatusProbeEnum.FILES_AND_DIRECTORIES, 1, 1);
+    Assertions.assertThat(status.isEmptyDirectory())
+        .describedAs(dynamicDescription(() ->
+            "FileStatus says directory is empty: " + status
+                + "\n" + ContractTestUtils.ls(fs, dir)))
+        .isNotEqualTo(Tristate.TRUE);
+  }
+
+  /**
+   * This creates a directory with a child and then deletes it.
+   * The parent dir must be found and declared as empty.
+   */
+  @Test
+  public void testDirGetFileStatusAfterChildDeleted() throws Throwable {
+    describe("performing getFileStatus on newly emptied directory");
+    S3AFileSystem fs = getFileSystem();
+    Path dir = methodPath();
+    fs.mkdirs(dir);
+    Path simpleFile = new Path(dir, "simple.txt");
+    touch(fs, simpleFile);
+
+    // delete a child may create a parent if there wasn't one
+    verifyMetrics(() -> {
+          fs.delete(simpleFile, false);
+          return "after fs.delete(simpleFile) " + metricSummary;
+        },
+        always(directoriesCreated, markerCreateRequests(1)),
+        always(directoriesDeleted, 0),
+        always(deleteRequests, 1 + markerDeleteRequests(1)));
+
+    S3AFileStatus status = execFileStatus(dir, true,
+        StatusProbeEnum.FILES_AND_DIRECTORIES, 1, 1);
+    Assertions.assertThat(status.isEmptyDirectory())
+        .describedAs(dynamicDescription(() ->
+                "FileStatus says directory is not empty: " + status
+                    + "\n" + ContractTestUtils.ls(fs, dir)))
+        .isEqualTo(Tristate.TRUE);
   }
 
   @Test
@@ -298,12 +404,16 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
       MetricDiff putBytes = new MetricDiff(s3a,
           OBJECT_PUT_BYTES);
 
-      Path remotePath = path("copied");
-      s3a.copyFromLocalFile(false, true, localPath, remotePath);
+      Path remotePath = methodPath();
+
+      verifyMetrics(() -> {
+            s3a.copyFromLocalFile(false, true, localPath, remotePath);
+            return "copy";
+          },
+          always(copyLocalOps, 1),
+          always(putRequests, 1),
+          always(putBytes, len));
       verifyFileContents(s3a, remotePath, data);
-      copyLocalOps.assertDiffEquals(1);
-      putRequests.assertDiffEquals(1);
-      putBytes.assertDiffEquals(len);
       // print final stats
       LOG.info("Filesystem {}", s3a);
     } finally {
@@ -318,123 +428,341 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     return true;
   }
 
+  /**
+   * How many marker delete requests are issued?
+   * This is dependent on the keep marker policy
+   * @param requests expected value if markers are not kept
+   * @return the number to use in assertions.
+   */
+  private int markerDeleteRequests(int requests) {
+    return keepMarkers ? 0: requests;
+  }
+
+  private int markerCreateRequests(int requests) {
+    return keepMarkers ? 0: requests;
+  }
+
+  /**
+   * How many markers will be deleted?
+   * This is dependent on the keep marker policy
+   * @param deleted expected value if markers are not kept
+   * @return the number to use in assertions.
+   */
+  private int markerDeletes(int deleted) {
+    return keepMarkers ? 0: deleted;
+  }
+
+  /**
+   * A metric diff which must always hold.
+   * @param metricDiff metric source
+   * @param expected expected value.
+   * @return the diff.
+   */
+  private ExpectedDiff always(final MetricDiff metricDiff, final int expected) {
+    return new ExpectedDiff(metricDiff, expected, ExpectedDiffCriteria.Always);
+  }
+
+  /**
+   * A metric diff which must hold when the fs is unguarded.
+   * @param metricDiff metric source
+   * @param expected expected value.
+   * @return the diff.
+   */
+  private ExpectedDiff raw(final MetricDiff metricDiff, final int expected) {
+    return new ExpectedDiff(metricDiff, expected,
+        ExpectedDiffCriteria.Unguarded);
+  }
+
+  /**
+   * A metric diff which must hold when the fs is guarded.
+   * @param metricDiff metric source
+   * @param expected expected value.
+   * @return the diff.
+   */
+  private ExpectedDiff guarded(final MetricDiff metricDiff,
+      final int expected) {
+    return new ExpectedDiff(metricDiff, expected,
+        ExpectedDiffCriteria.Guarded);
+  }
+
+  /**
+   * Criteria an for ExpectedDiff to use.
+   */
+  private enum ExpectedDiffCriteria {
+    Guarded,
+    Unguarded,
+    Always
+  }
+
+  /**
+   * An expected diff to verify given criteria to trigger an eval.
+   */
+  private final class ExpectedDiff {
+
+    private final MetricDiff metricDiff;
+
+    private final int expected;
+
+    private final ExpectedDiffCriteria criteria;
+
+    /**
+     * Create.
+     * @param metricDiff diff to evaluate.
+     * @param expected expected value.
+     * @param criteria criteria to trigger evaluation.
+     */
+    private ExpectedDiff(final MetricDiff metricDiff,
+        final int expected,
+        final ExpectedDiffCriteria criteria) {
+      this.metricDiff = metricDiff;
+      this.expected = expected;
+      this.criteria = criteria;
+    }
+
+    /**
+     * Verify a diff if the FS instance is compatible.
+     * @param message message to print; metric name is appended
+     */
+    private void verify(String message) {
+      boolean isGuarded = guardedFs();
+      boolean probe;
+      switch (criteria) {
+      case Guarded:
+        probe = isGuarded;
+        break;
+      case Unguarded:
+        probe = !isGuarded;
+        break;
+      case Always:
+      default:
+        probe = true;
+        break;
+      }
+      if (probe) {
+        metricDiff.assertDiffEquals(message, expected);
+      }
+    }
+  }
+
+  /**
+   * Execute a closure and verify the metrics.
+   * @param eval closure to evaluate
+   * @param expected varargs list of expected diffs
+   * @param <T> return type.
+   * @return the result of the evaluation
+   * @throws Exception
+   */
+  private <T> T verifyMetrics(
+      Callable<T> eval,
+      ExpectedDiff... expected) throws Exception {
+    resetMetricDiffs();
+    T r = eval.call();
+    String text = r.toString();
+    for (ExpectedDiff ed: expected) {
+      ed.verify(text);
+    }
+    return r;
+  }
+
+  /**
+   * Execute a closure, expecting an exception.
+   * Verify the metrics after the exception has been caught and
+   * validated.
+   * @param clazz type of exception
+   * @param text text to look for in exception (optional)
+   * @param eval closure to evaluate
+   * @param expected varargs list of expected diffs
+   * @param <T> return type of closure
+   * @param <E> exception type
+   * @return the exception caught.
+   * @throws Exception any other exception
+   */
+  private <T, E extends Throwable> E verifyMetricsIntercepting(
+      Class<E> clazz,
+      String text,
+      Callable<T> eval,
+      ExpectedDiff... expected) throws Exception {
+    resetMetricDiffs();
+    E e = intercept(clazz, eval);
+    for (ExpectedDiff ed: expected) {
+      ed.verify(text);
+    }
+    return e;
+  }
+
+  /**
+   * Execute a closure expecting an exception.
+   * @param clazz type of exception
+   * @param text text to look for in exception (optional)
+   * @param head expected head request count.
+   * @param list expected list request count.
+   * @param eval closure to evaluate
+   * @param <T> return type of closure
+   * @param <E> exception type
+   * @return the exception caught.
+   * @throws Exception any other exception
+   */
+  private <T, E extends Throwable> E verifyRawHeadListIntercepting(
+      Class<E> clazz,
+      String text,
+      int head,
+      int list,
+      Callable<T> eval) throws Exception {
+    return verifyMetricsIntercepting(clazz, text, eval,
+        raw(metadataRequests, head),
+        raw(listRequests, list));
+  }
+
+  /**
+   * Execute a closure expecting a specific number of HEAD/LIST calls
+   * on <i>raw</i> S3 stores only.
+   * @param head expected head request count.
+   * @param list expected list request count.
+   * @param eval closure to evaluate
+   * @param <T> return type of closure
+   * @return the result of the evaluation
+   */
+  private <T> T verifyRawHeadList(
+      int head,
+      int list,
+      Callable<T> eval) throws Exception {
+    return verifyMetrics(eval,
+        raw(metadataRequests, head),
+        raw(listRequests, list));
+  }
+
+  /**
+   * Execute innerGetFileStatus for the given probes
+   * and expect in raw FS to have the specific HEAD/LIST count.
+   */
+  public S3AFileStatus execFileStatus(final Path path,
+      boolean needEmptyDirectoryFlag,
+      Set<StatusProbeEnum> probes, int head, int list) throws Exception {
+    return verifyRawHeadList(head, list, () ->
+        getFileSystem().innerGetFileStatus(path, needEmptyDirectoryFlag,
+            probes));
+  }
+
+  /**
+   * A special object whose toString() value is the current
+   * state of the metrics.
+   */
+  private final Object metricSummary = new Object() {
+    @Override
+    public String toString() {
+      return String.format("[%s, %s, %s, %s, %s, %s]",
+          deleteRequests,
+          directoriesCreated,
+          directoriesDeleted,
+          fakeDirectoriesDeleted,
+          listRequests,
+          metadataRequests
+          );
+    }
+  };
+
   @Test
-  public void testFakeDirectoryDeletion() throws Throwable {
-    describe("Verify whether create file works after renaming a file. "
-        + "In S3, rename deletes any fake directories as a part of "
-        + "clean up activity");
+  public void testDirMarkersFileCreation() throws Throwable {
+    describe("verify cost of file creation");
     S3AFileSystem fs = getFileSystem();
 
-    Path srcBaseDir = path("src");
+    Path srcBaseDir = methodPath();
     mkdirs(srcBaseDir);
-    MetricDiff deleteRequests =
-        new MetricDiff(fs, Statistic.OBJECT_DELETE_REQUESTS);
-    MetricDiff directoriesDeleted =
-        new MetricDiff(fs, Statistic.DIRECTORIES_DELETED);
-    MetricDiff fakeDirectoriesDeleted =
-        new MetricDiff(fs, Statistic.FAKE_DIRECTORIES_DELETED);
-    MetricDiff directoriesCreated =
-        new MetricDiff(fs, Statistic.DIRECTORIES_CREATED);
 
     // when you call toString() on this, you get the stats
     // so it gets auto-evaluated in log calls.
-    Object summary = new Object() {
-      @Override
-      public String toString() {
-        return String.format("[%s, %s, %s, %s]",
-            directoriesCreated, directoriesDeleted,
-            deleteRequests, fakeDirectoriesDeleted);
-      }
-    };
-
-    // reset operation to invoke
-    Callable<Boolean> reset = () ->
-        reset(deleteRequests, directoriesCreated, directoriesDeleted,
-          fakeDirectoriesDeleted);
 
     Path srcDir = new Path(srcBaseDir, "1/2/3/4/5/6");
     int srcDirDepth = directoriesInPath(srcDir);
-    // one dir created, one removed
-    mkdirs(srcDir);
-    String state = "after mkdir(srcDir) " + summary;
-    directoriesCreated.assertDiffEquals(state, 1);
-    deleteRequests.assertDiffEquals(state, 1);
-    directoriesDeleted.assertDiffEquals(state, 0);
-    // HADOOP-14255 deletes unnecessary fake directory objects in mkdirs()
-    fakeDirectoriesDeleted.assertDiffEquals(state, srcDirDepth - 1);
-    reset.call();
+    // one dir created, possibly a parent removed
+    verifyMetrics(() -> {
+          mkdirs(srcDir);
+          return "after mkdir(srcDir) " + metricSummary;
+        },
+        always(directoriesCreated, 1),
+        always(directoriesDeleted, 0),
+        always(deleteRequests, markerDeleteRequests(1)),
+        always(fakeDirectoriesDeleted, markerDeleteRequests(srcDirDepth - 1)));
 
     // creating a file should trigger demise of the src dir
+    // unless markers are being kept
     final Path srcFilePath = new Path(srcDir, "source.txt");
+
+    verifyMetrics(() -> {
+          touch(fs, srcFilePath);
+          return "after touch(fs, srcFilePath) " + metricSummary;
+        },
+        always(directoriesCreated, 0),
+        always(directoriesDeleted, 0),
+        always(deleteRequests, markerDeleteRequests(1)),
+        always(fakeDirectoriesDeleted, markerDeleteRequests(srcDirDepth)));
+  }
+
+  @Test
+  public void testRenameFileToDifferentDirectory() throws Throwable {
+    describe("Verify cost of renaming");
+    S3AFileSystem fs = getFileSystem();
+
+    Path baseDir = methodPath();
+    mkdirs(baseDir);
+
+    Path srcDir = new Path(baseDir, "1/2/3/4/5/6");
+    final Path srcFilePath = new Path(srcDir, "source.txt");
+
     touch(fs, srcFilePath);
-    state = "after touch(fs, srcFilePath) " + summary;
-    deleteRequests.assertDiffEquals(state, 1);
-    directoriesCreated.assertDiffEquals(state, 0);
-    directoriesDeleted.assertDiffEquals(state, 0);
-    fakeDirectoriesDeleted.assertDiffEquals(state, srcDirDepth);
-
-    reset.call();
-
-    // create a directory tree, expect the dir to be created and
-    // a request to delete all parent directories made.
-    Path destBaseDir = path("dest");
-    Path destDir = new Path(destBaseDir, "1/2/3/4/5/6");
-    Path destFilePath = new Path(destDir, "dest.txt");
-    mkdirs(destDir);
-    state = "after mkdir(destDir) " + summary;
-
-    int destDirDepth = directoriesInPath(destDir);
-    directoriesCreated.assertDiffEquals(state, 1);
-    deleteRequests.assertDiffEquals(state, 1);
-    directoriesDeleted.assertDiffEquals(state, 0);
-    fakeDirectoriesDeleted.assertDiffEquals(state, destDirDepth - 1);
 
     // create a new source file.
     // Explicitly use a new path object to guarantee that the parent paths
     // are different object instances
     final Path srcFile2 = new Path(srcDir.toUri() + "/source2.txt");
     touch(fs, srcFile2);
-
-    reset.call();
+    // create a directory tree, expect the dir to be created and
+    // possibly a request to delete all parent directories made.
+    Path destBaseDir = new Path(baseDir, "dest");
+    Path destDir = new Path(destBaseDir, "1/2/3/4/5/6");
+    Path destFilePath = new Path(destDir, "dest.txt");
+    int destDirDepth = directoriesInPath(destDir);
+    mkdirs(destDir);
 
     // rename the source file to the destination file.
-    // this tests the file rename path, not the dir rename path
+    // this tests file rename, not dir rename
     // as srcFile2 exists, the parent dir of srcFilePath must not be created.
-    fs.rename(srcFilePath, destFilePath);
-    state = String.format("after rename(srcFilePath, destFilePath)"
-            + " %s dest dir depth=%d",
-        summary,
-        destDirDepth);
-
-    directoriesCreated.assertDiffEquals(state, 0);
-    // one for the renamed file, one for the parent of the dest dir
-    deleteRequests.assertDiffEquals(state, 2);
-    directoriesDeleted.assertDiffEquals(state, 0);
-    fakeDirectoriesDeleted.assertDiffEquals(state, destDirDepth);
+    verifyMetrics(() -> {
+      fs.rename(srcFilePath, destFilePath);
+      return String.format("after rename(%s, %s)"
+              + " %s dest dir depth=%d",
+          srcFilePath, destFilePath,
+          metricSummary,
+          destDirDepth);
+      },
+        raw(metadataRequests, HEAD_REQUESTS_SINGLE_FILE_RENAME),
+        raw(listRequests, LIST_REQUESTS_SINGLE_FILE_RENAME),
+        always(directoriesCreated, 0),
+        always(directoriesDeleted, 0),
+        always(deleteRequests, 1 + markerDeleteRequests(1)),
+        always(fakeDirectoriesDeleted, markerDeleteRequests(destDirDepth)));
 
     // these asserts come after the checks on iop counts, so they don't
     // interfere
     assertIsFile(destFilePath);
     assertIsDirectory(srcDir);
     assertPathDoesNotExist("should have gone in the rename", srcFilePath);
-    reset.call();
 
-    // rename the source file2 to the (no longer existing
-    // this tests the file rename path, not the dir rename path
-    // as srcFile2 exists, the parent dir of srcFilePath must not be created.
-    fs.rename(srcFile2, srcFilePath);
-    state = String.format("after rename(%s, %s) %s dest dir depth=%d",
-        srcFile2, srcFilePath,
-        summary,
-        destDirDepth);
-
-    // here we expect there to be no fake directories
-    directoriesCreated.assertDiffEquals(state, 0);
-    // one for the renamed file only
-    deleteRequests.assertDiffEquals(state, 1);
-    directoriesDeleted.assertDiffEquals(state, 0);
-    fakeDirectoriesDeleted.assertDiffEquals(state, 0);
+    // rename the source file2 to the (no longer existing) srcFilePath
+    // in the same directory
+/*    verifyMetrics(() -> {
+      fs.rename(srcFile2, srcFilePath);
+      return String.format("after rename(%s, %s) %s dest dir depth=%d",
+          srcFile2, srcFilePath,
+          metricSummary,
+          destDirDepth);
+      },
+        always(directoriesCreated, 0),
+        always(directoriesDeleted, 0),
+        always(deleteRequests, 1),
+        always(fakeDirectoriesDeleted, 0));*/
   }
+
 
   private int directoriesInPath(Path path) {
     return path.isRoot() ? 0 : 1 + directoriesInPath(path.getParent());
@@ -450,54 +778,37 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     String uuid = UUID.randomUUID().toString();
     Path src = new Path("/src-" + uuid);
     Path dest = new Path("/dest-" + uuid);
-
     try {
-      MetricDiff deleteRequests =
-          new MetricDiff(fs, Statistic.OBJECT_DELETE_REQUESTS);
-      MetricDiff directoriesDeleted =
-          new MetricDiff(fs, Statistic.DIRECTORIES_DELETED);
-      MetricDiff fakeDirectoriesDeleted =
-          new MetricDiff(fs, Statistic.FAKE_DIRECTORIES_DELETED);
-      MetricDiff directoriesCreated =
-          new MetricDiff(fs, Statistic.DIRECTORIES_CREATED);
+
       touch(fs, src);
-      fs.rename(src, dest);
-      Object summary = new Object() {
-        @Override
-        public String toString() {
-          return String.format("[%s, %s, %s, %s]",
-              directoriesCreated, directoriesDeleted,
-              deleteRequests, fakeDirectoriesDeleted);
-        }
-      };
-
-      String state = String.format("after touch(%s) %s",
-          src, summary);
-      touch(fs, src);
-      fs.rename(src, dest);
-      directoriesCreated.assertDiffEquals(state, 0);
-
-
-      state = String.format("after rename(%s, %s) %s",
-          src, dest, summary);
-      // here we expect there to be no fake directories
-      directoriesCreated.assertDiffEquals(state, 0);
-      // one for the renamed file only
-      deleteRequests.assertDiffEquals(state, 1);
-      directoriesDeleted.assertDiffEquals(state, 0);
-      fakeDirectoriesDeleted.assertDiffEquals(state, 0);
+      verifyMetrics(() -> {
+        fs.rename(src, dest);
+        return "after fs.rename(/src,/dest) " + metricSummary;
+        },
+          // TWO HEAD for exists, one for source MD in copy
+          raw(metadataRequests, HEAD_REQUESTS_SINGLE_FILE_RENAME),
+          raw(listRequests, 1),
+          // here we expect there to be no fake directories
+          always(directoriesCreated, 0),
+          // one for the renamed file only
+          always(deleteRequests, 1),
+          // no directories are deleted: This is root
+          always(directoriesDeleted, 0),
+          // no fake directories are deleted: This is root
+          always(fakeDirectoriesDeleted, 0));
 
       // delete that destination file, assert only the file delete was issued
-      reset(deleteRequests, directoriesCreated, directoriesDeleted,
-          fakeDirectoriesDeleted);
+      verifyMetrics(() -> {
+        fs.delete(dest, false);
+        return "after fs.delete(/dest) " + metricSummary;
+        },
+          always(directoriesCreated, 0),
+          always(directoriesDeleted, 0),
+          always(fakeDirectoriesDeleted, 0),
+          always(deleteRequests, 1),
+          raw(listRequests, 0)   /* no need to look at parent. */
+          );
 
-      fs.delete(dest, false);
-      // here we expect there to be no fake directories
-      directoriesCreated.assertDiffEquals(state, 0);
-      // one for the deleted file
-      deleteRequests.assertDiffEquals(state, 1);
-      directoriesDeleted.assertDiffEquals(state, 0);
-      fakeDirectoriesDeleted.assertDiffEquals(state, 0);
     } finally {
       fs.delete(src, false);
       fs.delete(dest, false);
@@ -508,70 +819,190 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   public void testDirProbes() throws Throwable {
     describe("Test directory probe cost -raw only");
     S3AFileSystem fs = getFileSystem();
-    assume("Unguarded FS only", !fs.hasMetadataStore());
+    assume("Unguarded FS only", !guardedFs());
     String dir = "testEmptyDirHeadProbe";
     Path emptydir = path(dir);
     // Create the empty directory.
     fs.mkdirs(emptydir);
 
     // metrics and assertions.
-    resetMetricDiffs();
-
-    intercept(FileNotFoundException.class, () ->
+    verifyRawHeadListIntercepting(FileNotFoundException.class, "",
+        1, 0, () ->
         fs.innerGetFileStatus(emptydir, false,
             StatusProbeEnum.HEAD_ONLY));
-    verifyOperationCount(1, 0);
+    verifyUnguardedOperationCount(1, 0);
 
     // a LIST will find it -but it doesn't consider it an empty dir.
     S3AFileStatus status = fs.innerGetFileStatus(emptydir, true,
         StatusProbeEnum.LIST_ONLY);
-    verifyOperationCount(0, 1);
+    verifyUnguardedOperationCount(0, 1);
     Assertions.assertThat(status)
         .describedAs("LIST output is not considered empty")
-        .matches(s -> !s.isEmptyDirectory().equals(Tristate.TRUE),  "is empty");
+        .matches(s -> s.isEmptyDirectory().equals(Tristate.TRUE));
 
-    // finally, skip all probes and expect no operations toThere are
+    // finally, skip all probes and expect no operations to
     // take place
     intercept(FileNotFoundException.class, () ->
         fs.innerGetFileStatus(emptydir, false,
             EnumSet.noneOf(StatusProbeEnum.class)));
-    verifyOperationCount(0, 0);
+    verifyUnguardedOperationCount(0, 0);
 
     // now add a trailing slash to the key and use the
     // deep internal s3GetFileStatus method call.
     String emptyDirTrailingSlash = fs.pathToKey(emptydir.getParent())
         + "/" + dir +  "/";
     // A HEAD request does not probe for keys with a trailing /
-    intercept(FileNotFoundException.class, () ->
+    verifyRawHeadListIntercepting(FileNotFoundException.class, "",
+        0, 0, () ->
         fs.s3GetFileStatus(emptydir, emptyDirTrailingSlash,
-            StatusProbeEnum.HEAD_ONLY, null));
-    verifyOperationCount(0, 0);
+            StatusProbeEnum.HEAD_ONLY, null, false));
 
     // but ask for a directory marker and you get the entry
     status = fs.s3GetFileStatus(emptydir,
         emptyDirTrailingSlash,
-        StatusProbeEnum.DIR_MARKER_ONLY, null);
-    verifyOperationCount(1, 0);
+        StatusProbeEnum.LIST_ONLY, null, true);
     assertEquals(emptydir, status.getPath());
+    assertEmptyDirStatus(status, Tristate.TRUE);
+    verifyUnguardedOperationCount(0, 1);
+    if (!dirMarkerProbesEnabled()) {
+      verifyRawHeadListIntercepting(FileNotFoundException.class, "",
+          0, 0, () ->
+          fs.s3GetFileStatus(emptydir,
+              emptyDirTrailingSlash,
+              StatusProbeEnum.DIR_MARKER_ONLY,
+              null,
+              false));
+    } else {
+      status = fs.s3GetFileStatus(emptydir,
+          emptyDirTrailingSlash,
+          StatusProbeEnum.DIR_MARKER_ONLY,
+          null,
+          false);
+      verifyUnguardedOperationCount(
+          probeHeadCost(StatusProbeEnum.DIR_MARKER_ONLY), 0);
+      assertEmptyDirStatus(status, Tristate.FALSE);
+    }
+  }
+
+  protected void assertEmptyDirStatus(final S3AFileStatus status,
+      final Tristate expected) {
+    assertEquals("Not an empty dir " + status,
+        expected,
+        status.isEmptyDirectory());
   }
 
   @Test
   public void testCreateCost() throws Throwable {
     describe("Test file creation cost -raw only");
     S3AFileSystem fs = getFileSystem();
-    assume("Unguarded FS only", !fs.hasMetadataStore());
+    assume("Unguarded FS only", !guardedFs());
     resetMetricDiffs();
     Path testFile = path("testCreateCost");
-
     // when overwrite is false, the path is checked for existence.
-    try (FSDataOutputStream out = fs.create(testFile, false)) {
-      verifyOperationCount(2, 1);
-    }
-
+    create(testFile, false, 1, 1);
     // but when true: only the directory checks take place.
-    try (FSDataOutputStream out = fs.create(testFile, true)) {
-      verifyOperationCount(1, 1);
-    }
+    create(testFile, true, 0, 1);
+
+    // now there is a file there, an attempt with overwrite == false will
+    // fail on the first HEAD.
+    verifyRawHeadListIntercepting(FileAlreadyExistsException.class, "",
+        1, 0, () -> {
+      FSDataOutputStream s = fs.create(testFile, false);
+      String msg = s.toString();
+      s.close();
+      return msg;
+    });
+  }
+
+  /**
+   * Use the builder API.
+   * This always looks for a parent unless the caller says otherwise.
+   */
+  @Test
+  public void testCreateBuilderCost() throws Throwable {
+    describe("Test builder file creation cost -raw only");
+    S3AFileSystem fs = getFileSystem();
+    assume("Unguarded FS only", !guardedFs());
+    Path testFile = path("testCreateBuilderCost");
+    Path parent = testFile.getParent();
+    assertMkdirs(fs, parent);
+
+    // builder defaults to looking for parent existence (non-recursive)
+    buildFile(testFile, false,  false, 1, 2);
+    // recursive = false and overwrite=true:
+    // only make sure the dest path isn't a directory.
+    buildFile(testFile, true, true,0, 1);
+
+    // now there is a file there, an attempt with overwrite == false will
+    // fail on the first HEAD.
+    verifyRawHeadListIntercepting(FileAlreadyExistsException.class, "",
+        1, 0, () ->
+            buildFile(testFile, false, true, 0, 0));
 
   }
+
+  /**
+   * Create then close the file.
+   * @param path path
+   * @param overwrite overwrite flag
+   * @param head expected head count
+   * @param list expected list count
+   */
+  private void create(Path path, boolean overwrite,
+      int head, int list) throws IOException {
+    resetMetricDiffs();
+    getFileSystem().create(path, overwrite).close();
+    verifyUnguardedOperationCount(head, list);
+  }
+
+  /**
+   * Create then close the file through the builder API.
+   * @param path path
+   * @param overwrite overwrite flag
+   * @param recursive true == skip parent existence check
+   * @param head expected head count
+   * @param list expected list count
+   */
+  private boolean buildFile(Path path,
+      boolean overwrite,
+      boolean recursive,
+      int head,
+      int list) throws IOException {
+    resetMetricDiffs();
+    FSDataOutputStreamBuilder builder = getFileSystem().createFile(path)
+        .overwrite(overwrite);
+    if (recursive) {
+      builder.recursive();
+    }
+    builder.build().close();
+    verifyUnguardedOperationCount(head, list);
+    return true;
+  }
+
+  /**
+   * This lets us control whether dir marker HEAD +/ probes are being
+   * used at all.
+   */
+  private boolean dirMarkerProbesEnabled() {
+    return false;
+  }
+  /**
+   * How many HEAD requests will this probe set make.
+   * It's a method to allow for dynamicness/ease
+   * of re-organizing and disabling the s3GetFileStatus
+   * code.
+   * @param probes probes to run.
+   * @return how many head requests.
+   */
+
+  private int probeHeadCost(Set<StatusProbeEnum> probes) {
+    int total = 0;
+    for (StatusProbeEnum probe : probes) {
+      if (probe == StatusProbeEnum.Head) {
+        total ++;
+      }
+    }
+    return total;
+  }
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -563,16 +563,16 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
         + "keeping the source dir present");
 
     Path baseDir = dir(methodPath());
-    final Path srcFilePath = file(new Path(baseDir, "source.txt"));
+    final Path sourceFile = file(new Path(baseDir, "source.txt"));
 
     // create a new source file.
     // Explicitly use a new path object to guarantee that the parent paths
     // are different object instances and so equals() rather than ==
     // is
-    Path parent2 = srcFilePath.getParent();
-    Path srcFile2 = file(new Path(parent2, "source2.txt"));
+    Path parent2 = sourceFile.getParent();
+    Path destFile = file(new Path(parent2, "dest"));
     verifyMetrics(() ->
-            execRename(srcFilePath, srcFile2),
+            execRename(sourceFile, destFile),
         raw(metadataRequests, HEAD_REQUESTS_SINGLE_FILE_RENAME - 1),
         raw(listRequests, LIST_REQUESTS_SINGLE_FILE_RENAME_DIFFERENT_DIR),
         always(directoriesCreated, 0),
@@ -580,11 +580,11 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
         always(fakeDirectoriesDeleted, 0));
   }
 
-  public String execRename(final Path srcFilePath,
-      final Path srcFile2) throws IOException {
-    getFileSystem().rename(srcFile2, srcFilePath);
+  public String execRename(final Path source,
+      final Path dest) throws IOException {
+    getFileSystem().rename(source, dest);
     return String.format("rename(%s, %s)",
-        srcFile2, srcFilePath);
+        dest, source);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
@@ -326,7 +326,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
    * @return a number >= 0.
    */
   private int getFileStatusHeadCount() {
-    return authMode ? 0 : 1;
+    return authMode ? 0 : 0;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardOutOfBandOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardOutOfBandOperations.java
@@ -56,6 +56,8 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.toChar;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeTextFile;
 import static org.apache.hadoop.fs.s3a.Constants.AUTHORITATIVE_PATH;
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_MODE;
+import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_MODE_NONE;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_METADATASTORE_METADATA_TTL;
 import static org.apache.hadoop.fs.s3a.Constants.METADATASTORE_AUTHORITATIVE;
 import static org.apache.hadoop.fs.s3a.Constants.METADATASTORE_METADATA_TTL;
@@ -169,12 +171,16 @@ public class ITestS3GuardOutOfBandOperations extends AbstractS3ATestBase {
         RETRY_LIMIT,
         RETRY_INTERVAL,
         S3GUARD_CONSISTENCY_RETRY_INTERVAL,
-        S3GUARD_CONSISTENCY_RETRY_LIMIT);
+        S3GUARD_CONSISTENCY_RETRY_LIMIT,
+        CHANGE_DETECT_MODE,
+        METADATASTORE_METADATA_TTL);
     conf.setInt(RETRY_LIMIT, 3);
     conf.setInt(S3GUARD_CONSISTENCY_RETRY_LIMIT, 3);
+    conf.set(CHANGE_DETECT_MODE, CHANGE_DETECT_MODE_NONE);
     final String delay = "10ms";
     conf.set(RETRY_INTERVAL, delay);
     conf.set(S3GUARD_CONSISTENCY_RETRY_INTERVAL, delay);
+    conf.set(METADATASTORE_METADATA_TTL, delay);
     return conf;
   }
 
@@ -232,12 +238,13 @@ public class ITestS3GuardOutOfBandOperations extends AbstractS3ATestBase {
     URI uri = testFS.getUri();
 
     removeBaseAndBucketOverrides(uri.getHost(), config,
+        CHANGE_DETECT_MODE,
         METADATASTORE_AUTHORITATIVE,
         METADATASTORE_METADATA_TTL,
         AUTHORITATIVE_PATH);
     config.setBoolean(METADATASTORE_AUTHORITATIVE, authoritativeMode);
     config.setLong(METADATASTORE_METADATA_TTL,
-        DEFAULT_METADATASTORE_METADATA_TTL);
+        5_000);
     final S3AFileSystem gFs = createFS(uri, config);
     // set back the same metadata store instance
     gFs.setMetadataStore(realMs);
@@ -857,7 +864,7 @@ public class ITestS3GuardOutOfBandOperations extends AbstractS3ATestBase {
             expectedLength, guardedLength);
       } else {
         assertEquals(
-            "File length in authoritative table with " + stats,
+            "File length in non-authoritative table with " + stats,
             expectedLength, guardedLength);
       }
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -618,6 +618,12 @@ public final class S3ATestUtils {
     // add this so that even on tests where the FS is shared,
     // the FS is always "magic"
     conf.setBoolean(MAGIC_COMMITTER_ENABLED, true);
+    String directoryRetention = getTestProperty(
+        conf,
+        DIRECTORY_MARKER_POLICY,
+        DEFAULT_DIRECTORY_MARKER_POLICY);
+    conf.set(DIRECTORY_MARKER_POLICY, directoryRetention);
+
     return conf;
   }
 
@@ -882,7 +888,8 @@ public final class S3ATestUtils {
   public static S3AFileStatus getStatusWithEmptyDirFlag(
       final S3AFileSystem fs,
       final Path dir) throws IOException {
-    return fs.innerGetFileStatus(dir, true, StatusProbeEnum.ALL);
+    return fs.innerGetFileStatus(dir, true,
+        StatusProbeEnum.ALL);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestDirectoryMarkerPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestDirectoryMarkerPolicy.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY;
+
+@RunWith(Parameterized.class)
+public class TestDirectoryMarkerPolicy extends AbstractHadoopTestBase {
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {
+            DirectoryPolicy.MarkerPolicy.Delete,
+            failIfInvoked,
+            false, false
+        },
+        {
+            DirectoryPolicy.MarkerPolicy.Keep,
+            failIfInvoked,
+            true, true
+        },
+        {
+            DirectoryPolicy.MarkerPolicy.Authoritative,
+            authPathOnly,
+            false, true
+        }});
+  }
+
+  private final DirectoryPolicyImpl retention;
+  private final boolean expectNonAuthDelete;
+  private final boolean expectAuthDelete;
+
+  public TestDirectoryMarkerPolicy(
+      final DirectoryPolicy.MarkerPolicy markerPolicy,
+      final Predicate<Path> authoritativeness,
+      final boolean expectNonAuthDelete,
+      final boolean expectAuthDelete) {
+    this.retention = retention(markerPolicy, authoritativeness);
+    this.expectNonAuthDelete = expectNonAuthDelete;
+    this.expectAuthDelete = expectAuthDelete;
+  }
+
+  /**
+   * Create a new retention policy.
+   * @param markerPolicy policy option
+   * @param authoritativeness predicate for determining if
+   * a path is authoritative.
+   * @return the retention policy.
+   */
+  private DirectoryPolicyImpl retention(
+      DirectoryPolicy.MarkerPolicy markerPolicy,
+      Predicate<Path> authoritativeness) {
+    Configuration c = new Configuration(false);
+    c.set(DIRECTORY_MARKER_POLICY, markerPolicy.name());
+    return new DirectoryPolicyImpl(c, authoritativeness);
+  }
+
+  private static final Predicate<Path> authPathOnly =
+      (p) -> p.toUri().getPath().startsWith("/auth/");
+
+  private static final Predicate<Path> failIfInvoked = (p) -> {
+    throw new RuntimeException("failed");
+  };
+
+  private final Path nonAuthPath = new Path("s3a://bucket/nonauth/data");
+  private final Path authPath = new Path("s3a://bucket/auth/data1");
+  private final Path deepAuth = new Path("s3a://bucket/auth/d1/d2/data2");
+
+  private void assertRetention(Path path, boolean retain) {
+    Assertions.assertThat(retention.keepDirectoryMarkers(path))
+        .describedAs("Retention of path %s by %s", path, retention)
+        .isEqualTo(retain);
+  }
+
+  @Test
+  public void testNonAuthPath() throws Throwable {
+    assertRetention(nonAuthPath, expectNonAuthDelete);
+  }
+
+  @Test
+  public void testAuthPath() throws Throwable {
+    assertRetention(authPath, expectAuthDelete);
+  }
+
+  @Test
+  public void testDeepAuthPath() throws Throwable {
+    assertRetention(deepAuth, expectAuthDelete);
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardDDBRootOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardDDBRootOperations.java
@@ -38,9 +38,12 @@ import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY;
+import static org.apache.hadoop.fs.s3a.Constants.DIRECTORY_MARKER_POLICY_DELETE;
 import static org.apache.hadoop.fs.s3a.Constants.ENABLE_MULTI_DELETE;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_BACKGROUND_SLEEP_MSEC_KEY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assume;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3AUtils.applyLocatedFiles;
@@ -82,13 +85,17 @@ public class ITestS3GuardDDBRootOperations extends AbstractS3ATestBase {
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     String bucketName = getTestBucketName(conf);
+    disableFilesystemCaching(conf);
 
     // set a sleep time of 0 on pruning, for speedier test runs.
-    removeBucketOverrides(bucketName, conf, ENABLE_MULTI_DELETE);
+    removeBucketOverrides(bucketName, conf, ENABLE_MULTI_DELETE,
+        DIRECTORY_MARKER_POLICY);
     conf.setTimeDuration(
         S3GUARD_DDB_BACKGROUND_SLEEP_MSEC_KEY,
         0,
         TimeUnit.MILLISECONDS);
+    conf.set(DIRECTORY_MARKER_POLICY,
+             DIRECTORY_MARKER_POLICY_DELETE);
     return conf;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDirListingMetadata.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestDirListingMetadata.java
@@ -316,18 +316,23 @@ public class TestDirListingMetadata {
     List<PathMetadata> listing = Arrays.asList(pathMeta1, pathMeta2, pathMeta3);
     DirListingMetadata meta = new DirListingMetadata(path, listing, false);
 
-    meta.removeExpiredEntriesFromListing(ttl, now);
+    List<PathMetadata> expired = meta.removeExpiredEntriesFromListing(ttl,
+        now);
 
     Assertions.assertThat(meta.getListing())
         .describedAs("Metadata listing for %s", path)
         .doesNotContain(pathMeta1)
         .contains(pathMeta2)
         .contains(pathMeta3);
+    Assertions.assertThat(expired)
+        .describedAs("Expire entries underr %s", path)
+        .doesNotContain(pathMeta2)
+        .contains(pathMeta1);
   }
 
-  /*
+  /**
    * Create DirListingMetadata with two dirs and one file living in directory
-   * 'parent'
+   * 'parent'.
    */
   private static DirListingMetadata makeTwoDirsOneFile(Path parent) {
     PathMetadata pathMeta1 = new PathMetadata(

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/HeadListCosts.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/HeadListCosts.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.test;
+
+/**
+ * Declaration of the costs of head and list calls for various FS IO operations.
+ */
+public class HeadListCosts {
+
+  /** Head costs for getFileStatus() directory probe: {@value}. */
+  public static final int GFS_DIR_PROBE_H = 0;
+
+  /** List costs for getFileStatus() directory probe: {@value}. */
+  public static final int GFS_DIR_PROBE_L = 1;
+
+
+  /** List costs for getFileStatus() on a non-empty directory: {@value}. */
+  public static final int GFS_DIR_L = GFS_DIR_PROBE_L;
+
+  /** List costs for getFileStatus() on an non-empty directory: {@value}. */
+  public static final int GFS_EMPTY_DIR_L = GFS_DIR_PROBE_L;
+
+  /** Head cost getFileStatus() file probe only. */
+  public static final int GFS_FILE_PROBE_H = 1;
+
+  /** Head costs getFileStatus() no file or dir. */
+  public static final int GFS_FNFE_H = GFS_FILE_PROBE_H;
+
+  /** List costs for getFileStatus() on an empty path: {@value}. */
+
+  public static final int GFS_FNFE_L = GFS_DIR_PROBE_L;
+
+  /**
+   * Cost of renaming a file to a diffrent directory.
+   * LIST on dest not found, look for dest dir, and then, at
+   * end of rename, whether a parent dir needs to be created.
+   */
+  public static final int RENAME_SINGLE_FILE_RENAME_DIFFERENT_DIR_L =
+      GFS_FNFE_L + GFS_DIR_L * 2;
+                             
+  /** source is found, dest not found, copy metadataRequests */
+  public static final int RENAME_SINGLE_FILE_RENAME_H =
+      GFS_FILE_PROBE_H + GFS_FNFE_H + 1;
+
+  /** getFileStatus() directory which is non-empty. */
+  public static final int GFS_DIR_H = GFS_FILE_PROBE_H;
+
+  /** getFileStatus() directory marker which exists. */
+  public static final int GFS_MARKER_H = GFS_FILE_PROBE_H;
+
+  /** getFileStatus() on a file which exists. */
+  public static final int GFS_SINGLE_FILE_H = GFS_FILE_PROBE_H;
+
+  public static final int GFS_FILE_PROBE_L = 0;
+
+  public static final int GFS_SINGLE_FILE_L = 0;
+
+  public static final int DELETE_OBJECT_REQUEST = 1;
+
+  public static final int DELETE_MARKER_REQUEST = 1;
+
+  /** listLocatedStatus always does a list. */
+  public static final int LIST_LOCATED_STATUS_L = 1;
+  
+  
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/OperationCostValidator.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/OperationCostValidator.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.Assumptions;
+
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.fs.s3a.Statistic;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Support for declarative assertions about operation cost.
+ */
+public class OperationCostValidator {
+
+  private final Map<String, S3ATestUtils.MetricDiff> metricDiffs
+      = new TreeMap<>();
+
+  public OperationCostValidator(Builder builder) {
+    builder.metrics.forEach(stat ->
+        metricDiffs.put(stat.getSymbol(),
+            new S3ATestUtils.MetricDiff(builder.fs, stat))
+    );
+    builder.metrics.clear();
+  }
+
+
+  /**
+   * Reset all the metrics being tracked.
+   */
+  public void resetMetricDiffs() {
+    metricDiffs.values().forEach(S3ATestUtils.MetricDiff::reset);
+  }
+
+  /**
+   * Get the diff of a statistic.
+   * @param stat statistic to look up
+   * @return the value
+   * @throws NullPointerException if there is no match
+   */
+  public S3ATestUtils.MetricDiff get(Statistic stat) {
+    S3ATestUtils.MetricDiff diff =
+        requireNonNull(metricDiffs.get(stat.getSymbol()),
+            () -> "No metric tracking for " + stat);
+    return diff;
+  }
+
+
+  /**
+   * Execute a closure and verify the metrics.
+   * <p></p>
+   * If no probes are active, the operation will
+   * raise an Assumption exception for the test to be skipped.
+   * @param eval closure to evaluate
+   * @param expected varargs list of expected diffs
+   * @param <T> return type.
+   * @return the result of the evaluation
+   */
+  public <T> T verify(
+      Callable<T> eval,
+      ExpectedProbe... expected) throws Exception {
+    resetMetricDiffs();
+    // verify that 1+ probe is enabled
+    assumeProbesEnabled(expected);
+    // if we get here, then yes.
+    // evaluate it
+    T r = eval.call();
+    // build the text for errors
+    String text = r != null ? r.toString() : "operation returning null";
+    for (ExpectedProbe ed : expected) {
+      ed.verify(this, text);
+    }
+    return r;
+  }
+
+  /**
+   * Scan all probes for being enabled.
+   * <p></p>
+   * If none of them are enabled, the evaluation will be skipped.
+   * @param expected list of expected probes
+   */
+  private void assumeProbesEnabled(ExpectedProbe[] expected) {
+    boolean enabled = false;
+    for (ExpectedProbe ed : expected) {
+      enabled |= ed.isEnabled();
+    }
+    Assumptions.assumeThat(enabled)
+        .describedAs("metrics to probe for")
+        .isTrue();
+  }
+
+  /**
+   * Execute a closure, expecting an exception.
+   * Verify the metrics after the exception has been caught and
+   * validated.
+   * @param clazz type of exception
+   * @param text text to look for in exception (optional)
+   * @param eval closure to evaluate
+   * @param expected varargs list of expected diffs
+   * @param <T> return type of closure
+   * @param <E> exception type
+   * @return the exception caught.
+   * @throws Exception any other exception
+   */
+  public <T, E extends Throwable> E verifyIntercepting(
+      Class<E> clazz,
+      String text,
+      Callable<T> eval,
+      ExpectedProbe... expected) throws Exception {
+
+    return verify(() ->
+            intercept(clazz, text, eval),
+        expected);
+  }
+
+  @Override
+  public String toString() {
+    return metricDiffs.values().stream()
+        .map(S3ATestUtils.MetricDiff::toString)
+        .collect(Collectors.joining(", "));
+  }
+
+  /**
+   * Create a builder for the cost checker.
+   *
+   * @param fs filesystem.
+   * @return builder.
+   */
+  public static Builder builder(S3AFileSystem fs) {
+    return new Builder(fs);
+  }
+
+  /**
+   * builder.
+   */
+  public static final class Builder {
+
+    private final List<Statistic> metrics = new ArrayList<>();
+
+    private final S3AFileSystem fs;
+
+
+    public Builder(final S3AFileSystem fs) {
+      this.fs = requireNonNull(fs);
+    }
+
+
+    public Builder withMetric(Statistic statistic) {
+      return withMetric(statistic);
+    }
+
+
+    public Builder withMetrics(Statistic...stats) {
+      metrics.addAll(Arrays.asList(stats));
+      return this;
+    }
+
+    public OperationCostValidator build() {
+      return new OperationCostValidator(this);
+    }
+  }
+
+  public static ExpectedProbe probe(final boolean enabled,
+      final Statistic statistic,
+      final int expected) {
+    return new ExpectedProbe(enabled, statistic, expected);
+  }
+
+  public static ExpectedProbe probe(
+      final Statistic statistic,
+      final int expected) {
+    return new ExpectedProbe(statistic, expected);
+  }
+
+  /**
+   * An expected probe to verify given criteria to trigger an eval.
+   * Probes can be conditional, in which case they are only evaluated
+   * when true.
+   */
+  public static final class ExpectedProbe {
+
+    private final Statistic statistic;
+
+    private final int expected;
+
+    private final boolean enabled;
+
+    /**
+     * Create.
+     * @param enabled criteria to trigger evaluation.
+     * @param statistic statistic
+     * @param expected expected value.
+     */
+    private ExpectedProbe(final boolean enabled,
+        final Statistic statistic,
+        final int expected) {
+      this.statistic = statistic;
+      this.expected = expected;
+      this.enabled = enabled;
+    }
+
+    /**
+     * Create a diff which is always evaluated
+     * @param statistic statistic
+     * @param expected expected value.
+     */
+    private ExpectedProbe(
+        final Statistic statistic,
+        final int expected) {
+      this.statistic = statistic;
+      this.expected = expected;
+      this.enabled = true;
+    }
+
+    /**
+     * Verify a diff if the FS instance is compatible.
+     * @param message message to print; metric name is appended
+     */
+    private void verify(OperationCostValidator diffs, String message) {
+
+      if (enabled) {
+        S3ATestUtils.MetricDiff md = diffs.get(statistic);
+
+        md.assertDiffEquals(message, expected);
+      }
+    }
+
+    public Statistic getStatistic() {
+      return statistic;
+    }
+
+    public int getExpected() {
+      return expected;
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+  }
+
+}


### PR DESCRIPTION
This allows a bucket to have policies of keep, delete or authoritative,
where the latter means "delete in auth dirs"

Retention policy is implemented in its own little class for testing;
does need a callback to probe for a path being auth or not.

[Design Document](https://docs.google.com/document/d/1pa52GYsRTC-x1-tfO2qmcO_Tw_v79kga9ryBL__yUpA/edit#heading=h.cyz5tlh49dpo)

Tests? Not yet, no.

Change-Id: Ibcd86048ffaa4c39bba5bd4ea796a24ea8d7f479
