### PR TITLE
HADOOP-16897. Sort fields in ReflectionUtils.java

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ReflectionUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ReflectionUtils.java
@@ -31,6 +31,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -350,7 +352,13 @@ public class ReflectionUtils {
   public static List<Field> getDeclaredFieldsIncludingInherited(Class<?> clazz) {
     List<Field> fields = new ArrayList<Field>();
     while (clazz != null) {
-      for (Field field : clazz.getDeclaredFields()) {
+      Field[] sortedFields = clazz.getDeclaredFields();
+      Arrays.sort(sortedFields, new Comparator<Field>() {
+        public int compare(Field a, Field b) {
+          return a.getName().compareTo(b.getName());
+        }
+      });
+      for (Field field : sortedFields) {
         fields.add(field);
       }
       clazz = clazz.getSuperclass();


### PR DESCRIPTION
This PR aims to solve the issue here: https://issues.apache.org/jira/browse/HADOOP-16897

The fix is to sort the fields returned by getDeclaredFields() so that the non-deterministic behaviour can be eliminated completely. In this way, the test becomes more stable and it will not suffer from the failure any more.
