### PR TITLE
HADOOP-16885. Followup to fix test failure of encryption zone file copy

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestCopy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestCopy.java
@@ -121,7 +121,7 @@ public class TestCopy {
 
     tryCopyStream(in, false);
     verify(mockFs, never()).rename(any(Path.class), any(Path.class));
-    verify(mockFs, never()).delete(eq(tmpPath), anyBoolean());
+    verify(mockFs).delete(eq(tmpPath), anyBoolean());
     verify(mockFs, never()).delete(eq(path), anyBoolean());
     verify(mockFs, never()).close();
   }


### PR DESCRIPTION
Followup to HADOOP-16885: Encryption zone file copy failure leaks a temp file

#1859

Moving the delete() call broke a mocking test.

Contributed by Steve Loughran.

(sorry; somehow missed this test failure. It's trivial enough to fix that I'm not going to revert the main patch)