### PR TITLE
HDFS-15208. Supress bogus AbstractWadlGeneratorGrammarGenerator in KMS stderr in hdfs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/log4j.properties
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/log4j.properties
@@ -71,3 +71,6 @@ log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.FILE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p \
   (%F:%L) %X{function} %X{resource} %X{user} %X{request} - \
   %m%n
+
+# Supress KMS error log
+log4j.logger.com.sun.jersey.server.wadl.generators.WadlGeneratorJAXBGrammarGenerator=OFF


### PR DESCRIPTION
Verified manually by running TestEncryptionZonesWithKMS.

Change-Id: I7abeaf4b65e2a4758356aa69ab8930f7e993077d