### PR TITLE
HADOOP-16661. Support TLS 1.3

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2974,6 +2974,7 @@
   <description>
     The supported SSL protocols. The parameter will only be used from
     DatanodeHttpServer.
+    Starting from Hadoop 3.3.0, TLSv1.3 is supported with Java 11 Runtime.
   </description>
 </property>
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
@@ -87,17 +87,19 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
       + "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA,"
       + "SSL_RSA_WITH_RC4_128_MD5 \t";
   private static final String ONE_ENABLED_CIPHERS = EXCLUDED_CIPHERS
-      + ",TLS_RSA_WITH_AES_128_CBC_SHA";
+      + ",TLS_RSA_WITH_AES_128_CBC_SHA,"
+      + "TLS_AES_128_GCM_SHA256";
   private static final String EXCLUSIVE_ENABLED_CIPHERS
       = "\tTLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, \n"
       + "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
       + "TLS_RSA_WITH_AES_128_CBC_SHA,"
       + "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,  "
       + "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,"
+      + "TLS_AES_128_GCM_SHA256,"
       + "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,\t\n "
       + "TLS_DHE_DSS_WITH_AES_128_CBC_SHA";
 
-  static final String INCLUDED_PROTOCOLS = "SSLv2Hello,TLSv1.1";
+  static final String INCLUDED_PROTOCOLS = "TLSv1.3";
 
   @BeforeClass
   public static void setup() throws Exception {


### PR DESCRIPTION
TLS 1.3 is supported in Hadoop 3.3.0 with the update of Jetty 9.4 and Java 11 Runtime.

This patch doesn't add any new capability. It simply adds a new test case to verify TLSv1.3 is enabled on Java 11.

Verified manually by:
```
JAVA_HOME=`/usr/libexec/java_home -v 11` mvn test -Dtest=TestSSLHttpServer#testIncludedProtocols
JAVA_HOME=`/usr/libexec/java_home -v 1.8` mvn test -Dtest=TestSSLHttpServer#testIncludedProtocols
```