### PR TITLE
YARN-10195. Dependency divergence building Timeline Service on HBase 2.2.0 and above.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -658,6 +658,12 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION

Manually verified with 

`mvn clean install -Dhbase.profile=2.0 -Dhbase.two.version=2.2.0 -Dmaven.javadoc.skip=true -DskipTests
`