### PR TITLE
HADOOP-16854 Fix to prevent OutOfMemoryException and Make the threadpool and bytebuffer pool common across all AbfsOutputStream instances

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
@@ -440,6 +440,25 @@ public class JsonUtilClient {
         .directoryCount(directoryCount)
         .erasureCodingPolicy(ecPolicy);
     builder = buildQuotaUsage(builder, m, ContentSummary.Builder.class);
+    if (m.get("snapshotLength") != null) {
+      long snapshotLength = ((Number) m.get("snapshotLength")).longValue();
+      builder.snapshotLength(snapshotLength);
+    }
+    if (m.get("snapshotFileCount") != null) {
+      long snapshotFileCount =
+          ((Number) m.get("snapshotFileCount")).longValue();
+      builder.snapshotFileCount(snapshotFileCount);
+    }
+    if (m.get("snapshotDirectoryCount") != null) {
+      long snapshotDirectoryCount =
+          ((Number) m.get("snapshotDirectoryCount")).longValue();
+      builder.snapshotDirectoryCount(snapshotDirectoryCount);
+    }
+    if (m.get("snapshotSpaceConsumed") != null) {
+      long snapshotSpaceConsumed =
+          ((Number) m.get("snapshotSpaceConsumed")).longValue();
+      builder.snapshotSpaceConsumed(snapshotSpaceConsumed);
+    }
     return builder.build();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
@@ -358,6 +358,11 @@ public class JsonUtil {
     // For ContentSummary we don't need this since we already have
     // separate count for file and directory.
     m.putAll(toJsonMap(contentsummary, false));
+    m.put("snapshotLength", contentsummary.getSnapshotLength());
+    m.put("snapshotFileCount", contentsummary.getSnapshotFileCount());
+    m.put("snapshotDirectoryCount",
+        contentsummary.getSnapshotDirectoryCount());
+    m.put("snapshotSpaceConsumed", contentsummary.getSnapshotSpaceConsumed());
     return toJsonString(ContentSummary.class, m);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtil.java
@@ -306,7 +306,13 @@ public class TestJsonUtil {
   @Test
   public void testToJsonFromContentSummary() {
     String jsonString =
-        "{\"ContentSummary\":{\"directoryCount\":33333,\"ecPolicy\":\"RS-6-3-1024k\",\"fileCount\":22222,\"length\":11111,\"quota\":44444,\"spaceConsumed\":55555,\"spaceQuota\":66666,\"typeQuota\":{}}}";
+        "{\"ContentSummary\":{\"directoryCount\":33333,\"ecPolicy\":"
+            + "\"RS-6-3-1024k\",\"fileCount\":22222,\"length\":11111,"
+            + "\"quota\":44444,\"snapshotDirectoryCount\":1,"
+            + "\"snapshotFileCount\":2,\"snapshotLength\":10,"
+            + "\"snapshotSpaceConsumed\":30,\"spaceConsumed\":55555,"
+            + "\"spaceQuota\":66666,\"typeQuota\":{}}}";
+
     long length = 11111;
     long fileCount = 22222;
     long directoryCount = 33333;
@@ -314,15 +320,22 @@ public class TestJsonUtil {
     long spaceConsumed = 55555;
     long spaceQuota = 66666;
     String ecPolicy = "RS-6-3-1024k";
+    long snapshotLength = 10;
+    long snapshotFileCount = 2;
+    long snapshotDirectoryCount = 1;
+    long snapshotSpaceConsumed = 30;
 
-    ContentSummary contentSummary = new ContentSummary.Builder().length(length).
-        fileCount(fileCount).directoryCount(directoryCount).quota(quota).
-        spaceConsumed(spaceConsumed).spaceQuota(spaceQuota).
-        erasureCodingPolicy(ecPolicy).build();
+    ContentSummary contentSummary = new ContentSummary.Builder().length(length)
+        .fileCount(fileCount).directoryCount(directoryCount).quota(quota)
+        .spaceConsumed(spaceConsumed).spaceQuota(spaceQuota)
+        .erasureCodingPolicy(ecPolicy).snapshotLength(snapshotLength)
+        .snapshotFileCount(snapshotFileCount)
+        .snapshotDirectoryCount(snapshotDirectoryCount)
+        .snapshotSpaceConsumed(snapshotSpaceConsumed).build();
 
     Assert.assertEquals(jsonString, JsonUtil.toJsonString(contentSummary));
   }
-  
+
   @Test
   public void testToJsonFromXAttrs() throws IOException {
     String jsonString = 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFS.java
@@ -994,6 +994,30 @@ public class TestWebHDFS {
         .assertTrue((contentSummary.getTypeQuota(StorageType.DISK) == 100000));
   }
 
+  /**
+   * Test Snapshot related information in ContentSummary.
+   */
+  @Test
+  public void testSnapshotInContentSummary() throws Exception {
+    final Configuration conf = WebHdfsTestUtil.createConf();
+    Path dirPath = new Path("/dir");
+    final Path filePath = new Path("/dir/file");
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    final WebHdfsFileSystem webHdfs = WebHdfsTestUtil.getWebHdfsFileSystem(conf,
+        WebHdfsConstants.WEBHDFS_SCHEME);
+    final DistributedFileSystem dfs = cluster.getFileSystem();
+    DFSTestUtil.createFile(dfs, filePath, 10, (short) 3, 0L);
+    dfs.allowSnapshot(dirPath);
+    dfs.createSnapshot(dirPath);
+    dfs.delete(filePath, true);
+    ContentSummary contentSummary = webHdfs.getContentSummary(dirPath);
+    assertEquals(1, contentSummary.getSnapshotFileCount());
+    assertEquals(10, contentSummary.getSnapshotLength());
+    assertEquals(30, contentSummary.getSnapshotSpaceConsumed());
+    assertEquals(dfs.getContentSummary(dirPath),
+        webHdfs.getContentSummary(dirPath));
+  }
+
   @Test
   public void testQuotaUsage() throws Exception {
     final Configuration conf = WebHdfsTestUtil.createConf();

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -91,7 +91,7 @@
     <hadoop.protobuf.version>3.7.1</hadoop.protobuf.version>
     <protoc.path>${env.HADOOP_PROTOC_PATH}</protoc.path>
 
-    <hadoop-thirdparty-protobuf.version>1.0.0-SNAPSHOT</hadoop-thirdparty-protobuf.version>
+    <hadoop-thirdparty-protobuf.version>1.0.0</hadoop-thirdparty-protobuf.version>
     <hadoop-thirdparty-shaded-prefix>org.apache.hadoop.thirdparty</hadoop-thirdparty-shaded-prefix>
     <hadoop-thirdparty-shaded-protobuf-prefix>${hadoop-thirdparty-shaded-prefix}.protobuf</hadoop-thirdparty-shaded-protobuf-prefix>
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -403,6 +403,10 @@ public class AbfsConfiguration{
     return this.rawConfig;
   }
 
+  public boolean shouldUseOlderAbfsOutputStream() {
+    return this.shouldUseOlderAbfsOutputStream;
+  }
+
   public int getWriteBufferSize() {
     return this.writeBufferSize;
   }
@@ -723,6 +727,12 @@ public class AbfsConfiguration{
   @VisibleForTesting
   void setDisableOutputStreamFlush(boolean disableOutputStreamFlush) {
     this.disableOutputStreamFlush = disableOutputStreamFlush;
+  }
+
+  @VisibleForTesting
+  void setShouldUseOlderAbfsOutputStream(
+      boolean shouldUseOlderAbfsOutputStream) {
+    this.shouldUseOlderAbfsOutputStream = shouldUseOlderAbfsOutputStream;
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -120,10 +120,16 @@ public class AbfsConfiguration{
       DefaultValue = AZURE_BLOCK_LOCATION_HOST_DEFAULT)
   private String azureBlockLocationHost;
 
-  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_CONCURRENT_CONNECTION_VALUE_OUT,
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_WRITE_CONCURRENCY_FACTOR,
       MinValue = 1,
-      DefaultValue = MAX_CONCURRENT_WRITE_THREADS)
-  private int maxConcurrentWriteThreads;
+      DefaultValue = DEFAULT_WRITE_CONCURRENCY_FACTOR)
+  private int writeConcurrencyFactor;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE,
+      MinValue = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+      MaxValue = MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+      DefaultValue = DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE)
+  private int maxWriteMemoryUsagePercentage;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LIST_MAX_RESULTS,
       MinValue = 1,
@@ -429,8 +435,12 @@ public class AbfsConfiguration{
     return this.azureBlockLocationHost;
   }
 
-  public int getMaxConcurrentWriteThreads() {
-    return this.maxConcurrentWriteThreads;
+  public int getWriteConcurrencyFactor() {
+    return this.writeConcurrencyFactor;
+  }
+
+  public int getMaxWriteMemoryUsagePercentage() {
+    return this.maxWriteMemoryUsagePercentage;
   }
 
   public int getMaxConcurrentReadThreads() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -120,6 +120,10 @@ public class AbfsConfiguration{
       DefaultValue = AZURE_BLOCK_LOCATION_HOST_DEFAULT)
   private String azureBlockLocationHost;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM,
+      DefaultValue = DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM)
+  private boolean shouldUseOlderAbfsOutputStream;
+
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_WRITE_CONCURRENCY_FACTOR,
       MinValue = 1,
       DefaultValue = DEFAULT_WRITE_CONCURRENCY_FACTOR)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -153,6 +153,10 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_FS_AZURE_ATOMIC_RENAME_DIRECTORIES)
   private String azureAtomicDirs;
 
+  @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_APPEND_BLOB_KEY,
+      DefaultValue = DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES)
+  private String azureAppendBlobDirs;
+
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION,
       DefaultValue = DEFAULT_AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION)
   private boolean createRemoteFileSystemDuringInitialization;
@@ -172,6 +176,10 @@ public class AbfsConfiguration{
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_DISABLE_OUTPUTSTREAM_FLUSH,
       DefaultValue = DEFAULT_DISABLE_OUTPUTSTREAM_FLUSH)
   private boolean disableOutputStreamFlush;
+
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_ENABLE_APPEND_WITH_FLUSH,
+      DefaultValue = DEFAULT_ENABLE_APPEND_WITH_FLUSH)
+  private boolean enableAppendWithFlush;
 
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_ENABLE_AUTOTHROTTLING,
       DefaultValue = DEFAULT_ENABLE_AUTOTHROTTLING)
@@ -467,6 +475,10 @@ public class AbfsConfiguration{
     return this.azureAtomicDirs;
   }
 
+  public String getAppendBlobDirs() {
+    return this.azureAppendBlobDirs;
+  }
+
   public boolean getCreateRemoteFileSystemDuringInitialization() {
     // we do not support creating the filesystem when AuthType is SAS
     return this.createRemoteFileSystemDuringInitialization
@@ -487,6 +499,10 @@ public class AbfsConfiguration{
 
   public boolean isOutputStreamFlushDisabled() {
     return this.disableOutputStreamFlush;
+  }
+
+  public boolean isAppendWithFlushEnabled() {
+    return this.enableAppendWithFlush;
   }
 
   public boolean isAutoThrottlingEnabled() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -79,7 +79,7 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsAclHelper;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsInputStream;
-import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.apache.hadoop.fs.azurebfs.services.AbfsPermission;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
@@ -110,6 +110,8 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.ROOT_PAT
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TOKEN_VERSION;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_ABFS_ENDPOINT;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM;
 
 /**
  * Provides the bridging logic between Hadoop's abstract filesystem and Azure Storage.
@@ -408,7 +410,11 @@ public class AzureBlobFileSystemStore implements Closeable {
               isNamespaceEnabled ? getOctalNotation(umask) : null);
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
 
-      return new AbfsOutputStream(
+
+      boolean shouldUseOldAbfsOutputStream =
+          abfsConfiguration.getBoolean(AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM,
+              DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM);
+      return new AbfsOutputStreamOld(
               client,
               AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path),
               0,
@@ -492,7 +498,7 @@ public class AzureBlobFileSystemStore implements Closeable {
 
       perfInfo.registerSuccess(true);
 
-      return new AbfsOutputStream(
+      return new AbfsOutputStreamOld(
               client,
               AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path),
               offset,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -412,9 +412,7 @@ public class AzureBlobFileSystemStore implements Closeable {
               client,
               AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path),
               0,
-              abfsConfiguration.getWriteBufferSize(),
-              abfsConfiguration.isFlushEnabled(),
-              abfsConfiguration.isOutputStreamFlushDisabled());
+              abfsConfiguration);
     }
   }
 
@@ -498,9 +496,7 @@ public class AzureBlobFileSystemStore implements Closeable {
               client,
               AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path),
               offset,
-              abfsConfiguration.getWriteBufferSize(),
-              abfsConfiguration.isFlushEnabled(),
-              abfsConfiguration.isOutputStreamFlushDisabled());
+              abfsConfiguration);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -40,6 +40,7 @@ public final class AbfsHttpConstants {
   public static final String CHECK_ACCESS = "checkAccess";
   public static final String GET_STATUS = "getStatus";
   public static final String DEFAULT_TIMEOUT = "90";
+  public static final String APPEND_BLOB_TYPE = "appendblob";
   public static final String TOKEN_VERSION = "2";
 
   public static final String JAVA_VERSION = "java.version";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -42,7 +42,8 @@ public final class ConfigurationKeys {
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
   public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
-  public static final String AZURE_CONCURRENT_CONNECTION_VALUE_OUT = "fs.azure.concurrentRequestCount.out";
+  public static final String AZURE_WRITE_CONCURRENCY_FACTOR = "fs.azure.write.concurrency.factor";
+  public static final String AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE = "fs.azure.max.write.memory.usage.percentage";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_IN = "fs.azure.concurrentRequestCount.in";
   public static final String AZURE_TOLERATE_CONCURRENT_APPEND = "fs.azure.io.read.tolerate.concurrent.append";
   public static final String AZURE_LIST_MAX_RESULTS = "fs.azure.list.max.results";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -42,7 +42,7 @@ public final class ConfigurationKeys {
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
   public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
-  public static final String AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = "fs.azure.use.oderabfsoutputstream";
+  public static final String AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = "fs.azure.use.olderabfsoutputstream";
   public static final String AZURE_WRITE_CONCURRENCY_FACTOR = "fs.azure.write.concurrency.factor";
   public static final String AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE = "fs.azure.max.write.memory.usage.percentage";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_IN = "fs.azure.concurrentRequestCount.in";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -53,6 +53,7 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ENABLE_AUTOTHROTTLING = "fs.azure.enable.autothrottling";
   public static final String FS_AZURE_ALWAYS_USE_HTTPS = "fs.azure.always.use.https";
   public static final String FS_AZURE_ATOMIC_RENAME_KEY = "fs.azure.atomic.rename.key";
+  public static final String FS_AZURE_APPEND_BLOB_KEY = "fs.azure.appendblob.key";
   public static final String FS_AZURE_READ_AHEAD_QUEUE_DEPTH = "fs.azure.readaheadqueue.depth";
   /** Provides a config control to enable or disable ABFS Flush operations -
    *  HFlush and HSync. Default is true. **/
@@ -63,6 +64,10 @@ public final class ConfigurationKeys {
    *  documentation does not have such expectations of data being persisted.
    *  Default value of this config is true. **/
   public static final String FS_AZURE_DISABLE_OUTPUTSTREAM_FLUSH = "fs.azure.disable.outputstream.flush";
+  /** Provides a config control to enable OutputStream AppendWithFlush API
+   *  operations in AbfsOutputStream.
+   *  Default value of this config is true. **/
+  public static final String FS_AZURE_ENABLE_APPEND_WITH_FLUSH = "fs.azure.enable.appendwithflush";
   public static final String FS_AZURE_USER_AGENT_PREFIX_KEY = "fs.azure.user.agent.prefix";
   public static final String FS_AZURE_SSL_CHANNEL_MODE_KEY = "fs.azure.ssl.channel.mode";
   /** Provides a config to enable/disable the checkAccess API.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -42,6 +42,7 @@ public final class ConfigurationKeys {
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
   public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
+  public static final String AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = "fs.azure.use.oderabfsoutputstream";
   public static final String AZURE_WRITE_CONCURRENCY_FACTOR = "fs.azure.write.concurrency.factor";
   public static final String AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE = "fs.azure.max.write.memory.usage.percentage";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_IN = "fs.azure.concurrentRequestCount.in";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -50,6 +50,7 @@ public final class FileSystemConfigurations {
 
   public static final int MAX_CONCURRENT_READ_THREADS = 12;
   public static final int DEFAULT_WRITE_CONCURRENCY_FACTOR = 4;
+  public static final boolean DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = false;
   public static final int MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 20;
   public static final int MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 90;
   public static final int DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -59,10 +59,12 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_AZURE_SKIP_USER_GROUP_METADATA_DURING_INITIALIZATION = false;
 
   public static final String DEFAULT_FS_AZURE_ATOMIC_RENAME_DIRECTORIES = "/hbase";
+  public static final String DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES = "";
 
   public static final int DEFAULT_READ_AHEAD_QUEUE_DEPTH = -1;
   public static final boolean DEFAULT_ENABLE_FLUSH = true;
   public static final boolean DEFAULT_DISABLE_OUTPUTSTREAM_FLUSH = true;
+  public static final boolean DEFAULT_ENABLE_APPEND_WITH_FLUSH = true;
   public static final boolean DEFAULT_ENABLE_AUTOTHROTTLING = true;
 
   public static final DelegatingSSLSocketFactory.SSLChannelMode DEFAULT_FS_AZURE_SSL_CHANNEL_MODE

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -49,7 +49,10 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_AZURE_LIST_MAX_RESULTS = 500;
 
   public static final int MAX_CONCURRENT_READ_THREADS = 12;
-  public static final int MAX_CONCURRENT_WRITE_THREADS = 8;
+  public static final int DEFAULT_WRITE_CONCURRENCY_FACTOR = 4;
+  public static final int MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 20;
+  public static final int MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 90;
+  public static final int DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
   public static final boolean DEFAULT_READ_TOLERATE_CONCURRENT_APPEND = false;
   public static final boolean DEFAULT_AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION = false;
   public static final boolean DEFAULT_AZURE_SKIP_USER_GROUP_METADATA_DURING_INITIALIZATION = false;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
@@ -38,6 +38,8 @@ public final class HttpQueryParams {
   public static final String QUERY_PARAM_RETAIN_UNCOMMITTED_DATA = "retainUncommittedData";
   public static final String QUERY_PARAM_CLOSE = "close";
   public static final String QUERY_PARAM_UPN = "upn";
+  public static final String QUERY_PARAM_FLUSH = "flush";
+  public static final String QUERY_PARAM_BLOBTYPE = "blobtype";
 
   private HttpQueryParams() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+
+/**
+ * Pool for byte[]
+ */
+public class AbfsByteBufferPool {
+
+  /**
+   * Queue holding the free buffers.
+   */
+  private ArrayBlockingQueue<byte[]> freeBuffers;
+  /**
+   * Count to track the buffers issued and yet to be returned.
+   */
+  private int numBuffersInUse;
+  /**
+   * Maximum number of buffers that can be in use.
+   */
+  private int maxBuffersInUse;
+  private int bufferSize;
+
+  /**
+   * @param bufferSize                 Size of the byte[] to be returned.
+   * @param maxConcurrentThreadCount   Maximum number of threads that will be
+   *                                   using the pool.
+   * @param maxWriteMemUsagePercentage Maximum percentage of memory that can
+   *                                   be used by the pool from the max
+   *                                   available memory.
+   */
+  public AbfsByteBufferPool(final int bufferSize,
+      final int maxConcurrentThreadCount,
+      final int maxWriteMemUsagePercentage) {
+    Preconditions.checkArgument(maxWriteMemUsagePercentage
+            >= MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE
+            && maxWriteMemUsagePercentage
+            <= MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+        "maxConcurrentThreadCount should be in range (%s - %s)",
+        MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+        MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE);
+    Preconditions.checkArgument(maxConcurrentThreadCount > 0,
+        "maxConcurrentThreadCount cannot be < 1");
+    this.bufferSize = bufferSize;
+    this.numBuffersInUse = 0;
+    freeBuffers = new ArrayBlockingQueue<>(maxConcurrentThreadCount + 1);
+
+    double maxMemoryAllowedForPoolInMBs =
+        Runtime.getRuntime().maxMemory() / (1024 * 1024)
+            * maxWriteMemUsagePercentage / 100;
+    double bufferCountByMemory = maxMemoryAllowedForPoolInMBs / bufferSize;
+    double bufferCountByConcurrency =
+        maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
+            + 1;
+    maxBuffersInUse = (int) Math
+        .ceil(Math.min(bufferCountByMemory, bufferCountByConcurrency));
+    if (maxBuffersInUse < 2) {
+      maxBuffersInUse = 2;
+    }
+  }
+
+  /**
+   * @return byte[] from the pool if available otherwise new byte[] is returned.
+   * Waits if pool is empty and already maximum number of buffers are in use.
+   */
+  public byte[] get() {
+    synchronized (this) {
+      numBuffersInUse++;
+      byte[] byteArray = freeBuffers.poll();
+      if (byteArray != null) {
+        return byteArray;
+      }
+      if (numBuffersInUse <= maxBuffersInUse) {
+        return new byte[bufferSize];
+      }
+    }
+    try {
+      return freeBuffers.take();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  /**
+   * @param byteArray The buffer to be offered back to the pool.
+   */
+  public synchronized void release(byte[] byteArray) {
+    Preconditions.checkArgument(byteArray.length == bufferSize,
+        "Buffer size has" + " to be %s", bufferSize);
+    numBuffersInUse--;
+    if (numBuffersInUse < 0) {
+      numBuffersInUse = 0;
+    }
+    freeBuffers.offer(byteArray);
+  }
+
+  @VisibleForTesting
+  public synchronized int getMaxBuffersInUse() {
+    return this.maxBuffersInUse;
+  }
+
+  @VisibleForTesting
+  public synchronized ArrayBlockingQueue<byte[]> getFreeBuffers() {
+    return freeBuffers;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
@@ -18,11 +18,10 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.util.concurrent.ArrayBlockingQueue;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
@@ -61,7 +60,7 @@ public class AbfsByteBufferPool {
             >= MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE
             && maxWriteMemUsagePercentage
             <= MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
-        "maxConcurrentThreadCount should be in range (%s - %s)",
+        "maxWriteMemUsagePercentage should be in range (%s - %s)",
         MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
         MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE);
     Preconditions.checkArgument(maxConcurrentThreadCount > 0,
@@ -70,10 +69,9 @@ public class AbfsByteBufferPool {
     this.numBuffersInUse = 0;
     freeBuffers = new ArrayBlockingQueue<>(maxConcurrentThreadCount + 1);
 
-    double maxMemoryAllowedForPoolInMBs =
-        Runtime.getRuntime().maxMemory() / (1024 * 1024)
-            * maxWriteMemUsagePercentage / 100;
-    double bufferCountByMemory = maxMemoryAllowedForPoolInMBs / bufferSize;
+    double maxMemoryAllowedForPool =
+        Runtime.getRuntime().maxMemory() * maxWriteMemUsagePercentage / 100;
+    double bufferCountByMemory = maxMemoryAllowedForPool / bufferSize;
     double bufferCountByConcurrency =
         maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
             + 1;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -119,7 +119,6 @@ public class AbfsClient implements Closeable {
     this.sasTokenProvider = sasTokenProvider;
   }
 
-  @Override
   public void close() throws IOException {
     if (tokenProvider instanceof Closeable) {
       IOUtils.cleanupWithLogger(LOG, (Closeable) tokenProvider);
@@ -261,7 +260,8 @@ public class AbfsClient implements Closeable {
   }
 
   public AbfsRestOperation createPath(final String path, final boolean isFile, final boolean overwrite,
-                                      final String permission, final String umask) throws AzureBlobFileSystemException {
+                                      final String permission, final String umask,
+                                      final boolean appendBlob) throws AzureBlobFileSystemException {
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     if (!overwrite) {
       requestHeaders.add(new AbfsHttpHeader(IF_NONE_MATCH, AbfsHttpConstants.STAR));
@@ -277,6 +277,9 @@ public class AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESOURCE, isFile ? FILE : DIRECTORY);
+    if (appendBlob) {
+      abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOBTYPE, APPEND_BLOB_TYPE);
+    }
 
     String operation = isFile
         ? SASTokenProvider.CREATEFILE_OPERATION
@@ -325,7 +328,8 @@ public class AbfsClient implements Closeable {
   }
 
   public AbfsRestOperation append(final String path, final long position, final byte[] buffer, final int offset,
-                                  final int length) throws AzureBlobFileSystemException {
+                                  final int length, boolean flush, boolean isClose)
+                                  throws AzureBlobFileSystemException {
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     // JDK7 does not support PATCH, so to workaround the issue we will use
     // PUT and specify the real method in the X-Http-Method-Override header.
@@ -335,6 +339,8 @@ public class AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_ACTION, APPEND_ACTION);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_POSITION, Long.toString(position));
+    abfsUriQueryBuilder.addQuery(QUERY_PARAM_FLUSH, String.valueOf(flush));
+    abfsUriQueryBuilder.addQuery(QUERY_PARAM_CLOSE, String.valueOf(isClose));
     appendSASTokenToQuery(path, SASTokenProvider.APPEND_OPERATION, abfsUriQueryBuilder);
 
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -323,11 +323,11 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
       }
     });
 
-    buffer = bufferPool.get();
     writeOperations.add(new WriteOperation(job, offset, bytesLength));
 
     // Try to shrink the queue
     shrinkWriteOperationQueue();
+    buffer = bufferPool.get();
   }
 
   private synchronized void flushWrittenBytesToService(boolean isClose) throws IOException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -47,7 +47,7 @@ import static org.apache.hadoop.io.IOUtils.wrapException;
 /**
  * The BlobFsOutputStream for Rest AbfsClient.
  */
-public class AbfsOutputStreamV2 extends OutputStream implements Syncable, StreamCapabilities {
+public class AbfsOutputStream extends OutputStream implements Syncable, StreamCapabilities {
 
   private final AbfsClient client;
   private final String path;
@@ -76,7 +76,7 @@ public class AbfsOutputStreamV2 extends OutputStream implements Syncable, Stream
    */
   private static AbfsByteBufferPool bufferPool;
 
-  public AbfsOutputStreamV2(
+  public AbfsOutputStream(
       final AbfsClient client,
       final String path,
       final long position,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamOld.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamOld.java
@@ -20,14 +20,14 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -36,9 +36,9 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
@@ -48,8 +48,7 @@ import static org.apache.hadoop.io.IOUtils.wrapException;
 /**
  * The BlobFsOutputStream for Rest AbfsClient.
  */
-public class AbfsOutputStream extends OutputStream implements Syncable, StreamCapabilities {
-
+public class AbfsOutputStreamOld extends OutputStream implements Syncable, StreamCapabilities {
   private final AbfsClient client;
   private final String path;
   private long position;
@@ -61,76 +60,53 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
   private long lastFlushOffset;
   private long lastTotalAppendOffset = 0;
 
-  private static int bufferSize;
+  private final int bufferSize;
   private byte[] buffer;
   private int bufferIndex;
-  private static int maxConcurrentThreadCount;
+  private final int maxConcurrentRequestCount;
 
-  private final ConcurrentLinkedDeque<WriteOperation> writeOperations = new ConcurrentLinkedDeque<>();
+  private ConcurrentLinkedDeque<WriteOperation> writeOperations;
+  private final ThreadPoolExecutor threadExecutor;
+  private final ExecutorCompletionService<Void> completionService;
 
-  private static ThreadPoolExecutor threadExecutor;
   /**
-   * Pool storing buffers with the size of the Azure block ready for
+   * Queue storing buffers with the size of the Azure block ready for
    * reuse. The pool allows reusing the blocks instead of allocating new
    * blocks. After the data is sent to the service, the buffer is returned
    * back to the queue
    */
-  private static AbfsByteBufferPool bufferPool;
+  private final ElasticByteBufferPool byteBufferPool
+          = new ElasticByteBufferPool();
 
-  public AbfsOutputStream(
+  public AbfsOutputStreamOld(
       final AbfsClient client,
       final String path,
       final long position,
-      final AbfsConfiguration abfsConfiguration) {
+      final int bufferSize,
+      final boolean supportFlush,
+      final boolean disableOutputStreamFlush) {
     this.client = client;
     this.path = path;
     this.position = position;
     this.closed = false;
-    this.supportFlush = abfsConfiguration.isFlushEnabled();
-    this.disableOutputStreamFlush = abfsConfiguration.isOutputStreamFlushDisabled();
+    this.supportFlush = supportFlush;
+    this.disableOutputStreamFlush = disableOutputStreamFlush;
     this.lastError = null;
     this.lastFlushOffset = 0;
+    this.bufferSize = bufferSize;
+    this.buffer = byteBufferPool.getBuffer(false, bufferSize).array();
     this.bufferIndex = 0;
+    this.writeOperations = new ConcurrentLinkedDeque<>();
 
-    init(abfsConfiguration);
-    this.buffer = new byte[abfsConfiguration.getWriteBufferSize()];
-  }
+    this.maxConcurrentRequestCount = 4 * Runtime.getRuntime().availableProcessors();
 
-  private static synchronized void init(final AbfsConfiguration conf) {
-    if (threadExecutor != null) {
-      return;
-    }
-
-    int availableProcessors = Runtime.getRuntime().availableProcessors();
-    maxConcurrentThreadCount =
-        conf.getWriteConcurrencyFactor() * availableProcessors;
-
-    bufferSize = conf.getWriteBufferSize();
-    bufferPool = new AbfsByteBufferPool(bufferSize, maxConcurrentThreadCount,
-        conf.getMaxWriteMemoryUsagePercentage());
-
-    ThreadFactory daemonThreadFactory = new ThreadFactory() {
-      @Override
-      public Thread newThread(Runnable runnable) {
-        Thread daemonThread = Executors.defaultThreadFactory()
-            .newThread(runnable);
-        daemonThread.setDaemon(true);
-        return daemonThread;
-      }
-    };
-    threadExecutor = new ThreadPoolExecutor(maxConcurrentThreadCount,
-        maxConcurrentThreadCount, 10L, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(), daemonThreadFactory);
-  }
-
-  @VisibleForTesting
-  public static void initWriteBufferPool(final AbfsConfiguration conf) {
-    if (bufferSize == conf.getWriteBufferSize()) {
-      return;
-    }
-    bufferSize = conf.getWriteBufferSize();
-    bufferPool = new AbfsByteBufferPool(conf.getWriteBufferSize(),
-        maxConcurrentThreadCount, conf.getMaxWriteMemoryUsagePercentage());
+    this.threadExecutor
+        = new ThreadPoolExecutor(maxConcurrentRequestCount,
+        maxConcurrentRequestCount,
+        10L,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>());
+    this.completionService = new ExecutorCompletionService<>(this.threadExecutor);
   }
 
   /**
@@ -271,6 +247,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
 
     try {
       flushInternal(true);
+      threadExecutor.shutdown();
     } catch (IOException e) {
       // Problems surface in try-with-resources clauses if
       // the exception thrown in a close == the one already thrown
@@ -283,6 +260,9 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
       bufferIndex = 0;
       closed = true;
       writeOperations.clear();
+      if (!threadExecutor.isShutdown()) {
+        threadExecutor.shutdownNow();
+      }
     }
   }
 
@@ -303,28 +283,33 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
       return;
     }
 
-    final byte[] byteArray = buffer;
+    final byte[] bytes = buffer;
     final int bytesLength = bufferIndex;
+    buffer = byteBufferPool.getBuffer(false, bufferSize).array();
     bufferIndex = 0;
     final long offset = position;
     position += bytesLength;
-    final Future<Void> job = threadExecutor.submit(new Callable<Void>() {
+
+    if (threadExecutor.getQueue().size() >= maxConcurrentRequestCount * 2) {
+      waitForTaskToComplete();
+    }
+
+    final Future<Void> job = completionService.submit(new Callable<Void>() {
       @Override
       public Void call() throws Exception {
         AbfsPerfTracker tracker = client.getAbfsPerfTracker();
         try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
                 "writeCurrentBufferToService", "append")) {
-          AbfsRestOperation op = client.append(path, offset, byteArray, 0,
+          AbfsRestOperation op = client.append(path, offset, bytes, 0,
                   bytesLength);
           perfInfo.registerResult(op.getResult());
-          bufferPool.release(byteArray);
+          byteBufferPool.putBuffer(ByteBuffer.wrap(bytes));
           perfInfo.registerSuccess(true);
           return null;
         }
       }
     });
 
-    buffer = bufferPool.get();
     writeOperations.add(new WriteOperation(job, offset, bytesLength));
 
     // Try to shrink the queue
@@ -400,6 +385,22 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
     }
   }
 
+  private void waitForTaskToComplete() throws IOException {
+    boolean completed;
+    for (completed = false; completionService.poll() != null; completed = true) {
+      // keep polling until there is no data
+    }
+
+    if (!completed) {
+      try {
+        completionService.take();
+      } catch (InterruptedException e) {
+        lastError = (IOException) new InterruptedIOException(e.toString()).initCause(e);
+        throw lastError;
+      }
+    }
+  }
+
   private static class WriteOperation {
     private final Future<Void> task;
     private final long startOffset;
@@ -417,8 +418,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
   }
 
   @VisibleForTesting
-  public synchronized void waitForPendingUploads()
-      throws ExecutionException, InterruptedException {
-      writeOperations.getFirst().task.get();
+  public synchronized void waitForPendingUploads() throws IOException {
+    waitForTaskToComplete();
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamV2.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamV2.java
@@ -1,0 +1,423 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.FSExceptionMessages;
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.Syncable;
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.io.IOUtils.wrapException;
+
+/**
+ * The BlobFsOutputStream for Rest AbfsClient.
+ */
+public class AbfsOutputStreamV2 extends OutputStream implements Syncable, StreamCapabilities {
+
+  private final AbfsClient client;
+  private final String path;
+  private long position;
+  private boolean closed;
+  private boolean supportFlush;
+  private boolean disableOutputStreamFlush;
+  private volatile IOException lastError;
+
+  private long lastFlushOffset;
+  private long lastTotalAppendOffset = 0;
+
+  private static int bufferSize;
+  private byte[] buffer;
+  private int bufferIndex;
+  private static int maxConcurrentThreadCount;
+
+  private final ConcurrentLinkedDeque<WriteOperation> writeOperations = new ConcurrentLinkedDeque<>();
+
+  private static ThreadPoolExecutor threadExecutor;
+  /**
+   * Pool storing buffers with the size of the Azure block ready for
+   * reuse. The pool allows reusing the blocks instead of allocating new
+   * blocks. After the data is sent to the service, the buffer is returned
+   * back to the queue
+   */
+  private static AbfsByteBufferPool bufferPool;
+
+  public AbfsOutputStreamV2(
+      final AbfsClient client,
+      final String path,
+      final long position,
+      final AbfsConfiguration abfsConfiguration) {
+    this.client = client;
+    this.path = path;
+    this.position = position;
+    this.closed = false;
+    this.supportFlush = abfsConfiguration.isFlushEnabled();
+    this.disableOutputStreamFlush = abfsConfiguration.isOutputStreamFlushDisabled();
+    this.lastError = null;
+    this.lastFlushOffset = 0;
+    this.bufferIndex = 0;
+
+    init(abfsConfiguration);
+    this.buffer = new byte[abfsConfiguration.getWriteBufferSize()];
+  }
+
+  private static synchronized void init(final AbfsConfiguration conf) {
+    if (threadExecutor != null) {
+      return;
+    }
+
+    int availableProcessors = Runtime.getRuntime().availableProcessors();
+    maxConcurrentThreadCount =
+        conf.getWriteConcurrencyFactor() * availableProcessors;
+
+    bufferSize = conf.getWriteBufferSize();
+    bufferPool = new AbfsByteBufferPool(bufferSize, maxConcurrentThreadCount,
+        conf.getMaxWriteMemoryUsagePercentage());
+
+    ThreadFactory daemonThreadFactory = new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable runnable) {
+        Thread daemonThread = Executors.defaultThreadFactory()
+            .newThread(runnable);
+        daemonThread.setDaemon(true);
+        return daemonThread;
+      }
+    };
+    threadExecutor = new ThreadPoolExecutor(maxConcurrentThreadCount,
+        maxConcurrentThreadCount, 10L, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(), daemonThreadFactory);
+  }
+
+  @VisibleForTesting
+  public static void initWriteBufferPool(final AbfsConfiguration conf) {
+    if (bufferSize == conf.getWriteBufferSize()) {
+      return;
+    }
+    bufferSize = conf.getWriteBufferSize();
+    bufferPool = new AbfsByteBufferPool(conf.getWriteBufferSize(),
+        maxConcurrentThreadCount, conf.getMaxWriteMemoryUsagePercentage());
+  }
+
+  /**
+   * Query the stream for a specific capability.
+   *
+   * @param capability string to query the stream support for.
+   * @return true for hsync and hflush.
+   */
+  @Override
+  public boolean hasCapability(String capability) {
+    switch (capability.toLowerCase(Locale.ENGLISH)) {
+      case StreamCapabilities.HSYNC:
+      case StreamCapabilities.HFLUSH:
+        return supportFlush;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Writes the specified byte to this output stream. The general contract for
+   * write is that one byte is written to the output stream. The byte to be
+   * written is the eight low-order bits of the argument b. The 24 high-order
+   * bits of b are ignored.
+   *
+   * @param byteVal the byteValue to write.
+   * @throws IOException if an I/O error occurs. In particular, an IOException may be
+   *                     thrown if the output stream has been closed.
+   */
+  @Override
+  public void write(final int byteVal) throws IOException {
+    write(new byte[]{(byte) (byteVal & 0xFF)});
+  }
+
+  /**
+   * Writes length bytes from the specified byte array starting at off to
+   * this output stream.
+   *
+   * @param data   the byte array to write.
+   * @param off the start off in the data.
+   * @param length the number of bytes to write.
+   * @throws IOException if an I/O error occurs. In particular, an IOException may be
+   *                     thrown if the output stream has been closed.
+   */
+  @Override
+  public synchronized void write(final byte[] data, final int off, final int length)
+      throws IOException {
+    maybeThrowLastError();
+
+    Preconditions.checkArgument(data != null, "null data");
+
+    if (off < 0 || length < 0 || length > data.length - off) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    int currentOffset = off;
+    int writableBytes = bufferSize - bufferIndex;
+    int numberOfBytesToWrite = length;
+
+    while (numberOfBytesToWrite > 0) {
+      if (writableBytes <= numberOfBytesToWrite) {
+        System.arraycopy(data, currentOffset, buffer, bufferIndex, writableBytes);
+        bufferIndex += writableBytes;
+        writeCurrentBufferToService();
+        currentOffset += writableBytes;
+        numberOfBytesToWrite = numberOfBytesToWrite - writableBytes;
+      } else {
+        System.arraycopy(data, currentOffset, buffer, bufferIndex, numberOfBytesToWrite);
+        bufferIndex += numberOfBytesToWrite;
+        numberOfBytesToWrite = 0;
+      }
+
+      writableBytes = bufferSize - bufferIndex;
+    }
+  }
+
+  /**
+   * Throw the last error recorded if not null.
+   * After the stream is closed, this is always set to
+   * an exception, so acts as a guard against method invocation once
+   * closed.
+   * @throws IOException if lastError is set
+   */
+  private void maybeThrowLastError() throws IOException {
+    if (lastError != null) {
+      throw lastError;
+    }
+  }
+
+  /**
+   * Flushes this output stream and forces any buffered output bytes to be
+   * written out. If any data remains in the payload it is committed to the
+   * service. Data is queued for writing and forced out to the service
+   * before the call returns.
+   */
+  @Override
+  public void flush() throws IOException {
+    if (!disableOutputStreamFlush) {
+      flushInternalAsync();
+    }
+  }
+
+  /** Similar to posix fsync, flush out the data in client's user buffer
+   * all the way to the disk device (but the disk may have it in its cache).
+   * @throws IOException if error occurs
+   */
+  @Override
+  public void hsync() throws IOException {
+    if (supportFlush) {
+      flushInternal(false);
+    }
+  }
+
+  /** Flush out the data in client's user buffer. After the return of
+   * this call, new readers will see the data.
+   * @throws IOException if any error occurs
+   */
+  @Override
+  public void hflush() throws IOException {
+    if (supportFlush) {
+      flushInternal(false);
+    }
+  }
+
+  /**
+   * Force all data in the output stream to be written to Azure storage.
+   * Wait to return until this is complete. Close the access to the stream and
+   * shutdown the upload thread pool.
+   * If the blob was created, its lease will be released.
+   * Any error encountered caught in threads and stored will be rethrown here
+   * after cleanup.
+   */
+  @Override
+  public synchronized void close() throws IOException {
+    if (closed) {
+      return;
+    }
+
+    try {
+      flushInternal(true);
+    } catch (IOException e) {
+      // Problems surface in try-with-resources clauses if
+      // the exception thrown in a close == the one already thrown
+      // -so we wrap any exception with a new one.
+      // See HADOOP-16785
+      throw wrapException(path, e.getMessage(), e);
+    } finally {
+      lastError = new IOException(FSExceptionMessages.STREAM_IS_CLOSED);
+      buffer = null;
+      bufferIndex = 0;
+      closed = true;
+      writeOperations.clear();
+    }
+  }
+
+  private synchronized void flushInternal(boolean isClose) throws IOException {
+    maybeThrowLastError();
+    writeCurrentBufferToService();
+    flushWrittenBytesToService(isClose);
+  }
+
+  private synchronized void flushInternalAsync() throws IOException {
+    maybeThrowLastError();
+    writeCurrentBufferToService();
+    flushWrittenBytesToServiceAsync();
+  }
+
+  private synchronized void writeCurrentBufferToService() throws IOException {
+    if (bufferIndex == 0) {
+      return;
+    }
+
+    final byte[] byteArray = buffer;
+    final int bytesLength = bufferIndex;
+    bufferIndex = 0;
+    final long offset = position;
+    position += bytesLength;
+    final Future<Void> job = threadExecutor.submit(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        AbfsPerfTracker tracker = client.getAbfsPerfTracker();
+        try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
+                "writeCurrentBufferToService", "append")) {
+          AbfsRestOperation op = client.append(path, offset, byteArray, 0,
+                  bytesLength);
+          perfInfo.registerResult(op.getResult());
+          bufferPool.release(byteArray);
+          perfInfo.registerSuccess(true);
+          return null;
+        }
+      }
+    });
+
+    buffer = bufferPool.get();
+    writeOperations.add(new WriteOperation(job, offset, bytesLength));
+
+    // Try to shrink the queue
+    shrinkWriteOperationQueue();
+  }
+
+  private synchronized void flushWrittenBytesToService(boolean isClose) throws IOException {
+    for (WriteOperation writeOperation : writeOperations) {
+      try {
+        writeOperation.task.get();
+      } catch (Exception ex) {
+        if (ex.getCause() instanceof AbfsRestOperationException) {
+          if (((AbfsRestOperationException) ex.getCause()).getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+            throw new FileNotFoundException(ex.getMessage());
+          }
+        }
+
+        if (ex.getCause() instanceof AzureBlobFileSystemException) {
+          ex = (AzureBlobFileSystemException) ex.getCause();
+        }
+        lastError = new IOException(ex);
+        throw lastError;
+      }
+    }
+    flushWrittenBytesToServiceInternal(position, false, isClose);
+  }
+
+  private synchronized void flushWrittenBytesToServiceAsync() throws IOException {
+    shrinkWriteOperationQueue();
+
+    if (this.lastTotalAppendOffset > this.lastFlushOffset) {
+      this.flushWrittenBytesToServiceInternal(this.lastTotalAppendOffset, true,
+        false/*Async flush on close not permitted*/);
+    }
+  }
+
+  private synchronized void flushWrittenBytesToServiceInternal(final long offset,
+      final boolean retainUncommitedData, final boolean isClose) throws IOException {
+    AbfsPerfTracker tracker = client.getAbfsPerfTracker();
+    try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
+            "flushWrittenBytesToServiceInternal", "flush")) {
+      AbfsRestOperation op = client.flush(path, offset, retainUncommitedData, isClose);
+      perfInfo.registerResult(op.getResult()).registerSuccess(true);
+    } catch (AzureBlobFileSystemException ex) {
+      if (ex instanceof AbfsRestOperationException) {
+        if (((AbfsRestOperationException) ex).getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+          throw new FileNotFoundException(ex.getMessage());
+        }
+      }
+      throw new IOException(ex);
+    }
+    this.lastFlushOffset = offset;
+  }
+
+  /**
+   * Try to remove the completed write operations from the beginning of write
+   * operation FIFO queue.
+   */
+  private synchronized void shrinkWriteOperationQueue() throws IOException {
+    try {
+      while (writeOperations.peek() != null && writeOperations.peek().task.isDone()) {
+        writeOperations.peek().task.get();
+        lastTotalAppendOffset += writeOperations.peek().length;
+        writeOperations.remove();
+      }
+    } catch (Exception e) {
+      if (e.getCause() instanceof AzureBlobFileSystemException) {
+        lastError = (AzureBlobFileSystemException) e.getCause();
+      } else {
+        lastError = new IOException(e);
+      }
+      throw lastError;
+    }
+  }
+
+  private static class WriteOperation {
+    private final Future<Void> task;
+    private final long startOffset;
+    private final long length;
+
+    WriteOperation(final Future<Void> task, final long startOffset, final long length) {
+      Preconditions.checkNotNull(task, "task");
+      Preconditions.checkArgument(startOffset >= 0, "startOffset");
+      Preconditions.checkArgument(length >= 0, "length");
+
+      this.task = task;
+      this.startOffset = startOffset;
+      this.length = length;
+    }
+  }
+
+  @VisibleForTesting
+  public synchronized void waitForPendingUploads()
+      throws ExecutionException, InterruptedException {
+      writeOperations.getFirst().task.get();
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -643,6 +643,10 @@ Consult the javadocs for `org.apache.hadoop.fs.azurebfs.constants.ConfigurationK
 `org.apache.hadoop.fs.azurebfs.AbfsConfiguration` for the full list
 of configuration options and their default values.
 
+### <a name="appendblobkeyconfigoptions"></a> Append Blob Directories Options
+#### Config `fs.azure.appendblob.key` provides
+an option for using append blob for the files prefixed by the config value.
+
 ### <a name="flushconfigoptions"></a> Flush Options
 
 #### <a name="abfsflushconfigoptions"></a> 1. Azure Blob File System Flush Options

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -661,7 +661,7 @@ Hflush() being the only documented API that can provide persistent data
 transfer, Flush() also attempting to persist buffered data will lead to
 performance issues.
 
-### <a name="flushconfigoptions"></a> Access Options
+### <a name="accessconfigoptions"></a> Access Options
 Config `fs.azure.enable.check.access` needs to be set true to enable
  the AzureBlobFileSystem.access().
 
@@ -710,6 +710,19 @@ logged with the last callee)
 Note that these performance numbers are also sent back to the ADLS Gen 2 API endpoints
 in the `x-ms-abfs-client-latency` HTTP headers in subsequent requests. Azure uses these
 settings to track their end-to-end latency.
+
+#### <a name="writeperfoptions"></a> 2. AbfsOutputStream Perf Options
+
+##### <a name="writeperfoptions"></a> 1. Concurrency Factor
+Config `fs.azure.write.concurrency.factor` can be used to tune the number of
+ threads in the AbfsOutputStream thread-pool. Number of threads will be
+  (available processors * Concurrency Factor). By default concurrency factor
+   will be 1.
+
+##### <a name="writeperfoptions"></a> 2. Write Memory Usage Percentage
+Config `fs.azure.max.write.memory.usage.percentage` can be used to tune the
+ maximum memory usage in percentage for the AbfsOutputStream. By default
+  write memory usage percentage             will be 20.
 
 ## <a name="troubleshooting"></a> Troubleshooting
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsByteBufferPool.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.azurebfs;
+
+import java.lang.Thread.State;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.azurebfs.services.AbfsByteBufferPool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Test class for AbfsByteBufferPool.
+ */
+public class ITestAbfsByteBufferPool {
+
+  @Test
+  public void testWithInvalidMaxWriteMemUsagePercentage() throws Exception {
+    List<Integer> invalidMaxWriteMemUsagePercentageList = Arrays
+        .asList(MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE - 1,
+            MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE + 1, -100, 101);
+    for (int val : invalidMaxWriteMemUsagePercentageList) {
+      intercept(IllegalArgumentException.class, String
+              .format("maxConcurrentThreadCount should be in range (%s - %s)",
+                  MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+                  MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE),
+          () -> new AbfsByteBufferPool(2, 2, val));
+    }
+  }
+
+  @Test
+  public void testWithInvalidMaxConcurrentThreadCount() throws Exception {
+    List<Integer> invalidMaxConcurrentThreadCount = Arrays.asList(0, -1);
+    for (int val : invalidMaxConcurrentThreadCount) {
+      intercept(IllegalArgumentException.class, String
+              .format("maxConcurrentThreadCount cannot be < 1",
+                  MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+                  MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE),
+          () -> new AbfsByteBufferPool(2, val, 20));
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReleaseNull() {
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(2, 5, 30);
+    pool.release(null);
+  }
+
+  @Test
+  public void testReleaseMoreThanPoolCapacity() {
+    int bufferSize = 2;
+    int maxConcurrentThreadCount = 3;
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(bufferSize,
+        maxConcurrentThreadCount, 25);
+    int expectedPoolCapacity = maxConcurrentThreadCount + 1;
+    for (int i = 0; i < expectedPoolCapacity * 2; i++) {
+      pool.release(new byte[bufferSize]);
+      assertThat(pool.getFreeBuffers()).describedAs("")
+          .hasSize(Math.min(i + 1, expectedPoolCapacity));
+    }
+  }
+
+  @Test
+  public void testReleaseWithSameBufferSize() {
+    int bufferSize = 2;
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(2, 3, 25);
+    pool.release(new byte[bufferSize]);
+  }
+
+  @Test
+  public void testReleaseWithDifferentBufferSize() throws Exception {
+    int bufferSize = 2;
+    String errorString = "Buffer size has to be %s";
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(bufferSize, 3, 25);
+    for (int i = 1; i < 2; i++) {
+      int finalI = i;
+      intercept(IllegalArgumentException.class,
+          String.format(errorString, bufferSize),
+          () -> pool.release(new byte[bufferSize + finalI]));
+      intercept(IllegalArgumentException.class,
+          String.format(errorString, bufferSize),
+          () -> pool.release(new byte[bufferSize - finalI]));
+    }
+  }
+
+  @Test
+  public void testGet() throws Exception {
+    int bufferSize = 2;
+    int maxConcurrentThreadCount = 3;
+    int expectedMaxBuffersInUse =
+        maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
+            + 1;
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(bufferSize,
+        maxConcurrentThreadCount, 90);
+
+    for (int i = 0; i < expectedMaxBuffersInUse; i++) {
+      byte[] byteBuffer = pool.get();
+      assertThat(byteBuffer.length).isEqualTo(bufferSize);
+    }
+
+    Thread getThread = new Thread(() -> pool.get());
+    getThread.start();
+    Thread.sleep(5000);
+    assertThat(getThread.getState()).isEqualTo(State.WAITING);
+    getThread.interrupt();
+
+    Callable<byte[]> callable = () -> pool.get();
+    FutureTask futureTask = new FutureTask(callable);
+    getThread = new Thread(futureTask);
+    getThread.start();
+    pool.release(new byte[bufferSize]);
+    byte[] byteBuffer = (byte[]) futureTask.get();
+    assertThat(byteBuffer.length).isEqualTo(bufferSize);
+  }
+
+  @Test
+  public void testMaxBuffersInUse() {
+    List<Object[]> testData = Arrays.asList(
+        new Object[][] {{1, 1, 20}, {1, 100000, 90}, {1, 2, 30},
+            {100, 100, 90}});
+    for (int i = 0; i < testData.size(); i++) {
+      int bufferSize = (int) testData.get(i)[0];
+      int maxConcurrentThreadCount = (int) testData.get(i)[1];
+      int maxWriteMemUsagePercentage = (int) testData.get(i)[2];
+      AbfsByteBufferPool pool = new AbfsByteBufferPool(bufferSize,
+          maxConcurrentThreadCount, maxWriteMemUsagePercentage);
+
+      double maxMemoryAllowedForPoolMB =
+          Runtime.getRuntime().maxMemory() / (1024 * 1024)
+              * maxWriteMemUsagePercentage / 100;
+      double bufferCountByMemory = maxMemoryAllowedForPoolMB / bufferSize;
+      double bufferCountByConcurrency =
+          maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
+              + 1;
+      int expectedMaxBuffersInUse = (int) Math
+          .ceil(Math.min(bufferCountByMemory, bufferCountByConcurrency));
+      if (expectedMaxBuffersInUse < 2) {
+        expectedMaxBuffersInUse = 2;
+      }
+
+      assertThat(pool.getMaxBuffersInUse())
+          .describedAs("Max buffers in use should be always greater than 1")
+          .isGreaterThan(1)
+          .describedAs("Max buffers in use should be equal to as expected")
+          .isEqualTo(expectedMaxBuffersInUse)
+          .describedAs("Max buffers in use should be <= number of "
+              + "buffers calculated by memory percentage")
+          .isLessThanOrEqualTo(
+          (int) Math.ceil(Math.max(2, bufferCountByMemory)))
+          .describedAs("Max buffers in use should <= number of buffers "
+              + "calculated by concurrency").isLessThanOrEqualTo(
+          (int) Math.ceil(Math.max(2, bufferCountByMemory)));
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,6 +72,7 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
+      AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
       stream.write(b);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.util.Arrays;
 import java.util.Random;
 
-import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -72,7 +72,7 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
-      AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
+      AbfsOutputStreamOld.initWriteBufferPool(abfsConfiguration);
       stream.write(b);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -67,13 +67,13 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final AbfsConfiguration abfsConfiguration = fs.getAbfsStore().getAbfsConfiguration();
 
     abfsConfiguration.setWriteBufferSize(bufferSize);
-    AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
     abfsConfiguration.setReadBufferSize(bufferSize);
 
 
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
+      AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
       stream.write(b);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,13 +67,13 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final AbfsConfiguration abfsConfiguration = fs.getAbfsStore().getAbfsConfiguration();
 
     abfsConfiguration.setWriteBufferSize(bufferSize);
+    AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
     abfsConfiguration.setReadBufferSize(bufferSize);
 
 
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
-      AbfsOutputStreamOld.initWriteBufferPool(abfsConfiguration);
       stream.write(b);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemE2E.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemE2E.java
@@ -206,10 +206,13 @@ public class ITestAzureBlobFileSystemE2E extends AbstractAbfsIntegrationTest {
 
     FSDataOutputStream stream = fs.create(testFilePath);
     assertTrue(fs.exists(testFilePath));
+    stream.write(TEST_BYTE);
 
     fs.delete(testFilePath, true);
     assertFalse(fs.exists(testFilePath));
+    AbfsConfiguration configuration = this.getConfiguration();
 
+    // trigger flush call
     intercept(FileNotFoundException.class,
             () -> stream.close());
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -34,7 +34,7 @@ import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.StreamCapabilities;
-import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -303,7 +303,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
       stream.write(buffer);
 
       // Write asynchronously uploads data, so we must wait for completion
-      AbfsOutputStream abfsStream = (AbfsOutputStream) stream
+      AbfsOutputStreamOld abfsStream = (AbfsOutputStreamOld) stream
           .getWrappedStream();
       abfsStream.waitForPendingUploads();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -24,22 +24,25 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.io.IOException;
 
-import org.apache.hadoop.fs.StreamCapabilities;
-import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
-import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Test flush operation.
@@ -53,9 +56,9 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   private static final int ONE_MB = 1024 * 1024;
   private static final int FLUSH_TIMES = 200;
   private static final int THREAD_SLEEP_TIME = 1000;
+  private static final int CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT = 25;
 
   private static final int TEST_FILE_LENGTH = 1024 * 1024 * 8;
-  private static final int WAITING_TIME = 1000;
 
   public ITestAzureBlobFileSystemFlush() throws Exception {
     super();
@@ -208,6 +211,70 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   }
 
   @Test
+  public void testWriteWithMultipleOutputStreamAtTheSameTime()
+      throws IOException, InterruptedException, ExecutionException {
+    AzureBlobFileSystem fs = getFileSystem();
+    String testFilePath = methodName.getMethodName();
+    Path[] testPaths = new Path[CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT];
+    createNStreamsAndWriteDifferentSizesConcurrently(fs, testFilePath,
+        CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT, testPaths);
+    assertSuccessfulWritesOnAllStreams(fs,
+        CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT, testPaths);
+  }
+
+  private void assertSuccessfulWritesOnAllStreams(final FileSystem fs,
+      final int numConcurrentObjects, final Path[] testPaths)
+      throws IOException {
+    for (int i = 0; i < numConcurrentObjects; i++) {
+      FileStatus fileStatus = fs.getFileStatus(testPaths[i]);
+      int numWritesMadeOnStream = i + 1;
+      long expectedLength = TEST_BUFFER_SIZE * numWritesMadeOnStream;
+      assertThat(fileStatus.getLen(), is(equalTo(expectedLength)));
+    }
+  }
+
+  private void createNStreamsAndWriteDifferentSizesConcurrently(
+      final FileSystem fs, final String testFilePath,
+      final int numConcurrentObjects, final Path[] testPaths)
+      throws ExecutionException, InterruptedException {
+    final byte[] b = new byte[TEST_BUFFER_SIZE];
+    new Random().nextBytes(b);
+    final ExecutorService es = Executors.newFixedThreadPool(40);
+    final List<Future<Void>> futureTasks = new ArrayList<>();
+    for (int i = 0; i < numConcurrentObjects; i++) {
+      Path testPath = new Path(testFilePath + i);
+      testPaths[i] = testPath;
+      int numWritesToBeDone = i + 1;
+      futureTasks.add(es.submit(() -> {
+        try (FSDataOutputStream stream = fs.create(testPath)) {
+          makeNWritesToStream(stream, numWritesToBeDone, b, es);
+        }
+        return null;
+      }));
+    }
+    for (Future<Void> futureTask : futureTasks) {
+      futureTask.get();
+    }
+    es.shutdownNow();
+  }
+
+  private void makeNWritesToStream(final FSDataOutputStream stream,
+      final int numWrites, final byte[] b, final ExecutorService es)
+      throws IOException, ExecutionException, InterruptedException {
+    final List<Future<Void>> futureTasks = new ArrayList<>();
+    for (int i = 0; i < numWrites; i++) {
+      futureTasks.add(es.submit(() -> {
+        stream.write(b);
+        return null;
+      }));
+    }
+    for (Future<Void> futureTask : futureTasks) {
+      futureTask.get();
+    }
+    stream.hflush();
+  }
+
+  @Test
   public void testFlushWithOutputStreamFlushEnabled() throws Exception {
     testFlush(false);
   }
@@ -357,7 +424,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
         assertThat(
             "Bytes read unexpectedly match bytes written.",
             readBuffer,
-            IsNot.not(IsEqual.equalTo(writeBuffer)));
+            IsNot.not(equalTo(writeBuffer)));
       }
     } finally {
       stream.close();
@@ -376,7 +443,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
                 String.format("Bytes read unexpectedly match bytes written to %1$s",
                         filePath),
                 readBuffer,
-                IsNot.not(IsEqual.equalTo(writeBuffer)));
+                IsNot.not(equalTo(writeBuffer)));
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -211,7 +211,17 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   }
 
   @Test
-  public void testWriteWithMultipleOutputStreamAtTheSameTime()
+  public void testWriteWithMultipleOutputStreamAtTheSameTimeWithOldAndNewAbfsOutputStream()
+      throws IOException, ExecutionException, InterruptedException {
+    getFileSystem().getAbfsStore().getAbfsConfiguration()
+        .setShouldUseOlderAbfsOutputStream(true);
+    testWriteWithMultipleOutputStreamAtTheSameTime();
+    getFileSystem().getAbfsStore().getAbfsConfiguration()
+        .setShouldUseOlderAbfsOutputStream(false);
+    testWriteWithMultipleOutputStreamAtTheSameTime();
+  }
+
+  private void testWriteWithMultipleOutputStreamAtTheSameTime()
       throws IOException, InterruptedException, ExecutionException {
     AzureBlobFileSystem fs = getFileSystem();
     String testFilePath = methodName.getMethodName();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -1,0 +1,407 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.conf.Configuration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.anyLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TestAbfsOutputStream {
+
+  private static final int bufferSize = 4096;
+  private static final int writeSize = 1000;
+  private static final String path = "~/testpath";
+  private final String globalKey = "fs.azure.configuration";
+  private final String accountName1 = "account1";
+  private final String accountKey1 = globalKey + "." + accountName1;
+  private final String accountValue1 = "one";
+
+  /**
+   * The test verifies OutputStream shortwrite case(2000bytes write followed by flush, hflush, hsync) is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyShortWriteRequest() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[writeSize];
+    new Random().nextBytes(b);
+    out.write(b);
+    out.hsync();
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    final byte[] b1 = new byte[2*writeSize];
+    new Random().nextBytes(b1);
+    out.write(b1);
+    out.flush();
+    out.hflush();
+
+    out.hsync();
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("Path of the requests").isEqualTo(acString.getAllValues());
+    assertThat(Arrays.asList(Long.valueOf(0), Long.valueOf(writeSize))).describedAs("Write Position").isEqualTo(acLong.getAllValues());
+    //flush=true, close=false, flush=true, close=false
+    assertThat(Arrays.asList(true, true)).describedAs("Flush = true/false").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, false)).describedAs("Close = true/false").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0,0)).describedAs("Buffer Offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(writeSize, 2*writeSize)).describedAs("Buffer length").isEqualTo(acBufferLength.getAllValues());
+
+  }
+
+  /**
+   * The test verifies OutputStream Write of writeSize(1000 bytes) followed by a close is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyWriteRequest() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[writeSize];
+    new Random().nextBytes(b);
+
+    for (int i = 0; i < 5; i++) {
+      out.write(b);
+    }
+    out.close();
+
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("Path").isEqualTo(acString.getAllValues());
+    assertThat(Arrays.asList(Long.valueOf(0), Long.valueOf(bufferSize))).describedAs("Position").isEqualTo(acLong.getAllValues());
+    //flush=false,close=false, flush=true,close=true
+    assertThat(Arrays.asList(false, true)).describedAs("Flush = true/false").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, true)).describedAs("Close = true/false").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0, 0)).describedAs("Buffer Offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(bufferSize, 5*writeSize-bufferSize)).describedAs("Buffer Length").isEqualTo(acBufferLength.getAllValues());
+
+  }
+
+  /**
+   * The test verifies OutputStream Write of bufferSize(4KB) followed by a close is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyWriteRequestOfBufferSizeAndClose() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+    when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[bufferSize];
+    new Random().nextBytes(b);
+
+    for (int i = 0; i < 2; i++) {
+      out.write(b);
+    }
+    out.close();
+
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("path").isEqualTo(acString.getAllValues());
+    assertThat(new HashSet<Long>(Arrays.asList(Long.valueOf(0), Long.valueOf(bufferSize)))).describedAs("Position").isEqualTo(new HashSet<Long>(
+               acLong.getAllValues()));
+    //flush=false, close=false, flush=false, close=false
+    assertThat(Arrays.asList(false, false)).describedAs("Flush = true/false").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, false)).describedAs("Close = true/false").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0, 0)).describedAs("Buffer Offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(bufferSize, bufferSize)).describedAs("Buffer Length").isEqualTo(acBufferLength.getAllValues());
+
+    ArgumentCaptor<String> acFlushString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acFlushLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Boolean> acFlushRetainUnCommittedData = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acFlushClose = ArgumentCaptor.forClass(Boolean.class);
+
+    verify(client, times(1)).flush(acFlushString.capture(), acFlushLong.capture(), acFlushRetainUnCommittedData.capture(), acFlushClose.capture());
+    assertThat(Arrays.asList(path)).describedAs("path").isEqualTo(acFlushString.getAllValues());
+    assertThat(Arrays.asList(Long.valueOf(2*bufferSize))).describedAs("position").isEqualTo(acFlushLong.getAllValues());
+    assertThat(Arrays.asList(false)).describedAs("RetainUnCommittedData flag").isEqualTo(acFlushRetainUnCommittedData.getAllValues());
+    assertThat(Arrays.asList(true)).describedAs("Close flag").isEqualTo(acFlushClose.getAllValues());
+
+  }
+
+  /**
+   * The test verifies OutputStream Write of bufferSize(4KB) is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyWriteRequestOfBufferSize() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[bufferSize];
+    new Random().nextBytes(b);
+
+    for (int i = 0; i < 2; i++) {
+      out.write(b);
+    }
+    Thread.sleep(1000);
+
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("File Path").isEqualTo(acString.getAllValues());
+    assertThat(new HashSet<Long>(Arrays.asList(Long.valueOf(0), Long.valueOf(bufferSize)))).describedAs("Position in file").isEqualTo(
+               new HashSet<Long>(acLong.getAllValues()));
+    //flush=false, close=false, flush=false, close=false
+    assertThat(Arrays.asList(false, false)).describedAs("flush flag").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, false)).describedAs("close flag").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0, 0)).describedAs("buffer offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(bufferSize, bufferSize)).describedAs("buffer length").isEqualTo(acBufferLength.getAllValues());
+
+  }
+
+  /**
+   * The test verifies OutputStream Write of bufferSize(4KB) on a AppendBlob based stream is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyWriteRequestOfBufferSizeWithAppendBlob() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[bufferSize];
+    new Random().nextBytes(b);
+
+    for (int i = 0; i < 2; i++) {
+      out.write(b);
+    }
+    Thread.sleep(1000);
+
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("File Path").isEqualTo(acString.getAllValues());
+    assertThat(Arrays.asList(Long.valueOf(0), Long.valueOf(bufferSize))).describedAs("File Position").isEqualTo(acLong.getAllValues());
+    //flush=false, close=false, flush=false, close=false
+    assertThat(Arrays.asList(false, false)).describedAs("Flush Flag").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, false)).describedAs("Close Flag").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0, 0)).describedAs("Buffer Offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(bufferSize, bufferSize)).describedAs("Buffer Length").isEqualTo(acBufferLength.getAllValues());
+
+  }
+
+  /**
+   * The test verifies OutputStream Write of bufferSize(4KB)  followed by a hflush call is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyWriteRequestOfBufferSizeAndHFlush() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+    when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[bufferSize];
+    new Random().nextBytes(b);
+
+    for (int i = 0; i < 2; i++) {
+      out.write(b);
+    }
+    out.hflush();
+
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("File Path").isEqualTo(acString.getAllValues());
+    assertThat(new HashSet<Long>(Arrays.asList(Long.valueOf(0), Long.valueOf(bufferSize)))).describedAs("File Position").isEqualTo(
+               new HashSet<Long>(acLong.getAllValues()));
+    //flush=false, close=false, flush=false, close=false
+    assertThat(Arrays.asList(false, false)).describedAs("Flush Flag").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, false)).describedAs("Close Flag").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0, 0)).describedAs("Buffer Offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(bufferSize, bufferSize)).describedAs("Buffer Length").isEqualTo(acBufferLength.getAllValues());
+
+    ArgumentCaptor<String> acFlushString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acFlushLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Boolean> acFlushRetainUnCommittedData = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acFlushClose = ArgumentCaptor.forClass(Boolean.class);
+
+    verify(client, times(1)).flush(acFlushString.capture(), acFlushLong.capture(), acFlushRetainUnCommittedData.capture(), acFlushClose.capture());
+    assertThat(Arrays.asList(path)).describedAs("path").isEqualTo(acFlushString.getAllValues());
+    assertThat(Arrays.asList(Long.valueOf(2*bufferSize))).describedAs("position").isEqualTo(acFlushLong.getAllValues());
+    assertThat(Arrays.asList(false)).describedAs("RetainUnCommittedData flag").isEqualTo(acFlushRetainUnCommittedData.getAllValues());
+    assertThat(Arrays.asList(false)).describedAs("Close flag").isEqualTo(acFlushClose.getAllValues());
+
+  }
+
+  /**
+   * The test verifies OutputStream Write of bufferSize(4KB)  followed by a flush call is making correct HTTP calls to the server
+   */
+  @Test
+  public void verifyWriteRequestOfBufferSizeAndFlush() throws Exception {
+
+    AbfsClient client = mock(AbfsClient.class);
+    AbfsRestOperation op = mock(AbfsRestOperation.class);
+    AbfsConfiguration abfsConf;
+    final Configuration conf = new Configuration();
+    conf.set(accountKey1, accountValue1);
+    abfsConf = new AbfsConfiguration(conf, accountName1);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
+    when(client.getAbfsPerfTracker()).thenReturn(tracker);
+    when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    final byte[] b = new byte[bufferSize];
+    new Random().nextBytes(b);
+
+    for (int i = 0; i < 2; i++) {
+      out.write(b);
+    }
+    out.flush();
+    Thread.sleep(1000);
+
+    ArgumentCaptor<String> acString = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> acLong = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Integer> acBufferOffset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> acBufferLength = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Boolean> acFlush = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> acClose = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<byte[]> acByteArray = ArgumentCaptor.forClass(byte[].class);
+
+    verify(client, times(2)).append(acString.capture(), acLong.capture(), acByteArray.capture(), acBufferOffset.capture(), acBufferLength.capture(),
+                                    acFlush.capture(), acClose.capture());
+    assertThat(Arrays.asList(path, path)).describedAs("path").isEqualTo(acString.getAllValues());
+    assertThat(new HashSet<Long>(Arrays.asList(Long.valueOf(0), Long.valueOf(bufferSize)))).describedAs("Position").isEqualTo(
+               new HashSet<Long>(acLong.getAllValues()));
+    //flush=false, close=false, flush=false, close=false
+    assertThat(Arrays.asList(false, false)).describedAs("Flush = true/false").isEqualTo(acFlush.getAllValues());
+    assertThat(Arrays.asList(false, false)).describedAs("Close = true/false").isEqualTo(acClose.getAllValues());
+    assertThat(Arrays.asList(0, 0)).describedAs("Buffer Offset").isEqualTo(acBufferOffset.getAllValues());
+    assertThat(Arrays.asList(bufferSize, bufferSize)).describedAs("Buffer Length").isEqualTo(acBufferLength.getAllValues());
+
+  }
+}


### PR DESCRIPTION
HADOOP-16854 Fix to prevent OutOfMemoryException and Make the threadpool and bytebuffer pool common across all AbfsOutputStream instances
