### PR TITLE
HADOOP-16854. Fix to prevent OutOfMemoryException and Make the threadpool and bytebuffer pool common across all AbfsOutputStream instances

### DIFF
--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -289,6 +289,22 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/net.jodah/concurrentunit -->
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>concurrentunit</artifactId>
+      <version>0.4.6</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+
+
   </dependencies>
 
   <profiles>

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -731,7 +731,7 @@ public class AbfsConfiguration{
   }
 
   @VisibleForTesting
-  void setWriteBufferSize(int bufferSize) {
+  public void setWriteBufferSize(int bufferSize) {
     this.writeBufferSize = bufferSize;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -120,10 +120,20 @@ public class AbfsConfiguration{
       DefaultValue = AZURE_BLOCK_LOCATION_HOST_DEFAULT)
   private String azureBlockLocationHost;
 
-  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_CONCURRENT_CONNECTION_VALUE_OUT,
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM,
+      DefaultValue = DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM)
+  private boolean shouldUseOlderAbfsOutputStream;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_WRITE_CONCURRENCY_FACTOR,
       MinValue = 1,
-      DefaultValue = MAX_CONCURRENT_WRITE_THREADS)
-  private int maxConcurrentWriteThreads;
+  DefaultValue = DEFAULT_WRITE_CONCURRENCY_FACTOR)
+  private int writeConcurrencyFactor;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE,
+      MinValue = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+      MaxValue = MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+      DefaultValue = DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE)
+  private int maxWriteMemoryUsagePercentage;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LIST_MAX_RESULTS,
       MinValue = 1,
@@ -437,12 +447,20 @@ public class AbfsConfiguration{
     return this.azureBlockLocationHost;
   }
 
-  public int getMaxConcurrentWriteThreads() {
-    return this.maxConcurrentWriteThreads;
-  }
-
   public int getMaxConcurrentReadThreads() {
     return this.maxConcurrentReadThreads;
+  }
+
+  public boolean shouldUseOlderAbfsOutputStream() {
+    return this.shouldUseOlderAbfsOutputStream;
+  }
+
+  public int getWriteConcurrencyFactor() {
+    return this.writeConcurrencyFactor;
+  }
+
+  public int getMaxWriteMemoryUsagePercentage() {
+    return this.maxWriteMemoryUsagePercentage;
   }
 
   public int getListMaxResults() {
@@ -730,6 +748,12 @@ public class AbfsConfiguration{
   @VisibleForTesting
   void setListMaxResults(int listMaxResults) {
     this.listMaxResults = listMaxResults;
+  }
+
+  @VisibleForTesting
+  void setShouldUseOlderAbfsOutputStream(
+      boolean shouldUseOlderAbfsOutputStream) {
+    this.shouldUseOlderAbfsOutputStream = shouldUseOlderAbfsOutputStream;
   }
 
   private String getTrimmedPasswordString(String key, String defaultValue) throws IOException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -731,7 +731,7 @@ public class AbfsConfiguration{
   }
 
   @VisibleForTesting
-  public void setWriteBufferSize(int bufferSize) {
+  void setWriteBufferSize(int bufferSize) {
     this.writeBufferSize = bufferSize;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -418,12 +418,12 @@ public class AzureBlobFileSystemStore implements Closeable {
     try (AbfsPerfInfo perfInfo = startTracking("createFile", "createPath")) {
       boolean isNamespaceEnabled = getIsNamespaceEnabled();
       LOG.debug("createFile filesystem: {} path: {} overwrite: {} permission: {} umask: {} isNamespaceEnabled: {}",
-          client.getFileSystem(),
-          path,
-          overwrite,
-          permission.toString(),
-          umask.toString(),
-          isNamespaceEnabled);
+              client.getFileSystem(),
+               path,
+               overwrite,
+               permission.toString(),
+               umask.toString(),
+               isNamespaceEnabled);
 
         boolean appendBlob = false;
         if (isAppendBlobKey(path.toString())) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -417,20 +417,23 @@ public class AzureBlobFileSystemStore implements Closeable {
                                  final FsPermission umask) throws AzureBlobFileSystemException {
     try (AbfsPerfInfo perfInfo = startTracking("createFile", "createPath")) {
       boolean isNamespaceEnabled = getIsNamespaceEnabled();
-      LOG.debug(
-          "createFile filesystem: {} path: {} overwrite: {} permission: {} umask: {} isNamespaceEnabled: {}",
-          client.getFileSystem(), path, overwrite, permission.toString(), umask.toString(),
+      LOG.debug("createFile filesystem: {} path: {} overwrite: {} permission: {} umask: {} isNamespaceEnabled: {}",
+          client.getFileSystem(),
+          path,
+          overwrite,
+          permission.toString(),
+          umask.toString(),
           isNamespaceEnabled);
 
-      boolean appendBlob = false;
-      if (isAppendBlobKey(path.toString())) {
-        appendBlob = true;
-      }
+        boolean appendBlob = false;
+        if (isAppendBlobKey(path.toString())) {
+          appendBlob = true;
+        }
 
-      client.createPath(AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path),
-          true, overwrite,
+      client.createPath(AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path), true, overwrite,
           isNamespaceEnabled ? getOctalNotation(permission) : null,
-          isNamespaceEnabled ? getOctalNotation(umask) : null, appendBlob);
+          isNamespaceEnabled ? getOctalNotation(umask) : null,
+          appendBlob);
 
       if (abfsConfiguration.shouldUseOlderAbfsOutputStream()) {
         return new AbfsOutputStreamOld(
@@ -443,6 +446,7 @@ public class AzureBlobFileSystemStore implements Closeable {
             abfsConfiguration.isAppendWithFlushEnabled(),
             appendBlob);
       }
+
       return new AbfsOutputStream(client,
           AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path), 0,
           abfsConfiguration.isFlushEnabled(),

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -419,11 +419,11 @@ public class AzureBlobFileSystemStore implements Closeable {
       boolean isNamespaceEnabled = getIsNamespaceEnabled();
       LOG.debug("createFile filesystem: {} path: {} overwrite: {} permission: {} umask: {} isNamespaceEnabled: {}",
               client.getFileSystem(),
-               path,
-               overwrite,
-               permission.toString(),
-               umask.toString(),
-               isNamespaceEnabled);
+              path,
+              overwrite,
+              permission.toString(),
+              umask.toString(),
+              isNamespaceEnabled);
 
         boolean appendBlob = false;
         if (isAppendBlobKey(path.toString())) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -445,7 +445,6 @@ public class AzureBlobFileSystemStore implements Closeable {
       }
       return new AbfsOutputStream(client,
           AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path), 0,
-          abfsConfiguration.getWriteBufferSize(),
           abfsConfiguration.isFlushEnabled(),
           abfsConfiguration.isOutputStreamFlushDisabled(),
           abfsConfiguration.isAppendWithFlushEnabled(),
@@ -549,7 +548,6 @@ public class AzureBlobFileSystemStore implements Closeable {
           client,
           AbfsHttpConstants.FORWARD_SLASH + getRelativePath(path),
           offset,
-          abfsConfiguration.getWriteBufferSize(),
           abfsConfiguration.isFlushEnabled(),
           abfsConfiguration.isOutputStreamFlushDisabled(),
           abfsConfiguration.isAppendWithFlushEnabled(),

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -41,7 +41,7 @@ public final class ConfigurationKeys {
   public static final String AZURE_WRITE_BUFFER_SIZE = "fs.azure.write.request.size";
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
-  public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";;
+  public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_OUT = "fs.azure.concurrentRequestCount.out";
   public static final String AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = "fs.azure.use.olderabfsoutputstream";
   public static final String AZURE_WRITE_CONCURRENCY_FACTOR = "fs.azure.write.concurrency.factor";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -41,8 +41,11 @@ public final class ConfigurationKeys {
   public static final String AZURE_WRITE_BUFFER_SIZE = "fs.azure.write.request.size";
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
-  public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
+  public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";;
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_OUT = "fs.azure.concurrentRequestCount.out";
+  public static final String AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = "fs.azure.use.olderabfsoutputstream";
+  public static final String AZURE_WRITE_CONCURRENCY_FACTOR = "fs.azure.write.concurrency.factor";
+  public static final String AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE = "fs.azure.max.write.memory.usage.percentage";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_IN = "fs.azure.concurrentRequestCount.in";
   public static final String AZURE_TOLERATE_CONCURRENT_APPEND = "fs.azure.io.read.tolerate.concurrent.append";
   public static final String AZURE_LIST_MAX_RESULTS = "fs.azure.list.max.results";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -49,7 +49,11 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_AZURE_LIST_MAX_RESULTS = 500;
 
   public static final int MAX_CONCURRENT_READ_THREADS = 12;
-  public static final int MAX_CONCURRENT_WRITE_THREADS = 8;
+  public static final int DEFAULT_WRITE_CONCURRENCY_FACTOR = 4;
+  public static final boolean DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = false;
+  public static final int MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 20;
+  public static final int MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 90;
+  public static final int DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
   public static final boolean DEFAULT_READ_TOLERATE_CONCURRENT_APPEND = false;
   public static final boolean DEFAULT_AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION = false;
   public static final boolean DEFAULT_AZURE_SKIP_USER_GROUP_METADATA_DURING_INITIALIZATION = false;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+
+/**
+ * Pool for byte[]
+ */
+public class AbfsByteBufferPool {
+
+  /**
+   * Queue holding the free buffers.
+   */
+  private ArrayBlockingQueue<byte[]> freeBuffers;
+  /**
+   * Count to track the buffers issued and yet to be returned.
+   */
+  private int numBuffersInUse;
+  /**
+   * Maximum number of buffers that can be in use.
+   */
+  private int maxBuffersInUse;
+  private int bufferSize;
+
+  /**
+   * @param bufferSize                 Size of the byte[] to be returned.
+   * @param maxConcurrentThreadCount   Maximum number of threads that will be
+   *                                   using the pool.
+   * @param maxWriteMemUsagePercentage Maximum percentage of memory that can
+   *                                   be used by the pool from the max
+   *                                   available memory.
+   */
+  public AbfsByteBufferPool(final int bufferSize,
+      final int maxConcurrentThreadCount,
+      final int maxWriteMemUsagePercentage) {
+    Preconditions.checkArgument(maxWriteMemUsagePercentage
+            >= MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE
+            && maxWriteMemUsagePercentage
+            <= MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+        "maxWriteMemUsagePercentage should be in range (%s - %s)",
+        MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+        MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE);
+    Preconditions.checkArgument(maxConcurrentThreadCount > 0,
+        "maxConcurrentThreadCount cannot be < 1");
+    this.bufferSize = bufferSize;
+    this.numBuffersInUse = 0;
+    freeBuffers = new ArrayBlockingQueue<>(maxConcurrentThreadCount + 1);
+
+    double maxMemoryAllowedForPool =
+        Runtime.getRuntime().maxMemory() * maxWriteMemUsagePercentage / 100;
+    double bufferCountByMemory = maxMemoryAllowedForPool / bufferSize;
+    double bufferCountByConcurrency =
+        maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
+            + 1;
+    maxBuffersInUse = (int) Math
+        .ceil(Math.min(bufferCountByMemory, bufferCountByConcurrency));
+    if (maxBuffersInUse < 2) {
+      maxBuffersInUse = 2;
+    }
+  }
+
+  /**
+   * @return byte[] from the pool if available otherwise new byte[] is returned.
+   * Waits if pool is empty and already maximum number of buffers are in use.
+   */
+  public byte[] get() {
+    synchronized (this) {
+      numBuffersInUse++;
+      byte[] byteArray = freeBuffers.poll();
+      if (byteArray != null) {
+        return byteArray;
+      }
+      if (numBuffersInUse <= maxBuffersInUse) {
+        return new byte[bufferSize];
+      }
+    }
+    try {
+      return freeBuffers.take();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  /**
+   * @param byteArray The buffer to be offered back to the pool.
+   */
+  public synchronized void release(byte[] byteArray) {
+    Preconditions.checkArgument(byteArray.length == bufferSize,
+        "Buffer size has" + " to be %s", bufferSize);
+    numBuffersInUse--;
+    if (numBuffersInUse < 0) {
+      numBuffersInUse = 0;
+    }
+    freeBuffers.offer(byteArray);
+  }
+
+  @VisibleForTesting
+  public synchronized int getMaxBuffersInUse() {
+    return this.maxBuffersInUse;
+  }
+
+  @VisibleForTesting
+  public synchronized ArrayBlockingQueue<byte[]> getFreeBuffers() {
+    return freeBuffers;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
@@ -45,7 +45,7 @@ public class AbfsByteBufferPool {
 
   private int bufferSize;
 
-  private int queueCapacity;
+  private int maxBuffersToPool;
   private int maxMemUsagePercentage;
 
   /**
@@ -62,7 +62,7 @@ public class AbfsByteBufferPool {
     this.maxMemUsagePercentage = maxMemUsagePercentage;
     this.bufferSize = bufferSize;
     this.numBuffersInUse = 0;
-    this.queueCapacity = queueCapacity;
+    this.maxBuffersToPool = queueCapacity;
     freeBuffers = new ArrayBlockingQueue<>(queueCapacity);
   }
 
@@ -82,7 +82,7 @@ public class AbfsByteBufferPool {
   private boolean isPossibleToIssueNewBuffer() {
     Runtime rt = Runtime.getRuntime();
     double bufferCountByMaxFreeBuffers = ceil(
-        queueCapacity + rt.availableProcessors());
+        maxBuffersToPool + rt.availableProcessors());
     if (numBuffersInUse >= bufferCountByMaxFreeBuffers) {
       return false;
     }
@@ -90,13 +90,13 @@ public class AbfsByteBufferPool {
     double freeMemory = rt.maxMemory() - (rt.totalMemory() - rt.freeMemory());
     double bufferCountByMemory = ceil(
         (freeMemory * maxMemUsagePercentage / 100) / bufferSize);
-    int numBuffersCanBeInUse = (int) min(bufferCountByMemory,
+    int maxBuffersThatCanBeInUse = (int) min(bufferCountByMemory,
         bufferCountByMaxFreeBuffers);
-    if (numBuffersCanBeInUse < 2) {
-      numBuffersCanBeInUse = 2;
+    if (maxBuffersThatCanBeInUse < 2) {
+      maxBuffersThatCanBeInUse = 2;
     }
 
-    return numBuffersInUse < numBuffersCanBeInUse;
+    return numBuffersInUse < maxBuffersThatCanBeInUse;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
-import java.util.concurrent.ArrayBlockingQueue;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+
+import java.util.concurrent.ArrayBlockingQueue;
 
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
@@ -109,8 +109,9 @@ public class AbfsByteBufferPool {
    * @param byteArray The buffer to be offered back to the pool.
    */
   public synchronized void release(byte[] byteArray) {
-    Preconditions.checkArgument(byteArray.length == bufferSize,
-        "Buffer size has" + " to be %s", bufferSize);
+    if (byteArray.length == bufferSize) {
+      return;
+    }
     numBuffersInUse--;
     if (numBuffersInUse < 0) {
       numBuffersInUse = 0;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -134,11 +134,11 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
       return true;
     }
 
-    boolean shouldInitialiseCommonPools = isFirstObj;
-    if (shouldInitialiseCommonPools) {
+    boolean isFirstObjTemp = isFirstObj;
+    if (isFirstObjTemp) {
       synchronized (AbfsOutputStream.class) {
-        shouldInitialiseCommonPools = isFirstObj;
-        if (shouldInitialiseCommonPools) {
+        isFirstObjTemp = isFirstObj;
+        if (isFirstObjTemp) {
           isFirstObj = false;
           return false;
         }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsByteBufferPool.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.azurebfs;
+
+import java.lang.Thread.State;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.azurebfs.services.AbfsByteBufferPool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Test class for AbfsByteBufferPool.
+ */
+public class ITestAbfsByteBufferPool {
+
+  private static final int TWO_MB = 2 * 1024 * 1024;
+
+  @Test
+  public void testWithInvalidMaxWriteMemUsagePercentage() throws Exception {
+    List<Integer> invalidMaxWriteMemUsagePercentageList = Arrays
+        .asList(MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE - 1,
+            MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE + 1, -100, 101);
+    for (int val : invalidMaxWriteMemUsagePercentageList) {
+      intercept(IllegalArgumentException.class, String
+              .format("maxWriteMemUsagePercentage should be in range (%s - %s)",
+                  MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+                  MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE),
+          () -> new AbfsByteBufferPool(TWO_MB, 2, val));
+    }
+  }
+
+  @Test
+  public void testWithInvalidMaxConcurrentThreadCount() throws Exception {
+    List<Integer> invalidMaxConcurrentThreadCount = Arrays.asList(0, -1);
+    for (int val : invalidMaxConcurrentThreadCount) {
+      intercept(IllegalArgumentException.class, String
+              .format("maxConcurrentThreadCount cannot be < 1",
+                  MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+                  MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE),
+          () -> new AbfsByteBufferPool(TWO_MB, val, 20));
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReleaseNull() {
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, 5, 30);
+    pool.release(null);
+  }
+
+  @Test
+  public void testReleaseMoreThanPoolCapacity() {
+    int maxConcurrentThreadCount = 3;
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB,
+        maxConcurrentThreadCount, 25);
+    int expectedPoolCapacity = maxConcurrentThreadCount + 1;
+    for (int i = 0; i < expectedPoolCapacity * 2; i++) {
+      pool.release(new byte[TWO_MB]);
+      assertThat(pool.getFreeBuffers()).describedAs(
+          "Pool size should never exceed the expected capacity irrespective "
+              + "of the number of objects released to the pool")
+          .hasSizeLessThanOrEqualTo(expectedPoolCapacity);
+    }
+  }
+
+  @Test
+  public void testReleaseWithSameBufferSize() {
+    int bufferSize = 2;
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(2, 3, 25);
+    pool.release(new byte[bufferSize]);
+  }
+
+  @Test
+  public void testReleaseWithDifferentBufferSize() throws Exception {
+    String errorString = "Buffer size has to be %s";
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, 3, 25);
+    for (int i = 1; i < 2; i++) {
+      int finalI = i;
+      intercept(IllegalArgumentException.class,
+          String.format(errorString, TWO_MB),
+          () -> pool.release(new byte[TWO_MB + finalI]));
+      intercept(IllegalArgumentException.class,
+          String.format(errorString, TWO_MB),
+          () -> pool.release(new byte[TWO_MB - finalI]));
+    }
+  }
+
+  @Test
+  public void testGet() throws Exception {
+    int maxConcurrentThreadCount = 3;
+    int expectedMaxBuffersInUse =
+        maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
+            + 1;
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB,
+        maxConcurrentThreadCount, 90);
+
+    for (int i = 0; i < expectedMaxBuffersInUse; i++) {
+      byte[] byteBuffer = pool.get();
+      assertThat(byteBuffer.length).describedAs("Pool has to return an object "
+          + "immediately, until maximum buffers are in use.").isEqualTo(TWO_MB);
+    }
+
+    pool.release(new byte[2 * 1024 * 1024]);
+    byte[] byteBuffer = pool.get();
+    assertThat(byteBuffer.length).describedAs("Pool has to return an object "
+        + "immediately, if there are free buffers available in the pool.")
+        .isEqualTo(TWO_MB);
+
+    Thread getThread = new Thread(() -> pool.get());
+    getThread.start();
+    Thread.sleep(5000);
+    assertThat(getThread.getState()).describedAs("When maximum number of "
+        + "buffers are in use and no free buffers available in the pool the "
+        + "get call is blocked until an object is released to the pool.")
+        .isEqualTo(State.WAITING);
+    getThread.interrupt();
+
+    Callable<byte[]> callable = () -> pool.get();
+    FutureTask futureTask = new FutureTask(callable);
+    getThread = new Thread(futureTask);
+    getThread.start();
+    pool.release(new byte[TWO_MB]);
+    byteBuffer = (byte[]) futureTask.get();
+    assertThat(byteBuffer.length).describedAs("The blocked get call unblocks "
+        + "when an object is released back to the pool.").isEqualTo(TWO_MB);
+  }
+
+  @Test
+  public void testMaxBuffersInUse() {
+    List<Object[]> testData = Arrays.asList(
+        new Object[][] {{1, 1, 20}, {1, 100000, 90}, {1, 2, 30},
+            {100, 100, 90}});
+    for (int i = 0; i < testData.size(); i++) {
+      int bufferSize = (int) testData.get(i)[0] * 1024 * 1024;
+      int maxConcurrentThreadCount = (int) testData.get(i)[1];
+      int maxWriteMemUsagePercentage = (int) testData.get(i)[2];
+      AbfsByteBufferPool pool = new AbfsByteBufferPool(bufferSize,
+          maxConcurrentThreadCount, maxWriteMemUsagePercentage);
+
+      double maxMemoryAllowedForPoolMB =
+          Runtime.getRuntime().maxMemory() * maxWriteMemUsagePercentage / 100;
+      double bufferCountByMemory = maxMemoryAllowedForPoolMB / bufferSize;
+      double bufferCountByConcurrency =
+          maxConcurrentThreadCount + Runtime.getRuntime().availableProcessors()
+              + 1;
+      int expectedMaxBuffersInUse = (int) Math
+          .ceil(Math.min(bufferCountByMemory, bufferCountByConcurrency));
+      if (expectedMaxBuffersInUse < 2) {
+        expectedMaxBuffersInUse = 2;
+      }
+
+      assertThat(pool.getMaxBuffersInUse())
+          .describedAs("Max buffers in use should be always greater than 1")
+          .isGreaterThan(1)
+          .describedAs("Max buffers in use should be equal to as expected")
+          .isEqualTo(expectedMaxBuffersInUse).describedAs(
+          "Max buffers in use should be <= number of "
+              + "buffers calculated by memory percentage")
+          .isLessThanOrEqualTo((int) Math.ceil(bufferCountByMemory))
+          .describedAs("Max buffers in use should <= number of buffers "
+              + "calculated by concurrency")
+          .isLessThanOrEqualTo((int) Math.ceil(bufferCountByMemory));
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,6 +72,7 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
+      AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
       stream.write(b);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -68,7 +68,6 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     abfsConfiguration.setWriteBufferSize(bufferSize);
     abfsConfiguration.setReadBufferSize(bufferSize);
 
-
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -67,11 +67,11 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
 
     abfsConfiguration.setWriteBufferSize(bufferSize);
     abfsConfiguration.setReadBufferSize(bufferSize);
+    AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
 
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
     try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
-      AbfsOutputStream.initWriteBufferPool(abfsConfiguration);
       stream.write(b);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -18,28 +18,33 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
+import org.assertj.core.api.Assertions;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.junit.Test;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.io.IOException;
 
-import org.apache.hadoop.fs.StreamCapabilities;
-import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
-import org.junit.Test;
-
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Test flush operation.
@@ -56,6 +61,8 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
 
   private static final int TEST_FILE_LENGTH = 1024 * 1024 * 8;
   private static final int WAITING_TIME = 1000;
+
+  private static final int CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT = 25;
 
   public ITestAzureBlobFileSystemFlush() throws Exception {
     super();
@@ -208,6 +215,92 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   }
 
   @Test
+  public void testShouldUseOlderAbfsOutputStreamConf() throws IOException {
+    AzureBlobFileSystem fs = getFileSystem();
+    Path testPath = new Path(methodName.getMethodName() + "1");
+    getFileSystem().getAbfsStore().getAbfsConfiguration()
+        .setShouldUseOlderAbfsOutputStream(true);
+    try (FSDataOutputStream stream = fs.create(testPath)) {
+      Assertions.assertThat(stream.getWrappedStream()).describedAs("When the "
+          + "shouldUseOlderAbfsOutputStream is set the wrapped stream inside "
+          + "the FSDataOutputStream object should be of class "
+          + "AbfsOutputStreamOld.").isInstanceOf(AbfsOutputStreamOld.class);
+    }
+    testPath = new Path(methodName.getMethodName());
+    getFileSystem().getAbfsStore().getAbfsConfiguration()
+        .setShouldUseOlderAbfsOutputStream(false);
+    try (FSDataOutputStream stream = fs.create(testPath)) {
+      Assertions.assertThat(stream.getWrappedStream()).describedAs("When the "
+          + "shouldUseOlderAbfsOutputStream is set the wrapped stream inside "
+          + "the FSDataOutputStream object should be of class "
+          + "AbfsOutputStream.").isInstanceOf(AbfsOutputStream.class);
+    }
+  }
+
+  @Test
+  public void testWriteWithMultipleOutputStreamAtTheSameTime()
+      throws IOException, InterruptedException, ExecutionException {
+    AzureBlobFileSystem fs = getFileSystem();
+    String testFilePath = methodName.getMethodName();
+    Path[] testPaths = new Path[CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT];
+    createNStreamsAndWriteDifferentSizesConcurrently(fs, testFilePath,
+        CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT, testPaths);
+    assertSuccessfulWritesOnAllStreams(fs,
+        CONCURRENT_STREAM_OBJS_TEST_OBJ_COUNT, testPaths);
+  }
+
+  private void assertSuccessfulWritesOnAllStreams(final FileSystem fs,
+      final int numConcurrentObjects, final Path[] testPaths)
+      throws IOException {
+    for (int i = 0; i < numConcurrentObjects; i++) {
+      FileStatus fileStatus = fs.getFileStatus(testPaths[i]);
+      int numWritesMadeOnStream = i + 1;
+      long expectedLength = TEST_BUFFER_SIZE * numWritesMadeOnStream;
+      assertThat(fileStatus.getLen(), is(equalTo(expectedLength)));
+    }
+  }
+
+  private void createNStreamsAndWriteDifferentSizesConcurrently(
+      final FileSystem fs, final String testFilePath,
+      final int numConcurrentObjects, final Path[] testPaths)
+      throws ExecutionException, InterruptedException {
+    final byte[] b = new byte[TEST_BUFFER_SIZE];
+    new Random().nextBytes(b);
+    final ExecutorService es = Executors.newFixedThreadPool(40);
+    final List<Future<Void>> futureTasks = new ArrayList<>();
+    for (int i = 0; i < numConcurrentObjects; i++) {
+      Path testPath = new Path(testFilePath + i);
+      testPaths[i] = testPath;
+      int numWritesToBeDone = i + 1;
+      futureTasks.add(es.submit(() -> {
+        try (FSDataOutputStream stream = fs.create(testPath)) {
+          makeNWritesToStream(stream, numWritesToBeDone, b, es);
+        }
+        return null;
+      }));
+    }
+    for (Future<Void> futureTask : futureTasks) {
+      futureTask.get();
+    }
+    es.shutdownNow();
+  }
+
+  private void makeNWritesToStream(final FSDataOutputStream stream,
+      final int numWrites, final byte[] b, final ExecutorService es)
+      throws ExecutionException, InterruptedException {
+    final List<Future<Void>> futureTasks = new ArrayList<>();
+    for (int i = 0; i < numWrites; i++) {
+      futureTasks.add(es.submit(() -> {
+        stream.write(b);
+        return null;
+      }));
+    }
+    for (Future<Void> futureTask : futureTasks) {
+      futureTask.get();
+    }
+  }
+
+  @Test
   public void testFlushWithOutputStreamFlushEnabled() throws Exception {
     testFlush(false);
   }
@@ -357,7 +450,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
         assertThat(
             "Bytes read unexpectedly match bytes written.",
             readBuffer,
-            IsNot.not(IsEqual.equalTo(writeBuffer)));
+            IsNot.not(equalTo(writeBuffer)));
       }
     } finally {
       stream.close();
@@ -376,7 +469,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
                 String.format("Bytes read unexpectedly match bytes written to %1$s",
                         filePath),
                 readBuffer,
-                IsNot.not(IsEqual.equalTo(writeBuffer)));
+                IsNot.not(equalTo(writeBuffer)));
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -329,10 +329,14 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
       stream.write(buffer);
 
       // Write asynchronously uploads data, so we must wait for completion
-      AbfsOutputStream abfsStream = (AbfsOutputStream) stream
-          .getWrappedStream();
-      abfsStream.waitForPendingUploads();
-
+      if(stream.getWrappedStream() instanceof AbfsOutputStream) {
+        AbfsOutputStream abfsStream = (AbfsOutputStream) stream.getWrappedStream();
+        abfsStream.waitForPendingUploads();
+      }else{
+        AbfsOutputStreamOld abfsStream =
+            (AbfsOutputStreamOld) stream.getWrappedStream();
+        abfsStream.waitForPendingUploads();
+      }
       // Flush commits the data so it can be read.
       stream.flush();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -287,7 +287,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
 
   private void makeNWritesToStream(final FSDataOutputStream stream,
       final int numWrites, final byte[] b, final ExecutorService es)
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, IOException {
     final List<Future<Void>> futureTasks = new ArrayList<>();
     for (int i = 0; i < numWrites; i++) {
       futureTasks.add(es.submit(() -> {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsByteBufferPool.java
@@ -15,28 +15,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.fs.azurebfs;
+package org.apache.hadoop.fs.azurebfs.services;
 
-import java.lang.Thread.State;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.FutureTask;
-
+import net.jodah.concurrentunit.Waiter;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNull;
 import org.junit.Test;
 
-import org.apache.hadoop.fs.azurebfs.services.AbfsByteBufferPool;
+import java.lang.Thread.State;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import static java.lang.Thread.sleep;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.doesNotHave;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
 
 /**
  * Test class for AbfsByteBufferPool.
  */
-public class ITestAbfsByteBufferPool {
+public class TestAbfsByteBufferPool {
 
   private static final int TWO_MB = 2 * 1024 * 1024;
 
@@ -75,8 +97,8 @@ public class ITestAbfsByteBufferPool {
   @Test
   public void testReleaseMoreThanPoolCapacity() {
     int maxFreeBuffers = 4;
-    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB,
-        maxFreeBuffers, 25);
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, maxFreeBuffers,
+        25);
     int expectedPoolCapacity = maxFreeBuffers;
     for (int i = 0; i < expectedPoolCapacity * 2; i++) {
       pool.release(new byte[TWO_MB]);
@@ -114,30 +136,41 @@ public class ITestAbfsByteBufferPool {
     int maxFreeBuffers = 4;
     int expectedMaxBuffersInUse =
         maxFreeBuffers + Runtime.getRuntime().availableProcessors();
-    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB,
-        maxFreeBuffers, 90);
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, maxFreeBuffers,
+        90);
 
+    //  Getting the maximum number of byte arrays from the pool
+    byte[] byteBuffer = null;
     for (int i = 0; i < expectedMaxBuffersInUse; i++) {
-      byte[] byteBuffer = pool.get();
+      byteBuffer = pool.get();
       assertThat(byteBuffer.length).describedAs("Pool has to return an object "
           + "immediately, until maximum buffers are in use.").isEqualTo(TWO_MB);
     }
 
-    pool.release(new byte[2 * 1024 * 1024]);
-    byte[] byteBuffer = pool.get();
-    assertThat(byteBuffer.length).describedAs("Pool has to return an object "
-        + "immediately, if there are free buffers available in the pool.")
-        .isEqualTo(TWO_MB);
-
+    //  Already maximum number of buffers are retrieved from the pool so the
+    //  next get call is going to be blocked
     Thread getThread = new Thread(() -> pool.get());
     getThread.start();
-    Thread.sleep(5000);
+    sleep(5000);
     assertThat(getThread.getState()).describedAs("When maximum number of "
         + "buffers are in use and no free buffers available in the pool the "
         + "get call is blocked until an object is released to the pool.")
         .isEqualTo(State.WAITING);
     getThread.interrupt();
 
+    //  Releasing one byte array back to the pool post which the get call we
+    //  are making should not be blocking
+    pool.release(byteBuffer);
+    byteBuffer = null;
+    byteBuffer = pool.get();
+    assertThat(byteBuffer.length).describedAs("Pool has to return an object "
+        + "immediately, if there are free buffers available in the pool.")
+        .isEqualTo(TWO_MB);
+
+    //  Again trying to get one byte buffer from the pool which will be
+    //  blocked as the pool has already dished out the maximum number of byte
+    //  arrays. Then we release another byte array and the blocked get call
+    //  gets unblocked.
     Callable<byte[]> callable = () -> pool.get();
     FutureTask futureTask = new FutureTask(callable);
     getThread = new Thread(futureTask);
@@ -184,5 +217,109 @@ public class ITestAbfsByteBufferPool {
               + "calculated by maxFreeBuffers")
           .isLessThanOrEqualTo((int) Math.ceil(bufferCountByMemory));
     }
+  }
+
+  @Test
+  public void testSynchronisation() throws Throwable {
+    final int maxFreeBuffers = 4;
+    final int expectedMaxBuffersInUse =
+        maxFreeBuffers + Runtime.getRuntime().availableProcessors();
+    final AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB,
+        maxFreeBuffers, 90);
+
+    final int numCategoryOfThreads = 4;
+    final int numThreadsForEachCategory = 4;
+    final int totalThreadCount =
+        numCategoryOfThreads * numThreadsForEachCategory;
+
+    final LinkedBlockingQueue<byte[]> objsQueue = new LinkedBlockingQueue();
+    final Waiter waiter = new Waiter();
+
+    //  Creating 3 types of runnables
+    //  getter: would make get calls
+    //  releaser: would make release calls
+    //  verifier: will be verifying the conditions
+    final Runnable getter = getNewGetterRunnable(pool, objsQueue, waiter,
+        expectedMaxBuffersInUse, maxFreeBuffers);
+    final Runnable releaser = getNewReleaserRunnable(pool, objsQueue, waiter,
+        expectedMaxBuffersInUse, maxFreeBuffers);
+    final Runnable verifier = getNewVerifierRunnable(pool,
+        expectedMaxBuffersInUse, maxFreeBuffers, waiter);
+
+    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors
+        .newFixedThreadPool(50);
+    for (int i = 0; i < numThreadsForEachCategory; i++) {
+      executor.submit(new Thread(getter));
+      executor.submit(new Thread(releaser));
+      executor.submit(new Thread(verifier));
+      executor.submit(new Thread(verifier));
+    }
+    waiter.await(60000, totalThreadCount);
+    executor.shutdown();
+  }
+
+  private Runnable getNewGetterRunnable(final AbfsByteBufferPool pool,
+      final LinkedBlockingQueue<byte[]> objsQueue, final Waiter waiter,
+      final int expectedMaxBuffersInUse, final int maxFreeBuffers) {
+    Runnable runnable = () -> {
+      for (int i = 0; i < 25; i++) {
+        verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+        objsQueue.offer(pool.get());
+        verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+        try {
+          sleep(100);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      waiter.resume();
+    };
+    return runnable;
+  }
+
+  private Runnable getNewReleaserRunnable(final AbfsByteBufferPool pool,
+      final LinkedBlockingQueue<byte[]> objsQueue, final Waiter waiter,
+      final int expectedMaxBuffersInUse, final int maxFreeBuffers) {
+    Runnable runnable = () -> {
+      for (int i = 0; i < 25; i++) {
+        try {
+          verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+          pool.release(objsQueue.take());
+          verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+          sleep(100);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      waiter.resume();
+    };
+    return runnable;
+  }
+
+  private Runnable getNewVerifierRunnable(final AbfsByteBufferPool pool,
+      final int expectedMaxBuffersInUse, final int maxFreeBuffers,
+      final Waiter waiter) {
+    Runnable runnable = () -> {
+      for (int i = 0; i < 25; i++) {
+        verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+        try {
+          sleep(50);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      waiter.resume();
+    };
+    return runnable;
+  }
+
+  private void verify(final AbfsByteBufferPool pool, final Waiter waiter,
+      final int maxFreeBuffers, final int expectedMaxBuffersInUse) {
+    waiter.assertThat(pool.getFreeBuffers(), is(notNullValue()));
+    waiter.assertThat(pool.getFreeBuffers().size(),
+        is(lessThanOrEqualTo(maxFreeBuffers)));
+    waiter.assertThat(pool.getBuffersInUse(),
+        is(lessThanOrEqualTo(expectedMaxBuffersInUse)));
+    waiter.assertThat(pool.getBuffersInUse(), is(greaterThanOrEqualTo(0)));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsByteBufferPool.java
@@ -17,43 +17,29 @@
  */
 package org.apache.hadoop.fs.azurebfs.services;
 
-import net.jodah.concurrentunit.Waiter;
-import org.hamcrest.Matchers;
-import org.hamcrest.core.Is;
-import org.hamcrest.core.IsNull;
-import org.junit.Test;
-
 import java.lang.Thread.State;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
+
+import org.junit.Test;
+import net.jodah.concurrentunit.Waiter;
 
 import static java.lang.Thread.sleep;
+
+import static org.assertj.core.api.Assertions.assertThat;;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.core.Is.is;
+
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.doesNotHave;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
 
 /**
  * Test class for AbfsByteBufferPool.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -22,6 +22,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
 
+import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsPerfTracker;
+import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.conf.Configuration;
 
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_WRITE_BUFFER_SIZE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
@@ -62,6 +68,7 @@ public final class TestAbfsOutputStream {
     AbfsRestOperation op = mock(AbfsRestOperation.class);
     AbfsConfiguration abfsConf;
     final Configuration conf = new Configuration();
+    conf.setInt(AZURE_WRITE_BUFFER_SIZE, bufferSize);
     conf.set(accountKey1, accountValue1);
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
@@ -69,7 +76,6 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
-    abfsConf.setWriteBufferSize(bufferSize);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[writeSize];
     new Random().nextBytes(b);
@@ -113,6 +119,7 @@ public final class TestAbfsOutputStream {
     AbfsRestOperation op = mock(AbfsRestOperation.class);
     AbfsConfiguration abfsConf;
     final Configuration conf = new Configuration();
+    conf.setInt(AZURE_WRITE_BUFFER_SIZE, bufferSize);
     conf.set(accountKey1, accountValue1);
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
@@ -121,7 +128,6 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
-    abfsConf.setWriteBufferSize(bufferSize);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[writeSize];
     new Random().nextBytes(b);
@@ -170,7 +176,6 @@ public final class TestAbfsOutputStream {
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
-    abfsConf.setWriteBufferSize(bufferSize);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
@@ -222,6 +227,7 @@ public final class TestAbfsOutputStream {
     AbfsRestOperation op = mock(AbfsRestOperation.class);
     AbfsConfiguration abfsConf;
     final Configuration conf = new Configuration();
+    conf.setInt(AZURE_WRITE_BUFFER_SIZE, bufferSize);
     conf.set(accountKey1, accountValue1);
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
@@ -230,7 +236,6 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
-    abfsConf.setWriteBufferSize(bufferSize);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
@@ -271,6 +276,7 @@ public final class TestAbfsOutputStream {
     AbfsRestOperation op = mock(AbfsRestOperation.class);
     AbfsConfiguration abfsConf;
     final Configuration conf = new Configuration();
+    conf.setInt(AZURE_WRITE_BUFFER_SIZE, bufferSize);
     conf.set(accountKey1, accountValue1);
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
@@ -279,7 +285,6 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
-    abfsConf.setWriteBufferSize(bufferSize);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
@@ -319,6 +324,7 @@ public final class TestAbfsOutputStream {
     AbfsRestOperation op = mock(AbfsRestOperation.class);
     AbfsConfiguration abfsConf;
     final Configuration conf = new Configuration();
+    conf.setInt(AZURE_WRITE_BUFFER_SIZE, bufferSize);
     conf.set(accountKey1, accountValue1);
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
@@ -327,7 +333,6 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    abfsConf.setWriteBufferSize(bufferSize);
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
@@ -380,6 +385,7 @@ public final class TestAbfsOutputStream {
     AbfsRestOperation op = mock(AbfsRestOperation.class);
     AbfsConfiguration abfsConf;
     final Configuration conf = new Configuration();
+    conf.setInt(AZURE_WRITE_BUFFER_SIZE, bufferSize);
     conf.set(accountKey1, accountValue1);
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
@@ -388,7 +394,6 @@ public final class TestAbfsOutputStream {
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
-    abfsConf.setWriteBufferSize(bufferSize);
     out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -68,7 +68,9 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[writeSize];
     new Random().nextBytes(b);
     out.write(b);
@@ -118,7 +120,9 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[writeSize];
     new Random().nextBytes(b);
 
@@ -165,7 +169,9 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -223,7 +229,9 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -270,7 +278,9 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -317,7 +327,9 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -374,7 +386,9 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    abfsConf.setWriteBufferSize(bufferSize);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -328,8 +328,8 @@ public final class TestAbfsOutputStream {
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     abfsConf.setWriteBufferSize(bufferSize);
-    AbfsOutputStream.initWriteBufferPool(abfsConf);
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
+    out.initWriteBufferPool(abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -68,7 +68,7 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[writeSize];
     new Random().nextBytes(b);
     out.write(b);
@@ -118,7 +118,7 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[writeSize];
     new Random().nextBytes(b);
 
@@ -165,7 +165,7 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -223,7 +223,7 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -270,7 +270,7 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -317,7 +317,7 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -374,7 +374,7 @@ public final class TestAbfsOutputStream {
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, bufferSize, true, false, true, false, abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -327,9 +327,9 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
     abfsConf.setWriteBufferSize(bufferSize);
-    out.initWriteBufferPool(abfsConf);
+    AbfsOutputStream.initWriteBufferPool(abfsConf);
+    AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
     final byte[] b = new byte[bufferSize];
     new Random().nextBytes(b);
 
@@ -385,6 +385,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
     when(client.append(anyString(), anyLong(), any(byte[].class), anyInt(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(op);
+    when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, path, 0, true, false, true, false, abfsConf);
     abfsConf.setWriteBufferSize(bufferSize);


### PR DESCRIPTION
HADOOP-16854 Fix to prevent OutOfMemoryException and Make the threadpool and bytebuffer pool common across all AbfsOutputStream instances