### PR TITLE
Revert "HADOOP-16054. Update Dockerfile to use Bionic."

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -18,7 +18,7 @@
 # Dockerfile for installing the necessary dependencies for building Hadoop.
 # See BUILDING.txt.
 
-FROM ubuntu:bionic
+FROM ubuntu:xenial
 
 WORKDIR /root
 
@@ -44,11 +44,9 @@ ENV DEBCONF_TERSE true
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends \
         apt-utils \
-        bats \
         build-essential \
         bzip2 \
         clang \
-        cmake \
         curl \
         doxygen \
         fuse \
@@ -64,7 +62,6 @@ RUN apt-get -q update \
         libsasl2-dev \
         libsnappy-dev \
         libssl-dev \
-        libsnappy-dev \
         libtool \
         libzstd1-dev \
         locales \
@@ -78,8 +75,8 @@ RUN apt-get -q update \
         python-setuptools \
         python-wheel \
         rsync \
-        shellcheck \
         software-properties-common \
+        snappy \
         sudo \
         valgrind \
         zlib1g-dev \
@@ -96,8 +93,20 @@ RUN apt-get -q update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+
 ######
-# Install Google Protobuf 3.7.1 (3.0.0 ships with Bionic)
+# Install cmake 3.1.0 (3.5.1 ships with Xenial)
+######
+RUN mkdir -p /opt/cmake \
+    && curl -L -s -S \
+      https://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz \
+      -o /opt/cmake.tar.gz \
+    && tar xzf /opt/cmake.tar.gz --strip-components 1 -C /opt/cmake
+ENV CMAKE_HOME /opt/cmake
+ENV PATH "${PATH}:/opt/cmake/bin"
+
+######
+# Install Google Protobuf 3.7.1 (2.6.0 ships with Xenial)
 ######
 # hadolint ignore=DL3003
 RUN mkdir -p /opt/protobuf-src \
@@ -114,7 +123,7 @@ ENV PROTOBUF_HOME /opt/protobuf
 ENV PATH "${PATH}:/opt/protobuf/bin"
 
 ######
-# Install Apache Maven 3.6.0 (3.6.0 ships with Bionic)
+# Install Apache Maven 3.3.9 (3.3.9 ships with Xenial)
 ######
 # hadolint ignore=DL3008
 RUN apt-get -q update \
@@ -122,11 +131,9 @@ RUN apt-get -q update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ENV MAVEN_HOME /usr
-# JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 ######
-# Install findbugs 3.1.0 (3.1.0 ships with Bionic)
+# Install findbugs 3.0.1 (3.0.1 ships with Xenial)
 # Ant is needed for findbugs
 ######
 # hadolint ignore=DL3008
@@ -135,6 +142,25 @@ RUN apt-get -q update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ENV FINDBUGS_HOME /usr
+
+####
+# Install shellcheck (0.4.6, the latest as of 2017-09-26)
+####
+# hadolint ignore=DL3008
+RUN add-apt-repository -y ppa:hvr/ghc \
+    && apt-get -q update \
+    && apt-get -q install -y --no-install-recommends shellcheck ghc-8.0.2 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+####
+# Install bats (0.4.0, the latest as of 2017-09-26, ships with Xenial)
+####
+# hadolint ignore=DL3008
+RUN apt-get -q update \
+    && apt-get -q install -y --no-install-recommends bats \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ####
 # Install pylint at fixed version (2.0.0 removed python2 support)


### PR DESCRIPTION
This reverts commit 367833cf41753f5b1c996f9a2a9c1f20e2011173.

The precommit job fails to add comments to JIRA and GitHub after the upgrade of the build image. Revert the upgrade to see if the precommit job can add comment to GitHub.