### PR TITLE
MAPREDUCE-7241. FileInputFormat listStatus with less memory footprint

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/FileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/FileInputFormat.java
@@ -193,7 +193,8 @@ public abstract class FileInputFormat<K, V> implements InputFormat<K, V> {
         if (stat.isDirectory()) {
           addInputPathRecursively(result, fs, stat.getPath(), inputFilter);
         } else {
-          result.add(stat);
+          result.add(org.apache.hadoop.mapreduce.lib.input.
+              FileInputFormat.shrinkStatus(stat));
         }
       }
     }
@@ -290,7 +291,8 @@ public abstract class FileInputFormat<K, V> implements InputFormat<K, V> {
                   addInputPathRecursively(result, fs, stat.getPath(),
                       inputFilter);
                 } else {
-                  result.add(stat);
+                  result.add(org.apache.hadoop.mapreduce.lib.input.
+                      FileInputFormat.shrinkStatus(stat));
                 }
               }
             }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/LocatedFileStatusFetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/LocatedFileStatusFetcher.java
@@ -259,7 +259,8 @@ public class LocatedFileStatusFetcher {
             if (recursive && stat.isDirectory()) {
               result.dirsNeedingRecursiveCalls.add(stat);
             } else {
-              result.locatedFileStatuses.add(stat);
+              result.locatedFileStatuses.add(org.apache.hadoop.mapreduce.lib.
+                  input.FileInputFormat.shrinkStatus(stat));
             }
           }
         }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/FileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/FileInputFormat.java
@@ -370,6 +370,19 @@ public abstract class FileInputFormat<K, V> extends InputFormat<K, V> {
     }
   }
 
+  /**
+   * The HdfsBlockLocation includes a LocatedBlock which contains messages
+   * for issuing more detailed queries to datanodes about a block, but these
+   * messages are useless during job submission currently. This method tries
+   * to exclude the LocatedBlock from HdfsBlockLocation by creating a new
+   * BlockLocation from original, reshaping the LocatedFileStatus,
+   * allowing {@link #listStatus(JobContext)} to scan more files with less
+   * memory footprint.
+   * @see BlockLocation
+   * @see org.apache.hadoop.fs.HdfsBlockLocation
+   * @param origStat The fat FileStatus.
+   * @return The FileStatus that has been shrunk.
+   */
   public static FileStatus shrinkStatus(FileStatus origStat) {
     if (origStat.isDirectory() || origStat.getLen() == 0 ||
         !(origStat instanceof LocatedFileStatus)) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFileInputFormat.java
@@ -258,6 +258,8 @@ public class TestFileInputFormat {
           (LocatedFileStatus)FileInputFormat.shrinkStatus(orig);
       Assert.assertTrue(orig.equals(shrink));
       if (shrink.getBlockLocations() != null) {
+        Assert.assertEquals(orig.getBlockLocations().length,
+            shrink.getBlockLocations().length);
         for (int i = 0; i < shrink.getBlockLocations().length; i++) {
           verified = true;
           BlockLocation location = shrink.getBlockLocations()[i];
@@ -266,18 +268,14 @@ public class TestFileInputFormat {
           Assert.assertEquals(BlockLocation.class.getName(),
               location.getClass().getName());
           Assert.assertArrayEquals(actual.getHosts(), location.getHosts());
-          Assert.assertArrayEquals(
-              actual.getCachedHosts(), location.getCachedHosts()
-          );
-          Assert.assertArrayEquals(
-              actual.getStorageIds(), location.getStorageIds()
-          );
-          Assert.assertArrayEquals(
-              actual.getStorageTypes(), location.getStorageTypes()
-          );
-          Assert.assertArrayEquals(
-              actual.getTopologyPaths(), location.getTopologyPaths()
-          );
+          Assert.assertArrayEquals(actual.getCachedHosts(),
+              location.getCachedHosts());
+          Assert.assertArrayEquals(actual.getStorageIds(),
+              location.getStorageIds());
+          Assert.assertArrayEquals(actual.getStorageTypes(),
+              location.getStorageTypes());
+          Assert.assertArrayEquals(actual.getTopologyPaths(),
+              location.getTopologyPaths());
           Assert.assertArrayEquals(actual.getNames(), location.getNames());
           Assert.assertEquals(actual.getLength(), location.getLength());
           Assert.assertEquals(actual.getOffset(), location.getOffset());
@@ -500,8 +498,8 @@ public class TestFileInputFormat {
       ExtendedBlock b1 = new ExtendedBlock("bpid", 0, blockLen, 0);
       ExtendedBlock b2 = new ExtendedBlock("bpid", 1, blockLen, 1);
       ExtendedBlock b3 = new ExtendedBlock("bpid", 2, len - 2 * blockLen, 2);
-      String[] names = new String[] { "localhost:9866", "otherhost:9866" };
-      String[] hosts = new String[] { "localhost", "otherhost" };
+      String[] names = new String[]{ "localhost:9866", "otherhost:9866" };
+      String[] hosts = new String[]{ "localhost", "otherhost" };
       String[] cachedHosts = {"localhost"};
       BlockLocation loc1 = new BlockLocation(names, hosts, cachedHosts,
           new String[0], 0, blockLen, false);
@@ -512,8 +510,7 @@ public class TestFileInputFormat {
       return new BlockLocation[]{
           new HdfsBlockLocation(loc1, new LocatedBlock(b1, ds)),
           new HdfsBlockLocation(loc2, new LocatedBlock(b2, ds)),
-          new HdfsBlockLocation(loc3, new LocatedBlock(b3, ds))
-      };
+          new HdfsBlockLocation(loc3, new LocatedBlock(b3, ds)) };
     }
 
     @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFileInputFormat.java
@@ -238,6 +238,44 @@ public class TestFileInputFormat {
     }
   }
 
+  @Test
+  public void testShrinkStatus() throws IOException {
+    Configuration conf = getConfiguration();
+    MockFileSystem mockFs =
+            (MockFileSystem) new Path("test:///").getFileSystem(conf);
+    Path dir1  = new Path("test:/a1");
+    RemoteIterator<LocatedFileStatus> statuses = mockFs.listLocatedStatus(dir1);
+    while (statuses.hasNext()) {
+      LocatedFileStatus orig = statuses.next();
+      LocatedFileStatus shrink =
+          (LocatedFileStatus)FileInputFormat.shrinkStatus(orig);
+      Assert.assertTrue(orig.equals(shrink));
+      if (shrink.getBlockLocations() != null) {
+        BlockLocation location = shrink.getBlockLocations()[0];
+        BlockLocation actual = orig.getBlockLocations()[0];
+        Assert.assertArrayEquals(actual.getHosts(), location.getHosts());
+        Assert.assertArrayEquals(
+            actual.getCachedHosts(), location.getCachedHosts()
+        );
+        Assert.assertArrayEquals(
+            actual.getStorageIds(), location.getStorageIds()
+        );
+        Assert.assertArrayEquals(
+            actual.getStorageTypes(), location.getStorageTypes()
+        );
+        Assert.assertArrayEquals(
+            actual.getTopologyPaths(), location.getTopologyPaths()
+        );
+        Assert.assertArrayEquals(actual.getNames(), location.getNames());
+        Assert.assertEquals(actual.getLength(), location.getLength());
+        Assert.assertEquals(actual.getOffset(), location.getOffset());
+        Assert.assertEquals(actual.isCorrupt(), location.isCorrupt());
+      } else {
+        Assert.assertTrue(orig.getBlockLocations() == null);
+      }
+    }
+  }
+
   public static List<Path> configureTestSimple(Configuration conf, FileSystem localFs)
       throws IOException {
     Path base1 = new Path(TEST_ROOT_DIR, "input1");


### PR DESCRIPTION
LocatedFileStatus returned by fs.listLocatedStatus contains the LocatedBlock, which is useless when MR submitting jobs.  The patch tries to exclude the LocatedBlock from the LocatedFileStatus, allows MR scanning more files with less memory footprint.