### PR TITLE
HADOOP-16922. ABFS: Change User-Agent header

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -171,6 +171,14 @@ public class AbfsConfiguration{
       DefaultValue = "")
   private String userAgentId;
 
+  @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_CLUSTER_NAME,
+      DefaultValue = DEFAULT_VALUE_UNKNOWN)
+  private String clusterName;
+
+  @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_CLUSTER_TYPE,
+      DefaultValue = DEFAULT_VALUE_UNKNOWN)
+  private String clusterType;
+
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_ENABLE_DELEGATION_TOKEN,
       DefaultValue = DEFAULT_ENABLE_DELEGATION_TOKEN)
   private boolean enableDelegationToken;
@@ -477,6 +485,14 @@ public class AbfsConfiguration{
 
   public String getCustomUserAgentPrefix() {
     return this.userAgentId;
+  }
+
+  public String getClusterName() {
+    return this.clusterName;
+  }
+
+  public String getClusterType() {
+    return this.clusterType;
   }
 
   public DelegatingSSLSocketFactory.SSLChannelMode getPreferredSSLFactoryOption() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -168,7 +168,7 @@ public class AbfsConfiguration{
   private boolean enableAutoThrottling;
 
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_USER_AGENT_PREFIX_KEY,
-      DefaultValue = "")
+      DefaultValue = DEFAULT_FS_AZURE_USER_AGENT_PREFIX)
   private String userAgentId;
 
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_CLUSTER_NAME,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -42,6 +42,7 @@ public final class AbfsHttpConstants {
   public static final String DEFAULT_TIMEOUT = "90";
   public static final String TOKEN_VERSION = "2";
 
+  public static final String JAVA_VENDOR = "java.vendor";
   public static final String JAVA_VERSION = "java.version";
   public static final String OS_NAME = "os.name";
   public static final String OS_VERSION = "os.version";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -45,7 +45,9 @@ public final class AbfsHttpConstants {
   public static final String JAVA_VERSION = "java.version";
   public static final String OS_NAME = "os.name";
   public static final String OS_VERSION = "os.version";
+  public static final String OS_ARCH = "os.arch";
 
+  public static final String APN_VERSION = "APN/1.0";
   public static final String CLIENT_VERSION = "Azure Blob FS/" + VersionInfo.getVersion();
 
   // Abfs Http Verb

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -62,6 +62,8 @@ public final class ConfigurationKeys {
    *  Default value of this config is true. **/
   public static final String FS_AZURE_DISABLE_OUTPUTSTREAM_FLUSH = "fs.azure.disable.outputstream.flush";
   public static final String FS_AZURE_USER_AGENT_PREFIX_KEY = "fs.azure.user.agent.prefix";
+  public static final String FS_AZURE_CLUSTER_NAME = "fs.azure.cluster.name";
+  public static final String FS_AZURE_CLUSTER_TYPE = "fs.azure.cluster.type";
   public static final String FS_AZURE_SSL_CHANNEL_MODE_KEY = "fs.azure.ssl.channel.mode";
   /** Provides a config to enable/disable the checkAccess API.
    *  By default this will be

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+
 /**
  * Responsible to keep all the Azure Blob File System related configurations.
  */
@@ -71,6 +73,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_ENABLE_CHECK_ACCESS = false;
   public static final boolean DEFAULT_ABFS_LATENCY_TRACK = false;
 
+  public static final String DEFAULT_FS_AZURE_USER_AGENT_PREFIX = EMPTY_STRING;
   public static final String DEFAULT_VALUE_UNKNOWN = "UNKNOWN";
 
   private FileSystemConfigurations() {}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -71,5 +71,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_ENABLE_CHECK_ACCESS = false;
   public static final boolean DEFAULT_ABFS_LATENCY_TRACK = false;
 
+  public static final String DEFAULT_VALUE_UNKNOWN = "UNKNOWN";
+
   private FileSystemConfigurations() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -679,32 +679,56 @@ public class AbfsClient implements Closeable {
 
   @VisibleForTesting
   String initializeUserAgent(final AbfsConfiguration abfsConfiguration,
-                             final String sslProviderName) {
+      final String sslProviderName) {
+
     StringBuilder sb = new StringBuilder();
-    sb.append("(JavaJRE ");
+
+    sb.append(APN_VERSION);
+    sb.append(SINGLE_WHITE_SPACE);
+    sb.append(CLIENT_VERSION);
+    sb.append(SINGLE_WHITE_SPACE);
+
+    sb.append("(");
+
+    sb.append("JavaJRE");
+    sb.append(SINGLE_WHITE_SPACE);
     sb.append(System.getProperty(JAVA_VERSION));
-    sb.append("; ");
-    sb.append(
-        System.getProperty(OS_NAME).replaceAll(SINGLE_WHITE_SPACE, EMPTY_STRING));
-    sb.append(" ");
+    sb.append(SEMICOLON);
+    sb.append(SINGLE_WHITE_SPACE);
+
+    sb.append(System.getProperty(OS_NAME)
+        .replaceAll(SINGLE_WHITE_SPACE, EMPTY_STRING));
+    sb.append(SINGLE_WHITE_SPACE);
     sb.append(System.getProperty(OS_VERSION));
-    if (sslProviderName != null && !sslProviderName.isEmpty()) {
-      sb.append("; ");
-      sb.append(sslProviderName);
-    }
-    String tokenProviderField =
-        ExtensionHelper.getUserAgentSuffix(tokenProvider, "");
-    if (!tokenProviderField.isEmpty()) {
-      sb.append("; ").append(tokenProviderField);
-    }
+    sb.append(FORWARD_SLASH);
+    sb.append(System.getProperty(OS_ARCH));
+
+    appendIfNotEmpty(sb, sslProviderName, true);
+    appendIfNotEmpty(sb,
+        ExtensionHelper.getUserAgentSuffix(tokenProvider, EMPTY_STRING), true);
+
+    sb.append(SINGLE_WHITE_SPACE);
+    sb.append(abfsConfiguration.getClusterName());
+    sb.append(FORWARD_SLASH);
+    sb.append(abfsConfiguration.getClusterType());
+
     sb.append(")");
-    final String userAgentComment = sb.toString();
-    String customUserAgentId = abfsConfiguration.getCustomUserAgentPrefix();
-    if (customUserAgentId != null && !customUserAgentId.isEmpty()) {
-      return String.format(Locale.ROOT, CLIENT_VERSION + " %s %s",
-          userAgentComment, customUserAgentId);
+
+    appendIfNotEmpty(sb, abfsConfiguration.getCustomUserAgentPrefix(), false);
+
+    return String.format(Locale.ROOT, sb.toString());
+  }
+
+  private void appendIfNotEmpty(StringBuilder sb, String str,
+      boolean shouldPrependSemiColon) {
+    if (str == null || str.trim().isEmpty()) {
+      return;
     }
-    return String.format(Locale.ROOT, CLIENT_VERSION + " %s", userAgentComment);
+    if (shouldPrependSemiColon) {
+      sb.append(SEMICOLON);
+    }
+    sb.append(SINGLE_WHITE_SPACE);
+    sb.append(str);
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -702,6 +702,7 @@ public class AbfsClient implements Closeable {
     sb.append(System.getProperty(OS_VERSION));
     sb.append(FORWARD_SLASH);
     sb.append(System.getProperty(OS_ARCH));
+    sb.append(SEMICOLON);
 
     appendIfNotEmpty(sb, sslProviderName, true);
     appendIfNotEmpty(sb,
@@ -719,16 +720,16 @@ public class AbfsClient implements Closeable {
     return String.format(Locale.ROOT, sb.toString());
   }
 
-  private void appendIfNotEmpty(StringBuilder sb, String str,
-      boolean shouldPrependSemiColon) {
-    if (str == null || str.trim().isEmpty()) {
+  private void appendIfNotEmpty(StringBuilder sb, String regEx,
+      boolean shouldAppendSemiColon) {
+    if (regEx == null || regEx.trim().isEmpty()) {
       return;
     }
-    if (shouldPrependSemiColon) {
+    sb.append(SINGLE_WHITE_SPACE);
+    sb.append(regEx);
+    if (shouldAppendSemiColon) {
       sb.append(SEMICOLON);
     }
-    sb.append(SINGLE_WHITE_SPACE);
-    sb.append(str);
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -690,6 +690,9 @@ public class AbfsClient implements Closeable {
 
     sb.append("(");
 
+    sb.append(System.getProperty(JAVA_VENDOR)
+        .replaceAll(SINGLE_WHITE_SPACE, EMPTY_STRING));
+    sb.append(SINGLE_WHITE_SPACE);
     sb.append("JavaJRE");
     sb.append(SINGLE_WHITE_SPACE);
     sb.append(System.getProperty(JAVA_VERSION));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -112,8 +112,10 @@ public final class TestAbfsClient {
     configuration.addResource(TEST_CONFIGURATION_FILE_NAME);
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
-    String userAgentStr = getUserAgentString(abfsConfiguration, false);
+    verifybBasicInfo(getUserAgentString(abfsConfiguration, false));
+  }
 
+  private void verifybBasicInfo(String userAgentStr) {
     assertThat(userAgentStr)
         .describedAs("User-Agent string [" + userAgentStr
             + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
@@ -142,10 +144,8 @@ public final class TestAbfsClient {
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
       .contains(FS_AZURE_USER_AGENT_PREFIX);
 
@@ -154,10 +154,8 @@ public final class TestAbfsClient {
         ACCOUNT_NAME);
     userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: "+this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should not contain " + FS_AZURE_USER_AGENT_PREFIX)
       .doesNotContain(FS_AZURE_USER_AGENT_PREFIX);
   }
@@ -172,19 +170,15 @@ public final class TestAbfsClient {
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, true);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should contain sslProvider")
       .contains(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
 
     userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should not contain sslProvider")
       .doesNotContain(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
   }
@@ -199,24 +193,21 @@ public final class TestAbfsClient {
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should contain cluster name")
       .contains(clusterName);
 
     configuration.unset(FS_AZURE_CLUSTER_NAME);
     abfsConfiguration = new AbfsConfiguration(configuration,
-        ACCOUNT_NAME);userAgentStr = getUserAgentString(abfsConfiguration, false);
+        ACCOUNT_NAME);
+    userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should not contain cluster name")
       .doesNotContain(clusterName)
-      .describedAs("User-Agent string should contain cluster UNKNOWN")
+      .describedAs("User-Agent string should contain UNKNOWN as cluster name config is absent")
       .contains("UNKNOWN");;
   }
 
@@ -230,24 +221,22 @@ public final class TestAbfsClient {
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should contain cluster type")
       .contains(clusterType);
 
     configuration.unset(FS_AZURE_CLUSTER_TYPE);
     abfsConfiguration = new AbfsConfiguration(configuration,
-        ACCOUNT_NAME);userAgentStr = getUserAgentString(abfsConfiguration, false);
+        ACCOUNT_NAME);
+    userAgentStr = getUserAgentString(abfsConfiguration, false);
 
+    verifybBasicInfo(userAgentStr);
     assertThat(userAgentStr)
-      .describedAs("User-Agent string [" + userAgentStr
-          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-      .matches(this.userAgentStringPattern)
       .describedAs("User-Agent string should not contain cluster type")
       .doesNotContain(clusterType)
-      .describedAs("User-Agent string should contain cluster UNKNOWN")
+      .describedAs("User-Agent string should contain UNKNOWN as cluster type config is absent")
       .contains("UNKNOWN");
   }
+
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -23,16 +23,15 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Pattern;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.APN_VERSION;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CLIENT_VERSION;
@@ -48,7 +47,6 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_W
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLUSTER_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLUSTER_TYPE;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test useragent of abfs client.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -23,6 +23,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Pattern;
 
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.apache.hadoop.util.VersionInfo;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -63,31 +65,31 @@ public final class TestAbfsClient {
     regEx.append("\\(");
     regEx.append("JavaJRE");
     regEx.append(SINGLE_WHITE_SPACE);
-    regEx.append("\\d+(\\.\\d+_?\\d*)*");  //  Regex for java version
+    regEx.append("\\d+(\\.\\d+_?\\d+)*"); //  Regex for java version
     regEx.append(SEMICOLON);
     regEx.append(SINGLE_WHITE_SPACE);
-    regEx.append("[a-zA-Z].*");            //   Regex for OS name and version
+    regEx.append("[a-zA-Z].*");           //   Regex for OS name and version
     regEx.append(FORWARD_SLASH);
-    regEx.append(".*");                    //  Regex for OS arch
-    regEx.append("(;[a-zA-Z].*)?");         // Regex for sslProviderName
-    regEx.append("(;[a-zA-Z].*)?");         // Regex for tokenProvider
+    regEx.append(".*");                   //  Regex for OS arch
+    regEx.append("(; [a-zA-Z].*)?");      // Regex for sslProviderName
+    regEx.append("(; [a-zA-Z].*)?");      // Regex for tokenProvider
     regEx.append(SINGLE_WHITE_SPACE);
-    regEx.append(".+");                      //cluster name
+    regEx.append(".+");                   //cluster name
     regEx.append(FORWARD_SLASH);
     regEx.append(".+");            // cluster type
     regEx.append("\\)");
-    regEx.append("( .*)?");                      //  Regex for user agent prefix
+    regEx.append("( .*)?");        //  Regex for user agent prefix
     this.userAgentStringPattern = Pattern.compile(regEx.toString());
   }
 
   private String getUserAgentString(AbfsConfiguration config,
-                                 boolean includeSSLProvider)
-      throws MalformedURLException {
-    AbfsClient client = new AbfsClient(new URL("http://azure.com"), null,
+      boolean includeSSLProvider) throws MalformedURLException {
+    AbfsClient client = new AbfsClient(new URL("https://azure.com"), null,
         config, null, (AccessTokenProvider) null, null);
     String sslProviderName = null;
     if (includeSSLProvider) {
-      sslProviderName = DelegatingSSLSocketFactory.getDefaultFactory().getProviderName();
+      sslProviderName = DelegatingSSLSocketFactory.getDefaultFactory()
+          .getProviderName();
     }
     return client.initializeUserAgent(config, sslProviderName);
   }
@@ -101,8 +103,11 @@ public final class TestAbfsClient {
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(
         abfsConfiguration, false);
-    Assertions.assertThat(userAgentStr).describedAs("User-Agent string ["+userAgentStr
-        + "] should be of the pattern: "+this.userAgentStringPattern.pattern()).matches(this.userAgentStringPattern);
+
+    Assertions.assertThat(userAgentStr)
+        .describedAs("User-Agent string [" + userAgentStr
+            + "] should be of the pattern: "+this.userAgentStringPattern.pattern())
+        .matches(this.userAgentStringPattern);
   }
 
   @Test
@@ -112,10 +117,12 @@ public final class TestAbfsClient {
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
-    Assertions.assertThat(userAgentStr).describedAs("User-Agent string ["+userAgentStr
-        + "] should be of the pattern: " + this.userAgentStringPattern
-        .pattern()).matches(this.userAgentStringPattern).describedAs(
-        "User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
+
+    Assertions.assertThat(userAgentStr)
+        .describedAs("User-Agent string [" + userAgentStr
+            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+        .matches(this.userAgentStringPattern)
+        .describedAs("User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
         .contains(FS_AZURE_USER_AGENT_PREFIX);
   }
 
@@ -128,13 +135,14 @@ public final class TestAbfsClient {
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, true);
-    Assertions.assertThat(userAgentStr).describedAs("User-Agent string ["+userAgentStr
-        + "] should be of the pattern: " + this.userAgentStringPattern
-        .pattern()).matches(this.userAgentStringPattern).describedAs(
-        "User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
+
+    Assertions.assertThat(userAgentStr)
+        .describedAs("User-Agent string [" + userAgentStr
+            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+        .matches(this.userAgentStringPattern)
+        .describedAs("User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
         .contains(FS_AZURE_USER_AGENT_PREFIX)
-        .describedAs("User-Agent string " + "should contain sslProvider")
-        .contains(
-            DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE.name());
+        .describedAs("User-Agent string should contain sslProvider")
+        .contains(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -54,7 +54,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test useragent of abfs client.
  *
  */
-@RunWith(JUnit4.class)
 public final class TestAbfsClient {
 
   private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -46,6 +46,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SEMICOLO
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLUSTER_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLUSTER_TYPE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DEFAULT_VALUE_UNKNOWN;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME;
 
 /**
@@ -208,7 +209,7 @@ public final class TestAbfsClient {
       .describedAs("User-Agent string should not contain cluster name")
       .doesNotContain(clusterName)
       .describedAs("User-Agent string should contain UNKNOWN as cluster name config is absent")
-      .contains("UNKNOWN");;
+      .contains(DEFAULT_VALUE_UNKNOWN);
   }
 
   @Test
@@ -236,7 +237,7 @@ public final class TestAbfsClient {
       .describedAs("User-Agent string should not contain cluster type")
       .doesNotContain(clusterType)
       .describedAs("User-Agent string should contain UNKNOWN as cluster type config is absent")
-      .contains("UNKNOWN");
+      .contains(DEFAULT_VALUE_UNKNOWN);
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -23,11 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Pattern;
 
-import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
-import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
-import org.apache.hadoop.util.VersionInfo;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -38,6 +38,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.APN_VERS
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CLIENT_VERSION;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.FORWARD_SLASH;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.JAVA_VENDOR;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.JAVA_VERSION;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.OS_ARCH;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.OS_NAME;
@@ -46,6 +47,8 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SEMICOLO
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLUSTER_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLUSTER_TYPE;
+import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test useragent of abfs client.
@@ -67,25 +70,30 @@ public final class TestAbfsClient {
     regEx.append(CLIENT_VERSION);
     regEx.append(SINGLE_WHITE_SPACE);
     regEx.append("\\(");
+    regEx.append(System.getProperty(JAVA_VENDOR)
+        .replaceAll(SINGLE_WHITE_SPACE, EMPTY_STRING));
+    regEx.append(SINGLE_WHITE_SPACE);
     regEx.append("JavaJRE");
     regEx.append(SINGLE_WHITE_SPACE);
-    regEx.append("\\d+\\.\\d+([\\._]\\d+)*"); //  Regex for java version
+    regEx.append(System.getProperty(JAVA_VERSION));
     regEx.append(SEMICOLON);
     regEx.append(SINGLE_WHITE_SPACE);
-    regEx.append("[a-zA-Z].*");           //   Regex for OS name and version
+    regEx.append(System.getProperty(OS_NAME)
+        .replaceAll(SINGLE_WHITE_SPACE, EMPTY_STRING));
+    regEx.append(SINGLE_WHITE_SPACE);
+    regEx.append(System.getProperty(OS_VERSION));
     regEx.append(FORWARD_SLASH);
-    regEx.append(".*");                   //  Regex for OS arch
+    regEx.append(System.getProperty(OS_ARCH));
     regEx.append(SEMICOLON);
-    regEx.append(SINGLE_WHITE_SPACE);
-
     regEx.append("([a-zA-Z].*; )?");      // Regex for sslProviderName
     regEx.append("([a-zA-Z].*; )?");      // Regex for tokenProvider
+    regEx.append(" ?");
     regEx.append(".+");                   // cluster name
     regEx.append(FORWARD_SLASH);
     regEx.append(".+");            // cluster type
     regEx.append("\\)");
     regEx.append("( .*)?");        //  Regex for user agent prefix
-
+    regEx.append("$");
     this.userAgentStringPattern = Pattern.compile(regEx.toString());
   }
 
@@ -104,11 +112,18 @@ public final class TestAbfsClient {
   @Test
   public void verifybBasicInfo() throws Exception {
     final Configuration configuration = new Configuration();
+    configuration.addResource(TEST_CONFIGURATION_FILE_NAME);
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
+    assertThat(userAgentStr)
+        .describedAs("User-Agent string [" + userAgentStr
+            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+        .matches(this.userAgentStringPattern)
+        .describedAs("User-Agent string should contain java vendor")
+        .contains(System.getProperty(JAVA_VENDOR)
+            .replaceAll(SINGLE_WHITE_SPACE, EMPTY_STRING))
         .describedAs("User-Agent string should contain java version")
         .contains(System.getProperty(JAVA_VERSION))
         .describedAs("User-Agent string should contain  OS name")
@@ -124,114 +139,118 @@ public final class TestAbfsClient {
   public void verifyUserAgentPrefix()
       throws IOException, IllegalAccessException {
     final Configuration configuration = new Configuration();
+    configuration.addResource(TEST_CONFIGURATION_FILE_NAME);
     configuration.set(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY, FS_AZURE_USER_AGENT_PREFIX);
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
-        .contains(FS_AZURE_USER_AGENT_PREFIX);
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
+      .contains(FS_AZURE_USER_AGENT_PREFIX);
 
     configuration.unset(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY);
     abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: "+this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should not contain " + FS_AZURE_USER_AGENT_PREFIX)
-        .doesNotContain(FS_AZURE_USER_AGENT_PREFIX);
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: "+this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should not contain " + FS_AZURE_USER_AGENT_PREFIX)
+      .doesNotContain(FS_AZURE_USER_AGENT_PREFIX);
   }
 
   @Test
   public void verifyUserAgentWithoutSSLProvider() throws Exception {
     final Configuration configuration = new Configuration();
+    configuration.addResource(TEST_CONFIGURATION_FILE_NAME);
     configuration.set(ConfigurationKeys.FS_AZURE_SSL_CHANNEL_MODE_KEY,
         DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE.name());
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, true);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should contain sslProvider")
-        .contains(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should contain sslProvider")
+      .contains(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
 
     userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should not contain sslProvider")
-        .doesNotContain(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should not contain sslProvider")
+      .doesNotContain(DelegatingSSLSocketFactory.getDefaultFactory().getProviderName());
   }
 
   @Test
   public void verifyUserAgentClusterName() throws Exception {
     final String clusterName = "testClusterName";
     final Configuration configuration = new Configuration();
+    configuration.addResource(TEST_CONFIGURATION_FILE_NAME);
     configuration.set(FS_AZURE_CLUSTER_NAME, clusterName);
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should contain cluster name")
-        .contains(clusterName);
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should contain cluster name")
+      .contains(clusterName);
 
     configuration.unset(FS_AZURE_CLUSTER_NAME);
     abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should not contain cluster name")
-        .doesNotContain(clusterName)
-        .describedAs("User-Agent string should contain cluster UNKNOWN")
-        .contains("UNKNOWN");;
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should not contain cluster name")
+      .doesNotContain(clusterName)
+      .describedAs("User-Agent string should contain cluster UNKNOWN")
+      .contains("UNKNOWN");;
   }
 
   @Test
   public void verifyUserAgentClusterType() throws Exception {
     final String clusterType = "testClusterType";
     final Configuration configuration = new Configuration();
+    configuration.addResource(TEST_CONFIGURATION_FILE_NAME);
     configuration.set(FS_AZURE_CLUSTER_TYPE, clusterType);
     AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);
     String userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should contain cluster type")
-        .contains(clusterType);
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should contain cluster type")
+      .contains(clusterType);
 
     configuration.unset(FS_AZURE_CLUSTER_TYPE);
     abfsConfiguration = new AbfsConfiguration(configuration,
         ACCOUNT_NAME);userAgentStr = getUserAgentString(abfsConfiguration, false);
 
-    Assertions.assertThat(userAgentStr)
-        .describedAs("User-Agent string [" + userAgentStr
-            + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
-        .matches(this.userAgentStringPattern)
-        .describedAs("User-Agent string should not contain cluster type")
-        .doesNotContain(clusterType)
-        .describedAs("User-Agent string should contain cluster UNKNOWN")
-        .contains("UNKNOWN");
+    assertThat(userAgentStr)
+      .describedAs("User-Agent string [" + userAgentStr
+          + "] should be of the pattern: " + this.userAgentStringPattern.pattern())
+      .matches(this.userAgentStringPattern)
+      .describedAs("User-Agent string should not contain cluster type")
+      .doesNotContain(clusterType)
+      .describedAs("User-Agent string should contain cluster UNKNOWN")
+      .contains("UNKNOWN");
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -18,80 +18,123 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Pattern;
 
-import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
-import org.apache.hadoop.util.VersionInfo;
+
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.APN_VERSION;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CLIENT_VERSION;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.FORWARD_SLASH;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SEMICOLON;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 
 /**
  * Test useragent of abfs client.
  *
  */
+@RunWith(JUnit4.class)
 public final class TestAbfsClient {
 
-  private final String accountName = "bogusAccountName.dfs.core.windows.net";
+  private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
+  private static final String FS_AZURE_USER_AGENT_PREFIX = "Partner Service";
 
-  private void validateUserAgent(String expectedPattern,
-                                 URL baseUrl,
-                                 AbfsConfiguration config,
+  private final Pattern userAgentStringPattern;
+
+  public TestAbfsClient(){
+    StringBuilder regEx = new StringBuilder();
+    regEx.append("^");
+    regEx.append(APN_VERSION);
+    regEx.append(SINGLE_WHITE_SPACE);
+    regEx.append(CLIENT_VERSION);
+    regEx.append(SINGLE_WHITE_SPACE);
+    regEx.append("\\(");
+    regEx.append("JavaJRE");
+    regEx.append(SINGLE_WHITE_SPACE);
+    regEx.append("\\d+(\\.\\d+_?\\d*)*");  //  Regex for java version
+    regEx.append(SEMICOLON);
+    regEx.append(SINGLE_WHITE_SPACE);
+    regEx.append("[a-zA-Z].*");            //   Regex for OS name and version
+    regEx.append(FORWARD_SLASH);
+    regEx.append(".*");                    //  Regex for OS arch
+    regEx.append("(;[a-zA-Z].*)?");         // Regex for sslProviderName
+    regEx.append("(;[a-zA-Z].*)?");         // Regex for tokenProvider
+    regEx.append(SINGLE_WHITE_SPACE);
+    regEx.append(".+");                      //cluster name
+    regEx.append(FORWARD_SLASH);
+    regEx.append(".+");            // cluster type
+    regEx.append("\\)");
+    regEx.append("( .*)?");                      //  Regex for user agent prefix
+    this.userAgentStringPattern = Pattern.compile(regEx.toString());
+  }
+
+  private String getUserAgentString(AbfsConfiguration config,
                                  boolean includeSSLProvider)
-      throws AzureBlobFileSystemException {
-    AbfsClient client = new AbfsClient(baseUrl, null,
+      throws MalformedURLException {
+    AbfsClient client = new AbfsClient(new URL("http://azure.com"), null,
         config, null, (AccessTokenProvider) null, null);
     String sslProviderName = null;
     if (includeSSLProvider) {
       sslProviderName = DelegatingSSLSocketFactory.getDefaultFactory().getProviderName();
     }
-    String userAgent = client.initializeUserAgent(config, sslProviderName);
-    Pattern pattern = Pattern.compile(expectedPattern);
-    Assert.assertTrue("Incorrect User Agent String",
-        pattern.matcher(userAgent).matches());
+    return client.initializeUserAgent(config, sslProviderName);
   }
 
   @Test
-  public void verifyUnknownUserAgent() throws Exception {
-    String clientVersion = "Azure Blob FS/" + VersionInfo.getVersion();
-    String expectedUserAgentPattern = String.format(clientVersion
-        + " %s", "\\(JavaJRE ([^\\)]+)\\)");
+  public void verifyUnknownUserAgent()
+      throws IOException, IllegalAccessException {
     final Configuration configuration = new Configuration();
     configuration.unset(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY);
-    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, accountName);
-    validateUserAgent(expectedUserAgentPattern, new URL("http://azure.com"),
+    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
+        ACCOUNT_NAME);
+    String userAgentStr = getUserAgentString(
         abfsConfiguration, false);
+    Assertions.assertThat(userAgentStr).describedAs("User-Agent string ["+userAgentStr
+        + "] should be of the pattern: "+this.userAgentStringPattern.pattern()).matches(this.userAgentStringPattern);
   }
 
   @Test
   public void verifyUserAgent() throws Exception {
-    String clientVersion = "Azure Blob FS/" + VersionInfo.getVersion();
-    String expectedUserAgentPattern = String.format(clientVersion
-        + " %s", "\\(JavaJRE ([^\\)]+)\\) Partner Service");
     final Configuration configuration = new Configuration();
-    configuration.set(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY, "Partner Service");
-    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, accountName);
-    validateUserAgent(expectedUserAgentPattern, new URL("http://azure.com"),
-        abfsConfiguration, false);
+    configuration.set(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY, FS_AZURE_USER_AGENT_PREFIX);
+    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
+        ACCOUNT_NAME);
+    String userAgentStr = getUserAgentString(abfsConfiguration, false);
+    Assertions.assertThat(userAgentStr).describedAs("User-Agent string ["+userAgentStr
+        + "] should be of the pattern: " + this.userAgentStringPattern
+        .pattern()).matches(this.userAgentStringPattern).describedAs(
+        "User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
+        .contains(FS_AZURE_USER_AGENT_PREFIX);
   }
 
   @Test
   public void verifyUserAgentWithSSLProvider() throws Exception {
-    String clientVersion = "Azure Blob FS/" + VersionInfo.getVersion();
-    String expectedUserAgentPattern = String.format(clientVersion
-        + " %s", "\\(JavaJRE ([^\\)]+)\\) Partner Service");
     final Configuration configuration = new Configuration();
-    configuration.set(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY, "Partner Service");
+    configuration.set(ConfigurationKeys.FS_AZURE_USER_AGENT_PREFIX_KEY, FS_AZURE_USER_AGENT_PREFIX);
     configuration.set(ConfigurationKeys.FS_AZURE_SSL_CHANNEL_MODE_KEY,
         DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE.name());
-    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration, accountName);
-    validateUserAgent(expectedUserAgentPattern, new URL("https://azure.com"),
-        abfsConfiguration, true);
+    AbfsConfiguration abfsConfiguration = new AbfsConfiguration(configuration,
+        ACCOUNT_NAME);
+    String userAgentStr = getUserAgentString(abfsConfiguration, true);
+    Assertions.assertThat(userAgentStr).describedAs("User-Agent string ["+userAgentStr
+        + "] should be of the pattern: " + this.userAgentStringPattern
+        .pattern()).matches(this.userAgentStringPattern).describedAs(
+        "User-Agent string should contain " + FS_AZURE_USER_AGENT_PREFIX)
+        .contains(FS_AZURE_USER_AGENT_PREFIX)
+        .describedAs("User-Agent string " + "should contain sslProvider")
+        .contains(
+            DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE.name());
   }
 }


### PR DESCRIPTION
HADOOP-16922. Changing User-Agent header.
- Add more inforrmation to the User-Agent header like cluster name, cluster type, java vendor etc.
- Add APN/1.0 in the begining

At present the User-Agent header would look like:
Azure Blob FS/3.4.0-SNAPSHOT (JavaJRE 1.8.0_241; Linux 5.3.0-46-generic; SunJSSE-1.8) MSFT

With this PR it would be:
APN/1.0 Azure Blob FS/3.4.0-SNAPSHOT (OracleCorporation JavaJRE 1.8.0_241; Linux 5.3.0-46-generic/amd64; SunJSSE-1.8; UNKNOWN/UNKNOWN) MSFT