### PR TITLE
HADOOP-16924. Update guava version to 28.2-jre DO NOT MERGE

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -101,7 +101,7 @@
     <spotbugs.version>3.1.0-RC1</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
-    <guava.version>27.0-jre</guava.version>
+    <guava.version>28.2-jre</guava.version>
     <guice.version>4.0</guice.version>
     <joda-time.version>2.9.9</joda-time.version>
 


### PR DESCRIPTION
Do not merge.

This is an experimental patch. I want to see if the updated API calls to guava pass the tests.