### PR TITLE
HADOOP-16465 listLocatedStatus() optimisation

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -4285,7 +4285,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           () -> {
             // Assuming the path to be a directory,
             // trigger a list call directly.
-            RemoteIterator<S3ALocatedFileStatus> locatedFileStatusIteratorForDir =
+            final RemoteIterator<S3ALocatedFileStatus>
+                    locatedFileStatusIteratorForDir =
                     getLocatedFileStatusIteratorForDir(path, filter);
 
             // If no listing is present then path might be a file.
@@ -4296,7 +4297,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
                 // simple case: File
                 LOG.debug("Path is a file");
                 return new Listing.SingleStatusRemoteIterator(
-                        filter.accept(path) ? toLocatedFileStatus(fileStatus) : null);
+                        filter.accept(path)
+                                ? toLocatedFileStatus(fileStatus)
+                                : null);
               }
             }
             // Either empty or non-empty directory.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -131,14 +131,18 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     describe("performing listLocatedStatus on an empty dir");
     Path dir = path(getMethodName());
     S3AFileSystem fs = getFileSystem();
-    mkdirs(dir);
+    fs.mkdirs(dir);
     resetMetricDiffs();
     fs.listLocatedStatus(dir);
     if (!fs.hasMetadataStore()) {
       // Unguarded FS.
       verifyOperationCount(2, 1);
     } else {
-      verifyOperationCount(0, 0);
+      if(fs.allowAuthoritative(dir)) {
+        verifyOperationCount(0, 0);
+      } else {
+        verifyOperationCount(0, 1);
+      }
     }
   }
 
@@ -147,8 +151,8 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
     describe("performing listLocatedStatus on a non empty dir");
     Path dir = path(getMethodName() + "dir");
     S3AFileSystem fs = getFileSystem();
-    mkdirs(dir);
-    Path file = new Path( dir, "file.txt");
+    fs.mkdirs(dir);
+    Path file = new Path(dir, "file.txt");
     touch(fs, file);
     resetMetricDiffs();
     fs.listLocatedStatus(dir);
@@ -156,7 +160,11 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
       // Unguarded FS.
       verifyOperationCount(0, 1);
     } else {
-      verifyOperationCount(0, 0);
+      if(fs.allowAuthoritative(dir)) {
+        verifyOperationCount(0, 0);
+      } else {
+        verifyOperationCount(0, 1);
+      }
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -112,6 +112,55 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
   }
 
   @Test
+  public void testCostOfLocatedFileStatusOnFile() throws Throwable {
+    describe("performing listLocatedStatus on a file");
+    Path file = path(getMethodName() + ".txt");
+    S3AFileSystem fs = getFileSystem();
+    touch(fs, file);
+    resetMetricDiffs();
+    fs.listLocatedStatus(file);
+    if (!fs.hasMetadataStore()) {
+      // Unguarded FS.
+      metadataRequests.assertDiffEquals(1);
+    }
+    listRequests.assertDiffEquals(1);
+  }
+
+  @Test
+  public void testCostOfListLocatedStatusOnEmptyDir() throws Throwable {
+    describe("performing listLocatedStatus on an empty dir");
+    Path dir = path(getMethodName());
+    S3AFileSystem fs = getFileSystem();
+    mkdirs(dir);
+    resetMetricDiffs();
+    fs.listLocatedStatus(dir);
+    if (!fs.hasMetadataStore()) {
+      // Unguarded FS.
+      verifyOperationCount(2, 1);
+    } else {
+      verifyOperationCount(0, 0);
+    }
+  }
+
+  @Test
+  public void testCostOfListLocatedStatusOnNonEmptyDir() throws Throwable {
+    describe("performing listLocatedStatus on a non empty dir");
+    Path dir = path(getMethodName() + "dir");
+    S3AFileSystem fs = getFileSystem();
+    mkdirs(dir);
+    Path file = new Path( dir, "file.txt");
+    touch(fs, file);
+    resetMetricDiffs();
+    fs.listLocatedStatus(dir);
+    if (!fs.hasMetadataStore()) {
+      // Unguarded FS.
+      verifyOperationCount(0, 1);
+    } else {
+      verifyOperationCount(0, 0);
+    }
+  }
+
+  @Test
   public void testCostOfGetFileStatusOnFile() throws Throwable {
     describe("performing getFileStatus on a file");
     Path simpleFile = path("simple.txt");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -138,7 +138,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ATestBase {
       // Unguarded FS.
       verifyOperationCount(2, 1);
     } else {
-      if(fs.allowAuthoritative(dir)) {
+      if (fs.allowAuthoritative(dir)) {
         verifyOperationCount(0, 0);
       } else {
         verifyOperationCount(0, 1);


### PR DESCRIPTION
Optimize S3AFileSystem.listLocatedStatus() to perform list
operations directly and then fallback to head checks for file

Ran test in ap-south-1 bucket with command:
mvn clean verify -Ds3guard -Ddynamo  -Dparallel-tests -DtestsThreadCount=8

There are two failures. I am looking at them.