### PR TITLE
HDFS-1820. FTPFileSystem attempts to close the outputstream even when it is not initialised.

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -276,6 +276,11 @@
       <artifactId>sshd-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ftpserver</groupId>
+      <artifactId>ftpserver-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.htrace</groupId>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
@@ -111,7 +111,9 @@ public class FTPFileSystem extends FileSystem {
 
     // get port information from uri, (overrides info in conf)
     int port = uri.getPort();
-    port = (port == -1) ? conf.getInt(FS_FTP_HOST_PORT, FTP.DEFAULT_PORT) : port;
+    if(port == -1){
+      port = conf.getInt(FS_FTP_HOST_PORT, FTP.DEFAULT_PORT);
+    }
     conf.setInt(FS_FTP_HOST_PORT, port);
 
     // get user/password information from URI (overrides info in conf)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.Progressable;
 import org.slf4j.Logger;
@@ -349,7 +350,7 @@ public class FTPFileSystem extends FileSystem {
       // The ftpClient is an inconsistent state. Must close the stream
       // which in turn will logout and disconnect from FTP server
       if (outputStream != null) {
-        outputStream.close();
+        IOUtils.closeStream(outputStream);
       }
       disconnect(client);
       throw new IOException("Unable to create file: " + file + ", Aborting");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/FtpTestServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/FtpTestServer.java
@@ -38,14 +38,14 @@ import org.apache.ftpserver.usermanager.impl.BaseUser;
  * Helper class facilitating to manage a local ftp
  * server for unit tests purposes only.
  */
-public class TestFtpServer {
+public class FtpTestServer {
 
   private int port;
   private Path ftpRoot;
   private UserManager userManager;
   private FtpServer server;
 
-  public TestFtpServer(Path ftpRoot) {
+  public FtpTestServer(Path ftpRoot) {
     this.ftpRoot = ftpRoot;
     this.userManager = new PropertiesUserManagerFactory().createUserManager();
     FtpServerFactory serverFactory = createServerFactory();
@@ -53,7 +53,7 @@ public class TestFtpServer {
     this.server = serverFactory.createServer();
   }
 
-  public TestFtpServer start() throws Exception {
+  public FtpTestServer start() throws Exception {
     server.start();
     Listener listener = ((DefaultFtpServer) server)
         .getListeners()

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -111,8 +111,8 @@ public class TestFTPFileSystem {
     LambdaTestUtils.intercept(
         IOException.class, "Unable to create file: test1.txt, Aborting",
         () -> {
-          try (FSDataOutputStream outputStream = fs.create(new Path("test1.txt"))) {
-            outputStream.write(bytesExpected);
+          try (FSDataOutputStream out = fs.create(new Path("test1.txt"))) {
+            out.write(bytesExpected);
           }
         }
     );

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Comparator;
 
 import com.google.common.base.Preconditions;
@@ -76,7 +75,7 @@ public class TestFTPFileSystem {
   }
 
   @Test
-  public void testCreateOutputStreamForUserWithWritePermissions() throws Exception {
+  public void testCreateWithWritePermissions() throws Exception {
     BaseUser user = server.addUser("test", "password", new WritePermission());
     Configuration configuration = new Configuration();
     configuration.set("fs.defaultFS", "ftp:///");
@@ -97,7 +96,7 @@ public class TestFTPFileSystem {
   }
 
   @Test
-  public void testCreateGracefullyReleasesResourcesWhenUserLacksWritePermissions() throws Exception {
+  public void testCreateWithoutWritePermissions() throws Exception {
     BaseUser user = server.addUser("test", "password");
     Configuration configuration = new Configuration();
     configuration.set("fs.defaultFS", "ftp:///");
@@ -113,7 +112,10 @@ public class TestFTPFileSystem {
     try (FSDataOutputStream outputStream = fs.create(new Path("test1.txt"))) {
       outputStream.write(bytesExpected);
     } catch (IOException ioException) {
-      assertThat(ioException.getMessage(), is("Unable to create file: test1.txt, Aborting"));
+      assertThat(
+          ioException.getMessage(),
+          is("Unable to create file: test1.txt, Aborting")
+      );
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -17,18 +17,36 @@
  */
 package org.apache.hadoop.fs.ftp;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Comparator;
+
 import com.google.common.base.Preconditions;
 import org.apache.commons.net.ftp.FTP;
-
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+import org.apache.ftpserver.usermanager.impl.WritePermission;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
-
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -37,8 +55,67 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestFTPFileSystem {
 
+  private TestFtpServer server;
+
   @Rule
   public Timeout testTimeout = new Timeout(180000);
+
+  @Before
+  public void setUp() throws Exception {
+    server = new TestFtpServer(GenericTestUtils.getTestDir().toPath()).start();
+  }
+
+  @After
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void tearDown() throws Exception {
+    server.stop();
+    Files.walk(server.getFtpRoot())
+        .sorted(Comparator.reverseOrder())
+        .map(java.nio.file.Path::toFile)
+        .forEach(File::delete);
+  }
+
+  @Test
+  public void testCreateOutputStreamForUserWithWritePermissions() throws Exception {
+    BaseUser user = server.addUser("test", "password", new WritePermission());
+    Configuration configuration = new Configuration();
+    configuration.set("fs.defaultFS", "ftp:///");
+    configuration.set("fs.ftp.host", "localhost");
+    configuration.setInt("fs.ftp.host.port", server.getPort());
+    configuration.set("fs.ftp.user.localhost", user.getName());
+    configuration.set("fs.ftp.password.localhost", user.getPassword());
+    configuration.set("fs.ftp.impl.disable.cache", "true");
+
+    FileSystem fs = FileSystem.get(configuration);
+    byte[] bytesExpected = "hello world".getBytes(StandardCharsets.UTF_8);
+    try (FSDataOutputStream outputStream = fs.create(new Path("test1.txt"))) {
+      outputStream.write(bytesExpected);
+    }
+    try (FSDataInputStream input = fs.open(new Path("test1.txt"))) {
+      assertThat(bytesExpected, equalTo(IOUtils.readFullyToByteArray(input)));
+    }
+  }
+
+  @Test
+  public void testCreateGracefullyReleasesResourcesWhenUserLacksWritePermissions() throws Exception {
+    BaseUser user = server.addUser("test", "password");
+    Configuration configuration = new Configuration();
+    configuration.set("fs.defaultFS", "ftp:///");
+    configuration.set("fs.ftp.host", "localhost");
+    configuration.setInt("fs.ftp.host.port", server.getPort());
+    configuration.set("fs.ftp.user.localhost", user.getName());
+    configuration.set("fs.ftp.password.localhost", user.getPassword());
+    configuration.set("fs.ftp.impl.disable.cache", "true");
+
+    FileSystem fs = FileSystem.get(configuration);
+    byte[] bytesExpected = "hello world".getBytes(StandardCharsets.UTF_8);
+
+    try (FSDataOutputStream outputStream = fs.create(new Path("test1.txt"))) {
+      outputStream.write(bytesExpected);
+    } catch (IOException ioException) {
+      assertThat(ioException.getMessage(), is("Unable to create file: test1.txt, Aborting"));
+    }
+  }
 
   @Test
   public void testFTPDefaultPort() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -67,11 +67,13 @@ public class TestFTPFileSystem {
   @After
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void tearDown() throws Exception {
-    server.stop();
-    Files.walk(server.getFtpRoot())
-        .sorted(Comparator.reverseOrder())
-        .map(java.nio.file.Path::toFile)
-        .forEach(File::delete);
+    if (server != null) {
+      server.stop();
+      Files.walk(server.getFtpRoot())
+          .sorted(Comparator.reverseOrder())
+          .map(java.nio.file.Path::toFile)
+          .forEach(File::delete);
+    }
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFtpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFtpServer.java
@@ -55,7 +55,9 @@ public class TestFtpServer {
 
   public TestFtpServer start() throws Exception {
     server.start();
-    Listener listener = ((DefaultFtpServer) server).getListeners().get("default");
+    Listener listener = ((DefaultFtpServer) server)
+        .getListeners()
+        .get("default");
     port = listener.getPort();
     return this;
   }
@@ -74,8 +76,9 @@ public class TestFtpServer {
     }
   }
 
-  public BaseUser addUser(String name, String password, Authority... authorities)
-      throws IOException, FtpException {
+  public BaseUser addUser(String name, String password,
+      Authority... authorities) throws IOException, FtpException {
+
     BaseUser user = new BaseUser();
     user.setName(name);
     user.setPassword(password);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFtpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFtpServer.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ftp;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.apache.ftpserver.FtpServer;
+import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.ftplet.Authority;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.UserManager;
+import org.apache.ftpserver.impl.DefaultFtpServer;
+import org.apache.ftpserver.listener.Listener;
+import org.apache.ftpserver.listener.ListenerFactory;
+import org.apache.ftpserver.usermanager.PropertiesUserManagerFactory;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+
+/**
+ * Helper class facilitating to manage a local ftp server for unit tests purposes only.
+ */
+public class TestFtpServer {
+
+    private int port;
+    private Path ftpRoot;
+    private UserManager userManager;
+    private FtpServer server;
+
+    public TestFtpServer(Path ftpRoot) {
+        this.ftpRoot = ftpRoot;
+        this.userManager = new PropertiesUserManagerFactory().createUserManager();
+        FtpServerFactory serverFactory = createServerFactory();
+        serverFactory.setUserManager(userManager);
+        this.server = serverFactory.createServer();
+    }
+
+    public TestFtpServer start() throws Exception {
+        server.start();
+        Listener listener = ((DefaultFtpServer) server).getListeners().get("default");
+        port = listener.getPort();
+        return this;
+    }
+
+    public Path getFtpRoot() {
+        return ftpRoot;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void stop() {
+        if (!server.isStopped()) {
+            server.stop();
+        }
+    }
+
+    public BaseUser addUser(String name, String password, Authority... authorities)
+        throws IOException, FtpException {
+        BaseUser user = new BaseUser();
+        user.setName(name);
+        user.setPassword(password);
+        Path userHome = Files.createDirectory(ftpRoot.resolve(name));
+        user.setHomeDirectory(userHome.toString());
+        user.setAuthorities(Arrays.asList(authorities));
+        userManager.save(user);
+        return user;
+    }
+
+    private FtpServerFactory createServerFactory() {
+        FtpServerFactory serverFactory = new FtpServerFactory();
+        ListenerFactory defaultListener = new ListenerFactory();
+        defaultListener.setPort(0);
+        serverFactory.addListener("default", defaultListener.createListener());
+        return serverFactory;
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFtpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFtpServer.java
@@ -35,61 +35,62 @@ import org.apache.ftpserver.usermanager.PropertiesUserManagerFactory;
 import org.apache.ftpserver.usermanager.impl.BaseUser;
 
 /**
- * Helper class facilitating to manage a local ftp server for unit tests purposes only.
+ * Helper class facilitating to manage a local ftp
+ * server for unit tests purposes only.
  */
 public class TestFtpServer {
 
-    private int port;
-    private Path ftpRoot;
-    private UserManager userManager;
-    private FtpServer server;
+  private int port;
+  private Path ftpRoot;
+  private UserManager userManager;
+  private FtpServer server;
 
-    public TestFtpServer(Path ftpRoot) {
-        this.ftpRoot = ftpRoot;
-        this.userManager = new PropertiesUserManagerFactory().createUserManager();
-        FtpServerFactory serverFactory = createServerFactory();
-        serverFactory.setUserManager(userManager);
-        this.server = serverFactory.createServer();
-    }
+  public TestFtpServer(Path ftpRoot) {
+    this.ftpRoot = ftpRoot;
+    this.userManager = new PropertiesUserManagerFactory().createUserManager();
+    FtpServerFactory serverFactory = createServerFactory();
+    serverFactory.setUserManager(userManager);
+    this.server = serverFactory.createServer();
+  }
 
-    public TestFtpServer start() throws Exception {
-        server.start();
-        Listener listener = ((DefaultFtpServer) server).getListeners().get("default");
-        port = listener.getPort();
-        return this;
-    }
+  public TestFtpServer start() throws Exception {
+    server.start();
+    Listener listener = ((DefaultFtpServer) server).getListeners().get("default");
+    port = listener.getPort();
+    return this;
+  }
 
-    public Path getFtpRoot() {
-        return ftpRoot;
-    }
+  public Path getFtpRoot() {
+    return ftpRoot;
+  }
 
-    public int getPort() {
-        return port;
-    }
+  public int getPort() {
+    return port;
+  }
 
-    public void stop() {
-        if (!server.isStopped()) {
-            server.stop();
-        }
+  public void stop() {
+    if (!server.isStopped()) {
+      server.stop();
     }
+  }
 
-    public BaseUser addUser(String name, String password, Authority... authorities)
-        throws IOException, FtpException {
-        BaseUser user = new BaseUser();
-        user.setName(name);
-        user.setPassword(password);
-        Path userHome = Files.createDirectory(ftpRoot.resolve(name));
-        user.setHomeDirectory(userHome.toString());
-        user.setAuthorities(Arrays.asList(authorities));
-        userManager.save(user);
-        return user;
-    }
+  public BaseUser addUser(String name, String password, Authority... authorities)
+      throws IOException, FtpException {
+    BaseUser user = new BaseUser();
+    user.setName(name);
+    user.setPassword(password);
+    Path userHome = Files.createDirectory(ftpRoot.resolve(name));
+    user.setHomeDirectory(userHome.toString());
+    user.setAuthorities(Arrays.asList(authorities));
+    userManager.save(user);
+    return user;
+  }
 
-    private FtpServerFactory createServerFactory() {
-        FtpServerFactory serverFactory = new FtpServerFactory();
-        ListenerFactory defaultListener = new ListenerFactory();
-        defaultListener.setPort(0);
-        serverFactory.addListener("default", defaultListener.createListener());
-        return serverFactory;
-    }
+  private FtpServerFactory createServerFactory() {
+    FtpServerFactory serverFactory = new FtpServerFactory();
+    ListenerFactory defaultListener = new ListenerFactory();
+    defaultListener.setPort(0);
+    serverFactory.addListener("default", defaultListener.createListener());
+    return serverFactory;
+  }
 }


### PR DESCRIPTION
- Making sure an underlying outputstream is successfully created by apache-commons FTPClient before wrapping it with FSDataOutputStream.  
- Gracefully release resources when a destination file can't be created due to lack of permissions. 

