### PR TITLE
HADOOP-13873 log DNS addresses on s3a init

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -163,6 +163,12 @@ public final class Constants {
   //use a custom endpoint?
   public static final String ENDPOINT = "fs.s3a.endpoint";
 
+  /**
+   * Default value of s3 endpoint. If not set explicitly using
+   * {@code AmazonS3#setEndpoint()}, this is used.
+   */
+  public static final String DEFAULT_ENDPOINT = "s3.amazonaws.com";
+
   //Enable path style access? Overrides default virtual hosting
   public static final String PATH_STYLE_ACCESS = "fs.s3a.path.style.access";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.text.DateFormat;
@@ -469,6 +470,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * S3AFileSystem initialization. When set to 1 or 2, bucket existence check
    * will be performed which is potentially slow.
    * If 3 or higher: warn and use the v2 check.
+   * Also logging DNS address of the s3 endpoint.
    * @throws UnknownStoreException the bucket is absent
    * @throws IOException any other problem talking to S3
    */
@@ -478,6 +480,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
             .getInt(S3A_BUCKET_PROBE, S3A_BUCKET_PROBE_DEFAULT);
     Preconditions.checkArgument(bucketProbe >= 0,
             "Value of " + S3A_BUCKET_PROBE + " should be >= 0");
+    String endPoint = getConf().getTrimmed(ENDPOINT, "");
+    if (!endPoint.isEmpty() && LOG.isDebugEnabled()) {
+      LOG.debug("Bucket endpoint : {}", InetAddress.getByName(endPoint).toString());
+    }
     switch (bucketProbe) {
     case 0:
       LOG.debug("skipping check for bucket existence");

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/NetworkBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/NetworkBinding.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.fs.s3a.impl;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.net.URI;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -30,9 +32,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SSL_CHANNEL_MODE;
+import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.SSL_CHANNEL_MODE;
 
 /**
@@ -120,5 +125,14 @@ public class NetworkBinding {
     return region == null || region.equals("US")
         ? "us-east-1"
         : region;
+  }
+
+  public static void logDnsLookup(Configuration conf) {
+    String endPoint = conf.getTrimmed(ENDPOINT, DEFAULT_ENDPOINT);
+    if (!endPoint.isEmpty() && LOG.isDebugEnabled()) {
+      LOG.debug("Bucket endpoint : {}/{}",
+              endPoint,
+              NetUtils.normalizeHostName(endPoint));
+    }
   }
 }


### PR DESCRIPTION
Tested with a bucket in ap-south-1 using  mvn clean verify -Ds3guard -Ddynamo  -Dparallel-tests -DtestsThreadCount=8  . All good.
