### PR TITLE
HADOOP-16953. tuning s3guard disabled warnings

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -740,9 +740,9 @@ public final class Constants {
    * The warn level if S3Guard is disabled.
    */
   public static final String S3GUARD_DISABLED_WARN_LEVEL
-      = "org.apache.hadoop.fs.s3a.s3guard.disabled.warn.level";
+      = "fs.s3a.s3guard.disabled.warn.level";
   public static final String DEFAULT_S3GUARD_DISABLED_WARN_LEVEL =
-      "INFORM";
+      "SILENT";
 
   /**
    * Inconsistency (visibility delay) injection settings.

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3guard.md
@@ -1236,6 +1236,35 @@ Deleting the metadata store table will simply result in a period of eventual
 consistency for any file modifications that were made right before the table
 was deleted.
 
+### Enabling a log message whenever S3Guard is *disabled*
+
+When dealing with support calls related to the S3A connector, "is S3Guard on?"
+is the usual opening question. This can be determined by looking at the application logs for
+messages about S3Guard starting -the absence of S3Guard can only be inferred by the absence
+of such messages.
+
+There is a another strategy: have the S3A Connector log whenever *S3Guard is not enabled*
+
+This can be done in the configuration option `fs.s3a.s3guard.disabled.warn.level`
+
+```xml
+<property>
+ <name>fs.s3a.s3guard.disabled.warn.level</name>
+ <value>silent</value>
+ <description>
+   Level to print a message when S3Guard is disabled.
+   Values: 
+   "warn": log at WARN level
+   "inform": log at INFO level
+   "silent": log at DEBUG level
+   "fail": raise an exception
+ </description>
+</property>
+```
+
+The `fail` option is clearly more than logging; it exists as an extreme debugging
+tool. Use with care.
+
 ### Failure Semantics
 
 Operations which modify metadata will make changes to S3 first. If, and only


### PR DESCRIPTION

Contributed by Steve Loughran

* change name of config option
* default -> silent
* javadocs
* site docs s3guard.md
* error text is a string to pass throught string.format so consistent
in logs and exceptions
* raises ExitException(49 + text) on no s3guard, this will result in
exit code 49 in the s3guard tools and other apps. That can be tested
in system tests.

