### PR TITLE
HADOOP-16798. S3A Committer thread pool shutdown problems.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/Tasks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/Tasks.java
@@ -75,7 +75,7 @@ public final class Tasks {
    */
   public static class Builder<I> {
     private final Iterable<I> items;
-    private Submitter service = new DisabledSubmitter();
+    private Submitter service = null;
     private FailureTask<I, ?> onFailure = null;
     private boolean stopOnFailure = false;
     private boolean suppressExceptions = false;
@@ -143,7 +143,7 @@ public final class Tasks {
     }
 
     public <E extends Exception> boolean run(Task<I, E> task) throws E {
-      if (service.enabled()) {
+      if (service != null) {
         return runParallel(task);
       } else {
         return runSingleThreaded(task);
@@ -418,29 +418,6 @@ public final class Tasks {
      * @return the future of the submitted task.
      */
     Future<?> submit(Runnable task);
-
-    /**
-     * Is this submitter enabled?
-     * @return true if work can be submitted to it.
-     */
-    boolean enabled();
-  }
-
-  /**
-   * The disabled submitter declares itself as not enabled, which is
-   * used to switch Task's execution to single threaded.
-   */
-  public static class DisabledSubmitter implements Tasks.Submitter {
-
-    @Override
-    public Future<?> submit(final Runnable task) {
-      throw new UnsupportedOperationException("submitter is disabled");
-    }
-
-    @Override
-    public boolean enabled() {
-      return false;
-    }
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/staging/StagingCommitter.java
@@ -699,7 +699,7 @@ public class StagingCommitter extends AbstractS3ACommitter {
         Tasks.foreach(taskOutput)
             .stopOnFailure()
             .suppressExceptions(false)
-            .executeWith(buildThreadPool(context))
+            .executeWith(buildSubmitter(context))
             .run(stat -> {
               Path path = stat.getPath();
               File localFile = new File(path.toUri().getPath());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestTasks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestTasks.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -57,6 +58,12 @@ public class TestTasks extends HadoopTestBase {
    * Thread pool for task execution.
    */
   private ExecutorService threadPool;
+
+  /**
+   * Task submitter bonded to the thread pool, or
+   * disabled for the 0-thread case.IsMeAs
+   */
+  Tasks.Submitter submitter;
   private final CounterTask failingTask
       = new CounterTask("failing committer", FAILPOINT, Item::commit);
 
@@ -117,6 +124,9 @@ public class TestTasks extends HadoopTestBase {
               .setDaemon(true)
               .setNameFormat(getMethodName() + "-pool-%d")
               .build());
+      submitter = new PoolSubmitter();
+    } else {
+      submitter = new Tasks.DisabledSubmitter();
     }
 
   }
@@ -129,12 +139,24 @@ public class TestTasks extends HadoopTestBase {
     }
   }
 
+  private class PoolSubmitter implements Tasks.Submitter {
+
+    @Override
+    public Future<?> submit(final Runnable task) {
+      return threadPool.submit(task);
+    }
+
+    @Override
+    public boolean enabled() {
+      return true;
+    }
+  }
   /**
    * create the builder.
    * @return pre-inited builder
    */
   private Tasks.Builder<Item> builder() {
-    return Tasks.foreach(items).executeWith(threadPool);
+    return Tasks.foreach(items).executeWith(submitter);
   }
 
   private void assertRun(Tasks.Builder<Item> builder,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestTasks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestTasks.java
@@ -61,7 +61,7 @@ public class TestTasks extends HadoopTestBase {
 
   /**
    * Task submitter bonded to the thread pool, or
-   * disabled for the 0-thread case.IsMeAs
+   * null for the 0-thread case.
    */
   Tasks.Submitter submitter;
   private final CounterTask failingTask
@@ -126,7 +126,7 @@ public class TestTasks extends HadoopTestBase {
               .build());
       submitter = new PoolSubmitter();
     } else {
-      submitter = new Tasks.DisabledSubmitter();
+      submitter = null;
     }
 
   }
@@ -146,11 +146,8 @@ public class TestTasks extends HadoopTestBase {
       return threadPool.submit(task);
     }
 
-    @Override
-    public boolean enabled() {
-      return true;
-    }
   }
+
   /**
    * create the builder.
    * @return pre-inited builder


### PR DESCRIPTION

Contributed by Steve Loughran.

Fixes a condition which can cause job commit to fail if a task was
aborted < 60s before the job commit commenced: the task abort
will shut down the thread pool with a hard exit after 60s; the
job commit POST requests would be scheduled through the same pool,
so be interrupted and fail. At present the access is synchronized,
but presumably the executor shutdown code is calling wait() and releasing
locks.

Task abort is triggered from the AM when task attempts succeed but
there are still active speculative task attempts running. Thus it
only surfaces when speculation is enabled and the final tasks are
speculating, which, given they are the stragglers, is not
unheard of.

The fix copies and clears the threadPool field in a synchronized block,
then shuts it down; job commit will encounter the empty field and
demand-create a new one. As would a sequence of task aborts.
