### PR TITLE
YARN-9898. Workaround of Netty-all dependency aarch64 support

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
@@ -64,7 +64,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${netty4.group}</groupId>
       <artifactId>netty-all</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -176,7 +176,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${netty4.group}</groupId>
       <artifactId>netty-all</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -892,7 +892,7 @@
       </dependency>
 
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${netty4.group}</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty4.version}</version>
       </dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -44,7 +44,7 @@
             <version>${protobuf.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
+            <groupId>${netty4.group}</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <shell-executable>bash</shell-executable>
 
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
+    <netty4.group>io.netty</netty4.group>
   </properties>
 
   <modules>
@@ -684,6 +685,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       <id>aarch64</id>
       <properties>
         <leveldbjni.group>org.openlabtesting.leveldbjni</leveldbjni.group>
+        <!-- To make hadoop fully support ARM64 now, here add a workaround using an unofficial
+        netty-all package which support ARM64. Once the Netty officially support ARM64 in a
+        new release, we need to remove this and upgrade to use Netty official package -->
+        <netty4.group>org.openlabtesting.netty</netty4.group>
       </properties>
       <activation>
         <os>


### PR DESCRIPTION
The YARM CSI client now depend on the netty-all 4.1.48.Final which is
lack of aarch64 support, We have tried to promote aarch64 support in
Netty community, see[1], but still in review progress. For the recent
Hadoop release, it is better to add a workaround for this issue by using
a manully built netty-all package uploaded in org.openlabtesting.netty
maven repo.

[1] https://github.com/netty/netty/pull/9804

