### PR TITLE
HDFS-14742. RBF: TestRouterFaultTolerant tests are flaky

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
@@ -474,7 +474,10 @@ public final class FederationTestUtils {
 
   /**
    * Add a mount table entry in some name services and wait until it is
-   * available.
+   * available. If there are multiple routers,
+   * {@link #createMountTableEntry(List, String, DestinationOrder, Collection)}
+   * should be used instead because the method does not refresh
+   * the other routers.
    * @param router Router to change.
    * @param mountPoint Name of the mount point.
    * @param order Order of the mount table entry.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
@@ -477,7 +477,7 @@ public final class FederationTestUtils {
    * available. If there are multiple routers,
    * {@link #createMountTableEntry(List, String, DestinationOrder, Collection)}
    * should be used instead because the method does not refresh
-   * the other routers.
+   * the mount tables of the other routers.
    * @param router Router to change.
    * @param mountPoint Name of the mount point.
    * @param order Order of the mount table entry.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterFaultTolerant.java
@@ -248,6 +248,7 @@ public class TestRouterFaultTolerant {
     LOG.info("Setup {} with order {}", mountPoint, order);
     createMountTableEntry(
         getRandomRouter(), mountPoint, order, namenodes.keySet());
+    refreshRoutersCaches(routers);
 
     LOG.info("Write in {} should succeed writing in ns0 and fail for ns1",
         mountPath);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-14742

The root cause: 
There are 2 routers in the test. When submitting a request to create a mount point to a router, the mount table of the other router is not refreshed. That's why the requests fail if destination of the requests is the other router.

How to fix:
Refresh the other router's mount table.