### PR TITLE
HADOOP-17001. The suffix name of the unified compression

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BZip2Codec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BZip2Codec.java
@@ -236,7 +236,7 @@ public class BZip2Codec implements Configurable, SplittableCompressionCodec {
   */
   @Override
   public String getDefaultExtension() {
-    return ".bz2";
+    return CodecConstants.BZIP2_CODEC_EXTENSION;
   }
 
   private static class BZip2CompressionOutputStream extends

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecConstants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecConstants.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * Codec related constants.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public final class CodecConstants {
+
+  private CodecConstants() {
+  }
+  /**
+   * Default extension for {@link org.apache.hadoop.io.compress.DefaultCodec}.
+   */
+  public static final String DEFAULT_CODEC_EXTENSION = ".deflate";
+
+  /**
+   * Default extension for {@link org.apache.hadoop.io.compress.BZip2Codec}.
+   */
+  public static final String BZIP2_CODEC_EXTENSION = ".bz2";
+
+  /**
+   * Default extension for {@link org.apache.hadoop.io.compress.GzipCodec}.
+   */
+  public static final String GZIP_CODEC_EXTENSION = ".gz";
+
+  /**
+   * Default extension for {@link org.apache.hadoop.io.compress.Lz4Codec}.
+   */
+  public static final String LZ4_CODEC_EXTENSION = ".lz4";
+
+  /**
+   * Default extension for
+   * {@link org.apache.hadoop.io.compress.PassthroughCodec}.
+   */
+  public static final String PASSTHROUGH_CODEC_EXTENSION = ".passthrough";
+
+  /**
+   * Default extension for {@link org.apache.hadoop.io.compress.SnappyCodec}.
+   */
+  public static final String SNAPPY_CODEC_EXTENSION = ".snappy";
+
+  /**
+   * Default extension for {@link org.apache.hadoop.io.compress.ZStandardCodec}.
+   */
+  public static final String ZSTANDARD_CODEC_EXTENSION = ".zst";
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/DefaultCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/DefaultCodec.java
@@ -114,7 +114,7 @@ public class DefaultCodec implements Configurable, CompressionCodec, DirectDecom
   
   @Override
   public String getDefaultExtension() {
-    return ".deflate";
+    return CodecConstants.DEFAULT_CODEC_EXTENSION;
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/GzipCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/GzipCodec.java
@@ -206,7 +206,7 @@ public class GzipCodec extends DefaultCodec {
 
   @Override
   public String getDefaultExtension() {
-    return ".gz";
+    return CodecConstants.GZIP_CODEC_EXTENSION;
   }
 
   static final class GzipZlibCompressor extends ZlibCompressor {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/Lz4Codec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/Lz4Codec.java
@@ -221,6 +221,6 @@ public class Lz4Codec implements Configurable, CompressionCodec {
    */
   @Override
   public String getDefaultExtension() {
-    return ".lz4";
+    return CodecConstants.LZ4_CODEC_EXTENSION;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/PassthroughCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/PassthroughCodec.java
@@ -77,7 +77,8 @@ public class PassthroughCodec
    * This default extension is here so that if no extension has been defined,
    * some value is still returned: {@value}..
    */
-  public static final String DEFAULT_EXTENSION = ".passthrough";
+  public static final String DEFAULT_EXTENSION =
+    CodecConstants.PASSTHROUGH_CODEC_EXTENSION;
 
   private Configuration conf;
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/SnappyCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/SnappyCodec.java
@@ -225,6 +225,6 @@ public class SnappyCodec implements Configurable, CompressionCodec, DirectDecomp
    */
   @Override
   public String getDefaultExtension() {
-    return ".snappy";
+    return CodecConstants.SNAPPY_CODEC_EXTENSION;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/ZStandardCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/ZStandardCodec.java
@@ -230,7 +230,7 @@ public class ZStandardCodec implements
    */
   @Override
   public String getDefaultExtension() {
-    return ".zst";
+    return CodecConstants.ZSTANDARD_CODEC_EXTENSION;
   }
 
   @Override


### PR DESCRIPTION
JIRA:   https://issues.apache.org/jira/browse/HADOOP-17001

The suffix name of the unified compression class,I think the suffix name in the compression class should be extracted into a constant class, which is helpful for developers to understand the structure of the compression class as a whole.

