### PR TITLE
HDFS-15301. statfs function in hdfs-fuse not working - fixed.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -3409,7 +3409,7 @@ tOffset hdfsGetUsed(hdfsFS fs)
     }
     fss = (jobject)jVal.l;
     jthr = invokeMethod(env, &jVal, INSTANCE, fss, JC_FS_STATUS,
-            HADOOP_FSSTATUS,"getUsed", "()J");
+     "getUsed", "()J");
     destroyLocalReference(env, fss);
     if (jthr) {
         errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -3409,7 +3409,7 @@ tOffset hdfsGetUsed(hdfsFS fs)
     }
     fss = (jobject)jVal.l;
     jthr = invokeMethod(env, &jVal, INSTANCE, fss, JC_FS_STATUS,
-     "getUsed", "()J");
+            "getUsed", "()J");
     destroyLocalReference(env, fss);
     if (jthr) {
         errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,


### PR DESCRIPTION
statfs function in hdfs-fuse is not working. It gives error like:

could not find method org/apache/hadoop/fs/FsStatus from class org/apache/hadoop/fs/FsStatus with signature getUsed

hdfsGetUsed: FsStatus#getUsed error:

NoSuchMethodError: org/apache/hadoop/fs/FsStatusjava.lang.NoSuchMethodError: org/apache/hadoop/fs/FsStatus

Problem: Incorrect passing of parameters in invokeMethod function.
invokeMethod(env, &jVal, INSTANCE, fss, JC_FS_STATUS,
HADOOP_FSSTATUS,"getUsed", "()J");