### PR TITLE
HADOOP-16830. IOStatistics API.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BufferedFSInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/BufferedFSInputStream.java
@@ -24,6 +24,10 @@ import java.io.IOException;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStatistics;
 
 
 /**
@@ -33,7 +37,8 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class BufferedFSInputStream extends BufferedInputStream
-implements Seekable, PositionedReadable, HasFileDescriptor {
+implements Seekable, PositionedReadable, HasFileDescriptor,
+    IOStatisticsSource {
   /**
    * Creates a <code>BufferedFSInputStream</code>
    * with the specified buffer size,
@@ -125,5 +130,10 @@ implements Seekable, PositionedReadable, HasFileDescriptor {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public IOStatistics getIOStatistics() {
+    return retrieveIOStatistics(in);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -38,6 +38,9 @@ import org.apache.hadoop.fs.impl.FutureDataInputStreamBuilderImpl;
 import org.apache.hadoop.fs.impl.OpenFileParameters;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.IOStatisticsSupport;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.LambdaUtils;
 import org.apache.hadoop.util.Progressable;
@@ -134,7 +137,8 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
    * For open()'s FSInputStream
    * It verifies that data matches checksums.
    *******************************************************/
-  private static class ChecksumFSInputChecker extends FSInputChecker {
+  private static class ChecksumFSInputChecker extends FSInputChecker implements
+      IOStatisticsSource {
     private ChecksumFileSystem fs;
     private FSDataInputStream datas;
     private FSDataInputStream sums;
@@ -270,6 +274,17 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
       }
       return nread;
     }
+
+    /**
+     * Get the IO Statistics of the nested stream, falling back to
+     * null if the stream does not implement the interface
+     * {@link IOStatisticsSource}.
+     * @return an IOStatistics instance or null
+     */
+    @Override
+    public IOStatistics getIOStatistics() {
+      return IOStatisticsSupport.retrieveIOStatistics(datas);
+    }
   }
   
   private static class FSDataBoundedInputStream extends FSDataInputStream {
@@ -395,7 +410,8 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
 
   /** This class provides an output stream for a checksummed file.
    * It generates checksums for data. */
-  private static class ChecksumFSOutputSummer extends FSOutputSummer {
+  private static class ChecksumFSOutputSummer extends FSOutputSummer
+      implements IOStatisticsSource {
     private FSDataOutputStream datas;    
     private FSDataOutputStream sums;
     private static final float CHKSUM_AS_FRACTION = 0.01f;
@@ -448,6 +464,17 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
       if (isClosed) {
         throw new ClosedChannelException();
       }
+    }
+
+    /**
+     * Get the IO Statistics of the nested stream, falling back to
+     * null if the stream does not implement the interface
+     * {@link IOStatisticsSource}.
+     * @return an IOStatistics instance or null
+     */
+    @Override
+    public IOStatistics getIOStatistics() {
+      return IOStatisticsSupport.retrieveIOStatistics(datas);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataInputStream.java
@@ -29,6 +29,9 @@ import java.util.EnumSet;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.IOStatisticsSupport;
 import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.util.IdentityHashStore;
 
@@ -40,7 +43,7 @@ public class FSDataInputStream extends DataInputStream
     implements Seekable, PositionedReadable, 
       ByteBufferReadable, HasFileDescriptor, CanSetDropBehind, CanSetReadahead,
       HasEnhancedByteBufferAccess, CanUnbuffer, StreamCapabilities,
-      ByteBufferPositionedReadable {
+      ByteBufferPositionedReadable, IOStatisticsSource {
   /**
    * Map ByteBuffers that we have handed out to readers to ByteBufferPool 
    * objects
@@ -266,5 +269,16 @@ public class FSDataInputStream extends DataInputStream
       throw new UnsupportedOperationException("Byte-buffer pread " +
               "unsupported by " + in.getClass().getCanonicalName());
     }
+  }
+
+  /**
+   * Get the IO Statistics of the nested stream, falling back to
+   * null if the stream does not implement the interface
+   * {@link IOStatisticsSource}.
+   * @return an IOStatistics instance or null
+   */
+  @Override
+  public IOStatistics getIOStatistics() {
+    return IOStatisticsSupport.retrieveIOStatistics(in);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
@@ -24,13 +24,17 @@ import java.io.OutputStream;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.IOStatisticsSupport;
 
 /** Utility that wraps a {@link OutputStream} in a {@link DataOutputStream}.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public class FSDataOutputStream extends DataOutputStream
-    implements Syncable, CanSetDropBehind, StreamCapabilities {
+    implements Syncable, CanSetDropBehind, StreamCapabilities,
+      IOStatisticsSource {
   private final OutputStream wrappedStream;
 
   private static class PositionCache extends FilterOutputStream {
@@ -154,5 +158,16 @@ public class FSDataOutputStream extends DataOutputStream
       throw new UnsupportedOperationException("the wrapped stream does " +
           "not support setting the drop-behind caching setting.");
     }
+  }
+
+  /**
+   * Get the IO Statistics of the nested stream, falling back to
+   * empty statistics if the stream does not implement the interface
+   * {@link IOStatisticsSource}.
+   * @return an IOStatistics instance.
+   */
+  @Override
+  public IOStatistics getIOStatistics() {
+    return IOStatisticsSupport.retrieveIOStatistics(wrappedStream);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSInputStream.java
@@ -24,6 +24,9 @@ import java.io.InputStream;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,5 +136,24 @@ public abstract class FSInputStream extends InputStream
   public void readFully(long position, byte[] buffer)
     throws IOException {
     readFully(position, buffer, 0, buffer.length);
+  }
+
+  /**
+   * toString method returns the superclass toString, but if the subclass
+   * implements {@link IOStatisticsSource} then those statistics are
+   * extracted and included in the output.
+   * That is: statistics of subclasses are automatically reported.
+   * @return a string value.
+   */
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(super.toString());
+    sb.append('{');
+    if (this instanceof IOStatisticsSource) {
+      sb.append(IOStatisticsLogging.iostatisticsSourceToString(
+          (IOStatisticsSource) this));
+    }
+    sb.append('}');
+    return sb.toString();
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSInputStream.java
@@ -150,7 +150,7 @@ public abstract class FSInputStream extends InputStream
     final StringBuilder sb = new StringBuilder(super.toString());
     sb.append('{');
     if (this instanceof IOStatisticsSource) {
-      sb.append(IOStatisticsLogging.iostatisticsSourceToString(
+      sb.append(IOStatisticsLogging.sourceToString(
           (IOStatisticsSource) this));
     }
     sb.append('}');

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSInputStream.java
@@ -150,7 +150,7 @@ public abstract class FSInputStream extends InputStream
     final StringBuilder sb = new StringBuilder(super.toString());
     sb.append('{');
     if (this instanceof IOStatisticsSource) {
-      sb.append(IOStatisticsLogging.sourceToString(
+      sb.append(IOStatisticsLogging.ioStatisticsSourceToString(
           (IOStatisticsSource) this));
     }
     sb.append('}');

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
@@ -47,6 +47,10 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.impl.BufferedIOStatisticsOutputStream;
+import org.apache.hadoop.fs.statistics.impl.CounterIOStatistics;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.nativeio.NativeIO;
 import org.apache.hadoop.util.Progressable;
@@ -54,6 +58,14 @@ import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
 
 import static org.apache.hadoop.fs.impl.PathCapabilitiesSupport.validatePathCapabilityArgs;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_EXCEPTIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SKIP_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SKIP_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_WRITE_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_WRITE_EXCEPTIONS;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.counterIOStatistics;
 
 /****************************************************************
  * Implement the FileSystem API for the raw local filesystem.
@@ -105,9 +117,20 @@ public class RawLocalFileSystem extends FileSystem {
   /*******************************************************
    * For open()'s FSInputStream.
    *******************************************************/
-  class LocalFSFileInputStream extends FSInputStream implements HasFileDescriptor {
+  class LocalFSFileInputStream extends FSInputStream implements HasFileDescriptor,
+      IOStatisticsSource {
     private FileInputStream fis;
     private long position;
+
+    /**
+     * Minimal set of counters.
+     */
+    private final CounterIOStatistics ioStatistics = counterIOStatistics(
+        STREAM_READ_BYTES,
+        STREAM_READ_EXCEPTIONS,
+        STREAM_READ_SEEK_OPERATIONS,
+        STREAM_READ_SKIP_OPERATIONS,
+        STREAM_READ_SKIP_BYTES);
 
     public LocalFSFileInputStream(Path f) throws IOException {
       fis = new FileInputStream(pathToFile(f));
@@ -150,9 +173,11 @@ public class RawLocalFileSystem extends FileSystem {
         if (value >= 0) {
           this.position++;
           statistics.incrementBytesRead(1);
+          ioStatistics.increment(STREAM_READ_BYTES, 1);
         }
         return value;
       } catch (IOException e) {                 // unexpected exception
+        ioStatistics.increment(STREAM_READ_EXCEPTIONS, 1);
         throw new FSError(e);                   // assume native fs error
       }
     }
@@ -166,9 +191,11 @@ public class RawLocalFileSystem extends FileSystem {
         if (value > 0) {
           this.position += value;
           statistics.incrementBytesRead(value);
+          ioStatistics.increment(STREAM_READ_BYTES, value);
         }
         return value;
       } catch (IOException e) {                 // unexpected exception
+        ioStatistics.increment(STREAM_READ_EXCEPTIONS, 1);
         throw new FSError(e);                   // assume native fs error
       }
     }
@@ -187,18 +214,22 @@ public class RawLocalFileSystem extends FileSystem {
         int value = fis.getChannel().read(bb, position);
         if (value > 0) {
           statistics.incrementBytesRead(value);
+          ioStatistics.increment(STREAM_READ_BYTES, value);
         }
         return value;
       } catch (IOException e) {
+        ioStatistics.increment(STREAM_READ_EXCEPTIONS, 1);
         throw new FSError(e);
       }
     }
     
     @Override
     public long skip(long n) throws IOException {
+      ioStatistics.increment(STREAM_READ_SKIP_OPERATIONS, 1);
       long value = fis.skip(n);
       if (value > 0) {
         this.position += value;
+        ioStatistics.increment(STREAM_READ_SKIP_BYTES, value);
       }
       return value;
     }
@@ -206,6 +237,11 @@ public class RawLocalFileSystem extends FileSystem {
     @Override
     public FileDescriptor getFileDescriptor() throws IOException {
       return fis.getFD();
+    }
+
+    @Override
+    public IOStatistics getIOStatistics() {
+      return ioStatistics;
     }
   }
   
@@ -231,9 +267,17 @@ public class RawLocalFileSystem extends FileSystem {
   /*********************************************************
    * For create()'s FSOutputStream.
    *********************************************************/
-  class LocalFSFileOutputStream extends OutputStream {
+  class LocalFSFileOutputStream extends OutputStream implements
+      IOStatisticsSource {
     private FileOutputStream fos;
-    
+
+    /**
+     * Minimal set of counters.
+     */
+    private final CounterIOStatistics ioStatistics = counterIOStatistics(
+        STREAM_WRITE_BYTES,
+        STREAM_WRITE_EXCEPTIONS);
+
     private LocalFSFileOutputStream(Path f, boolean append,
         FsPermission permission) throws IOException {
       File file = pathToFile(f);
@@ -273,7 +317,9 @@ public class RawLocalFileSystem extends FileSystem {
     public void write(byte[] b, int off, int len) throws IOException {
       try {
         fos.write(b, off, len);
+        ioStatistics.increment(STREAM_WRITE_BYTES, len);
       } catch (IOException e) {                // unexpected exception
+        ioStatistics.increment(STREAM_WRITE_EXCEPTIONS, 1);
         throw new FSError(e);                  // assume native fs error
       }
     }
@@ -282,9 +328,16 @@ public class RawLocalFileSystem extends FileSystem {
     public void write(int b) throws IOException {
       try {
         fos.write(b);
+        ioStatistics.increment(STREAM_WRITE_BYTES, 1);
       } catch (IOException e) {              // unexpected exception
+        ioStatistics.increment(STREAM_WRITE_EXCEPTIONS, 1);
         throw new FSError(e);                // assume native fs error
       }
+    }
+
+    @Override
+    public IOStatistics getIOStatistics() {
+      return ioStatistics;
     }
   }
 
@@ -318,7 +371,7 @@ public class RawLocalFileSystem extends FileSystem {
     if (parent != null && !mkdirs(parent)) {
       throw new IOException("Mkdirs failed to create " + parent.toString());
     }
-    return new FSDataOutputStream(new BufferedOutputStream(
+    return new FSDataOutputStream(new BufferedIOStatisticsOutputStream(
         createOutputStreamWithMode(f, false, permission), bufferSize),
         statistics);
   }
@@ -340,7 +393,7 @@ public class RawLocalFileSystem extends FileSystem {
     if (exists(f) && !flags.contains(CreateFlag.OVERWRITE)) {
       throw new FileAlreadyExistsException("File already exists: " + f);
     }
-    return new FSDataOutputStream(new BufferedOutputStream(
+    return new FSDataOutputStream(new BufferedIOStatisticsOutputStream(
         createOutputStreamWithMode(f, false, permission), bufferSize),
             statistics);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StorageStatistics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.fs;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 
 import java.util.Iterator;
 
@@ -27,6 +28,7 @@ import java.util.Iterator;
  * instance.
  */
 @InterfaceAudience.Public
+@InterfaceStability.Stable
 public abstract class StorageStatistics {
 
   /**
@@ -43,39 +45,40 @@ public abstract class StorageStatistics {
    *   underscores.</li>
    *   <li>the value of the constants are lowercase of the constant names.</li>
    * </ul>
+   * See {@link StoreStatisticNames} for the field names used here and elsewhere.
    */
   @InterfaceStability.Evolving
   public interface CommonStatisticNames {
     // The following names are for file system operation invocations
-    String OP_APPEND = "op_append";
-    String OP_COPY_FROM_LOCAL_FILE = "op_copy_from_local_file";
-    String OP_CREATE = "op_create";
-    String OP_CREATE_NON_RECURSIVE = "op_create_non_recursive";
-    String OP_DELETE = "op_delete";
-    String OP_EXISTS = "op_exists";
-    String OP_GET_CONTENT_SUMMARY = "op_get_content_summary";
-    String OP_GET_DELEGATION_TOKEN = "op_get_delegation_token";
-    String OP_GET_FILE_CHECKSUM = "op_get_file_checksum";
-    String OP_GET_FILE_STATUS = "op_get_file_status";
-    String OP_GET_STATUS = "op_get_status";
-    String OP_GLOB_STATUS = "op_glob_status";
-    String OP_IS_FILE = "op_is_file";
-    String OP_IS_DIRECTORY = "op_is_directory";
-    String OP_LIST_FILES = "op_list_files";
-    String OP_LIST_LOCATED_STATUS = "op_list_located_status";
-    String OP_LIST_STATUS = "op_list_status";
-    String OP_MKDIRS = "op_mkdirs";
-    String OP_MODIFY_ACL_ENTRIES = "op_modify_acl_entries";
-    String OP_OPEN = "op_open";
-    String OP_REMOVE_ACL = "op_remove_acl";
-    String OP_REMOVE_ACL_ENTRIES = "op_remove_acl_entries";
-    String OP_REMOVE_DEFAULT_ACL = "op_remove_default_acl";
-    String OP_RENAME = "op_rename";
-    String OP_SET_ACL = "op_set_acl";
-    String OP_SET_OWNER = "op_set_owner";
-    String OP_SET_PERMISSION = "op_set_permission";
-    String OP_SET_TIMES = "op_set_times";
-    String OP_TRUNCATE = "op_truncate";
+    String OP_APPEND = StoreStatisticNames.OP_APPEND;
+    String OP_COPY_FROM_LOCAL_FILE = StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE;
+    String OP_CREATE = StoreStatisticNames.OP_CREATE;
+    String OP_CREATE_NON_RECURSIVE = StoreStatisticNames.OP_CREATE_NON_RECURSIVE;
+    String OP_DELETE = StoreStatisticNames.OP_DELETE;
+    String OP_EXISTS = StoreStatisticNames.OP_EXISTS;
+    String OP_GET_CONTENT_SUMMARY = StoreStatisticNames.OP_GET_CONTENT_SUMMARY;
+    String OP_GET_DELEGATION_TOKEN = StoreStatisticNames.OP_GET_DELEGATION_TOKEN;
+    String OP_GET_FILE_CHECKSUM = StoreStatisticNames.OP_GET_FILE_CHECKSUM;
+    String OP_GET_FILE_STATUS = StoreStatisticNames.OP_GET_FILE_STATUS;
+    String OP_GET_STATUS = StoreStatisticNames.OP_GET_STATUS;
+    String OP_GLOB_STATUS = StoreStatisticNames.OP_GLOB_STATUS;
+    String OP_IS_FILE = StoreStatisticNames.OP_IS_FILE;
+    String OP_IS_DIRECTORY = StoreStatisticNames.OP_IS_DIRECTORY;
+    String OP_LIST_FILES = StoreStatisticNames.OP_LIST_FILES;
+    String OP_LIST_LOCATED_STATUS = StoreStatisticNames.OP_LIST_LOCATED_STATUS;
+    String OP_LIST_STATUS = StoreStatisticNames.OP_LIST_STATUS;
+    String OP_MKDIRS = StoreStatisticNames.OP_MKDIRS;
+    String OP_MODIFY_ACL_ENTRIES = StoreStatisticNames.OP_MODIFY_ACL_ENTRIES;
+    String OP_OPEN = StoreStatisticNames.OP_OPEN;
+    String OP_REMOVE_ACL = StoreStatisticNames.OP_REMOVE_ACL;
+    String OP_REMOVE_ACL_ENTRIES = StoreStatisticNames.OP_REMOVE_ACL_ENTRIES;
+    String OP_REMOVE_DEFAULT_ACL = StoreStatisticNames.OP_REMOVE_DEFAULT_ACL;
+    String OP_RENAME = StoreStatisticNames.OP_RENAME;
+    String OP_SET_ACL = StoreStatisticNames.OP_SET_ACL;
+    String OP_SET_OWNER = StoreStatisticNames.OP_SET_OWNER;
+    String OP_SET_PERMISSION = StoreStatisticNames.OP_SET_PERMISSION;
+    String OP_SET_TIMES = StoreStatisticNames.OP_SET_TIMES;
+    String OP_TRUNCATE = StoreStatisticNames.OP_TRUNCATE;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StorageStatistics.java
@@ -33,11 +33,11 @@ public abstract class StorageStatistics {
 
   /**
    * These are common statistic names.
-   *
+   * <p>
    * The following names are considered general and preserved across different
    * StorageStatistics classes. When implementing a new StorageStatistics, it is
    * highly recommended to use the common statistic names.
-   *
+   * <p>
    * When adding new common statistic name constants, please make them unique.
    * By convention, they are implicitly unique:
    * <ul>
@@ -45,19 +45,24 @@ public abstract class StorageStatistics {
    *   underscores.</li>
    *   <li>the value of the constants are lowercase of the constant names.</li>
    * </ul>
-   * See {@link StoreStatisticNames} for the field names used here and elsewhere.
+   * See {@link StoreStatisticNames} for the field names used here
+   * and elsewhere.
    */
   @InterfaceStability.Evolving
   public interface CommonStatisticNames {
     // The following names are for file system operation invocations
     String OP_APPEND = StoreStatisticNames.OP_APPEND;
-    String OP_COPY_FROM_LOCAL_FILE = StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE;
+    String OP_COPY_FROM_LOCAL_FILE =
+        StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE;
     String OP_CREATE = StoreStatisticNames.OP_CREATE;
-    String OP_CREATE_NON_RECURSIVE = StoreStatisticNames.OP_CREATE_NON_RECURSIVE;
+    String OP_CREATE_NON_RECURSIVE =
+        StoreStatisticNames.OP_CREATE_NON_RECURSIVE;
     String OP_DELETE = StoreStatisticNames.OP_DELETE;
     String OP_EXISTS = StoreStatisticNames.OP_EXISTS;
-    String OP_GET_CONTENT_SUMMARY = StoreStatisticNames.OP_GET_CONTENT_SUMMARY;
-    String OP_GET_DELEGATION_TOKEN = StoreStatisticNames.OP_GET_DELEGATION_TOKEN;
+    String OP_GET_CONTENT_SUMMARY =
+        StoreStatisticNames.OP_GET_CONTENT_SUMMARY;
+    String OP_GET_DELEGATION_TOKEN =
+        StoreStatisticNames.OP_GET_DELEGATION_TOKEN;
     String OP_GET_FILE_CHECKSUM = StoreStatisticNames.OP_GET_FILE_CHECKSUM;
     String OP_GET_FILE_STATUS = StoreStatisticNames.OP_GET_FILE_STATUS;
     String OP_GET_STATUS = StoreStatisticNames.OP_GET_STATUS;
@@ -65,7 +70,8 @@ public abstract class StorageStatistics {
     String OP_IS_FILE = StoreStatisticNames.OP_IS_FILE;
     String OP_IS_DIRECTORY = StoreStatisticNames.OP_IS_DIRECTORY;
     String OP_LIST_FILES = StoreStatisticNames.OP_LIST_FILES;
-    String OP_LIST_LOCATED_STATUS = StoreStatisticNames.OP_LIST_LOCATED_STATUS;
+    String OP_LIST_LOCATED_STATUS =
+        StoreStatisticNames.OP_LIST_LOCATED_STATUS;
     String OP_LIST_STATUS = StoreStatisticNames.OP_LIST_STATUS;
     String OP_MKDIRS = StoreStatisticNames.OP_MKDIRS;
     String OP_MODIFY_ACL_ENTRIES = StoreStatisticNames.OP_MODIFY_ACL_ENTRIES;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticEntry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticEntry.java
@@ -18,6 +18,13 @@
 
 package org.apache.hadoop.fs.statistics;
 
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+import static org.apache.commons.lang3.StringUtils.join;
+
 /**
  * Entry of an IOStatistic.
  * <p></p>
@@ -33,8 +40,181 @@ package org.apache.hadoop.fs.statistics;
  * <p></p>
  * This isn't perfect, as we'd really want a union of types,
  * so doubles could be passed round too.
+ * The length of the array can be queried with the {@link #length()}
+ * method; the {@code _1(), _2()} and {@code _3()} methods return
+ * the first, second and third entries in the array
+ * respectively.
+ * <p></p>
+ * In this context, <i>arity</i> is the number of elements in the array.
  */
-public class IOStatisticEntry {
-  int type;
-  long[] values;
+public final class IOStatisticEntry implements Serializable {
+
+  /**
+   * Counter type: {@value}.
+   * <p></p>
+   * Arity 1: (count)
+   * <p></p>
+   * aggregation {@code l._1() + r._1()}
+   */
+  public static final int IOSTATISTIC_COUNTER = 0;
+
+  /**
+   * Counter type: {@value}.
+   * <p></p>
+   * Arity 2: (mean, sample-count)
+   * <p></p>
+   * Aggregation:
+   * {@code (l._1() * l._2() + r._1() * r._2()) / (l._2() + r._2())}
+   */
+  public static final int IOSTATISTIC_MEAN = 1;
+
+  /**
+   * Max value type: {@value}.
+   * <p></p>
+   * Arity 1: (max)
+   * <p></p>
+   * Aggregation {@code max(l._1(), r._1()}
+   */
+  public static final int IOSTATISTIC_MAX = 2;
+
+  /**
+   * Min value type: {@value}.
+   * <p></p>
+   * Arity 1: (min)
+   * <p></p>
+   * Aggregation {@code min(l._1(), r._1()}
+   */
+  public static final int IOSTATISTIC_MIN = 3;
+
+  /**
+   * Names of the originally defined types.
+   */
+  private static final String[] TYPE_NAMES = new String[]{
+      "counter",
+      "mean",
+      "max",
+      "min"
+  };
+
+  /**
+   * Arity of the defined types.
+   */
+  private static final int[] TYPE_ARITY = new int[]{1, 2, 1, 1};
+
+  private static final long serialVersionUID = 5925626116768440629L;
+
+  /**
+   * Type of statistic.
+   */
+  private int type;
+
+  /**
+   * value array.
+   */
+  private long[] values;
+
+  /**
+   * Instantiate from an array of values.
+   * This includes a verification that the
+   * length of the array matches that expected of the given
+   * type (if it is known)
+   * @param type type of entry
+   * @param values values
+   */
+  public IOStatisticEntry(final int type, final long[] values) {
+    Preconditions.checkArgument(type >= 0,
+        "type out of range %d", type);
+    this.type = type;
+    this.values = Objects.requireNonNull(values);
+    int len = values.length;
+    Preconditions.checkArgument(len > 0,
+        "entry value array is empty");
+    if (type < TYPE_ARITY.length) {
+      Preconditions.checkArgument(len == TYPE_ARITY[type],
+          "arity value of %d does not match required value: %d",
+          len, TYPE_ARITY[type]);
+    }
+  }
+
+  public IOStatisticEntry() {
+  }
+
+  public int getType() {
+    return type;
+  }
+
+  public long[] getValues() {
+    return values;
+  }
+
+  public int length() {
+    return values.length;
+  }
+
+  public void requireType(int r) {
+    Preconditions.checkState(type == r,
+        "Required type=%d actual type=%d",
+        r, type);
+  }
+
+  public void requireLength(int r) {
+    Preconditions.checkState(length() == r,
+        "Required length=%d actual length=%d",
+        r, length());
+  }
+
+  public long _1() {
+    return values[0];
+  }
+
+  public long _2() {
+    return values[1];
+  }
+
+  public long _3() {
+    return values[2];
+  }
+
+  /**
+   * Get the first value in the array, verifying
+   * that the type is as expected.
+   * @param type required type
+   * @return the value
+   */
+  public long singleValue(int type) {
+    requireLength(1);
+    requireType(type);
+    return _1();
+  }
+
+  /**
+   * Type to string; if it is a known type this
+   * will be a meaningful string.
+   * @return a value for logging.
+   */
+  public String typeAsString() {
+    return type < TYPE_NAMES.length
+        ? TYPE_NAMES[type]
+        : Integer.toString(type);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("(type=").append(typeAsString());
+    sb.append(", (").append(join(values, ','));
+    sb.append(')');
+    return sb.toString();
+  }
+
+  /**
+   * Entry of arity 1.
+   * @param t type
+   * @param v value
+   * @return new entry
+   */
+  public static IOStatisticEntry entry(int t, long...v) {
+    return new IOStatisticEntry(t, v);
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticEntry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticEntry.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+/**
+ * Entry of an IOStatistic.
+ * <p></p>
+ * it's a pair of (type, values[]) such that it is
+ * trivially serializable and we can add new types
+ * with multiple entries.
+ * <p></p>
+ * For example, the data for a mean value would be
+ * (mean, sample count);
+ * for a maximum it would just be the max value.
+ * What is key is that each entry MUST provide all
+ * the data needed to aggregate two entries together.
+ * <p></p>
+ * This isn't perfect, as we'd really want a union of types,
+ * so doubles could be passed round too.
+ */
+public class IOStatisticEntry {
+  int type;
+  long[] values;
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
@@ -21,12 +21,14 @@ package org.apache.hadoop.fs.statistics;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * IO Statistics.
  * <p>
- *   These are low-cost per-instance statistics provided by any IO components.
+ * These are low-cost per-instance statistics provided by any Hadoop
+ * I/O class instance.
  * <p>
  * The statistics MUST BE for the specific instance of the source;
  * possibly including aggregate statistics from other objects
@@ -44,6 +46,7 @@ import org.apache.hadoop.classification.InterfaceStability;
  *     The set of statistic keys SHOULD remain unchanged, and MUST NOT
  *     remove keys.
  *   </li>
+ *   <li>
  *     The statistics SHOULD be dynamic: every call to {@code iterator()}
  *     MAY return a current/recent set of statistics.
  *   </li>
@@ -70,12 +73,13 @@ import org.apache.hadoop.classification.InterfaceStability;
  *   </li>
  *   <li>
  *     Thread safety: an instance of IOStatistics can be shared across threads;
- *     a call to @code iterator()} is thread safe.
+ *     a call to {@code iterator()} is thread safe.
  *     The actual Iterable returned MUST NOT be shared across threads.
  *   </li>
  *
  * </ol>
  */
+@InterfaceAudience.Public
 @InterfaceStability.Unstable
 public interface IOStatistics extends Iterable<Map.Entry<String, Long>> {
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
@@ -41,16 +41,11 @@ import org.apache.hadoop.classification.InterfaceStability;
  * The iterator is a possibly empty iterator over all monitored statistics.
  * <ol>
  *   <li>
- *     The attributes of an instance can be probed for with
- *     {@link #hasAttribute(Attributes)}.
- *   </li>
- *   <li>
  *     The set of statistic keys SHOULD remain unchanged, and MUST NOT
- *     ever remove keys.
+ *     remove keys.
  *   </li>
- *     The statistics MAY BE dynamic: every call to {@code iterator()}
+ *     The statistics SHOULD be dynamic: every call to {@code iterator()}
  *     MAY return a current/recent set of statistics.
- *     This
  *   </li>
  *   <li>
  *     The values MAY change across invocations of {@code iterator()}.
@@ -78,15 +73,6 @@ import org.apache.hadoop.classification.InterfaceStability;
  *     a call to @code iterator()} is thread safe.
  *     The actual Iterable returned MUST NOT be shared across threads.
  *   </li>
- *   <li>
- *     If the instance declares that it has the attribute {@link Attributes#Snapshotted},
- *     then it will take a snapshot of the attribute values in the call {@link #snapshot()}.
- *     These values MUST NOT change until a subsequent snapshot() operation.
- *   </li>
- *   <li>
- *     A snapshot MAY NOT be consistent, i.e. during the snapshot operation
- *     the underlying values may change.
- *   </li>
  *
  * </ol>
  */
@@ -108,22 +94,6 @@ public interface IOStatistics extends Iterable<Map.Entry<String, Long>> {
   boolean isTracked(String key);
 
   /**
-   * Probe for an attribute of this statistics set.
-   * @return true if the source has the attribute.
-   */
-  default boolean hasAttribute(Attributes attr) {
-    return false;
-  }
-
-  /**
-   * Create a snapshot; no-op if not supported.
-   * @return true if this call had any effect
-   */
-  default boolean snapshot() {
-    return false;
-  }
-
-  /**
    * Get the set of keys.
    * No guarantees are made about the mutability/immutability
    * of this set.
@@ -131,21 +101,4 @@ public interface IOStatistics extends Iterable<Map.Entry<String, Long>> {
    */
   Set<String> keys();
 
-  /**
-   * Possible attributes of the statistics.
-   * This is very limited right now
-   */
-  enum Attributes {
-    /** The attributes never update. */
-    Static,
-
-    /** The statistics are dynamic: when you re-read a value it may change. */
-    Dynamic,
-
-    /**
-     * The statistics are actually snapshots, updated when you call snapshot(),
-     * or iterator();
-     */
-    Snapshotted
-  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * IO Statistics.
+ * <p>
+ *   These are low-cost per-instance statistics provided by any IO components.
+ * <p>
+ * The statistics MUST BE for the specific instance of the source;
+ * possibly including aggregate statistics from other objects
+ * created by that stores.
+ * For example, the statistics of a filesystem instance must be unique
+ * to that instant and not shared with any other.
+ * However, those statistics may also collect and aggregate statistics
+ * generated in the use of input and output streams created by that
+ * file system instance.
+ *
+ * <p>
+ * The iterator is a possibly empty iterator over all monitored statistics.
+ * <ol>
+ *   <li>
+ *     The attributes of an instance can be probed for with
+ *     {@link #hasAttribute(Attributes)}.
+ *   </li>
+ *   <li>
+ *     The set of statistic keys SHOULD remain unchanged, and MUST NOT
+ *     ever remove keys.
+ *   </li>
+ *     The statistics MAY BE dynamic: every call to {@code iterator()}
+ *     MAY return a current/recent set of statistics.
+ *     This
+ *   </li>
+ *   <li>
+ *     The values MAY change across invocations of {@code iterator()}.
+ *   </li>
+ *   <li>
+ *     The update MAY be in the iterable() call, or MAY be in the actual
+ *     Iterable.next() operation.
+ *   </li>
+ *   <li>
+ *     The returned Map.Entry instances MUST return the same value on
+ *     repeated getValue() calls.
+ *   </li>
+ *   <li>
+ *     Queries of statistics SHOULD Be fast and Nonblocking to the extent
+ *     that if invoked during a long operation, they will prioritize
+ *     returning fast over most timely values.
+ *   </li>
+ *   <li>
+ *     The statistics MAY lag; especially for statistics collected in separate
+ *     operations (e.g stream IO statistics as provided by a filesystem
+ *     instance).
+ *   </li>
+ *   <li>
+ *     Thread safety: an instance of IOStatistics can be shared across threads;
+ *     a call to @code iterator()} is thread safe.
+ *     The actual Iterable returned MUST NOT be shared across threads.
+ *   </li>
+ *   <li>
+ *     If the instance declares that it has the attribute {@link Attributes#Snapshotted},
+ *     then it will take a snapshot of the attribute values in the call {@link #snapshot()}.
+ *     These values MUST NOT change until a subsequent snapshot() operation.
+ *   </li>
+ *   <li>
+ *     A snapshot MAY NOT be consistent, i.e. during the snapshot operation
+ *     the underlying values may change.
+ *   </li>
+ *
+ * </ol>
+ */
+@InterfaceStability.Unstable
+public interface IOStatistics extends Iterable<Map.Entry<String, Long>> {
+
+  /**
+   * Get the value of a statistic.
+   *
+   * @return The value of the statistic, or null if not tracked.
+   */
+  Long getStatistic(String key);
+
+  /**
+   * Return true if a statistic is being tracked.
+   *
+   * @return True only if the statistic is being tracked.
+   */
+  boolean isTracked(String key);
+
+  /**
+   * Probe for an attribute of this statistics set.
+   * @return true if the source has the attribute.
+   */
+  default boolean hasAttribute(Attributes attr) {
+    return false;
+  }
+
+  /**
+   * Create a snapshot; no-op if not supported.
+   * @return true if this call had any effect
+   */
+  default boolean snapshot() {
+    return false;
+  }
+
+  /**
+   * Get the set of keys.
+   * No guarantees are made about the mutability/immutability
+   * of this set.
+   * @return the set of keys.
+   */
+  Set<String> keys();
+
+  /**
+   * Possible attributes of the statistics.
+   * This is very limited right now
+   */
+  enum Attributes {
+    /** The attributes never update. */
+    Static,
+
+    /** The statistics are dynamic: when you re-read a value it may change. */
+    Dynamic,
+
+    /**
+     * The statistics are actually snapshots, updated when you call snapshot(),
+     * or iterator();
+     */
+    Snapshotted
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
@@ -81,14 +81,15 @@ import org.apache.hadoop.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
-public interface IOStatistics extends Iterable<Map.Entry<String, Long>> {
+public interface IOStatistics
+    extends Iterable<Map.Entry<String, IOStatisticEntry>> {
 
   /**
    * Get the value of a statistic.
    *
    * @return The value of the statistic, or null if not tracked.
    */
-  Long getStatistic(String key);
+  IOStatisticEntry getStatistic(String key);
 
   /**
    * Return true if a statistic is being tracked.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatistics.java
@@ -85,9 +85,9 @@ public interface IOStatistics
     extends Iterable<Map.Entry<String, IOStatisticEntry>> {
 
   /**
-   * Get the value of a statistic.
+   * Get the entry of a statistic.
    *
-   * @return The value of the statistic, or null if not tracked.
+   * @return The entry of the statistic, or null if not tracked.
    */
   IOStatisticEntry getStatistic(String key);
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -31,16 +31,19 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStat
  * Utility operations convert IO Statistics sources/instances
  * to strings, especially for robustly logging.
  */
-public class IOStatisticsLogging {
+public final class IOStatisticsLogging {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(IOStatisticsLogging.class);
+
+  private IOStatisticsLogging() {
+  }
 
   /** Pattern used for each entry. */
   @VisibleForTesting
   static final String ENTRY_PATTERN = "(%s=%s)";
 
-  /** used when a source is null. */
+  /** String to return when a source is null. */
   static final String NULL_SOURCE = "()";
 
   /**
@@ -71,6 +74,7 @@ public class IOStatisticsLogging {
 
   /**
    * Extract the statistics from a source.
+   * <p>
    * Exceptions are caught and downgraded to debug logging.
    * @param source source of statistics.
    * @return a string for logging.
@@ -86,8 +90,10 @@ public class IOStatisticsLogging {
 
   /**
    * On demand stringifier.
+   * <p>
    * Whenever this object's toString() method is called, it evaluates the
    * statistics.
+   * <p>
    * This is designed to affordable to use in log statements.
    * @param source source of statistics.
    * @return an object whose toString() operation returns the current values.
@@ -99,8 +105,10 @@ public class IOStatisticsLogging {
 
   /**
    * On demand stringifier.
+   * <p>
    * Whenever this object's toString() method is called, it evaluates the
    * statistics.
+   * <p>
    * This is for use in log statements where for the cost of creation
    * of this entry is low; it is affordable to use in log statements.
    * @param statistics statistics to scan.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStatistics;
+
+/**
+ * Utility operations to work with IO Statistics, especially log them.
+ */
+public class IOStatisticsLogging {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(IOStatisticsLogging.class);
+
+  /**
+   * Convert IOStatistics to a string form.
+   * @param statistics A statistics instance.
+   * @return string value or the emtpy string if null
+   */
+  private static String iostatisticsToString(
+      @Nullable final IOStatistics statistics) {
+    if (statistics != null) {
+      StringBuilder sb = new StringBuilder(" {");
+      for (Map.Entry entry : statistics) {
+        sb.append("{")
+            .append(entry.getKey())
+            .append("=")
+            .append(entry.getValue())
+            .append("} ");
+      }
+      sb.append('}');
+      return sb.toString();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Extract the statistics from a source.
+   * Exceptions are caught and downgraded to debug logging.
+   * @param source source of statistics.
+   * @return a string for logging.
+   */
+  public static String iostatisticsSourceToString(final IOStatisticsSource source) {
+    try {
+      return iostatisticsToString(retrieveIOStatistics(source));
+    } catch (RuntimeException e) {
+      LOG.debug("Ignoring", e);
+      return "";
+    }
+  }
+
+  /**
+   * On demand stringifier.
+   * Whenever this object's toString() method is called, it
+   * retrieves the latest statistics instance and re-evaluates it.
+   */
+  public static final class SourceToString {
+
+    private final String origin;
+
+    private final IOStatisticsSource source;
+
+    public SourceToString(String origin, IOStatisticsSource source) {
+      this.origin = origin;
+      this.source = source;
+    }
+
+    @Override
+    public String toString() {
+      return source != null
+          ? ("Statistics of " + origin + " " + iostatisticsSourceToString(source))
+          : "";
+    }
+  }
+
+  /**
+   * Stringifier of statistics: low cost to instantiate and every
+   * toString/logging will re-evaluate the statistics.
+   */
+  public static final class StatisticsToString {
+
+    private final String origin;
+
+    private final IOStatistics statistics;
+
+    /**
+     * Constructor.
+     * @param origin source (for message)
+     * @param statistics statistics
+     */
+    public StatisticsToString(String origin, IOStatistics statistics) {
+      this.origin = origin;
+      this.statistics = statistics;
+    }
+
+    @Override
+    public String toString() {
+      return statistics != null
+          ? ("Statistics of " + origin + " " + iostatisticsToString(statistics))
+          : "";
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.statistics;
 import javax.annotation.Nullable;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,13 @@ public class IOStatisticsLogging {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(IOStatisticsLogging.class);
+
+  /** Pattern used for each entry. */
+  @VisibleForTesting
+  static final String ENTRY_PATTERN = "(%s=%s)";
+
+  /** used when a source is null. */
+  static final String NULL_SOURCE = "()";
 
   /**
    * Convert IOStatistics to a string form.
@@ -50,11 +58,9 @@ public class IOStatisticsLogging {
           sb.append(' ');
         }
         count++;
-        sb.append("(")
-            .append(entry.getKey())
-            .append("=")
-            .append(entry.getValue())
-            .append(")");
+        sb.append(String.format(ENTRY_PATTERN,
+            entry.getKey(),
+            entry.getValue()));
       }
       sb.append(")");
       return sb.toString();
@@ -82,8 +88,9 @@ public class IOStatisticsLogging {
    * On demand stringifier.
    * Whenever this object's toString() method is called, it evaluates the
    * statistics.
-   * This is for use in log statements where for the cost of creation
-   * of this entry is low; it is affordable to use in log statements.
+   * This is designed to affordable to use in log statements.
+   * @param source source of statistics.
+   * @return an object whose toString() operation returns the current values.
    */
    public static Object demandStringify(
        @Nullable IOStatisticsSource source) {
@@ -96,9 +103,11 @@ public class IOStatisticsLogging {
    * statistics.
    * This is for use in log statements where for the cost of creation
    * of this entry is low; it is affordable to use in log statements.
+   * @param statistics statistics to scan.
+   * @return an object whose toString() operation returns the current values.
    */
-   public static Object demandStringify(@Nullable IOStatistics source) {
-     return new StatisticsToString(source);
+   public static Object demandStringify(@Nullable IOStatistics statistics) {
+     return new StatisticsToString(statistics);
   }
 
   /**
@@ -118,7 +127,7 @@ public class IOStatisticsLogging {
     public String toString() {
       return source != null
           ? sourceToString(source)
-          : "";
+          : NULL_SOURCE;
     }
   }
 
@@ -146,7 +155,7 @@ public class IOStatisticsLogging {
     public String toString() {
       return statistics != null
           ? iostatisticsToString(statistics)
-          : "";
+          : NULL_SOURCE;
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -43,13 +43,18 @@ public class IOStatisticsLogging {
   public static String iostatisticsToString(
       @Nullable final IOStatistics statistics) {
     if (statistics != null) {
-      StringBuilder sb = new StringBuilder("( ");
+      int count = 0;
+      StringBuilder sb = new StringBuilder("(");
       for (Map.Entry entry : statistics) {
+        if (count > 0) {
+          sb.append(' ');
+        }
+        count++;
         sb.append("(")
             .append(entry.getKey())
-            .append(", ")
+            .append("=")
             .append(entry.getValue())
-            .append(") ");
+            .append(")");
       }
       sb.append(")");
       return sb.toString();
@@ -80,7 +85,8 @@ public class IOStatisticsLogging {
    * This is for use in log statements where for the cost of creation
    * of this entry is low; it is affordable to use in log statements.
    */
-   public static Object stringify(@Nullable IOStatisticsSource source) {
+   public static Object demandStringify(
+       @Nullable IOStatisticsSource source) {
      return new SourceToString(source);
   }
 
@@ -91,7 +97,7 @@ public class IOStatisticsLogging {
    * This is for use in log statements where for the cost of creation
    * of this entry is low; it is affordable to use in log statements.
    */
-   public static Object stringify(@Nullable IOStatistics source) {
+   public static Object demandStringify(@Nullable IOStatistics source) {
      return new StatisticsToString(source);
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -55,12 +55,12 @@ public final class IOStatisticsLogging {
     if (statistics != null) {
       int count = 0;
       StringBuilder sb = new StringBuilder("(");
-      for (Map.Entry<String, Long> entry : statistics) {
+      for (Map.Entry<String, IOStatisticEntry> entry : statistics) {
         if (count > 0) {
           sb.append(' ');
         }
         count++;
-        sb.append(entrytoString(entry));
+        sb.append(entrytoString(entry.getKey(), entry.getValue()));
       }
       sb.append(")");
       return sb.toString();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -21,16 +21,22 @@ package org.apache.hadoop.fs.statistics;
 import javax.annotation.Nullable;
 import java.util.Map;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationUtils;
+
 import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStatistics;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationUtils.entrytoString;
 
 /**
  * Utility operations convert IO Statistics sources/instances
  * to strings, especially for robustly logging.
  */
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
 public final class IOStatisticsLogging {
 
   private static final Logger LOG =
@@ -38,13 +44,6 @@ public final class IOStatisticsLogging {
 
   private IOStatisticsLogging() {
   }
-
-  /** Pattern used for each entry. */
-  @VisibleForTesting
-  static final String ENTRY_PATTERN = "(%s=%s)";
-
-  /** String to return when a source is null. */
-  static final String NULL_SOURCE = "()";
 
   /**
    * Convert IOStatistics to a string form.
@@ -56,14 +55,12 @@ public final class IOStatisticsLogging {
     if (statistics != null) {
       int count = 0;
       StringBuilder sb = new StringBuilder("(");
-      for (Map.Entry entry : statistics) {
+      for (Map.Entry<String, Long> entry : statistics) {
         if (count > 0) {
           sb.append(' ');
         }
         count++;
-        sb.append(String.format(ENTRY_PATTERN,
-            entry.getKey(),
-            entry.getValue()));
+        sb.append(entrytoString(entry));
       }
       sb.append(")");
       return sb.toString();
@@ -135,7 +132,7 @@ public final class IOStatisticsLogging {
     public String toString() {
       return source != null
           ? sourceToString(source)
-          : NULL_SOURCE;
+          : IOStatisticsImplementationUtils.NULL_SOURCE;
     }
   }
 
@@ -163,7 +160,7 @@ public final class IOStatisticsLogging {
     public String toString() {
       return statistics != null
           ? iostatisticsToString(statistics)
-          : NULL_SOURCE;
+          : IOStatisticsImplementationUtils.NULL_SOURCE;
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsLogging.java
@@ -70,13 +70,14 @@ public final class IOStatisticsLogging {
   }
 
   /**
-   * Extract the statistics from a source.
+   * Extract the statistics from a source object -or ""
+   * if it is not a source of statistics
    * <p>
    * Exceptions are caught and downgraded to debug logging.
    * @param source source of statistics.
    * @return a string for logging.
    */
-  public static String sourceToString(@Nullable IOStatisticsSource source) {
+  public static String ioStatisticsSourceToString(@Nullable Object source) {
     try {
       return iostatisticsToString(retrieveIOStatistics(source));
     } catch (RuntimeException e) {
@@ -117,6 +118,7 @@ public final class IOStatisticsLogging {
 
   /**
    * On demand stringifier.
+   * <p>
    * Whenever this object's toString() method is called, it
    * retrieves the latest statistics instance and re-evaluates it.
    */
@@ -131,7 +133,7 @@ public final class IOStatisticsLogging {
     @Override
     public String toString() {
       return source != null
-          ? sourceToString(source)
+          ? ioStatisticsSourceToString(source)
           : IOStatisticsImplementationUtils.NULL_SOURCE;
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSource.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSource.java
@@ -29,8 +29,10 @@ public interface IOStatisticsSource {
 
   /**
    * Return a statistics instance.
+   * <p>
    * It is not a requirement that the same instance is returned every time.
    * {@link IOStatisticsSource}.
+   * <p>
    * If the object implementing this is Closeable, this method
    * may return null if invoked on a closed object, even if
    * it returns a valid instance when called earlier.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSource.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSource.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * A source of IO statistics.
+ * These statistics MUST be instance specific, not thread local.
+ */
+@InterfaceStability.Unstable
+public interface IOStatisticsSource {
+
+  /**
+   * Return a statistics instance.
+   * It is not a requirement that the same instance is returned every time.
+   * {@link IOStatisticsSource}.
+   * If the object implementing this is Closeable, this method
+   * may return null if invoked on a closed object, even if
+   * it returns a valid instance when called earlier.
+   * @return an IOStatistics instance or null
+   */
+  default IOStatistics getIOStatistics() {
+    return null;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSource.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSource.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * A source of IO statistics.
+ * <p></p>
  * These statistics MUST be instance specific, not thread local.
  */
 @InterfaceStability.Unstable

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -36,7 +36,9 @@ public final class IOStatisticsSupport {
 
   /**
    * Take a snapshot of the current statistics state.
+   * <p>
    * This is not an atomic option.
+   * <p>
    * The instance can be serialized, and its
    * {@code toString()} method lists all the values.
    * @param statistics statistics

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -18,24 +18,34 @@
 
 package org.apache.hadoop.fs.statistics;
 
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationHelper;
+import java.io.Serializable;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 
 /**
  * Support for working with statistics.
  */
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
 public final class IOStatisticsSupport {
 
   private IOStatisticsSupport() {
   }
 
   /**
-   * Wrap a (dynamic) source with a snapshot IOStatistics instance.
-   * @param source source
-   * @return a wrapped instance.
+   * Take a snapshot of the current statistics state.
+   * This is not an atomic option.
+   * The instance can be serialized.
+   * @param statistics statistics
+   * @return a snapshot of the current values.
    */
-  public static IOStatistics takeSnapshot(IOStatistics source) {
-    return IOStatisticsImplementationHelper.wrapWithSnapshot(source);
+  public static <X extends IOStatistics & Serializable> X snapshot(
+      IOStatistics statistics) {
+    return IOStatisticsBinding.snapshotStatistics(statistics);
   }
+
 
   /**
    * Get the IOStatistics of the source, falling back to

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 
 /**
- * Support for working with statistics.
+ * Support for working with IOStatistics.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
@@ -37,7 +37,7 @@ public final class IOStatisticsSupport {
   /**
    * Take a snapshot of the current statistics state.
    * This is not an atomic option.
-   * The instance can be serialized,. and it's
+   * The instance can be serialized, and its
    * {@code toString()} method lists all the values.
    * @param statistics statistics
    * @return a snapshot of the current values.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationHelper;
+
+/**
+ * Support for working with statistics.
+ */
+public final class IOStatisticsSupport {
+
+  private IOStatisticsSupport() {
+  }
+
+  /**
+   * Wrap a (dynamic) source with a snapshot IOStatistics instance.
+   * @param source source
+   * @return a wrapped instance.
+   */
+  public static IOStatistics takeSnapshot(IOStatistics source) {
+    return IOStatisticsImplementationHelper.wrapWithSnapshot(source);
+  }
+
+  /**
+   * Get the IOStatistics of the source, falling back to
+   * null if the source does not implement
+   * {@link IOStatisticsSource}, or the return value
+   * of {@link IOStatisticsSource#getIOStatistics()} was null.
+   * @return an IOStatistics instance or null
+   */
+
+  public static IOStatistics retrieveIOStatistics(
+      final Object source) {
+    return (source instanceof IOStatisticsSource)
+        ? ((IOStatisticsSource) source).getIOStatistics()
+        : null;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -37,7 +37,8 @@ public final class IOStatisticsSupport {
   /**
    * Take a snapshot of the current statistics state.
    * This is not an atomic option.
-   * The instance can be serialized.
+   * The instance can be serialized,. and it's
+   * {@code toString()} method lists all the values.
    * @param statistics statistics
    * @return a snapshot of the current values.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -62,6 +62,6 @@ public final class IOStatisticsSupport {
       final Object source) {
     return (source instanceof IOStatisticsSource)
         ? ((IOStatisticsSource) source).getIOStatistics()
-        : null;
+        : null; // null source or interface not implemented
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsSupport.java
@@ -64,4 +64,5 @@ public final class IOStatisticsSupport {
         ? ((IOStatisticsSource) source).getIOStatistics()
         : null; // null source or interface not implemented
   }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * These are common statistic names.
- *
+ * <p>
  * When adding new common statistic name constants, please make them unique.
  * By convention, they are implicitly unique:
  * <ul>
@@ -32,7 +32,11 @@ import org.apache.hadoop.classification.InterfaceStability;
  * </ul>
  */
 @InterfaceStability.Unstable
-public class StoreStatisticNames {
+public final class StoreStatisticNames {
+
+
+  private StoreStatisticNames() {
+  }
 
   /** {@value}. */
   public static final String OP_APPEND = "op_append";
@@ -45,7 +49,8 @@ public class StoreStatisticNames {
   public static final String OP_CREATE = "op_create";
 
   /** {@value}. */
-  public static final String OP_CREATE_NON_RECURSIVE = "op_create_non_recursive";
+  public static final String OP_CREATE_NON_RECURSIVE =
+      "op_create_non_recursive";
 
   /** {@value}. */
   public static final String OP_DELETE = "op_delete";
@@ -54,13 +59,16 @@ public class StoreStatisticNames {
   public static final String OP_EXISTS = "op_exists";
 
   /** {@value}. */
-  public static final String OP_GET_CONTENT_SUMMARY = "op_get_content_summary";
+  public static final String OP_GET_CONTENT_SUMMARY =
+      "op_get_content_summary";
 
   /** {@value}. */
-  public static final String OP_GET_DELEGATION_TOKEN = "op_get_delegation_token";
+  public static final String OP_GET_DELEGATION_TOKEN =
+      "op_get_delegation_token";
 
   /** {@value}. */
-  public static final String OP_GET_FILE_CHECKSUM = "op_get_file_checksum";
+  public static final String OP_GET_FILE_CHECKSUM =
+      "op_get_file_checksum";
 
   /** {@value}. */
   public static final String OP_GET_FILE_STATUS = "op_get_file_status";
@@ -81,7 +89,8 @@ public class StoreStatisticNames {
   public static final String OP_LIST_FILES = "op_list_files";
 
   /** {@value}. */
-  public static final String OP_LIST_LOCATED_STATUS = "op_list_located_status";
+  public static final String OP_LIST_LOCATED_STATUS =
+      "op_list_located_status";
 
   /** {@value}. */
   public static final String OP_LIST_STATUS = "op_list_status";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * These are common statistic names.
+ *
+ * When adding new common statistic name constants, please make them unique.
+ * By convention, they are implicitly unique:
+ * <ul>
+ *   <li>the name of the constants are uppercase, words separated by
+ *   underscores.</li>
+ *   <li>the value of the constants are lowercase of the constant names.</li>
+ * </ul>
+ */
+@InterfaceStability.Unstable
+public class StoreStatisticNames {
+
+  /** {@value}. */
+  public static final String OP_APPEND = "op_append";
+
+  /** {@value}. */
+  public static final String OP_COPY_FROM_LOCAL_FILE =
+      "op_copy_from_local_file";
+
+  /** {@value}. */
+  public static final String OP_CREATE = "op_create";
+
+  /** {@value}. */
+  public static final String OP_CREATE_NON_RECURSIVE = "op_create_non_recursive";
+
+  /** {@value}. */
+  public static final String OP_DELETE = "op_delete";
+
+  /** {@value}. */
+  public static final String OP_EXISTS = "op_exists";
+
+  /** {@value}. */
+  public static final String OP_GET_CONTENT_SUMMARY = "op_get_content_summary";
+
+  /** {@value}. */
+  public static final String OP_GET_DELEGATION_TOKEN = "op_get_delegation_token";
+
+  /** {@value}. */
+  public static final String OP_GET_FILE_CHECKSUM = "op_get_file_checksum";
+
+  /** {@value}. */
+  public static final String OP_GET_FILE_STATUS = "op_get_file_status";
+
+  /** {@value}. */
+  public static final String OP_GET_STATUS = "op_get_status";
+
+  /** {@value}. */
+  public static final String OP_GLOB_STATUS = "op_glob_status";
+
+  /** {@value}. */
+  public static final String OP_IS_FILE = "op_is_file";
+
+  /** {@value}. */
+  public static final String OP_IS_DIRECTORY = "op_is_directory";
+
+  /** {@value}. */
+  public static final String OP_LIST_FILES = "op_list_files";
+
+  /** {@value}. */
+  public static final String OP_LIST_LOCATED_STATUS = "op_list_located_status";
+
+  /** {@value}. */
+  public static final String OP_LIST_STATUS = "op_list_status";
+
+  /** {@value}. */
+  public static final String OP_MKDIRS = "op_mkdirs";
+
+  /** {@value}. */
+  public static final String OP_MODIFY_ACL_ENTRIES = "op_modify_acl_entries";
+
+  /** {@value}. */
+  public static final String OP_OPEN = "op_open";
+
+  /** {@value}. */
+  public static final String OP_REMOVE_ACL = "op_remove_acl";
+
+  /** {@value}. */
+  public static final String OP_REMOVE_ACL_ENTRIES = "op_remove_acl_entries";
+
+  /** {@value}. */
+  public static final String OP_REMOVE_DEFAULT_ACL = "op_remove_default_acl";
+
+  /** {@value}. */
+  public static final String OP_RENAME = "op_rename";
+
+  /** {@value}. */
+  public static final String OP_SET_ACL = "op_set_acl";
+
+  /** {@value}. */
+  public static final String OP_SET_OWNER = "op_set_owner";
+
+  /** {@value}. */
+  public static final String OP_SET_PERMISSION = "op_set_permission";
+
+  /** {@value}. */
+  public static final String OP_SET_TIMES = "op_set_times";
+
+  /** {@value}. */
+  public static final String OP_TRUNCATE = "op_truncate";
+
+  /** {@value}. */
+  public static final String DELEGATION_TOKENS_ISSUED
+      = "delegation_tokens_issued";
+
+  /** Requests throttled and retried: {@value}. */
+  public static final String STORE_IO_THROTTLED
+      = "store_io_throttled";
+
+  /** Requests made of a store: {@value}. */
+  public static final String STORE_IO_REQUEST
+    =  "store_io_request";
+
+  /**
+   * IO retried: {@value}.
+   */
+  public static final String STORE_IO_RETRY
+      = "store_io_retry";
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * These are common statistic names.
- *
+ * <p>
  * When adding new common statistic name constants, please make them unique.
  * By convention, they are implicitly unique:
  * <ul>
@@ -36,7 +36,10 @@ import org.apache.hadoop.classification.InterfaceStability;
  * </ul>
  */
 @InterfaceStability.Unstable
-public class StreamStatisticNames {
+public final class StreamStatisticNames {
+
+  private StreamStatisticNames() {
+  }
 
   /** {@value}. */
   public static final String STREAM_ABORTED = "stream_aborted";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -111,7 +111,6 @@ public class StreamStatisticNames {
   public static final String STREAM_READ_SEEK_BACKWARD_OPERATIONS =
       "stream_read_seek_backward_operations";
 
-
   /** {@value}. */
   public static final String STREAM_WRITE_FAILURES =
       "stream_write_failures";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * These are common statistic names.
+ *
+ * When adding new common statistic name constants, please make them unique.
+ * By convention, they are implicitly unique:
+ * <ul>
+ *   <li>
+ *     The name of the constants are uppercase, words separated by
+ *     underscores.
+ *   </li>
+ *   <li>
+ *     The value of the constants are lowercase of the constant names.
+ *   </li>
+ * </ul>
+ */
+@InterfaceStability.Unstable
+public class StreamStatisticNames {
+
+  /** {@value}. */
+  public static final String STREAM_ABORTED = "stream_aborted";
+
+  /** {@value}. */
+  public static final String STREAM_BYTES_DISCARDED_ABORT
+      = "stream_bytes_discarded_in_abort";
+
+  /** {@value}. */
+  public static final String STREAM_BYTES_DISCARDED_SEEK
+      = "stream_bytes_discarded_in_seek";
+
+  /** {@value}. */
+  public static final String STREAM_CLOSED = "stream_closed";
+
+  /** {@value}. */
+  public static final String STREAM_CLOSE_BYTES_READ
+      = "stream_bytes_read_in_close";
+
+  /** {@value}. */
+  public static final String STREAM_CLOSE_OPERATIONS
+      = "stream_close_operations";
+
+  /** {@value}. */
+  public static final String STREAM_OPENED = "stream_opened";
+
+  /** {@value}. */
+  public static final String STREAM_READ_BYTES
+      = "stream_read_bytes";
+
+  /** {@value}. */
+  public static final String STREAM_READ_EXCEPTIONS =
+      "stream_read_exceptions";
+
+  /** {@value}. */
+  public static final String STREAM_READ_FULLY_OPERATIONS
+      = "stream_read_fully_operations";
+
+  /** {@value}. */
+  public static final String STREAM_READ_OPERATIONS =
+      "stream_read_operations";
+
+  /** {@value}. */
+  public static final String STREAM_READ_OPERATIONS_INCOMPLETE
+      = "stream_read_operations_incomplete";
+
+  /** {@value}. */
+  public static final String STREAM_READ_VERSION_MISMATCHES
+      = "stream_read_version_mismatches";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_BYTES_BACKWARDS
+      = "stream_bytes_backwards_on_seek";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_BYTES_READ =
+      "stream_read_seek_bytes_read";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_BYTES_SKIPPED
+      = "stream_bytes_skipped_on_seek";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_FORWARD_OPERATIONS
+      = "stream_read_seek_forward_operations";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_OPERATIONS =
+      "stream_read_seek_operations";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_BACKWARD_OPERATIONS =
+      "stream_read_seek_backward_operations";
+
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_FAILURES =
+      "stream_write_failures";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BLOCK_UPLOADS
+      = "stream_write_block_uploads";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BLOCK_UPLOADS_ABORTED
+      = "stream_write_block_uploads_aborted";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BLOCK_UPLOADS_ACTIVE
+      = "stream_write_block_uploads_active";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BLOCK_UPLOADS_COMMITTED
+      = "stream_write_block_uploads_committed";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BLOCK_UPLOADS_PENDING
+      = "stream_write_block_uploads_pending";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BLOCK_UPLOADS_DATA_PENDING =
+      "stream_write_block_uploads_data_pending";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_BYTES
+      = "stream_write_bytes";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_TOTAL_TIME
+      = "stream_write_total_time";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_QUEUE_DURATION
+      = "stream_write_queue_duration";
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -115,8 +115,16 @@ public final class StreamStatisticNames {
       "stream_read_seek_backward_operations";
 
   /** {@value}. */
-  public static final String STREAM_WRITE_FAILURES =
-      "stream_write_failures";
+  public static final String STREAM_READ_SKIP_OPERATIONS =
+      "stream_read_skip_operations";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SKIP_BYTES =
+      "stream_read_skip_bytes";
+
+  /** {@value}. */
+  public static final String STREAM_WRITE_EXCEPTIONS =
+      "stream_write_exceptions";
 
   /** {@value}. */
   public static final String STREAM_WRITE_BLOCK_UPLOADS

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -42,29 +42,29 @@ public final class StreamStatisticNames {
   }
 
   /** {@value}. */
-  public static final String STREAM_ABORTED = "stream_aborted";
+  public static final String STREAM_READ_ABORTED = "stream_aborted";
 
   /** {@value}. */
-  public static final String STREAM_BYTES_DISCARDED_ABORT
-      = "stream_bytes_discarded_in_abort";
+  public static final String STREAM_READ_BYTES_DISCARDED_ABORT
+      = "stream_read_bytes_discarded_in_abort";
 
   /** {@value}. */
-  public static final String STREAM_BYTES_DISCARDED_SEEK
-      = "stream_bytes_discarded_in_seek";
+  public static final String STREAM_READ_BYTES_DISCARDED_SEEK
+      = "stream_read_bytes_discarded_in_seek";
 
   /** {@value}. */
-  public static final String STREAM_CLOSED = "stream_closed";
+  public static final String STREAM_READ_CLOSED = "stream_read_closed";
 
   /** {@value}. */
-  public static final String STREAM_CLOSE_BYTES_READ
-      = "stream_bytes_read_in_close";
+  public static final String STREAM_READ_CLOSE_BYTES_READ
+      = "stream_read_bytes_read_in_close";
 
   /** {@value}. */
-  public static final String STREAM_CLOSE_OPERATIONS
-      = "stream_close_operations";
+  public static final String STREAM_READ_CLOSE_OPERATIONS
+      = "stream_read_close_operations";
 
   /** {@value}. */
-  public static final String STREAM_OPENED = "stream_opened";
+  public static final String STREAM_READ_OPENED = "stream_read_opened";
 
   /** {@value}. */
   public static final String STREAM_READ_BYTES
@@ -92,15 +92,7 @@ public final class StreamStatisticNames {
 
   /** {@value}. */
   public static final String STREAM_READ_SEEK_BYTES_BACKWARDS
-      = "stream_bytes_backwards_on_seek";
-
-  /** {@value}. */
-  public static final String STREAM_READ_SEEK_BYTES_READ =
-      "stream_read_seek_bytes_read";
-
-  /** {@value}. */
-  public static final String STREAM_READ_SEEK_BYTES_SKIPPED
-      = "stream_bytes_skipped_on_seek";
+      = "stream_read_bytes_backwards_on_seek";
 
   /** {@value}. */
   public static final String STREAM_READ_SEEK_FORWARD_OPERATIONS
@@ -113,6 +105,14 @@ public final class StreamStatisticNames {
   /** {@value}. */
   public static final String STREAM_READ_SEEK_BACKWARD_OPERATIONS =
       "stream_read_seek_backward_operations";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_BYTES_READ =
+      "stream_read_seek_bytes_read";
+
+  /** {@value}. */
+  public static final String STREAM_READ_SEEK_BYTES_SKIPPED
+      = "stream_read_bytes_skipped_on_seek";
 
   /** {@value}. */
   public static final String STREAM_READ_SKIP_OPERATIONS =

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/BufferedIOStatisticsInputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/BufferedIOStatisticsInputStream.java
@@ -18,50 +18,35 @@
 
 package org.apache.hadoop.fs.statistics.impl;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 
-import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStatistics;
 
 /**
- * Wrap IOStatistics source with another (dynamic) wrapper.
+ * An extension of {@code BufferedInputStream} which implements
+ * {@link IOStatisticsSource} and forwards requests for the
+ * {@link IOStatistics} to the wrapped stream.
+ * This should be used when any input stream needs buffering while
+ * allowing the inner stream to be a source of statistics.
  */
-public class WrappedIOStatistics implements IOStatistics {
+public class BufferedIOStatisticsInputStream
+    extends BufferedInputStream
+    implements IOStatisticsSource {
 
-  private IOStatistics source;
-
-  public WrappedIOStatistics(final IOStatistics source) {
-    this.source = source;
+  public BufferedIOStatisticsInputStream(final InputStream in) {
+    super(in);
   }
 
-
-  protected IOStatistics getSource() {
-    return source;
-  }
-
-  protected void setSource(final IOStatistics source) {
-    this.source = source;
+  public BufferedIOStatisticsInputStream(final InputStream in, final int size) {
+    super(in, size);
   }
 
   @Override
-  public IOStatisticEntry getStatistic(final String key) {
-    return source.getStatistic(key);
-  }
-
-  @Override
-  public boolean isTracked(final String key) {
-    return source.isTracked(key);
-  }
-
-  @Override
-  public Set<String> keys() {
-    return source.keys();
-  }
-
-  @Override
-  public Iterator<Map.Entry<String, IOStatisticEntry>> iterator() {
-    return source.iterator();
+  public IOStatistics getIOStatistics() {
+    return retrieveIOStatistics(in);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/BufferedIOStatisticsOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/BufferedIOStatisticsOutputStream.java
@@ -30,9 +30,12 @@ import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStat
  * An extension of {@code BufferedOutputStream} which implements
  * {@link IOStatisticsSource} and forwards requests for the
  * {@link IOStatistics} to the wrapped stream.
+ * This should be used when any output stream needs buffering while
+ * allowing the inner stream to be a source of statistics.
  */
-public class BufferedIOStatisticsOutputStream extends BufferedOutputStream implements
-    IOStatisticsSource {
+public class BufferedIOStatisticsOutputStream
+    extends BufferedOutputStream
+    implements IOStatisticsSource {
 
   public BufferedIOStatisticsOutputStream(final OutputStream out) {
     super(out);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/BufferedIOStatisticsOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/BufferedIOStatisticsOutputStream.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStatistics;
+
+/**
+ * An extension of {@code BufferedOutputStream} which implements
+ * {@link IOStatisticsSource} and forwards requests for the
+ * {@link IOStatistics} to the wrapped stream.
+ */
+public class BufferedIOStatisticsOutputStream extends BufferedOutputStream implements
+    IOStatisticsSource {
+
+  public BufferedIOStatisticsOutputStream(final OutputStream out) {
+    super(out);
+  }
+
+  public BufferedIOStatisticsOutputStream(final OutputStream out,
+      final int size) {
+    super(out, size);
+  }
+
+  @Override
+  public IOStatistics getIOStatistics() {
+    return retrieveIOStatistics(out);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
@@ -42,4 +42,9 @@ public interface CounterIOStatistics extends IOStatistics {
    */
   void set(String key, long value);
 
+  /**
+   * Reset all counters.
+   * Unsynchronized.
+   */
+  void resetCounters();
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
@@ -28,18 +28,18 @@ import org.apache.hadoop.fs.statistics.IOStatistics;
  */
 public interface CounterIOStatistics extends IOStatistics {
 
-  /**
-   * Increment the counter.
-   * No-op if the counter is unknown.
-   * @param value incremental value.
-   */
-  void increment(String key, long value);
+  long increment(String key, long value);
 
   /**
-   * Set the counter.
+   * Increment the counter by one.
    * No-op if the counter is unknown.
-   * @param value new value.
+   * @param key statistics key
+   * @return old value or 0
    */
+  default long increment(String key) {
+    return increment(key, 1);
+  }
+
   void set(String key, long value);
 
   /**
@@ -47,4 +47,28 @@ public interface CounterIOStatistics extends IOStatistics {
    * Unsynchronized.
    */
   void resetCounters();
+
+  /**
+   * Update the counter values from a statistics source.
+   * The source must have all keys in this instance;
+   * extra keys are ignored.
+   * @param source source of statistics.
+   */
+  void copy(IOStatistics source);
+
+  /**
+   * Add the counter values from a statistics source.
+   * The source must have all keys in this instance;
+   * extra keys are ignored.
+   * @param source source of statistics.
+   */
+  void add(IOStatistics source);
+
+  /**
+   * Subtract the counter values from a statistics source.
+   * The source must have all keys in this instance;
+   * extra keys are ignored.
+   * @param source source of statistics.
+   */
+  void subtract(IOStatistics source);
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * Interface an IOStatistics source where all the counters
+ * are implemented as a static set of counters.
+ * <p></p>
+ * Thread safe.
+ */
+public interface CounterIOStatistics extends IOStatistics {
+
+  /**
+   * Increment the counter.
+   * No-op if the counter is unknown.
+   * @param value incremental value.
+   */
+  void increment(String key, long value);
+
+  /**
+   * Set the counter.
+   * No-op if the counter is unknown.
+   * @param value new value.
+   */
+  void set(String key, long value);
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatistics.java
@@ -58,6 +58,9 @@ public interface CounterIOStatistics extends IOStatistics {
 
   /**
    * Add the counter values from a statistics source.
+   * <p></p>
+   * All entries must be counters.
+   * <p></p>
    * The source must have all keys in this instance;
    * extra keys are ignored.
    * @param source source of statistics.
@@ -66,6 +69,9 @@ public interface CounterIOStatistics extends IOStatistics {
 
   /**
    * Subtract the counter values from a statistics source.
+   * <p></p>
+   * All entries must be counters.
+   * <p></p>
    * The source must have all keys in this instance;
    * extra keys are ignored.
    * @param source source of statistics.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatisticsImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatisticsImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.dynamicIOStatistics;
+
+/**
+ * Implement statistics as a map of atomic longs.
+ */
+final class CounterIOStatisticsImpl extends WrappedIOStatistics
+    implements CounterIOStatistics {
+
+
+  private final Map<String, AtomicLong> counters = new HashMap<>();
+
+  /**
+   * Constructor.
+   * @param keys keys to use for the counter statistics.
+   */
+  CounterIOStatisticsImpl(String[] keys) {
+    super(null);
+    DynamicIOStatisticsBuilder builder = dynamicIOStatistics();
+    for (int i = 0; i < keys.length; i++) {
+      AtomicLong counter = new AtomicLong();
+      String key = keys[i];
+      counters.put(key, counter);
+      builder.add(key, counter);
+    }
+    setSource(builder.build());
+  }
+
+  @Override
+  public void increment(final String key, final long value) {
+    AtomicLong counter = counters.get(key);
+    if (counter != null) {
+      counter.addAndGet(value);
+    }
+  }
+
+  @Override
+  public void set(final String key, final long value) {
+    AtomicLong counter = counters.get(key);
+    if (counter != null) {
+      counter.set(value);
+    }
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatisticsImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatisticsImpl.java
@@ -31,7 +31,8 @@ import org.apache.hadoop.fs.statistics.IOStatistics;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.dynamicIOStatistics;
 
 /**
- * Implement statistics as a map of atomic longs.
+ * Implement counter statistics as a map of AtomicLong counters
+ * created in the constructor.
  */
 final class CounterIOStatisticsImpl extends WrappedIOStatistics
     implements CounterIOStatistics {
@@ -80,12 +81,6 @@ final class CounterIOStatisticsImpl extends WrappedIOStatistics
     counters.values().forEach(a -> a.set(0));
   }
 
-  /**
-   * Update the counter values from a statistics source.
-   * The source must have all keys in this instance;
-   * extra keys are ignored.
-   * @param source source of statistics.
-   */
   @Override
   public void copy(final IOStatistics source) {
     counters.entrySet().forEach(e -> {
@@ -94,18 +89,12 @@ final class CounterIOStatisticsImpl extends WrappedIOStatistics
       Preconditions.checkState(statisticValue != null,
           "No statistic %s in IOStatistic source %s",
           key, source);
-      e.getValue().set(statisticValue.singleValue(
+      e.getValue().set(statisticValue.scalar(
           IOStatisticEntry.IOSTATISTIC_COUNTER
       ));
     });
   }
 
-  /**
-   * Add the counter values from a statistics source.
-   * The source must have all keys in this instance;
-   * extra keys are ignored.
-   * @param source source of statistics.
-   */
   @Override
   public void add(final IOStatistics source) {
     counters.entrySet().forEach(e -> {
@@ -114,18 +103,12 @@ final class CounterIOStatisticsImpl extends WrappedIOStatistics
       Preconditions.checkState(statisticValue != null,
           "No statistic %s in IOStatistic source %s",
           key, source);
-      long v = statisticValue.singleValue(
+      long v = statisticValue.scalar(
           IOStatisticEntry.IOSTATISTIC_COUNTER);
       e.getValue().addAndGet(v);
     });
   }
 
-  /**
-   * Subtract the counter values from a statistics source.
-   * The source must have all keys in this instance;
-   * extra keys are ignored.
-   * @param source source of statistics.
-   */
   @Override
   public void subtract(final IOStatistics source) {
     counters.entrySet().forEach(e -> {
@@ -134,7 +117,7 @@ final class CounterIOStatisticsImpl extends WrappedIOStatistics
       Preconditions.checkState(statisticValue != null,
           "No statistic %s in IOStatistic source %s",
           key, source);
-      long v = statisticValue.singleValue(
+      long v = statisticValue.scalar(
           IOStatisticEntry.IOSTATISTIC_COUNTER);
       e.getValue().addAndGet(-v);
     });

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatisticsImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/CounterIOStatisticsImpl.java
@@ -66,4 +66,13 @@ final class CounterIOStatisticsImpl extends WrappedIOStatistics
     }
   }
 
+  /**
+   * Reset all counters.
+   * Unsynchronized.
+   */
+  @Override
+  public void resetCounters() {
+    counters.values().forEach(a -> a.set(0));
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatistics.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.ToLongFunction;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * These statistics are dynamically evaluated by the supplied
+ * String -&gt; Long functions.
+ *
+ * This allows statistic sources to supply a list of callbacks used to
+ * generate the statistics on demand; similar to some of the Coda Hale metrics.
+ *
+ * The evaluation actually takes place during the iteration's {@code next()}
+ * call; the returned a value is fixed.
+ */
+final class DynamicIOStatistics implements IOStatistics {
+
+  /**
+   * Treemaps sort their insertions so the iterator is ordered.
+   */
+  private final Map<String, ToLongFunction<String>> evaluators
+      = new TreeMap<>();
+
+  DynamicIOStatistics() {
+  }
+
+  /**
+   * add a mapping of a key to an evaluator.
+   * @param key the key
+   * @param eval the evaluator
+   */
+  void add(String key, ToLongFunction<String> eval) {
+    evaluators.put(key, eval);
+  }
+
+  /**
+   * Get the value of a key.
+   * If the key is present, this will (re)evaluate it
+   * @param key key to look for.
+   * @return the latest value of that statistic, if found, else null.
+   */
+  @Override
+  public Long getStatistic(final String key) {
+    ToLongFunction<String> fn = evaluators.get(key);
+    return fn != null
+        ? fn.applyAsLong(key)
+        : null;
+  }
+
+  @Override
+  public boolean isTracked(final String key) {
+    return evaluators.containsKey(key);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, Long>> iterator() {
+    return new DynamicIterator();
+  }
+
+  @Override
+  public boolean hasAttribute(final Attributes attr) {
+    return Attributes.Dynamic == attr;
+  }
+
+  @Override
+  public Set<String> keys() {
+    return evaluators.keySet();
+  }
+
+  /**
+   * Iterator over the entries, evaluating each one in the next() call.
+   */
+  private final class DynamicIterator
+      implements Iterator<Map.Entry<String, Long>> {
+
+    private final Iterator<Map.Entry<String, ToLongFunction<String>>>
+        iterator = evaluators.entrySet().iterator();
+
+    private DynamicIterator() {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public Map.Entry<String, Long> next() {
+      final Map.Entry<String, ToLongFunction<String>> entry = iterator.next();
+      return new IOStatisticsImplementationHelper.StatsMapEntry(
+          entry.getKey(),
+          entry.getValue().applyAsLong(entry.getKey()));
+    }
+
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatistics.java
@@ -29,18 +29,18 @@ import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 
-import static org.apache.hadoop.fs.statistics.IOStatisticEntry.entry;
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.statsEntry;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.snapshotStatistics;
 
 /**
  * These statistics are dynamically evaluated by the supplied
  * String -&gt; Long functions.
- *
+ * <p></p>
  * This allows statistic sources to supply a list of callbacks used to
  * generate the statistics on demand; similar to some of the Coda Hale metrics.
- *
+ * <p></p>
  * The evaluation actually takes place during the iteration's {@code next()}
- * call; the returned a value is fixed.
+ * call.
  */
 final class DynamicIOStatistics implements IOStatistics {
 
@@ -61,7 +61,7 @@ final class DynamicIOStatistics implements IOStatistics {
    */
   void addLongFunction(String key, ToLongFunction<String> eval) {
     addFunction(key, k ->
-        entry(IOStatisticEntry.IOSTATISTIC_COUNTER,
+        statsEntry(IOStatisticEntry.IOSTATISTIC_COUNTER,
             eval.applyAsLong(k)));
   }
 
@@ -99,7 +99,6 @@ final class DynamicIOStatistics implements IOStatistics {
    */
   @Override
   public Iterator<Map.Entry<String, IOStatisticEntry>> iterator() {
-
     return snapshotStatistics(this).iterator();
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatisticsBuilder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatisticsBuilder.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.ToLongFunction;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Builder of Dynamic IO Statistics.
+ * Instantiate through
+ * {@link IOStatisticsImplementationHelper#createDynamicIOStatistics()}.
+ */
+public class DynamicIOStatisticsBuilder {
+
+  /**
+   * the instance being built up. Will be null after the (single)
+   * call to {@link #build()}.
+   */
+  private DynamicIOStatistics instance = new DynamicIOStatistics();
+
+  /**
+   * Add a new evaluator to the statistics being built up.
+   * @param key key of this statistic
+   * @param eval evaluator for the statistic
+   * @return the builder.
+   */
+  public DynamicIOStatisticsBuilder add(String key,
+      ToLongFunction<String> eval) {
+    activeInstance().add(key, eval);
+    return this;
+  }
+
+  /**
+   * Add a statistic to dynamically return the
+   * latest value of the source.
+   * @param key key of this statistic
+   * @param source atomic long counter
+   * @return the builder.
+   */
+  public DynamicIOStatisticsBuilder add(String key,
+      AtomicLong source) {
+    add(key, s -> source.get());
+    return this;
+  }
+
+  /**
+   * Add a statistic to dynamically return the
+   * latest value of the source.
+   * @param key key of this statistic
+   * @param source atomic int counter
+   * @return the builder.
+   */
+  public DynamicIOStatisticsBuilder add(String key,
+      AtomicInteger source) {
+    add(key, s -> source.get());
+    return this;
+  }
+
+  /**
+   * Build a dynamic statistic from a
+   * {@link MutableCounterLong}.
+   * @param key key of this statistic
+   * @param source mutable long counter
+   * @return the builder.
+   */
+  public DynamicIOStatisticsBuilder add(String key,
+      MutableCounterLong source) {
+    add(key, s -> source.value());
+    return this;
+  }
+
+  /**
+   * Build the IOStatistics instance.
+   * @return an instance.
+   * @throws IllegalStateException if the builder has already been built.
+   */
+  public IOStatistics build() {
+    final DynamicIOStatistics stats = activeInstance();
+    // stop the builder from working any more.
+    instance = null;
+    return stats;
+  }
+
+  /**
+   * Get the statistics instance.
+   * @return the instance to build/return
+   * @throws IllegalStateException if the builder has already been built.
+   */
+  private DynamicIOStatistics activeInstance() {
+    checkState(instance != null, "Already built");
+    return instance;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatisticsBuilder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatisticsBuilder.java
@@ -30,7 +30,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Builder of Dynamic IO Statistics.
  * Instantiate through
- * {@link IOStatisticsImplementationHelper#createDynamicIOStatistics()}.
+ * {@link IOStatisticsBinding#dynamicIOStatistics()}.
  */
 public class DynamicIOStatisticsBuilder {
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatisticsBuilder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/DynamicIOStatisticsBuilder.java
@@ -20,15 +20,17 @@ package org.apache.hadoop.fs.statistics.impl;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.function.ToLongFunction;
 
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 import static com.google.common.base.Preconditions.checkState;
 
 /**
- * Builder of Dynamic IO Statistics.
+ * Builder of Dynamic IO Statistics which serve up up longs.
  * Instantiate through
  * {@link IOStatisticsBinding#dynamicIOStatistics()}.
  */
@@ -46,9 +48,21 @@ public class DynamicIOStatisticsBuilder {
    * @param eval evaluator for the statistic
    * @return the builder.
    */
-  public DynamicIOStatisticsBuilder add(String key,
+  public DynamicIOStatisticsBuilder withFunction(String key,
+      Function<String, IOStatisticEntry> eval) {
+    activeInstance().addFunction(key, eval);
+    return this;
+  }
+
+  /**
+   * Add a new evaluator to the statistics being built up.
+   * @param key key of this statistic
+   * @param eval evaluator for the statistic
+   * @return the builder.
+   */
+  public DynamicIOStatisticsBuilder withLongFunction(String key,
       ToLongFunction<String> eval) {
-    activeInstance().add(key, eval);
+    activeInstance().addLongFunction(key, eval);
     return this;
   }
 
@@ -59,9 +73,9 @@ public class DynamicIOStatisticsBuilder {
    * @param source atomic long counter
    * @return the builder.
    */
-  public DynamicIOStatisticsBuilder add(String key,
+  public DynamicIOStatisticsBuilder withAtomicLong(String key,
       AtomicLong source) {
-    add(key, s -> source.get());
+    withLongFunction(key, s -> source.get());
     return this;
   }
 
@@ -72,9 +86,9 @@ public class DynamicIOStatisticsBuilder {
    * @param source atomic int counter
    * @return the builder.
    */
-  public DynamicIOStatisticsBuilder add(String key,
+  public DynamicIOStatisticsBuilder withAtomicInteger(String key,
       AtomicInteger source) {
-    add(key, s -> source.get());
+    withLongFunction(key, s -> source.get());
     return this;
   }
 
@@ -85,9 +99,9 @@ public class DynamicIOStatisticsBuilder {
    * @param source mutable long counter
    * @return the builder.
    */
-  public DynamicIOStatisticsBuilder add(String key,
+  public DynamicIOStatisticsBuilder withMutableCounter(String key,
       MutableCounterLong source) {
-    add(key, s -> source.value());
+    withLongFunction(key, s -> source.value());
     return this;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/EmptyIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/EmptyIOStatistics.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * An empty IO Statistics implementation for classes which always
+ * want to return a non-null set of statistics.
+ */
+public final class EmptyIOStatistics implements IOStatistics {
+
+  /**
+   * The sole instance of this class.
+   */
+  private static final EmptyIOStatistics INSTANCE = new EmptyIOStatistics();
+
+  private EmptyIOStatistics() {
+  }
+
+  @Override
+  public Long getStatistic(final String key) {
+    return null;
+  }
+
+  @Override
+  public boolean isTracked(final String key) {
+    return false;
+  }
+
+  @Override
+  public boolean hasAttribute(final Attributes attr) {
+    return Attributes.Static == attr;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, Long>> iterator() {
+    return new EmptyIterator();
+  }
+
+  @Override
+  public Set<String> keys() {
+    return Collections.emptySet();
+  }
+
+  /**
+   * The empty iterator has no entries.
+   */
+  private static class EmptyIterator implements
+      Iterator<Map.Entry<String, Long>> {
+
+    @Override
+    public boolean hasNext() {
+      return false;
+    }
+
+    @SuppressWarnings("NewExceptionWithoutArguments")
+    @Override
+    public Map.Entry<String, Long> next() {
+      throw new NoSuchElementException();
+    }
+  }
+
+  /**
+   * Get the single instance of this class.
+   * @return a shared, empty instance.
+   */
+  public static IOStatistics getInstance() {
+    return INSTANCE;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/EmptyIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/EmptyIOStatistics.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.statistics.IOStatistics;
  * An empty IO Statistics implementation for classes which always
  * want to return a non-null set of statistics.
  */
-public final class EmptyIOStatistics implements IOStatistics {
+final class EmptyIOStatistics implements IOStatistics {
 
   /**
    * The sole instance of this class.
@@ -48,11 +48,6 @@ public final class EmptyIOStatistics implements IOStatistics {
   @Override
   public boolean isTracked(final String key) {
     return false;
-  }
-
-  @Override
-  public boolean hasAttribute(final Attributes attr) {
-    return Attributes.Static == attr;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/EmptyIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/EmptyIOStatistics.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 
 /**
@@ -41,7 +42,7 @@ final class EmptyIOStatistics implements IOStatistics {
   }
 
   @Override
-  public Long getStatistic(final String key) {
+  public IOStatisticEntry getStatistic(final String key) {
     return null;
   }
 
@@ -51,7 +52,7 @@ final class EmptyIOStatistics implements IOStatistics {
   }
 
   @Override
-  public Iterator<Map.Entry<String, Long>> iterator() {
+  public Iterator<Map.Entry<String, IOStatisticEntry>> iterator() {
     return new EmptyIterator();
   }
 
@@ -64,7 +65,7 @@ final class EmptyIOStatistics implements IOStatistics {
    * The empty iterator has no entries.
    */
   private static class EmptyIterator implements
-      Iterator<Map.Entry<String, Long>> {
+      Iterator<Map.Entry<String, IOStatisticEntry>> {
 
     @Override
     public boolean hasNext() {
@@ -73,7 +74,7 @@ final class EmptyIOStatistics implements IOStatistics {
 
     @SuppressWarnings("NewExceptionWithoutArguments")
     @Override
-    public Map.Entry<String, Long> next() {
+    public Map.Entry<String, IOStatisticEntry> next() {
       throw new NoSuchElementException();
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsBinding.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsBinding.java
@@ -45,6 +45,22 @@ public final class IOStatisticsBinding {
   }
 
   /**
+   * Create a diff of the current statistics states.
+   * This is not an atomic option.
+   * The instance can be serialized.
+   * @param left left value
+   * @param right right value
+   * @return a snapshot of the differences between left and right stats.
+   */
+  public static <X extends IOStatistics & Serializable> X diffStatistics(
+      IOStatistics left, IOStatistics right) {
+    SnapshotIOStatistics diff = new SnapshotIOStatistics();
+    diff.subtract(left, right);
+    return (X) diff;
+  }
+
+
+  /**
    * Create a builder for dynamic IO Statistics.
    * @return a builder to be completed.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsBinding.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsBinding.java
@@ -80,4 +80,16 @@ public final class IOStatisticsBinding {
   public static IOStatisticsSource wrap(IOStatistics statistics) {
     return new SourceWrappedStatistics(statistics);
   }
+
+  /**
+   * Create an IOStatistics instance from a varargs list of counter keys.
+   * This is the simplest way to build an IOStatistics instance as all
+   * the details are handled internally.
+   *
+   * @param keys key to use for the counter statistics.
+   * @return a new instance.
+   */
+  public static CounterIOStatistics counterIOStatistics(String...keys) {
+    return new CounterIOStatisticsImpl(keys);
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsBinding.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsBinding.java
@@ -45,22 +45,6 @@ public final class IOStatisticsBinding {
   }
 
   /**
-   * Create a diff of the current statistics states.
-   * This is not an atomic option.
-   * The instance can be serialized.
-   * @param left left value
-   * @param right right value
-   * @return a snapshot of the differences between left and right stats.
-   */
-  public static <X extends IOStatistics & Serializable> X diffStatistics(
-      IOStatistics left, IOStatistics right) {
-    SnapshotIOStatistics diff = new SnapshotIOStatistics();
-    diff.subtract(left, right);
-    return (X) diff;
-  }
-
-
-  /**
    * Create a builder for dynamic IO Statistics.
    * @return a builder to be completed.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.fs.statistics.IOStatistics;
 /**
  * This provides an IOStatistics implementation from a storage statistics
  * instance.
- * If a null statistics instance is passed in, the statistics are empty.
- * This makes it possible to instantiate this from any filesystem.t
  */
 final class IOStatisticsFromStorageStatistics
     implements IOStatistics {
@@ -93,7 +91,8 @@ final class IOStatisticsFromStorageStatistics
      */
     private final Iterator<StorageStatistics.LongStatistic> iterator;
 
-    private MapEntryIterator(final Iterator<StorageStatistics.LongStatistic> iterator) {
+    private MapEntryIterator(
+        final Iterator<StorageStatistics.LongStatistic> iterator) {
       this.iterator = iterator;
     }
 
@@ -108,10 +107,6 @@ final class IOStatisticsFromStorageStatistics
       return new StatsMapEntry(entry.getName(), entry.getValue());
     }
 
-    @Override
-    public void remove() {
-      iterator.remove();
-    }
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+/**
+ * This provides an IOStatistics implementation from a storage statistics
+ * instance.
+ * If a null statistics instance is passed in, the statistics are empty.
+ * This makes it possible to instantiate this from any filesystem.t
+ */
+public class IOStatisticsFromStorageStatistics
+    implements IOStatisticsSource {
+
+  private final IOStatistics binding;
+
+  /**
+   * Instantiate from a storage statistics instance, which may be null,
+   * in which case the statistics are empty.
+   * @param storageStatistics from storage statistics.
+   */
+  public IOStatisticsFromStorageStatistics(
+      final StorageStatistics storageStatistics) {
+    if (storageStatistics != null) {
+      binding = new IOStatisticsBinding(storageStatistics);
+    } else {
+      binding = null;
+    }
+  }
+
+  /**
+   * Get any IO statistics.
+   * @return the IO statistics bound to.
+   */
+  @Override
+  public IOStatistics getIOStatistics() {
+    return binding;
+  }
+
+  /**
+   * The internal binding.
+   */
+  private static final class IOStatisticsBinding implements IOStatistics {
+
+    /**
+     * Source.
+     */
+    private final StorageStatistics storageStatistics;
+
+    /**
+     * Keys, calculated in the constructor.
+     */
+    private final Set<String> keys;
+
+    private IOStatisticsBinding(final StorageStatistics storageStatistics) {
+      Preconditions.checkArgument(storageStatistics != null,
+          "Null storage statistics");
+      this.storageStatistics = storageStatistics;
+      // build the keys.
+      keys = new TreeSet<>();
+      final Iterator<StorageStatistics.LongStatistic> st
+          = storageStatistics.getLongStatistics();
+      while (st.hasNext()) {
+        keys.add(st.next().getName());
+      }
+    }
+
+    @Override
+    public boolean hasAttribute(final Attributes attr) {
+      return Attributes.Dynamic == attr;
+    }
+
+    @Override
+    public Long getStatistic(final String key) {
+      return storageStatistics.getLong(key);
+    }
+
+    @Override
+    public boolean isTracked(final String key) {
+      return storageStatistics.isTracked(key);
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, Long>> iterator() {
+      return new MapEntryIterator(storageStatistics.getLongStatistics());
+    }
+
+    @Override
+    public Set<String> keys() {
+      return keys;
+    }
+  }
+
+  /**
+   * An iterator which takes a long statistic iterator from StorageStatistics
+   * and converts to an IOStatistics-compatible type.
+   */
+  private static final class MapEntryIterator
+      implements Iterator<Map.Entry<String, Long>> {
+
+    /**
+     * The iterator over the storage statistic s.
+     */
+    private final Iterator<StorageStatistics.LongStatistic> iterator;
+
+    private MapEntryIterator(final Iterator<StorageStatistics.LongStatistic> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public Map.Entry<String, Long> next() {
+      final StorageStatistics.LongStatistic entry = iterator.next();
+      return new IOStatisticsImplementationHelper.StatsMapEntry(
+          entry.getName(), entry.getValue());
+    }
+
+    @Override
+    public void remove() {
+      iterator.remove();
+    }
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 
 /**
- * This provides an IOStatistics implementation from a storage statistics
+ * This provides an IOStatistics instance from a {@link StorageStatistics}
  * instance.
  */
 final class IOStatisticsFromStorageStatistics
@@ -45,6 +45,11 @@ final class IOStatisticsFromStorageStatistics
    */
   private final Set<String> keys;
 
+  /**
+   * Instantiate. This will iterate through the
+   * statistics to enumerate the keys.
+   * @param storageStatistics source
+   */
   IOStatisticsFromStorageStatistics(
       final StorageStatistics storageStatistics) {
     Preconditions.checkArgument(storageStatistics != null,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
@@ -26,7 +26,10 @@ import java.util.TreeSet;
 import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.entry;
 
 /**
  * This provides an IOStatistics instance from a {@link StorageStatistics}
@@ -65,8 +68,9 @@ final class IOStatisticsFromStorageStatistics
   }
 
   @Override
-  public Long getStatistic(final String key) {
-    return storageStatistics.getLong(key);
+  public IOStatisticEntry getStatistic(final String key) {
+    return entry(IOStatisticEntry.IOSTATISTIC_COUNTER,
+        storageStatistics.getLong(key));
   }
 
   @Override
@@ -75,7 +79,7 @@ final class IOStatisticsFromStorageStatistics
   }
 
   @Override
-  public Iterator<Map.Entry<String, Long>> iterator() {
+  public Iterator<Map.Entry<String, IOStatisticEntry>> iterator() {
     return new MapEntryIterator(storageStatistics.getLongStatistics());
   }
 
@@ -89,7 +93,7 @@ final class IOStatisticsFromStorageStatistics
    * and converts to an IOStatistics-compatible type.
    */
   private static final class MapEntryIterator
-      implements Iterator<Map.Entry<String, Long>> {
+      implements Iterator<Map.Entry<String, IOStatisticEntry>> {
 
     /**
      * The iterator over the storage statistics.
@@ -107,9 +111,9 @@ final class IOStatisticsFromStorageStatistics
     }
 
     @Override
-    public Map.Entry<String, Long> next() {
+    public Map.Entry<String, IOStatisticEntry> next() {
       final StorageStatistics.LongStatistic entry = iterator.next();
-      return new StatsMapEntry(entry.getName(), entry.getValue());
+      return StatsMapEntry.counter(entry.getName(), entry.getValue());
     }
 
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsFromStorageStatistics.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 
-import static org.apache.hadoop.fs.statistics.IOStatisticEntry.entry;
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.statsEntry;
 
 /**
  * This provides an IOStatistics instance from a {@link StorageStatistics}
@@ -69,7 +69,7 @@ final class IOStatisticsFromStorageStatistics
 
   @Override
   public IOStatisticEntry getStatistic(final String key) {
-    return entry(IOStatisticEntry.IOSTATISTIC_COUNTER,
+    return statsEntry(IOStatisticEntry.IOSTATISTIC_COUNTER,
         storageStatistics.getLong(key));
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsImplementationHelper.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsImplementationHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Map;
+
+import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+/**
+ * Support for implementing IOStatistics interfaces.
+ */
+public final class IOStatisticsImplementationHelper {
+
+  private IOStatisticsImplementationHelper() {
+  }
+
+  /**
+   * Wrap a (dynamic) source with a snapshot IOStatistics instance.
+   * @param source source
+   * @return a wrapped instance.
+   */
+  public static IOStatistics wrapWithSnapshot(IOStatistics source) {
+    return new SnapshotIOStatistics(source);
+  }
+
+  /**
+   * Create a builder for dynamic IO Statistics.
+   * @return a builder to be completed.
+   */
+  public static DynamicIOStatisticsBuilder
+    createDynamicIOStatistics() {
+
+    return new DynamicIOStatisticsBuilder();
+  }
+
+  /**
+   * Create an IO statistics source from a storage statistics instance.
+   * This will be updated as the storage statistics change.
+   * @param storageStatistics source data.
+   * @return an IO statistics source.
+   */
+  public static IOStatisticsSource createFromStorageStatistics(
+      StorageStatistics storageStatistics) {
+    return new IOStatisticsFromStorageStatistics(storageStatistics);
+  }
+
+  /**
+   * A map entry for implementations to return.
+   */
+  static final class StatsMapEntry implements Map.Entry<String, Long> {
+
+    /**
+     * Key.
+     */
+    private final String key;
+
+    /**
+     * Value.
+     */
+    private Long value;
+
+    /**
+     * Constructor.
+     * @param key key
+     * @param value value
+     */
+    StatsMapEntry(final String key, final Long value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public Long getValue() {
+      return value;
+    }
+
+    @SuppressWarnings("NestedAssignment")
+    @Override
+    public Long setValue(final Long value) {
+      return this.value = value;
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsImplementationUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsImplementationUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Map;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * Constants used in the implementation.
+ *
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class IOStatisticsImplementationUtils {
+
+  /** Pattern used for each entry. */
+  public static final String ENTRY_PATTERN = "(%s=%s)";
+
+  /** String to return when a source is null. */
+  @VisibleForTesting
+  public static final String NULL_SOURCE = "()";
+
+  /**
+   * Convert an entry to the string format used in logging.
+   *
+   * @param entry entry to evaluate
+   * @return formatted string
+   */
+  public static String entrytoString(final Map.Entry<String, Long> entry) {
+    return entrytoString(entry.getKey(), entry.getValue());
+  }
+
+  /**
+   * Convert entry values to the string format used in logging.
+   *
+   * @param name statistic name
+   * @param value stat value
+   * @return formatted string
+   */
+  public static String entrytoString(final String name, final Long value) {
+    return String.format(
+        ENTRY_PATTERN,
+        name,
+        value);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsImplementationUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsImplementationUtils.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 
 /**
  * Constants used in the implementation.
@@ -46,7 +47,8 @@ public class IOStatisticsImplementationUtils {
    * @param entry entry to evaluate
    * @return formatted string
    */
-  public static String entrytoString(final Map.Entry<String, Long> entry) {
+  public static String entrytoString(
+      final Map.Entry<String, IOStatisticEntry> entry) {
     return entrytoString(entry.getKey(), entry.getValue());
   }
 
@@ -57,7 +59,8 @@ public class IOStatisticsImplementationUtils {
    * @param value stat value
    * @return formatted string
    */
-  public static String entrytoString(final String name, final Long value) {
+  public static String entrytoString(
+      final String name, final IOStatisticEntry value) {
     return String.format(
         ENTRY_PATTERN,
         name,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * Snapshotted IO statistics; will update on a call to snapshot().
+ */
+class SnapshotIOStatistics implements IOStatistics {
+
+  /**
+   * Treemaps sort their insertions so the iterator is ordered.
+   */
+  private final Map<String, Long> entries
+      = new TreeMap<>();
+
+  /**
+   * Snapshot source.
+   */
+  private final IOStatistics source;
+
+  SnapshotIOStatistics(final IOStatistics source) {
+    this.source = source;
+    snapshot();
+  }
+
+  @Override
+  public Long getStatistic(final String key) {
+    return entries.get(key);
+  }
+
+  @Override
+  public boolean isTracked(final String key) {
+    return false;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, Long>> iterator() {
+    return entries.entrySet().iterator();
+  }
+
+  @Override
+  public boolean hasAttribute(final Attributes attr) {
+    return Attributes.Snapshotted == attr;
+  }
+
+  @Override
+  public Set<String> keys() {
+    return entries.keySet();
+  }
+
+  @Override
+  public synchronized boolean snapshot() {
+    entries.clear();
+    for (Map.Entry<String, Long> sourceEntry : source) {
+      entries.put(sourceEntry.getKey(), sourceEntry.getValue());
+    }
+    return true;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 
 /**
  * Snapshot of statistics from a different source.
+ * <p>
  * It is serializable so that frameworks which can use java serialization
  * to propagate data (Spark, Flink...) can send the statistics
  * back.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 
 /**
  * Snapshot of statistics from a different source.
@@ -91,5 +92,10 @@ class SnapshotIOStatistics implements IOStatistics, Serializable {
     for (String key : source.keys()) {
       entries.put(key, source.getStatistic(key));
     }
+  }
+
+  @Override
+  public String toString() {
+    return IOStatisticsLogging.iostatisticsToString(this);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
@@ -55,7 +55,7 @@ class SnapshotIOStatistics implements IOStatistics, Serializable {
   }
 
   /**
-   * Empty constructor.
+   * Empty constructor for deserialization.
    */
   SnapshotIOStatistics() {
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SnapshotIOStatistics.java
@@ -24,10 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import com.google.common.base.Preconditions;
-
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
-import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 
 /**
  * Snapshot of statistics from a different source.
@@ -45,7 +43,7 @@ class SnapshotIOStatistics implements IOStatistics, Serializable {
    * Treemaps sort their insertions so the iterator is ordered.
    * They are also serializable.
    */
-  private final TreeMap<String, Long> entries
+  private final TreeMap<String, IOStatisticEntry> entries
       = new TreeMap<>();
 
   /**
@@ -63,7 +61,7 @@ class SnapshotIOStatistics implements IOStatistics, Serializable {
   }
 
   @Override
-  public Long getStatistic(final String key) {
+  public IOStatisticEntry getStatistic(final String key) {
     return entries.get(key);
   }
 
@@ -73,7 +71,7 @@ class SnapshotIOStatistics implements IOStatistics, Serializable {
   }
 
   @Override
-  public Iterator<Map.Entry<String, Long>> iterator() {
+  public Iterator<Map.Entry<String, IOStatisticEntry>> iterator() {
     return entries.entrySet().iterator();
   }
 
@@ -97,26 +95,5 @@ class SnapshotIOStatistics implements IOStatistics, Serializable {
     }
   }
 
-  /**
-   * Build a diff of two statistics, using the left
-   * instance as the list of entries to build and value
-   * from which the diff is subtracted.
-   * All matching values must be in the right instance.
-   * @param left left value
-   * @param right right value
-   */
-   void subtract(IOStatistics left, IOStatistics right) {
-    entries.clear();
-    // MUST NOT use iterator() because IOStatistics implementations
-    // may create a snapshot when iterator() is invoked;
-    // enumerating keys and querying values avoids stack
-    // overflows
-    for (String key : left.keys()) {
-      Long rs = right.getStatistic(key);
-      Preconditions.checkArgument(rs != null,
-          "diff source lacks statistic %s", key);
-      entries.put(key, left.getStatistic(key) - rs);
-    }
-  }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SourceWrappedStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SourceWrappedStatistics.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+
+/**
+ * Wrap a statistics instance with an {@link IOStatisticsSource}
+ * instance which will then serve up the statistics when asked.
+ */
+public class SourceWrappedStatistics implements IOStatisticsSource {
+
+  private final IOStatistics source;
+
+  public SourceWrappedStatistics(final IOStatistics source) {
+    this.source = source;
+  }
+
+  @Override
+  public IOStatistics getIOStatistics() {
+    return source;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SourceWrappedStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/SourceWrappedStatistics.java
@@ -29,6 +29,10 @@ public class SourceWrappedStatistics implements IOStatisticsSource {
 
   private final IOStatistics source;
 
+  /**
+   * Constructor.
+   * @param source source of statistics.
+   */
   public SourceWrappedStatistics(final IOStatistics source) {
     this.source = source;
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
@@ -55,8 +55,9 @@ public final class StatsMapEntry implements Map.Entry<String, Long> {
 
   @SuppressWarnings("NestedAssignment")
   @Override
-  public Long setValue(final Long value) {
-    return this.value = value;
+  public Long setValue(final Long val) {
+    this.value = val;
+    return val;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Map;
+
+/**
+ * A map entry for implementations to use if they need to.
+ */
+public final class StatsMapEntry implements Map.Entry<String, Long> {
+
+  /**
+   * Key.
+   */
+  private final String key;
+
+  /**
+   * Value.
+   */
+  private Long value;
+
+  /**
+   * Constructor.
+   * @param key key
+   * @param value value
+   */
+  StatsMapEntry(final String key, final Long value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public Long getValue() {
+    return value;
+  }
+
+  @SuppressWarnings("NestedAssignment")
+  @Override
+  public Long setValue(final Long value) {
+    return this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(%s, %s)", key, value);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
@@ -20,10 +20,15 @@ package org.apache.hadoop.fs.statistics.impl;
 
 import java.util.Map;
 
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.entry;
+
 /**
  * A map entry for implementations to use if they need to.
  */
-public final class StatsMapEntry implements Map.Entry<String, Long> {
+public final class StatsMapEntry
+    implements Map.Entry<String, IOStatisticEntry> {
 
   /**
    * Key.
@@ -33,14 +38,14 @@ public final class StatsMapEntry implements Map.Entry<String, Long> {
   /**
    * Value.
    */
-  private Long value;
+  private IOStatisticEntry value;
 
   /**
    * Constructor.
    * @param key key
    * @param value value
    */
-  StatsMapEntry(final String key, final Long value) {
+  StatsMapEntry(final String key, final IOStatisticEntry value) {
     this.key = key;
     this.value = value;
   }
@@ -49,13 +54,12 @@ public final class StatsMapEntry implements Map.Entry<String, Long> {
     return key;
   }
 
-  public Long getValue() {
+  public IOStatisticEntry getValue() {
     return value;
   }
 
-  @SuppressWarnings("NestedAssignment")
   @Override
-  public Long setValue(final Long val) {
+  public IOStatisticEntry setValue(final IOStatisticEntry val) {
     this.value = val;
     return val;
   }
@@ -63,5 +67,16 @@ public final class StatsMapEntry implements Map.Entry<String, Long> {
   @Override
   public String toString() {
     return String.format("(%s, %s)", key, value);
+  }
+
+
+  /**
+   * Counter value.
+   * @param key key
+   * @param value value
+   */
+  public static StatsMapEntry counter(final String key, final long value) {
+    return new StatsMapEntry(key,
+        entry(IOStatisticEntry.IOSTATISTIC_COUNTER, value));
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StatsMapEntry.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 
-import static org.apache.hadoop.fs.statistics.IOStatisticEntry.entry;
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.statsEntry;
 
 /**
  * A map entry for implementations to use if they need to.
@@ -77,6 +77,6 @@ public final class StatsMapEntry
    */
   public static StatsMapEntry counter(final String key, final long value) {
     return new StatsMapEntry(key,
-        entry(IOStatisticEntry.IOSTATISTIC_COUNTER, value));
+        statsEntry(IOStatisticEntry.IOSTATISTIC_COUNTER, value));
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/WrappedIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/WrappedIOStatistics.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * Wrap IOStatistics source with another (dynamic) wrapper.
+ */
+public class WrappedIOStatistics implements IOStatistics {
+
+  private IOStatistics source;
+
+  public WrappedIOStatistics(final IOStatistics source) {
+    this.source = source;
+  }
+
+
+  protected IOStatistics getSource() {
+    return source;
+  }
+
+  protected void setSource(final IOStatistics source) {
+    this.source = source;
+  }
+
+  @Override
+  public Long getStatistic(final String key) {
+    return source.getStatistic(key);
+  }
+
+  @Override
+  public boolean isTracked(final String key) {
+    return source.isTracked(key);
+  }
+
+  @Override
+  public Set<String> keys() {
+    return source.keys();
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, Long>> iterator() {
+    return source.iterator();
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Implementation support for statistics.
+ * For use internally; external filesystems MAY use this if the implementors
+ * accept that it is unstable and that incompatible changes may take
+ * place over minor point releases.
+ */
+@InterfaceAudience.LimitedPrivate("Filesystems")
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.statistics.impl;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
@@ -45,8 +45,11 @@
  * to get its statistics.
  * If this is non-null, the client has statistics on the current
  * state of the statistics.
- * If dynamic, statistics can be enumerated and whenever
- * they are retrieved: the latest value will be returned.
+ *
+ * The expectation is that a statistics source is dynamic: when a value is
+ * looked up the most recent values are returned.
+ * When iterating through the set, the values of the iterator SHOULD
+ * be frozen at the time the iterator was requested.
  *
  * These statistics can be used to: log operations, profile applications, make
  * assertions about the state of the output.
@@ -68,7 +71,9 @@
  * IOStatistics keys SHOULD be standard names where possible.
  * </li>
  * <li>
- * MUST be unique to that specific instance of {@link IOStatisticsSource}.
+ * An IOStatistics instance MUST be unique to that specific instance of
+ * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource}.
+ * (i.e. not shared the way StorageStatistics are)
  * </li>
  * <li>
  * MUST return the same values irrespective of which thread the statistics are

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains support for statistic collection and reporting.
+ * This is the public API; implementation classes are to be kept elsewhere.
+ *
+ * This package is defines two interfaces
+ *
+ * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource}:
+ * a source of statistic data, which can be retrieved
+ * through a call to
+ * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource#getIOStatistics()} .
+ *
+ * {@link org.apache.hadoop.fs.statistics.IOStatistics} the statistics retrieved from a statistics source.
+ *
+ * The retrieved statistics may be an immutable snapshot -in which case to get
+ * updated statistics another call to
+ * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource#getIOStatistics()}
+ * must be made. Or they may be dynamic -in which case every time a specific
+ * statistic is retrieved, the latest version is returned. Callers should assume
+ * that if a statistics instance is dynamic, there is no atomicity when querying
+ * multiple statistics. If the statistics source was a closeable object (e.g. a
+ * stream), the statistics MUST remain valid after the stream is closed.
+ *
+ * Use pattern:
+ *
+ * An application probes an object (filesystem, stream etc) for implementation of
+ * {@code IOStatisticsSource}, and, if it is, calls {@code getIOStatistics()}
+ * to get its statistics.
+ * If this is non-null, the client has statistics on the current
+ * state of the statistics.
+ * If dynamic, statistics can be enumerated and whenever
+ * they are retrieved: the latest value will be returned.
+ *
+ * These statistics can be used to: log operations, profile applications, make
+ * assertions about the state of the output.
+ *
+ * The names of statistics are a matter of choice of the specific source.
+ * However, {@link org.apache.hadoop.fs.statistics.StoreStatisticNames}
+ * contains a
+ * set of names recommended for object store operations.
+ * {@link org.apache.hadoop.fs.statistics.StreamStatisticNames} declares
+ * recommended names for statistics provided for
+ * input and output streams.
+ *
+ * They can also be serialized to build statistics on the overall cost of
+ * operations, or printed to help diagnose performance/cost issues.
+ *
+ * Implementors notes
+ * <ol>
+ * <li>
+ * IOStatistics keys SHOULD be standard names where possible.
+ * </li>
+ * <li>
+ * MUST be unique to that specific instance of {@link IOStatisticsSource}.
+ * </li>
+ * <li>
+ * MUST return the same values irrespective of which thread the statistics are
+ * retrieved or its keys evaluated.
+ * </li>
+ * <li>
+ * MUST NOT remove keys once a statistic instance has been created.
+ * </li>
+ * <li>
+ * MUST NOT add keys once a statistic instance has been created.
+ * </li>
+ * <li>
+ * MUST NOT block for long periods of time while blocking operations
+ * (reads, writes) are taking place in the source.
+ * That is: minimal synchronization points (AtomicLongs etc.) may be
+ * used to share values, but retrieval of statistics should
+ * be fast and return values even while slow/blocking remote IO is underway.
+ * </li>
+ * <li>
+ * MUST support value enumeration and retrieval after the source has been closed.
+ * </li>
+ * <li>
+ * SHOULD NOT have back-references to potentially expensive objects (filesystem
+ * instances etc)
+ * </li>
+ * <li>
+ * SHOULD provide statistics which can be added to generate aggregate statistics.
+ * </li>
+ * </ol>
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
@@ -20,7 +20,7 @@
  * This package contains support for statistic collection and reporting.
  * This is the public API; implementation classes are to be kept elsewhere.
  *
- * This package is defines two interfaces
+ * This package defines two interfaces:
  *
  * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource}:
  * a source of statistic data, which can be retrieved
@@ -37,23 +37,23 @@
  * that if a statistics instance is dynamic, there is no atomicity when querying
  * multiple statistics. If the statistics source was a closeable object (e.g. a
  * stream), the statistics MUST remain valid after the stream is closed.
- *
+ * <p>
  * Use pattern:
- *
+ * <p>
  * An application probes an object (filesystem, stream etc) for implementation of
  * {@code IOStatisticsSource}, and, if it is, calls {@code getIOStatistics()}
  * to get its statistics.
  * If this is non-null, the client has statistics on the current
  * state of the statistics.
- *
+ * <p>
  * The expectation is that a statistics source is dynamic: when a value is
  * looked up the most recent values are returned.
  * When iterating through the set, the values of the iterator SHOULD
  * be frozen at the time the iterator was requested.
- *
+ * <p>
  * These statistics can be used to: log operations, profile applications, make
  * assertions about the state of the output.
- *
+ * <p>
  * The names of statistics are a matter of choice of the specific source.
  * However, {@link org.apache.hadoop.fs.statistics.StoreStatisticNames}
  * contains a
@@ -61,10 +61,22 @@
  * {@link org.apache.hadoop.fs.statistics.StreamStatisticNames} declares
  * recommended names for statistics provided for
  * input and output streams.
+ * <p>
+ * Utility classes are includes to assist use
+ * <ul>
+ *   <li>
+ *     {@link org.apache.hadoop.fs.statistics.IOStatisticsSupport}.
+ *     General support, including the ability to take a serializable
+ *     snapshot of the current state of an IOStatistics instance.
+ *   </li>
+ *   <li>
+ *     {@link org.apache.hadoop.fs.statistics.IOStatisticsLogging}.
+ *     Methods for robust/on-demand string conversion, designed
+ *     for use in logging statements and {@code toString()} implementations.
+ *   </li>
+ * </ul>
  *
- * They can also be serialized to build statistics on the overall cost of
- * operations, or printed to help diagnose performance/cost issues.
- *
+ * <p>
  * Implementors notes
  * <ol>
  * <li>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/package-info.java
@@ -19,16 +19,17 @@
 /**
  * This package contains support for statistic collection and reporting.
  * This is the public API; implementation classes are to be kept elsewhere.
- *
+ * <p>
  * This package defines two interfaces:
- *
+ * <p>
  * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource}:
  * a source of statistic data, which can be retrieved
  * through a call to
  * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource#getIOStatistics()} .
- *
- * {@link org.apache.hadoop.fs.statistics.IOStatistics} the statistics retrieved from a statistics source.
- *
+ * <p>
+ * {@link org.apache.hadoop.fs.statistics.IOStatistics} the statistics retrieved
+ * from a statistics source.
+ * <p>
  * The retrieved statistics may be an immutable snapshot -in which case to get
  * updated statistics another call to
  * {@link org.apache.hadoop.fs.statistics.IOStatisticsSource#getIOStatistics()}
@@ -51,15 +52,15 @@
  * When iterating through the set, the values of the iterator SHOULD
  * be frozen at the time the iterator was requested.
  * <p>
- * These statistics can be used to: log operations, profile applications, make
- * assertions about the state of the output.
+ * These statistics can be used to: log operations, profile applications,
+ * and make assertions about the state of the output.
  * <p>
  * The names of statistics are a matter of choice of the specific source.
  * However, {@link org.apache.hadoop.fs.statistics.StoreStatisticNames}
  * contains a
  * set of names recommended for object store operations.
  * {@link org.apache.hadoop.fs.statistics.StreamStatisticNames} declares
- * recommended names for statistics provided for
+ * recommended names for statistics provided forInconsistentS3ClientFactoryInconsistentS3ClientFactory
  * input and output streams.
  * <p>
  * Utility classes are includes to assist use
@@ -77,7 +78,7 @@
  * </ul>
  *
  * <p>
- * Implementors notes
+ * Implementors notes:
  * <ol>
  * <li>
  * IOStatistics keys SHOULD be standard names where possible.
@@ -105,14 +106,16 @@
  * be fast and return values even while slow/blocking remote IO is underway.
  * </li>
  * <li>
- * MUST support value enumeration and retrieval after the source has been closed.
+ * MUST support value enumeration and retrieval after the source has been
+ * closed.
  * </li>
  * <li>
- * SHOULD NOT have back-references to potentially expensive objects (filesystem
- * instances etc)
+ * SHOULD NOT have back-references to potentially expensive objects
+ * (filesystem instances etc.)
  * </li>
  * <li>
- * SHOULD provide statistics which can be added to generate aggregate statistics.
+ * SHOULD provide statistics which can be added to generate aggregate
+ * statistics.
  * </li>
  * </ol>
  */

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/index.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/index.md
@@ -38,3 +38,4 @@ HDFS as these are commonly expected by Hadoop client applications.
 2. [Testing with the Filesystem specification](testing.html)
 2. [Extending the specification and its tests](extending.html)
 1. [Uploading a file using Multiple Parts](multipartuploader.html)
+1. [IOStatistics](iostatistics.html)

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/iostatistics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/iostatistics.md
@@ -1,0 +1,207 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Introduction to the IOStatistics API
+
+```java
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+```
+
+The `IOStatistics` API is intended to provide statistics on individual IO
+classes -such as input and output streams, *in a standard way which 
+applications can query*
+
+Many filesystem-related classes have implemented statistics gathering
+and provided private/unstable ways to query this, but as they were
+not common across implementations it was unsafe for applications
+to reference these values. Example: `S3AInputStream` and its statistics
+API. This is used in internal tests, but cannot be used downstream in
+applications such as 
+
+The new IOStatistics API is intended to 
+
+1. Be instance specific:, rather than shared across multiple instances
+   of a class.
+1. Be public and stable enough to be used by applications.
+1. Be easy to use in applications written in Java, Scala, and, via libhdfs, C/C++
+1. Have foundational interfaces and classes in the `hadoop-common` JAR.
+
+## Core model
+
+IO classes *may* implement `IOStatisticsSource`
+
+Wrapper IO Classes (e.g `FSDataInputStream`, `FSDataOutputStream` *should*
+implement the interface and forward it to the wrapped class, if they also
+implement it -or return `null` if they do not.
+
+`IOStatisticsSource` implementations `getIOStatistics()` return an
+instance of `IOStatistics` enumerating the statistics of that specific
+instance.
+
+The `IOStatistics` implementations provide
+
+* A way to enumerate all keys/statistics monitored.
+* An iterator over all such keys and their latest values.
+* A way to explitly request the value of specific statistic.
+
+
+<!--  ============================================================= -->
+<!--  Interface: IOStatisticsSource -->
+<!--  ============================================================= -->
+
+# class `org.apache.hadoop.fs.statistics.IOStatisticsSource`
+
+```java
+
+/**
+ * A source of IO statistics.
+ * These statistics MUST be instance specific, not thread local.
+ */
+@InterfaceStability.Unstable
+public interface IOStatisticsSource {
+
+  /**
+   * Return a statistics instance.
+   * It is not a requirement that the same instance is returned every time.
+   * {@link IOStatisticsSource}.
+   * If the object implementing this is Closeable, this method
+   * may return null if invoked on a closed object, even if
+   * it returns a valid instance when called earlier.
+   * @return an IOStatistics instance or null
+   */
+  IOStatistics getIOStatistics();
+}
+```
+
+This is the interface which an object instance MUST implement if they are a source of
+IOStatistics information.
+
+<!--  ============================================================= -->
+<!--  Interface: IOStatistics -->
+<!--  ============================================================= -->
+
+# class `org.apache.hadoop.fs.statistics.IOStatistics`
+
+These are low-cost per-instance statistics provided by any Hadoop I/O class instance.
+
+```java
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+public interface IOStatistics extends Iterable<Map.Entry<String, Long>> {
+
+  /**
+   * Get the value of a statistic.
+   *
+   * @return The value of the statistic, or null if not tracked.
+   */
+  Long getStatistic(String key);
+
+  /**
+   * Return true if a statistic is being tracked.
+   *
+   * @return True only if the statistic is being tracked.
+   */
+  boolean isTracked(String key);
+
+  /**
+   * Get the set of keys.
+   * No guarantees are made about the mutability/immutability
+   * of this set.
+   * @return the set of keys.
+   */
+  Set<String> keys();
+
+}
+```
+
+
+The statistics MUST BE for the specific instance of the source;
+possibly including aggregate statistics from other objects
+created by that stores.
+For example, the statistics of a filesystem instance must be unique
+to that instant and not shared with any other.
+However, those statistics may also collect and aggregate statistics
+generated in the use of input and output streams created by that
+file system instance.
+
+The iterator is a possibly empty iterator over all monitored statistics.
+
+* The set of statistic keys SHOULD remain unchanged, and MUST NOT
+remove keys.
+
+*  The statistics SHOULD be dynamic: every call to `iterator()`
+ MAY return a current/recent set of statistics.
+
+* The values MAY change across invocations of `iterator()`.
+
+* The update MAY be in the `iterable()` call, or MAY be in the actual
+ `iterable.next()` operation.
+
+* The returned Map.Entry instances MUST return the same value on
+ repeated `getValue()` calls.
+
+* Queries of statistics SHOULD Be fast and Nonblocking to the extent
+ that if invoked during a long operation, they will prioritize
+ returning fast over most timely values.
+
+* The statistics MAY lag; especially for statistics collected in separate
+ operations (e.g stream IO statistics as provided by a filesystem
+ instance).
+
+* Thread safety: an instance of IOStatistics can be shared across threads;
+ a call to `iterator()` is thread safe.
+ 
+The actual `Iterable` returned MUST NOT be shared across threads.
+
+
+## Helper Classes
+
+
+### class `org.apache.hadoop.fs.statistics.IOStatisticsSupport`
+
+This provides helper methods to work with IOStatistics sources and instances.
+
+Consult the javadocs for its operations. 
+
+### class `org.apache.hadoop.fs.statistics.IOStatisticsLogging`
+
+Support for efficiently logging `IOStatistics`/`IOStatisticsSource`
+instances.
+
+These are intended for assisting logging, including only enumerating the
+state of an `IOStatistics` instance when the log level needs it. 
+
+```java
+LOG.info("IOStatistics after upload: {}", demandStringify(iostats));
+
+// or even better, as it results in only a single object creations
+Object latest = demandStringify(iostats);
+LOG.info("IOStatistics : {}", latest);
+/* do some work. */
+LOG.info("IOStatistics : {}", latest);
+
+``` 
+
+## Package `org.apache.hadoop.fs.statistics.impl`
+
+This contains implementation classes to support providing statistics to applications.
+
+These MUST NOT be used by applications. If a feature is needed from this package then
+the provisioning of a public implementation should be raised via the Hadoop development
+channels.
+
+These MAY be used by those implementations of the Hadoop `FileSystem`, `AbstractFileSystem`
+and related classes which are not in the hadoop source tree. Implementors must
+be aware that all this code is unstable.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractStreamIOStatisticsTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractStreamIOStatisticsTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.contract;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatistics.Attributes;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.*;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_WRITE_BYTES;
+
+/**
+ * Tests {@link IOStatistics} support in input streams.
+ * Requires both the input and output streams to offer statistics.
+ */
+public abstract class AbstractContractStreamIOStatisticsTest
+    extends AbstractFSContractTestBase {
+
+  @Test
+  public void testOutputStreamStatisticKeys() throws Throwable {
+    describe("Look at the statistic keys of an output stream");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    fs.mkdirs(path.getParent());
+    try (FSDataOutputStream out = fs.create(path, true)) {
+      IOStatistics statistics = extractStatistics(out);
+      outputStreamAttributes().forEach(a ->
+          assertIOStatisticsHasAttribute(statistics, a));
+      final List<String> keys = outputStreamStatisticKeys();
+      Assertions.assertThat(statistics.keys())
+          .describedAs("statistic keys of %s", statistics)
+          .containsAll(keys);
+      Assertions.assertThat(keys)
+          .describedAs("Statistics supported by the stream %s", out)
+          .contains(STREAM_WRITE_BYTES);
+    } finally {
+      fs.delete(path, false);
+    }
+  }
+
+  @Test
+  public void testWriteSingleByte() throws Throwable {
+    describe("Write a byte to a file and verify"
+        + " the stream statistics are updated");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    fs.mkdirs(path.getParent());
+    try (FSDataOutputStream out = fs.create(path, true)) {
+      IOStatistics statistics = extractStatistics(out);
+      // before a write, no bytes
+      verifyStatisticValue(statistics, STREAM_WRITE_BYTES, 0);
+      out.write('0');
+      statistics = maybeUpdate(statistics, out);
+      verifyStatisticValue(statistics, STREAM_WRITE_BYTES, 1);
+      // close the stream
+      out.close();
+      // statistics are still valid after the close
+      // always call the output stream to check that behavior
+      statistics = extractStatistics(out);
+      verifyStatisticValue(statistics, STREAM_WRITE_BYTES, 1);
+    } finally {
+      fs.delete(path, false);
+    }
+  }
+
+  @Test
+  public void testWriteByteArrays() throws Throwable {
+    describe("Write byte arrays to a file and verify"
+        + " the stream statistics are updated");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    fs.mkdirs(path.getParent());
+    try (FSDataOutputStream out = fs.create(path, true)) {
+      // before a write, no bytes
+      final byte[] bytes = ContractTestUtils.toAsciiByteArray(
+          "statistically-speaking");
+      final int len = bytes.length;
+      out.write(bytes);
+      IOStatistics statistics = extractStatistics(out);
+      verifyStatisticValue(statistics, STREAM_WRITE_BYTES, len);
+      out.write(bytes);
+      statistics = maybeUpdate(statistics, out);
+      verifyStatisticValue(statistics, STREAM_WRITE_BYTES, len * 2);
+      // close the stream
+      out.close();
+      // statistics are still valid after the close
+      // always call the output stream to check that behavior
+      statistics = extractStatistics(out);
+      verifyStatisticValue(statistics, STREAM_WRITE_BYTES, len * 2);
+    } finally {
+      fs.delete(path, false);
+    }
+  }
+
+  @Test
+  public void testInputStreamStatisticKeys() throws Throwable {
+    describe("Look at the statistic keys of an input stream");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    ContractTestUtils.touch(fs, path);
+    try (FSDataInputStream in = fs.open(path)) {
+      IOStatistics statistics = extractStatistics(in);
+      inputStreamAttributes().forEach(a ->
+          assertIOStatisticsHasAttribute(statistics, a));
+      final List<String> keys = inputStreamStatisticKeys();
+      Assertions.assertThat(statistics.keys())
+          .describedAs("statistic keys of %s", statistics)
+          .containsAll(keys);
+      Assertions.assertThat(keys)
+          .describedAs("Statistics supported by the stream %s", in)
+          .contains(STREAM_READ_BYTES);
+      verifyStatisticValue(statistics, STREAM_READ_BYTES, 0);
+    } finally {
+      fs.delete(path, false);
+    }
+  }
+
+  @Test
+  public void testInputStreamStatisticRead() throws Throwable {
+    describe("Read Data from an input stream");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    final int fileLen = 1024;
+    final byte[] ds = dataset(fileLen, 'a', 26);
+    ContractTestUtils.writeDataset(fs, path, ds, fileLen, 8_000, true);
+
+    try (FSDataInputStream in = fs.open(path)) {
+      long current = 0;
+      IOStatistics statistics = extractStatistics(in);
+      verifyStatisticValue(statistics, STREAM_READ_BYTES, 0);
+      Assertions.assertThat(in.read()).isEqualTo('a');
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES, 1);
+      final int bufferLen = 128;
+      byte[] buf128 = new byte[bufferLen];
+      in.read(buf128);
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES, current +
+          + bufferLen);
+      in.readFully(buf128);
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES, current
+          + bufferLen);
+      in.readFully(0, buf128);
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES, current
+          + bufferLen);
+      // seek must not increment the read counter
+      in.seek(256);
+      verifyStatisticValue(statistics, STREAM_READ_BYTES, current);
+
+      // if a stream implements lazy-seek the seek operation
+      // may be postponed until the read
+      final int sublen = 32;
+      Assertions.assertThat(in.read(buf128, 0, sublen))
+          .isEqualTo(sublen);
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES,
+          current + sublen);
+
+      // perform some read operations near the end of the file such that
+      // the buffer will not be completely read.
+      final int pos = fileLen - sublen;
+      in.seek(pos);
+      Assertions.assertThat(in.read(buf128))
+          .describedAs("Read overlapping EOF")
+          .isEqualTo(sublen);
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES,
+          current + sublen);
+      Assertions.assertThat(in.read(pos, buf128, 0, bufferLen))
+          .describedAs("Read(buffer) overlapping EOF")
+          .isEqualTo(sublen);
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES,
+          current + sublen);
+    } finally {
+      fs.delete(path, false);
+    }
+  }
+
+  /**
+   * Attributes of the output stream's statistics.
+   * @return all attributes which are expected.
+   */
+  public Set<Attributes> outputStreamAttributes() {
+    return EnumSet.of(Attributes.Dynamic);
+  }
+
+  /**
+   * Keys which the output stream must support.
+   * @return a list of keys
+   */
+  public List<String> outputStreamStatisticKeys() {
+    return Collections.singletonList(STREAM_WRITE_BYTES);
+  }
+
+  /**
+   * Attributes of the input stream's statistics.
+   * @return all attributes which are expected.
+   */
+  public Set<Attributes> inputStreamAttributes() {
+    return EnumSet.of(Attributes.Dynamic);
+  }
+
+  /**
+   * Keys which the output stream must support.
+   * @return a list of keys
+   */
+  public List<String> inputStreamStatisticKeys() {
+    return Collections.singletonList(STREAM_READ_BYTES);
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractStreamIOStatisticsTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractStreamIOStatisticsTest.java
@@ -209,7 +209,7 @@ public abstract class AbstractContractStreamIOStatisticsTest
   }
 
   /**
-   * Keys which the output stream must support.
+   * Keys which the input stream must support.
    * @return a list of keys
    */
   public List<String> inputStreamStatisticKeys() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractStreamIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractStreamIOStatistics.java
@@ -21,21 +21,10 @@ package org.apache.hadoop.fs.contract.localfs;
 import java.util.Arrays;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractStreamIOStatisticsTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.fs.statistics.IOStatistics;
 
-import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
-import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.extractStatistics;
-import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticValue;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_EXCEPTIONS;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractStreamIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractStreamIOStatistics.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.contract.localfs;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractStreamIOStatisticsTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.extractStatistics;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticValue;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_EXCEPTIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SKIP_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_SKIP_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_WRITE_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_WRITE_EXCEPTIONS;
+
+/**
+ * Test IOStatistics through the local FS.
+ */
+public class TestLocalFSContractStreamIOStatistics extends
+    AbstractContractStreamIOStatisticsTest {
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new LocalFSContract(conf);
+  }
+
+  /**
+   * Keys which the input stream must support.
+   * @return a list of keys
+   */
+  public List<String> inputStreamStatisticKeys() {
+    return Arrays.asList(STREAM_READ_BYTES,
+        STREAM_READ_EXCEPTIONS,
+        STREAM_READ_SEEK_OPERATIONS,
+        STREAM_READ_SKIP_OPERATIONS,
+        STREAM_READ_SKIP_BYTES);
+  }
+
+  /**
+   * Keys which the output stream must support.
+   * @return a list of keys
+   */
+  @Override
+  public List<String> outputStreamStatisticKeys() {
+    return Arrays.asList(STREAM_WRITE_BYTES,
+        STREAM_WRITE_EXCEPTIONS);
+  }
+
+  @Override
+  public int readBlockSize() {
+    return 1024;
+  }
+
+  @Override
+  public boolean streamWritesInBlocks() {
+    return true;
+  }
+
+  @Test
+  public void testInputStreamStatisticRead() throws Throwable {
+    describe("Read Data from an input stream");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    final int fileLen = 1024;
+    final byte[] ds = dataset(fileLen, 'a', 26);
+    ContractTestUtils.writeDataset(fs, path, ds, fileLen, 8_000, true);
+
+    try (FSDataInputStream in = fs.open(path)) {
+      long current = 0;
+      IOStatistics statistics = extractStatistics(in);
+      verifyStatisticValue(statistics, STREAM_READ_BYTES, 0);
+      Assertions.assertThat(in.read()).isEqualTo('a');
+      int blockSize = readBlockSize();
+      current = verifyStatisticValue(statistics, STREAM_READ_BYTES, blockSize);
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractStreamIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractStreamIOStatistics.java
@@ -78,7 +78,7 @@ public class TestLocalFSContractStreamIOStatistics extends
   }
 
   @Override
-  public int readBlockSize() {
+  public int readBufferSize() {
     return 1024;
   }
 
@@ -87,22 +87,5 @@ public class TestLocalFSContractStreamIOStatistics extends
     return true;
   }
 
-  @Test
-  public void testInputStreamStatisticRead() throws Throwable {
-    describe("Read Data from an input stream");
-    Path path = methodPath();
-    FileSystem fs = getFileSystem();
-    final int fileLen = 1024;
-    final byte[] ds = dataset(fileLen, 'a', 26);
-    ContractTestUtils.writeDataset(fs, path, ds, fileLen, 8_000, true);
 
-    try (FSDataInputStream in = fs.open(path)) {
-      long current = 0;
-      IOStatistics statistics = extractStatistics(in);
-      verifyStatisticValue(statistics, STREAM_READ_BYTES, 0);
-      Assertions.assertThat(in.read()).isEqualTo('a');
-      int blockSize = readBlockSize();
-      current = verifyStatisticValue(statistics, STREAM_READ_BYTES, blockSize);
-    }
-  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
@@ -116,7 +116,7 @@ public final class IOStatisticAssertions {
   }
 
   /**
-   * query the source for the statistics; fails if the statistics
+   * Query the source for the statistics; fails if the statistics
    * returned are null.
    * @param source source object.
    * @return the statistics it provides.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Assertions and any other support for IOStatistics testing.
+ * If used downstream, know it is unstable.
+ * There's some oddness here related to AssertJ's handling of iterables;
+ * we need to explicitly cast it to call methods on the interface
+ * other than iterator().
+ */
+@InterfaceStability.Unstable
+public final class IOStatisticAssertions {
+
+  private IOStatisticAssertions() {
+  }
+
+  /**
+   * Assert that a statistics instance has an attribute.
+   * Note: some type inference in Assertions causes confusion
+   * with the .matches predicate; it needs to be cast down to its type
+   * again.
+   * @param stats statistics source
+   * @param attr attribute to probe for
+   */
+  public static void assertIOStatisticsHasAttribute(
+      final IOStatistics stats,
+      final IOStatistics.Attributes attr) {
+    assertThat(stats)
+        .describedAs("Statistics %s and attribute %s", stats, attr)
+        .isNotNull()
+        .matches(s -> ((IOStatistics) s).hasAttribute(attr),
+            "Does not have attribute " + attr);
+  }
+
+  /**
+   * Assert that a statistics instance has an attribute.
+   * Note: some type inference in Assertions causes confusion
+   * with the .matches predicate; it needs to be cast down to its type
+   * again.
+   * @param stats statistics source
+   * @param attr attribute to probe for
+   */
+  public static void assertIOStatisticsAttributeNotFound(
+      final IOStatistics stats,
+      final IOStatistics.Attributes attr) {
+    assertThat(stats)
+        .describedAs("Statistics %s and attribute %s", stats, attr)
+        .isNotNull()
+        .matches(s -> !((IOStatistics) s).hasAttribute(attr),
+            "Should not have attribute " + attr);
+  }
+
+  /**
+   * Assert that a given statistic has an expected value.
+   * @param stats statistics source
+   * @param key statistic key
+   * @param value expected value.
+   * @return the value (which always equals the expected value)
+   */
+  public static long verifyStatisticValue(
+      final IOStatistics stats,
+      final String key,
+      final long value) {
+    final Long statistic = stats.getStatistic(key);
+    assertThat(statistic)
+        .describedAs("Statistics %s and key %s with expected value %s", stats,
+            key, value)
+        .isNotNull()
+        .isEqualTo(value);
+    return statistic;
+  }
+
+  /**
+   * Assert that a given statistic is unknown.
+   * @param stats statistics source
+   * @param key statistic key
+   */
+  public static void assertStatisticIsUnknown(
+      final IOStatistics stats,
+      final String key) {
+    assertThat(stats.getStatistic(key))
+        .describedAs("Statistics %s and key %s", stats,
+            key)
+        .isNull();
+  }
+
+  /**
+   * Assert that a given statistic is tracked.
+   * @param stats statistics source
+   * @param key statistic key
+   */
+  public static void assertStatisticIsTracked(
+      final IOStatistics stats,
+      final String key) {
+    assertThat(stats.isTracked(key))
+        .describedAs("Statistic %s is not tracked in %s", key, stats)
+        .isTrue();
+  }
+
+  /**
+   * Assert that a given statistic is untracked.
+   * @param stats statistics source
+   * @param key statistic key
+   */
+  public static void assertStatisticIsUntracked(
+      final IOStatistics stats,
+      final String key) {
+    assertThat(stats.isTracked(key))
+        .describedAs("Statistic %s is tracked in %s", key, stats)
+        .isFalse();
+  }
+
+  /**
+   * Assert that an object is a statistics source and that the
+   * statistics is not null.
+   * @param source source object.
+   */
+  public static void assertIsStatisticsSource(Object source) {
+    assertThat(source)
+        .describedAs("Object %s", source )
+        .isInstanceOf(IOStatisticsSource.class)
+        .extracting(o -> ((IOStatisticsSource)o).getIOStatistics())
+        .isNotNull();
+  }
+
+  /**
+   * query the source for the statistics; fails if the statistics
+   * returned are null.
+   * @param source source object.
+   * @return the statistics it provides.
+   */
+  public static IOStatistics extractStatistics(Object source) {
+    assertThat(source)
+        .describedAs("Object %s", source)
+        .isInstanceOf(IOStatisticsSource.class);
+    IOStatistics statistics = ((IOStatisticsSource) source).getIOStatistics();
+    assertThat(statistics)
+        .describedAs("Statistics from %s", source)
+        .isNotNull();
+    return statistics;
+  }
+
+  /**
+   * Update IO statistics from the source if they are static;
+   * dynamic stats are returned as is.
+   * @param statistics current statistics (or null)
+   * @param origin origin of the statistics.
+   * @return the possibly updated statistics
+   */
+  public static IOStatistics maybeUpdate(final IOStatistics statistics,
+      final Object origin) {
+    if (statistics == null
+        || !statistics.hasAttribute(IOStatistics.Attributes.Dynamic)) {
+      return extractStatistics(origin);
+    } else {
+      return statistics;
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.IOSTATISTIC_COUNTER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -46,6 +47,23 @@ public final class IOStatisticAssertions {
   }
 
   /**
+   * Get a required counter statistic
+   * @param stats statistics source
+   * @param key statistic key
+   * @return the value
+   */
+  public static long extractCounterStatistic(
+      final IOStatistics stats,
+      final String key) {
+    final IOStatisticEntry statistic = stats.getStatistic(key);
+    assertThat(statistic)
+        .describedAs("Statistics %s and key %s", stats,
+            key)
+        .isNotNull();
+    return statistic.scalar(IOSTATISTIC_COUNTER);
+  }
+
+  /**
    * Assert that a given statistic has an expected value.
    * @param stats statistics source
    * @param key statistic key
@@ -61,9 +79,9 @@ public final class IOStatisticAssertions {
         .describedAs("Statistics %s and key %s with expected value %s", stats,
             key, value)
         .isNotNull()
-        .extracting(f -> f.singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER))
+        .extracting(f -> f.scalar(IOSTATISTIC_COUNTER))
         .isEqualTo(value);
-    return statistic.singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER);
+    return statistic.scalar(IOSTATISTIC_COUNTER);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
@@ -25,6 +25,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * we need to explicitly cast it to call methods on the interface
  * other than iterator().
  */
+
+@InterfaceAudience.Private
 @InterfaceStability.Unstable
 public final class IOStatisticAssertions {
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/IOStatisticAssertions.java
@@ -52,17 +52,18 @@ public final class IOStatisticAssertions {
    * @param value expected value.
    * @return the value (which always equals the expected value)
    */
-  public static long verifyStatisticValue(
+  public static long verifyStatisticCounterValue(
       final IOStatistics stats,
       final String key,
       final long value) {
-    final Long statistic = stats.getStatistic(key);
+    final IOStatisticEntry statistic = stats.getStatistic(key);
     assertThat(statistic)
         .describedAs("Statistics %s and key %s with expected value %s", stats,
             key, value)
         .isNotNull()
+        .extracting(f -> f.singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER))
         .isEqualTo(value);
-    return statistic;
+    return statistic.singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.statistics.impl.SourceWrappedStatistics;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
@@ -81,8 +82,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
 
   private long evalLong;
 
-  private static final String[] keys = new String[]{ALONG, AINT, COUNT, EVAL};
-
+  private static final String[] KEYS = new String[]{ALONG, AINT, COUNT, EVAL};
 
   @Before
   public void setUp() throws Exception {
@@ -92,7 +92,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
         .add(COUNT, counter)
         .add(EVAL, x -> evalLong)
         .build();
-    statsSource = new StaticSource(statistics);
+    statsSource = new SourceWrappedStatistics(statistics);
   }
 
   /**
@@ -142,7 +142,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
   public void testKeys() throws Throwable {
     Assertions.assertThat(statistics.keys())
         .describedAs("statistic keys of %s", statistics)
-        .containsExactlyInAnyOrder(keys);
+        .containsExactlyInAnyOrder(KEYS);
   }
 
   @Test
@@ -151,7 +151,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
     // the values.
     assertThat(statistics)
         .extracting(s -> s.getKey())
-        .containsExactlyInAnyOrder(keys);
+        .containsExactlyInAnyOrder(KEYS);
   }
 
   /**
@@ -210,7 +210,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
     IOStatistics deser = IOStatisticAssertions.roundTrip(stat);
     assertThat(deser)
         .extracting(s -> s.getKey())
-        .containsExactlyInAnyOrder(keys);
+        .containsExactlyInAnyOrder(KEYS);
     for (Map.Entry<String, Long> e: deser) {
       assertThat(e.getValue())
           .describedAs("Value of entry %s", e)
@@ -222,7 +222,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
   public void testStringification() throws Throwable {
     assertThat(iostatisticsToString(statistics))
         .isNotBlank()
-        .contains(keys);
+        .contains(KEYS);
   }
 
   @Test
@@ -310,17 +310,4 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
     }
   }
 
-  private final class StaticSource implements IOStatisticsSource {
-
-    private final IOStatistics statistics;
-
-    private StaticSource(IOStatistics statistics) {
-      this.statistics = statistics;
-    }
-
-    @Override
-    public IOStatistics getIOStatistics() {
-      return statistics;
-    }
-  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsTracked;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUnknown;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUntracked;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticValue;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.iostatisticsToString;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.dynamicIOStatistics;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStatistics;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * verify dynamic statistics are dynamic, except when you iterate through
+ * them, along with other tests of the class's behavior.
+ */
+public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDynamicIOStatistics.class);
+
+  private static final String ALONG = "along";
+
+  private static final String AINT = "aint";
+
+  private static final String COUNT = "count";
+
+  private static final String EVAL = "eval";
+
+  private IOStatistics statistics = emptyStatistics();
+
+  private AtomicLong aLong = new AtomicLong();
+
+  private AtomicInteger aInt = new AtomicInteger();
+
+  private MutableCounterLong counter = new MutableCounterLong(
+      new Info("counter"), 0);
+
+  private long evalLong;
+
+  private static final String[] keys = new String[]{ALONG, AINT, COUNT, EVAL};
+
+  @Before
+  public void setUp() throws Exception {
+    statistics = dynamicIOStatistics()
+        .add(ALONG, aLong)
+        .add(AINT, aInt)
+        .add(COUNT, counter)
+        .add(EVAL, x -> evalLong)
+        .build();
+  }
+
+  /**
+   * The eval operation is foundational.
+   */
+  @Test
+  public void testEval() throws Throwable {
+    verifyStatisticValue(statistics, EVAL, 0);
+    evalLong = 10;
+    verifyStatisticValue(statistics, EVAL, 10);
+  }
+
+  /**
+   * Atomic Long statistic.
+   */
+  @Test
+  public void testAlong() throws Throwable {
+    verifyStatisticValue(statistics, ALONG, 0);
+    aLong.addAndGet(1);
+    verifyStatisticValue(statistics, ALONG, 1);
+  }
+
+  /**
+   * Atomic Int statistic.
+   */
+  @Test
+  public void testAint() throws Throwable {
+    verifyStatisticValue(statistics, AINT, 0);
+    aInt.addAndGet(1);
+    verifyStatisticValue(statistics, AINT, 1);
+  }
+
+  /**
+   * Metrics2 counter.
+   */
+  @Test
+  public void testCounter() throws Throwable {
+    verifyStatisticValue(statistics, COUNT, 0);
+    counter.incr();
+    verifyStatisticValue(statistics, COUNT, 1);
+  }
+
+  /**
+   * keys() returns all the keys.
+   */
+  @Test
+  public void testKeys() throws Throwable {
+    Assertions.assertThat(statistics.keys())
+        .describedAs("statistic keys of %s", statistics)
+        .containsExactlyInAnyOrder(keys);
+  }
+
+  @Test
+  public void testIteratorHasAllKeys() throws Throwable {
+    // go through the statistics iterator and assert that it contains exactly
+    // the values.
+    assertThat(statistics)
+        .extracting(s -> s.getKey())
+        .containsExactlyInAnyOrder(keys);
+  }
+
+  /**
+   * Verify that the iterator is taken from
+   * a snapshot of the values.
+   */
+  @Test
+  public void testIteratorIsSnapshot() throws Throwable {
+    // set the counters all to 1
+    incrementAllCounters();
+    // take the snapshot
+    final Iterator<Map.Entry<String, Long>> it = statistics.iterator();
+    // reset the counters
+    incrementAllCounters();
+    // now assert that all the iterator values are of value 1
+    while (it.hasNext()) {
+      Map.Entry<String, Long> next = it.next();
+      assertThat(next.getValue())
+          .describedAs("Value of entry %s", next)
+          .isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void testUnknownStatistic() throws Throwable {
+    assertStatisticIsUnknown(statistics, "anything");
+    assertStatisticIsUntracked(statistics, "anything");
+  }
+
+  @Test
+  public void testStatisticsTrackedAssertion() throws Throwable {
+    // expect an exception to be raised when an assertion
+    // is made that an unknown statistic is tracked,.
+    assertThatThrownBy(() ->
+        assertStatisticIsTracked(statistics, "anything"))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void testStatisticsValueAssertion() throws Throwable {
+    // expect an exception to be raised when
+    // an assertion is made about the value of an unknown statistics
+    assertThatThrownBy(() ->
+        verifyStatisticValue(statistics, "anything", 0))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  /**
+   * Serialization round trip will preserve all the values.
+   */
+  @Test
+  public void testSerDeser() throws Throwable {
+    incrementAllCounters();
+    IOStatistics stat = IOStatisticsSupport.snapshot(statistics);
+    incrementAllCounters();
+    IOStatistics deser = IOStatisticAssertions.roundTrip(stat);
+    assertThat(deser)
+        .extracting(s -> s.getKey())
+        .containsExactlyInAnyOrder(keys);
+    for (Map.Entry<String, Long> e: deser) {
+      assertThat(e.getValue())
+          .describedAs("Value of entry %s", e)
+          .isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void testStringification() throws Throwable {
+    assertThat(iostatisticsToString(statistics))
+        .isNotBlank()
+        .contains(keys);
+  }
+
+  @Test
+  public void testStringification2() throws Throwable {
+    assertThat(IOStatisticsLogging.stringify(statistics)
+        .toString())
+        .contains(keys);
+  }
+
+  /**
+   * Increment all the counters from their current value.
+   */
+  public void incrementAllCounters() {
+    aLong.incrementAndGet();
+    aInt.incrementAndGet();
+    evalLong += 1;
+    counter.incr();
+  }
+
+  /**
+   * Needed to provide a metrics info instance for the counter
+   * constructor.
+   */
+  private final class Info implements MetricsInfo {
+
+    private final String name;
+
+    private Info(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public String description() {
+      return name;
+    }
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
@@ -215,7 +215,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
 
   @Test
   public void testStringification2() throws Throwable {
-    assertThat(IOStatisticsLogging.stringify(statistics)
+    assertThat(IOStatisticsLogging.demandStringify(statistics)
         .toString())
         .contains(keys);
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
@@ -170,7 +170,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
     while (it.hasNext()) {
       Map.Entry<String, IOStatisticEntry> next = it.next();
       assertThat(
-          next.getValue().singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER))
+          next.getValue().scalar(IOStatisticEntry.IOSTATISTIC_COUNTER))
           .describedAs("Value of entry %s", next)
           .isEqualTo(1);
     }
@@ -214,7 +214,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
         .containsExactlyInAnyOrder(KEYS);
     for (Map.Entry<String, IOStatisticEntry> e: deser) {
       assertThat(e.getValue()
-          .singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER))
+          .scalar(IOStatisticEntry.IOSTATISTIC_COUNTER))
           .describedAs("Value of entry %s", e)
           .isEqualTo(1);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestDynamicIOStatistics.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationUtils;
 import org.apache.hadoop.fs.statistics.impl.SourceWrappedStatistics;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
@@ -38,7 +39,7 @@ import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatis
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUnknown;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUntracked;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticValue;
-import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.NULL_SOURCE;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationUtils.NULL_SOURCE;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.demandStringify;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.iostatisticsToString;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.dynamicIOStatistics;
@@ -233,7 +234,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
     Object demandSource = demandStringify(statsSource);
 
     // show it evaluates
-    String formatted1 = String.format(IOStatisticsLogging.ENTRY_PATTERN,
+    String formatted1 = String.format(IOStatisticsImplementationUtils.ENTRY_PATTERN,
         ALONG, aLong.get());
     assertThat(demand
         .toString())
@@ -246,7 +247,7 @@ public class TestDynamicIOStatistics extends AbstractHadoopTestBase {
     incrementAllCounters();
     incrementAllCounters();
     // there are new values to expect
-    String formatted2 = String.format(IOStatisticsLogging.ENTRY_PATTERN,
+    String formatted2 = String.format(IOStatisticsImplementationUtils.ENTRY_PATTERN,
         ALONG, aLong.get());
     assertThat(demand
         .toString())

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestEmptyIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestEmptyIOStatistics.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.statistics.impl.EmptyIOStatistics;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertIOStatisticsAttributeNotFound;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertIOStatisticsHasAttribute;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsTracked;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUnknown;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUntracked;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticValue;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test handling of the empty IO statistics class.
+ */
+public class TestEmptyIOStatistics extends AbstractHadoopTestBase {
+
+  private final IOStatistics stats = EmptyIOStatistics.getInstance();
+
+  @Test
+  public void testAttributes() throws Throwable {
+    assertIOStatisticsHasAttribute(stats,
+        IOStatistics.Attributes.Static);
+    assertIOStatisticsAttributeNotFound(stats,
+        IOStatistics.Attributes.Dynamic);
+    assertIOStatisticsAttributeNotFound(stats,
+        IOStatistics.Attributes.Snapshotted);
+  }
+
+  @Test
+  public void testSnapshotUnsupported() throws Throwable {
+    assertThat(stats.snapshot())
+        .describedAs("Snapshot of %s", stats)
+        .isFalse();
+  }
+
+  @Test
+  public void testIterator() throws Throwable {
+    Iterator<Map.Entry<String, Long>> iterator = stats.iterator();
+
+    assertThat(iterator.hasNext())
+        .describedAs("iterator.hasNext()")
+        .isFalse();
+    intercept(NoSuchElementException.class, iterator::next);
+  }
+
+  @Test
+  public void testUnknownStatistic() throws Throwable {
+    assertStatisticIsUnknown(stats, "anything");
+    assertStatisticIsUntracked(stats, "anything");
+  }
+
+  @Test
+  public void testStatisticsTrackedAssertion() throws Throwable {
+    // expect an exception to be raised when an assertion
+    // is made that an unknown statistic is tracked,.
+    assertThatThrownBy(() ->
+        assertStatisticIsTracked(stats, "anything"))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void testStatisticsValueAssertion() throws Throwable {
+    // expect an exception to be raised when the
+    //
+    assertThatThrownBy(() ->
+        verifyStatisticValue(stats, "anything", 0))
+        .isInstanceOf(AssertionError.class);
+  }
+
+
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestEmptyIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestEmptyIOStatistics.java
@@ -105,14 +105,14 @@ public class TestEmptyIOStatistics extends AbstractHadoopTestBase {
 
   @Test
   public void testStringifyNullSource() throws Throwable {
-    assertThat(IOStatisticsLogging.sourceToString(null))
+    assertThat(IOStatisticsLogging.ioStatisticsSourceToString(null))
         .isEmpty();
   }
 
   @Test
   public void testStringifyNullStats() throws Throwable {
     assertThat(
-        IOStatisticsLogging.sourceToString(
+        IOStatisticsLogging.ioStatisticsSourceToString(
             IOStatisticsBinding.wrap(null)))
         .isEmpty();
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestEmptyIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/TestEmptyIOStatistics.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.test.AbstractHadoopTestBase;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsTracked;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUnknown;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertStatisticIsUntracked;
-import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticValue;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.iostatisticsToString;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStatistics;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -46,7 +46,7 @@ public class TestEmptyIOStatistics extends AbstractHadoopTestBase {
 
   @Test
   public void testIterator() throws Throwable {
-    Iterator<Map.Entry<String, Long>> iterator = empty.iterator();
+    Iterator<Map.Entry<String, IOStatisticEntry>> iterator = empty.iterator();
 
     assertThat(iterator.hasNext())
         .describedAs("iterator.hasNext()")
@@ -74,7 +74,7 @@ public class TestEmptyIOStatistics extends AbstractHadoopTestBase {
     // expect an exception to be raised when
     // an assertion is made about the value of an unknown statistics
     assertThatThrownBy(() ->
-        verifyStatisticValue(empty, "anything", 0))
+        verifyStatisticCounterValue(empty, "anything", 0))
         .isInstanceOf(AssertionError.class);
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/impl/TestIOStatisticEntry.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/statistics/impl/TestIOStatisticEntry.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.statistics.impl;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.*;
+import static org.apache.hadoop.fs.statistics.IOStatisticEntry.statsEntry;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationUtils.aggregate;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the IOStatisticEntry class and util methods in
+ * the statistics.impl package.
+ */
+public class TestIOStatisticEntry extends AbstractHadoopTestBase {
+
+  /**
+   * This is a type we know is not in the list of known types,
+   * so lacks an aggregator or any rule about aggregation
+   */
+  public static final int X = 10;
+
+  private final IOStatisticEntry counter1 = statsEntry(IOSTATISTIC_COUNTER, 1);
+  private final IOStatisticEntry counter2 = statsEntry(IOSTATISTIC_COUNTER, 2);
+  private final IOStatisticEntry min1 = statsEntry(IOSTATISTIC_MIN, 1);
+  private final IOStatisticEntry min2 = statsEntry(IOSTATISTIC_MIN, 2);
+  private final IOStatisticEntry max1 = statsEntry(IOSTATISTIC_MAX, 1);
+  private final IOStatisticEntry max2 = statsEntry(IOSTATISTIC_MAX, 2);
+  private final IOStatisticEntry mean1 = statsEntry(IOSTATISTIC_MEAN, 1, 1);
+  private final IOStatisticEntry mean12 = statsEntry(IOSTATISTIC_MEAN, 1, 2);
+  private final IOStatisticEntry mean2 = statsEntry(IOSTATISTIC_MEAN, 2, 10);
+
+  @Test
+  public void testCounterAdd() throws Throwable {
+    assertThat(aggregate(counter1, counter1))
+        .isEqualTo(counter2);
+  }
+
+  @Test
+  public void testMinAggregate() throws Throwable {
+    assertThat(aggregate(min1, min2))
+        .isEqualTo(min1);
+  }
+
+  @Test
+  public void testMaxAggregate() throws Throwable {
+    assertThat(aggregate(max1, max2))
+        .isEqualTo(max2);
+  }
+
+  @Test
+  public void testMeanAggregate1() throws Throwable {
+    assertThat(aggregate(mean1, mean1))
+        .isEqualTo(mean12);
+  }
+
+  @Test
+  public void testMeanAggregateRounding() throws Throwable {
+    assertThat(aggregate(mean1, mean2))
+        .isEqualTo(statsEntry(IOSTATISTIC_MEAN, 2, 11));
+  }
+
+  /**
+   * Unknown types are aggregated just by taking
+   * the left value.
+   */
+  @Test
+  public void testUnknownTypeAggregation() throws Throwable {
+    IOStatisticEntry e1 = statsEntry(X, 1);
+    IOStatisticEntry e2 = statsEntry(X, 2);
+    assertThat(aggregate(e1, e2))
+        .isEqualTo(e1);
+  }
+
+  @Test
+  public void testAccessors() throws Throwable {
+    IOStatisticEntry e1 = statsEntry(X, 1, 2, 3, 4);
+    assertThat(e1)
+        .extracting(IOStatisticEntry::_1)
+        .isEqualTo(1L);
+    assertThat(e1)
+        .extracting(IOStatisticEntry::_2)
+        .isEqualTo(2L);
+    assertThat(e1)
+        .extracting(IOStatisticEntry::_3)
+        .isEqualTo(3L);
+    assertThat(e1.arity())
+        .isEqualTo(4);
+    assertThat(e1.typeAsString())
+        .isEqualTo("10");
+    long[] data = e1.getData();
+    assertThat(data.length)
+        .isEqualTo(e1.arity())
+        .isEqualTo(4);
+  }
+
+  @Test
+  public void testStringAccessors() throws Throwable {
+   assertThat(counter1.typeAsString())
+        .isEqualTo("counter");
+    assertThat(min1.typeAsString())
+        .isEqualTo("min");
+    assertThat(max1.typeAsString())
+        .isEqualTo("max");
+    assertThat(mean1.typeAsString())
+        .isEqualTo("mean");
+  }
+
+  @Test
+  public void testWrongArity() throws Throwable {
+    intercept(IllegalArgumentException.class, () ->
+        statsEntry(IOSTATISTIC_COUNTER, 1, 1));
+    intercept(IllegalArgumentException.class, () ->
+        statsEntry(IOSTATISTIC_MEAN, 1));
+  }
+
+  @Test
+  public void testNoData() throws Throwable {
+    intercept(IllegalArgumentException.class, () ->
+        statsEntry(X));
+  }
+}

--- a/hadoop-tools/hadoop-aws/dev-support/findbugs-exclude.xml
+++ b/hadoop-tools/hadoop-aws/dev-support/findbugs-exclude.xml
@@ -74,4 +74,14 @@
     <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
   </Match>
 
+  <!--
+  Some of the S3A Instrumentation classes increment volatile references from
+  within synchronized contexts; they use volatile to keep the cost
+  of these updates and reading them down.
+   -->
+  <Match>
+    <Class name="org.apache.hadoop.fs.s3a.S3AInstrumentation$InputStreamStatisticsImpl"/>
+    <Bug pattern="VO_VOLATILE_INCREMENT"/>
+  </Match>
+
 </FindBugsFilter>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -51,7 +51,7 @@ import static org.apache.hadoop.fs.s3a.Constants.PATH_STYLE_ACCESS;
 
 /**
  * The default {@link S3ClientFactory} implementation.
- * This which calls the AWS SDK to configure and create an
+ * This calls the AWS SDK to configure and create an
  * {@link AmazonS3Client} that communicates with the S3 service.
  */
 @InterfaceAudience.Private
@@ -71,6 +71,7 @@ public class DefaultS3ClientFactory extends Configured
 
   /**
    * Create the client.
+   * <p>
    * If the AWS stats are not null then a {@link AwsStatisticsCollector}.
    * is created to bind to the two.
    * <i>Important: until this binding works properly across regions,
@@ -140,6 +141,7 @@ public class DefaultS3ClientFactory extends Configured
 
   /**
    * Use the (newer) Builder SDK to create a an AWS S3 client.
+   * <p>
    * This has a more complex endpoint configuration in a
    * way which does not yet work in this code in a way
    * which doesn't trigger regressions. So it is only used
@@ -179,7 +181,10 @@ public class DefaultS3ClientFactory extends Configured
 
   /**
    * Wrapper around constructor for {@link AmazonS3} client.
-   * Override this to provide an extended version of the client
+   * Override this to provide an extended version of the client.
+   * <p>
+   * This uses a deprecated constructor -it is currently
+   * the only one which works for us.
    * @param credentials credentials to use
    * @param awsConf  AWS configuration
    * @param endpoint endpoint string; may be ""
@@ -197,7 +202,7 @@ public class DefaultS3ClientFactory extends Configured
 
   /**
    * Configure classic S3 client.
-   *
+   * <p>
    * This includes: endpoint, Path Access and possibly other
    * options.
    *
@@ -227,18 +232,19 @@ public class DefaultS3ClientFactory extends Configured
    * the Hadoop configuration.
    * This is different from the general AWS configuration creation as
    * it is unique to S3 connections.
-   *
+   * <p>
    * The {@link Constants#PATH_STYLE_ACCESS} option enables path-style access
    * to S3 buckets if configured.  By default, the
    * behavior is to use virtual hosted-style access with URIs of the form
    * {@code http://bucketname.s3.amazonaws.com}
+   * <p>
    * Enabling path-style access and a
    * region-specific endpoint switches the behavior to use URIs of the form
    * {@code http://s3-eu-west-1.amazonaws.com/bucketname}.
    * It is common to use this when connecting to private S3 servers, as it
    * avoids the need to play with DNS entries.
    * @param s3 S3 client
-   * @param conf Hadoop configuration
+   * @param pathStyleAccess enable path style access?
    * @return the S3 client
    */
   protected static AmazonS3 applyS3ClientOptions(AmazonS3 s3,
@@ -255,6 +261,7 @@ public class DefaultS3ClientFactory extends Configured
   /**
    * Given an endpoint string, return an endpoint config, or null, if none
    * is needed.
+   * <p>
    * This is a pretty painful piece of code. It is trying to replicate
    * what AwsClient.setEndpoint() does, because you can't
    * call that setter on an AwsClient constructed via

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
@@ -56,13 +56,7 @@ public class InconsistentS3ClientFactory extends DefaultS3ClientFactory {
     LOG.warn("** FAILURE INJECTION ENABLED.  Do not run in production! **");
     InconsistentAmazonS3Client s3
         = new InconsistentAmazonS3Client(credentials, awsConf, getConf());
-    if (pathStyleAccess) {
-      LOG.debug("Enabling path style access!");
-      s3.setS3ClientOptions(S3ClientOptions.builder()
-          .setPathStyleAccess(true)
-          .build());
-    }
-    setEndpoint(s3, endpoint);
+    configureAmazonS3Client(s3, endpoint, pathStyleAccess);
     return s3;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
@@ -22,7 +22,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.S3ClientOptions;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -165,7 +165,7 @@ class S3ABlockOutputStream extends OutputStream implements
     this.statistics = statistics;
     // test instantiations may not provide statistics;
     iostatistics = statistics != null
-        ? statistics.createIOStatistics()
+        ? statistics.getIOStatistics()
         : emptyStatistics();
     this.writeOperationHelper = writeOperationHelper;
     this.putTracker = putTracker;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -49,6 +49,11 @@ import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 import org.apache.hadoop.fs.s3a.commit.PutTracker;
+import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.impl.EmptyIOStatistics;
 import org.apache.hadoop.util.Progressable;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.*;
@@ -67,7 +72,7 @@ import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 class S3ABlockOutputStream extends OutputStream implements
-    StreamCapabilities {
+    StreamCapabilities, IOStatisticsSource {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(S3ABlockOutputStream.class);
@@ -80,6 +85,9 @@ class S3ABlockOutputStream extends OutputStream implements
 
   /** Size of all blocks. */
   private final int blockSize;
+
+  /** IO Statistics. */
+  private final IOStatistics iostatistics;
 
   /** Total bytes for uploads submitted so far. */
   private long bytesSubmitted;
@@ -109,7 +117,7 @@ class S3ABlockOutputStream extends OutputStream implements
   private long blockCount = 0;
 
   /** Statistics to build up. */
-  private final S3AInstrumentation.OutputStreamStatistics statistics;
+  private final BlockOutputStreamStatistics statistics;
 
   /**
    * Write operation helper; encapsulation of the filesystem operations.
@@ -146,7 +154,7 @@ class S3ABlockOutputStream extends OutputStream implements
       Progressable progress,
       long blockSize,
       S3ADataBlocks.BlockFactory blockFactory,
-      S3AInstrumentation.OutputStreamStatistics statistics,
+      BlockOutputStreamStatistics statistics,
       WriteOperationHelper writeOperationHelper,
       PutTracker putTracker)
       throws IOException {
@@ -155,6 +163,10 @@ class S3ABlockOutputStream extends OutputStream implements
     this.blockFactory = blockFactory;
     this.blockSize = (int) blockSize;
     this.statistics = statistics;
+    // test instantiations may not provide statistics;
+    iostatistics = statistics != null
+        ? statistics.createIOStatistics()
+        : EmptyIOStatistics.getInstance();
     this.writeOperationHelper = writeOperationHelper;
     this.putTracker = putTracker;
     Preconditions.checkArgument(blockSize >= Constants.MULTIPART_MIN_SIZE,
@@ -282,6 +294,7 @@ class S3ABlockOutputStream extends OutputStream implements
     if (len == 0) {
       return;
     }
+    statistics.writeBytes(len);
     S3ADataBlocks.DataBlock block = createBlockIfNeeded();
     int written = block.write(source, offset, len);
     int remainingCapacity = block.remainingCapacity();
@@ -473,6 +486,7 @@ class S3ABlockOutputStream extends OutputStream implements
     if (block != null) {
       sb.append(", activeBlock=").append(block);
     }
+    sb.append(IOStatisticsLogging.iostatisticsSourceToString(this));
     sb.append('}');
     return sb.toString();
   }
@@ -493,7 +507,7 @@ class S3ABlockOutputStream extends OutputStream implements
    * Get the statistics for this stream.
    * @return stream statistics
    */
-  S3AInstrumentation.OutputStreamStatistics getStatistics() {
+  BlockOutputStreamStatistics getStatistics() {
     return statistics;
   }
 
@@ -523,6 +537,11 @@ class S3ABlockOutputStream extends OutputStream implements
     default:
       return false;
     }
+  }
+
+  @Override
+  public IOStatistics getIOStatistics() {
+    return iostatistics;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -486,7 +486,7 @@ class S3ABlockOutputStream extends OutputStream implements
     if (block != null) {
       sb.append(", activeBlock=").append(block);
     }
-    sb.append(IOStatisticsLogging.sourceToString(this));
+    sb.append(IOStatisticsLogging.ioStatisticsSourceToString(this));
     sb.append('}');
     return sb.toString();
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -53,11 +53,11 @@ import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
-import org.apache.hadoop.fs.statistics.impl.EmptyIOStatistics;
 import org.apache.hadoop.util.Progressable;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.*;
 import static org.apache.hadoop.fs.s3a.Statistic.*;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStatistics;
 import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 
 /**
@@ -166,7 +166,7 @@ class S3ABlockOutputStream extends OutputStream implements
     // test instantiations may not provide statistics;
     iostatistics = statistics != null
         ? statistics.createIOStatistics()
-        : EmptyIOStatistics.getInstance();
+        : emptyStatistics();
     this.writeOperationHelper = writeOperationHelper;
     this.putTracker = putTracker;
     Preconditions.checkArgument(blockSize >= Constants.MULTIPART_MIN_SIZE,
@@ -486,7 +486,7 @@ class S3ABlockOutputStream extends OutputStream implements
     if (block != null) {
       sb.append(", activeBlock=").append(block);
     }
-    sb.append(IOStatisticsLogging.iostatisticsSourceToString(this));
+    sb.append(IOStatisticsLogging.sourceToString(this));
     sb.append('}');
     return sb.toString();
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.FSExceptionMessages;
+import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.util.DirectBufferPool;
 
 import static org.apache.hadoop.fs.s3a.S3ADataBlocks.DataBlock.DestState.*;
@@ -180,7 +181,7 @@ final class S3ADataBlocks {
      * @return a new block.
      */
     abstract DataBlock create(long index, int limit,
-        S3AInstrumentation.OutputStreamStatistics statistics)
+        BlockOutputStreamStatistics statistics)
         throws IOException;
 
     /**
@@ -210,10 +211,10 @@ final class S3ADataBlocks {
 
     private volatile DestState state = Writing;
     protected final long index;
-    protected final S3AInstrumentation.OutputStreamStatistics statistics;
+    protected final BlockOutputStreamStatistics statistics;
 
     protected DataBlock(long index,
-        S3AInstrumentation.OutputStreamStatistics statistics) {
+        BlockOutputStreamStatistics statistics) {
       this.index = index;
       this.statistics = statistics;
     }
@@ -387,7 +388,7 @@ final class S3ADataBlocks {
 
     @Override
     DataBlock create(long index, int limit,
-        S3AInstrumentation.OutputStreamStatistics statistics)
+        BlockOutputStreamStatistics statistics)
         throws IOException {
       return new ByteArrayBlock(0, limit, statistics);
     }
@@ -432,7 +433,7 @@ final class S3ADataBlocks {
 
     ByteArrayBlock(long index,
         int limit,
-        S3AInstrumentation.OutputStreamStatistics statistics) {
+        BlockOutputStreamStatistics statistics) {
       super(index, statistics);
       this.limit = limit;
       buffer = new S3AByteArrayOutputStream(limit);
@@ -510,7 +511,7 @@ final class S3ADataBlocks {
 
     @Override
     ByteBufferBlock create(long index, int limit,
-        S3AInstrumentation.OutputStreamStatistics statistics)
+        BlockOutputStreamStatistics statistics)
         throws IOException {
       return new ByteBufferBlock(index, limit, statistics);
     }
@@ -560,7 +561,7 @@ final class S3ADataBlocks {
        */
       ByteBufferBlock(long index,
           int bufferSize,
-          S3AInstrumentation.OutputStreamStatistics statistics) {
+          BlockOutputStreamStatistics statistics) {
         super(index, statistics);
         this.bufferSize = bufferSize;
         blockBuffer = requestBuffer(bufferSize);
@@ -805,7 +806,7 @@ final class S3ADataBlocks {
     @Override
     DataBlock create(long index,
         int limit,
-        S3AInstrumentation.OutputStreamStatistics statistics)
+        BlockOutputStreamStatistics statistics)
         throws IOException {
       File destFile = getOwner()
           .createTmpFileForWrite(String.format("s3ablock-%04d-", index),
@@ -829,7 +830,7 @@ final class S3ADataBlocks {
     DiskBlock(File bufferFile,
         int limit,
         long index,
-        S3AInstrumentation.OutputStreamStatistics statistics)
+        BlockOutputStreamStatistics statistics)
         throws FileNotFoundException {
       super(index, statistics);
       this.limit = limit;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ADataBlocks.java
@@ -211,7 +211,7 @@ final class S3ADataBlocks {
 
     private volatile DestState state = Writing;
     protected final long index;
-    protected final BlockOutputStreamStatistics statistics;
+    private final BlockOutputStreamStatistics statistics;
 
     protected DataBlock(long index,
         BlockOutputStreamStatistics statistics) {
@@ -372,6 +372,10 @@ final class S3ADataBlocks {
       if (statistics != null) {
         statistics.blockReleased();
       }
+    }
+
+    protected BlockOutputStreamStatistics getStatistics() {
+      return statistics;
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -203,8 +203,7 @@ import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class S3AFileSystem extends FileSystem implements StreamCapabilities,
-    AWSPolicyProvider, DelegationTokenProvider,
-    IOStatisticsSource {
+    AWSPolicyProvider, DelegationTokenProvider, IOStatisticsSource {
   /**
    * Default blocksize as used in blocksize and FS status queries.
    */
@@ -1755,6 +1754,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    */
   protected void incrementStatistic(Statistic statistic, long count) {
     statisticsContext.incrementCounter(statistic, count);
+    storageStatistics.incrementCounter(statistic, count);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -118,7 +118,7 @@ import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.fs.s3a.select.InternalSelectConstants;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationHelper;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.TokenIdentifier;
@@ -1860,8 +1860,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    */
   @Override
   public IOStatistics getIOStatistics() {
-    return IOStatisticsImplementationHelper.createFromStorageStatistics(
-        storageStatistics).getIOStatistics();
+    return IOStatisticsBinding.fromStorageStatistics(
+        storageStatistics);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -111,7 +111,7 @@ import org.apache.hadoop.fs.s3a.impl.RenameOperation;
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 import org.apache.hadoop.fs.s3a.impl.statistics.CommitterStatistics;
-import org.apache.hadoop.fs.s3a.impl.statistics.IntegratedS3AStatisticsContext;
+import org.apache.hadoop.fs.s3a.impl.statistics.BondedS3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
@@ -525,8 +525,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * different statistics binding, if desired.
    */
   protected void initializeStatisticsBinding() {
-    statisticsContext = new IntegratedS3AStatisticsContext(
-        new IntegratedS3AStatisticsContext.S3AFSStatisticsSource() {
+    statisticsContext = new BondedS3AStatisticsContext(
+        new BondedS3AStatisticsContext.S3AFSStatisticsSource() {
 
           @Override
           public S3AInstrumentation getInstrumentation() {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -325,7 +325,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * bucket-specific options are patched over the base ones before any use is
    * made of the config.
    */
-  public void initialize(URI name, Configuration originalConf)
+  public void
+  initialize(URI name, Configuration originalConf)
       throws IOException {
     // get the host; this is guaranteed to be non-null, non-empty
     bucket = name.getHost();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -156,7 +156,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     this.uri = "s3a://" + this.bucket + "/" + this.key;
     this.streamStatistics = ctx.getS3AStatisticsContext()
         .newInputStreamStatistics();
-    this.ioStatistics = streamStatistics.createIOStatistics();
+    this.ioStatistics = streamStatistics.getIOStatistics();
     this.serverSideEncryptionAlgorithm =
         s3Attributes.getServerSideEncryptionAlgorithm();
     this.serverSideEncryptionKey = s3Attributes.getServerSideEncryptionKey();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -63,7 +63,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationHelper.createDynamicIOStatistics;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.dynamicIOStatistics;
 import static org.apache.hadoop.fs.s3a.Statistic.*;
 
 /**
@@ -974,7 +974,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public IOStatistics createIOStatistics() {
       DynamicIOStatisticsBuilder builder
-          = createDynamicIOStatistics();
+          = dynamicIOStatistics();
 
       builder.add(StreamStatisticNames.STREAM_BYTES_DISCARDED_ABORT,
           bytesDiscardedInAbort);
@@ -1355,7 +1355,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public IOStatistics createIOStatistics() {
-      DynamicIOStatisticsBuilder builder = createDynamicIOStatistics();
+      DynamicIOStatisticsBuilder builder = dynamicIOStatistics();
 
       builder.add(StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,
           blocksSubmitted);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -655,9 +655,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
   /**
    * Statistics updated by an input stream during its actual operation.
-   * These counters are marked as volatile so that IOStatistics on the stream
-   * will get the latest values.
-   * They are only to be incremented within synchronized blocks.
+   * AtomicLongs so statististics can be queries.
    */
   private final class InputStreamStatisticsImpl implements
       S3AInputStreamStatistics {
@@ -968,11 +966,11 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     }
 
     /**
-     * Convert to an IOStatistics source which is dynamically updated.
+     * Create an IOStatistics instance which is dynamically updated.
      * @return statistics
      */
     @Override
-    public IOStatistics createIOStatistics() {
+    public IOStatistics getIOStatistics() {
       DynamicIOStatisticsBuilder builder
           = dynamicIOStatistics();
 
@@ -1350,11 +1348,11 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     }
 
     /**
-     * Convert to an IOStatistics source which is dynamically updated.
+     * Create an IOStatistics instance which is dynamically updated.
      * @return statistics
      */
     @Override
-    public IOStatistics createIOStatistics() {
+    public IOStatistics getIOStatistics() {
       DynamicIOStatisticsBuilder builder = dynamicIOStatistics();
 
       builder.add(StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -18,14 +18,27 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.FileSystem.Statistics;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.s3a.impl.statistics.ChangeTrackerStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.CommitterStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.CountersAndGauges;
+import org.apache.hadoop.fs.s3a.impl.statistics.CountingChangeTracker;
+import org.apache.hadoop.fs.s3a.impl.statistics.DelegationTokenStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AInputStreamStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
+import org.apache.hadoop.fs.statistics.impl.DynamicIOStatisticsBuilder;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricStringBuilder;
 import org.apache.hadoop.metrics2.MetricsCollector;
@@ -43,12 +56,14 @@ import org.apache.hadoop.metrics2.lib.MutableQuantiles;
 
 import java.io.Closeable;
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsImplementationHelper.createDynamicIOStatistics;
 import static org.apache.hadoop.fs.s3a.Statistic.*;
 
 /**
@@ -63,32 +78,33 @@ import static org.apache.hadoop.fs.s3a.Statistic.*;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
-public class S3AInstrumentation implements Closeable, MetricsSource {
+public class S3AInstrumentation implements Closeable, MetricsSource,
+    CountersAndGauges {
   private static final Logger LOG = LoggerFactory.getLogger(
       S3AInstrumentation.class);
 
   private static final String METRICS_SOURCE_BASENAME = "S3AMetrics";
 
   /**
-   * {@value #METRICS_SYSTEM_NAME} The name of the s3a-specific metrics
+   * {@value} The name of the s3a-specific metrics
    * system instance used for s3a metrics.
    */
   public static final String METRICS_SYSTEM_NAME = "s3a-file-system";
 
   /**
-   * {@value #CONTEXT} Currently all s3a metrics are placed in a single
+   * {@value} Currently all s3a metrics are placed in a single
    * "context". Distinct contexts may be used in the future.
    */
   public static final String CONTEXT = "s3aFileSystem";
 
   /**
-   * {@value #METRIC_TAG_FILESYSTEM_ID} The name of a field added to metrics
+   * {@value} The name of a field added to metrics
    * records that uniquely identifies a specific FileSystem instance.
    */
   public static final String METRIC_TAG_FILESYSTEM_ID = "s3aFileSystemId";
 
   /**
-   * {@value #METRIC_TAG_BUCKET} The name of a field added to metrics records
+   * {@value} The name of a field added to metrics records
    * that indicates the hostname portion of the FS URL.
    */
   public static final String METRIC_TAG_BUCKET = "bucket";
@@ -192,6 +208,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       S3GUARD_METADATASTORE_THROTTLED,
       S3GUARD_METADATASTORE_AUTHORITATIVE_DIRECTORIES_UPDATED,
       STORE_IO_THROTTLED,
+      STORE_IO_REQUEST,
+      STORE_IO_RETRY,
       DELEGATION_TOKENS_ISSUED,
       FILES_DELETE_REJECTED
   };
@@ -561,9 +579,11 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
   /**
    * Create a stream input statistics instance.
    * @return the new instance
+   * @param filesystemStatistics FS Stats.
    */
-  public InputStreamStatistics newInputStreamStatistics() {
-    return new InputStreamStatistics();
+  public S3AInputStreamStatistics newInputStreamStatistics(
+      final FileSystem.Statistics filesystemStatistics) {
+    return new InputStreamStatisticsImpl(filesystemStatistics);
   }
 
   /**
@@ -579,8 +599,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
    * Create a new instance of the committer statistics.
    * @return a new committer statistics instance
    */
-  CommitterStatistics newCommitterStatistics() {
-    return new CommitterStatistics();
+  public CommitterStatistics newCommitterStatistics() {
+    return new CommitterStatisticsImpl();
   }
 
   /**
@@ -588,23 +608,23 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
    * the filesystem-wide statistics.
    * @param statistics stream statistics
    */
-  private void mergeInputStreamStatistics(InputStreamStatistics statistics) {
-    streamOpenOperations.incr(statistics.openOperations);
-    streamCloseOperations.incr(statistics.closeOperations);
-    streamClosed.incr(statistics.closed);
-    streamAborted.incr(statistics.aborted);
-    streamSeekOperations.incr(statistics.seekOperations);
-    streamReadExceptions.incr(statistics.readExceptions);
-    streamForwardSeekOperations.incr(statistics.forwardSeekOperations);
-    streamBytesSkippedOnSeek.incr(statistics.bytesSkippedOnSeek);
-    streamBackwardSeekOperations.incr(statistics.backwardSeekOperations);
-    streamBytesBackwardsOnSeek.incr(statistics.bytesBackwardsOnSeek);
-    streamBytesRead.incr(statistics.bytesRead);
-    streamReadOperations.incr(statistics.readOperations);
-    streamReadFullyOperations.incr(statistics.readFullyOperations);
-    streamReadsIncomplete.incr(statistics.readsIncomplete);
-    streamBytesReadInClose.incr(statistics.bytesReadInClose);
-    streamBytesDiscardedInAbort.incr(statistics.bytesDiscardedInAbort);
+  private void mergeInputStreamStatistics(InputStreamStatisticsImpl statistics) {
+    streamOpenOperations.incr(statistics.openOperations.get());
+    streamCloseOperations.incr(statistics.closeOperations.get());
+    streamClosed.incr(statistics.closed.get());
+    streamAborted.incr(statistics.aborted.get());
+    streamSeekOperations.incr(statistics.seekOperations.get());
+    streamReadExceptions.incr(statistics.readExceptions.get());
+    streamForwardSeekOperations.incr(statistics.forwardSeekOperations.get());
+    streamBytesSkippedOnSeek.incr(statistics.bytesSkippedOnSeek.get());
+    streamBackwardSeekOperations.incr(statistics.backwardSeekOperations.get());
+    streamBytesBackwardsOnSeek.incr(statistics.bytesBackwardsOnSeek.get());
+    streamBytesRead.incr(statistics.bytesRead.get());
+    streamReadOperations.incr(statistics.readOperations.get());
+    streamReadFullyOperations.incr(statistics.readFullyOperations.get());
+    streamReadsIncomplete.incr(statistics.readsIncomplete.get());
+    streamBytesReadInClose.incr(statistics.bytesReadInClose.get());
+    streamBytesDiscardedInAbort.incr(statistics.bytesDiscardedInAbort.get());
     incrementCounter(STREAM_READ_VERSION_MISMATCHES,
         statistics.versionMismatches.get());
   }
@@ -622,7 +642,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       throttleRateQuantile.stop();
       s3GuardThrottleRateQuantile.stop();
       metricsSystem.unregisterSource(metricsSourceName);
-      int activeSources = --metricsSourceActiveCounter;
+      metricsSourceActiveCounter--;
+      int activeSources = metricsSourceActiveCounter;
       if (activeSources == 0) {
         LOG.debug("Shutting down metrics publisher");
         metricsSystem.publishMetricsNow();
@@ -634,35 +655,44 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
 
   /**
    * Statistics updated by an input stream during its actual operation.
-   * These counters not thread-safe and are for use in a single instance
-   * of a stream.
+   * These counters are marked as volatile so that IOStatistics on the stream
+   * will get the latest values.
+   * They are only to be incremented within synchronized blocks.
    */
-  @InterfaceAudience.Private
-  @InterfaceStability.Unstable
-  public final class InputStreamStatistics implements AutoCloseable {
-    public long openOperations;
-    public long closeOperations;
-    public long closed;
-    public long aborted;
-    public long seekOperations;
-    public long readExceptions;
-    public long forwardSeekOperations;
-    public long backwardSeekOperations;
-    public long bytesRead;
-    public long bytesSkippedOnSeek;
-    public long bytesBackwardsOnSeek;
-    public long readOperations;
-    public long readFullyOperations;
-    public long readsIncomplete;
-    public long bytesReadInClose;
-    public long bytesDiscardedInAbort;
-    public long policySetCount;
-    public long inputPolicy;
-    /** This is atomic so that it can be passed as a reference. */
-    private final AtomicLong versionMismatches = new AtomicLong(0);
-    private InputStreamStatistics mergedStats;
+  private final class InputStreamStatisticsImpl implements
+      S3AInputStreamStatistics {
 
-    private InputStreamStatistics() {
+    /**
+     * Distance used when incrementing FS stats.
+     */
+    private static final int DISTANCE = 5;
+
+    private final FileSystem.Statistics filesystemStatistics;
+
+    public final AtomicLong openOperations= new AtomicLong(0);
+    public final AtomicLong closeOperations= new AtomicLong(0);
+    public final AtomicLong closed= new AtomicLong(0);
+    public final AtomicLong aborted= new AtomicLong(0);
+    public final AtomicLong seekOperations= new AtomicLong(0);
+    public final AtomicLong readExceptions= new AtomicLong(0);
+    public final AtomicLong forwardSeekOperations= new AtomicLong(0);
+    public final AtomicLong backwardSeekOperations= new AtomicLong(0);
+    public final AtomicLong bytesRead= new AtomicLong(0);
+    public final AtomicLong bytesSkippedOnSeek= new AtomicLong(0);
+    public final AtomicLong bytesBackwardsOnSeek= new AtomicLong(0);
+    public final AtomicLong readOperations= new AtomicLong(0);
+    public final AtomicLong readFullyOperations= new AtomicLong(0);
+    public final AtomicLong readsIncomplete= new AtomicLong(0);
+    public final AtomicLong bytesReadInClose= new AtomicLong(0);
+    public final AtomicLong bytesDiscardedInAbort= new AtomicLong(0);
+    public final AtomicLong policySetCount= new AtomicLong(0);
+    public volatile long inputPolicy;
+    private final AtomicLong versionMismatches = new AtomicLong(0);
+    private InputStreamStatisticsImpl mergedStats;
+
+    private InputStreamStatisticsImpl(
+        FileSystem.Statistics filesystemStatistics) {
+      this.filesystemStatistics = filesystemStatistics;
     }
 
     /**
@@ -670,10 +700,11 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * @param negativeOffset how far was the seek?
      * This is expected to be negative.
      */
+    @Override
     public void seekBackwards(long negativeOffset) {
-      seekOperations++;
-      backwardSeekOperations++;
-      bytesBackwardsOnSeek -= negativeOffset;
+      seekOperations.incrementAndGet();
+      backwardSeekOperations.incrementAndGet();
+      bytesBackwardsOnSeek.addAndGet(-negativeOffset);
     }
 
     /**
@@ -682,11 +713,12 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * @param skipped number of bytes skipped by reading from the stream.
      * If the seek was implemented by a close + reopen, set this to zero.
      */
+    @Override
     public void seekForwards(long skipped) {
-      seekOperations++;
-      forwardSeekOperations++;
+      seekOperations.incrementAndGet();
+      forwardSeekOperations.incrementAndGet();
       if (skipped > 0) {
-        bytesSkippedOnSeek += skipped;
+        bytesSkippedOnSeek.addAndGet(skipped);
       }
     }
 
@@ -694,10 +726,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * The inner stream was opened.
      * @return the previous count
      */
+    @Override
     public long streamOpened() {
-      long count = openOperations;
-      openOperations++;
-      return count;
+      return openOperations.getAndIncrement();
     }
 
     /**
@@ -707,23 +738,25 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * @param remainingInCurrentRequest the number of bytes remaining in
      * the current request.
      */
+    @Override
     public void streamClose(boolean abortedConnection,
         long remainingInCurrentRequest) {
-      closeOperations++;
+      closeOperations.incrementAndGet();
       if (abortedConnection) {
-        this.aborted++;
-        bytesDiscardedInAbort += remainingInCurrentRequest;
+        aborted.incrementAndGet();
+        bytesDiscardedInAbort.addAndGet(remainingInCurrentRequest);
       } else {
-        closed++;
-        bytesReadInClose += remainingInCurrentRequest;
+        closed.incrementAndGet();
+        bytesReadInClose.addAndGet(remainingInCurrentRequest);
       }
     }
 
     /**
      * An ignored stream read exception was received.
      */
+    @Override
     public void readException() {
-      readExceptions++;
+      readExceptions.incrementAndGet();
     }
 
     /**
@@ -731,9 +764,10 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * no-op if the argument is negative.
      * @param bytes number of bytes read
      */
+    @Override
     public void bytesRead(long bytes) {
       if (bytes > 0) {
-        bytesRead += bytes;
+        bytesRead.addAndGet(bytes);
       }
     }
 
@@ -742,8 +776,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * @param pos starting position of the read
      * @param len length of bytes to read
      */
+    @Override
     public void readOperationStarted(long pos, long len) {
-      readOperations++;
+      readOperations.incrementAndGet();
     }
 
     /**
@@ -752,8 +787,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * @param pos starting position of the read
      * @param len length of bytes to read
      */
+    @Override
     public void readFullyOperationStarted(long pos, long len) {
-      readFullyOperations++;
+      readFullyOperations.incrementAndGet();
     }
 
     /**
@@ -761,9 +797,10 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * @param requested number of requested bytes
      * @param actual the actual number of bytes
      */
+    @Override
     public void readOperationCompleted(int requested, int actual) {
       if (requested > actual) {
-        readsIncomplete++;
+        readsIncomplete.incrementAndGet();
       }
     }
 
@@ -780,17 +817,20 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * The input policy has been switched.
      * @param updatedPolicy enum value of new policy.
      */
+    @Override
     public void inputPolicySet(int updatedPolicy) {
-      policySetCount++;
+      policySetCount.incrementAndGet();
       inputPolicy = updatedPolicy;
     }
 
     /**
-     * Get a reference to the version mismatch counter.
-     * @return a counter which can be incremented.
+     * The change tracker increments {@code versionMismatches} on any
+     * mismatch.
+     * @return change tracking.
      */
-    public AtomicLong getVersionMismatchCounter() {
-      return versionMismatches;
+    @Override
+    public ChangeTrackerStatistics getChangeTrackerStatistics() {
+      return new CountingChangeTracker(versionMismatches);
     }
 
     /**
@@ -804,26 +844,26 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     public String toString() {
       final StringBuilder sb = new StringBuilder(
           "StreamStatistics{");
-      sb.append("OpenOperations=").append(openOperations);
-      sb.append(", CloseOperations=").append(closeOperations);
-      sb.append(", Closed=").append(closed);
-      sb.append(", Aborted=").append(aborted);
-      sb.append(", SeekOperations=").append(seekOperations);
-      sb.append(", ReadExceptions=").append(readExceptions);
+      sb.append("OpenOperations=").append(openOperations.get());
+      sb.append(", CloseOperations=").append(closeOperations.get());
+      sb.append(", Closed=").append(closed.get());
+      sb.append(", Aborted=").append(aborted.get());
+      sb.append(", SeekOperations=").append(seekOperations.get());
+      sb.append(", ReadExceptions=").append(readExceptions.get());
       sb.append(", ForwardSeekOperations=")
-          .append(forwardSeekOperations);
+          .append(forwardSeekOperations.get());
       sb.append(", BackwardSeekOperations=")
-          .append(backwardSeekOperations);
-      sb.append(", BytesSkippedOnSeek=").append(bytesSkippedOnSeek);
-      sb.append(", BytesBackwardsOnSeek=").append(bytesBackwardsOnSeek);
-      sb.append(", BytesRead=").append(bytesRead);
+          .append(backwardSeekOperations.get());
+      sb.append(", BytesSkippedOnSeek=").append(bytesSkippedOnSeek.get());
+      sb.append(", BytesBackwardsOnSeek=").append(bytesBackwardsOnSeek.get());
+      sb.append(", BytesRead=").append(bytesRead.get());
       sb.append(", BytesRead excluding skipped=")
-          .append(bytesRead - bytesSkippedOnSeek);
-      sb.append(", ReadOperations=").append(readOperations);
-      sb.append(", ReadFullyOperations=").append(readFullyOperations);
-      sb.append(", ReadsIncomplete=").append(readsIncomplete);
-      sb.append(", BytesReadInClose=").append(bytesReadInClose);
-      sb.append(", BytesDiscardedInAbort=").append(bytesDiscardedInAbort);
+          .append(bytesRead.get() - bytesSkippedOnSeek.get());
+      sb.append(", ReadOperations=").append(readOperations.get());
+      sb.append(", ReadFullyOperations=").append(readFullyOperations.get());
+      sb.append(", ReadsIncomplete=").append(readsIncomplete.get());
+      sb.append(", BytesReadInClose=").append(bytesReadInClose.get());
+      sb.append(", BytesDiscardedInAbort=").append(bytesDiscardedInAbort.get());
       sb.append(", InputPolicy=").append(inputPolicy);
       sb.append(", InputPolicySetCount=").append(policySetCount);
       sb.append(", versionMismatches=").append(versionMismatches.get());
@@ -839,78 +879,217 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * stats into the fs-wide stats. <b>Behavior is undefined if called on a
      * closed instance.</b>
      */
-    void merge(boolean isClosed) {
+    @Override
+    public void merge(boolean isClosed) {
       if (mergedStats != null) {
-        mergeInputStreamStatistics(diff(mergedStats));
+        mergeInputStreamStatistics(setd(mergedStats));
       } else {
         mergeInputStreamStatistics(this);
       }
       // If stats are closed, no need to create another copy
       if (!isClosed) {
         mergedStats = copy();
+      } else {
+        // stream is being closed.
+        // increment the filesystem statistics for this thread.
+        if (filesystemStatistics != null) {
+          filesystemStatistics.incrementBytesReadByDistance(DISTANCE,
+              bytesRead.get() + bytesReadInClose.get());
+        }
       }
     }
 
     /**
-     * Returns a diff between this {@link InputStreamStatistics} instance and
-     * the given {@link InputStreamStatistics} instance.
+     * Set the dest variable to the difference of the two
+     * other values
+     * @param dest destination
+     * @param l left side
+     * @param r right side
      */
-    private InputStreamStatistics diff(InputStreamStatistics inputStats) {
-      InputStreamStatistics diff = new InputStreamStatistics();
-      diff.openOperations = openOperations - inputStats.openOperations;
-      diff.closeOperations = closeOperations - inputStats.closeOperations;
-      diff.closed = closed - inputStats.closed;
-      diff.aborted = aborted - inputStats.aborted;
-      diff.seekOperations = seekOperations - inputStats.seekOperations;
-      diff.readExceptions = readExceptions - inputStats.readExceptions;
-      diff.forwardSeekOperations =
-              forwardSeekOperations - inputStats.forwardSeekOperations;
-      diff.backwardSeekOperations =
-              backwardSeekOperations - inputStats.backwardSeekOperations;
-      diff.bytesRead = bytesRead - inputStats.bytesRead;
-      diff.bytesSkippedOnSeek =
-              bytesSkippedOnSeek - inputStats.bytesSkippedOnSeek;
-      diff.bytesBackwardsOnSeek =
-              bytesBackwardsOnSeek - inputStats.bytesBackwardsOnSeek;
-      diff.readOperations = readOperations - inputStats.readOperations;
-      diff.readFullyOperations =
-              readFullyOperations - inputStats.readFullyOperations;
-      diff.readsIncomplete = readsIncomplete - inputStats.readsIncomplete;
-      diff.bytesReadInClose = bytesReadInClose - inputStats.bytesReadInClose;
-      diff.bytesDiscardedInAbort =
-              bytesDiscardedInAbort - inputStats.bytesDiscardedInAbort;
-      diff.policySetCount = policySetCount - inputStats.policySetCount;
-      diff.inputPolicy = inputPolicy - inputStats.inputPolicy;
+    private void setd(AtomicLong dest, AtomicLong l, AtomicLong r) {
+      dest.set(l.get() - r.get());
+    }
+
+    /**
+     * Returns a diff between this {@link InputStreamStatisticsImpl} instance and
+     * the given {@link InputStreamStatisticsImpl} instance.
+     */
+    private InputStreamStatisticsImpl setd(InputStreamStatisticsImpl inputStats) {
+      InputStreamStatisticsImpl diff =
+          new InputStreamStatisticsImpl(filesystemStatistics);
+      setd(diff.openOperations, openOperations, inputStats.openOperations);
+      setd(diff.closeOperations, closeOperations, inputStats.closeOperations);
+      setd(diff.closed, closed, inputStats.closed);
+      setd(diff.aborted, aborted, inputStats.aborted);
+      setd(diff.seekOperations, seekOperations, inputStats.seekOperations);
+      setd(diff.readExceptions, readExceptions, inputStats.readExceptions);
+      setd(diff.forwardSeekOperations, forwardSeekOperations, inputStats.forwardSeekOperations);
+      setd(diff.backwardSeekOperations, backwardSeekOperations, inputStats.backwardSeekOperations);
+      setd(diff.bytesRead, bytesRead, inputStats.bytesRead);
+      setd(diff.bytesSkippedOnSeek, bytesSkippedOnSeek, inputStats.bytesSkippedOnSeek);
+      setd(diff.bytesBackwardsOnSeek, bytesBackwardsOnSeek, inputStats.bytesBackwardsOnSeek);
+      setd(diff.readOperations, readOperations, inputStats.readOperations);
+      setd(diff.readFullyOperations, readFullyOperations, inputStats.readFullyOperations);
+      setd(diff.readsIncomplete, readsIncomplete, inputStats.readsIncomplete);
+      setd(diff.bytesReadInClose, bytesReadInClose, inputStats.bytesReadInClose);
+      setd(diff.bytesDiscardedInAbort, bytesDiscardedInAbort, inputStats.bytesDiscardedInAbort);
+      setd(diff.policySetCount, policySetCount, inputStats.policySetCount);
+      diff.inputPolicy = inputPolicy -inputStats.inputPolicy;
       diff.versionMismatches.set(versionMismatches.longValue() -
               inputStats.versionMismatches.longValue());
       return diff;
     }
 
     /**
-     * Returns a new {@link InputStreamStatistics} instance with all the same
-     * values as this {@link InputStreamStatistics}.
+     * Returns a new {@link InputStreamStatisticsImpl} instance with
+     * all the same values as this {@link InputStreamStatisticsImpl}.
      */
-    private InputStreamStatistics copy() {
-      InputStreamStatistics copy = new InputStreamStatistics();
-      copy.openOperations = openOperations;
-      copy.closeOperations = closeOperations;
-      copy.closed = closed;
-      copy.aborted = aborted;
-      copy.seekOperations = seekOperations;
-      copy.readExceptions = readExceptions;
-      copy.forwardSeekOperations = forwardSeekOperations;
-      copy.backwardSeekOperations = backwardSeekOperations;
-      copy.bytesRead = bytesRead;
-      copy.bytesSkippedOnSeek = bytesSkippedOnSeek;
-      copy.bytesBackwardsOnSeek = bytesBackwardsOnSeek;
-      copy.readOperations = readOperations;
-      copy.readFullyOperations = readFullyOperations;
-      copy.readsIncomplete = readsIncomplete;
-      copy.bytesReadInClose = bytesReadInClose;
-      copy.bytesDiscardedInAbort = bytesDiscardedInAbort;
-      copy.policySetCount = policySetCount;
+    private InputStreamStatisticsImpl copy() {
+      InputStreamStatisticsImpl copy = new InputStreamStatisticsImpl(filesystemStatistics);
+      copy.openOperations.set(openOperations.get());
+      copy.closeOperations.set(closeOperations.get());
+      copy.closed.set(closed.get());
+      copy.aborted.set(aborted.get());
+      copy.seekOperations.set(seekOperations.get());
+      copy.readExceptions.set(readExceptions.get());
+      copy.forwardSeekOperations.set(forwardSeekOperations.get());
+      copy.backwardSeekOperations.set(backwardSeekOperations.get());
+      copy.bytesRead.set(bytesRead.get());
+      copy.bytesSkippedOnSeek.set(bytesSkippedOnSeek.get());
+      copy.bytesBackwardsOnSeek.set(bytesBackwardsOnSeek.get());
+      copy.readOperations.set(readOperations.get());
+      copy.readFullyOperations.set(readFullyOperations.get());
+      copy.readsIncomplete.set(readsIncomplete.get());
+      copy.bytesReadInClose.set(bytesReadInClose.get());
+      copy.bytesDiscardedInAbort.set(bytesDiscardedInAbort.get());
+      copy.policySetCount.set(policySetCount.get());
       copy.inputPolicy = inputPolicy;
       return copy;
+    }
+
+    /**
+     * Convert to an IOStatistics source which is dynamically updated.
+     * @return statistics
+     */
+    @Override
+    public IOStatistics createIOStatistics() {
+      DynamicIOStatisticsBuilder builder
+          = createDynamicIOStatistics();
+
+      builder.add(StreamStatisticNames.STREAM_BYTES_DISCARDED_ABORT,
+          bytesDiscardedInAbort);
+      builder.add(StreamStatisticNames.STREAM_CLOSED,
+          closed);
+      builder.add(StreamStatisticNames.STREAM_CLOSE_OPERATIONS,
+          closeOperations);
+      builder.add(StreamStatisticNames.STREAM_OPENED,
+          openOperations);
+      builder.add(StreamStatisticNames.STREAM_READ_BYTES,
+          bytesRead);
+      builder.add(StreamStatisticNames.STREAM_READ_EXCEPTIONS,
+          readExceptions);
+      builder.add(StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS,
+          readFullyOperations);
+      builder.add(StreamStatisticNames.STREAM_READ_OPERATIONS,
+          readOperations);
+      builder.add(StreamStatisticNames.STREAM_READ_OPERATIONS_INCOMPLETE,
+          readsIncomplete);
+      return builder.build();
+    }
+
+    @Override
+    public long getCloseOperations() {
+      return closeOperations.get();
+    }
+
+    @Override
+    public long getClosed() {
+      return closed.get();
+    }
+
+    @Override
+    public long getAborted() {
+      return aborted.get();
+    }
+
+    @Override
+    public long getForwardSeekOperations() {
+      return forwardSeekOperations.get();
+    }
+
+    @Override
+    public long getBackwardSeekOperations() {
+      return backwardSeekOperations.get();
+    }
+
+    @Override
+    public long getBytesRead() {
+      return bytesRead.get();
+    }
+
+    @Override
+    public long getBytesSkippedOnSeek() {
+      return bytesSkippedOnSeek.get();
+    }
+
+    @Override
+    public long getBytesBackwardsOnSeek() {
+      return bytesBackwardsOnSeek.get();
+    }
+
+    @Override
+    public long getBytesReadInClose() {
+      return bytesReadInClose.get();
+    }
+
+    @Override
+    public long getBytesDiscardedInAbort() {
+      return bytesDiscardedInAbort.get();
+    }
+
+    @Override
+    public long getOpenOperations() {
+      return openOperations.get();
+    }
+
+    @Override
+    public long getSeekOperations() {
+      return seekOperations.get();
+    }
+
+    @Override
+    public long getReadExceptions() {
+      return readExceptions.get();
+    }
+
+    @Override
+    public long getReadOperations() {
+      return readOperations.get();
+    }
+
+    @Override
+    public long getReadFullyOperations() {
+      return readFullyOperations.get();
+    }
+
+    @Override
+    public long getReadsIncomplete() {
+      return readsIncomplete.get();
+    }
+
+    @Override
+    public long getPolicySetCount() {
+      return policySetCount.get();
+    }
+
+    @Override
+    public long getVersionMismatches() {
+      return versionMismatches.get();
+    }
+
+    @Override
+    public long getInputPolicy() {
+      return inputPolicy;
     }
   }
 
@@ -918,31 +1097,33 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
    * Create a stream output statistics instance.
    * @return the new instance
    */
-  OutputStreamStatistics newOutputStreamStatistics(Statistics statistics) {
-    return new OutputStreamStatistics(statistics);
+  public BlockOutputStreamStatistics newOutputStreamStatistics(
+      FileSystem.Statistics filesystemStatistics) {
+    return new BlockOutputStreamStatisticsImpl(filesystemStatistics);
   }
 
   /**
    * Merge in the statistics of a single output stream into
    * the filesystem-wide statistics.
-   * @param statistics stream statistics
+   * @param source stream statistics
    */
-  private void mergeOutputStreamStatistics(OutputStreamStatistics statistics) {
-    incrementCounter(STREAM_WRITE_TOTAL_TIME, statistics.totalUploadDuration());
-    incrementCounter(STREAM_WRITE_QUEUE_DURATION, statistics.queueDuration);
-    incrementCounter(STREAM_WRITE_TOTAL_DATA, statistics.bytesUploaded);
+  private void mergeOutputStreamStatistics(BlockOutputStreamStatisticsImpl source) {
+    incrementCounter(STREAM_WRITE_TOTAL_TIME, source.totalUploadDuration());
+    incrementCounter(STREAM_WRITE_QUEUE_DURATION, source.queueDuration);
+    incrementCounter(STREAM_WRITE_TOTAL_DATA, source.bytesUploaded);
     incrementCounter(STREAM_WRITE_BLOCK_UPLOADS,
-        statistics.blockUploadsCompleted);
+        source.blockUploadsCompleted);
+    incrementCounter(STREAM_WRITE_FAILURES, source.blockUploadsFailed);
   }
 
   /**
    * Statistics updated by an output stream during its actual operation.
-   * Some of these stats may be relayed. However, as block upload is
-   * spans multiple
+   * Some of these stats are propagated to any passed in
+   * {@link FileSystem.Statistics} instance; this is only done
+   * in close() for better cross-thread accounting.
    */
-  @InterfaceAudience.Private
-  @InterfaceStability.Unstable
-  public final class OutputStreamStatistics implements Closeable {
+  private final class BlockOutputStreamStatisticsImpl implements
+      BlockOutputStreamStatistics {
     private final AtomicLong blocksSubmitted = new AtomicLong(0);
     private final AtomicLong blocksInQueue = new AtomicLong(0);
     private final AtomicLong blocksActive = new AtomicLong(0);
@@ -950,6 +1131,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     private final AtomicLong blockUploadsFailed = new AtomicLong(0);
     private final AtomicLong bytesPendingUpload = new AtomicLong(0);
 
+    private final AtomicLong bytesWritten = new AtomicLong(0);
     private final AtomicLong bytesUploaded = new AtomicLong(0);
     private final AtomicLong transferDuration = new AtomicLong(0);
     private final AtomicLong queueDuration = new AtomicLong(0);
@@ -957,30 +1139,34 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     private final AtomicInteger blocksAllocated = new AtomicInteger(0);
     private final AtomicInteger blocksReleased = new AtomicInteger(0);
 
-    private Statistics statistics;
+    private final FileSystem.Statistics filesystemStatistics;
 
-    public OutputStreamStatistics(Statistics statistics){
-      this.statistics = statistics;
+    private BlockOutputStreamStatisticsImpl(
+        @Nullable FileSystem.Statistics filesystemStatistics) {
+      this.filesystemStatistics = filesystemStatistics;
     }
 
     /**
      * A block has been allocated.
      */
-    void blockAllocated() {
+    @Override
+    public void blockAllocated() {
       blocksAllocated.incrementAndGet();
     }
 
     /**
      * A block has been released.
      */
-    void blockReleased() {
+    @Override
+    public void blockReleased() {
       blocksReleased.incrementAndGet();
     }
 
     /**
      * Block is queued for upload.
      */
-    void blockUploadQueued(int blockSize) {
+    @Override
+    public void blockUploadQueued(int blockSize) {
       blocksSubmitted.incrementAndGet();
       blocksInQueue.incrementAndGet();
       bytesPendingUpload.addAndGet(blockSize);
@@ -989,7 +1175,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     }
 
     /** Queued block has been scheduled for upload. */
-    void blockUploadStarted(long duration, int blockSize) {
+    @Override
+    public void blockUploadStarted(long duration, int blockSize) {
       queueDuration.addAndGet(duration);
       blocksInQueue.decrementAndGet();
       blocksActive.incrementAndGet();
@@ -998,8 +1185,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     }
 
     /** A block upload has completed. */
-    void blockUploadCompleted(long duration, int blockSize) {
-      this.transferDuration.addAndGet(duration);
+    @Override
+    public void blockUploadCompleted(long duration, int blockSize) {
+      transferDuration.addAndGet(duration);
       incrementGauge(STREAM_WRITE_BLOCK_UPLOADS_ACTIVE, -1);
       blocksActive.decrementAndGet();
       blockUploadsCompleted.incrementAndGet();
@@ -1010,14 +1198,15 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      *  A final transfer completed event is still expected, so this
      *  does not decrement the active block counter.
      */
-    void blockUploadFailed(long duration, int blockSize) {
+    @Override
+    public void blockUploadFailed(long duration, int blockSize) {
       blockUploadsFailed.incrementAndGet();
     }
 
     /** Intermediate report of bytes uploaded. */
-    void bytesTransferred(long byteCount) {
+    @Override
+    public void bytesTransferred(long byteCount) {
       bytesUploaded.addAndGet(byteCount);
-      statistics.incrementBytesWritten(byteCount);
       bytesPendingUpload.addAndGet(-byteCount);
       incrementGauge(STREAM_WRITE_BLOCK_UPLOADS_DATA_PENDING, -byteCount);
     }
@@ -1026,7 +1215,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * Note exception in a multipart complete.
      * @param count count of exceptions
      */
-    void exceptionInMultipartComplete(int count) {
+    @Override
+    public void exceptionInMultipartComplete(int count) {
       if (count > 0) {
         exceptionsInMultipartFinalize.addAndGet(count);
       }
@@ -1035,7 +1225,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     /**
      * Note an exception in a multipart abort.
      */
-    void exceptionInMultipartAbort() {
+    @Override
+    public void exceptionInMultipartAbort() {
       exceptionsInMultipartFinalize.incrementAndGet();
     }
 
@@ -1043,6 +1234,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * Get the number of bytes pending upload.
      * @return the number of bytes in the pending upload state.
      */
+    @Override
     public long getBytesPendingUpload() {
       return bytesPendingUpload.get();
     }
@@ -1052,6 +1244,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * to be called at the end of the write.
      * @param size size in bytes
      */
+    @Override
     public void commitUploaded(long size) {
       incrementCounter(COMMITTER_BYTES_UPLOADED, size);
     }
@@ -1067,6 +1260,12 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
             " as pending upload in {}", this);
       }
       mergeOutputStreamStatistics(this);
+      // and patch the FS statistics.
+      // provided the stream is closed in the worker thread, this will
+      // ensure that the thread-specific worker stats are updated.
+      if (filesystemStatistics != null) {
+        filesystemStatistics.incrementBytesWritten(bytesUploaded.get());
+      }
     }
 
     long averageQueueTime() {
@@ -1084,11 +1283,13 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       return queueDuration.get() + transferDuration.get();
     }
 
-    public int blocksAllocated() {
+    @Override
+    public int getBlocksAllocated() {
       return blocksAllocated.get();
     }
 
-    public int blocksReleased() {
+    @Override
+    public int getBlocksReleased() {
       return blocksReleased.get();
     }
 
@@ -1097,10 +1298,28 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * if the numbers change during the (non-synchronized) calculation.
      * @return the number of actively allocated blocks.
      */
-    public int blocksActivelyAllocated() {
+    @Override
+    public int getBlocksActivelyAllocated() {
       return blocksAllocated.get() - blocksReleased.get();
     }
 
+    /**
+     * Record bytes written.
+     * @param count number of bytes
+     */
+    @Override
+    public void writeBytes(long count) {
+      bytesWritten.addAndGet(count);
+    }
+
+    /**
+     * Get the current count of bytes written.
+     * @return the counter value.
+     */
+    @Override
+    public long getBytesWritten() {
+      return bytesWritten.get();
+    }
 
     @Override
     public String toString() {
@@ -1113,9 +1332,10 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       sb.append(", blockUploadsFailed=").append(blockUploadsFailed);
       sb.append(", bytesPendingUpload=").append(bytesPendingUpload);
       sb.append(", bytesUploaded=").append(bytesUploaded);
+      sb.append(", bytesWritten=").append(bytesWritten);
       sb.append(", blocksAllocated=").append(blocksAllocated);
       sb.append(", blocksReleased=").append(blocksReleased);
-      sb.append(", blocksActivelyAllocated=").append(blocksActivelyAllocated());
+      sb.append(", blocksActivelyAllocated=").append(getBlocksActivelyAllocated());
       sb.append(", exceptionsInMultipartFinalize=").append(
           exceptionsInMultipartFinalize);
       sb.append(", transferDuration=").append(transferDuration).append(" ms");
@@ -1127,6 +1347,23 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
           .append(" bytes/s");
       sb.append('}');
       return sb.toString();
+    }
+
+    /**
+     * Convert to an IOStatistics source which is dynamically updated.
+     * @return statistics
+     */
+    @Override
+    public IOStatistics createIOStatistics() {
+      DynamicIOStatisticsBuilder builder = createDynamicIOStatistics();
+
+      builder.add(StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,
+          blocksSubmitted);
+      builder.add(StreamStatisticNames.STREAM_WRITE_BYTES,
+          bytesWritten);
+      builder.add(StreamStatisticNames.STREAM_WRITE_FAILURES,
+          blockUploadsFailed);
+      return builder.build();
     }
   }
 
@@ -1192,13 +1429,12 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
   }
 
   /**
-   * Instrumentation exported to S3Guard Committers.
+   * Instrumentation exported to S3A Committers.
    */
-  @InterfaceAudience.Private
-  @InterfaceStability.Unstable
-  public final class CommitterStatistics {
+  private final class CommitterStatisticsImpl implements CommitterStatistics {
 
     /** A commit has been created. */
+    @Override
     public void commitCreated() {
       incrementCounter(COMMITTER_COMMITS_CREATED, 1);
     }
@@ -1207,6 +1443,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * Data has been uploaded to be committed in a subsequent operation.
      * @param size size in bytes
      */
+    @Override
     public void commitUploaded(long size) {
       incrementCounter(COMMITTER_BYTES_UPLOADED, size);
     }
@@ -1215,24 +1452,29 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      * A commit has been completed.
      * @param size size in bytes
      */
+    @Override
     public void commitCompleted(long size) {
       incrementCounter(COMMITTER_COMMITS_COMPLETED, 1);
       incrementCounter(COMMITTER_BYTES_COMMITTED, size);
     }
 
     /** A commit has been aborted. */
+    @Override
     public void commitAborted() {
       incrementCounter(COMMITTER_COMMITS_ABORTED, 1);
     }
 
+    @Override
     public void commitReverted() {
       incrementCounter(COMMITTER_COMMITS_REVERTED, 1);
     }
 
+    @Override
     public void commitFailed() {
       incrementCounter(COMMITTER_COMMITS_FAILED, 1);
     }
 
+    @Override
     public void taskCompleted(boolean success) {
       incrementCounter(
           success ? COMMITTER_TASKS_SUCCEEDED
@@ -1240,6 +1482,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
           1);
     }
 
+    @Override
     public void jobCompleted(boolean success) {
       incrementCounter(
           success ? COMMITTER_JOBS_SUCCEEDED
@@ -1253,20 +1496,20 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
    * @return an instance of delegation token statistics
    */
   public DelegationTokenStatistics newDelegationTokenStatistics() {
-    return new DelegationTokenStatistics();
+    return new DelegationTokenStatisticsImpl();
   }
 
   /**
    * Instrumentation exported to S3A Delegation Token support.
    */
-  @InterfaceAudience.Private
-  @InterfaceStability.Unstable
-  public final class DelegationTokenStatistics {
+  private final class DelegationTokenStatisticsImpl implements
+      DelegationTokenStatistics {
 
-    private DelegationTokenStatistics() {
+    private DelegationTokenStatisticsImpl() {
     }
 
     /** A token has been issued. */
+    @Override
     public void tokenIssued() {
       incrementCounter(DELEGATION_TOKENS_ISSUED, 1);
     }
@@ -1364,6 +1607,68 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
      */
     public Map<String, Long> getMap() {
       return map;
+    }
+  }
+
+  public StatisticsFromAwsSdk newStatisticsFromAwsSdk() {
+    return new StatisticsFromAwsSdkImpl(this);
+  }
+
+  /**
+   * Hook up AWS SDK Statistics to the S3 counters.
+   * Durations are not currently being used; that could be
+   * changed in future once an effective strategy for reporting
+   * them is determined.
+   */
+  private static final class StatisticsFromAwsSdkImpl implements
+      StatisticsFromAwsSdk {
+
+    private final CountersAndGauges countersAndGauges;
+
+    private StatisticsFromAwsSdkImpl(final CountersAndGauges countersAndGauges) {
+      this.countersAndGauges = countersAndGauges;
+    }
+
+    @Override
+    public void updateAwsRequestCount(final long count) {
+      countersAndGauges.incrementCounter(STORE_IO_REQUEST, count);
+    }
+
+    @Override
+    public void updateAwsRetryCount(final long count) {
+      countersAndGauges.incrementCounter(STORE_IO_RETRY, count);
+
+    }
+
+    @Override
+    public void updateAwsThrottleExceptionsCount(final long count) {
+      countersAndGauges.incrementCounter(STORE_IO_THROTTLED, count);
+      countersAndGauges.addValueToQuantiles(STORE_IO_THROTTLE_RATE, count);
+    }
+
+    @Override
+    public void noteAwsRequestTime(final Duration duration) {
+
+    }
+
+    @Override
+    public void noteAwsClientExecuteTime(final Duration duration) {
+
+    }
+
+    @Override
+    public void noteRequestMarshallTime(final Duration duration) {
+
+    }
+
+    @Override
+    public void noteRequestSigningTime(final Duration duration) {
+
+    }
+
+    @Override
+    public void noteResponseProcessingTime(final Duration duration) {
+
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -608,7 +608,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
    * the filesystem-wide statistics.
    * @param statistics stream statistics
    */
-  private void mergeInputStreamStatistics(InputStreamStatisticsImpl statistics) {
+  private void mergeInputStreamStatistics(
+      InputStreamStatisticsImpl statistics) {
     streamOpenOperations.incr(statistics.openOperations.get());
     streamCloseOperations.incr(statistics.closeOperations.get());
     streamClosed.incr(statistics.closed.get());
@@ -655,7 +656,6 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
   /**
    * Statistics updated by an input stream during its actual operation.
-   * AtomicLongs so statististics can be queries.
    */
   private final class InputStreamStatisticsImpl implements
       S3AInputStreamStatistics {
@@ -667,24 +667,24 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
     private final FileSystem.Statistics filesystemStatistics;
 
-    public final AtomicLong openOperations= new AtomicLong(0);
-    public final AtomicLong closeOperations= new AtomicLong(0);
-    public final AtomicLong closed= new AtomicLong(0);
-    public final AtomicLong aborted= new AtomicLong(0);
-    public final AtomicLong seekOperations= new AtomicLong(0);
-    public final AtomicLong readExceptions= new AtomicLong(0);
-    public final AtomicLong forwardSeekOperations= new AtomicLong(0);
-    public final AtomicLong backwardSeekOperations= new AtomicLong(0);
-    public final AtomicLong bytesRead= new AtomicLong(0);
-    public final AtomicLong bytesSkippedOnSeek= new AtomicLong(0);
-    public final AtomicLong bytesBackwardsOnSeek= new AtomicLong(0);
-    public final AtomicLong readOperations= new AtomicLong(0);
-    public final AtomicLong readFullyOperations= new AtomicLong(0);
-    public final AtomicLong readsIncomplete= new AtomicLong(0);
-    public final AtomicLong bytesReadInClose= new AtomicLong(0);
-    public final AtomicLong bytesDiscardedInAbort= new AtomicLong(0);
-    public final AtomicLong policySetCount= new AtomicLong(0);
-    public volatile long inputPolicy;
+    private final AtomicLong openOperations= new AtomicLong(0);
+    private final AtomicLong closeOperations= new AtomicLong(0);
+    private final AtomicLong closed= new AtomicLong(0);
+    private final AtomicLong aborted= new AtomicLong(0);
+    private final AtomicLong seekOperations= new AtomicLong(0);
+    private final AtomicLong readExceptions= new AtomicLong(0);
+    private final AtomicLong forwardSeekOperations= new AtomicLong(0);
+    private final AtomicLong backwardSeekOperations= new AtomicLong(0);
+    private final AtomicLong bytesRead= new AtomicLong(0);
+    private final AtomicLong bytesSkippedOnSeek= new AtomicLong(0);
+    private final AtomicLong bytesBackwardsOnSeek= new AtomicLong(0);
+    private final AtomicLong readOperations= new AtomicLong(0);
+    private final AtomicLong readFullyOperations= new AtomicLong(0);
+    private final AtomicLong readsIncomplete= new AtomicLong(0);
+    private final AtomicLong bytesReadInClose= new AtomicLong(0);
+    private final AtomicLong bytesDiscardedInAbort= new AtomicLong(0);
+    private final AtomicLong policySetCount= new AtomicLong(0);
+    private volatile long inputPolicy;
     private final AtomicLong versionMismatches = new AtomicLong(0);
     private InputStreamStatisticsImpl mergedStats;
 
@@ -899,7 +899,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
     /**
      * Set the dest variable to the difference of the two
-     * other values
+     * other values.
      * @param dest destination
      * @param l left side
      * @param r right side
@@ -909,29 +909,44 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     }
 
     /**
-     * Returns a diff between this {@link InputStreamStatisticsImpl} instance and
-     * the given {@link InputStreamStatisticsImpl} instance.
+     * Returns a diff between this {@link InputStreamStatisticsImpl} instance
+     * and the given {@link InputStreamStatisticsImpl} instance.
      */
-    private InputStreamStatisticsImpl setd(InputStreamStatisticsImpl inputStats) {
+    private InputStreamStatisticsImpl setd(
+        InputStreamStatisticsImpl inputStats) {
       InputStreamStatisticsImpl diff =
           new InputStreamStatisticsImpl(filesystemStatistics);
-      setd(diff.openOperations, openOperations, inputStats.openOperations);
-      setd(diff.closeOperations, closeOperations, inputStats.closeOperations);
+      setd(diff.openOperations, openOperations,
+          inputStats.openOperations);
+      setd(diff.closeOperations, closeOperations,
+          inputStats.closeOperations);
       setd(diff.closed, closed, inputStats.closed);
       setd(diff.aborted, aborted, inputStats.aborted);
-      setd(diff.seekOperations, seekOperations, inputStats.seekOperations);
-      setd(diff.readExceptions, readExceptions, inputStats.readExceptions);
-      setd(diff.forwardSeekOperations, forwardSeekOperations, inputStats.forwardSeekOperations);
-      setd(diff.backwardSeekOperations, backwardSeekOperations, inputStats.backwardSeekOperations);
+      setd(diff.seekOperations, seekOperations,
+          inputStats.seekOperations);
+      setd(diff.readExceptions, readExceptions,
+          inputStats.readExceptions);
+      setd(diff.forwardSeekOperations, forwardSeekOperations,
+          inputStats.forwardSeekOperations);
+      setd(diff.backwardSeekOperations, backwardSeekOperations,
+          inputStats.backwardSeekOperations);
       setd(diff.bytesRead, bytesRead, inputStats.bytesRead);
-      setd(diff.bytesSkippedOnSeek, bytesSkippedOnSeek, inputStats.bytesSkippedOnSeek);
-      setd(diff.bytesBackwardsOnSeek, bytesBackwardsOnSeek, inputStats.bytesBackwardsOnSeek);
-      setd(diff.readOperations, readOperations, inputStats.readOperations);
-      setd(diff.readFullyOperations, readFullyOperations, inputStats.readFullyOperations);
-      setd(diff.readsIncomplete, readsIncomplete, inputStats.readsIncomplete);
-      setd(diff.bytesReadInClose, bytesReadInClose, inputStats.bytesReadInClose);
-      setd(diff.bytesDiscardedInAbort, bytesDiscardedInAbort, inputStats.bytesDiscardedInAbort);
-      setd(diff.policySetCount, policySetCount, inputStats.policySetCount);
+      setd(diff.bytesSkippedOnSeek, bytesSkippedOnSeek,
+          inputStats.bytesSkippedOnSeek);
+      setd(diff.bytesBackwardsOnSeek, bytesBackwardsOnSeek,
+          inputStats.bytesBackwardsOnSeek);
+      setd(diff.readOperations, readOperations,
+          inputStats.readOperations);
+      setd(diff.readFullyOperations, readFullyOperations,
+          inputStats.readFullyOperations);
+      setd(diff.readsIncomplete, readsIncomplete,
+          inputStats.readsIncomplete);
+      setd(diff.bytesReadInClose, bytesReadInClose,
+          inputStats.bytesReadInClose);
+      setd(diff.bytesDiscardedInAbort, bytesDiscardedInAbort,
+          inputStats.bytesDiscardedInAbort);
+      setd(diff.policySetCount, policySetCount,
+          inputStats.policySetCount);
       diff.inputPolicy = inputPolicy -inputStats.inputPolicy;
       diff.versionMismatches.set(versionMismatches.longValue() -
               inputStats.versionMismatches.longValue());
@@ -943,7 +958,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      * all the same values as this {@link InputStreamStatisticsImpl}.
      */
     private InputStreamStatisticsImpl copy() {
-      InputStreamStatisticsImpl copy = new InputStreamStatisticsImpl(filesystemStatistics);
+      InputStreamStatisticsImpl copy =
+          new InputStreamStatisticsImpl(filesystemStatistics);
       copy.openOperations.set(openOperations.get());
       copy.closeOperations.set(closeOperations.get());
       copy.closed.set(closed.get());
@@ -1105,7 +1121,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
    * the filesystem-wide statistics.
    * @param source stream statistics
    */
-  private void mergeOutputStreamStatistics(BlockOutputStreamStatisticsImpl source) {
+  private void mergeOutputStreamStatistics(
+      BlockOutputStreamStatisticsImpl source) {
     incrementCounter(STREAM_WRITE_TOTAL_TIME, source.totalUploadDuration());
     incrementCounter(STREAM_WRITE_QUEUE_DURATION, source.queueDuration);
     incrementCounter(STREAM_WRITE_TOTAL_DATA, source.bytesUploaded);
@@ -1116,6 +1133,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
   /**
    * Statistics updated by an output stream during its actual operation.
+   * <p>
    * Some of these stats are propagated to any passed in
    * {@link FileSystem.Statistics} instance; this is only done
    * in close() for better cross-thread accounting.
@@ -1292,7 +1310,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     }
 
     /**
-     * Get counters of blocks actively allocated; my be inaccurate
+     * Get counters of blocks actively allocated; may be inaccurate
      * if the numbers change during the (non-synchronized) calculation.
      * @return the number of actively allocated blocks.
      */
@@ -1333,9 +1351,10 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
       sb.append(", bytesWritten=").append(bytesWritten);
       sb.append(", blocksAllocated=").append(blocksAllocated);
       sb.append(", blocksReleased=").append(blocksReleased);
-      sb.append(", blocksActivelyAllocated=").append(getBlocksActivelyAllocated());
-      sb.append(", exceptionsInMultipartFinalize=").append(
-          exceptionsInMultipartFinalize);
+      sb.append(", blocksActivelyAllocated=")
+          .append(getBlocksActivelyAllocated());
+      sb.append(", exceptionsInMultipartFinalize=")
+          .append(exceptionsInMultipartFinalize);
       sb.append(", transferDuration=").append(transferDuration).append(" ms");
       sb.append(", queueDuration=").append(queueDuration).append(" ms");
       sb.append(", averageQueueTime=").append(averageQueueTime()).append(" ms");
@@ -1623,7 +1642,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
     private final CountersAndGauges countersAndGauges;
 
-    private StatisticsFromAwsSdkImpl(final CountersAndGauges countersAndGauges) {
+    private StatisticsFromAwsSdkImpl(
+        final CountersAndGauges countersAndGauges) {
       this.countersAndGauges = countersAndGauges;
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.s3a.impl.statistics.S3AInputStreamStatistics;
 import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
+import org.apache.hadoop.fs.statistics.IOStatisticEntry;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 import org.apache.hadoop.fs.statistics.IOStatisticsSupport;
@@ -731,7 +732,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
     @Override
     public Long getStatistic(final String name) {
-      return statsCounters.getStatistic(name);
+      return statsCounters.getStatistic(name)
+          .singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER);
     }
 
     /**
@@ -1346,12 +1348,13 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     public IOStatistics getIOStatistics() {
       DynamicIOStatisticsBuilder builder = dynamicIOStatistics();
 
-      builder.add(StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,
-          blocksSubmitted);
-      builder.add(StreamStatisticNames.STREAM_WRITE_BYTES,
-          bytesWritten);
-      builder.add(StreamStatisticNames.STREAM_WRITE_EXCEPTIONS,
-          blockUploadsFailed);
+      builder
+          .withAtomicLong(StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,
+              blocksSubmitted)
+          .withAtomicLong(StreamStatisticNames.STREAM_WRITE_BYTES,
+              bytesWritten)
+          .withAtomicLong(StreamStatisticNames.STREAM_WRITE_EXCEPTIONS,
+              blockUploadsFailed);
       return builder.build();
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -68,8 +68,23 @@ import static org.apache.hadoop.fs.s3a.Statistic.*;
 
 /**
  * Instrumentation of S3a.
- * Derived from the {@code AzureFileSystemInstrumentation}.
- *
+ * <p></p>
+ * History
+ * <ol>
+ *   <li>
+ *    HADOOP-13028. Initial implementation.
+ *    Derived from the {@code AzureFileSystemInstrumentation}.
+ *   </li>
+ *   <li>
+ *    Broadly (and directly) used in S3A.
+ *    The use of direct references causes "problems" in mocking tests.
+ *   </li>
+ *   <li>
+ *     HADOOP-16830. IOStatistics. Move to an interface and implementation
+ *     design for the different inner classes.
+ *   </li>
+ * </ol>
+ * <p></p>
  * Counters and metrics are generally addressed in code by their name or
  * {@link Statistic} key. There <i>may</i> be some Statistics which do
  * not have an entry here. To avoid attempts to access such counters failing,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -733,7 +733,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public Long getStatistic(final String name) {
       return statsCounters.getStatistic(name)
-          .singleValue(IOStatisticEntry.IOSTATISTIC_COUNTER);
+          .scalar(IOStatisticEntry.IOSTATISTIC_COUNTER);
     }
 
     /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -1378,7 +1378,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
           blocksSubmitted);
       builder.add(StreamStatisticNames.STREAM_WRITE_BYTES,
           bytesWritten);
-      builder.add(StreamStatisticNames.STREAM_WRITE_FAILURES,
+      builder.add(StreamStatisticNames.STREAM_WRITE_EXCEPTIONS,
           blockUploadsFailed);
       return builder.build();
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -37,7 +37,10 @@ import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
+import org.apache.hadoop.fs.statistics.IOStatisticsSupport;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
+import org.apache.hadoop.fs.statistics.impl.CounterIOStatistics;
 import org.apache.hadoop.fs.statistics.impl.DynamicIOStatisticsBuilder;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricStringBuilder;
@@ -63,6 +66,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_OPENED;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.counterIOStatistics;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.dynamicIOStatistics;
 import static org.apache.hadoop.fs.s3a.Statistic.*;
 
@@ -625,24 +630,25 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
    */
   private void mergeInputStreamStatistics(
       InputStreamStatisticsImpl statistics) {
-    streamOpenOperations.incr(statistics.openOperations.get());
-    streamCloseOperations.incr(statistics.closeOperations.get());
-    streamClosed.incr(statistics.closed.get());
-    streamAborted.incr(statistics.aborted.get());
-    streamSeekOperations.incr(statistics.seekOperations.get());
-    streamReadExceptions.incr(statistics.readExceptions.get());
-    streamForwardSeekOperations.incr(statistics.forwardSeekOperations.get());
-    streamBytesSkippedOnSeek.incr(statistics.bytesSkippedOnSeek.get());
-    streamBackwardSeekOperations.incr(statistics.backwardSeekOperations.get());
-    streamBytesBackwardsOnSeek.incr(statistics.bytesBackwardsOnSeek.get());
-    streamBytesRead.incr(statistics.bytesRead.get());
-    streamReadOperations.incr(statistics.readOperations.get());
-    streamReadFullyOperations.incr(statistics.readFullyOperations.get());
-    streamReadsIncomplete.incr(statistics.readsIncomplete.get());
-    streamBytesReadInClose.incr(statistics.bytesReadInClose.get());
-    streamBytesDiscardedInAbort.incr(statistics.bytesDiscardedInAbort.get());
+
+    streamOpenOperations.incr(statistics.getStatistic(STREAM_READ_OPENED));
+    streamCloseOperations.incr(statistics.getCloseOperations());
+    streamClosed.incr(statistics.getClosed());
+    streamAborted.incr(statistics.getAborted());
+    streamSeekOperations.incr(statistics.getSeekOperations());
+    streamReadExceptions.incr(statistics.getReadExceptions());
+    streamForwardSeekOperations.incr(statistics.getForwardSeekOperations());
+    streamBytesSkippedOnSeek.incr(statistics.getBytesSkippedOnSeek());
+    streamBackwardSeekOperations.incr(statistics.getBackwardSeekOperations());
+    streamBytesBackwardsOnSeek.incr(statistics.getBytesBackwardsOnSeek());
+    streamBytesRead.incr(statistics.getBytesRead());
+    streamReadOperations.incr(statistics.getReadOperations());
+    streamReadFullyOperations.incr(statistics.getReadFullyOperations());
+    streamReadsIncomplete.incr(statistics.getReadsIncomplete());
+    streamBytesReadInClose.incr(statistics.getBytesReadInClose());
+    streamBytesDiscardedInAbort.incr(statistics.getBytesDiscardedInAbort());
     incrementCounter(STREAM_READ_VERSION_MISMATCHES,
-        statistics.versionMismatches.get());
+        statistics.getVersionMismatches());
   }
 
   @Override
@@ -682,22 +688,29 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
 
     private final FileSystem.Statistics filesystemStatistics;
 
-    private final AtomicLong openOperations= new AtomicLong(0);
-    private final AtomicLong closeOperations= new AtomicLong(0);
-    private final AtomicLong closed= new AtomicLong(0);
-    private final AtomicLong aborted= new AtomicLong(0);
-    private final AtomicLong seekOperations= new AtomicLong(0);
-    private final AtomicLong readExceptions= new AtomicLong(0);
-    private final AtomicLong forwardSeekOperations= new AtomicLong(0);
-    private final AtomicLong backwardSeekOperations= new AtomicLong(0);
-    private final AtomicLong bytesRead= new AtomicLong(0);
-    private final AtomicLong bytesSkippedOnSeek= new AtomicLong(0);
-    private final AtomicLong bytesBackwardsOnSeek= new AtomicLong(0);
-    private final AtomicLong readOperations= new AtomicLong(0);
-    private final AtomicLong readFullyOperations= new AtomicLong(0);
-    private final AtomicLong readsIncomplete= new AtomicLong(0);
-    private final AtomicLong bytesReadInClose= new AtomicLong(0);
-    private final AtomicLong bytesDiscardedInAbort= new AtomicLong(0);
+    /**
+     * Counters implemented directly in the IOStatistics.
+     */
+    private final CounterIOStatistics statsCounters = counterIOStatistics(
+        StreamStatisticNames.STREAM_READ_ABORTED,
+        StreamStatisticNames.STREAM_READ_BYTES_DISCARDED_ABORT,
+        StreamStatisticNames.STREAM_READ_CLOSED,
+        StreamStatisticNames.STREAM_READ_CLOSE_BYTES_READ,
+        StreamStatisticNames.STREAM_READ_CLOSE_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_OPENED,
+        StreamStatisticNames.STREAM_READ_BYTES,
+        StreamStatisticNames.STREAM_READ_EXCEPTIONS,
+        StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_OPERATIONS_INCOMPLETE,
+        StreamStatisticNames.STREAM_READ_VERSION_MISMATCHES,
+        StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_READ,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED);
+
     private final AtomicLong policySetCount= new AtomicLong(0);
     private volatile long inputPolicy;
     private final AtomicLong versionMismatches = new AtomicLong(0);
@@ -708,6 +721,19 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
       this.filesystemStatistics = filesystemStatistics;
     }
 
+    private long increment(String name) {
+      return statsCounters.increment(name);
+    }
+
+    private long increment(String name, long value) {
+      return statsCounters.increment(name, value);
+    }
+
+    @Override
+    public Long getStatistic(final String name) {
+      return statsCounters.getStatistic(name);
+    }
+
     /**
      * Seek backwards, incrementing the seek and backward seek counters.
      * @param negativeOffset how far was the seek?
@@ -715,9 +741,10 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public void seekBackwards(long negativeOffset) {
-      seekOperations.incrementAndGet();
-      backwardSeekOperations.incrementAndGet();
-      bytesBackwardsOnSeek.addAndGet(-negativeOffset);
+      increment(StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS);
+      increment(StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS);
+      increment(StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS,
+          -negativeOffset);
     }
 
     /**
@@ -728,10 +755,11 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public void seekForwards(long skipped) {
-      seekOperations.incrementAndGet();
-      forwardSeekOperations.incrementAndGet();
+      increment(StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS);
+      increment(StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS);
       if (skipped > 0) {
-        bytesSkippedOnSeek.addAndGet(skipped);
+        increment(StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED,
+            skipped);
       }
     }
 
@@ -741,7 +769,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public long streamOpened() {
-      return openOperations.getAndIncrement();
+      return increment(STREAM_READ_OPENED);
     }
 
     /**
@@ -754,13 +782,15 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public void streamClose(boolean abortedConnection,
         long remainingInCurrentRequest) {
-      closeOperations.incrementAndGet();
+      increment(StreamStatisticNames.STREAM_READ_CLOSED);
       if (abortedConnection) {
-        aborted.incrementAndGet();
-        bytesDiscardedInAbort.addAndGet(remainingInCurrentRequest);
+        increment(StreamStatisticNames.STREAM_READ_ABORTED);
+        increment(StreamStatisticNames.STREAM_READ_BYTES_DISCARDED_ABORT,
+            remainingInCurrentRequest);
       } else {
-        closed.incrementAndGet();
-        bytesReadInClose.addAndGet(remainingInCurrentRequest);
+        increment(StreamStatisticNames.STREAM_READ_CLOSED);
+        increment(StreamStatisticNames.STREAM_READ_CLOSE_BYTES_READ,
+            remainingInCurrentRequest);
       }
     }
 
@@ -769,7 +799,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public void readException() {
-      readExceptions.incrementAndGet();
+      increment(StreamStatisticNames.STREAM_READ_EXCEPTIONS);
     }
 
     /**
@@ -780,7 +810,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public void bytesRead(long bytes) {
       if (bytes > 0) {
-        bytesRead.addAndGet(bytes);
+        increment(StreamStatisticNames.STREAM_READ_BYTES, bytes);
       }
     }
 
@@ -791,7 +821,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public void readOperationStarted(long pos, long len) {
-      readOperations.incrementAndGet();
+      increment(StreamStatisticNames.STREAM_READ_OPERATIONS);
     }
 
     /**
@@ -802,7 +832,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public void readFullyOperationStarted(long pos, long len) {
-      readFullyOperations.incrementAndGet();
+      increment(StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS);
     }
 
     /**
@@ -813,7 +843,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public void readOperationCompleted(int requested, int actual) {
       if (requested > actual) {
-        readsIncomplete.incrementAndGet();
+        increment(StreamStatisticNames.STREAM_READ_OPERATIONS_INCOMPLETE);
       }
     }
 
@@ -857,26 +887,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     public String toString() {
       final StringBuilder sb = new StringBuilder(
           "StreamStatistics{");
-      sb.append("OpenOperations=").append(openOperations.get());
-      sb.append(", CloseOperations=").append(closeOperations.get());
-      sb.append(", Closed=").append(closed.get());
-      sb.append(", Aborted=").append(aborted.get());
-      sb.append(", SeekOperations=").append(seekOperations.get());
-      sb.append(", ReadExceptions=").append(readExceptions.get());
-      sb.append(", ForwardSeekOperations=")
-          .append(forwardSeekOperations.get());
-      sb.append(", BackwardSeekOperations=")
-          .append(backwardSeekOperations.get());
-      sb.append(", BytesSkippedOnSeek=").append(bytesSkippedOnSeek.get());
-      sb.append(", BytesBackwardsOnSeek=").append(bytesBackwardsOnSeek.get());
-      sb.append(", BytesRead=").append(bytesRead.get());
-      sb.append(", BytesRead excluding skipped=")
-          .append(bytesRead.get() - bytesSkippedOnSeek.get());
-      sb.append(", ReadOperations=").append(readOperations.get());
-      sb.append(", ReadFullyOperations=").append(readFullyOperations.get());
-      sb.append(", ReadsIncomplete=").append(readsIncomplete.get());
-      sb.append(", BytesReadInClose=").append(bytesReadInClose.get());
-      sb.append(", BytesDiscardedInAbort=").append(bytesDiscardedInAbort.get());
+      sb.append(IOStatisticsLogging.iostatisticsToString(statsCounters));
       sb.append(", InputPolicy=").append(inputPolicy);
       sb.append(", InputPolicySetCount=").append(policySetCount);
       sb.append(", versionMismatches=").append(versionMismatches.get());
@@ -889,8 +900,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      * Takes a diff between the current version of the stats and the
      * version of the stats when merge was last called, and merges the diff
      * into the instrumentation instance. Used to periodically merge the
-     * stats into the fs-wide stats. <b>Behavior is undefined if called on a
-     * closed instance.</b>
+     * stats into the fs-wide stats.
+     * <p></p>
+     * <b>Behavior is undefined if called on a closed instance.</b>
      */
     @Override
     public void merge(boolean isClosed) {
@@ -907,7 +919,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
         // increment the filesystem statistics for this thread.
         if (filesystemStatistics != null) {
           filesystemStatistics.incrementBytesReadByDistance(DISTANCE,
-              bytesRead.get() + bytesReadInClose.get());
+              getBytesRead() - getBytesReadInClose());
         }
       }
     }
@@ -931,38 +943,14 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
         InputStreamStatisticsImpl inputStats) {
       InputStreamStatisticsImpl diff =
           new InputStreamStatisticsImpl(filesystemStatistics);
-      setd(diff.openOperations, openOperations,
-          inputStats.openOperations);
-      setd(diff.closeOperations, closeOperations,
-          inputStats.closeOperations);
-      setd(diff.closed, closed, inputStats.closed);
-      setd(diff.aborted, aborted, inputStats.aborted);
-      setd(diff.seekOperations, seekOperations,
-          inputStats.seekOperations);
-      setd(diff.readExceptions, readExceptions,
-          inputStats.readExceptions);
-      setd(diff.forwardSeekOperations, forwardSeekOperations,
-          inputStats.forwardSeekOperations);
-      setd(diff.backwardSeekOperations, backwardSeekOperations,
-          inputStats.backwardSeekOperations);
-      setd(diff.bytesRead, bytesRead, inputStats.bytesRead);
-      setd(diff.bytesSkippedOnSeek, bytesSkippedOnSeek,
-          inputStats.bytesSkippedOnSeek);
-      setd(diff.bytesBackwardsOnSeek, bytesBackwardsOnSeek,
-          inputStats.bytesBackwardsOnSeek);
-      setd(diff.readOperations, readOperations,
-          inputStats.readOperations);
-      setd(diff.readFullyOperations, readFullyOperations,
-          inputStats.readFullyOperations);
-      setd(diff.readsIncomplete, readsIncomplete,
-          inputStats.readsIncomplete);
-      setd(diff.bytesReadInClose, bytesReadInClose,
-          inputStats.bytesReadInClose);
-      setd(diff.bytesDiscardedInAbort, bytesDiscardedInAbort,
-          inputStats.bytesDiscardedInAbort);
+
+      // build the io stats diff
+      diff.statsCounters.copy(statsCounters);
+      diff.statsCounters.subtract(inputStats.statsCounters);
+
       setd(diff.policySetCount, policySetCount,
           inputStats.policySetCount);
-      diff.inputPolicy = inputPolicy -inputStats.inputPolicy;
+      diff.inputPolicy = inputPolicy - inputStats.inputPolicy;
       diff.versionMismatches.set(versionMismatches.longValue() -
               inputStats.versionMismatches.longValue());
       return diff;
@@ -975,23 +963,9 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     private InputStreamStatisticsImpl copy() {
       InputStreamStatisticsImpl copy =
           new InputStreamStatisticsImpl(filesystemStatistics);
-      copy.openOperations.set(openOperations.get());
-      copy.closeOperations.set(closeOperations.get());
-      copy.closed.set(closed.get());
-      copy.aborted.set(aborted.get());
-      copy.seekOperations.set(seekOperations.get());
-      copy.readExceptions.set(readExceptions.get());
-      copy.forwardSeekOperations.set(forwardSeekOperations.get());
-      copy.backwardSeekOperations.set(backwardSeekOperations.get());
-      copy.bytesRead.set(bytesRead.get());
-      copy.bytesSkippedOnSeek.set(bytesSkippedOnSeek.get());
-      copy.bytesBackwardsOnSeek.set(bytesBackwardsOnSeek.get());
-      copy.readOperations.set(readOperations.get());
-      copy.readFullyOperations.set(readFullyOperations.get());
-      copy.readsIncomplete.set(readsIncomplete.get());
-      copy.bytesReadInClose.set(bytesReadInClose.get());
-      copy.bytesDiscardedInAbort.set(bytesDiscardedInAbort.get());
+
       copy.policySetCount.set(policySetCount.get());
+      copy.versionMismatches.set(versionMismatches.get());
       copy.inputPolicy = inputPolicy;
       return copy;
     }
@@ -1002,113 +976,96 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
      */
     @Override
     public IOStatistics getIOStatistics() {
-      DynamicIOStatisticsBuilder builder
-          = dynamicIOStatistics();
-
-      builder.add(StreamStatisticNames.STREAM_BYTES_DISCARDED_ABORT,
-          bytesDiscardedInAbort);
-      builder.add(StreamStatisticNames.STREAM_CLOSED,
-          closed);
-      builder.add(StreamStatisticNames.STREAM_CLOSE_OPERATIONS,
-          closeOperations);
-      builder.add(StreamStatisticNames.STREAM_OPENED,
-          openOperations);
-      builder.add(StreamStatisticNames.STREAM_READ_BYTES,
-          bytesRead);
-      builder.add(StreamStatisticNames.STREAM_READ_EXCEPTIONS,
-          readExceptions);
-      builder.add(StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS,
-          readFullyOperations);
-      builder.add(StreamStatisticNames.STREAM_READ_OPERATIONS,
-          readOperations);
-      builder.add(StreamStatisticNames.STREAM_READ_OPERATIONS_INCOMPLETE,
-          readsIncomplete);
-      return builder.build();
+      return IOStatisticsSupport.snapshot(statsCounters);
     }
 
     @Override
     public long getCloseOperations() {
-      return closeOperations.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSE_OPERATIONS);
     }
 
     @Override
     public long getClosed() {
-      return closed.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSED);
     }
 
     @Override
     public long getAborted() {
-      return aborted.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_ABORTED);
     }
 
     @Override
     public long getForwardSeekOperations() {
-      return forwardSeekOperations.get();
+      return getStatistic(
+          StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS);
     }
 
     @Override
     public long getBackwardSeekOperations() {
-      return backwardSeekOperations.get();
+      return getStatistic(
+          StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS);
     }
 
     @Override
     public long getBytesRead() {
-      return bytesRead.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_BYTES);
     }
 
     @Override
     public long getBytesSkippedOnSeek() {
-      return bytesSkippedOnSeek.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED);
     }
-
+    
     @Override
     public long getBytesBackwardsOnSeek() {
-      return bytesBackwardsOnSeek.get();
+      return getStatistic(
+          StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS);
     }
 
     @Override
     public long getBytesReadInClose() {
-      return bytesReadInClose.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSE_BYTES_READ);
     }
 
     @Override
     public long getBytesDiscardedInAbort() {
-      return bytesDiscardedInAbort.get();
+      return getStatistic(
+          StreamStatisticNames.STREAM_READ_BYTES_DISCARDED_ABORT);
     }
 
     @Override
     public long getOpenOperations() {
-      return openOperations.get();
+      return getStatistic(STREAM_READ_OPENED);
     }
 
     @Override
     public long getSeekOperations() {
-      return seekOperations.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS);
     }
-
+    
     @Override
     public long getReadExceptions() {
-      return readExceptions.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_EXCEPTIONS);
     }
 
     @Override
     public long getReadOperations() {
-      return readOperations.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSED);
     }
 
     @Override
     public long getReadFullyOperations() {
-      return readFullyOperations.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSED);
     }
 
     @Override
     public long getReadsIncomplete() {
-      return readsIncomplete.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSED);
     }
 
     @Override
     public long getPolicySetCount() {
-      return policySetCount.get();
+      return getStatistic(StreamStatisticNames.STREAM_READ_CLOSED);
     }
 
     @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AOpContext.java
@@ -24,19 +24,23 @@ import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.s3a.impl.ActiveOperationContext;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
 
 /**
- * Base class for operation context struct passed through codepaths for main
+ * Class for operation context struct passed through codepaths for main
  * S3AFileSystem operations.
  * Anything op-specific should be moved to a subclass of this.
+ *
+ * This was originally a base class, but {@link ActiveOperationContext} was
+ * created to be more minimal and cover many more operation type.
  */
-@SuppressWarnings("visibilitymodifier")  // I want a struct of finals, for real.
-public class S3AOpContext {
+@SuppressWarnings("visibilitymodifier")
+public class S3AOpContext extends ActiveOperationContext {
 
   final boolean isS3GuardEnabled;
   final Invoker invoker;
   @Nullable final FileSystem.Statistics stats;
-  final S3AInstrumentation instrumentation;
   @Nullable final Invoker s3guardInvoker;
 
   /** FileStatus for "destination" path being operated on. */
@@ -53,9 +57,14 @@ public class S3AOpContext {
    * @param dstFileStatus file status from existence check
    */
   public S3AOpContext(boolean isS3GuardEnabled, Invoker invoker,
-      Invoker s3guardInvoker, @Nullable FileSystem.Statistics stats,
-      S3AInstrumentation instrumentation, FileStatus dstFileStatus) {
+      @Nullable Invoker s3guardInvoker,
+      @Nullable FileSystem.Statistics stats,
+      S3AStatisticsContext instrumentation,
+      FileStatus dstFileStatus) {
 
+    super(newOperationId(),
+        instrumentation,
+        null);
     Preconditions.checkNotNull(invoker, "Null invoker arg");
     Preconditions.checkNotNull(instrumentation, "Null instrumentation arg");
     Preconditions.checkNotNull(dstFileStatus, "Null dstFileStatus arg");
@@ -65,7 +74,6 @@ public class S3AOpContext {
     this.invoker = invoker;
     this.s3guardInvoker = s3guardInvoker;
     this.stats = stats;
-    this.instrumentation = instrumentation;
     this.dstFileStatus = dstFileStatus;
   }
 
@@ -77,8 +85,10 @@ public class S3AOpContext {
    * @param instrumentation instrumentation to use
    * @param dstFileStatus file status from existence check
    */
-  public S3AOpContext(boolean isS3GuardEnabled, Invoker invoker,
-      @Nullable FileSystem.Statistics stats, S3AInstrumentation instrumentation,
+  public S3AOpContext(boolean isS3GuardEnabled,
+      Invoker invoker,
+      @Nullable FileSystem.Statistics stats,
+      S3AStatisticsContext instrumentation,
       FileStatus dstFileStatus) {
     this(isS3GuardEnabled, invoker, null, stats, instrumentation,
         dstFileStatus);
@@ -95,10 +105,6 @@ public class S3AOpContext {
   @Nullable
   public FileSystem.Statistics getStats() {
     return stats;
-  }
-
-  public S3AInstrumentation getInstrumentation() {
-    return instrumentation;
   }
 
   @Nullable

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
 
 import javax.annotation.Nullable;
 
@@ -60,8 +61,8 @@ public class S3AReadOpContext extends S3AOpContext {
    * @param isS3GuardEnabled true iff S3Guard is enabled.
    * @param invoker invoker for normal retries.
    * @param s3guardInvoker S3Guard-specific retry invoker.
-   * @param stats statistics (may be null)
-   * @param instrumentation FS instrumentation
+   * @param stats Fileystem statistics (may be null)
+   * @param instrumentation statistics context
    * @param dstFileStatus target file status
    * @param inputPolicy the input policy
    * @param readahead readahead for GET operations/skip, etc.
@@ -71,13 +72,14 @@ public class S3AReadOpContext extends S3AOpContext {
       final Path path,
       boolean isS3GuardEnabled,
       Invoker invoker,
-      Invoker s3guardInvoker,
+      @Nullable Invoker s3guardInvoker,
       @Nullable FileSystem.Statistics stats,
-      S3AInstrumentation instrumentation,
+      S3AStatisticsContext instrumentation,
       FileStatus dstFileStatus,
       S3AInputPolicy inputPolicy,
       ChangeDetectionPolicy changeDetectionPolicy,
       final long readahead) {
+
     super(isS3GuardEnabled, invoker, s3guardInvoker, stats, instrumentation,
         dstFileStatus);
     this.path = checkNotNull(path);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -22,10 +22,12 @@ import java.io.IOException;
 import java.net.URI;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.s3.AmazonS3;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 
 /**
  * Factory for creation of {@link AmazonS3} client instances.
@@ -41,12 +43,14 @@ public interface S3ClientFactory {
    * @param bucket Optional bucket to use to look up per-bucket proxy secrets
    * @param credentialSet credentials to use
    * @param userAgentSuffix optional suffix for the UA field.
+   * @param statisticsFromAwsSdk binding for AWS stats
    * @return S3 client
    * @throws IOException IO problem
    */
   AmazonS3 createS3Client(URI name,
       String bucket,
       AWSCredentialsProvider credentialSet,
-      String userAgentSuffix) throws IOException;
+      String userAgentSuffix,
+      StatisticsFromAwsSdk statisticsFromAwsSdk) throws IOException;
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -43,7 +43,7 @@ public interface S3ClientFactory {
    * @param bucket Optional bucket to use to look up per-bucket proxy secrets
    * @param credentialSet credentials to use
    * @param userAgentSuffix optional suffix for the UA field.
-   * @param statisticsFromAwsSdk binding for AWS stats
+   * @param statisticsFromAwsSdk binding for AWS stats - may be null
    * @return S3 client
    * @throws IOException IO problem
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import org.apache.hadoop.fs.StorageStatistics.CommonStatisticNames;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,39 +50,56 @@ public enum Statistic {
   FAKE_DIRECTORIES_DELETED("fake_directories_deleted",
       "Total number of fake directory deletes submitted to object store."),
   IGNORED_ERRORS("ignored_errors", "Errors caught and ignored"),
-  INVOCATION_COPY_FROM_LOCAL_FILE(CommonStatisticNames.OP_COPY_FROM_LOCAL_FILE,
+  INVOCATION_COPY_FROM_LOCAL_FILE(
+      StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE,
       "Calls of copyFromLocalFile()"),
-  INVOCATION_CREATE(CommonStatisticNames.OP_CREATE,
+  INVOCATION_CREATE(
+      StoreStatisticNames.OP_CREATE,
       "Calls of create()"),
-  INVOCATION_CREATE_NON_RECURSIVE(CommonStatisticNames.OP_CREATE_NON_RECURSIVE,
+  INVOCATION_CREATE_NON_RECURSIVE(
+      StoreStatisticNames.OP_CREATE_NON_RECURSIVE,
       "Calls of createNonRecursive()"),
-  INVOCATION_DELETE(CommonStatisticNames.OP_DELETE,
+  INVOCATION_DELETE(
+      StoreStatisticNames.OP_DELETE,
       "Calls of delete()"),
-  INVOCATION_EXISTS(CommonStatisticNames.OP_EXISTS,
+  INVOCATION_EXISTS(
+      StoreStatisticNames.OP_EXISTS,
       "Calls of exists()"),
-  INVOCATION_GET_DELEGATION_TOKEN(CommonStatisticNames.OP_GET_DELEGATION_TOKEN,
+  INVOCATION_GET_DELEGATION_TOKEN(
+      StoreStatisticNames.OP_GET_DELEGATION_TOKEN,
       "Calls of getDelegationToken()"),
-  INVOCATION_GET_FILE_CHECKSUM(CommonStatisticNames.OP_GET_FILE_CHECKSUM,
+  INVOCATION_GET_FILE_CHECKSUM(
+      StoreStatisticNames.OP_GET_FILE_CHECKSUM,
       "Calls of getFileChecksum()"),
-  INVOCATION_GET_FILE_STATUS(CommonStatisticNames.OP_GET_FILE_STATUS,
+  INVOCATION_GET_FILE_STATUS(
+      StoreStatisticNames.OP_GET_FILE_STATUS,
       "Calls of getFileStatus()"),
-  INVOCATION_GLOB_STATUS(CommonStatisticNames.OP_GLOB_STATUS,
+  INVOCATION_GLOB_STATUS(
+      StoreStatisticNames.OP_GLOB_STATUS,
       "Calls of globStatus()"),
-  INVOCATION_IS_DIRECTORY(CommonStatisticNames.OP_IS_DIRECTORY,
+  INVOCATION_IS_DIRECTORY(
+      StoreStatisticNames.OP_IS_DIRECTORY,
       "Calls of isDirectory()"),
-  INVOCATION_IS_FILE(CommonStatisticNames.OP_IS_FILE,
+  INVOCATION_IS_FILE(
+      StoreStatisticNames.OP_IS_FILE,
       "Calls of isFile()"),
-  INVOCATION_LIST_FILES(CommonStatisticNames.OP_LIST_FILES,
+  INVOCATION_LIST_FILES(
+      StoreStatisticNames.OP_LIST_FILES,
       "Calls of listFiles()"),
-  INVOCATION_LIST_LOCATED_STATUS(CommonStatisticNames.OP_LIST_LOCATED_STATUS,
+  INVOCATION_LIST_LOCATED_STATUS(
+      StoreStatisticNames.OP_LIST_LOCATED_STATUS,
       "Calls of listLocatedStatus()"),
-  INVOCATION_LIST_STATUS(CommonStatisticNames.OP_LIST_STATUS,
+  INVOCATION_LIST_STATUS(
+      StoreStatisticNames.OP_LIST_STATUS,
       "Calls of listStatus()"),
-  INVOCATION_MKDIRS(CommonStatisticNames.OP_MKDIRS,
+  INVOCATION_MKDIRS(
+      StoreStatisticNames.OP_MKDIRS,
       "Calls of mkdirs()"),
-  INVOCATION_OPEN(CommonStatisticNames.OP_OPEN,
+  INVOCATION_OPEN(
+      StoreStatisticNames.OP_OPEN,
       "Calls of open()"),
-  INVOCATION_RENAME(CommonStatisticNames.OP_RENAME,
+  INVOCATION_RENAME(
+      StoreStatisticNames.OP_RENAME,
       "Calls of rename()"),
   OBJECT_COPY_REQUESTS("object_copy_requests", "Object copy requests"),
   OBJECT_DELETE_REQUESTS("object_delete_requests", "Object delete requests"),
@@ -106,51 +124,75 @@ public enum Statistic {
       "number of bytes queued for upload/being actively uploaded"),
   OBJECT_SELECT_REQUESTS("object_select_requests",
       "Count of S3 Select requests issued"),
-  STREAM_ABORTED("stream_aborted",
+  STREAM_ABORTED(
+      StreamStatisticNames.STREAM_ABORTED,
       "Count of times the TCP stream was aborted"),
-  STREAM_BACKWARD_SEEK_OPERATIONS("stream_backward_seek_operations",
+  STREAM_BACKWARD_SEEK_OPERATIONS(
+      StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS,
       "Number of executed seek operations which went backwards in a stream"),
-  STREAM_CLOSED("stream_closed", "Count of times the TCP stream was closed"),
-  STREAM_CLOSE_OPERATIONS("stream_close_operations",
+  STREAM_CLOSED(
+      StreamStatisticNames.STREAM_CLOSED,
+      "Count of times the TCP stream was closed"),
+  STREAM_CLOSE_OPERATIONS(
+      StreamStatisticNames.STREAM_CLOSE_OPERATIONS,
       "Total count of times an attempt to close a data stream was made"),
-  STREAM_FORWARD_SEEK_OPERATIONS("stream_forward_seek_operations",
+  STREAM_FORWARD_SEEK_OPERATIONS(
+      StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS,
       "Number of executed seek operations which went forward in a stream"),
-  STREAM_OPENED("stream_opened",
-      "Total count of times an input stream to object store was opened"),
-  STREAM_READ_EXCEPTIONS("stream_read_exceptions",
-      "Number of exceptions invoked on input streams"),
-  STREAM_READ_FULLY_OPERATIONS("stream_read_fully_operations",
+  STREAM_OPENED(
+      StreamStatisticNames.STREAM_OPENED,
+      "Total count of times an input stream to object store data was opened"),
+  STREAM_READ_EXCEPTIONS(
+      StreamStatisticNames.STREAM_READ_EXCEPTIONS,
+      "Number of exceptions raised during input stream reads"),
+  STREAM_READ_FULLY_OPERATIONS(
+      StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS,
       "Count of readFully() operations in streams"),
-  STREAM_READ_OPERATIONS("stream_read_operations",
+  STREAM_READ_OPERATIONS(
+      StreamStatisticNames.STREAM_READ_OPERATIONS,
       "Count of read() operations in streams"),
-  STREAM_READ_OPERATIONS_INCOMPLETE("stream_read_operations_incomplete",
+  STREAM_READ_OPERATIONS_INCOMPLETE(
+      StreamStatisticNames.STREAM_READ_OPERATIONS_INCOMPLETE,
       "Count of incomplete read() operations in streams"),
-  STREAM_READ_VERSION_MISMATCHES("stream_read_version_mismatches",
+  STREAM_READ_VERSION_MISMATCHES(
+      StreamStatisticNames.STREAM_READ_VERSION_MISMATCHES,
       "Count of version mismatches encountered while reading streams"),
-  STREAM_SEEK_BYTES_BACKWARDS("stream_bytes_backwards_on_seek",
+  STREAM_SEEK_BYTES_BACKWARDS(
+      StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS,
       "Count of bytes moved backwards during seek operations"),
-  STREAM_SEEK_BYTES_READ("stream_bytes_read",
+  STREAM_SEEK_BYTES_READ(
+      StreamStatisticNames.STREAM_READ_SEEK_BYTES_READ,
       "Count of bytes read during seek() in stream operations"),
-  STREAM_SEEK_BYTES_SKIPPED("stream_bytes_skipped_on_seek",
+  STREAM_SEEK_BYTES_SKIPPED(
+      StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED,
       "Count of bytes skipped during forward seek operation"),
-  STREAM_SEEK_OPERATIONS("stream_seek_operations",
+  STREAM_SEEK_OPERATIONS(
+      StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS,
       "Number of seek operations during stream IO."),
-  STREAM_CLOSE_BYTES_READ("stream_bytes_read_in_close",
+  STREAM_CLOSE_BYTES_READ(
+      StreamStatisticNames.STREAM_CLOSE_BYTES_READ,
       "Count of bytes read when closing streams during seek operations."),
-  STREAM_ABORT_BYTES_DISCARDED("stream_bytes_discarded_in_abort",
+  STREAM_ABORT_BYTES_DISCARDED(
+      StreamStatisticNames.STREAM_BYTES_DISCARDED_ABORT,
       "Count of bytes discarded by aborting the stream"),
-  STREAM_WRITE_FAILURES("stream_write_failures",
+  STREAM_WRITE_FAILURES(
+      StreamStatisticNames.STREAM_WRITE_FAILURES,
       "Count of stream write failures reported"),
-  STREAM_WRITE_BLOCK_UPLOADS("stream_write_block_uploads",
+  STREAM_WRITE_BLOCK_UPLOADS(
+      StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,
       "Count of block/partition uploads completed"),
-  STREAM_WRITE_BLOCK_UPLOADS_ACTIVE("stream_write_block_uploads_active",
+  STREAM_WRITE_BLOCK_UPLOADS_ACTIVE(
+      StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS_ACTIVE,
       "Count of block/partition uploads completed"),
-  STREAM_WRITE_BLOCK_UPLOADS_COMMITTED("stream_write_block_uploads_committed",
+  STREAM_WRITE_BLOCK_UPLOADS_COMMITTED(
+      StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS_COMMITTED,
       "Count of number of block uploads committed"),
-  STREAM_WRITE_BLOCK_UPLOADS_ABORTED("stream_write_block_uploads_aborted",
+  STREAM_WRITE_BLOCK_UPLOADS_ABORTED(
+      StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS_ABORTED,
       "Count of number of block uploads aborted"),
 
-  STREAM_WRITE_BLOCK_UPLOADS_PENDING("stream_write_block_uploads_pending",
+  STREAM_WRITE_BLOCK_UPLOADS_PENDING(
+      StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS_PENDING,
       "Gauge of block/partitions uploads queued to be written"),
   STREAM_WRITE_BLOCK_UPLOADS_DATA_PENDING(
       "stream_write_block_uploads_data_pending",
@@ -159,6 +201,9 @@ public enum Statistic {
       "Count of total time taken for uploads to complete"),
   STREAM_WRITE_TOTAL_DATA("stream_write_total_data",
       "Count of total data uploaded in block output"),
+  STREAM_WRITE_BYTES(
+      StreamStatisticNames.STREAM_WRITE_BYTES,
+      "Count of bytes written to output stream (including all not yet uploaded"),
   STREAM_WRITE_QUEUE_DURATION("stream_write_queue_duration",
       "Total queue duration of all block uploads"),
 
@@ -233,8 +278,17 @@ public enum Statistic {
   STORE_IO_THROTTLE_RATE("store_io_throttle_rate",
       "Rate of S3 request throttling"),
 
-  DELEGATION_TOKENS_ISSUED("delegation_tokens_issued",
-      "Number of delegation tokens issued");
+  DELEGATION_TOKENS_ISSUED(
+      StoreStatisticNames.DELEGATION_TOKENS_ISSUED,
+      "Number of delegation tokens issued"),
+
+  STORE_IO_REQUEST(StoreStatisticNames.STORE_IO_REQUEST,
+      "requests made of the remote store"),
+
+  STORE_IO_RETRY(StoreStatisticNames.STORE_IO_RETRY,
+      "retried requests made of the remote store"),
+
+      ;
 
   private static final Map<String, Statistic> SYMBOL_MAP =
       new HashMap<>(Statistic.values().length);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -203,7 +203,8 @@ public enum Statistic {
       "Count of total data uploaded in block output"),
   STREAM_WRITE_BYTES(
       StreamStatisticNames.STREAM_WRITE_BYTES,
-      "Count of bytes written to output stream (including all not yet uploaded"),
+      "Count of bytes written to output stream"
+          + " (including all not yet uploaded"),
   STREAM_WRITE_QUEUE_DURATION("stream_write_queue_duration",
       "Total queue duration of all block uploads"),
 
@@ -286,9 +287,7 @@ public enum Statistic {
       "requests made of the remote store"),
 
   STORE_IO_RETRY(StoreStatisticNames.STORE_IO_RETRY,
-      "retried requests made of the remote store"),
-
-      ;
+      "retried requests made of the remote store");
 
   private static final Map<String, Statistic> SYMBOL_MAP =
       new HashMap<>(Statistic.values().length);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -176,7 +176,7 @@ public enum Statistic {
       StreamStatisticNames.STREAM_BYTES_DISCARDED_ABORT,
       "Count of bytes discarded by aborting the stream"),
   STREAM_WRITE_FAILURES(
-      StreamStatisticNames.STREAM_WRITE_FAILURES,
+      StreamStatisticNames.STREAM_WRITE_EXCEPTIONS,
       "Count of stream write failures reported"),
   STREAM_WRITE_BLOCK_UPLOADS(
       StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
@@ -27,8 +28,13 @@ import java.util.Map;
 /**
  * Statistic which are collected in S3A.
  * These statistics are available at a low level in {@link S3AStorageStatistics}
- * and as metrics in {@link S3AInstrumentation}
+ * and as metrics in {@link S3AInstrumentation}.
+ * <p></p>
+ * Where possible, stream names come from {@link StreamStatisticNames}
+ * and {@link StoreStatisticNames}
+ *
  */
+@InterfaceStability.Unstable
 public enum Statistic {
 
   DIRECTORIES_CREATED("directories_created",
@@ -125,22 +131,22 @@ public enum Statistic {
   OBJECT_SELECT_REQUESTS("object_select_requests",
       "Count of S3 Select requests issued"),
   STREAM_ABORTED(
-      StreamStatisticNames.STREAM_ABORTED,
+      StreamStatisticNames.STREAM_READ_ABORTED,
       "Count of times the TCP stream was aborted"),
   STREAM_BACKWARD_SEEK_OPERATIONS(
       StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS,
       "Number of executed seek operations which went backwards in a stream"),
   STREAM_CLOSED(
-      StreamStatisticNames.STREAM_CLOSED,
+      StreamStatisticNames.STREAM_READ_CLOSED,
       "Count of times the TCP stream was closed"),
   STREAM_CLOSE_OPERATIONS(
-      StreamStatisticNames.STREAM_CLOSE_OPERATIONS,
+      StreamStatisticNames.STREAM_READ_CLOSE_OPERATIONS,
       "Total count of times an attempt to close a data stream was made"),
   STREAM_FORWARD_SEEK_OPERATIONS(
       StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS,
       "Number of executed seek operations which went forward in a stream"),
   STREAM_OPENED(
-      StreamStatisticNames.STREAM_OPENED,
+      StreamStatisticNames.STREAM_READ_OPENED,
       "Total count of times an input stream to object store data was opened"),
   STREAM_READ_EXCEPTIONS(
       StreamStatisticNames.STREAM_READ_EXCEPTIONS,
@@ -170,10 +176,10 @@ public enum Statistic {
       StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS,
       "Number of seek operations during stream IO."),
   STREAM_CLOSE_BYTES_READ(
-      StreamStatisticNames.STREAM_CLOSE_BYTES_READ,
+      StreamStatisticNames.STREAM_READ_CLOSE_BYTES_READ,
       "Count of bytes read when closing streams during seek operations."),
   STREAM_ABORT_BYTES_DISCARDED(
-      StreamStatisticNames.STREAM_BYTES_DISCARDED_ABORT,
+      StreamStatisticNames.STREAM_READ_BYTES_DISCARDED_ABORT,
       "Count of bytes discarded by aborting the stream"),
   STREAM_WRITE_FAILURES(
       StreamStatisticNames.STREAM_WRITE_EXCEPTIONS,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.fs.s3a.s3guard.S3Guard;
 import org.apache.hadoop.fs.s3a.select.SelectBinding;
@@ -109,16 +110,25 @@ public class WriteOperationHelper {
   private final String bucket;
 
   /**
+   * statistics context.
+   */
+  private final S3AStatisticsContext statisticsContext;
+
+  /**
    * Constructor.
    * @param owner owner FS creating the helper
    * @param conf Configuration object
+   * @param statisticsContext statistics context
    *
    */
-  protected WriteOperationHelper(S3AFileSystem owner, Configuration conf) {
+  protected WriteOperationHelper(S3AFileSystem owner,
+      Configuration conf,
+      S3AStatisticsContext statisticsContext) {
     this.owner = owner;
     this.invoker = new Invoker(new S3ARetryPolicy(conf),
         this::operationRetried);
     this.conf = conf;
+    this.statisticsContext = statisticsContext;
     bucket = owner.getBucket();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/S3ADelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/S3ADelegationTokens.java
@@ -34,9 +34,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.s3a.impl.statistics.DelegationTokenStatistics;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -134,9 +134,9 @@ public class S3ADelegationTokens extends AbstractDTService {
           AWSPolicyProvider.AccessLevel.WRITE);
 
   /**
-   * Statistics for the owner FS.
+   * Statistics for the operations.
    */
-  private S3AInstrumentation.DelegationTokenStatistics stats;
+  private DelegationTokenStatistics stats;
 
   /**
    * Name of the token binding as extracted from token kind; used for

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
@@ -45,13 +45,13 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
 import org.apache.hadoop.fs.s3a.commit.files.PendingSet;
 import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
 import org.apache.hadoop.fs.s3a.commit.files.SuccessData;
 import org.apache.hadoop.fs.s3a.impl.InternalConstants;
+import org.apache.hadoop.fs.s3a.impl.statistics.CommitterStatistics;
 import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.DurationInfo;
@@ -81,7 +81,7 @@ public class CommitOperations {
   private final S3AFileSystem fs;
 
   /** Statistics. */
-  private final S3AInstrumentation.CommitterStatistics statistics;
+  private final CommitterStatistics statistics;
 
   /**
    * Write operations for the destination fs.
@@ -128,7 +128,7 @@ public class CommitOperations {
   }
 
   /** @return statistics. */
-  protected S3AInstrumentation.CommitterStatistics getStatistics() {
+  protected CommitterStatistics getStatistics() {
     return statistics;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/MagicCommitIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/MagicCommitIntegration.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.commit.magic.MagicCommitTracker;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 import static org.apache.hadoop.fs.s3a.commit.MagicCommitPaths.*;
 
@@ -50,6 +51,8 @@ public class MagicCommitIntegration {
   private final S3AFileSystem owner;
   private final boolean magicCommitEnabled;
 
+  private final StoreContext storeContext;
+
   /**
    * Instantiate.
    * @param owner owner class
@@ -59,6 +62,7 @@ public class MagicCommitIntegration {
       boolean magicCommitEnabled) {
     this.owner = owner;
     this.magicCommitEnabled = magicCommitEnabled;
+    storeContext = owner.createStoreContext();
   }
 
   /**
@@ -94,10 +98,9 @@ public class MagicCommitIntegration {
       if (isMagicCommitPath(elements)) {
         final String destKey = keyOfFinalDestination(elements, key);
         String pendingsetPath = key + CommitConstants.PENDING_SUFFIX;
-        owner.getInstrumentation()
-            .incrementCounter(Statistic.COMMITTER_MAGIC_FILES_CREATED, 1);
+        storeContext.incrementStatistic(Statistic.COMMITTER_MAGIC_FILES_CREATED);
         tracker = new MagicCommitTracker(path,
-            owner.getBucket(),
+            storeContext.getBucket(),
             key,
             destKey,
             pendingsetPath,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/MagicCommitIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/MagicCommitIntegration.java
@@ -98,7 +98,8 @@ public class MagicCommitIntegration {
       if (isMagicCommitPath(elements)) {
         final String destKey = keyOfFinalDestination(elements, key);
         String pendingsetPath = key + CommitConstants.PENDING_SUFFIX;
-        storeContext.incrementStatistic(Statistic.COMMITTER_MAGIC_FILES_CREATED);
+        storeContext.incrementStatistic(
+            Statistic.COMMITTER_MAGIC_FILES_CREATED);
         tracker = new MagicCommitTracker(path,
             storeContext.getBucket(),
             key,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ActiveOperationContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ActiveOperationContext.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
+
+/**
+ * Context for any active operation.
+ */
+public class ActiveOperationContext {
+
+  /**
+   * An operation ID; currently just for logging...proper tracing needs more.
+   */
+  private final long operationId;
+
+  /**
+   * Statistics context
+   */
+  private final S3AStatisticsContext statisticsContext;
+
+  /**
+   * S3Guard bulk operation state, if (currently) set.
+   */
+  @Nullable private BulkOperationState bulkOperationState;
+
+  public ActiveOperationContext(
+      final long operationId,
+      final S3AStatisticsContext statisticsContext,
+      @Nullable final BulkOperationState bulkOperationState) {
+    this.operationId = operationId;
+    this.statisticsContext = Objects.requireNonNull(statisticsContext,
+        "null statistics context");
+    this.bulkOperationState = bulkOperationState;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(
+        "ActiveOperation{");
+    sb.append("operationId=").append(operationId);
+    sb.append(", bulkOperationState=").append(bulkOperationState);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  @Nullable
+  public BulkOperationState getBulkOperationState() {
+    return bulkOperationState;
+  }
+
+  public long getOperationId() {
+    return operationId;
+  }
+
+  public S3AStatisticsContext getS3AStatisticsContext() {
+    return statisticsContext;
+  }
+
+  private static final AtomicLong nextOperationId = new AtomicLong(0);
+
+  /**
+   * Create an operation ID. The nature of it should be opaque.
+   * @return an ID for the constructor.
+   */
+  protected static long newOperationId() {
+    return nextOperationId.incrementAndGet();
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ActiveOperationContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ActiveOperationContext.java
@@ -37,7 +37,7 @@ public class ActiveOperationContext {
   private final long operationId;
 
   /**
-   * Statistics context
+   * Statistics context.
    */
   private final S3AStatisticsContext statisticsContext;
 
@@ -79,14 +79,14 @@ public class ActiveOperationContext {
     return statisticsContext;
   }
 
-  private static final AtomicLong nextOperationId = new AtomicLong(0);
+  private static final AtomicLong NEXT_OPERATION_ID = new AtomicLong(0);
 
   /**
    * Create an operation ID. The nature of it should be opaque.
    * @return an ID for the constructor.
    */
   protected static long newOperationId() {
-    return nextOperationId.incrementAndGet();
+    return NEXT_OPERATION_ID.incrementAndGet();
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/BulkDeleteRetryHandler.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/BulkDeleteRetryHandler.java
@@ -26,9 +26,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.s3a.AWSClientIOException;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.isThrottleException;
 import static org.apache.hadoop.fs.s3a.Statistic.IGNORED_ERRORS;
@@ -53,7 +53,7 @@ public class BulkDeleteRetryHandler extends AbstractStoreOperation {
    */
   public static final String XML_PARSE_BROKEN = "Failed to parse XML document";
 
-  private final S3AInstrumentation instrumentation;
+  private final S3AStatisticsContext instrumentation;
 
   private final S3AStorageStatistics storageStatistics;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ChangeTracker.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkBaseException;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
@@ -39,6 +37,7 @@ import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.NoVersionAttributeException;
 import org.apache.hadoop.fs.s3a.RemoteFileChangedException;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.impl.statistics.ChangeTrackerStatistics;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -72,7 +71,7 @@ public class ChangeTracker {
    * Mismatch counter; expected to be wired up to StreamStatistics except
    * during testing.
    */
-  private final AtomicLong versionMismatches;
+  private final ChangeTrackerStatistics versionMismatches;
 
   /**
    * Revision identifier (e.g. eTag or versionId, depending on change
@@ -90,7 +89,7 @@ public class ChangeTracker {
    */
   public ChangeTracker(final String uri,
       final ChangeDetectionPolicy policy,
-      final AtomicLong versionMismatches,
+      final ChangeTrackerStatistics versionMismatches,
       final S3ObjectAttributes s3ObjectAttributes) {
     this.policy = checkNotNull(policy);
     this.uri = uri;
@@ -111,8 +110,8 @@ public class ChangeTracker {
   }
 
   @VisibleForTesting
-  public AtomicLong getVersionMismatches() {
-    return versionMismatches;
+  public long getVersionMismatches() {
+    return versionMismatches.getVersionMismatches();
   }
 
   /**
@@ -177,7 +176,7 @@ public class ChangeTracker {
       if (revisionId != null) {
         // the requirements of the change detection policy wasn't met: the
         // object was not returned.
-        versionMismatches.incrementAndGet();
+        versionMismatches.versionMismatchError();
         throw new RemoteFileChangedException(uri, operation,
             String.format(CHANGE_REPORTED_BY_S3
                     + " during %s"
@@ -235,7 +234,7 @@ public class ChangeTracker {
       // This isn't really going to be hit due to
       // https://github.com/aws/aws-sdk-java/issues/1644
       if (serviceException.getStatusCode() == SC_PRECONDITION_FAILED) {
-        versionMismatches.incrementAndGet();
+        versionMismatches.versionMismatchError();
         throw new RemoteFileChangedException(uri, operation, String.format(
             RemoteFileChangedException.PRECONDITIONS_FAILED
                 + " on %s."
@@ -292,10 +291,10 @@ public class ChangeTracker {
               uri,
               pos,
               operation,
-              versionMismatches.get());
+              versionMismatches.getVersionMismatches());
       if (pair.left) {
         // an mismatch has occurred: note it.
-        versionMismatches.incrementAndGet();
+        versionMismatches.versionMismatchError();
       }
       if (pair.right != null) {
         // there's an exception to raise: do it

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -110,4 +110,11 @@ public final class InternalConstants {
    * Value: {@value}.
    */
   public static final int DEFAULT_UPLOAD_PART_COUNT_LIMIT = 10000;
+
+  /**
+   * Flag to enable AWS Statistics binding. As this is triggering
+   * problems related to region/endpoint setup, it is currently
+   * disabled.
+   */
+  public static final boolean AWS_SDK_METRICS_ENABLED = false;
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StoreContext.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AInputPolicy;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.s3guard.ITtlTimeProvider;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -84,7 +84,7 @@ public class StoreContext {
   private final Invoker invoker;
 
   /** Instrumentation and statistics. */
-  private final S3AInstrumentation instrumentation;
+  private final S3AStatisticsContext instrumentation;
   private final S3AStorageStatistics storageStatistics;
 
   /** Seek policy. */
@@ -126,7 +126,7 @@ public class StoreContext {
       final ListeningExecutorService executor,
       final int executorCapacity,
       final Invoker invoker,
-      final S3AInstrumentation instrumentation,
+      final S3AStatisticsContext instrumentation,
       final S3AStorageStatistics storageStatistics,
       final S3AInputPolicy inputPolicy,
       final ChangeDetectionPolicy changeDetectionPolicy,
@@ -183,7 +183,7 @@ public class StoreContext {
     return invoker;
   }
 
-  public S3AInstrumentation getInstrumentation() {
+  public S3AStatisticsContext getInstrumentation() {
     return instrumentation;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/AwsStatisticsCollector.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/AwsStatisticsCollector.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.metrics.RequestMetricCollector;
+import com.amazonaws.util.TimingInfo;
+
+import static com.amazonaws.util.AWSRequestMetrics.Field.ClientExecuteTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.HttpClientRetryCount;
+import static com.amazonaws.util.AWSRequestMetrics.Field.HttpRequestTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.RequestCount;
+import static com.amazonaws.util.AWSRequestMetrics.Field.RequestMarshallTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.RequestSigningTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.ResponseProcessingTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.ThrottleException;
+
+/**
+ * Collect statistics from the AWS SDK and update our statistics.
+ *
+ * See {@code com.facebook.presto.hive.s3.PrestoS3FileSystemMetricCollector}
+ * for the inspiration for this.
+ * See {@code com.amazonaws.util.AWSRequestMetrics} for metric names.
+ */
+public class AwsStatisticsCollector extends RequestMetricCollector {
+
+  /**
+   * final destination of updates.
+   */
+  private final StatisticsFromAwsSdk collector;
+
+  /**
+   * Instantiate.
+   * @param collector final destination of updates
+   */
+  public AwsStatisticsCollector(final StatisticsFromAwsSdk collector) {
+    this.collector = collector;
+  }
+
+  @Override
+  public void collectMetrics(
+      final Request<?> request,
+      final Response<?> response) {
+
+    TimingInfo timingInfo = request.getAWSRequestMetrics().getTimingInfo();
+
+    counter(timingInfo, HttpClientRetryCount.name(),
+        collector::updateAwsRetryCount);
+    counter(timingInfo, RequestCount.name(),
+        collector::updateAwsRequestCount);
+    counter(timingInfo, ThrottleException.name(),
+        collector::updateAwsThrottleExceptionsCount);
+
+    timing(timingInfo, ClientExecuteTime.name(),
+        collector::noteAwsClientExecuteTime);
+    timing(timingInfo, HttpRequestTime.name(),
+        collector::noteAwsRequestTime);
+    timing(timingInfo, RequestMarshallTime.name(),
+        collector::noteRequestMarshallTime);
+    timing(timingInfo, RequestSigningTime.name(),
+        collector::noteRequestSigningTime);
+    timing(timingInfo, ResponseProcessingTime.name(),
+        collector::noteResponseProcessingTime);
+  }
+
+  /**
+   * Process a timing.
+   * @param timingInfo timing info
+   * @param subMeasurementName sub measurement
+   * @param durationConsumer consumer
+   */
+  private void timing(
+      TimingInfo timingInfo,
+      String subMeasurementName,
+      Consumer<Duration> durationConsumer) {
+    TimingInfo t1 = timingInfo.getSubMeasurement(subMeasurementName);
+    if (t1 != null && t1.getTimeTakenMillisIfKnown() != null) {
+      durationConsumer.accept(Duration.ofMillis(
+          t1.getTimeTakenMillisIfKnown().longValue()));
+    }
+  }
+
+  /**
+   * Process a counter.
+   * @param timingInfo timing info
+   * @param subMeasurementName sub measurement
+   * @param consumer consumer
+   */
+  private void counter(
+      TimingInfo timingInfo,
+      String subMeasurementName,
+      LongConsumer consumer) {
+    Number n = timingInfo.getCounter(subMeasurementName);
+    if (n != null) {
+      consumer.accept(n.longValue());
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/AwsStatisticsCollector.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/AwsStatisticsCollector.java
@@ -38,9 +38,10 @@ import static com.amazonaws.util.AWSRequestMetrics.Field.ThrottleException;
 
 /**
  * Collect statistics from the AWS SDK and update our statistics.
- *
+ * <p>
  * See {@code com.facebook.presto.hive.s3.PrestoS3FileSystemMetricCollector}
  * for the inspiration for this.
+ * <p>
  * See {@code com.amazonaws.util.AWSRequestMetrics} for metric names.
  */
 public class AwsStatisticsCollector extends RequestMetricCollector {
@@ -58,6 +59,12 @@ public class AwsStatisticsCollector extends RequestMetricCollector {
     this.collector = collector;
   }
 
+  /**
+   * This is the callback from the AWS SDK where metrics
+   * can be collected.
+   * @param request AWS request
+   * @param response AWS response
+   */
   @Override
   public void collectMetrics(
       final Request<?> request,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BlockOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BlockOutputStreamStatistics.java
@@ -20,12 +20,13 @@ package org.apache.hadoop.fs.s3a.impl.statistics;
 
 import java.io.Closeable;
 
-import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
  * Block output stream statistics.
  */
-public interface BlockOutputStreamStatistics extends Closeable {
+public interface BlockOutputStreamStatistics extends Closeable,
+    IOStatisticsSource {
 
   /**
    * Block is queued for upload.
@@ -94,13 +95,6 @@ public interface BlockOutputStreamStatistics extends Closeable {
    * @return the counter value.
    */
   long getBytesWritten();
-
-  /**
-   * Convert to an IOStatistics source which is
-   * dynamically updated.
-   * @return statistics
-   */
-  IOStatistics createIOStatistics();
 
   /**
    * A block has been allocated.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BlockOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BlockOutputStreamStatistics.java
@@ -41,6 +41,7 @@ public interface BlockOutputStreamStatistics extends Closeable,
 
   /**
    *  A block upload has failed.
+   * <p>
    *  A final transfer completed event is still expected, so this
    *  does not decrement the active block counter.
    */
@@ -78,7 +79,7 @@ public interface BlockOutputStreamStatistics extends Closeable,
   int getBlocksReleased();
 
   /**
-   * Get counters of blocks actively allocated; my be inaccurate
+   * Get counters of blocks actively allocated; may be inaccurate
    * if the numbers change during the (non-synchronized) calculation.
    * @return the number of actively allocated blocks.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BlockOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BlockOutputStreamStatistics.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import java.io.Closeable;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * Block output stream statistics.
+ */
+public interface BlockOutputStreamStatistics extends Closeable {
+
+  /**
+   * Block is queued for upload.
+   */
+  void blockUploadQueued(int blockSize);
+
+  /** Queued block has been scheduled for upload. */
+  void blockUploadStarted(long duration, int blockSize);
+
+  /** A block upload has completed. */
+  void blockUploadCompleted(long duration, int blockSize);
+
+  /**
+   *  A block upload has failed.
+   *  A final transfer completed event is still expected, so this
+   *  does not decrement the active block counter.
+   */
+  void blockUploadFailed(long duration, int blockSize);
+
+  /** Intermediate report of bytes uploaded. */
+  void bytesTransferred(long byteCount);
+
+  /**
+   * Note exception in a multipart complete.
+   * @param count count of exceptions
+   */
+  void exceptionInMultipartComplete(int count);
+
+  /**
+   * Note an exception in a multipart abort.
+   */
+  void exceptionInMultipartAbort();
+
+  /**
+   * Get the number of bytes pending upload.
+   * @return the number of bytes in the pending upload state.
+   */
+  long getBytesPendingUpload();
+
+  /**
+   * Data has been uploaded to be committed in a subsequent operation;
+   * to be called at the end of the write.
+   * @param size size in bytes
+   */
+  void commitUploaded(long size);
+
+  int getBlocksAllocated();
+
+  int getBlocksReleased();
+
+  /**
+   * Get counters of blocks actively allocated; my be inaccurate
+   * if the numbers change during the (non-synchronized) calculation.
+   * @return the number of actively allocated blocks.
+   */
+  int getBlocksActivelyAllocated();
+
+  /**
+   * Record bytes written.
+   * @param count number of bytes
+   */
+  void writeBytes(long count);
+
+  /**
+   * Get the current count of bytes written.
+   * @return the counter value.
+   */
+  long getBytesWritten();
+
+  /**
+   * Convert to an IOStatistics source which is
+   * dynamically updated.
+   * @return statistics
+   */
+  IOStatistics createIOStatistics();
+
+  /**
+   * A block has been allocated.
+   */
+  void blockAllocated();
+
+  /**
+   * A block has been released.
+   */
+  void blockReleased();
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BondedS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BondedS3AStatisticsContext.java
@@ -29,40 +29,44 @@ import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
  * An S3A statistics context which is bonded to a
  * S3AInstrumentation instance -inevitably that of an S3AFileSystem
  * instance.
+ * <p>
  * An interface is used to bind to the relevant fields, rather
  * than have them passed in the constructor because some
  * production code, specifically, DelegateToFileSystem,
  * patches the protected field after initialization.
- *
+ * <p>
  * All operations are passed through directly to that class.
+ * <p>
  *
  * If an instance of FileSystem.Statistics is passed in, it
  * will be used whenever input stream statistics are created -
  * However, Internally always increments the statistics in the
  * current thread.
  * As a result, cross-thread IO will under-report.
+ * <p>
  *
  * This is addressed through the stream statistics classes
  * only updating the stats in the close() call. Provided
  * they are closed in the worker thread, all stats collected in
  * helper threads will be included.
  */
-public class IntegratedS3AStatisticsContext implements S3AStatisticsContext {
+public class BondedS3AStatisticsContext implements S3AStatisticsContext {
 
+  /** Source of statistics services. */
   private final S3AFSStatisticsSource statisticsSource;
 
   /**
    * Instantiate.
    * @param statisticsSource integration binding
    */
-  public IntegratedS3AStatisticsContext(
+  public BondedS3AStatisticsContext(
       final S3AFSStatisticsSource statisticsSource) {
     this.statisticsSource = statisticsSource;
   }
 
 
   /**
-   * Get the instrumentation from the FS integraation.
+   * Get the instrumentation from the FS integration.
    * @return instrumentation instance.
    */
   private S3AInstrumentation getInstrumentation() {
@@ -83,7 +87,7 @@ public class IntegratedS3AStatisticsContext implements S3AStatisticsContext {
    * @return the S3Guard getInstrumentation() point.
    */
   @Override
-  public MetastoreInstrumentation getMetastoreInstrumentation() {
+  public MetastoreInstrumentation getS3GuardInstrumentation() {
     return getInstrumentation().getS3GuardInstrumentation();
   }
 
@@ -118,6 +122,7 @@ public class IntegratedS3AStatisticsContext implements S3AStatisticsContext {
 
   /**
    * Increment a specific counter.
+   * <p>
    * No-op if not defined.
    * @param op operation
    * @param count increment value
@@ -129,6 +134,7 @@ public class IntegratedS3AStatisticsContext implements S3AStatisticsContext {
 
   /**
    * Increment a specific gauge.
+   * <p>
    * No-op if not defined.
    * @param op operation
    * @param count increment value
@@ -141,6 +147,7 @@ public class IntegratedS3AStatisticsContext implements S3AStatisticsContext {
 
   /**
    * Decrement a specific gauge.
+   * <p>
    * No-op if not defined.
    * @param op operation
    * @param count increment value

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BondedS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/BondedS3AStatisticsContext.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
  * will be used whenever input stream statistics are created -
  * However, Internally always increments the statistics in the
  * current thread.
+ * <p>
  * As a result, cross-thread IO will under-report.
  * <p>
  *

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/ChangeTrackerStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/ChangeTrackerStatistics.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+/**
+ * Interface for change tracking.
+ */
+public interface ChangeTrackerStatistics {
+
+  /**
+   * A version mismatch was detected.
+   */
+  void versionMismatchError();
+
+  /**
+   * How many version mismatches have occurred.
+   */
+  long getVersionMismatches();
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/ChangeTrackerStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/ChangeTrackerStatistics.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.s3a.impl.statistics;
 
 /**
- * Interface for change tracking.
+ * Interface for change tracking statistics.
  */
 public interface ChangeTrackerStatistics {
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/CommitterStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/CommitterStatistics.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+/**
+ * Statistics for committed work.
+ */
+public interface CommitterStatistics {
+
+  /** A commit has been created. */
+  void commitCreated();
+
+  /**
+   * Data has been uploaded to be committed in a subsequent operation.
+   * @param size size in bytes
+   */
+  void commitUploaded(long size);
+
+  /**
+   * A commit has been completed.
+   * @param size size in bytes
+   */
+  void commitCompleted(long size);
+
+  /** A commit has been aborted. */
+  void commitAborted();
+
+  /**
+   * A commit was reverted.
+   */
+  void commitReverted();
+
+  /**
+   * A commit failed.
+   */
+  void commitFailed();
+
+  /**
+   * Note that a task has completed.
+   * @param success success flag
+   */
+  void taskCompleted(boolean success);
+
+  /**
+   * Note that a job has completed.
+   * @param success success flag
+   */
+  void jobCompleted(boolean success);
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/CountersAndGauges.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/CountersAndGauges.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import org.apache.hadoop.fs.s3a.Statistic;
+
+/**
+ * This is the foundational API for collecting S3A statistics.
+ */
+public interface CountersAndGauges {
+
+  /**
+   * Increment a specific counter.
+   * No-op if not defined.
+   * @param op operation
+   * @param count increment value
+   */
+  void incrementCounter(Statistic op, long count);
+
+  /**
+   * Increment a specific gauge.
+   * No-op if not defined.
+   * @param op operation
+   * @param count increment value
+   * @throws ClassCastException if the metric is of the wrong type
+   */
+  void incrementGauge(Statistic op, long count);
+
+  /**
+   * Decrement a specific gauge.
+   * No-op if not defined.
+   * @param op operation
+   * @param count increment value
+   * @throws ClassCastException if the metric is of the wrong type
+   */
+  void decrementGauge(Statistic op, long count);
+
+  /**
+   * Add a value to a quantiles statistic. No-op if the quantile
+   * isn't found.
+   * @param op operation to look up.
+   * @param value value to add.
+   * @throws ClassCastException if the metric is not a Quantiles.
+   */
+  void addValueToQuantiles(Statistic op, long value);
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/CountingChangeTracker.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/CountingChangeTracker.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A change tracker which increments an atomic long.
+ */
+public class CountingChangeTracker implements
+    ChangeTrackerStatistics {
+
+  /**
+   * The counter which is updated on every mismatch.
+   */
+  private final AtomicLong counter;
+
+  public CountingChangeTracker(final AtomicLong counter) {
+    this.counter = counter;
+  }
+
+  public CountingChangeTracker() {
+    this(new AtomicLong());
+  }
+
+  @Override
+  public void versionMismatchError() {
+    counter.incrementAndGet();
+  }
+
+  @Override
+  public long getVersionMismatches() {
+    return counter.get();
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/DelegationTokenStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/DelegationTokenStatistics.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+/**
+ * Instrumentation exported to for S3A Delegation Token support.
+ */
+public interface DelegationTokenStatistics {
+
+  /** A token has been issued. */
+  void tokenIssued();
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
@@ -25,7 +25,8 @@ import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
 import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentationImpl;
 import org.apache.hadoop.fs.statistics.IOStatistics;
-import org.apache.hadoop.fs.statistics.impl.EmptyIOStatistics;
+
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStatistics;
 
 /**
  * Special statistics context, all of whose context operations are no-ops.
@@ -160,7 +161,7 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
      */
     @Override
     public IOStatistics createIOStatistics() {
-      return EmptyIOStatistics.getInstance();
+      return emptyStatistics();
     }
 
     @Override
@@ -373,7 +374,7 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
 
     @Override
     public IOStatistics createIOStatistics() {
-      return EmptyIOStatistics.getInstance();
+      return emptyStatistics();
     }
 
     @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
@@ -160,7 +160,7 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
      * @return an empty IO statistics instance.
      */
     @Override
-    public IOStatistics createIOStatistics() {
+    public IOStatistics getIOStatistics() {
       return emptyStatistics();
     }
 
@@ -373,7 +373,7 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
     }
 
     @Override
-    public IOStatistics createIOStatistics() {
+    public IOStatistics getIOStatistics() {
       return emptyStatistics();
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
+import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentationImpl;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.impl.EmptyIOStatistics;
+
+/**
+ * Special statistics context, all of whose context operations are no-ops.
+ * All statistics instances it returns are also empty.
+ *
+ * This class is here primarily to aid in testing, but it also allows for
+ * classes to require a non-empty statistics context in their constructor -yet
+ * still be instantiated without one bound to any filesystem.
+ */
+public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
+
+  @Override
+  public MetastoreInstrumentation getMetastoreInstrumentation() {
+    return new MetastoreInstrumentationImpl();
+  }
+
+  @Override
+  public S3AInputStreamStatistics newInputStreamStatistics() {
+    return new EmptyInputStreamStatistics();
+  }
+
+  @Override
+  public CommitterStatistics newCommitterStatistics() {
+    return new EmptyCommitterStatistics();
+  }
+
+  @Override
+  public BlockOutputStreamStatistics newOutputStreamStatistics() {
+    return new EmptyBlockOutputStreamStatistics();
+  }
+
+  @Override
+  public DelegationTokenStatistics newDelegationTokenStatistics() {
+    return new EmptyDelegationTokenStatistics();
+  }
+
+  @Override
+  public StatisticsFromAwsSdk newStatisticsFromAwsSdk() {
+    return new EmptyStatisticsFromAwsSdk();
+  }
+
+  @Override
+  public void incrementCounter(final Statistic op, final long count) {
+
+  }
+
+  @Override
+  public void incrementGauge(final Statistic op, final long count) {
+
+  }
+
+  @Override
+  public void decrementGauge(final Statistic op, final long count) {
+
+  }
+
+  @Override
+  public void addValueToQuantiles(final Statistic op, final long value) {
+
+  }
+
+  /**
+   * Input Stream statistics callbacks.
+   */
+  private static final class EmptyInputStreamStatistics
+      implements S3AInputStreamStatistics {
+
+    @Override
+    public void seekBackwards(final long negativeOffset) {
+
+    }
+
+    @Override
+    public void seekForwards(final long skipped) {
+
+    }
+
+    @Override
+    public long streamOpened() {
+      return 0;
+    }
+
+    @Override
+    public void streamClose(final boolean abortedConnection,
+        final long remainingInCurrentRequest) {
+
+    }
+
+    @Override
+    public void readException() {
+
+    }
+
+    @Override
+    public void bytesRead(final long bytes) {
+
+    }
+
+    @Override
+    public void readOperationStarted(final long pos, final long len) {
+
+    }
+
+    @Override
+    public void readFullyOperationStarted(final long pos, final long len) {
+
+    }
+
+    @Override
+    public void readOperationCompleted(final int requested, final int actual) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void inputPolicySet(final int updatedPolicy) {
+
+    }
+
+    @Override
+    public void merge(final boolean isClosed) {
+
+    }
+
+    /**
+     * Return an IO statistics instance.
+     * @return an empty IO statistics instance.
+     */
+    @Override
+    public IOStatistics createIOStatistics() {
+      return EmptyIOStatistics.getInstance();
+    }
+
+    @Override
+    public long getCloseOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getClosed() {
+      return 0;
+    }
+
+    @Override
+    public long getAborted() {
+      return 0;
+    }
+
+    @Override
+    public long getForwardSeekOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getBackwardSeekOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getBytesRead() {
+      return 0;
+    }
+
+    @Override
+    public long getBytesSkippedOnSeek() {
+      return 0;
+    }
+
+    @Override
+    public long getBytesBackwardsOnSeek() {
+      return 0;
+    }
+
+    @Override
+    public long getBytesReadInClose() {
+      return 0;
+    }
+
+    @Override
+    public long getBytesDiscardedInAbort() {
+      return 0;
+    }
+
+    @Override
+    public long getOpenOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getSeekOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getReadExceptions() {
+      return 0;
+    }
+
+    @Override
+    public long getReadOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getReadFullyOperations() {
+      return 0;
+    }
+
+    @Override
+    public long getReadsIncomplete() {
+      return 0;
+    }
+
+    @Override
+    public long getPolicySetCount() {
+      return 0;
+    }
+
+    @Override
+    public long getVersionMismatches() {
+      return 0;
+    }
+
+    @Override
+    public long getInputPolicy() {
+      return 0;
+    }
+
+    @Override
+    public ChangeTrackerStatistics getChangeTrackerStatistics() {
+      return new CountingChangeTracker();
+    }
+  }
+
+  private static final class EmptyCommitterStatistics
+      implements CommitterStatistics {
+
+    @Override
+    public void commitCreated() {
+
+    }
+
+    @Override
+    public void commitUploaded(final long size) {
+
+    }
+
+    @Override
+    public void commitCompleted(final long size) {
+
+    }
+
+    @Override
+    public void commitAborted() {
+
+    }
+
+    @Override
+    public void commitReverted() {
+
+    }
+
+    @Override
+    public void commitFailed() {
+
+    }
+
+    @Override
+    public void taskCompleted(final boolean success) {
+
+    }
+
+    @Override
+    public void jobCompleted(final boolean success) {
+
+    }
+  }
+
+  private static final class EmptyBlockOutputStreamStatistics
+      implements BlockOutputStreamStatistics {
+
+    @Override
+    public void blockUploadQueued(final int blockSize) {
+
+    }
+
+    @Override
+    public void blockUploadStarted(final long duration, final int blockSize) {
+
+    }
+
+    @Override
+    public void blockUploadCompleted(final long duration, final int blockSize) {
+
+    }
+
+    @Override
+    public void blockUploadFailed(final long duration, final int blockSize) {
+
+    }
+
+    @Override
+    public void bytesTransferred(final long byteCount) {
+
+    }
+
+    @Override
+    public void exceptionInMultipartComplete(final int count) {
+
+    }
+
+    @Override
+    public void exceptionInMultipartAbort() {
+
+    }
+
+    @Override
+    public long getBytesPendingUpload() {
+      return 0;
+    }
+
+    @Override
+    public void commitUploaded(final long size) {
+
+    }
+
+    @Override
+    public int getBlocksAllocated() {
+      return 0;
+    }
+
+    @Override
+    public int getBlocksReleased() {
+      return 0;
+    }
+
+    @Override
+    public int getBlocksActivelyAllocated() {
+      return 0;
+    }
+
+    @Override
+    public IOStatistics createIOStatistics() {
+      return EmptyIOStatistics.getInstance();
+    }
+
+    @Override
+    public void blockAllocated() {
+
+    }
+
+    @Override
+    public void blockReleased() {
+
+    }
+
+    @Override
+    public void writeBytes(final long count) {
+    }
+
+    @Override
+    public long getBytesWritten() {
+      return 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+
+  private static final class EmptyDelegationTokenStatistics
+      implements DelegationTokenStatistics {
+
+    @Override
+    public void tokenIssued() {
+
+    }
+  }
+
+  private static final class EmptyStatisticsFromAwsSdk implements
+      StatisticsFromAwsSdk {
+
+    @Override
+    public void updateAwsRequestCount(final long longValue) {
+
+    }
+
+    @Override
+    public void updateAwsRetryCount(final long longValue) {
+
+    }
+
+    @Override
+    public void updateAwsThrottleExceptionsCount(final long longValue) {
+
+    }
+
+    @Override
+    public void noteAwsRequestTime(final Duration ofMillis) {
+
+    }
+
+    @Override
+    public void noteAwsClientExecuteTime(final Duration ofMillis) {
+
+    }
+
+    @Override
+    public void noteRequestMarshallTime(final Duration duration) {
+
+    }
+
+    @Override
+    public void noteRequestSigningTime(final Duration duration) {
+
+    }
+
+    @Override
+    public void noteResponseProcessingTime(final Duration duration) {
+
+    }
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
@@ -39,7 +39,7 @@ import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStat
 public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
 
   @Override
-  public MetastoreInstrumentation getMetastoreInstrumentation() {
+  public MetastoreInstrumentation getS3GuardInstrumentation() {
     return new MetastoreInstrumentationImpl();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
@@ -31,7 +31,7 @@ import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.emptyStat
 /**
  * Special statistics context, all of whose context operations are no-ops.
  * All statistics instances it returns are also empty.
- *
+ * <p>
  * This class is here primarily to aid in testing, but it also allows for
  * classes to require a non-empty statistics context in their constructor -yet
  * still be instantiated without one bound to any filesystem.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/EmptyS3AStatisticsContext.java
@@ -260,6 +260,11 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
     }
 
     @Override
+    public Long getStatistic(final String name) {
+      return 0L;
+    }
+
+    @Override
     public ChangeTrackerStatistics getChangeTrackerStatistics() {
       return new CountingChangeTracker();
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/IntegratedS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/IntegratedS3AStatisticsContext.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import javax.annotation.Nullable;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.s3a.S3AInstrumentation;
+import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
+
+/**
+ * An S3A statistics context which is bonded to a
+ * S3AInstrumentation instance -inevitably that of an S3AFileSystem
+ * instance.
+ * An interface is used to bind to the relevant fields, rather
+ * than have them passed in the constructor because some
+ * production code, specifically, DelegateToFileSystem,
+ * patches the protected field after initialization.
+ *
+ * All operations are passed through directly to that class.
+ *
+ * If an instance of FileSystem.Statistics is passed in, it
+ * will be used whenever input stream statistics are created -
+ * However, Internally always increments the statistics in the
+ * current thread.
+ * As a result, cross-thread IO will under-report.
+ *
+ * This is addressed through the stream statistics classes
+ * only updating the stats in the close() call. Provided
+ * they are closed in the worker thread, all stats collected in
+ * helper threads will be included.
+ */
+public class IntegratedS3AStatisticsContext implements S3AStatisticsContext {
+
+  private final S3AFSStatisticsSource statisticsSource;
+
+  /**
+   * Instantiate.
+   * @param statisticsSource integration binding
+   */
+  public IntegratedS3AStatisticsContext(
+      final S3AFSStatisticsSource statisticsSource) {
+    this.statisticsSource = statisticsSource;
+  }
+
+
+  /**
+   * Get the instrumentation from the FS integraation.
+   * @return instrumentation instance.
+   */
+  private S3AInstrumentation getInstrumentation() {
+    return statisticsSource.getInstrumentation();
+  }
+
+  /**
+   * The filesystem statistics: know this is thread-local.
+   * @return FS statistics.
+   */
+  private FileSystem.Statistics getInstanceStatistics() {
+    return statisticsSource.getInstanceStatistics();
+  }
+
+  /**
+   * Get a MetastoreInstrumentation getInstrumentation() instance for this
+   * context.
+   * @return the S3Guard getInstrumentation() point.
+   */
+  @Override
+  public MetastoreInstrumentation getMetastoreInstrumentation() {
+    return getInstrumentation().getS3GuardInstrumentation();
+  }
+
+  /**
+   * Create a stream input statistics instance.
+   * @return the new instance
+   */
+  @Override
+  public S3AInputStreamStatistics newInputStreamStatistics() {
+    return getInstrumentation().newInputStreamStatistics(
+        statisticsSource.getInstanceStatistics());
+  }
+
+  /**
+   * Create a new instance of the committer statistics.
+   * @return a new committer statistics instance
+   */
+  @Override
+  public CommitterStatistics newCommitterStatistics() {
+    return getInstrumentation().newCommitterStatistics();
+  }
+
+  /**
+   * Create a stream output statistics instance.
+   * @return the new instance
+   */
+  @Override
+  public BlockOutputStreamStatistics newOutputStreamStatistics() {
+    return getInstrumentation()
+        .newOutputStreamStatistics(getInstanceStatistics());
+  }
+
+  /**
+   * Increment a specific counter.
+   * No-op if not defined.
+   * @param op operation
+   * @param count increment value
+   */
+  @Override
+  public void incrementCounter(Statistic op, long count) {
+    getInstrumentation().incrementCounter(op, count);
+  }
+
+  /**
+   * Increment a specific gauge.
+   * No-op if not defined.
+   * @param op operation
+   * @param count increment value
+   * @throws ClassCastException if the metric is of the wrong type
+   */
+  @Override
+  public void incrementGauge(Statistic op, long count) {
+    getInstrumentation().incrementGauge(op, count);
+  }
+
+  /**
+   * Decrement a specific gauge.
+   * No-op if not defined.
+   * @param op operation
+   * @param count increment value
+   * @throws ClassCastException if the metric is of the wrong type
+   */
+  @Override
+  public void decrementGauge(Statistic op, long count) {
+    getInstrumentation().decrementGauge(op, count);
+  }
+
+  /**
+   * Add a value to a quantiles statistic. No-op if the quantile
+   * isn't found.
+   * @param op operation to look up.
+   * @param value value to add.
+   * @throws ClassCastException if the metric is not a Quantiles.
+   */
+  @Override
+  public void addValueToQuantiles(Statistic op, long value) {
+    getInstrumentation().addValueToQuantiles(op, value);
+  }
+
+  /**
+   * Create a delegation token statistics instance.
+   * @return an instance of delegation token statistics
+   */
+  @Override
+  public DelegationTokenStatistics newDelegationTokenStatistics() {
+    return getInstrumentation().newDelegationTokenStatistics();
+  }
+
+  @Override
+  public StatisticsFromAwsSdk newStatisticsFromAwsSdk() {
+    return getInstrumentation().newStatisticsFromAwsSdk();
+  }
+
+  /**
+   * This is the interface which an integration source must implement
+   * for the integration.
+   * Note that the FileSystem.statistics field may be null for a class;
+   */
+  public interface S3AFSStatisticsSource {
+
+    /**
+     * Get the S3A Instrumentation.
+     * @return a non-null instrumentation instance
+     */
+    S3AInstrumentation getInstrumentation();
+
+    /**
+     * Get the statistics of the FS instance, shared across all threads.
+     * @return filesystem statistics
+     */
+    @Nullable
+    FileSystem.Statistics getInstanceStatistics();
+
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import org.apache.hadoop.fs.statistics.IOStatistics;
+
+/**
+ * Statistics updated by an input stream during its actual operation.
+ * It also contains getters for tests.
+ */
+public interface S3AInputStreamStatistics extends AutoCloseable {
+
+  /**
+   * Seek backwards, incrementing the seek and backward seek counters.
+   * @param negativeOffset how far was the seek?
+   * This is expected to be negative.
+   */
+  void seekBackwards(long negativeOffset);
+
+  /**
+   * Record a forward seek, adding a seek operation, a forward
+   * seek operation, and any bytes skipped.
+   * @param skipped number of bytes skipped by reading from the stream.
+   * If the seek was implemented by a close + reopen, set this to zero.
+   */
+  void seekForwards(long skipped);
+
+  /**
+   * The inner stream was opened.
+   * @return the previous count
+   */
+  long streamOpened();
+
+  /**
+   * The inner stream was closed.
+   * @param abortedConnection flag to indicate the stream was aborted,
+   * rather than closed cleanly
+   * @param remainingInCurrentRequest the number of bytes remaining in
+   * the current request.
+   */
+  void streamClose(boolean abortedConnection,
+      long remainingInCurrentRequest);
+
+  /**
+   * An ignored stream read exception was received.
+   */
+  void readException();
+
+  /**
+   * Increment the bytes read counter by the number of bytes;
+   * no-op if the argument is negative.
+   * @param bytes number of bytes read
+   */
+  void bytesRead(long bytes);
+
+  /**
+   * A {@code read(byte[] buf, int off, int len)} operation has started.
+   * @param pos starting position of the read
+   * @param len length of bytes to read
+   */
+  void readOperationStarted(long pos, long len);
+
+  /**
+   * A {@code PositionedRead.read(position, buffer, offset, length)}
+   * operation has just started.
+   * @param pos starting position of the read
+   * @param len length of bytes to read
+   */
+  void readFullyOperationStarted(long pos, long len);
+
+  /**
+   * A read operation has completed.
+   * @param requested number of requested bytes
+   * @param actual the actual number of bytes
+   */
+  void readOperationCompleted(int requested, int actual);
+
+  @Override
+  void close();
+
+  /**
+   * The input policy has been switched.
+   * @param updatedPolicy enum value of new policy.
+   */
+  void inputPolicySet(int updatedPolicy);
+
+  /**
+   * Get a reference to the change tracker statistics for this
+   * stream.
+   * @return a reference to the change tracker statistics
+   */
+  ChangeTrackerStatistics getChangeTrackerStatistics();
+
+  /**
+   * Merge the statistics into the filesystem's instrumentation instance.
+   * Takes a diff between the current version of the stats and the
+   * version of the stats when merge was last called, and merges the diff
+   * into the instrumentation instance. Used to periodically merge the
+   * stats into the fs-wide stats. <b>Behavior is undefined if called on a
+   * closed instance.</b>
+   */
+  void merge(boolean isClosed);
+
+  /**
+   * Convert to an IOStatistics source which is
+   * dynamically updated.
+   * @return statistics
+   */
+  IOStatistics createIOStatistics();
+
+  long getCloseOperations();
+
+  long getClosed();
+
+  long getAborted();
+
+  long getForwardSeekOperations();
+
+  long getBackwardSeekOperations();
+
+  long getBytesRead();
+
+  long getBytesSkippedOnSeek();
+
+  long getBytesBackwardsOnSeek();
+
+  long getBytesReadInClose();
+
+  long getBytesDiscardedInAbort();
+
+  long getOpenOperations();
+
+  long getSeekOperations();
+
+  long getReadExceptions();
+
+  long getReadOperations();
+
+  long getReadFullyOperations();
+
+  long getReadsIncomplete();
+
+  long getPolicySetCount();
+
+  long getVersionMismatches();
+
+  long getInputPolicy();
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.fs.s3a.impl.statistics;
 
-import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
  * Statistics updated by an input stream during its actual operation.
  * It also contains getters for tests.
  */
-public interface S3AInputStreamStatistics extends AutoCloseable {
+public interface S3AInputStreamStatistics extends AutoCloseable,
+    IOStatisticsSource {
 
   /**
    * Seek backwards, incrementing the seek and backward seek counters.
@@ -116,13 +117,6 @@ public interface S3AInputStreamStatistics extends AutoCloseable {
    * closed instance.</b>
    */
   void merge(boolean isClosed);
-
-  /**
-   * Convert to an IOStatistics source which is
-   * dynamically updated.
-   * @return statistics
-   */
-  IOStatistics createIOStatistics();
 
   long getCloseOperations();
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
@@ -157,4 +157,6 @@ public interface S3AInputStreamStatistics extends AutoCloseable,
   long getVersionMismatches();
 
   long getInputPolicy();
+
+  Long getStatistic(String name);
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AInputStreamStatistics.java
@@ -110,11 +110,13 @@ public interface S3AInputStreamStatistics extends AutoCloseable,
 
   /**
    * Merge the statistics into the filesystem's instrumentation instance.
+   * <p>
    * Takes a diff between the current version of the stats and the
    * version of the stats when merge was last called, and merges the diff
    * into the instrumentation instance. Used to periodically merge the
-   * stats into the fs-wide stats. <b>Behavior is undefined if called on a
-   * closed instance.</b>
+   * stats into the fs-wide stats
+   * <p>
+   * <b>Behavior is undefined if called on a closed instance.</b>
    */
   void merge(boolean isClosed);
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AStatisticsContext.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import org.apache.hadoop.fs.s3a.s3guard.MetastoreInstrumentation;
+
+/**
+ * This is the statistics context for ongoing operations in S3A.
+ */
+public interface S3AStatisticsContext extends CountersAndGauges {
+
+  /**
+   * Get the metastore instrumentation.
+   * @return an instance of the metastore statistics tracking.
+   */
+  MetastoreInstrumentation getMetastoreInstrumentation();
+
+  /**
+   * Create a stream input statistics instance.
+   * @return the new instance
+   */
+  S3AInputStreamStatistics newInputStreamStatistics();
+
+  /**
+   * Create a new instance of the committer statistics.
+   * @return a new committer statistics instance
+   */
+  CommitterStatistics newCommitterStatistics();
+
+  /**
+   * Create a stream output statistics instance.
+   * @return the new instance
+   */
+  BlockOutputStreamStatistics newOutputStreamStatistics();
+
+  /**
+   * Create a delegation token statistics instance.
+   * @return an instance of delegation token statistics
+   */
+  DelegationTokenStatistics newDelegationTokenStatistics();
+
+  /**
+   * Create a StatisticsFromAwsSdk instance.
+   * @return an instance of StatisticsFromAwsSdk
+   */
+  StatisticsFromAwsSdk newStatisticsFromAwsSdk();
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/S3AStatisticsContext.java
@@ -29,7 +29,7 @@ public interface S3AStatisticsContext extends CountersAndGauges {
    * Get the metastore instrumentation.
    * @return an instance of the metastore statistics tracking.
    */
-  MetastoreInstrumentation getMetastoreInstrumentation();
+  MetastoreInstrumentation getS3GuardInstrumentation();
 
   /**
    * Create a stream input statistics instance.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/StatisticsFromAwsSdk.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/StatisticsFromAwsSdk.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import java.time.Duration;
+
+/**
+ * interface to receive statistics events from the AWS SDK
+ * by way of {@link AwsStatisticsCollector}.
+ */
+public interface StatisticsFromAwsSdk {
+
+  /**
+   * Record a number of AWS requests.
+   * @param count number of events.
+   */
+  void updateAwsRequestCount(long count);
+
+  /**
+   * Record a number of AWS request retries.
+   * @param count number of events.
+   */
+  void updateAwsRetryCount(long count);
+
+  /**
+   * Record a number of throttle exceptions received.
+   * @param count number of events.
+   */
+  void updateAwsThrottleExceptionsCount(long count);
+
+  /**
+   * Record how long a request took overall.
+   * @param duration duration of operation.
+   */
+  void noteAwsRequestTime(Duration duration);
+
+  /**
+   * Record how long a request took to execute on the
+   * client.
+   * @param duration duration of operation.
+   */
+  void noteAwsClientExecuteTime(Duration duration);
+
+  /**
+   * Record how long a request took to marshall into
+   * XML.
+   * @param duration duration of operation.
+   */
+  void noteRequestMarshallTime(Duration duration);
+
+  /**
+   * Record how long a request took to sign, including
+   * any calls to EC2 credential endpoints.
+   * @param duration duration of operation.
+   */
+  void noteRequestSigningTime(Duration duration);
+
+  /**
+   * Record how long it took to process the response.
+   * @param duration duration of operation.
+   */
+  void noteResponseProcessingTime(Duration duration);
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/package-info.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/statistics/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Statistics collection for the S3A connector.
+ */
+
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.fs.s3a.impl.statistics;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
@@ -450,7 +450,8 @@ public class DynamoDBMetadataStore implements MetadataStore,
     owner = fs;
     conf = owner.getConf();
     StoreContext context = owner.createStoreContext();
-    instrumentation = context.getInstrumentation().getS3GuardInstrumentation();
+    instrumentation = context.getInstrumentation()
+        .getMetastoreInstrumentation();
     username = context.getUsername();
     executor = context.createThrottledExecutor();
     ttlTimeProvider = Preconditions.checkNotNull(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DynamoDBMetadataStore.java
@@ -450,8 +450,7 @@ public class DynamoDBMetadataStore implements MetadataStore,
     owner = fs;
     conf = owner.getConf();
     StoreContext context = owner.createStoreContext();
-    instrumentation = context.getInstrumentation()
-        .getMetastoreInstrumentation();
+    instrumentation = context.getInstrumentation().getS3GuardInstrumentation();
     username = context.getUsername();
     executor = context.createThrottledExecutor();
     ttlTimeProvider = Preconditions.checkNotNull(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectInputStream.java
@@ -39,9 +39,9 @@ import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.Retries;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AInputStreamStatistics;
 import org.apache.hadoop.io.IOUtils;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -103,7 +103,7 @@ public class SelectInputStream extends FSInputStream implements
 
   private final S3AReadOpContext readContext;
 
-  private final S3AInstrumentation.InputStreamStatistics streamStatistics;
+  private final S3AInputStreamStatistics streamStatistics;
 
   private long readahead;
 
@@ -130,7 +130,7 @@ public class SelectInputStream extends FSInputStream implements
     this.uri = "s3a://" + this.bucket + "/" + this.key;
     this.readContext = readContext;
     this.readahead = readContext.getReadahead();
-    this.streamStatistics = readContext.getInstrumentation()
+    this.streamStatistics = readContext.getS3AStatisticsContext()
         .newInputStreamStatistics();
     SelectRecordsInputStream stream = once(
         "S3 Select",
@@ -428,7 +428,7 @@ public class SelectInputStream extends FSInputStream implements
    */
   @InterfaceAudience.Private
   @InterfaceStability.Unstable
-  public S3AInstrumentation.InputStreamStatistics getS3AStreamStatistics() {
+  public S3AInputStreamStatistics getS3AStreamStatistics() {
     return streamStatistics;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractStreamIOStatistics.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.contract.s3a;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractStreamIOStatisticsTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeEnableS3Guard;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
+
+/**
+ * Test the S3A Streams IOStatistics support.
+ */
+public class ITestS3AContractStreamIOStatistics extends
+    AbstractContractStreamIOStatisticsTest {
+
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    // patch in S3Guard options
+    maybeEnableS3Guard(conf);
+    return conf;
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new S3AContract(conf);
+  }
+
+  /**
+   * Keys which the output stream must support.
+   * @return a list of keys
+   */
+  @Override
+  public List<String> outputStreamStatisticKeys() {
+    return Arrays.asList(STREAM_WRITE_BYTES,
+        STREAM_WRITE_BLOCK_UPLOADS,
+        STREAM_WRITE_FAILURES);
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.io.IOUtils;
 
 import org.junit.BeforeClass;
@@ -94,16 +95,16 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
     Path dest = path("testBlocksClosed");
     describe(" testBlocksClosed");
     FSDataOutputStream stream = getFileSystem().create(dest, true);
-    S3AInstrumentation.OutputStreamStatistics statistics
+    BlockOutputStreamStatistics statistics
         = S3ATestUtils.getOutputStreamStatistics(stream);
     byte[] data = ContractTestUtils.dataset(16, 'a', 26);
     stream.write(data);
     LOG.info("closing output stream");
     stream.close();
     assertEquals("total allocated blocks in " + statistics,
-        1, statistics.blocksAllocated());
+        1, statistics.getBlocksAllocated());
     assertEquals("actively allocated blocks in " + statistics,
-        0, statistics.blocksActivelyAllocated());
+        0, statistics.getBlocksActivelyAllocated());
     LOG.info("end of test case");
   }
 
@@ -129,7 +130,7 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
       throws Exception {
     S3AInstrumentation instrumentation =
         new S3AInstrumentation(new URI("s3a://example"));
-    S3AInstrumentation.OutputStreamStatistics outstats
+    BlockOutputStreamStatistics outstats
         = instrumentation.newOutputStreamStatistics(null);
     S3ADataBlocks.DataBlock block = factory.create(1, BLOCK_SIZE, outstats);
     block.write(dataset, 0, dataset.length);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AUnbuffer.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AUnbuffer.java
@@ -71,7 +71,7 @@ public class ITestS3AUnbuffer extends AbstractS3ATestBase {
 
   /**
    * Test that calling {@link S3AInputStream#unbuffer()} merges a stream's
-   * {@link org.apache.hadoop.fs.s3a.S3AInstrumentation.InputStreamStatistics}
+   * {@code InputStreamStatistics}
    * into the {@link S3AFileSystem}'s {@link S3AInstrumentation} instance.
    */
   @Test
@@ -108,7 +108,7 @@ public class ITestS3AUnbuffer extends AbstractS3ATestBase {
     // Validate that the input stream stats are correct when the file is closed
     assertEquals("S3AInputStream statistics were not updated properly", 12,
             ((S3AInputStream) inputStream.getWrappedStream())
-                    .getS3AStreamStatistics().bytesRead);
+                    .getS3AStreamStatistics().getBytesRead());
   }
 
   private boolean isObjectStreamOpen(FSDataInputStream inputStream) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -39,11 +39,12 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.commit.staging.StagingTestBase;
+import org.apache.hadoop.fs.s3a.impl.statistics.CommitterStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.EmptyS3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.util.Progressable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 
 /**
  * Relays FS calls to the mocked FS, allows for some extra logging with
@@ -83,8 +84,6 @@ public class MockS3AFileSystem extends S3AFileSystem {
    * mock FS.
    */
   private int logEvents = LOG_NAME;
-  private final S3AInstrumentation instrumentation =
-      new S3AInstrumentation(FS_URI);
   private Configuration conf;
   private WriteOperationHelper writeHelper;
 
@@ -146,12 +145,12 @@ public class MockS3AFileSystem extends S3AFileSystem {
   public void initialize(URI name, Configuration originalConf)
       throws IOException {
     conf = originalConf;
-    writeHelper = new WriteOperationHelper(this, conf);
+    writeHelper = new WriteOperationHelper(this, conf,
+        new EmptyS3AStatisticsContext());
   }
 
   @Override
   public void close() {
-    cleanupWithLogger(LOG, instrumentation);
   }
 
   @Override
@@ -359,12 +358,56 @@ public class MockS3AFileSystem extends S3AFileSystem {
   }
 
   @Override
-  public S3AInstrumentation.CommitterStatistics newCommitterStatistics() {
-    return instrumentation.newCommitterStatistics();
+  public CommitterStatistics newCommitterStatistics() {
+    return new StubCommitterStatistics();
   }
 
   @Override
   public void operationRetried(Exception ex) {
     /** no-op */
   }
+
+  private final class StubCommitterStatistics implements CommitterStatistics {
+
+    @Override
+    public void commitCreated() {
+
+    }
+
+    @Override
+    public void commitUploaded(final long size) {
+
+    }
+
+    @Override
+    public void commitCompleted(final long size) {
+
+    }
+
+    @Override
+    public void commitAborted() {
+
+    }
+
+    @Override
+    public void commitReverted() {
+
+    }
+
+    @Override
+    public void commitFailed() {
+
+    }
+
+    @Override
+    public void taskCompleted(final boolean success) {
+
+    }
+
+    @Override
+    public void jobCompleted(final boolean success) {
+
+    }
+  }
+
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.util.ArrayList;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.MultipartUploadListing;
 import com.amazonaws.services.s3.model.Region;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
@@ -24,9 +24,12 @@ import java.net.URI;
 import java.util.ArrayList;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.MultipartUploadListing;
 import com.amazonaws.services.s3.model.Region;
+
+import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 
 /**
  * An {@link S3ClientFactory} that returns Mockito mocks of the {@link AmazonS3}
@@ -38,7 +41,8 @@ public class MockS3ClientFactory implements S3ClientFactory {
   public AmazonS3 createS3Client(URI name,
       final String bucket,
       final AWSCredentialsProvider credentialSet,
-      final String userAgentSuffix) {
+      final String userAgentSuffix,
+      final StatisticsFromAwsSdk statisticsFromAwsSdks) {
     AmazonS3 s3 = mock(AmazonS3.class);
     when(s3.doesBucketExist(bucket)).thenReturn(true);
     when(s3.doesBucketExistV2(bucket)).thenReturn(true);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
 import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
-
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
+import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStoreCapabilities;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
@@ -1162,7 +1162,7 @@ public final class S3ATestUtils {
    * @param out output stream
    * @return the (active) stats of the write
    */
-  public static S3AInstrumentation.OutputStreamStatistics
+  public static BlockOutputStreamStatistics
       getOutputStreamStatistics(FSDataOutputStream out) {
     S3ABlockOutputStream blockOutputStream
         = (S3ABlockOutputStream) out.getWrappedStream();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.commit.PutTracker;
+import org.apache.hadoop.fs.s3a.impl.statistics.EmptyS3AStatisticsContext;
 import org.apache.hadoop.util.Progressable;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +70,8 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     S3AFileSystem s3a = mock(S3AFileSystem.class);
     when(s3a.getBucket()).thenReturn("bucket");
     WriteOperationHelper woh = new WriteOperationHelper(s3a,
-        new Configuration());
+        new Configuration(),
+        new EmptyS3AStatisticsContext());
     ByteArrayInputStream inputStream = new ByteArrayInputStream(
         "a".getBytes());
     // first one works

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -50,11 +50,10 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     S3ADataBlocks.BlockFactory blockFactory =
         mock(S3ADataBlocks.BlockFactory.class);
     long blockSize = Constants.DEFAULT_MULTIPART_SIZE;
-    S3AInstrumentation.OutputStreamStatistics statistics = null;
     WriteOperationHelper oHelper = mock(WriteOperationHelper.class);
     PutTracker putTracker = mock(PutTracker.class);
     stream = spy(new S3ABlockOutputStream(fs, "", executorService,
-      progressable, blockSize, blockFactory, statistics, oHelper,
+      progressable, blockSize, blockFactory, null, oHelper,
       putTracker));
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestStreamChangeTracker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestStreamChangeTracker.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkBaseException;
 import com.amazonaws.services.s3.Headers;
@@ -36,6 +34,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeTracker;
+import org.apache.hadoop.fs.s3a.impl.statistics.CountingChangeTracker;
 import org.apache.hadoop.test.HadoopTestBase;
 
 import static org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.CHANGE_DETECTED;
@@ -359,7 +358,7 @@ public class TestStreamChangeTracker extends HadoopTestBase {
       final ChangeTracker tracker,
       final int expectedCount) {
     assertEquals("counter in tracker " + tracker,
-        expectedCount, tracker.getVersionMismatches().get());
+        expectedCount, tracker.getVersionMismatches());
   }
 
   /**
@@ -386,7 +385,7 @@ public class TestStreamChangeTracker extends HadoopTestBase {
         source,
         requireVersion);
     ChangeTracker tracker = new ChangeTracker(URI, policy,
-        new AtomicLong(0), objectAttributes);
+        new CountingChangeTracker(), objectAttributes);
     if (objectAttributes.getVersionId() == null
         && objectAttributes.getETag() == null) {
       assertFalse("Tracker should not have applied constraints " + tracker,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -305,6 +305,9 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
     describe("Delegation tokens can be passed to a new filesystem;"
         + " if role restricted, permissions are tightened.");
     S3AFileSystem fs = getFileSystem();
+    // force a probe of the remote FS to make sure its endpoint is valid
+    // (this always hits S3, even when S3Guard is enabled)
+    fs.getObjectMetadata(new Path("/"));
     readLandsatMetadata(fs);
 
     URI uri = fs.getUri();
@@ -562,7 +565,7 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
     factory.setConf(conf);
     String host = landsat.getHost();
     AmazonS3 s3 = factory.createS3Client(landsat, host, testing,
-        "ITestSessionDelegationInFileystem");
+        "ITestSessionDelegationInFileystem", null);
 
     return Invoker.once("HEAD", host,
         () -> s3.getObjectMetadata(host, landsat.getPath().substring(1)));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -44,6 +44,8 @@ import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.statistics.EmptyS3AStatisticsContext;
+import org.apache.hadoop.fs.s3a.impl.statistics.StatisticsFromAwsSdk;
 import org.apache.hadoop.hdfs.tools.DelegationTokenFetcher;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.security.TokenCache;
@@ -70,6 +72,7 @@ import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationTokenIOExceptio
 import static org.apache.hadoop.fs.s3a.auth.delegation.MiniKerberizedHadoopCluster.ALICE;
 import static org.apache.hadoop.fs.s3a.auth.delegation.MiniKerberizedHadoopCluster.assertSecurityEnabled;
 import static org.apache.hadoop.fs.s3a.auth.delegation.S3ADelegationTokens.lookupS3ADelegationToken;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AWS_SDK_METRICS_ENABLED;
 import static org.apache.hadoop.test.LambdaTestUtils.doAs;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.hamcrest.Matchers.containsString;
@@ -564,8 +567,13 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
     conf.set(ENDPOINT, "");
     factory.setConf(conf);
     String host = landsat.getHost();
+    StatisticsFromAwsSdk awsStats = null;
+    if (AWS_SDK_METRICS_ENABLED) {
+      awsStats = new EmptyS3AStatisticsContext()
+          .newStatisticsFromAwsSdk();
+    }
     AmazonS3 s3 = factory.createS3Client(landsat, host, testing,
-        "ITestSessionDelegationInFileystem", null);
+        "ITestSessionDelegationInFileystem", awsStats);
 
     return Invoker.once("HEAD", host,
         () -> s3.getObjectMetadata(host, landsat.getPath().substring(1)));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestNetworkBinding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestNetworkBinding.java
@@ -18,19 +18,23 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
-import org.assertj.core.api.Assertions;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import org.junit.Test;
 
-import org.apache.hadoop.test.HadoopTestBase;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 
+import static org.apache.hadoop.fs.s3a.DefaultS3ClientFactory.createEndpointConfiguration;
 import static org.apache.hadoop.fs.s3a.impl.NetworkBinding.fixBucketRegion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests related to the {@link NetworkBinding} class.
  */
-public class TestNeworkBinding extends HadoopTestBase {
+public class TestNetworkBinding extends AbstractHadoopTestBase {
 
   private static final String US_EAST_1 = "us-east-1";
+
   private static final String US_WEST_2 = "us-west-2";
 
   @Test
@@ -54,8 +58,45 @@ public class TestNeworkBinding extends HadoopTestBase {
   }
 
   private static void assertRegionFixup(String region, String expected) {
-    Assertions.assertThat(fixBucketRegion(region))
+    assertThat(fixBucketRegion(region))
         .describedAs("Fixup of %s", region)
         .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNull() throws Throwable {
+    expectEndpoint("", true, "unused");
+  }
+
+  @Test
+  public void testUSEastEndpoint() throws Throwable {
+    expectEndpoint(US_EAST_1, false, US_EAST_1);
+  }
+
+  @Test
+  public void testUSWestEndpoint() throws Throwable {
+    expectEndpoint(US_WEST_2, false, US_WEST_2);
+  }
+
+  public void expectEndpoint(final String src,
+      final boolean expectNull,
+      final String expectRegion) {
+    AwsClientBuilder.EndpointConfiguration epr =
+        createEndpointConfiguration(src, new ClientConfiguration());
+    String eprStr = epr == null
+        ? "(empty)"
+        : ("(" + epr.getServiceEndpoint() + " " + epr.getSigningRegion());
+    if (expectNull) {
+      assertThat(epr)
+          .describedAs("Endpoint configuration of %s =",
+              src, eprStr)
+          .isNull();
+    } else {
+      assertThat(epr)
+          .describedAs("Endpoint configuration of %s =",
+              src, eprStr)
+          .hasFieldOrPropertyWithValue("serviceEndpoint", src)
+          .hasFieldOrPropertyWithValue("signingRegion", expectRegion);
+    }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestNetworkBinding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestNetworkBinding.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a.impl;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.hadoop.test.AbstractHadoopTestBase;
@@ -69,11 +70,13 @@ public class TestNetworkBinding extends AbstractHadoopTestBase {
   }
 
   @Test
+  @Ignore("disabled until endpoint logic works for S3 client builder API")
   public void testUSEastEndpoint() throws Throwable {
     expectEndpoint(US_EAST_1, false, US_EAST_1);
   }
 
   @Test
+  @Ignore("disabled until endpoint logic works for S3 client builder API")
   public void testUSWestEndpoint() throws Throwable {
     expectEndpoint(US_WEST_2, false, US_WEST_2);
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestPartialDeleteFailures.java
@@ -48,8 +48,8 @@ import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AInputPolicy;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
+import org.apache.hadoop.fs.s3a.impl.statistics.EmptyS3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.fs.s3a.s3guard.DirListingMetadata;
 import org.apache.hadoop.fs.s3a.s3guard.ITtlTimeProvider;
@@ -216,7 +216,7 @@ public class TestPartialDeleteFailures {
             "s3a-transfer-shared"),
         Constants.DEFAULT_EXECUTOR_CAPACITY,
         new Invoker(RetryPolicies.TRY_ONCE_THEN_FAIL, Invoker.LOG_EVENT),
-        new S3AInstrumentation(name),
+        new EmptyS3AStatisticsContext(),
         new S3AStorageStatistics(),
         S3AInputPolicy.Normal,
         ChangeDetectionPolicy.createPolicy(ChangeDetectionPolicy.Mode.None,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/statistics/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/statistics/ITestS3AContractStreamIOStatistics.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.fs.contract.s3a;
+package org.apache.hadoop.fs.s3a.impl.statistics;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractStreamIOStatisticsTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.s3a.S3AContract;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeEnableS3Guard;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/statistics/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/statistics/ITestS3AContractStreamIOStatistics.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractStreamIOStatisticsTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeEnableS3Guard;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
@@ -46,6 +47,33 @@ public class ITestS3AContractStreamIOStatistics extends
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
     return new S3AContract(conf);
+  }
+
+  /**
+   * Keys which the input stream must support.
+   * @return a list of keys
+   */
+  public List<String> inputStreamStatisticKeys() {
+    return Arrays.asList(
+        StreamStatisticNames.STREAM_READ_ABORTED,
+        StreamStatisticNames.STREAM_READ_BYTES_DISCARDED_ABORT,
+        StreamStatisticNames.STREAM_READ_CLOSED,
+        StreamStatisticNames.STREAM_READ_CLOSE_BYTES_READ,
+        StreamStatisticNames.STREAM_READ_CLOSE_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_OPENED,
+        StreamStatisticNames.STREAM_READ_BYTES,
+        StreamStatisticNames.STREAM_READ_EXCEPTIONS,
+        StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_OPERATIONS_INCOMPLETE,
+        StreamStatisticNames.STREAM_READ_VERSION_MISMATCHES,
+        StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_READ,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED
+    );
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/statistics/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/statistics/ITestS3AContractStreamIOStatistics.java
@@ -56,7 +56,7 @@ public class ITestS3AContractStreamIOStatistics extends
   public List<String> outputStreamStatisticKeys() {
     return Arrays.asList(STREAM_WRITE_BYTES,
         STREAM_WRITE_BLOCK_UPLOADS,
-        STREAM_WRITE_FAILURES);
+        STREAM_WRITE_EXCEPTIONS);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -25,8 +25,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.event.ProgressListener;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -36,12 +34,14 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
+import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.util.Progressable;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
@@ -170,7 +170,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     Statistic putBytesPending = Statistic.OBJECT_PUT_BYTES_PENDING;
 
     ContractTestUtils.NanoTimer timer = new ContractTestUtils.NanoTimer();
-    S3AInstrumentation.OutputStreamStatistics streamStatistics;
+    BlockOutputStreamStatistics streamStatistics;
     long blocksPer10MB = blocksPerMB * 10;
     ProgressCallback progress = new ProgressCallback(timer);
     try (FSDataOutputStream out = fs.create(fileToCreate,
@@ -234,7 +234,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
         "Put file " + fileToCreate + " of size " + filesize);
     if (streamStatistics != null) {
       assertEquals("actively allocated blocks in " + streamStatistics,
-          0, streamStatistics.blocksActivelyAllocated());
+          0, streamStatistics.getBlocksActivelyAllocated());
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.impl.statistics.BlockOutputStreamStatistics;
 import org.apache.hadoop.fs.statistics.IOStatistics;
-import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 import org.apache.hadoop.util.Progressable;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.event.ProgressListener;
+import org.assertj.core.api.Assertions;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -223,6 +224,9 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     LOG.info("Statistics after stream closed: {}", streamStatistics);
     long putRequestCount = storageStatistics.getLong(putRequests);
     Long putByteCount = storageStatistics.getLong(putBytes);
+    Assertions.assertThat(putRequestCount)
+        .describedAs("Put request count from filesystem stats")
+        .isGreaterThan(0);
     LOG.info("PUT {} bytes in {} operations; {} MB/operation",
         putByteCount, putRequestCount,
         putByteCount / (putRequestCount * _1MB));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.s3a.S3AInputStream;
 import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AInputStreamStatistics;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 import org.slf4j.Logger;
@@ -162,7 +163,7 @@ public class S3AScaleTestBase extends AbstractS3ATestBase {
    * @param in wrapper
    * @return the statistics for the inner stream
    */
-  protected S3AInstrumentation.InputStreamStatistics getInputStreamStatistics(
+  protected S3AInputStreamStatistics getInputStreamStatistics(
       FSDataInputStream in) {
     return getS3AInputStream(in).getS3AStreamStatistics();
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3Select.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3Select.java
@@ -47,9 +47,9 @@ import org.apache.hadoop.fs.s3a.AWSServiceIOException;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AInputStream;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AInputStreamStatistics;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
@@ -302,8 +302,8 @@ public class ITestS3Select extends AbstractS3SelectTest {
                  SELECT_EVERYTHING)) {
       SelectInputStream sis
           = (SelectInputStream) seekStream.getWrappedStream();
-      S3AInstrumentation.InputStreamStatistics streamStats
-          = sis.getS3AStreamStatistics();
+      S3AInputStreamStatistics streamStats =
+          sis.getS3AStreamStatistics();
       // lazy seek doesn't raise a problem here
       seekStream.seek(0);
       assertEquals("first byte read", fullData[0], seekStream.read());
@@ -344,7 +344,7 @@ public class ITestS3Select extends AbstractS3SelectTest {
       assertEquals("byte at seek position",
           fullData[(int)seekStream.getPos()], seekStream.read());
       assertEquals("Seek bytes skipped in " + streamStats,
-          seekRange, streamStats.bytesSkippedOnSeek);
+          seekRange, streamStats.getBytesSkippedOnSeek());
 
       // try an invalid readahead range
       intercept(IllegalArgumentException.class,
@@ -588,13 +588,14 @@ public class ITestS3Select extends AbstractS3SelectTest {
     stream.setReadahead(1L);
     assertEquals("Readahead on " + sis, 1, sis.getReadahead());
     stream.read();
-    S3AInstrumentation.InputStreamStatistics stats
-        = sis.getS3AStreamStatistics();
+    S3AInputStreamStatistics stats
+        = (S3AInputStreamStatistics)
+        sis.getS3AStreamStatistics();
     assertEquals("Read count in " + sis,
-        1, stats.bytesRead);
+        1, stats.getBytesRead());
     stream.close();
     assertEquals("Abort count in " + sis,
-        1, stats.aborted);
+        1, stats.getAborted());
     readOps.assertDiffEquals("Read operations are still considered active",
         0);
     intercept(PathIOException.class, FSExceptionMessages.STREAM_IS_CLOSED,
@@ -608,12 +609,14 @@ public class ITestS3Select extends AbstractS3SelectTest {
         "SELECT * FROM S3OBJECT s");
     stream.setReadahead(0x1000L);
     SelectInputStream sis = (SelectInputStream) stream.getWrappedStream();
-    S3AInstrumentation.InputStreamStatistics stats
-        = sis.getS3AStreamStatistics();
+    S3AInputStreamStatistics stats
+        = (S3AInputStreamStatistics)
+        sis.getS3AStreamStatistics();
     stream.close();
-    assertEquals("Close count in " + sis, 1, stats.closed);
-    assertEquals("Abort count in " + sis, 0, stats.aborted);
-    assertTrue("No bytes read in close of " + sis, stats.bytesReadInClose > 0);
+    assertEquals("Close count in " + sis, 1, stats.getClosed());
+    assertEquals("Abort count in " + sis, 0, stats.getAborted());
+    assertTrue("No bytes read in close of " + sis,
+        stats.getBytesReadInClose() > 0);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
+import org.apache.hadoop.fs.s3a.impl.statistics.S3AInputStreamStatistics;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.mapred.JobConf;
@@ -381,7 +381,7 @@ public class ITestS3SelectLandsat extends AbstractS3SelectTest {
                  SELECT_EVERYTHING)) {
       SelectInputStream sis
           = (SelectInputStream) seekStream.getWrappedStream();
-      S3AInstrumentation.InputStreamStatistics streamStats
+      S3AInputStreamStatistics streamStats
           = sis.getS3AStreamStatistics();
       // lazy seek doesn't raise a problem here
       seekStream.seek(0);
@@ -410,7 +410,7 @@ public class ITestS3SelectLandsat extends AbstractS3SelectTest {
       assertEquals("byte at seek position",
           dataset[(int) seekStream.getPos()], seekStream.read());
       assertEquals("Seek bytes skipped in " + streamStats,
-          seekRange, streamStats.bytesSkippedOnSeek);
+          seekRange, streamStats.getBytesSkippedOnSeek());
       long offset;
       long increment = 64 * _1KB;
 

--- a/hadoop-tools/hadoop-aws/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-aws/src/test/resources/log4j.properties
@@ -75,3 +75,6 @@ log4j.logger.org.apache.hadoop.fs.s3a.s3guard.Operations=DEBUG
 
 log4j.logger.org.apache.hadoop.mapreduce.lib.output=DEBUG
 log4j.logger.org.apache.hadoop.fs.s3a.S3AStorageStatistics=INFO
+
+# Set to debug if you need to debug S3A endpoint problems.
+#log4j.logger.org.apache.hadoop.fs.s3a.DefaultS3ClientFactory=DEBUG


### PR DESCRIPTION
Contributed by Steve Loughran.

This patch adds to hadoop-common an API For querying IO classes (Especially
input and output streams) for statistics.

It includes a big rework of the S3A Statistics including

* implementation of the IOStatistics APIs
* and contract tests for those and any other streams which implement the same interfaces and	the same bytes read/written counters.
* A split  of the existing S3AInstrumentation classes into interface/implementations.
* Troubled attempt to wire up the AWSSDK metrics

The AWS metric binding is breaking some of the S3 region handling code, so is
disabled, we're still using the old "create client then set endpoint" logic rather
than the builder API for constructing the S3 client. 

Doing the public interface hand-in-hand with that implementation helps evolve
the interface, but it makes for a bigger patch.

There are contract tests for those and any other streams which implement
the same interfaces and	the same bytes read/written counters.

Proposed: once the reviewers are happy with the design we can split the two up
into the hadoop-common changes (which can be used in ABFS) and the S3A FS
changes.


