### PR TITLE
HADOOP-17018. Intermittent failing of ITestAbfsStreamStatistics in ABFS

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
@@ -96,7 +96,8 @@ public class ITestAbfsStreamStatistics extends AbstractAbfsIntegrationTest {
        * different setups.
        *
        */
-      assertTrue("Mismatch in read operations",
+      assertTrue(String.format("The actual value of %d was not equal to the "
+              + "expected value of 2 or 3", statistics.getReadOps()),
           statistics.getReadOps() == 2 || statistics.getReadOps() == 3);
 
     } finally {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
@@ -84,12 +84,20 @@ public class ITestAbfsStreamStatistics extends AbstractAbfsIntegrationTest {
 
       LOG.info("Result of Read operation : {}", result);
       /*
-      Testing if 2 read_ops value is coming after reading full content from a
-      file (3 if anything to read from Buffer too).
-      Reason: read() call gives read_ops=1,
-      reading from AbfsClient(http GET) gives read_ops=2.
+       * Testing if 2 read_ops value is coming after reading full content
+       * from a file (3 if anything to read from Buffer too). Reason: read()
+       * call gives read_ops=1, reading from AbfsClient(http GET) gives
+       * read_ops=2.
+       *
+       * In some cases ABFS-prefetch thread runs in the background which
+       * returns some bytes from buffer and gives an extra readOp.
+       * Thus, making readOps values arbitrary and giving intermittent
+       * failures in some cases. Hence, readOps values of 2 or 3 is seen in
+       * different setups.
+       *
        */
-      assertReadWriteOps("read", 2, statistics.getReadOps());
+      assertTrue("Mismatch in read operations",
+          statistics.getReadOps() == 2 || statistics.getReadOps() == 3);
 
     } finally {
       IOUtils.cleanupWithLogger(LOG, inForOneOperation,


### PR DESCRIPTION
In some cases, ABFS-prefetch thread runs in the background which returns some bytes from the buffer and gives an extra readOp. Thus, making readOps values arbitrary and giving intermittent failures in some cases. Hence, readOps values of 2 or 3 are seen in different setups.

test runs: 
- mvn -T 1C -Dparallel-tests=abfs clean verify
- mvn -T 1C -Dparallel-tests=abfs clean verify -Dtest=none -Dit.test=ITestAbfsStreamStatistics

Region: East US, West US

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.azurebfs.ITestAbfsStreamStatistics
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 165.964 s - in org.apache.hadoop.fs.azurebfs.ITestAbfsStreamStatistics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M1:integration-test (integration-test-abfs-parallel-classes) @ hadoop-azure ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.azurebfs.ITestAbfsStreamStatistics
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 256.797 s - in org.apache.hadoop.fs.azurebfs.ITestAbfsStreamStatistics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (depcheck) @ hadoop-azure ---
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M1:verify (integration-test-abfs-parallel-classesAndMethods) @ hadoop-azure ---
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M1:verify (integration-test-abfs-parallel-classes) @ hadoop-azure ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:14 min (Wall Clock)
[INFO] Finished at: 2020-04-30T18:01:26+05:30
