### PR TITLE
HDFS-15320. StringIndexOutOfBoundsException in HostRestrictingAuthorizationFilter

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
@@ -229,9 +229,14 @@ public class HostRestrictingAuthorizationFilter implements Filter {
       throws IOException, ServletException {
     final String address = interaction.getRemoteAddr();
     final String query = interaction.getQueryString();
-    final String path =
-        interaction.getRequestURI()
-            .substring(WebHdfsFileSystem.PATH_PREFIX.length());
+    final String uri = interaction.getRequestURI();
+    if (!uri.startsWith(WebHdfsFileSystem.PATH_PREFIX)) {
+      LOG.trace("Rejecting interaction; wrong path");
+      interaction.sendError(HttpServletResponse.SC_NOT_FOUND,
+          "The request URI must start with " + WebHdfsFileSystem.PATH_PREFIX);
+      return;
+    }
+    final String path = uri.substring(WebHdfsFileSystem.PATH_PREFIX.length());
     String user = interaction.getRemoteUser();
 
     LOG.trace("Got request user: {}, remoteIp: {}, query: {}, path: {}",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
@@ -231,7 +231,7 @@ public class HostRestrictingAuthorizationFilter implements Filter {
     final String query = interaction.getQueryString();
     final String uri = interaction.getRequestURI();
     if (!uri.startsWith(WebHdfsFileSystem.PATH_PREFIX)) {
-      LOG.trace("Rejecting interaction; wrong path");
+      LOG.trace("Rejecting interaction; wrong URI: {}", uri);
       interaction.sendError(HttpServletResponse.SC_NOT_FOUND,
           "The request URI must start with " + WebHdfsFileSystem.PATH_PREFIX);
       return;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
@@ -266,7 +266,8 @@ public class TestHostRestrictingAuthorizationFilter {
     filter.doFilter(request, response,
         (servletRequest, servletResponse) -> {});
     Mockito.verify(response, Mockito.times(1))
-        .sendError(Mockito.eq(404), Mockito.anyString());
+        .sendError(Mockito.eq(HttpServletResponse.SC_NOT_FOUND),
+                   Mockito.anyString());
     filter.destroy();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
@@ -243,18 +243,15 @@ public class TestHostRestrictingAuthorizationFilter {
     filter.destroy();
   }
 
-  /*
+  /**
    * Test acceptable behavior to malformed requests
    * Case: the request URI does not start with "/webhdfs/v1"
    */
   @Test
   public void testInvalidURI() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(request.getRemoteAddr()).thenReturn(null);
     Mockito.when(request.getMethod()).thenReturn("GET");
     Mockito.when(request.getRequestURI()).thenReturn("/InvalidURI");
-    Mockito.when(request.getQueryString()).thenReturn(null);
-
     HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
     Filter filter = new HostRestrictingAuthorizationFilter();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
@@ -257,15 +257,14 @@ public class TestHostRestrictingAuthorizationFilter {
 
     HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
-    FilterChain chain = (servletRequest, servletResponse) -> {};
     Filter filter = new HostRestrictingAuthorizationFilter();
-
     HashMap<String, String> configs = new HashMap<String, String>() {};
     configs.put(AuthenticationFilter.AUTH_TYPE, "simple");
     FilterConfig fc = new DummyFilterConfig(configs);
 
     filter.init(fc);
-    filter.doFilter(request, response, chain);
+    filter.doFilter(request, response,
+        (servletRequest, servletResponse) -> {});
     Mockito.verify(response, Mockito.times(1))
         .sendError(Mockito.eq(404), Mockito.anyString());
     filter.destroy();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
@@ -243,6 +243,34 @@ public class TestHostRestrictingAuthorizationFilter {
     filter.destroy();
   }
 
+  /*
+   * Test acceptable behavior to malformed requests
+   * Case: the request URI does not start with "/webhdfs/v1"
+   */
+  @Test
+  public void testInvalidURI() throws Exception {
+    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(request.getRemoteAddr()).thenReturn(null);
+    Mockito.when(request.getMethod()).thenReturn("GET");
+    Mockito.when(request.getRequestURI()).thenReturn("/InvalidURI");
+    Mockito.when(request.getQueryString()).thenReturn(null);
+
+    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+    FilterChain chain = (servletRequest, servletResponse) -> {};
+    Filter filter = new HostRestrictingAuthorizationFilter();
+
+    HashMap<String, String> configs = new HashMap<String, String>() {};
+    configs.put(AuthenticationFilter.AUTH_TYPE, "simple");
+    FilterConfig fc = new DummyFilterConfig(configs);
+
+    filter.init(fc);
+    filter.doFilter(request, response, chain);
+    Mockito.verify(response, Mockito.times(1))
+        .sendError(Mockito.eq(404), Mockito.anyString());
+    filter.destroy();
+  }
+
   private static class DummyFilterConfig implements FilterConfig {
     final Map<String, String> map;
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15320

In HostRestrictingAuthorizationFitler, if there is a request to invalid URI, return 404 response code instead of throwing an exception and logging the stacktrace.