### PR TITLE
HADOOP-17021. Add concat fs command

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
@@ -1,0 +1,62 @@
+package org.apache.hadoop.fs.shell;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+/**
+ * Concat the given files.
+ */
+@InterfaceAudience.Private @InterfaceStability.Unstable public class Concat
+    extends FsCommand {
+  public static void registerCommands(CommandFactory factory) {
+    factory.addClass(Concat.class, "-concat");
+  }
+
+  public static final String NAME = "concat";
+  public static final String USAGE = "<target path> <src path> <src path> ...";
+  public static final String DESCRIPTION =
+      "Concatenate existing source files into the target file.";
+  private static FileSystem tstFs; // test only.
+
+  @Override
+  protected void processArguments(LinkedList<PathData> args)
+      throws IOException {
+    if (args.size() < 1) {
+      throw new IOException("Target path not specified.");
+    }
+    if (args.size() < 3) {
+      throw new IOException("The number of source paths is less than 2.");
+    }
+    PathData target = args.removeFirst();
+    LinkedList<PathData> srcList = args;
+    if (!target.exists || !target.stat.isFile()) {
+      throw new IOException(String.format("Target path %s does not exist or is"
+              + " not file.", target.path));
+    }
+    Path[] srcArray = new Path[srcList.size()];
+    for (int i = 0; i < args.size(); i++) {
+      PathData src = srcList.get(i);
+      if (!src.exists || !src.stat.isFile()) {
+        throw new IOException(
+            String.format("%s does not exist or is not file.", src.path));
+      }
+      srcArray[i] = src.path;
+    }
+    FileSystem fs = target.fs;
+    if (tstFs != null) {
+      fs = tstFs;
+    }
+    fs.concat(target.path, srcArray);
+  }
+
+  @VisibleForTesting
+  static void setTstFs(FileSystem fs) {
+    tstFs = fs;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
@@ -22,7 +22,9 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathIOException;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.LinkedList;
 
@@ -47,22 +49,24 @@ public class Concat extends FsCommand {
   protected void processArguments(LinkedList<PathData> args)
       throws IOException {
     if (args.size() < 1) {
-      throw new IOException("Target path not specified.");
+      throw new IOException("Target path not specified. " + USAGE);
     }
     if (args.size() < 3) {
-      throw new IOException("The number of source paths is less than 2.");
+      throw new IOException(
+          "The number of source paths is less than 2. " + USAGE);
     }
     PathData target = args.removeFirst();
     LinkedList<PathData> srcList = args;
     if (!target.exists || !target.stat.isFile()) {
-      throw new IOException(String.format("Target path %s does not exist or is"
-              + " not file.", target.path));
+      throw new FileNotFoundException(String
+          .format("Target path %s does not exist or is" + " not file.",
+              target.path));
     }
     Path[] srcArray = new Path[srcList.size()];
     for (int i = 0; i < args.size(); i++) {
       PathData src = srcList.get(i);
       if (!src.exists || !src.stat.isFile()) {
-        throw new IOException(
+        throw new FileNotFoundException(
             String.format("%s does not exist or is not file.", src.path));
       }
       srcArray[i] = src.path;
@@ -74,8 +78,8 @@ public class Concat extends FsCommand {
     try {
       fs.concat(target.path, srcArray);
     } catch (UnsupportedOperationException exception) {
-      throw new IOException("Dest filesystem '" + fs.getUri().getScheme()
-          + "' doesn't support concat.");
+      throw new PathIOException("Dest filesystem '" + fs.getUri().getScheme()
+          + "' doesn't support concat.", exception);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
@@ -17,16 +17,17 @@
  */
 package org.apache.hadoop.fs.shell;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.LinkedList;
+
 import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.LinkedList;
 
 /**
  * Concat the given files.
@@ -43,7 +44,7 @@ public class Concat extends FsCommand {
   public static final String DESCRIPTION = "Concatenate existing source files"
       + " into the target file. Target file and source files should be in the"
       + " same directory.";
-  private static FileSystem tstFs; // test only.
+  private static FileSystem testFs; // test only.
 
   @Override
   protected void processArguments(LinkedList<PathData> args)
@@ -72,8 +73,8 @@ public class Concat extends FsCommand {
       srcArray[i] = src.path;
     }
     FileSystem fs = target.fs;
-    if (tstFs != null) {
-      fs = tstFs;
+    if (testFs != null) {
+      fs = testFs;
     }
     try {
       fs.concat(target.path, srcArray);
@@ -84,7 +85,7 @@ public class Concat extends FsCommand {
   }
 
   @VisibleForTesting
-  static void setTstFs(FileSystem fs) {
-    tstFs = fs;
+  static void setTestFs(FileSystem fs) {
+    testFs = fs;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Concat.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.fs.shell;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -12,16 +29,18 @@ import java.util.LinkedList;
 /**
  * Concat the given files.
  */
-@InterfaceAudience.Private @InterfaceStability.Unstable public class Concat
-    extends FsCommand {
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class Concat extends FsCommand {
   public static void registerCommands(CommandFactory factory) {
     factory.addClass(Concat.class, "-concat");
   }
 
   public static final String NAME = "concat";
   public static final String USAGE = "<target path> <src path> <src path> ...";
-  public static final String DESCRIPTION =
-      "Concatenate existing source files into the target file.";
+  public static final String DESCRIPTION = "Concatenate existing source files"
+      + " into the target file. Target file and source files should be in the"
+      + " same directory.";
   private static FileSystem tstFs; // test only.
 
   @Override
@@ -52,7 +71,12 @@ import java.util.LinkedList;
     if (tstFs != null) {
       fs = tstFs;
     }
-    fs.concat(target.path, srcArray);
+    try {
+      fs.concat(target.path, srcArray);
+    } catch (UnsupportedOperationException exception) {
+      throw new IOException("Dest filesystem '" + fs.getUri().getScheme()
+          + "' doesn't support concat.");
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/FsCommand.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/FsCommand.java
@@ -70,6 +70,7 @@ abstract public class FsCommand extends Command {
     factory.registerCommands(Truncate.class);
     factory.registerCommands(SnapshotCommands.class);
     factory.registerCommands(XAttrCommands.class);
+    factory.registerCommands(Concat.class);
   }
 
   protected FsCommand() {}

--- a/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
@@ -823,7 +823,7 @@ files should be in the same directory.
 
 Example:
 
-* `hadoop fs -concat /user/hadoop/target-file /user/hadoop/file-0 /user/hadoop/file-1`
+* `hadoop fs -concat hdfs://cluster/user/hadoop/target-file hdfs://cluster/user/hadoop/file-0 hdfs://cluster/user/hadoop/file-1`
 * `hadoop fs -concat /user/hadoop/target-file /user/hadoop/file-*`
 
 usage

--- a/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
@@ -824,7 +824,6 @@ files should be in the same directory.
 Example:
 
 * `hadoop fs -concat hdfs://cluster/user/hadoop/target-file hdfs://cluster/user/hadoop/file-0 hdfs://cluster/user/hadoop/file-1`
-* `hadoop fs -concat /user/hadoop/target-file /user/hadoop/file-*`
 
 usage
 -----

--- a/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
@@ -813,6 +813,19 @@ Example:
 * `hadoop fs -truncate 55 /user/hadoop/file1 /user/hadoop/file2`
 * `hadoop fs -truncate -w 127 hdfs://nn1.example.com/user/hadoop/file1`
 
+concat
+--------
+
+Usage: `hadoop fs -concat <target file> <source files>`
+
+Concatenate existing source files into the target file. Target file and source
+files should be in the same directory.
+
+Example:
+
+* `hadoop fs -concat /user/hadoop/target-file /user/hadoop/file-0 /user/hadoop/file-1`
+* `hadoop fs -concat /user/hadoop/target-file /user/hadoop/file-*`
+
 usage
 -----
 
@@ -1092,6 +1105,7 @@ actually fail.
 | `setfattr` | generally unsupported permissions model |
 | `setrep`| has no effect |
 | `truncate` | generally unsupported |
+| `concat` | generally unsupported |
 
 Different object store clients *may* support these commands: do consult the
 documentation and test against the target store.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestFsShellConcat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestFsShellConcat.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.fs.shell;
 
 import org.apache.hadoop.conf.Configuration;
@@ -11,9 +28,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
 import java.util.Random;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -25,10 +45,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class TestFsShellConcat {
 
-  static Configuration conf;
-  static FsShell shell;
-  static LocalFileSystem lfs;
-  static Path testRootDir, dstPath;
+  private static Configuration conf;
+  private static FsShell shell;
+  private static LocalFileSystem lfs;
+  private static Path testRootDir;
+  private static Path dstPath;
 
   @Before
   public void before() throws IOException {
@@ -44,6 +65,7 @@ public class TestFsShellConcat {
     lfs.mkdirs(testRootDir);
     lfs.setWorkingDirectory(testRootDir);
     dstPath = new Path(testRootDir, "dstFile");
+    lfs.create(dstPath).close();
 
     Random random = new Random();
     for (int i = 0; i < 10; i++) {
@@ -64,13 +86,32 @@ public class TestFsShellConcat {
       return null;
     }).when(mockFs).concat(any(Path.class), any(Path[].class));
     Concat.setTstFs(mockFs);
-    shellRun(0, "-concat", dstPath.toString(), testRootDir+"/*");
+    shellRun(0, "-concat", dstPath.toString(), testRootDir+"/file-*");
 
     assertTrue(lfs.exists(dstPath));
     assertEquals(1, lfs.listStatus(testRootDir).length);
   }
 
-  private void shellRun(int n, String ... args) throws Exception {
+  @Test
+  public void testUnsupportedFs() throws Exception {
+    FileSystem mockFs = Mockito.mock(FileSystem.class);
+    Mockito.doThrow(
+        new UnsupportedOperationException("Mock unsupported exception."))
+        .when(mockFs).concat(any(Path.class), any(Path[].class));
+    Mockito.doAnswer(invocationOnMock -> new URI("mockfs:///")).when(mockFs)
+        .getUri();
+    Concat.setTstFs(mockFs);
+    PrintStream oldErr = System.err;
+    final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(err));
+    shellRun(1, "-concat", dstPath.toString(), testRootDir + "/file-*");
+    System.setErr(oldErr);
+    System.err.print(err.toString());
+    assertTrue(err.toString()
+        .contains("Dest filesystem 'mockfs' doesn't support concat"));
+  }
+
+  private void shellRun(int n, String... args) {
     assertEquals(n, shell.run(args));
   }
 
@@ -78,10 +119,21 @@ public class TestFsShellConcat {
    * Simple simulation of concat.
    */
   private void mockConcat(Path target, Path[] srcArray) throws IOException {
+    Path tmp = new Path(target.getParent(), target.getName() + ".bak");
+    lfs.rename(target, tmp);
     OutputStream out = lfs.create(target);
     try {
+      InputStream in = lfs.open(tmp);
+      try {
+        IOUtils.copyBytes(in, out, 1024);
+      } finally {
+        if (in != null) {
+          in.close();
+        }
+        lfs.delete(tmp, true);
+      }
       for (int i = 0; i < srcArray.length; i++) {
-        InputStream in = lfs.open(srcArray[i]);
+        in = lfs.open(srcArray[i]);
         try {
           IOUtils.copyBytes(in, out, 1024);
         } finally {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestFsShellConcat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestFsShellConcat.java
@@ -17,10 +17,6 @@
  */
 package org.apache.hadoop.fs.shell;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.assertj.core.api.Assertions;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -29,14 +25,19 @@ import java.io.PrintStream;
 import java.net.URI;
 import java.util.Random;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.assertj.core.api.Assertions;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsShell;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -97,13 +98,13 @@ public class TestFsShellConcat extends AbstractHadoopTestBase {
       mockConcat(target, src);
       return null;
     }).when(mockFs).concat(any(Path.class), any(Path[].class));
-    Concat.setTstFs(mockFs);
+    Concat.setTestFs(mockFs);
     shellRun(0, "-concat", dstPath.toString(), testRootDir+"/file-*");
 
     // Verify concat result.
     ContractTestUtils
         .assertPathExists(lfs, "The target file doesn't exist.", dstPath);
-    assertEquals(1, lfs.listStatus(testRootDir).length);
+    Assertions.assertThat(lfs.listStatus(testRootDir).length).isEqualTo(1);
     assertEquals(expectContent.length, lfs.getFileStatus(dstPath).getLen());
     out = new ByteArrayOutputStream();
     try (InputStream in = lfs.open(dstPath)) {
@@ -124,7 +125,7 @@ public class TestFsShellConcat extends AbstractHadoopTestBase {
         .when(mockFs).concat(any(Path.class), any(Path[].class));
     Mockito.doAnswer(invocationOnMock -> new URI("mockfs:///")).when(mockFs)
         .getUri();
-    Concat.setTstFs(mockFs);
+    Concat.setTestFs(mockFs);
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
     PrintStream oldErr = System.err;
     System.setErr(new PrintStream(err));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestFsShellConcat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestFsShellConcat.java
@@ -1,0 +1,100 @@
+package org.apache.hadoop.fs.shell;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FsShell;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test Concat.
+ */
+public class TestFsShellConcat {
+
+  static Configuration conf;
+  static FsShell shell;
+  static LocalFileSystem lfs;
+  static Path testRootDir, dstPath;
+
+  @Before
+  public void before() throws IOException {
+    conf = new Configuration();
+    shell = new FsShell(conf);
+    lfs = FileSystem.getLocal(conf);
+    testRootDir = lfs.makeQualified(new Path(GenericTestUtils.getTempPath(
+        "testFsShellCopy")));
+
+    if (lfs.exists(testRootDir)) {
+      lfs.delete(testRootDir, true);
+    }
+    lfs.mkdirs(testRootDir);
+    lfs.setWorkingDirectory(testRootDir);
+    dstPath = new Path(testRootDir, "dstFile");
+
+    Random random = new Random();
+    for (int i = 0; i < 10; i++) {
+      OutputStream out = lfs.create(new Path(testRootDir, "file-" + i));
+      out.write(random.nextInt());
+      out.close();
+    }
+  }
+
+  @Test
+  public void testConcat() throws Exception {
+    FileSystem mockFs = Mockito.mock(FileSystem.class);
+    Mockito.doAnswer(invocation -> {
+      Object[] args = invocation.getArguments();
+      Path target = (Path)args[0];
+      Path[] src = (Path[]) args[1];
+      mockConcat(target, src);
+      return null;
+    }).when(mockFs).concat(any(Path.class), any(Path[].class));
+    Concat.setTstFs(mockFs);
+    shellRun(0, "-concat", dstPath.toString(), testRootDir+"/*");
+
+    assertTrue(lfs.exists(dstPath));
+    assertEquals(1, lfs.listStatus(testRootDir).length);
+  }
+
+  private void shellRun(int n, String ... args) throws Exception {
+    assertEquals(n, shell.run(args));
+  }
+
+  /**
+   * Simple simulation of concat.
+   */
+  private void mockConcat(Path target, Path[] srcArray) throws IOException {
+    OutputStream out = lfs.create(target);
+    try {
+      for (int i = 0; i < srcArray.length; i++) {
+        InputStream in = lfs.open(srcArray[i]);
+        try {
+          IOUtils.copyBytes(in, out, 1024);
+        } finally {
+          if (in != null) {
+            in.close();
+          }
+          lfs.delete(srcArray[i], true);
+        }
+      }
+    } finally {
+      if (out != null) {
+        out.close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
We should add one concat fs command for ease of use. It concatenates existing source files into the target file using FileSystem.concat().