### PR TITLE
HDFS-15331. Remove invalid exclusions that minicluster dependency on HDFS

### DIFF
--- a/hadoop-minicluster/pom.xml
+++ b/hadoop-minicluster/pom.xml
@@ -67,12 +67,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.kubernetes</groupId>
-          <artifactId>client-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Ozone has split into independent repo, but the invalid exclusions (kubernetes client) that minicluster dependency on HDFS is kept.

https://issues.apache.org/jira/browse/HDFS-15331