### PR TITLE
YARN-10250 - find: File system loop detected - list debug force true

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1342,11 +1342,11 @@ public class ContainerLaunch implements Callable<Integer> {
       // find will follow symlinks outside the work dir if such sylimks exist
       // (like public/app local resources)
       line("echo \"find -L . -maxdepth 5 -ls:\" 1>>\"", output.toString(),
-          "\"");
-      line("find -L . -maxdepth 5 -ls 1>>\"", output.toString(), "\"");
+          "\" || :");
+      line("find -L . -maxdepth 5 -ls 1>>\"", output.toString(), "\" || :");
       line("echo \"broken symlinks(find -L . -maxdepth 5 -type l -ls):\" 1>>\"",
-          output.toString(), "\"");
-      line("find -L . -maxdepth 5 -type l -ls 1>>\"", output.toString(), "\"");
+          output.toString(), "\" || :");
+      line("find -L . -maxdepth 5 -type l -ls 1>>\"", output.toString(), "\" || :");
     }
 
     @Override


### PR DESCRIPTION
This will allow debugging info to still get listed, but will ensure find does not kill the launch of the container due to "File system loop detected".