### PR TITLE
HADOOP-16888. [JDK11] Support JDK11 in the precommit job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 24, unit: 'HOURS')
+        timeout (time: 20, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 5, unit: 'HOURS')
+        timeout (time: 10, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 10, unit: 'HOURS')
+        timeout (time: 24, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 20, unit: 'HOURS')
+        timeout (time: 5, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,6 +154,9 @@ pipeline {
                         # use emoji vote so it is easier to find the broken line
                         YETUS_ARGS+=("--github-use-emoji-vote")
 
+                        # test with Java 8 and 11
+                        YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/java-11-openjdk-amd64")
+
                         "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"
                         '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 24, unit: 'HOURS')
+        timeout (time: 10, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }
@@ -157,6 +157,7 @@ pipeline {
                         # test with Java 8 and 11
                         YETUS_ARGS+=("--java-home=/usr/lib/jvm/java-8-openjdk-amd64")
                         YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/java-11-openjdk-amd64")
+                        YETUS_ARGS+=("--multijdktests=compile")
 
                         "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"
                         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,6 +155,7 @@ pipeline {
                         YETUS_ARGS+=("--github-use-emoji-vote")
 
                         # test with Java 8 and 11
+                        YETUS_ARGS+=("--java-home=/usr/lib/jvm/java-8-openjdk-amd64")
                         YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/java-11-openjdk-amd64")
 
                         "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -65,8 +65,8 @@ RUN apt-get -q update \
         locales \
         make \
         maven \
-        openjdk-8-jdk \
         openjdk-11-jdk \
+        openjdk-8-jdk \
         pinentry-curses \
         pkg-config \
         python \

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -33,16 +33,10 @@ RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_TERSE true
 
-######
-# Install common dependencies from packages. Versions here are either
-# sufficient or irrelevant.
-#
-# WARNING: DO NOT PUT JAVA APPS HERE! Otherwise they will install default
-# Ubuntu Java.  See Java section below!
-######
 # hadolint ignore=DL3008
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends \
+        ant \
         apt-utils \
         bats \
         build-essential \
@@ -51,11 +45,13 @@ RUN apt-get -q update \
         cmake \
         curl \
         doxygen \
+        findbugs \
         fuse \
         g++ \
         gcc \
         git \
         gnupg-agent \
+        libbcprov-java \
         libbz2-dev \
         libcurl4-openssl-dev \
         libfuse-dev \
@@ -64,11 +60,12 @@ RUN apt-get -q update \
         libsasl2-dev \
         libsnappy-dev \
         libssl-dev \
-        libsnappy-dev \
         libtool \
         libzstd1-dev \
         locales \
         make \
+        maven \
+        openjdk-8-jdk \
         pinentry-curses \
         pkg-config \
         python \
@@ -86,15 +83,13 @@ RUN apt-get -q update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-
-#######
-# OpenJDK 8
-#######
-# hadolint ignore=DL3008
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends openjdk-8-jdk libbcprov-java \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+######
+# Set env vars required to build Hadoop
+######
+ENV MAVEN_HOME /usr
+# JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV FINDBUGS_HOME /usr
 
 ######
 # Install Google Protobuf 3.7.1 (3.0.0 ships with Bionic)
@@ -112,29 +107,6 @@ RUN mkdir -p /opt/protobuf-src \
     && rm -rf /opt/protobuf-src
 ENV PROTOBUF_HOME /opt/protobuf
 ENV PATH "${PATH}:/opt/protobuf/bin"
-
-######
-# Install Apache Maven 3.6.0 (3.6.0 ships with Bionic)
-######
-# hadolint ignore=DL3008
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends maven \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-ENV MAVEN_HOME /usr
-# JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-
-######
-# Install findbugs 3.1.0 (3.1.0 ships with Bionic)
-# Ant is needed for findbugs
-######
-# hadolint ignore=DL3008
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends findbugs ant \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-ENV FINDBUGS_HOME /usr
 
 ####
 # Install pylint at fixed version (2.0.0 removed python2 support)

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get -q update \
         make \
         maven \
         openjdk-8-jdk \
+        openjdk-11-jdk \
         pinentry-curses \
         pkg-config \
         python \


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-16888

* Install JDK 11 in the build image.
* Run mvninstall, compile, javac, and javadoc with JDK 8 and JDK 11. (Now javadoc with JDK 11 is broken.)
* Run the unit tests with JDK 8 only. This is because it takes too long to run unit tests with both JDK 8 and JDK 11.

After that, I'll prepare daily qbt jobs for JDK 11. The job will run full unit tests with JDK 11.