### PR TITLE
HADOOP-16854. ABFS: Fix for the OutOfMemoryException in AbfsOutputStream

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -206,7 +206,6 @@
     <powermock.version>1.5.6</powermock.version>
     <solr.version>7.7.0</solr.version>
     <openssl-wildfly.version>1.0.7.Final</openssl-wildfly.version>
-    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <dependencyManagement>
@@ -1356,11 +1355,6 @@
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
       </dependency>
-      <dependency> 
-        <groupId>com.google.code.findbugs</groupId> 
-        <artifactId>annotations</artifactId> 
-        <version>3.0.1</version> 
-      </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
@@ -1688,13 +1682,7 @@
         <dependency>
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-library</artifactId>
-          <version>${hamcrest.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-          <version>${hamcrest.version}</version>
-          <scope>test</scope>
+          <version>1.3</version>
         </dependency>
         <dependency>
           <groupId>org.assertj</groupId>
@@ -1722,14 +1710,6 @@
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>net.jodah</groupId>
-        <artifactId>concurrentunit</artifactId>
-        <version>0.4.6</version>
-        <scope>test</scope>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -206,6 +206,7 @@
     <powermock.version>1.5.6</powermock.version>
     <solr.version>7.7.0</solr.version>
     <openssl-wildfly.version>1.0.7.Final</openssl-wildfly.version>
+    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <dependencyManagement>
@@ -1355,6 +1356,11 @@
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
       </dependency>
+      <dependency> 
+        <groupId>com.google.code.findbugs</groupId> 
+        <artifactId>annotations</artifactId> 
+        <version>3.0.1</version> 
+      </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
@@ -1682,7 +1688,13 @@
         <dependency>
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-library</artifactId>
-          <version>1.3</version>
+          <version>${hamcrest.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+          <version>${hamcrest.version}</version>
+          <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.assertj</groupId>
@@ -1710,6 +1722,14 @@
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>net.jodah</groupId>
+        <artifactId>concurrentunit</artifactId>
+        <version>0.4.6</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -172,6 +172,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -210,6 +216,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
     </dependency>
 
     <!-- dependencies use for test only -->
@@ -288,19 +299,14 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- https://.mvnrepository.com/artifact/net.jodah/concurrentunit -->
-    <dependency>
-      <groupId>net.jodah</groupId>
-      <artifactId>concurrentunit</artifactId>
-      <version>0.4.6</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>concurrentunit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -218,11 +218,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-
     <!-- dependencies use for test only -->
     <dependency>
       <groupId>junit</groupId>
@@ -300,13 +295,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>net.jodah</groupId>
       <artifactId>concurrentunit</artifactId>
+      <version>0.4.6</version>
       <scope>test</scope>
     </dependency>
 

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -289,6 +289,21 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- https://.mvnrepository.com/artifact/net.jodah/concurrentunit -->
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>concurrentunit</artifactId>
+      <version>0.4.6</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <profiles>

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -130,10 +130,20 @@ public class AbfsConfiguration{
       DefaultValue = AZURE_BLOCK_LOCATION_HOST_DEFAULT)
   private String azureBlockLocationHost;
 
-  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_CONCURRENT_CONNECTION_VALUE_OUT,
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM,
+      DefaultValue = DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM)
+  private boolean shouldUseOlderAbfsOutputStream;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_WRITE_CONCURRENCY_FACTOR,
       MinValue = 1,
-      DefaultValue = MAX_CONCURRENT_WRITE_THREADS)
-  private int maxConcurrentWriteThreads;
+      DefaultValue = DEFAULT_WRITE_CONCURRENCY_FACTOR)
+  private int writeConcurrencyFactor;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE,
+      MinValue = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+      MaxValue = MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+      DefaultValue = DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE)
+  private int maxWriteMemoryUsagePercentage;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LIST_MAX_RESULTS,
       MinValue = 1,
@@ -455,8 +465,16 @@ public class AbfsConfiguration{
     return this.azureBlockLocationHost;
   }
 
-  public int getMaxConcurrentWriteThreads() {
-    return this.maxConcurrentWriteThreads;
+  public boolean shouldUseOlderAbfsOutputStream() {
+    return this.shouldUseOlderAbfsOutputStream;
+  }
+
+  public int getWriteConcurrencyFactor() {
+    return this.writeConcurrencyFactor;
+  }
+
+  public int getMaxWriteMemoryUsagePercentage() {
+    return this.maxWriteMemoryUsagePercentage;
   }
 
   public int getMaxConcurrentReadThreads() {
@@ -773,6 +791,12 @@ public class AbfsConfiguration{
       authority = authority + AbfsHttpConstants.FORWARD_SLASH;
     }
     return authority;
+  }
+
+  @VisibleForTesting
+  void setShouldUseOlderAbfsOutputStream(
+      boolean shouldUseOlderAbfsOutputStream) {
+    this.shouldUseOlderAbfsOutputStream = shouldUseOlderAbfsOutputStream;
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -51,7 +51,6 @@ import java.util.Set;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +85,7 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsInputStream;
 import org.apache.hadoop.fs.azurebfs.services.AbfsInputStreamContext;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamOld;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamContext;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamStatisticsImpl;
 import org.apache.hadoop.fs.azurebfs.services.AbfsPermission;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -51,6 +51,9 @@ public final class ConfigurationKeys {
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
   public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_OUT = "fs.azure.concurrentRequestCount.out";
+  public static final String AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = "fs.azure.use.olderabfsoutputstream";
+  public static final String AZURE_WRITE_CONCURRENCY_FACTOR = "fs.azure.write.concurrency.factor";
+  public static final String AZURE_MAX_WRITE_MEM_USAGE_PERCENTAGE = "fs.azure.max.write.memory.usage.percentage";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_IN = "fs.azure.concurrentRequestCount.in";
   public static final String AZURE_TOLERATE_CONCURRENT_APPEND = "fs.azure.io.read.tolerate.concurrent.append";
   public static final String AZURE_LIST_MAX_RESULTS = "fs.azure.list.max.results";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -56,6 +56,11 @@ public final class FileSystemConfigurations {
 
   public static final int MAX_CONCURRENT_READ_THREADS = 12;
   public static final int MAX_CONCURRENT_WRITE_THREADS = 8;
+  public static final int DEFAULT_WRITE_CONCURRENCY_FACTOR = 4;
+  public static final boolean DEFAULT_AZURE_SHOULD_USE_OLD_ABFSOUTPUTSTREAM = false;
+  public static final int MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 20;
+  public static final int MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = 90;
+  public static final int DEFAULT_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE = MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
   public static final boolean DEFAULT_READ_TOLERATE_CONCURRENT_APPEND = false;
   public static final boolean DEFAULT_AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION = false;
   public static final boolean DEFAULT_AZURE_SKIP_USER_GROUP_METADATA_DURING_INITIALIZATION = false;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsByteBufferPool.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+import static java.lang.Math.ceil;
+import static java.lang.Math.min;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+
+/**
+ * Pool for byte[]
+ */
+public class AbfsByteBufferPool {
+
+  private static final int HUNDRED = 100;
+
+  /**
+   * Queue holding the free buffers.
+   */
+  private ArrayBlockingQueue<byte[]> freeBuffers;
+  /**
+   * Count to track the buffers issued from AbfsByteBufferPool and yet to be
+   * returned.
+   */
+  private int numBuffersInUse;
+
+  private int bufferSize;
+
+  private int maxBuffersToPool;
+  private int maxMemUsagePercentage;
+
+  /**
+   * @param bufferSize            Size of the byte[] to be returned.
+   * @param queueCapacity         Maximum number of buffers that the pool can
+   *                              keep within the pool.
+   * @param maxMemUsagePercentage Maximum percentage of memory that can
+   *                              be used by the pool from the max
+   *                              available memory.
+   */
+  public AbfsByteBufferPool(final int bufferSize, final int queueCapacity,
+      final int maxMemUsagePercentage) {
+    validate(queueCapacity, maxMemUsagePercentage);
+    this.maxMemUsagePercentage = maxMemUsagePercentage;
+    this.bufferSize = bufferSize;
+    this.numBuffersInUse = 0;
+    this.maxBuffersToPool = queueCapacity;
+    freeBuffers = new ArrayBlockingQueue<>(queueCapacity);
+  }
+
+  private void validate(final int queueCapacity,
+      final int maxWriteMemUsagePercentage) {
+    Preconditions.checkArgument(maxWriteMemUsagePercentage
+            >= MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE
+            && maxWriteMemUsagePercentage
+            <= MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+        "maxWriteMemUsagePercentage should be in range (%s - %s)",
+        MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+        MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE);
+    Preconditions
+        .checkArgument(queueCapacity > 0, "queueCapacity cannot be < 1");
+  }
+
+  private boolean isPossibleToIssueNewBuffer() {
+    Runtime rt = Runtime.getRuntime();
+    double bufferCountByMaxFreeBuffers = ceil(
+        maxBuffersToPool + rt.availableProcessors());
+    if (numBuffersInUse >= bufferCountByMaxFreeBuffers) {
+      return false;
+    }
+
+    double freeMemory = rt.maxMemory() - (rt.totalMemory() - rt.freeMemory());
+    double bufferCountByMemory = ceil(
+        (freeMemory * maxMemUsagePercentage / HUNDRED) / bufferSize);
+    int maxBuffersThatCanBeInUse = (int) min(bufferCountByMemory,
+        bufferCountByMaxFreeBuffers);
+    if (maxBuffersThatCanBeInUse < 2) {
+      maxBuffersThatCanBeInUse = 2;
+    }
+
+    return numBuffersInUse < maxBuffersThatCanBeInUse;
+  }
+
+  /**
+   * @return byte[] from the pool if available otherwise new byte[] is returned.
+   * Waits if pool is empty and already maximum number of buffers are in use.
+   */
+  public byte[] get() {
+    isPossibleToIssueNewBuffer();
+    byte[] byteArray = null;
+    synchronized (this) {
+      byteArray = freeBuffers.poll();
+      if (byteArray == null && isPossibleToIssueNewBuffer()) {
+        byteArray = new byte[bufferSize];
+      }
+      if (byteArray != null) {
+        numBuffersInUse++;
+        return byteArray;
+      }
+    }
+    try {
+      byteArray = freeBuffers.take();
+      synchronized (this) {
+        numBuffersInUse++;
+        return byteArray;
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  /**
+   * @param byteArray The buffer to be offered back to the pool.
+   */
+  public synchronized void release(byte[] byteArray) {
+    Preconditions.checkArgument(byteArray.length == bufferSize,
+        "Buffer size has" + " to be %s (Received buffer length: %s)",
+        bufferSize, byteArray.length);
+    numBuffersInUse--;
+    if (numBuffersInUse < 0) {
+      numBuffersInUse = 0;
+    }
+    freeBuffers.offer(byteArray);
+  }
+
+  @VisibleForTesting
+  public synchronized int getBuffersInUse() {
+    return this.numBuffersInUse;
+  }
+
+  @VisibleForTesting
+  public synchronized ArrayBlockingQueue<byte[]> getFreeBuffers() {
+    return freeBuffers;
+  }
+
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -157,8 +157,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
     return true;
   }
 
-  @VisibleForTesting
-  public static synchronized void initWriteBufferPool(AbfsOutputStreamContext abfsosContext) {
+  private static synchronized void initWriteBufferPool(AbfsOutputStreamContext abfsosContext) {
     bufferSize = abfsosContext.getWriteBufferSize();
     int corePoolSize =
         1 + (abfsosContext.getWriteConcurrencyFactor() * Runtime.getRuntime()

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamContext.java
@@ -29,6 +29,10 @@ public class AbfsOutputStreamContext extends AbfsStreamContext {
 
   private boolean disableOutputStreamFlush;
 
+  private int writeConcurrencyFactor;
+
+  private int maxWriteMemoryUsagePercentage;
+
   private AbfsOutputStreamStatistics streamStatistics;
 
   public AbfsOutputStreamContext() {
@@ -57,6 +61,18 @@ public class AbfsOutputStreamContext extends AbfsStreamContext {
     return this;
   }
 
+  public AbfsOutputStreamContext withWriteConcurrencyFactor(
+      final int writeConcurrencyFactor) {
+    this.writeConcurrencyFactor = writeConcurrencyFactor;
+    return this;
+  }
+
+  public AbfsOutputStreamContext withMaxWriteMemoryUsagePercentage(
+      final int maxWriteMemoryUsagePercentage) {
+    this.maxWriteMemoryUsagePercentage = maxWriteMemoryUsagePercentage;
+    return this;
+  }
+
   public AbfsOutputStreamContext build() {
     // Validation of parameters to be done here.
     return this;
@@ -72,6 +88,14 @@ public class AbfsOutputStreamContext extends AbfsStreamContext {
 
   public boolean isDisableOutputStreamFlush() {
     return disableOutputStreamFlush;
+  }
+
+  public int getWriteConcurrencyFactor() {
+    return writeConcurrencyFactor;
+  }
+
+  public int getMaxWriteMemoryUsagePercentage() {
+    return maxWriteMemoryUsagePercentage;
   }
 
   public AbfsOutputStreamStatistics getStreamStatistics() {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsByteBufferPool.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsByteBufferPool.java
@@ -1,0 +1,299 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.lang.Thread.State;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import net.jodah.concurrentunit.Waiter;
+import org.junit.Test;
+
+import static java.lang.Thread.sleep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.core.Is.is;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Test class for AbfsByteBufferPool.
+ */
+public class TestAbfsByteBufferPool {
+
+  private static final int TWO_MB = 2 * 1024 * 1024;
+
+  private static final int MINUS_HUNDRED = -100;
+  private static final int HUNDRED_AND_ONE = 101;
+
+  private static final int MEM_USAGE_PC_20 = 20;
+  private static final int MEM_USAGE_PC_25 = 25;
+  private static final int MEM_USAGE_PC_30 = 30;
+  private static final int MEM_USAGE_PC_90 = 90;
+
+  private static final int SYNC_TEST_THREAD_CATEGORY_COUNT = 4;
+  private static final int SYNC_TEST_THREAD_COUNT_PER_CATEGORY = 4;
+  private static final int SYNC_TEST_VERIFICATION_PER_CATEGORY = 25;
+  private static final int SYNC_TEST_THREAD_POOL_SIZE = 50;
+  private static final int SYNC_TEST_MAX_FREE_BUFFER_COUNT = 4;
+  private static final long SYNC_TEST_WAITER_WAIT_TIME_6000_MS = 6000;
+  private static final long SYNC_TEST_VERIFIER_SLEEP_TIME_50_MS = 50;
+  private static final long SYNC_TEST_NON_VERIFIER_SLEEP_TIME_100_MS = 100;
+
+  private static final int BUFFER_SIZE_2 = 2;
+
+  private static final int QUEUE_CAPACITY_2 = 2;
+  private static final int QUEUE_CAPACITY_3 = 3;
+  private static final int QUEUE_CAPACITY_5 = 5;
+
+  private static final int MAX_FREE_BUFFERS_4 = 4;
+
+  private static final long SLEEP_TIME_5000_MS = 5000;
+
+  @Test
+  public void testWithInvalidMaxWriteMemUsagePercentage() throws Exception {
+    List<Integer> invalidMaxWriteMemUsagePercentageList = Arrays
+        .asList(MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE - 1,
+            MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE + 1, MINUS_HUNDRED,
+            HUNDRED_AND_ONE);
+    for (int val : invalidMaxWriteMemUsagePercentageList) {
+      intercept(IllegalArgumentException.class, String
+              .format("maxWriteMemUsagePercentage should be in range (%s - %s)",
+                  MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+                  MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE),
+          () -> new AbfsByteBufferPool(TWO_MB, QUEUE_CAPACITY_2, val));
+    }
+  }
+
+  @Test
+  public void testWithInvalidMaxFreeBuffers() throws Exception {
+    List<Integer> invalidMaxFreeBuffers = Arrays.asList(0, -1);
+    for (int val : invalidMaxFreeBuffers) {
+      intercept(IllegalArgumentException.class, String
+              .format("queueCapacity cannot be < 1",
+                  MIN_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE,
+                  MAX_VALUE_MAX_AZURE_WRITE_MEM_USAGE_PERCENTAGE),
+          () -> new AbfsByteBufferPool(TWO_MB, val, MEM_USAGE_PC_20));
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReleaseNull() {
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, QUEUE_CAPACITY_5,
+        MEM_USAGE_PC_30);
+    pool.release(null);
+  }
+
+  @Test
+  public void testReleaseMoreThanPoolCapacity() {
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, MAX_FREE_BUFFERS_4,
+        MEM_USAGE_PC_25);
+    int expectedPoolCapacity = MAX_FREE_BUFFERS_4;
+    for (int i = 0; i < expectedPoolCapacity * 2; i++) {
+      pool.release(new byte[TWO_MB]);
+      assertThat(pool.getFreeBuffers()).describedAs(
+          "Pool size should never exceed the expected capacity irrespective "
+              + "of the number of objects released to the pool")
+          .hasSizeLessThanOrEqualTo(expectedPoolCapacity);
+    }
+  }
+
+  @Test
+  public void testReleaseWithSameBufferSize() {
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(BUFFER_SIZE_2,
+        QUEUE_CAPACITY_3, MEM_USAGE_PC_25);
+    pool.release(new byte[BUFFER_SIZE_2]);
+  }
+
+  @Test
+  public void testReleaseWithDifferentBufferSize() throws Exception {
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, QUEUE_CAPACITY_3,
+        MEM_USAGE_PC_25);
+    for (int i = 1; i < 2; i++) {
+      int finalI = i;
+      intercept(IllegalArgumentException.class,
+          String.format("Buffer size has to be %s", TWO_MB),
+          () -> pool.release(new byte[TWO_MB + finalI]));
+      intercept(IllegalArgumentException.class,
+          String.format("Buffer size has to be %s", TWO_MB),
+          () -> pool.release(new byte[TWO_MB - finalI]));
+    }
+  }
+
+  @Test
+  public void testGet() throws Exception {
+    int expectedMaxBuffersInUse =
+        MAX_FREE_BUFFERS_4 + Runtime.getRuntime().availableProcessors();
+    AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB, MAX_FREE_BUFFERS_4,
+        MEM_USAGE_PC_90);
+
+    //  Getting the maximum number of byte arrays from the pool
+    byte[] byteBuffer = null;
+    for (int i = 0; i < expectedMaxBuffersInUse; i++) {
+      byteBuffer = pool.get();
+      assertThat(byteBuffer.length).describedAs("Pool has to return an object "
+          + "immediately, until maximum buffers are in use.").isEqualTo(TWO_MB);
+    }
+
+    //  Already maximum number of buffers are retrieved from the pool so the
+    //  next get call is going to be blocked
+    Thread getThread = new Thread(() -> pool.get());
+    getThread.start();
+    sleep(SLEEP_TIME_5000_MS);
+    assertThat(getThread.getState()).describedAs("When maximum number of "
+        + "buffers are in use and no free buffers available in the pool the "
+        + "get call is blocked until an object is released to the pool.")
+        .isEqualTo(State.WAITING);
+    getThread.interrupt();
+
+    //  Releasing one byte array back to the pool post which the get call we
+    //  are making should not be blocking
+    pool.release(byteBuffer);
+    byteBuffer = null;
+    byteBuffer = pool.get();
+    assertThat(byteBuffer.length).describedAs("Pool has to return an object "
+        + "immediately, if there are free buffers available in the pool.")
+        .isEqualTo(TWO_MB);
+
+    //  Again trying to get one byte buffer from the pool which will be
+    //  blocked as the pool has already dished out the maximum number of byte
+    //  arrays. Then we release another byte array and the blocked get call
+    //  gets unblocked.
+    Callable<byte[]> callable = () -> pool.get();
+    FutureTask futureTask = new FutureTask(callable);
+    getThread = new Thread(futureTask);
+    getThread.start();
+    pool.release(new byte[TWO_MB]);
+    byteBuffer = (byte[]) futureTask.get();
+    assertThat(byteBuffer.length).describedAs("The blocked get call unblocks "
+        + "when an object is released back to the pool.").isEqualTo(TWO_MB);
+  }
+
+  @Test
+  public void testSynchronisation() throws Throwable {
+    final int expectedMaxBuffersInUse =
+        SYNC_TEST_MAX_FREE_BUFFER_COUNT + Runtime.getRuntime()
+            .availableProcessors();
+    final AbfsByteBufferPool pool = new AbfsByteBufferPool(TWO_MB,
+        SYNC_TEST_MAX_FREE_BUFFER_COUNT, MEM_USAGE_PC_90);
+
+    final int totalThreadCount =
+        SYNC_TEST_THREAD_CATEGORY_COUNT * SYNC_TEST_THREAD_COUNT_PER_CATEGORY;
+
+    final LinkedBlockingQueue<byte[]> objsQueue = new LinkedBlockingQueue();
+    final Waiter waiter = new Waiter();
+
+    //  Creating 3 types of runnables
+    //  getter: would make get calls
+    //  releaser: would make release calls
+    //  verifier: will be verifying the conditions
+    final Runnable getter = getNewGetterRunnable(pool, objsQueue, waiter,
+        expectedMaxBuffersInUse, SYNC_TEST_MAX_FREE_BUFFER_COUNT);
+    final Runnable releaser = getNewReleaserRunnable(pool, objsQueue, waiter,
+        expectedMaxBuffersInUse, SYNC_TEST_MAX_FREE_BUFFER_COUNT);
+    final Runnable verifier = getNewVerifierRunnable(pool,
+        expectedMaxBuffersInUse, SYNC_TEST_MAX_FREE_BUFFER_COUNT, waiter);
+
+    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors
+        .newFixedThreadPool(SYNC_TEST_THREAD_POOL_SIZE);
+    for (int i = 0; i < SYNC_TEST_THREAD_COUNT_PER_CATEGORY; i++) {
+      executor.submit(new Thread(getter));
+      executor.submit(new Thread(releaser));
+      executor.submit(new Thread(verifier));
+      executor.submit(new Thread(verifier));
+    }
+    waiter.await(SYNC_TEST_WAITER_WAIT_TIME_6000_MS, totalThreadCount);
+    executor.shutdown();
+  }
+
+  private Runnable getNewGetterRunnable(final AbfsByteBufferPool pool,
+      final LinkedBlockingQueue<byte[]> objsQueue, final Waiter waiter,
+      final int expectedMaxBuffersInUse, final int maxFreeBuffers) {
+    Runnable runnable = () -> {
+      for (int i = 0; i < SYNC_TEST_VERIFICATION_PER_CATEGORY; i++) {
+        verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+        objsQueue.offer(pool.get());
+        verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+        try {
+          sleep(SYNC_TEST_NON_VERIFIER_SLEEP_TIME_100_MS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      waiter.resume();
+    };
+    return runnable;
+  }
+
+  private Runnable getNewReleaserRunnable(final AbfsByteBufferPool pool,
+      final LinkedBlockingQueue<byte[]> objsQueue, final Waiter waiter,
+      final int expectedMaxBuffersInUse, final int maxFreeBuffers) {
+    Runnable runnable = () -> {
+      for (int i = 0; i < SYNC_TEST_VERIFICATION_PER_CATEGORY; i++) {
+        try {
+          verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+          pool.release(objsQueue.take());
+          verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+          sleep(SYNC_TEST_NON_VERIFIER_SLEEP_TIME_100_MS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      waiter.resume();
+    };
+    return runnable;
+  }
+
+  private Runnable getNewVerifierRunnable(final AbfsByteBufferPool pool,
+      final int expectedMaxBuffersInUse, final int maxFreeBuffers,
+      final Waiter waiter) {
+    Runnable runnable = () -> {
+      for (int i = 0; i < SYNC_TEST_VERIFICATION_PER_CATEGORY; i++) {
+        verify(pool, waiter, maxFreeBuffers, expectedMaxBuffersInUse);
+        try {
+          sleep(SYNC_TEST_VERIFIER_SLEEP_TIME_50_MS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      waiter.resume();
+    };
+    return runnable;
+  }
+
+  private void verify(final AbfsByteBufferPool pool, final Waiter waiter,
+      final int maxFreeBuffers, final int expectedMaxBuffersInUse) {
+    waiter.assertThat(pool.getFreeBuffers(), is(notNullValue()));
+    waiter.assertThat(pool.getFreeBuffers().size(),
+        is(lessThanOrEqualTo(maxFreeBuffers)));
+    waiter.assertThat(pool.getBuffersInUse(),
+        is(lessThanOrEqualTo(expectedMaxBuffersInUse)));
+    waiter.assertThat(pool.getBuffersInUse(), is(greaterThanOrEqualTo(0)));
+  }
+
+}


### PR DESCRIPTION
Currently in environments where memory is restricted, It is observed at times a large number of buffers needed for the execution and the same and are kept within the bufferpool for ever this lead to out Of Memory exceptions. 
This change addresses certain improvemnts to AbfsOutputStream which help fix the issue.

- Getting rid of the ElasticByteBufferPool. This actually hold up to the buffers created for ever. No upper bound for the number of buffers that can be contained within the pool. This could lead to high memory consumption.
- A new BufferPool is implemented to over come the shortcomings of ElasticByteBufferPool. For more information find the doc attached with the JIRA.
- Sharing the Threadpool across all the AbfsOutputStream instances.
- Sharing the buffer pool across all the AbfsOutputStream instances

**Driver test results using accounts in Central India**
mvn -T 1C -Dparallel-tests=abfs -Dscale -DtestsThreadCount=8 clean verify

**Account with HNS Support**
[INFO] Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 426, Failures: 0, Errors: 0, Skipped: 66
[WARNING] Tests run: 206, Failures: 0, Errors: 0, Skipped: 24

**Account without HNS support**
[INFO] Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 426, Failures: 0, Errors: 0, Skipped: 240
[WARNING] Tests run: 206, Failures: 0, Errors: 0, Skipped: 24

