### PR TITLE
HDFS-15353. use sudo instead of su to allow nologin user for secure DataNode

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -2051,6 +2051,7 @@ function hadoop_start_secure_daemon_wrapper
     hadoop_error "ERROR: Cannot disconnect ${daemonname} process $!"
   fi
   # capture the ulimit output
+  #shellcheck disable=SC2024
   sudo -u "${HADOOP_SECURE_USER}" bash -c "ulimit -a" >> "${jsvcoutfile}" 2>&1
   #shellcheck disable=SC2086
   if ! ps -p $! >/dev/null 2>&1; then

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -213,7 +213,7 @@ function hadoop_privilege_check
   [[ "${EUID}" = 0 ]]
 }
 
-## @description  Execute a command via su when running as root
+## @description  Execute a command via sudo when running as root
 ## @description  if the given user is found or exit with
 ## @description  failure if not.
 ## @description  otherwise just run it.  (This is intended to
@@ -224,14 +224,14 @@ function hadoop_privilege_check
 ## @param        user
 ## @param        commandstring
 ## @return       exitstatus
-function hadoop_su
+function hadoop_sudo
 {
   declare user=$1
   shift
 
   if hadoop_privilege_check; then
     if hadoop_verify_user_resolves user; then
-       su -l "${user}" -- "$@"
+       sudo -u "${user}" -- "$@"
     else
       hadoop_error "ERROR: Refusing to run as root: ${user} account is not found. Aborting."
       return 1
@@ -241,7 +241,7 @@ function hadoop_su
   fi
 }
 
-## @description  Execute a command via su when running as root
+## @description  Execute a command via sudo when running as root
 ## @description  with extra support for commands that might
 ## @description  legitimately start as root (e.g., datanode)
 ## @description  (This is intended to
@@ -259,7 +259,7 @@ function hadoop_uservar_su
   #
   # if $EUID != 0, then exec
   # if $EUID =0 then
-  #    if hdfs_subcmd_user is defined, call hadoop_su to exec
+  #    if hdfs_subcmd_user is defined, call hadoop_sudo to exec
   #    if hdfs_subcmd_user is not defined, error
   #
   # For secure daemons, this means both the secure and insecure env vars need to be
@@ -283,7 +283,7 @@ function hadoop_uservar_su
     svar=$(hadoop_build_custom_subcmd_var "${program}" "${command}" SECURE_USER)
 
     if [[ -n "${!uvar}" ]]; then
-      hadoop_su "${!uvar}" "$@"
+      hadoop_sudo "${!uvar}" "$@"
     elif [[ -n "${!svar}" ]]; then
       ## if we are here, then SECURE_USER with no USER defined
       ## we are already privileged, so just run the command and hope
@@ -2051,7 +2051,7 @@ function hadoop_start_secure_daemon_wrapper
     hadoop_error "ERROR: Cannot disconnect ${daemonname} process $!"
   fi
   # capture the ulimit output
-  su "${HADOOP_SECURE_USER}" -c 'bash -c "ulimit -a"' >> "${jsvcoutfile}" 2>&1
+  sudo -u "${HADOOP_SECURE_USER}" bash -c "ulimit -a" >> "${jsvcoutfile}" 2>&1
   #shellcheck disable=SC2086
   if ! ps -p $! >/dev/null 2>&1; then
     return 1


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15353

This PR changes privilege escalation from su to sudo in hadoop-functions.sh.
It allows launching secure DataNode by a `--disabled-login`(eg. `/sbin/nologin`) user.