### PR TITLE
HADOOP-17029. Return correct permission and owner for listing on internal directories in ViewFs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1087,7 +1087,6 @@ public class ViewFileSystem extends FileSystem {
     final long creationTime; // of the the mount table
     final UserGroupInformation ugi; // the user/group of user who created mtable
     final URI myUri;
-    final Configuration conf;
     
     public InternalDirOfViewFs(final InodeTree.INodeDir<FileSystem> dir,
         final long cTime, final UserGroupInformation ugi, URI uri,
@@ -1101,7 +1100,6 @@ public class ViewFileSystem extends FileSystem {
       theInternalDir = dir;
       creationTime = cTime;
       this.ugi = ugi;
-      this.conf = config;
     }
 
     static private void checkPathIsSlash(final Path f) throws IOException {
@@ -1205,14 +1203,17 @@ public class ViewFileSystem extends FileSystem {
           // For MERGE or NFLY links, the first target link is considered
           // for fetching the FileStatus with an assumption that the permission
           // and the owner will be the same for all the target directories.
-          FileStatus status = FileSystem.get(link.targetDirLinkList[0], conf)
+          ChRootedFileSystem linkedFs = (ChRootedFileSystem)
+              link.getTargetFileSystem();
+          FileStatus status = linkedFs.getMyFs()
               .getFileStatus(new Path(link.targetDirLinkList[0].toString()));
 
-          result[i++] = new FileStatus(status.getLen(), false, 0, 0,
-              status.getModificationTime(), status.getAccessTime(),
-              status.getPermission(), status.getOwner(), status.getGroup(),
-              link.getTargetLink(),
-              new Path(inode.fullPath).makeQualified(
+          result[i++] = new FileStatus(status.getLen(), false,
+            status.getReplication(), status.getBlockSize(),
+            status.getModificationTime(), status.getAccessTime(),
+            status.getPermission(), status.getOwner(), status.getGroup(),
+            link.getTargetLink(),
+            new Path(inode.fullPath).makeQualified(
                 myUri, null));
         } else {
           result[i++] = new FileStatus(0, true, 0, 0,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1200,14 +1200,9 @@ public class ViewFileSystem extends FileSystem {
         INode<FileSystem> inode = iEntry.getValue();
         if (inode.isLink()) {
           INodeLink<FileSystem> link = (INodeLink<FileSystem>) inode;
-          // For MERGE or NFLY links, the first target link is considered
-          // for fetching the FileStatus with an assumption that the permission
-          // and the owner will be the same for all the target directories.
-          Path linkedPath = new Path(link.targetDirLinkList[0].toString());
-          ChRootedFileSystem linkedFs = (ChRootedFileSystem)
-              link.getTargetFileSystem();
           try {
-            FileStatus status = linkedFs.getMyFs().getFileStatus(linkedPath);
+            FileStatus status = link.getTargetFileSystem()
+                .getFileStatus(new Path("/"));
             result[i++] = new FileStatus(status.getLen(), false,
               status.getReplication(), status.getBlockSize(),
               status.getModificationTime(), status.getAccessTime(),

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1201,8 +1201,10 @@ public class ViewFileSystem extends FileSystem {
         if (inode.isLink()) {
           INodeLink<FileSystem> link = (INodeLink<FileSystem>) inode;
           try {
-            FileStatus status = link.getTargetFileSystem()
-                .getFileStatus(new Path("/"));
+            String linkedPath = link.getTargetFileSystem().getUri().getPath();
+            FileStatus status =
+                ((ChRootedFileSystem)link.getTargetFileSystem())
+                .getMyFs().getFileStatus(new Path(linkedPath));
             result[i++] = new FileStatus(status.getLen(), false,
               status.getReplication(), status.getBlockSize(),
               status.getModificationTime(), status.getAccessTime(),

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1203,18 +1203,26 @@ public class ViewFileSystem extends FileSystem {
           // For MERGE or NFLY links, the first target link is considered
           // for fetching the FileStatus with an assumption that the permission
           // and the owner will be the same for all the target directories.
+          Path linkedPath = new Path(link.targetDirLinkList[0].toString());
           ChRootedFileSystem linkedFs = (ChRootedFileSystem)
               link.getTargetFileSystem();
-          FileStatus status = linkedFs.getMyFs()
-              .getFileStatus(new Path(link.targetDirLinkList[0].toString()));
-
-          result[i++] = new FileStatus(status.getLen(), false,
-            status.getReplication(), status.getBlockSize(),
-            status.getModificationTime(), status.getAccessTime(),
-            status.getPermission(), status.getOwner(), status.getGroup(),
-            link.getTargetLink(),
-            new Path(inode.fullPath).makeQualified(
-                myUri, null));
+          try {
+            FileStatus status = linkedFs.getMyFs().getFileStatus(linkedPath);
+            result[i++] = new FileStatus(status.getLen(), false,
+              status.getReplication(), status.getBlockSize(),
+              status.getModificationTime(), status.getAccessTime(),
+              status.getPermission(), status.getOwner(), status.getGroup(),
+              link.getTargetLink(),
+              new Path(inode.fullPath).makeQualified(
+                  myUri, null));
+          } catch (FileNotFoundException ex) {
+            result[i++] = new FileStatus(0, false, 0, 0,
+              creationTime, creationTime, PERMISSION_555,
+              ugi.getShortUserName(), ugi.getPrimaryGroupName(),
+              link.getTargetLink(),
+              new Path(inode.fullPath).makeQualified(
+                  myUri, null));
+          }
         } else {
           result[i++] = new FileStatus(0, true, 0, 0,
             creationTime, creationTime, PERMISSION_555,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -917,8 +917,13 @@ public class ViewFs extends AbstractFileSystem {
       if (inode.isLink()) {
         INodeLink<AbstractFileSystem> inodelink = 
           (INodeLink<AbstractFileSystem>) inode;
-        result = new FileStatus(0, false, 0, 0, creationTime, creationTime,
-            PERMISSION_555, ugi.getShortUserName(), ugi.getPrimaryGroupName(),
+        ChRootedFs linkedFs = (ChRootedFs) inodelink.getTargetFileSystem();
+        FileStatus status = linkedFs.getMyFs()
+            .getFileStatus(new Path(inodelink.targetDirLinkList[0].toString()));
+        result = new FileStatus(status.getLen(), false,
+            status.getReplication(), status.getBlockSize(),
+            status.getModificationTime(), status.getAccessTime(),
+            status.getPermission(), status.getOwner(), status.getGroup(),
             inodelink.getTargetLink(),
             new Path(inode.fullPath).makeQualified(
                 myUri, null));
@@ -976,9 +981,14 @@ public class ViewFs extends AbstractFileSystem {
           INodeLink<AbstractFileSystem> link = 
             (INodeLink<AbstractFileSystem>) inode;
 
-          result[i++] = new FileStatus(0, false, 0, 0,
-            creationTime, creationTime,
-            PERMISSION_555, ugi.getShortUserName(), ugi.getPrimaryGroupName(),
+          ChRootedFs linkedFs = (ChRootedFs) link.getTargetFileSystem();
+          FileStatus status = linkedFs.getMyFs()
+              .getFileStatus(new Path(link.targetDirLinkList[0].toString()));
+
+          result[i++] = new FileStatus(status.getLen(), false,
+            status.getReplication(), status.getBlockSize(),
+            status.getModificationTime(), status.getAccessTime(),
+            status.getPermission(), status.getOwner(), status.getGroup(),
             link.getTargetLink(),
             new Path(inode.fullPath).makeQualified(
                 myUri, null));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -917,10 +917,9 @@ public class ViewFs extends AbstractFileSystem {
       if (inode.isLink()) {
         INodeLink<AbstractFileSystem> inodelink = 
           (INodeLink<AbstractFileSystem>) inode;
-        Path linkedPath = new Path(inodelink.targetDirLinkList[0].toString());
-        ChRootedFs linkedFs = (ChRootedFs) inodelink.getTargetFileSystem();
         try {
-          FileStatus status = linkedFs.getMyFs().getFileStatus(linkedPath);
+          FileStatus status = inodelink.getTargetFileSystem()
+              .getFileStatus(new Path("/"));
           result = new FileStatus(status.getLen(), false,
             status.getReplication(), status.getBlockSize(),
             status.getModificationTime(), status.getAccessTime(),
@@ -989,10 +988,9 @@ public class ViewFs extends AbstractFileSystem {
           INodeLink<AbstractFileSystem> link = 
             (INodeLink<AbstractFileSystem>) inode;
 
-          Path linkedPath = new Path(link.targetDirLinkList[0].toString());
-          ChRootedFs linkedFs = (ChRootedFs) link.getTargetFileSystem();
           try {
-            FileStatus status = linkedFs.getMyFs().getFileStatus(linkedPath);
+            FileStatus status = link.getTargetFileSystem()
+                .getFileStatus(new Path("/"));
             result[i++] = new FileStatus(status.getLen(), false,
               status.getReplication(), status.getBlockSize(),
               status.getModificationTime(), status.getAccessTime(),

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -918,8 +918,10 @@ public class ViewFs extends AbstractFileSystem {
         INodeLink<AbstractFileSystem> inodelink = 
           (INodeLink<AbstractFileSystem>) inode;
         try {
-          FileStatus status = inodelink.getTargetFileSystem()
-              .getFileStatus(new Path("/"));
+          String linkedPath = inodelink.getTargetFileSystem()
+              .getUri().getPath();
+          FileStatus status = ((ChRootedFs)inodelink.getTargetFileSystem())
+              .getMyFs().getFileStatus(new Path(linkedPath));
           result = new FileStatus(status.getLen(), false,
             status.getReplication(), status.getBlockSize(),
             status.getModificationTime(), status.getAccessTime(),
@@ -989,8 +991,9 @@ public class ViewFs extends AbstractFileSystem {
             (INodeLink<AbstractFileSystem>) inode;
 
           try {
-            FileStatus status = link.getTargetFileSystem()
-                .getFileStatus(new Path("/"));
+            String linkedPath = link.getTargetFileSystem().getUri().getPath();
+            FileStatus status = ((ChRootedFs)link.getTargetFileSystem())
+                .getMyFs().getFileStatus(new Path(linkedPath));
             result[i++] = new FileStatus(status.getLen(), false,
               status.getReplication(), status.getBlockSize(),
               status.getModificationTime(), status.getAccessTime(),

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewfsFileStatus.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewfsFileStatus.java
@@ -32,7 +32,9 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -48,6 +50,17 @@ public class TestViewfsFileStatus {
   private static final File TEST_DIR = GenericTestUtils.getTestDir(
       TestViewfsFileStatus.class.getSimpleName());
 
+  @Before
+  public void setUp() {
+    FileUtil.fullyDelete(TEST_DIR);
+    assertTrue(TEST_DIR.mkdirs());
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    FileUtil.fullyDelete(TEST_DIR);
+  }
+
   @Test
   public void testFileStatusSerialziation()
       throws IOException, URISyntaxException {
@@ -56,38 +69,71 @@ public class TestViewfsFileStatus {
     File infile = new File(TEST_DIR, testfilename);
     final byte[] content = "dingos".getBytes();
 
-    FileOutputStream fos = null;
-    try {
-      fos = new FileOutputStream(infile);
+    try (FileOutputStream fos =  new FileOutputStream(infile)) {
       fos.write(content);
-    } finally {
-      if (fos != null) {
-        fos.close();
-      }
     }
     assertEquals((long)content.length, infile.length());
 
     Configuration conf = new Configuration();
     ConfigUtil.addLink(conf, "/foo/bar/baz", TEST_DIR.toURI());
-    FileSystem vfs = FileSystem.get(FsConstants.VIEWFS_URI, conf);
-    assertEquals(ViewFileSystem.class, vfs.getClass());
-    Path path = new Path("/foo/bar/baz", testfilename);
-    FileStatus stat = vfs.getFileStatus(path);
-    assertEquals(content.length, stat.getLen());
-    ContractTestUtils.assertNotErasureCoded(vfs, path);
-    assertTrue(path + " should have erasure coding unset in " +
-            "FileStatus#toString(): " + stat,
-        stat.toString().contains("isErasureCoded=false"));
+    try (FileSystem vfs = FileSystem.get(FsConstants.VIEWFS_URI, conf)) {
+      assertEquals(ViewFileSystem.class, vfs.getClass());
+      Path path = new Path("/foo/bar/baz", testfilename);
+      FileStatus stat = vfs.getFileStatus(path);
+      assertEquals(content.length, stat.getLen());
+      ContractTestUtils.assertNotErasureCoded(vfs, path);
+      assertTrue(path + " should have erasure coding unset in " +
+          "FileStatus#toString(): " + stat,
+          stat.toString().contains("isErasureCoded=false"));
 
-    // check serialization/deserialization
-    DataOutputBuffer dob = new DataOutputBuffer();
-    stat.write(dob);
-    DataInputBuffer dib = new DataInputBuffer();
-    dib.reset(dob.getData(), 0, dob.getLength());
-    FileStatus deSer = new FileStatus();
-    deSer.readFields(dib);
-    assertEquals(content.length, deSer.getLen());
-    assertFalse(deSer.isErasureCoded());
+      // check serialization/deserialization
+      DataOutputBuffer dob = new DataOutputBuffer();
+      stat.write(dob);
+      DataInputBuffer dib = new DataInputBuffer();
+      dib.reset(dob.getData(), 0, dob.getLength());
+      FileStatus deSer = new FileStatus();
+      deSer.readFields(dib);
+      assertEquals(content.length, deSer.getLen());
+      assertFalse(deSer.isErasureCoded());
+    }
+  }
+
+  @Test
+  public void testListStatusACL()
+      throws IOException, URISyntaxException {
+    String testfilename = "testFileACL";
+    String childDirectoryName = "testDirectoryACL";
+    TEST_DIR.mkdirs();
+    File infile = new File(TEST_DIR, testfilename);
+    final byte[] content = "dingos".getBytes();
+
+    try (FileOutputStream fos =  new FileOutputStream(infile)) {
+      fos.write(content);
+    }
+    assertEquals((long)content.length, infile.length());
+    File childDir = new File(TEST_DIR, childDirectoryName);
+    childDir.mkdirs();
+
+    Configuration conf = new Configuration();
+    ConfigUtil.addLink(conf, "/file", infile.toURI());
+    ConfigUtil.addLink(conf, "/dir", childDir.toURI());
+
+    try (FileSystem vfs = FileSystem.get(FsConstants.VIEWFS_URI, conf)) {
+      assertEquals(ViewFileSystem.class, vfs.getClass());
+      FileStatus[] statuses = vfs.listStatus(new Path("/"));
+
+      FileSystem localFs = FileSystem.getLocal(conf);
+      FileStatus fileStat = localFs.getFileStatus(new Path(infile.getPath()));
+      FileStatus dirStat = localFs.getFileStatus(new Path(childDir.getPath()));
+
+      for (FileStatus status : statuses) {
+        if (status.getPath().getName().equals("file")) {
+          assertEquals(fileStat.getPermission(), status.getPermission());
+        } else {
+          assertEquals(dirStat.getPermission(), status.getPermission());
+        }
+      }
+    }
   }
 
   // Tests that ViewFileSystem.getFileChecksum calls res.targetFileSystem


### PR DESCRIPTION
[HADOOP-17029](https://issues.apache.org/jira/browse/HADOOP-17029). ViewFS does not return correct user/group and ACL