### PR TITLE
HADOOP-17049. javax.activation-api and jakarta.activation-api define overlapping classes

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -385,7 +385,7 @@ com.google.protobuf:protobuf-java:3.6.1
 com.google.re2j:re2j:1.1
 com.jcraft:jsch:0.1.54
 com.thoughtworks.paranamer:paranamer:2.3
-javax.activation:javax.activation-api:1.2.0
+jakarta.activation:jakarta.activation-api:1.2.1
 org.fusesource.leveldbjni:leveldbjni-all:1.8
 org.jline:jline:3.9.0
 org.hamcrest:hamcrest-core:1.3

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -94,8 +94,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>javax.activation-api</artifactId>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/hadoop-common-project/hadoop-common/src/main/resources/org.apache.hadoop.application-classloader.properties
+++ b/hadoop-common-project/hadoop-common/src/main/resources/org.apache.hadoop.application-classloader.properties
@@ -19,7 +19,7 @@
 # contains key properties for setting up the application classloader
 system.classes.default=java.,\
   javax.accessibility.,\
-  javax.activation.,\
+  -javax.activation.,\
   javax.activity.,\
   javax.annotation.,\
   javax.annotation.processing.,\

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1696,9 +1696,9 @@
         <version>1.0.13</version>
       </dependency>
       <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>javax.activation-api</artifactId>
-        <version>1.2.0</version>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>1.2.1</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17049

Remove javax.activation-api from dependency.