### PR TITLE
HADOOP-17054. ABFS: Fix test AbfsClient authentication instance

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -246,6 +246,9 @@ public final class TestAbfsClient {
       AbfsClient baseAbfsClientInstance,
       AbfsConfiguration abfsConfig)
       throws AzureBlobFileSystemException {
+    AuthType currentAuthType = abfsConfig.getAuthType(
+        abfsConfig.getAccountName());
+
     AbfsPerfTracker tracker = new AbfsPerfTracker("test",
         abfsConfig.getAccountName(),
         abfsConfig);
@@ -253,8 +256,7 @@ public final class TestAbfsClient {
     // Create test AbfsClient
     AbfsClient testClient = new AbfsClient(
         baseAbfsClientInstance.getBaseUrl(),
-        ((abfsConfig.getAuthType(abfsConfig.getAccountName())
-            == AuthType.SharedKey) ?
+        (currentAuthType == AuthType.SharedKey ?
             new SharedKeyCredentials(
                 abfsConfig.getAccountName().substring(0,
                     abfsConfig.getAccountName().indexOf(DOT)),
@@ -262,8 +264,8 @@ public final class TestAbfsClient {
             : null),
         abfsConfig,
         new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()),
-        ((abfsConfig.getAuthType(abfsConfig.getAccountName())
-            == AuthType.OAuth) ? abfsConfig.getTokenProvider() : null),
+        (currentAuthType == AuthType.OAuth ? abfsConfig.getTokenProvider()
+            : null),
         tracker);
 
     return testClient;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -256,15 +256,16 @@ public final class TestAbfsClient {
     // Create test AbfsClient
     AbfsClient testClient = new AbfsClient(
         baseAbfsClientInstance.getBaseUrl(),
-        (currentAuthType == AuthType.SharedKey ?
-            new SharedKeyCredentials(
-                abfsConfig.getAccountName().substring(0,
-                    abfsConfig.getAccountName().indexOf(DOT)),
-                abfsConfig.getStorageAccountKey())
+        (currentAuthType == AuthType.SharedKey
+            ? new SharedKeyCredentials(
+            abfsConfig.getAccountName().substring(0,
+                abfsConfig.getAccountName().indexOf(DOT)),
+            abfsConfig.getStorageAccountKey())
             : null),
         abfsConfig,
         new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()),
-        (currentAuthType == AuthType.OAuth ? abfsConfig.getTokenProvider()
+        (currentAuthType == AuthType.OAuth
+            ? abfsConfig.getTokenProvider()
             : null),
         tracker);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -246,21 +246,26 @@ public final class TestAbfsClient {
       AbfsClient baseAbfsClientInstance,
       AbfsConfiguration abfsConfig)
       throws AzureBlobFileSystemException {
-      AbfsPerfTracker tracker = new AbfsPerfTracker("test",
-          abfsConfig.getAccountName(),
-          abfsConfig);
+    AbfsPerfTracker tracker = new AbfsPerfTracker("test",
+        abfsConfig.getAccountName(),
+        abfsConfig);
 
-      // Create test AbfsClient
-      AbfsClient testClient = new AbfsClient(
-          baseAbfsClientInstance.getBaseUrl(),
-          new SharedKeyCredentials(abfsConfig.getAccountName().substring(0,
-              abfsConfig.getAccountName().indexOf(DOT)),
-              abfsConfig.getStorageAccountKey()),
-          abfsConfig,
-          new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()),
-          abfsConfig.getTokenProvider(),
-          tracker);
+    // Create test AbfsClient
+    AbfsClient testClient = new AbfsClient(
+        baseAbfsClientInstance.getBaseUrl(),
+        ((abfsConfig.getAuthType(abfsConfig.getAccountName())
+            == AuthType.SharedKey) ?
+            new SharedKeyCredentials(
+                abfsConfig.getAccountName().substring(0,
+                    abfsConfig.getAccountName().indexOf(DOT)),
+                abfsConfig.getStorageAccountKey())
+            : null),
+        abfsConfig,
+        new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()),
+        ((abfsConfig.getAuthType(abfsConfig.getAccountName())
+            == AuthType.OAuth) ? abfsConfig.getTokenProvider() : null),
+        tracker);
 
-      return testClient;
-    }
+    return testClient;
+  }
 }


### PR DESCRIPTION
Idempotency related tests added as part of 
https://issues.apache.org/jira/browse/HADOOP-17015
create a test AbfsClient instance. This mock instance wrongly accepts valid sharedKey and oauth token provider instance instead of only one. This leads to test failures with exception message : 
"Invalid auth type: SharedKey is being used, expecting OAuth"

