### PR TITLE
HADOOP-hdfs-native-client. Fix a typo in fuse options struct for compile

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_options.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_options.c
@@ -18,6 +18,7 @@
 
 #include "fuse_context_handle.h"
 #include "fuse_dfs.h"
+#define __FUSE_OPTIONS_STRUCT__
 #include "fuse_options.h"
 
 #include <getopt.h>

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_options.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_options.h
@@ -20,6 +20,10 @@
 #define __FUSE_OPTIONS_H__
 
 /** options for fuse_opt.h */
+#ifndef __FUSE_OPTIONS_STRUCT__
+#define __FUSE_OPTIONS_STRUCT__
+extern
+#endif
 struct options {
   char* protected;
   char* nn_uri;


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
