### PR TITLE
YARN-10302. make node comparator configurable

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -103,6 +103,8 @@ import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -188,8 +190,7 @@ public class FairScheduler extends
   @Deprecated
   protected volatile int continuousSchedulingSleepMs;
   // Node available resource comparator
-  private Comparator<FSSchedulerNode> nodeAvailableResourceComparator =
-          new NodeAvailableResourceComparator();
+  private Comparator<FSSchedulerNode> nodeAvailableResourceComparator;
   protected double nodeLocalityThreshold; // Cluster threshold for node locality
   protected double rackLocalityThreshold; // Cluster threshold for rack locality
   @Deprecated
@@ -292,6 +293,28 @@ public class FairScheduler extends
           + " allocation configuration: "
           + FairSchedulerConfiguration.RM_SCHEDULER_INCREMENT_ALLOCATION_VCORES
           + "=" + incrementVcore + ". Values must be greater than 0.");
+    }
+  }
+
+  private Comparator<FSSchedulerNode> initNodeComparator(FairSchedulerConfiguration config) {
+    Class<?> nodeComparatorClass = config.getNodeComparatorClass();
+    if (!Comparator.class.isAssignableFrom(nodeComparatorClass)) {
+      throw new YarnRuntimeException("Class: " + nodeComparatorClass.getCanonicalName()
+          + " not instance of " + Comparator.class.getCanonicalName() + "<FSSchedulerNode>");
+    }
+
+    try {
+      try {
+        Constructor constructor = nodeComparatorClass.getDeclaredConstructor(FairScheduler.class);
+        constructor.setAccessible(true);
+        return (Comparator<FSSchedulerNode>) constructor.newInstance(this);
+      } catch (NoSuchMethodException e) {
+        // constructor doesn't exist, use default
+        return (Comparator<FSSchedulerNode>) nodeComparatorClass.newInstance();
+      }
+    } catch (ClassCastException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new YarnRuntimeException(
+          "Could not create instance of class: " + nodeComparatorClass.getCanonicalName(), e);
     }
   }
 
@@ -1054,12 +1077,12 @@ public class FairScheduler extends
   }
 
   /** Sort nodes by available resource */
-  private class NodeAvailableResourceComparator
+  protected static class NodeAvailableResourceComparator
       implements Comparator<FSSchedulerNode> {
 
     @Override
     public int compare(FSSchedulerNode n1, FSSchedulerNode n2) {
-      return RESOURCE_CALCULATOR.compare(getClusterResource(),
+      return RESOURCE_CALCULATOR.compare(null, // unused by DefaultResourceCalculator
           n2.getUnallocatedResource(),
           n1.getUnallocatedResource());
     }
@@ -1432,6 +1455,7 @@ public class FairScheduler extends
       sizeBasedWeight = this.conf.getSizeBasedWeight();
       usePortForNodeName = this.conf.getUsePortForNodeName();
       reservableNodesRatio = this.conf.getReservableNodes();
+      nodeAvailableResourceComparator = initNodeComparator(this.conf);
 
       updateInterval = this.conf.getUpdateInterval();
       if (updateInterval < 0) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairSchedulerConfiguration.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -250,6 +251,8 @@ public class FairSchedulerConfiguration extends Configuration {
    */
   private static final String RESOURCES_WITH_SPACES_PATTERN =
       "-?\\d+(?:\\.\\d*)?\\s*[a-z]+\\s*";
+
+  public static final String NODE_COMPARATOR_CLASS = CONF_PREFIX + "node.comparator.class";
 
   public FairSchedulerConfiguration() {
     super();
@@ -756,5 +759,14 @@ public class FairSchedulerConfiguration extends Configuration {
       }
     }
     throw new AllocationConfigurationException("Missing resource: " + resource);
+  }
+
+  protected Class<?> getNodeComparatorClass() {
+    try {
+      return getClassByName(get(NODE_COMPARATOR_CLASS,
+          "org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler$NodeAvailableResourceComparator"));
+    } catch (ClassNotFoundException e) {
+      throw new YarnRuntimeException("Could not find class for " + NODE_COMPARATOR_CLASS);
+    }
   }
 }


### PR DESCRIPTION
Add `yarn.scheduler.fair.node.comparator.class` config to control the `FairScheduler` node comparator.
