### PR TITLE
HADOOP-17056. shelldoc fails in hadoop-common.

### DIFF
--- a/dev-support/bin/yetus-wrapper
+++ b/dev-support/bin/yetus-wrapper
@@ -144,7 +144,7 @@ else
   exit 1
 fi
 
-if [[ -n "${GPGBIN}" ]]; then
+if [[ -n "${GPGBIN}" && ! "${HADOOP_SKIP_YETUS_VERIFICATION}" = true ]]; then
   if ! mkdir -p .gpg; then
     yetus_error "ERROR: yetus-dl: Unable to create ${HADOOP_PATCHPROCESS}/.gpg"
     exit 1

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -183,6 +183,9 @@ RUN curl -L -s -S \
 ###
 ENV MAVEN_OPTS -Xms256m -Xmx1536m
 
+# Skip gpg verification when downlonading Yetus via yetus-wrapper
+ENV HADOOP_SKIP_YETUS_VERIFICATION true
+
 ###
 # Everything past this point is either not needed for testing or breaks Yetus.
 # So tell Yetus not to read the rest of the file:

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -218,6 +218,9 @@ RUN mkdir -p /opt/phantomjs \
 ###
 ENV MAVEN_OPTS -Xms256m -Xmx1536m
 
+# Skip gpg verification when downlonading Yetus via yetus-wrapper
+ENV HADOOP_SKIP_YETUS_VERIFICATION true
+
 ###
 # Everything past this point is either not needed for testing or breaks Yetus.
 # So tell Yetus not to read the rest of the file:


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17056

Skip GPG verification in the docker build image.