### PR TITLE
HDFS-15408. Add a new parameter to control the timeout properties of Connection in case that the command ‘hdfs fsck’ would failed with SocketTimeoutException.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1493,6 +1493,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final boolean DFS_PROTECTED_SUBDIRECTORIES_ENABLE_DEFAULT =
       false;
 
+  public static final String DFS_FSCK_HTTP_TIMEOUT_KEY = "dfs.fsck.http.timeout.ms";
+  public static final String DFS_FSCK_HTTP_TIMEOUT_KEY_DEFAULT = 60000;
+
   // dfs.client.retry confs are moved to HdfsClientConfigKeys.Retry
   @Deprecated
   public static final String  DFS_CLIENT_RETRY_POLICY_ENABLED_KEY

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
@@ -137,9 +137,20 @@ public class DFSck extends Configured implements Tool {
     super(conf);
     this.ugi = UserGroupInformation.getCurrentUser();
     this.out = out;
+    int httpTimeOut = getHttpTimeOut(conf);
     this.connectionFactory = URLConnectionFactory
-        .newDefaultURLConnectionFactory(conf);
+            .newDefaultURLConnectionFactory(httpTimeOut, httpTimeOut, conf);
     this.isSpnegoEnabled = UserGroupInformation.isSecurityEnabled();
+  }
+
+  /**
+   *  try to get httpTimeOut parameter from conf
+   */
+  private int getHttpTimeOut(Configuration conf) {
+    int httpTimeOut = conf.getInt(
+            DFSConfigKeys.DFS_FSCK_HTTP_TIMEOUT_KEY,
+            DFSConfigKeys.DFS_FSCK_HTTP_TIMEOUT_KEY_DEFAULT);
+    return httpTimeOut <= 0 ? DFSConfigKeys.DFS_FSCK_HTTP_TIMEOUT_KEY_DEFAULT : httpTimeOut;
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15408