### PR TITLE
HADOOP-16998 WASB : NativeAzureFsOutputStream#close() throwing java.l…

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
@@ -22,11 +22,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
  * Support the Syncable interface on top of a DataOutputStream.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
@@ -22,11 +22,12 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.fs.StreamCapabilities;
-import org.apache.hadoop.fs.Syncable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.Syncable;
+import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
  * Support the Syncable interface on top of a DataOutputStream.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
@@ -34,6 +36,8 @@ import org.apache.hadoop.classification.InterfaceAudience;
  */
 public class SyncableDataOutputStream extends DataOutputStream
     implements Syncable, StreamCapabilities {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SyncableDataOutputStream.class);
 
   public SyncableDataOutputStream(OutputStream out) {
     super(out);
@@ -68,6 +72,36 @@ public class SyncableDataOutputStream extends DataOutputStream
   public void hsync() throws IOException {
     if (out instanceof Syncable) {
       ((Syncable) out).hsync();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    IOException ioeFromFlush = null;
+    try {
+      flush();
+    } catch (IOException e) {
+      ioeFromFlush = e;
+      throw e;
+    } finally {
+      try {
+        this.out.close();
+      } catch (IOException e) {
+        // If there was an Exception during flush(), the Azure SDK will throw back the
+        // same when we call close on the same stream. When try and finally both throw
+        // Exception, Java will use Throwable#addSuppressed for one of the Exception so
+        // that the caller will get one exception back. When within this, if both
+        // Exceptions are equal, it will throw back IllegalStateException. This makes us
+        // to throw back a non IOE. The below special handling is to avoid this.
+        if (ioeFromFlush == e) {
+          // Do nothing..
+          // The close() call gave back the same IOE which flush() gave. Just swallow it
+          LOG.debug("flush() and close() throwing back same Exception. Just swallowing the latter", e);
+        } else {
+          // Let Java handle 2 different Exceptions been thrown from try and finally.
+          throw e;
+        }
+      }
     }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SyncableDataOutputStream.java
@@ -25,9 +25,9 @@ import java.io.OutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
-import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
  * Support the Syncable interface on top of a DataOutputStream.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
@@ -17,11 +17,10 @@
  */
 package org.apache.hadoop.fs.azure;
 
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.Test;
 
 public class TestSyncableDataOutputStream {
@@ -31,11 +30,13 @@ public class TestSyncableDataOutputStream {
     MockOutputStream out = new MockOutputStream();
     SyncableDataOutputStream sdos = new SyncableDataOutputStream(out);
     out.flushThrowIOE = true;
-    try {
-      sdos.close();
-      fail("Expecting IOE");
-    } catch (IOException e) {
-    }
+    LambdaTestUtils.intercept(IOException.class, "An IOE from flush", () -> sdos.close());
+    MockOutputStream out2 = new MockOutputStream();
+    out2.flushThrowIOE = true;
+    LambdaTestUtils.intercept(IOException.class, "An IOE from flush", () -> {
+      try (SyncableDataOutputStream sdos2 = new SyncableDataOutputStream(out2)) {
+      }
+    });
   }
 
   private static class MockOutputStream extends OutputStream {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import org.apache.hadoop.test.LambdaTestUtils;
+
 import org.junit.Test;
 
 public class TestSyncableDataOutputStream {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.azure;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.Test;
+
+public class TestSyncableDataOutputStream {
+
+  @Test
+  public void testCloseWhenFlushThrowingIOException() throws Exception {
+    MockOutputStream out = new MockOutputStream();
+    SyncableDataOutputStream sdos = new SyncableDataOutputStream(out);
+    out.flushThrowIOE = true;
+    try {
+      sdos.close();
+      fail("Expecting IOE");
+    } catch (IOException e) {
+    }
+  }
+
+  private static class MockOutputStream extends OutputStream {
+
+    boolean flushThrowIOE = false;
+    private IOException lastException = null;
+
+    @Override
+    public void write(int arg0) throws IOException {
+
+    }
+
+    @Override
+    public void flush() throws IOException {
+      if (this.flushThrowIOE) {
+        this.lastException = new IOException("An IOE from flush");
+        throw this.lastException;
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (this.lastException != null) {
+        throw this.lastException;
+      }
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
@@ -41,7 +41,7 @@ public class TestSyncableDataOutputStream {
 
   private static class MockOutputStream extends OutputStream {
 
-    boolean flushThrowIOE = false;
+    private boolean flushThrowIOE = false;
     private IOException lastException = null;
 
     @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
@@ -20,9 +20,9 @@ package org.apache.hadoop.fs.azure;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.hadoop.test.LambdaTestUtils;
-
 import org.junit.Test;
+
+import org.apache.hadoop.test.LambdaTestUtils;
 
 public class TestSyncableDataOutputStream {
 


### PR DESCRIPTION
…ang.IllegalArgumentException instead of IOE which causes HBase RS to get aborted.
