### PR TITLE
HADOOP-17079. Optimize UGI#getGroups by adding UGI#getGroupsSet.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -2695,7 +2695,7 @@ public abstract class FileSystem extends Configured
       if (perm.getUserAction().implies(mode)) {
         return;
       }
-    } else if (ugi.getGroups().contains(stat.getGroup())) {
+    } else if (ugi.getGroupsSet().contains(stat.getGroup())) {
       if (perm.getGroupAction().implies(mode)) {
         return;
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SecureIOUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SecureIOUtils.java
@@ -272,7 +272,7 @@ public class SecureIOUtils {
             UserGroupInformation.createRemoteUser(expectedOwner);
         final String adminsGroupString = "Administrators";
         success = owner.equals(adminsGroupString)
-            && ugi.getGroups().contains(adminsGroupString);
+            && ugi.getGroupsSet().contains(adminsGroupString);
       } else {
         success = false;
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/CompositeGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/CompositeGroupsMapping.java
@@ -120,9 +120,11 @@ public class CompositeGroupsMapping
             user, provider.getClass().getSimpleName(), e.toString());
         LOG.debug("Stacktrace: ", e);
       }
-      if (groups != null && ! groups.isEmpty()) {
+      if (groups != null && !groups.isEmpty()) {
         groupSet.addAll(groups);
-        if (!combined) break;
+        if (!combined) {
+          break;
+        }
       }
     }
     return groupSet;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/CompositeGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/CompositeGroupsMapping.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.security;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -104,6 +105,27 @@ public class CompositeGroupsMapping
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
     // does nothing in this provider of user to groups mapping
+  }
+
+  @Override
+  public synchronized Set<String> getGroupsSet(String user) throws IOException {
+    Set<String> groupSet = new HashSet<String>();
+
+    Set<String> groups = null;
+    for (GroupMappingServiceProvider provider : providersList) {
+      try {
+        groups = provider.getGroupsSet(user);
+      } catch (Exception e) {
+        LOG.warn("Unable to get groups for user {} via {} because: {}",
+            user, provider.getClass().getSimpleName(), e.toString());
+        LOG.debug("Stacktrace: ", e);
+      }
+      if (groups != null && ! groups.isEmpty()) {
+        groupSet.addAll(groups);
+        if (!combined) break;
+      }
+    }
+    return groupSet;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/GroupMappingServiceProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/GroupMappingServiceProvider.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.security;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -52,4 +53,13 @@ public interface GroupMappingServiceProvider {
    * @throws IOException
    */
   public void cacheGroupsAdd(List<String> groups) throws IOException;
+
+  /**
+   * Get all various group memberships of a given user.
+   * Returns EMPTY set in case of non-existing user
+   * @param user User's name
+   * @return set of group memberships of user
+   * @throws IOException
+   */
+  public Set<String> getGroupsSet(String user) throws IOException;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/GroupMappingServiceProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/GroupMappingServiceProvider.java
@@ -61,5 +61,5 @@ public interface GroupMappingServiceProvider {
    * @return set of group memberships of user
    * @throws IOException
    */
-  public Set<String> getGroupsSet(String user) throws IOException;
+  Set<String> getGroupsSet(String user) throws IOException;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -242,7 +242,7 @@ public class Groups {
     if (staticUserToGroupsMap != null) {
       Set<String> staticMapping = staticUserToGroupsMap.get(user);
       if (staticMapping != null) {
-        return Collections.unmodifiableSet(staticMapping);
+        return staticMapping;
       }
     }
 
@@ -417,7 +417,7 @@ public class Groups {
         LOG.warn("Potential performance problem: getGroups(user=" + user +") " +
           "took " + deltaMs + " milliseconds.");
       }
-      return Collections.unmodifiableSet(groups);
+      return groups;
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -383,14 +383,11 @@ public class Groups {
 
       backgroundRefreshQueued.incrementAndGet();
       ListenableFuture<Set<String>> listenableFuture =
-          executorService.submit(new Callable<Set<String>>() {
-            @Override
-            public Set<String> call() throws Exception {
-              backgroundRefreshQueued.decrementAndGet();
-              backgroundRefreshRunning.incrementAndGet();
-              Set<String> results = load(key);
-              return results;
-            }
+          executorService.submit(() -> {
+            backgroundRefreshQueued.decrementAndGet();
+            backgroundRefreshRunning.incrementAndGet();
+            Set<String> results = load(key);
+            return results;
           });
       Futures.addCallback(listenableFuture, new FutureCallback<Set<String>>() {
         @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -78,8 +78,8 @@ public class Groups {
   
   private final GroupMappingServiceProvider impl;
 
-  private final LoadingCache<String, List<String>> cache;
-  private final AtomicReference<Map<String, List<String>>> staticMapRef =
+  private final LoadingCache<String, Set<String>> cache;
+  private final AtomicReference<Map<String, Set<String>>> staticMapRef =
       new AtomicReference<>();
   private final long cacheTimeout;
   private final long negativeCacheTimeout;
@@ -168,8 +168,8 @@ public class Groups {
         CommonConfigurationKeys.HADOOP_USER_GROUP_STATIC_OVERRIDES_DEFAULT);
     Collection<String> mappings = StringUtils.getStringCollection(
         staticMapping, ";");
-    Map<String, List<String>> staticUserToGroupsMap =
-        new HashMap<String, List<String>>();
+    Map<String, Set<String>> staticUserToGroupsMap =
+        new HashMap<>();
     for (String users : mappings) {
       Collection<String> userToGroups = StringUtils.getStringCollection(users,
           "=");
@@ -181,10 +181,10 @@ public class Groups {
       String[] userToGroupsArray = userToGroups.toArray(new String[userToGroups
           .size()]);
       String user = userToGroupsArray[0];
-      List<String> groups = Collections.emptyList();
+      Set<String> groups = Collections.emptySet();
       if (userToGroupsArray.length == 2) {
-        groups = (List<String>) StringUtils
-            .getStringCollection(userToGroupsArray[1]);
+        groups = new LinkedHashSet(StringUtils
+            .getStringCollection(userToGroupsArray[1]));
       }
       staticUserToGroupsMap.put(user, groups);
     }
@@ -203,17 +203,47 @@ public class Groups {
   /**
    * Get the group memberships of a given user.
    * If the user's group is not cached, this method may block.
+   * Note this method can be expensive as it involves Set->List conversion.
+   * For user with large group membership (i.e., > 1000 groups), we recommend
+   * using getGroupSet to avoid the conversion and fast membership look up via
+   * contains().
    * @param user User's name
-   * @return the group memberships of the user
+   * @return the group memberships of the user as list
    * @throws IOException if user does not exist
    */
   public List<String> getGroups(final String user) throws IOException {
+    return Collections.unmodifiableList(new ArrayList<>(
+        getGroupInternal(user)));
+  }
+
+  /**
+   * Get the group memberships of a given user.
+   * If the user's group is not cached, this method may block.
+   * This provide better performance when user has large group membership via
+   * 1) avoid set->list->set conversion for the caller UGI/PermissionCheck
+   * 2) fast lookup using contains() via Set instead of List
+   * @param user User's name
+   * @return the group memberships of the user as set
+   * @throws IOException if user does not exist
+   */
+  public Set<String> getGroupsSet(final String user) throws IOException {
+    return Collections.unmodifiableSet(getGroupInternal(user));
+  }
+
+  /**
+   * Get the group memberships of a given user.
+   * If the user's group is not cached, this method may block.
+   * @param user User's name
+   * @return the group memberships of the user as Set
+   * @throws IOException if user does not exist
+   */
+  private Set<String> getGroupInternal(final String user) throws IOException {
     // No need to lookup for groups of static users
-    Map<String, List<String>> staticUserToGroupsMap = staticMapRef.get();
+    Map<String, Set<String>> staticUserToGroupsMap = staticMapRef.get();
     if (staticUserToGroupsMap != null) {
-      List<String> staticMapping = staticUserToGroupsMap.get(user);
+      Set<String> staticMapping = staticUserToGroupsMap.get(user);
       if (staticMapping != null) {
-        return staticMapping;
+        return Collections.unmodifiableSet(staticMapping);
       }
     }
 
@@ -267,7 +297,7 @@ public class Groups {
   /**
    * Deals with loading data into the cache.
    */
-  private class GroupCacheLoader extends CacheLoader<String, List<String>> {
+  private class GroupCacheLoader extends CacheLoader<String, Set<String>> {
 
     private ListeningExecutorService executorService;
 
@@ -308,7 +338,7 @@ public class Groups {
      * @throws IOException to prevent caching negative entries
      */
     @Override
-    public List<String> load(String user) throws Exception {
+    public Set<String> load(String user) throws Exception {
       LOG.debug("GroupCacheLoader - load.");
       TraceScope scope = null;
       Tracer tracer = Tracer.curThreadTracer();
@@ -316,9 +346,9 @@ public class Groups {
         scope = tracer.newScope("Groups#fetchGroupList");
         scope.addKVAnnotation("user", user);
       }
-      List<String> groups = null;
+      Set<String> groups = null;
       try {
-        groups = fetchGroupList(user);
+        groups = fetchGroupSet(user);
       } finally {
         if (scope != null) {
           scope.close();
@@ -334,9 +364,7 @@ public class Groups {
         throw noGroupsForUser(user);
       }
 
-      // return immutable de-duped list
-      return Collections.unmodifiableList(
-          new ArrayList<>(new LinkedHashSet<>(groups)));
+      return groups;
     }
 
     /**
@@ -345,8 +373,8 @@ public class Groups {
      * implementation, otherwise is arranges for the cache to be updated later
      */
     @Override
-    public ListenableFuture<List<String>> reload(final String key,
-                                                 List<String> oldValue)
+    public ListenableFuture<Set<String>> reload(final String key,
+                                                 Set<String> oldValue)
         throws Exception {
       LOG.debug("GroupCacheLoader - reload (async).");
       if (!reloadGroupsInBackground) {
@@ -354,19 +382,19 @@ public class Groups {
       }
 
       backgroundRefreshQueued.incrementAndGet();
-      ListenableFuture<List<String>> listenableFuture =
-          executorService.submit(new Callable<List<String>>() {
+      ListenableFuture<Set<String>> listenableFuture =
+          executorService.submit(new Callable<Set<String>>() {
             @Override
-            public List<String> call() throws Exception {
+            public Set<String> call() throws Exception {
               backgroundRefreshQueued.decrementAndGet();
               backgroundRefreshRunning.incrementAndGet();
-              List<String> results = load(key);
+              Set<String> results = load(key);
               return results;
             }
           });
-      Futures.addCallback(listenableFuture, new FutureCallback<List<String>>() {
+      Futures.addCallback(listenableFuture, new FutureCallback<Set<String>>() {
         @Override
-        public void onSuccess(List<String> result) {
+        public void onSuccess(Set<String> result) {
           backgroundRefreshSuccess.incrementAndGet();
           backgroundRefreshRunning.decrementAndGet();
         }
@@ -380,11 +408,12 @@ public class Groups {
     }
 
     /**
-     * Queries impl for groups belonging to the user. This could involve I/O and take awhile.
+     * Queries impl for groups belonging to the user.
+     * This could involve I/O and take awhile.
      */
-    private List<String> fetchGroupList(String user) throws IOException {
+    private Set<String> fetchGroupSet(String user) throws IOException {
       long startMs = timer.monotonicNow();
-      List<String> groupList = impl.getGroups(user);
+      Set<String> groups = impl.getGroupsSet(user);
       long endMs = timer.monotonicNow();
       long deltaMs = endMs - startMs ;
       UserGroupInformation.metrics.addGetGroups(deltaMs);
@@ -392,8 +421,7 @@ public class Groups {
         LOG.warn("Potential performance problem: getGroups(user=" + user +") " +
           "took " + deltaMs + " milliseconds.");
       }
-
-      return groupList;
+      return Collections.unmodifiableSet(groups);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -167,8 +167,7 @@ public class Groups {
         CommonConfigurationKeys.HADOOP_USER_GROUP_STATIC_OVERRIDES_DEFAULT);
     Collection<String> mappings = StringUtils.getStringCollection(
         staticMapping, ";");
-    Map<String, Set<String>> staticUserToGroupsMap =
-        new HashMap<>();
+    Map<String, Set<String>> staticUserToGroupsMap = new HashMap<>();
     for (String users : mappings) {
       Collection<String> userToGroups = StringUtils.getStringCollection(users,
           "=");
@@ -209,7 +208,9 @@ public class Groups {
    * @param user User's name
    * @return the group memberships of the user as list
    * @throws IOException if user does not exist
+   * @deprecated Use {@link #getGroupsSet(String user)} instead.
    */
+  @Deprecated
   public List<String> getGroups(final String user) throws IOException {
     return Collections.unmodifiableList(new ArrayList<>(
         getGroupInternal(user)));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsMapping.java
@@ -19,7 +19,10 @@
 package org.apache.hadoop.security;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.classification.InterfaceAudience;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsMapping.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.security;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -75,6 +75,18 @@ public class JniBasedUnixGroupsMapping implements GroupMappingServiceProvider {
 
   @Override
   public List<String> getGroups(String user) throws IOException {
+    return Arrays.asList(getGroupsInternal(user));
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    String[] groups = getGroupsInternal(user);
+    Set<String> result = new LinkedHashSet(groups.length);
+    CollectionUtils.addAll(result, groups);
+    return result;
+  }
+
+  private String[] getGroupsInternal(String user) throws IOException {
     String[] groups = new String[0];
     try {
       groups = getGroupsForUser(user);
@@ -85,7 +97,7 @@ public class JniBasedUnixGroupsMapping implements GroupMappingServiceProvider {
         LOG.info("Error getting groups for " + user + ": " + e.getMessage());
       }
     }
-    return Arrays.asList(groups);
+    return groups;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsMappingWithFallback.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsMappingWithFallback.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.security;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.util.NativeCodeLoader;
 import org.apache.hadoop.util.PerformanceAdvisory;
@@ -59,6 +60,11 @@ public class JniBasedUnixGroupsMappingWithFallback implements
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
     impl.cacheGroupsAdd(groups);
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return impl.getGroupsSet(user);
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsNetgroupMappingWithFallback.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/JniBasedUnixGroupsNetgroupMappingWithFallback.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.security;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.util.NativeCodeLoader;
 import org.slf4j.Logger;
@@ -58,6 +59,11 @@ public class JniBasedUnixGroupsNetgroupMappingWithFallback implements
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
     impl.cacheGroupsAdd(groups);
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return impl.getGroupsSet(user);
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
@@ -519,7 +519,7 @@ public class LdapGroupsMapping
     }
     SearchResult result = results.nextElement();
 
-    Set<String> groups = null;
+    Set<String> groups = Collections.emptySet();
     if (useOneQuery) {
       try {
         /**
@@ -698,7 +698,7 @@ public class LdapGroupsMapping
   }
 
   @Override
-  public Set<String> getGroupsSet(String user) throws IOException {
+  public Set<String> getGroupsSet(String user) {
     /*
      * Normal garbage collection takes care of removing Context instances when
      * they are no longer in use. Connections used by Context instances being

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NullGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NullGroupsMapping.java
@@ -43,7 +43,7 @@ public class NullGroupsMapping implements GroupMappingServiceProvider {
    */
   @Override
   public Set<String> getGroupsSet(String user) throws IOException {
-    return null;
+    return Collections.emptySet();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NullGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NullGroupsMapping.java
@@ -15,8 +15,10 @@
  */
 package org.apache.hadoop.security;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class provides groups mapping for {@link UserGroupInformation} when the
@@ -29,6 +31,19 @@ public class NullGroupsMapping implements GroupMappingServiceProvider {
    */
   @Override
   public void cacheGroupsAdd(List<String> groups) {
+  }
+
+  /**
+   * Get all various group memberships of a given user.
+   * Returns EMPTY set in case of non-existing user
+   *
+   * @param user User's name
+   * @return set of group memberships of user
+   * @throws IOException
+   */
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return null;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
@@ -93,16 +93,15 @@ public class RuleBasedLdapGroupsMapping extends LdapGroupsMapping {
   public synchronized Set<String> getGroupsSet(String user) {
     Set<String> groups = super.getGroupsSet(user);
     switch (rule) {
-      case TO_UPPER:
-        return groups.stream().map(StringUtils::toUpperCase).collect(
-            Collectors.toCollection(LinkedHashSet::new));
-      case TO_LOWER:
-        return groups.stream().map(StringUtils::toLowerCase).collect(
-            Collectors.toCollection(LinkedHashSet::new));
-      case NONE:
-      default:
-        return groups;
+    case TO_UPPER:
+      return groups.stream().map(StringUtils::toUpperCase).collect(
+          Collectors.toCollection(LinkedHashSet::new));
+    case TO_LOWER:
+      return groups.stream().map(StringUtils::toLowerCase).collect(
+          Collectors.toCollection(LinkedHashSet::new));
+    case NONE:
+    default:
+      return groups;
     }
   }
-
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
@@ -24,8 +24,10 @@ import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -93,10 +95,10 @@ public class RuleBasedLdapGroupsMapping extends LdapGroupsMapping {
     switch (rule) {
       case TO_UPPER:
         return groups.stream().map(StringUtils::toUpperCase).collect(
-            Collectors.toSet());
+            Collectors.toCollection(LinkedHashSet::new));
       case TO_LOWER:
         return groups.stream().map(StringUtils::toLowerCase).collect(
-            Collectors.toSet());
+            Collectors.toCollection(LinkedHashSet::new));
       case NONE:
       default:
         return groups;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.security;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -26,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -85,6 +85,21 @@ public class RuleBasedLdapGroupsMapping extends LdapGroupsMapping {
     case NONE:
     default:
       return groups;
+    }
+  }
+
+  public synchronized Set<String> getGroupsSet(String user) {
+    Set<String> groups = super.getGroupsSet(user);
+    switch (rule) {
+      case TO_UPPER:
+        return groups.stream().map(StringUtils::toUpperCase).collect(
+            Collectors.toSet());
+      case TO_LOWER:
+        return groups.stream().map(StringUtils::toLowerCase).collect(
+            Collectors.toSet());
+      case NONE:
+      default:
+        return groups;
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/RuleBasedLdapGroupsMapping.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ShellBasedUnixGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ShellBasedUnixGroupsMapping.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.security;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -97,7 +97,7 @@ public class ShellBasedUnixGroupsMapping extends Configured
    */
   @Override
   public List<String> getGroups(String userName) throws IOException {
-    return Lists.newArrayList(getUnixGroups(userName).iterator());
+    return new ArrayList(getUnixGroups(userName));
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ShellBasedUnixGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ShellBasedUnixGroupsMapping.java
@@ -18,13 +18,16 @@
 package org.apache.hadoop.security;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -53,7 +56,7 @@ public class ShellBasedUnixGroupsMapping extends Configured
 
   private long timeout = CommonConfigurationKeys.
       HADOOP_SECURITY_GROUP_SHELL_COMMAND_TIMEOUT_DEFAULT;
-  private static final List<String> EMPTY_GROUPS = new LinkedList<>();
+  private static final Set<String> EMPTY_GROUPS_SET = Collections.emptySet();
 
   @Override
   public void setConf(Configuration conf) {
@@ -94,7 +97,7 @@ public class ShellBasedUnixGroupsMapping extends Configured
    */
   @Override
   public List<String> getGroups(String userName) throws IOException {
-    return getUnixGroups(userName);
+    return Lists.newArrayList(getUnixGroups(userName).iterator());
   }
 
   /**
@@ -113,6 +116,11 @@ public class ShellBasedUnixGroupsMapping extends Configured
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
     // does nothing in this provider of user to groups mapping
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String userName) throws IOException {
+    return getUnixGroups(userName);
   }
 
   /**
@@ -192,44 +200,33 @@ public class ShellBasedUnixGroupsMapping extends Configured
    *         group is returned first.
    * @throws IOException if encounter any error when running the command
    */
-  private List<String> getUnixGroups(String user) throws IOException {
+  private Set<String> getUnixGroups(String user) throws IOException {
     ShellCommandExecutor executor = createGroupExecutor(user);
 
-    List<String> groups;
+    Set<String> groups;
     try {
       executor.execute();
       groups = resolveFullGroupNames(executor.getOutput());
     } catch (ExitCodeException e) {
       if (handleExecutorTimeout(executor, user)) {
-        return EMPTY_GROUPS;
+        return EMPTY_GROUPS_SET;
       } else {
         try {
           groups = resolvePartialGroupNames(user, e.getMessage(),
               executor.getOutput());
         } catch (PartialGroupNameException pge) {
           LOG.warn("unable to return groups for user {}", user, pge);
-          return EMPTY_GROUPS;
+          return EMPTY_GROUPS_SET;
         }
       }
     } catch (IOException ioe) {
       if (handleExecutorTimeout(executor, user)) {
-        return EMPTY_GROUPS;
+        return EMPTY_GROUPS_SET;
       } else {
         // If its not an executor timeout, we should let the caller handle it
         throw ioe;
       }
     }
-
-    // remove duplicated primary group
-    if (!Shell.WINDOWS) {
-      for (int i = 1; i < groups.size(); i++) {
-        if (groups.get(i).equals(groups.get(0))) {
-          groups.remove(i);
-          break;
-        }
-      }
-    }
-
     return groups;
   }
 
@@ -242,13 +239,13 @@ public class ShellBasedUnixGroupsMapping extends Configured
    * @return a linked list of group names
    * @throws PartialGroupNameException
    */
-  private List<String> parsePartialGroupNames(String groupNames,
+  private Set<String> parsePartialGroupNames(String groupNames,
       String groupIDs) throws PartialGroupNameException {
     StringTokenizer nameTokenizer =
         new StringTokenizer(groupNames, Shell.TOKEN_SEPARATOR_REGEX);
     StringTokenizer idTokenizer =
         new StringTokenizer(groupIDs, Shell.TOKEN_SEPARATOR_REGEX);
-    List<String> groups = new LinkedList<String>();
+    Set<String> groups = new LinkedHashSet<>();
     while (nameTokenizer.hasMoreTokens()) {
       // check for unresolvable group names.
       if (!idTokenizer.hasMoreTokens()) {
@@ -277,10 +274,10 @@ public class ShellBasedUnixGroupsMapping extends Configured
    * @param userName the user's name
    * @param errMessage error message from the shell command
    * @param groupNames the incomplete list of group names
-   * @return a list of resolved group names
+   * @return a set of resolved group names
    * @throws PartialGroupNameException if the resolution fails or times out
    */
-  private List<String> resolvePartialGroupNames(String userName,
+  private Set<String> resolvePartialGroupNames(String userName,
       String errMessage, String groupNames) throws PartialGroupNameException {
     // Exception may indicate that some group names are not resolvable.
     // Shell-based implementation should tolerate unresolvable groups names,
@@ -322,16 +319,16 @@ public class ShellBasedUnixGroupsMapping extends Configured
   }
 
   /**
-   * Split group names into a linked list.
+   * Split group names into a set.
    *
    * @param groupNames a string representing the user's group names
-   * @return a linked list of group names
+   * @return a set of group names
    */
   @VisibleForTesting
-  protected List<String> resolveFullGroupNames(String groupNames) {
+  protected Set<String> resolveFullGroupNames(String groupNames) {
     StringTokenizer tokenizer =
         new StringTokenizer(groupNames, Shell.TOKEN_SEPARATOR_REGEX);
-    List<String> groups = new LinkedList<String>();
+    Set<String> groups = new LinkedHashSet<>();
     while (tokenizer.hasMoreTokens()) {
       groups.add(tokenizer.nextToken());
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -1563,11 +1563,11 @@ public class UserGroupInformation {
   }
 
   public String getPrimaryGroupName() throws IOException {
-    Collection<String> groups = getGroupsSet();
-    if (groups.isEmpty()) {
+    Set<String> groupsSet = getGroupsSet();
+    if (groupsSet.isEmpty()) {
       throw new IOException("There is no primary group for UGI " + this);
     }
-    return groups.iterator().next();
+    return groupsSet.iterator().next();
   }
 
   /**
@@ -1686,8 +1686,8 @@ public class UserGroupInformation {
    *    fails, it returns an empty list.
    */
   public String[] getGroupNames() {
-    Collection<String> groups = getGroupsSet();
-    return groups.toArray(new String[groups.size()]);
+    Collection<String> groupsSet = getGroupsSet();
+    return groupsSet.toArray(new String[groupsSet.size()]);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -69,6 +69,7 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
+import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -1699,8 +1700,9 @@ public class UserGroupInformation {
    * expensive alternative when checking for a contained element.
    * @return the list of users with the primary group first. If the command
    *    fails, it returns an empty list.
-   * Use {@link #getGroupsSet()}
+   * @deprecated Use {@link #getGroupsSet()} instead.
    */
+  @Deprecated
   public List<String> getGroups() {
     ensureInitialized();
     try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -1563,11 +1563,11 @@ public class UserGroupInformation {
   }
 
   public String getPrimaryGroupName() throws IOException {
-    List<String> groups = getGroups();
+    Collection<String> groups = getGroupsSet();
     if (groups.isEmpty()) {
       throw new IOException("There is no primary group for UGI " + this);
     }
-    return groups.get(0);
+    return groups.iterator().next();
   }
 
   /**
@@ -1680,20 +1680,22 @@ public class UserGroupInformation {
   }
 
   /**
-   * Get the group names for this user. {@link #getGroups()} is less
+   * Get the group names for this user. {@link #getGroupsSet()} is less
    * expensive alternative when checking for a contained element.
    * @return the list of users with the primary group first. If the command
    *    fails, it returns an empty list.
    */
   public String[] getGroupNames() {
-    List<String> groups = getGroups();
+    Collection<String> groups = getGroupsSet();
     return groups.toArray(new String[groups.size()]);
   }
 
   /**
-   * Get the group names for this user.
+   * Get the group names for this user. {@link #getGroupsSet()} is less
+   * expensive alternative when checking for a contained element.
    * @return the list of users with the primary group first. If the command
    *    fails, it returns an empty list.
+   * Use {@link #getGroupsSet()}
    */
   public List<String> getGroups() {
     ensureInitialized();
@@ -1702,6 +1704,21 @@ public class UserGroupInformation {
     } catch (IOException ie) {
       LOG.debug("Failed to get groups for user {}", getShortUserName(), ie);
       return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Get the groups names for the user as a Set.
+   * @return the set of users with the primary group first. If the command
+   *     fails, it returns an empty set.
+   */
+  public Set<String> getGroupsSet() {
+    ensureInitialized();
+    try {
+      return groups.getGroupsSet(getShortUserName());
+    } catch (IOException ie) {
+      LOG.debug("Failed to get groups for user {}", getShortUserName(), ie);
+      return Collections.emptySet();
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -40,7 +40,6 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -70,7 +69,6 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
-import org.apache.commons.compress.utils.Lists;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -69,7 +69,6 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
-import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authorize/AccessControlList.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authorize/AccessControlList.java
@@ -20,10 +20,7 @@ package org.apache.hadoop.security.authorize;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -231,8 +228,9 @@ public class AccessControlList implements Writable {
     if (allAllowed || users.contains(ugi.getShortUserName())) {
       return true;
     } else if (!groups.isEmpty()) {
-      for (String group : ugi.getGroups()) {
-        if (groups.contains(group)) {
+      Set<String> ugiGroups = ugi.getGroupsSet();
+      for (String group : groups) {
+        if (ugiGroups.contains(group)) {
           return true;
         }
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authorize/AccessControlList.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/authorize/AccessControlList.java
@@ -20,7 +20,11 @@ package org.apache.hadoop.security.authorize;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
@@ -62,8 +62,10 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -409,6 +411,13 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     @Override
     public List<String> getGroups(String user) throws IOException {
       return mapping.get(user);
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      Set<String> result = new HashSet();
+      result.addAll(mapping.get(user));
+      return result;
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestCompositeGroupMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestCompositeGroupMapping.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -87,12 +89,21 @@ public class TestCompositeGroupMapping {
     public void cacheGroupsAdd(List<String> groups) throws IOException {
       
     }
-    
+
     protected List<String> toList(String group) {
       if (group != null) {
         return Arrays.asList(new String[] {group});
       }
       return new ArrayList<String>();
+    }
+
+    protected Set<String> toSet(String group) {
+      if (group != null) {
+        Set<String> result = new HashSet<>();
+        result.add(group);
+        return result;
+      }
+      return new HashSet<String>();
     }
     
     protected void checkTestConf(String expectedValue) {
@@ -106,32 +117,49 @@ public class TestCompositeGroupMapping {
   private static class UserProvider extends GroupMappingProviderBase {
     @Override
     public List<String> getGroups(String user) throws IOException {
+      return toList(getGroupInternal(user));
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return toSet(getGroupInternal(user));
+    }
+
+    private String getGroupInternal(String user) throws IOException {
       checkTestConf(PROVIDER_SPECIFIC_CONF_VALUE_FOR_USER);
-      
+
       String group = null;
       if (user.equals(john.name)) {
         group = john.group;
       } else if (user.equals(jack.name)) {
         group = jack.group;
       }
-      
-      return toList(group);
+      return group;
     }
   }
   
   private static class ClusterProvider extends GroupMappingProviderBase {    
     @Override
     public List<String> getGroups(String user) throws IOException {
+      return toList(getGroupsInternal(user));
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return toSet(getGroupsInternal(user));
+    }
+
+    private String getGroupsInternal(String user) throws IOException {
       checkTestConf(PROVIDER_SPECIFIC_CONF_VALUE_FOR_CLUSTER);
-      
+
       String group = null;
       if (user.equals(hdfs.name)) {
         group = hdfs.group;
       } else if (user.equals(jack.name)) { // jack has another group from clusterProvider
         group = jack.group2;
       }
-      
-      return toList(group);
+      return group;
+
     }
   }
   

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -75,7 +75,7 @@ public class TestGroupsCaching {
     private static volatile CountDownLatch latch = null;
 
     @Override
-    public List<String> getGroups(String user) throws IOException {
+    public Set<String> getGroupsSet(String user) throws IOException {
       TESTLOG.info("Getting groups for " + user);
       delayIfNecessary();
 
@@ -86,9 +86,14 @@ public class TestGroupsCaching {
       }
 
       if (blackList.contains(user)) {
-        return new LinkedList<String>();
+        return Collections.emptySet();
       }
-      return new LinkedList<String>(allGroups);
+      return Collections.unmodifiableSet(allGroups);
+    }
+
+    @Override
+    public List<String> getGroups(String user) throws IOException {
+      return new ArrayList<>(getGroupsSet(user));
     }
 
     /**
@@ -129,7 +134,7 @@ public class TestGroupsCaching {
       TESTLOG.info("Resetting FakeGroupMapping");
       blackList.clear();
       allGroups.clear();
-      requestCount = 0;
+      resetRequestCount();
       getGroupsDelayMs = 0;
       throwException = false;
       latch = null;
@@ -193,6 +198,12 @@ public class TestGroupsCaching {
 
     @Override
     public List<String> getGroups(String user) throws IOException {
+      requestCount++;
+      throw new IOException("For test");
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
       requestCount++;
       throw new IOException("For test");
     }
@@ -550,7 +561,7 @@ public class TestGroupsCaching {
     FakeGroupMapping.clearBlackList();
 
     // We make an initial request to populate the cache
-    groups.getGroups("me");
+    List<String> g1 = groups.getGroups("me");
 
     // add another group
     groups.cacheGroupsAdd(Arrays.asList("grp3"));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
@@ -88,7 +88,7 @@ public class TestGroupsCaching {
       if (blackList.contains(user)) {
         return Collections.emptySet();
       }
-      return Collections.unmodifiableSet(allGroups);
+      return new LinkedHashSet<>(allGroups);
     }
 
     @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestRuleBasedLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestRuleBasedLdapGroupsMapping.java
@@ -24,7 +24,9 @@ import org.mockito.Mockito;
 
 import javax.naming.NamingException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.hadoop.security.RuleBasedLdapGroupsMapping
     .CONVERSION_RULE_KEY;
@@ -40,7 +42,7 @@ public class TestRuleBasedLdapGroupsMapping  {
   public void testGetGroupsToUpper() throws NamingException {
     RuleBasedLdapGroupsMapping groupsMapping = Mockito.spy(
         new RuleBasedLdapGroupsMapping());
-    List<String> groups = new ArrayList<>();
+    Set<String> groups = new LinkedHashSet<>();
     groups.add("group1");
     groups.add("group2");
     Mockito.doReturn(groups).when((LdapGroupsMapping) groupsMapping)
@@ -61,7 +63,7 @@ public class TestRuleBasedLdapGroupsMapping  {
   public void testGetGroupsToLower() throws NamingException {
     RuleBasedLdapGroupsMapping groupsMapping = Mockito.spy(
         new RuleBasedLdapGroupsMapping());
-    List<String> groups = new ArrayList<>();
+    Set<String> groups = new LinkedHashSet<>();
     groups.add("GROUP1");
     groups.add("GROUP2");
     Mockito.doReturn(groups).when((LdapGroupsMapping) groupsMapping)
@@ -82,7 +84,7 @@ public class TestRuleBasedLdapGroupsMapping  {
   public void testGetGroupsInvalidRule() throws NamingException {
     RuleBasedLdapGroupsMapping groupsMapping = Mockito.spy(
         new RuleBasedLdapGroupsMapping());
-    List<String> groups = new ArrayList<>();
+    Set<String> groups = new LinkedHashSet<>();
     groups.add("group1");
     groups.add("GROUP2");
     Mockito.doReturn(groups).when((LdapGroupsMapping) groupsMapping)
@@ -93,7 +95,7 @@ public class TestRuleBasedLdapGroupsMapping  {
     conf.set(CONVERSION_RULE_KEY, "none");
     groupsMapping.setConf(conf);
 
-    Assert.assertEquals(groups, groupsMapping.getGroups("admin"));
+    Assert.assertEquals(groups, groupsMapping.getGroupsSet("admin"));
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -96,6 +96,7 @@ import java.text.MessageFormat;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Main class of HttpFSServer server.
@@ -288,7 +289,7 @@ public class HttpFSServer {
     case INSTRUMENTATION: {
       enforceRootPath(op.value(), path);
       Groups groups = HttpFSServerWebApp.get().get(Groups.class);
-      List<String> userGroups = groups.getGroups(user.getShortUserName());
+      Set<String> userGroups = groups.getGroupsSet(user.getShortUserName());
       if (!userGroups.contains(HttpFSServerWebApp.get().getAdminGroup())) {
         throw new AccessControlException(
             "User not in HttpFSServer admin group");

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/Groups.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/Groups.java
@@ -22,10 +22,13 @@ import org.apache.hadoop.classification.InterfaceAudience;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 @InterfaceAudience.Private
 public interface Groups {
 
   public List<String> getGroups(String user) throws IOException;
+
+  public Set<String> getGroupsSet(String user) throws IOException;
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/Groups.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/Groups.java
@@ -29,6 +29,6 @@ public interface Groups {
 
   public List<String> getGroups(String user) throws IOException;
 
-  public Set<String> getGroupsSet(String user) throws IOException;
+  Set<String> getGroupsSet(String user) throws IOException;
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/security/GroupsService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/security/GroupsService.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.lib.util.ConfigurationUtils;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 @InterfaceAudience.Private
 public class GroupsService extends BaseService implements Groups {
@@ -50,9 +51,18 @@ public class GroupsService extends BaseService implements Groups {
     return Groups.class;
   }
 
+  /**
+   * @deprecated use {@link #getGroupsSet(String)}
+   */
+  @Deprecated
   @Override
   public List<String> getGroups(String user) throws IOException {
     return hGroups.getGroups(user);
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return hGroups.getGroupsSet(user);
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/security/GroupsService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/security/GroupsService.java
@@ -52,7 +52,7 @@ public class GroupsService extends BaseService implements Groups {
   }
 
   /**
-   * @deprecated use {@link #getGroupsSet(String)}
+   * @deprecated use {@link #getGroupsSet(String user)}
    */
   @Deprecated
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
@@ -60,9 +60,11 @@ import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -168,6 +170,11 @@ public class TestHttpFSServer extends HFSTestCase {
     @Override
     public List<String> getGroups(String user) throws IOException {
       return Arrays.asList(HadoopUsersConfTestHelper.getHadoopUserGroups(user));
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return new HashSet<>(getGroups(user));
     }
 
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/DummyGroupMapping.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/DummyGroupMapping.java
@@ -54,8 +54,7 @@ public class DummyGroupMapping implements GroupMappingServiceProvider {
   public Set<String> getGroupsSet(String user) throws IOException {
     if (user.equals("root")) {
       return Sets.newHashSet("admin");
-    }
-    else if (user.equals("nobody")) {
+    } else if (user.equals("nobody")) {
       return Sets.newHashSet("nobody");
     } else {
       String[] groups = HadoopUsersConfTestHelper.getHadoopUserGroups(user);

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/DummyGroupMapping.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/DummyGroupMapping.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.security.GroupMappingServiceProvider;
 import org.apache.hadoop.test.HadoopUsersConfTestHelper;
@@ -46,5 +47,10 @@ public class DummyGroupMapping implements GroupMappingServiceProvider {
 
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return null;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/DummyGroupMapping.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/DummyGroupMapping.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.apache.hadoop.security.GroupMappingServiceProvider;
 import org.apache.hadoop.test.HadoopUsersConfTestHelper;
 
@@ -51,6 +52,15 @@ public class DummyGroupMapping implements GroupMappingServiceProvider {
 
   @Override
   public Set<String> getGroupsSet(String user) throws IOException {
-    return null;
+    if (user.equals("root")) {
+      return Sets.newHashSet("admin");
+    }
+    else if (user.equals("nobody")) {
+      return Sets.newHashSet("nobody");
+    } else {
+      String[] groups = HadoopUsersConfTestHelper.getHadoopUserGroups(user);
+      return (groups != null) ? Sets.newHashSet(groups) :
+          Collections.emptySet();
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterPermissionChecker.java
@@ -18,8 +18,6 @@
 package org.apache.hadoop.hdfs.server.federation.router;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterPermissionChecker.java
@@ -126,8 +126,7 @@ public class RouterPermissionChecker extends FSPermissionChecker {
     }
 
     // Is the user a member of the super group?
-    List<String> groups = ugi.getGroups();
-    if (groups.contains(superGroup)) {
+    if (ugi.getGroupsSet().contains(superGroup)) {
       return;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MountTable.java
@@ -149,7 +149,7 @@ public abstract class MountTable extends BaseRecord {
     // Set permission fields
     UserGroupInformation ugi = NameNode.getRemoteUser();
     record.setOwnerName(ugi.getShortUserName());
-    String group = ugi.getGroups().isEmpty() ? ugi.getShortUserName()
+    String group = ugi.getGroupsSet().isEmpty() ? ugi.getShortUserName()
         : ugi.getPrimaryGroupName();
     record.setGroupName(group);
     record.setMode(new FsPermission(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRefreshSuperUserGroupsConfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRefreshSuperUserGroupsConfiguration.java
@@ -45,6 +45,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -135,6 +136,8 @@ public class TestRouterRefreshSuperUserGroupsConfiguration {
     when(ugi.getRealUser()).thenReturn(impersonator);
     when(ugi.getUserName()).thenReturn("victim");
     when(ugi.getGroups()).thenReturn(Arrays.asList("groupVictim"));
+    when(ugi.getGroupsSet()).thenReturn(new LinkedHashSet<>(Arrays.asList(
+        "groupVictim")));
 
     // Exception should be thrown before applying config
     LambdaTestUtils.intercept(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
@@ -57,6 +57,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -203,6 +204,10 @@ public class TestRouterUserMappings {
     final List<String> groupNames2 = new ArrayList<>();
     groupNames2.add("gr3");
     groupNames2.add("gr4");
+    final Set<String> groupNamesSet1 = new LinkedHashSet<>();
+    groupNamesSet1.addAll(groupNames1);
+    final Set<String> groupNamesSet2 = new LinkedHashSet<>();
+    groupNamesSet2.addAll(groupNames2);
 
     //keys in conf
     String userKeyGroups = DefaultImpersonationProvider.getTestProvider().
@@ -234,6 +239,8 @@ public class TestRouterUserMappings {
     // set groups for users
     when(ugi1.getGroups()).thenReturn(groupNames1);
     when(ugi2.getGroups()).thenReturn(groupNames2);
+    when(ugi1.getGroupsSet()).thenReturn(groupNamesSet1);
+    when(ugi2.getGroupsSet()).thenReturn(groupNamesSet2);
 
     // check before refresh
     LambdaTestUtils.intercept(AuthorizationException.class,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileSystem;
@@ -115,7 +116,12 @@ public class TestRouterUserMappings {
 
     @Override
     public Set<String> getGroupsSet(String user) throws IOException {
-      return null;
+      LOG.info("Getting groups in MockUnixGroupsMapping");
+      String g1 = user + (10 * i + 1);
+      String g2 = user + (10 * i + 2);
+      Set<String> s = Sets.newHashSet(g1, g2);
+      i++;
+      return s;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterUserMappings.java
@@ -57,6 +57,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -110,6 +111,11 @@ public class TestRouterUserMappings {
 
     @Override
     public void cacheGroupsAdd(List<String> groups) throws IOException {
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return null;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1082,8 +1082,7 @@ public class DataNode extends ReconfigurableBase
     }
 
     // Is the user a member of the super group?
-    List<String> groups = callerUgi.getGroups();
-    if (groups.contains(supergroup)) {
+    if (callerUgi.getGroupsSet().contains(supergroup)) {
       return;
     }
     // Not a superuser.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
@@ -103,7 +103,7 @@ public class FSPermissionChecker implements AccessControlEnforcer {
     this.fsOwner = fsOwner;
     this.supergroup = supergroup;
     this.callerUgi = callerUgi;
-    this.groups = callerUgi.getGroups();
+    this.groups = callerUgi.getGroupsSet();
     user = callerUgi.getShortUserName();
     isSuper = user.equals(fsOwner) || groups.contains(supergroup);
     this.attributeProvider = attributeProvider;
@@ -549,7 +549,6 @@ public class FSPermissionChecker implements AccessControlEnforcer {
    * - Default entries may be present, but they are ignored during enforcement.
    *
    * @param inode INodeAttributes accessed inode
-   * @param snapshotId int snapshot ID
    * @param access FsAction requested permission
    * @param mode FsPermission mode from inode
    * @param aclFeature AclFeature of inode

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
@@ -549,6 +549,7 @@ public class FSPermissionChecker implements AccessControlEnforcer {
    * - Default entries may be present, but they are ignored during enforcement.
    *
    * @param inode INodeAttributes accessed inode
+   * @param snapshotId int snapshot ID
    * @param access FsAction requested permission
    * @param mode FsPermission mode from inode
    * @param aclFeature AclFeature of inode

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/security/TestRefreshUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/security/TestRefreshUserMappings.java
@@ -34,9 +34,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -87,8 +90,13 @@ public class TestRefreshUserMappings {
     }
 
     @Override
-    public Set<String> getGroupsSet(String user) throws IOException {
-      return null;
+    public Set<String> getGroupsSet(String user) {
+      LOG.info("Getting groups in MockUnixGroupsMapping");
+      String g1 = user + (10 * i + 1);
+      String g2 = user + (10 * i + 2);
+      Set<String> s = Sets.newHashSet(g1, g2);
+      i++;
+      return s;
     }
   }
   
@@ -202,6 +210,8 @@ public class TestRefreshUserMappings {
     // set groups for users
     when(ugi1.getGroups()).thenReturn(groupNames1);
     when(ugi2.getGroups()).thenReturn(groupNames2);
+    when(ugi1.getGroupsSet()).thenReturn(new LinkedHashSet<>(groupNames1));
+    when(ugi2.getGroupsSet()).thenReturn(new LinkedHashSet<>(groupNames2));
 
 
     // check before

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/security/TestRefreshUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/security/TestRefreshUserMappings.java
@@ -34,7 +34,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/security/TestRefreshUserMappings.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/security/TestRefreshUserMappings.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -83,6 +84,11 @@ public class TestRefreshUserMappings {
   
     @Override
     public void cacheGroupsAdd(List<String> groups) throws IOException {
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return null;
     }
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/server/TestHSAdminServer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/server/TestHSAdminServer.java
@@ -27,7 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -90,6 +92,14 @@ public class TestHSAdminServer {
 
     @Override
     public void cacheGroupsAdd(List<String> groups) throws IOException {
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      Set<String> result =
+          ImmutableSet.of(user + (10 * i + 1) , user + (10 * i +2));
+      i++;
+      return result;
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/server/TestHSAdminServer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/server/TestHSAdminServer.java
@@ -26,10 +26,10 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.verify;
 
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.yarn.logaggregation.AggregatedLogDeletionService;
+import org.mockito.internal.util.collections.Sets;
 
 @RunWith(Parameterized.class)
 public class TestHSAdminServer {
@@ -96,8 +97,9 @@ public class TestHSAdminServer {
 
     @Override
     public Set<String> getGroupsSet(String user) throws IOException {
-      Set<String> result =
-          ImmutableSet.of(user + (10 * i + 1), user + (10 * i +2));
+      Set<String> result = new LinkedHashSet<>();
+      result.add(user + (10 * i + 1));
+      result.add(user + (10 * i +2));
       i++;
       return result;
     }
@@ -199,6 +201,9 @@ public class TestHSAdminServer {
     when(superUser.getUserName()).thenReturn("superuser");
     when(ugi.getGroups())
         .thenReturn(Arrays.asList(new String[] { "group3" }));
+    when(ugi.getGroupsSet())
+        .thenReturn(Sets.newSet("group3"));
+
     when(ugi.getUserName()).thenReturn("regularUser");
 
     // Set super user groups not to include groups of regularUser

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/server/TestHSAdminServer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/server/TestHSAdminServer.java
@@ -97,7 +97,7 @@ public class TestHSAdminServer {
     @Override
     public Set<String> getGroupsSet(String user) throws IOException {
       Set<String> result =
-          ImmutableSet.of(user + (10 * i + 1) , user + (10 * i +2));
+          ImmutableSet.of(user + (10 * i + 1), user + (10 * i +2));
       i++;
       return result;
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesAcls.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/webapp/TestHsWebServicesAcls.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -275,6 +276,11 @@ public class TestHsWebServicesAcls {
 
     @Override
     public void cacheGroupsAdd(List<String> groups) throws IOException {
+    }
+
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return Collections.emptySet();
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/NetworkTagMappingJsonManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/NetworkTagMappingJsonManager.java
@@ -86,7 +86,7 @@ public class NetworkTagMappingJsonManager implements NetworkTagMappingManager {
         container.getUser());
     List<Group> groups = this.networkTagMapping.getGroups();
     for(Group group : groups) {
-      if (userUGI.getGroups().contains(group.getGroupName())) {
+      if (userUGI.getGroupsSet().contains(group.getGroupName())) {
         return group.getNetworkTagID();
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/JavaSandboxLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/JavaSandboxLinuxContainerRuntime.java
@@ -303,9 +303,9 @@ public class JavaSandboxLinuxContainerRuntime
   private static List<String> getGroupPolicyFiles(Configuration conf,
       String user) throws ContainerExecutionException {
     Groups groups = Groups.getUserToGroupsMappingService(conf);
-    List<String> userGroups;
+    Set<String> userGroups;
     try {
-      userGroups = groups.getGroups(user);
+      userGroups = groups.getGroupsSet(user);
     } catch (IOException e) {
       throw new ContainerExecutionException("Container user does not exist");
     }
@@ -330,11 +330,11 @@ public class JavaSandboxLinuxContainerRuntime
     String whitelistGroup = configuration.get(
         YarnConfiguration.YARN_CONTAINER_SANDBOX_WHITELIST_GROUP);
     Groups groups = Groups.getUserToGroupsMappingService(configuration);
-    List<String> userGroups;
+    Set<String> userGroups;
     boolean isWhitelisted = false;
 
     try {
-      userGroups = groups.getGroups(username);
+      userGroups = groups.getGroupsSet(username);
     } catch (IOException e) {
       throw new ContainerExecutionException("Container user does not exist");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/PrimaryGroupPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/PrimaryGroupPlacementRule.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.placement.FairQueuePlacementUtils.DOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.placement.FairQueuePlacementUtils.assureRoot;
@@ -62,19 +62,19 @@ public class PrimaryGroupPlacementRule extends FSPlacementRule {
 
     // All users should have at least one group the primary group. If no groups
     // are returned then there is a real issue.
-    final List<String> groupList;
+    final Set<String> groupSet;
     try {
-      groupList = groupProvider.getGroups(user);
+      groupSet = groupProvider.getGroupsSet(user);
     } catch (IOException ioe) {
       throw new YarnException("Group resolution failed", ioe);
     }
-    if (groupList.isEmpty()) {
+    if (groupSet.isEmpty()) {
       LOG.error("Group placement rule failed: No groups returned for user {}",
           user);
       throw new YarnException("No groups returned for user " + user);
     }
 
-    String cleanGroup = cleanName(groupList.get(0));
+    String cleanGroup = cleanName(groupSet.iterator().next());
     String queueName;
     PlacementRule parentRule = getParentRule();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/SecondaryGroupExistingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/SecondaryGroupExistingPlacementRule.java
@@ -30,7 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Iterator;
+import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.placement.FairQueuePlacementUtils.DOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.placement.FairQueuePlacementUtils.assureRoot;
@@ -65,9 +66,9 @@ public class SecondaryGroupExistingPlacementRule extends FSPlacementRule {
 
     // All users should have at least one group the primary group. If no groups
     // are returned then there is a real issue.
-    final List<String> groupList;
+    final Set<String> groupSet;
     try {
-      groupList = groupProvider.getGroups(user);
+      groupSet = groupProvider.getGroupsSet(user);
     } catch (IOException ioe) {
       throw new YarnException("Group resolution failed", ioe);
     }
@@ -90,8 +91,9 @@ public class SecondaryGroupExistingPlacementRule extends FSPlacementRule {
           parentQueue);
     }
     // now check the groups inside the parent
-    for (int i = 1; i < groupList.size(); i++) {
-      String group = cleanName(groupList.get(i));
+    Iterator<String> it = groupSet.iterator();
+    while (it.hasNext()) {
+      String group = cleanName(it.next());
       String queueName =
           parentQueue == null ? assureRoot(group) : parentQueue + DOT + group;
       if (configuredQueue(queueName)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/UserGroupMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/UserGroupMappingPlacementRule.java
@@ -86,6 +86,7 @@ public class UserGroupMappingPlacementRule extends PlacementRule {
     // and position is not guaranteed) and ensure there is queue with
     // the same name
     Iterator<String> it = groupsSet.iterator();
+    it.next();
     while (it.hasNext()) {
       String group = it.next();
       if (this.queueManager.getQueue(group) != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/UserGroupMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/UserGroupMappingPlacementRule.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.yarn.server.resourcemanager.placement;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -74,18 +76,20 @@ public class UserGroupMappingPlacementRule extends PlacementRule {
   }
 
   private String getPrimaryGroup(String user) throws IOException {
-    return groups.getGroups(user).get(0);
+    return groups.getGroupsSet(user).iterator().next();
   }
 
   private String getSecondaryGroup(String user) throws IOException {
-    List<String> groupsList = groups.getGroups(user);
+    Set<String> groupsSet = groups.getGroupsSet(user);
     String secondaryGroup = null;
     // Traverse all secondary groups (as there could be more than one
     // and position is not guaranteed) and ensure there is queue with
     // the same name
-    for (int i = 1; i < groupsList.size(); i++) {
-      if (this.queueManager.getQueue(groupsList.get(i)) != null) {
-        secondaryGroup = groupsList.get(i);
+    Iterator<String> it = groupsSet.iterator();
+    while (it.hasNext()) {
+      String group = it.next();
+      if (this.queueManager.getQueue(group) != null) {
+        secondaryGroup = group;
         break;
       }
     }
@@ -180,7 +184,7 @@ public class UserGroupMappingPlacementRule extends PlacementRule {
         }
       }
       if (mapping.getType().equals(MappingType.GROUP)) {
-        for (String userGroups : groups.getGroups(user)) {
+        for (String userGroups : groups.getGroupsSet(user)) {
           if (userGroups.equals(mapping.getSource())) {
             if (mapping.getQueue().equals(CURRENT_USER_MAPPING)) {
               if (LOG.isDebugEnabled()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMAdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMAdminService.java
@@ -1459,6 +1459,11 @@ public class TestRMAdminService {
       // Do nothing
     }
 
+    @Override
+    public Set<String> getGroupsSet(String user) throws IOException {
+      return ImmutableSet.copyOf(group);
+    }
+
     public static void updateGroups() {
       group.clear();
       group.add("test_group_D");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/PeriodGroupsMapping.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/PeriodGroupsMapping.java
@@ -18,17 +18,20 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.security.GroupMappingServiceProvider;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class PeriodGroupsMapping implements GroupMappingServiceProvider {
   
   @Override
   public List<String> getGroups(String user) {
-    return Arrays.asList(user + ".group", user + "subgroup1", user + "subgroup2");
+    return Arrays.asList(user + ".group", user + "subgroup1",
+        user + "subgroup2");
   }
 
   @Override
@@ -41,4 +44,9 @@ public class PeriodGroupsMapping implements GroupMappingServiceProvider {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return ImmutableSet.of(user + ".group", user + "subgroup1",
+        user + "subgroup2");
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/PrimaryGroupMapping.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/PrimaryGroupMapping.java
@@ -22,7 +22,9 @@ import org.apache.hadoop.security.GroupMappingServiceProvider;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Group Mapping class used for test cases. Returns only primary group of the
@@ -43,5 +45,10 @@ public class PrimaryGroupMapping implements GroupMappingServiceProvider {
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return Collections.singleton(user + "group");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/SimpleGroupsMapping.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/SimpleGroupsMapping.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.security.GroupMappingServiceProvider;
 
 public class SimpleGroupsMapping implements GroupMappingServiceProvider {
@@ -37,5 +39,11 @@ public class SimpleGroupsMapping implements GroupMappingServiceProvider {
 
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
+  }
+
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    return ImmutableSet.of(user + "group", user + "subgroup1",
+        user + "subgroup2");
   }
 }


### PR DESCRIPTION
## NOTICE

https://issues.apache.org/jira/browse/HADOOP-17079

UserGroupInformation.java adding getGroupsSet() that returns a Set instead of List. The callers of Groups#getGroups() in Hadoop are replaced with getGroupsSet() as we know Set#contains() will be
generally faster than List#contains expecially the user has large group memeberships. In some of our cusotmers' datalake use cases, user can typically have hundreds or thousands of group members. Changing from list to set make a big difference. 

GroupMappingServiceProvider.java add a new method that returns result as Set instead of List
Groups.java Change to maintain cached user -> groups mapping as a set instead of list. 

