### PR TITLE
HADOOP-16862. [JDK11] Support JavaDoc.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2399,6 +2399,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
+              <source>8</source>
               <additionalOptions>
                 <!-- TODO: remove -html4 option to generate html5 docs when we stop supporting JDK8 -->
                 <additionalOption>-html4</additionalOption>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-16862

Reference: https://bugs.openjdk.java.net/browse/JDK-8212233

> UPDATE FOR THOSE WHO GOOGLED THIS BUG:
> If the project uses source/target 8, adding <source>8</source> in javadoc configuration should make the project buildable on jdk {11, 12, 13}:
```
  <plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-javadoc-plugin</artifactId>
    <configuration>
      <source>8</source>
    </configuration>
     ...
  </plugin>
```