### PR TITLE
HADOOP-17091. [JDK11] Fix Javadoc errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile"
         YETUS='yetus'
         // Branch or tag name.  Yetus release tags are 'rel/X.Y.Z'
-        YETUS_VERSION='rel/0.12.0'
+        YETUS_VERSION='YETUS-972'
     }
 
     parameters {
@@ -51,7 +51,7 @@ pipeline {
                     checkout([
                         $class: 'GitSCM',
                         branches: [[name: "${env.YETUS_VERSION}"]],
-                        userRemoteConfigs: [[ url: 'https://github.com/apache/yetus.git']]]
+                        userRemoteConfigs: [[ url: 'https://github.com/aajisaka/yetus.git']]]
                     )
                 }
             }
@@ -159,7 +159,8 @@ pipeline {
                         YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/java-11-openjdk-amd64")
                         YETUS_ARGS+=("--multijdktests=compile")
 
-                        "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"
+                        # custom javadoc goal
+                        YETUS_ARGS+=("--mvn-javadoc=process-sources javadoc:javadoc-no-fork")
                         '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,6 +161,8 @@ pipeline {
 
                         # custom javadoc goal
                         YETUS_ARGS+=("--mvn-javadoc=process-sources javadoc:javadoc-no-fork")
+
+                        "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"
                         '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile"
         YETUS='yetus'
         // Branch or tag name.  Yetus release tags are 'rel/X.Y.Z'
-        YETUS_VERSION='YETUS-972'
+        YETUS_VERSION='master'
     }
 
     parameters {
@@ -51,7 +51,7 @@ pipeline {
                     checkout([
                         $class: 'GitSCM',
                         branches: [[name: "${env.YETUS_VERSION}"]],
-                        userRemoteConfigs: [[ url: 'https://github.com/aajisaka/yetus.git']]]
+                        userRemoteConfigs: [[ url: 'https://github.com/apache/yetus.git']]]
                     )
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,8 +159,8 @@ pipeline {
                         YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/java-11-openjdk-amd64")
                         YETUS_ARGS+=("--multijdktests=compile")
 
-                        # custom javadoc goal
-                        YETUS_ARGS+=("--mvn-javadoc=process-sources javadoc:javadoc-no-fork")
+                        # custom javadoc goals
+                        YETUS_ARGS+=("--mvn-javadoc-goals=process-sources,javadoc:javadoc-no-fork")
 
                         "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"
                         '''

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -35,6 +35,7 @@
     <is.hadoop.common.component>true</is.hadoop.common.component>
     <wsce.config.dir>../etc/hadoop</wsce.config.dir>
     <wsce.config.file>wsce-site.xml</wsce.config.file>
+    <javadoc.skip.jdk11>true</javadoc.skip.jdk11>
   </properties>
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <hadoop.component>hdfs</hadoop.component>
+    <javadoc.skip.jdk11>true</javadoc.skip.jdk11>
   </properties>
 
   <dependencies>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <hadoop.component>hdfs</hadoop.component>
+    <javadoc.skip.jdk11>true</javadoc.skip.jdk11>
   </properties>
 
   <dependencies>

--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -32,6 +32,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <hadoop.component>hdfs</hadoop.component>
     <is.hadoop.component>true</is.hadoop.component>
+    <javadoc.skip.jdk11>true</javadoc.skip.jdk11>
   </properties>
 
   <dependencies>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -152,6 +152,7 @@
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>
+    <javadoc.skip.jdk11>false</javadoc.skip.jdk11>
 
     <!-- The java version enforced by the maven enforcer -->
     <!-- more complex patterns can be used here, such as
@@ -2399,6 +2400,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
+              <skip>${javadoc.skip.jdk11}</skip>
               <source>8</source>
               <additionalOptions>
                 <!-- TODO: remove -html4 option to generate html5 docs when we stop supporting JDK8 -->

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2399,6 +2399,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
+              <source>8</source>
               <additionalOptions>
                 <!-- TODO: remove -html4 option to generate html5 docs when we stop supporting JDK8 -->
                 <additionalOption>-html4</additionalOption>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -35,6 +35,7 @@
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
     <hadoop.tmp.dir>${project.build.directory}/test</hadoop.tmp.dir>
+    <javadoc.skip.jdk11>true</javadoc.skip.jdk11>
 
     <!-- are scale tests enabled ? -->
     <fs.s3a.scale.test.enabled>unset</fs.s3a.scale.test.enabled>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17091

* Set javadoc goals to "process-sources javadoc:javadoc-no-fork" to replace `com.google.protobuf.*` with `org.apache.hadoop.thirdparty.protobuf.*` before running javadoc.
* Use Yetus master to include https://issues.apache.org/jira/browse/YETUS-972
* Fix the following error by setting the source version to 8. Reference: https://bugs.openjdk.java.net/browse/JDK-8212233
* Skip failing modules in jdk11 for now.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:javadoc (default-cli) on project hadoop-annotations: An error has occurred in Javadoc report generation: 
[ERROR] Exit code: 1 - javadoc: warning - You have specified the HTML version as HTML 4.01 by using the -html4 option.
[ERROR] The default is currently HTML5 and the support for HTML 4.01 will be removed
[ERROR] in a future release. To suppress this warning, please ensure that any HTML constructs
[ERROR] in your comments are valid in HTML5, and remove the -html4 option.
[ERROR] javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[ERROR] 
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/Users/aajisaka/git/hadoop/hadoop-common-project/hadoop-annotations/target/site/apidocs' dir.
```