### PR TITLE
YARN-10331. Upgrade node.js to 10.21.0.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -123,7 +123,7 @@ RUN pip2 install \
 RUN pip2 install python-dateutil==2.7.3
 
 ###
-# Install node.js 8.17.0 for web UI framework (4.2.6 ships with Xenial)
+# Install node.js 10.21.0 for web UI framework (4.2.6 ships with Xenial)
 ###
 RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=10.21.0-1nodesource1 \

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -125,8 +125,8 @@ RUN pip2 install python-dateutil==2.7.3
 ###
 # Install node.js 8.17.0 for web UI framework (4.2.6 ships with Xenial)
 ###
-RUN curl -L -s -S https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=8.17.0-1nodesource1 \
+RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs=10.21.0-1nodesource1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g bower@1.8.8

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -184,10 +184,10 @@ RUN pip2 install \
 RUN pip2 install python-dateutil==2.7.3
 
 ###
-# Install node.js 8.17.0 for web UI framework (4.2.6 ships with Xenial)
+# Install node.js 10.21.0 for web UI framework (4.2.6 ships with Xenial)
 ###
-RUN curl -L -s -S https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=8.17.0-1nodesource1 \
+RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs=10.21.0-1nodesource1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g bower@1.8.8

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
@@ -184,7 +184,7 @@
                   <goal>install-node-and-yarn</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v8.17.0</nodeVersion>
+                  <nodeVersion>v10.21.0</nodeVersion>
                   <yarnVersion>v1.21.1</yarnVersion>
                 </configuration>
               </execution>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YARN-10331

Ran `mvn install -DskipTests -Pyarn-ui` locally and it passed.