### PR TITLE
HADOOP-17097. start-build-env.sh fails in branch-3.1.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -165,14 +165,14 @@ RUN pip2 install \
 RUN pip2 install python-dateutil
 
 ###
-# Install node.js for web UI framework (4.2.6 ships with Xenial)
+# Install node.js 5.x for web UI framework
+# (instead of 4.2.6 shipped with Xenial)
 ###
-RUN apt-get -y install nodejs && \
-    ln -s /usr/bin/nodejs /usr/bin/node && \
-    apt-get -y install npm && \
-    npm install npm@latest -g && \
-    npm install -g bower && \
-    npm install -g ember-cli
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g npm@5.10.0 && \
+    npm install -g bower@1.7.7 && \
+    npm install -g ember-cli@1.13.14
 
 ###
 # Avoid out of memory errors in builds


### PR DESCRIPTION
I aligned the versions with the one pulled by frontend-maven-plugin (used in `mvn install -Pyarn-ui`).

* https://github.com/apache/hadoop/blob/branch-3.1/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml#L146-L147
* https://github.com/apache/hadoop/blob/branch-3.1/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/package.json#L22
* https://github.com/apache/hadoop/blob/branch-3.1/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/package.json#L29

The packages installed by apt-get are optional ones for interactive debugging. While I think we should use node.js pulled by frontend-maven-plugin along with the doc added by YARN-10020 (#1750), removing the packages here would surprise existing users of the env.