### PR TITLE
HADOOP-17090. Increase precommit job timeout from 5 hours to 20 hours.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 5, unit: 'HOURS')
+        timeout (time: 20, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17090