### PR TITLE
HDFS-15448.When starting a DataNode, call BlockPoolManager#startAll() twice.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2711,7 +2711,11 @@ public class DataNode extends ReconfigurableBase
    *  If this thread is specifically interrupted, it will stop waiting.
    */
   public void runDatanodeDaemon() throws IOException {
-    blockPoolManager.startAll();
+
+    // Verify that blockPoolManager has been started.
+    if (!isDatanodeUp()) {
+      throw new IOException("Failed to instantiate DataNode.");
+    }
 
     // start dataXceiveServer
     dataXceiverServer.start();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeExit.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeExit.java
@@ -82,6 +82,17 @@ public class TestDataNodeExit {
         dn.getBpOsCount());
   }
 
+  @Test
+  public void testBPServiceState() {
+    List<DataNode> dataNodes = cluster.getDataNodes();
+    for (DataNode dataNode : dataNodes) {
+      List<BPOfferService> bposList = dataNode.getAllBpOs();
+      for (BPOfferService bpOfferService : bposList) {
+        assertTrue(bpOfferService.isAlive());
+      }
+    }
+  }
+
   /**
    * Test BPService Thread Exit
    */


### PR DESCRIPTION
… twice.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
