### PR TITLE
HADOOP-17101. replace Guava Function

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -123,7 +123,7 @@
           <property name="regexp" value="true"/>
           <property name="illegalPkgs" value="^sun\.[^.]+"/>
           <property name="illegalClasses"
-            value="^com\.google\.common\.base\.(Optional)"/>
+            value="^com\.google\.common\.base\.(Optional|Function), ^com\.google\.common\.collect\.(Multimaps|ImmutableListMultimap)"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/noguava/ListMultiMap.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/noguava/ListMultiMap.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.noguava;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * The type List multi map.
+ *
+ * @param <K> the type parameter
+ * @param <V> the type parameter
+ */
+public class ListMultiMap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, List<V>> entries;
+
+  /**
+   * Instantiates a new List multi map.
+   *
+   * @param map the map
+   */
+  public ListMultiMap(final Map<K, List<V>> map) {
+    this.entries = map;
+  }
+
+  /**
+   * Instantiates a new List multi map.
+   */
+  public ListMultiMap() {
+    this(new HashMap<>());
+  }
+
+  @Override
+  public boolean put(final K key, final V value) {
+    this.entries.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    return false;
+  }
+
+  @Override
+  public void remove(final K key, final V value) {
+    this.entries.computeIfPresent(key,
+        (k, set) -> set.remove(value) && set.isEmpty() ? null : set);
+  }
+
+  @Override
+  public void clear() {
+    entries.clear();
+  }
+
+  public List<V> get(K key) {
+    return this.entries.getOrDefault(key, Collections.emptyList());
+  }
+
+  public int size() {
+    return this.entries.values().stream().mapToInt(List::size).sum();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return keySet().isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(final Object key) {
+    return keySet().contains(key);
+  }
+
+  @Override
+  public boolean containsValue(final Object value) {
+    return values().contains(value);
+  }
+
+  @Override
+  public List<V> values() {
+    return (List<V>) entries.values().stream().flatMap(List::stream);
+  }
+
+  @Override
+  public Set<K> keySet() {
+    return entries.keySet();
+  }
+
+  /**
+   * Creates an index {@code ImmutableListMultimap} that contains the results
+   * of applying a specified function to each item in an {@code Iterable}
+   * of values.
+   *
+   * @param <K>         the type parameter
+   * @param <V>         the type parameter
+   * @param values      the values to use when constructing the {@code
+   * ListMultimap}
+   * @param keyFunction the function used to produce the key for each value
+   * @return {@code ListMultimap} mapping the result of evaluating the
+   * function {@code keyFunction} on each value in the input collection
+   * to that value
+   * @throws NullPointerException if any element of {@code values} is
+   *                              {@code null}, or if {@code keyFunction}
+   *                              produces {@code null} for        any key
+   */
+  public static <K, V> ListMultiMap<K, V> index(
+      Iterable<V> values, Function<? super V, K> keyFunction) {
+    Map<K, List<V>> immutableMap =
+        StreamSupport.stream(values.spliterator(), false)
+            .collect(Collectors.toMap(keyFunction,
+                val -> Stream.of(val).collect(Collectors.toList()),
+                (a, b) -> Stream.of(a, b).flatMap(Collection::stream).collect(
+                    Collectors.toList())));
+    return new ListMultiMap<>(immutableMap);
+  }
+
+
+}
+

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/noguava/Multimap.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/noguava/Multimap.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.noguava;
+
+import java.util.Collection;
+import java.util.Set;
+
+
+/**
+ * A collection that maps keys to values, similar to {@link java.util.Map},
+ * but in which each key may be associated with <i>multiple</i> values.
+ */
+public interface Multimap <K, V> {
+
+  int size();
+  boolean isEmpty();
+  boolean containsKey(Object key);
+  boolean containsValue(Object value);
+
+  /**
+   * Stores a key-value pair in this multimap.
+   *
+   * <p>Some multimap implementations allow duplicate key-value pairs, in
+   * which case {@code put}
+   * always adds a new key-value pair and increases the multimap size by 1.
+   * Other implementations
+   * prohibit duplicates, and storing a key-value pair that's already in the
+   * multimap has no effect.
+   *
+   * @return {@code true} if the method increased the size of the multimap,
+   * or {@code false} if the
+   * multimap already contained the key-value pair and doesn't allow duplicates
+   */
+  boolean put(K key, V value);
+  void remove(K key, V value);
+  void clear();
+  Collection<V> get(K key);
+  Set<K> keySet();
+  Collection<V> values();
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/noguava/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/noguava/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util.noguava;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
@@ -17,19 +17,18 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.UnmodifiableIterator;
 
-import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 
@@ -101,14 +100,14 @@ public class HostSet implements Iterable<InetSocketAddress> {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("HostSet(");
-    Joiner.on(",").appendTo(sb, Iterators.transform(iterator(),
-        new Function<InetSocketAddress, String>() {
-          @Override
-          public String apply(@Nullable InetSocketAddress addr) {
-            assert addr != null;
-            return addr.getAddress().getHostAddress() + ":" + addr.getPort();
-          }
-        }));
+    List<String> addresses = new ArrayList<>();
+    iterator().forEachRemaining(
+        addr -> {
+          assert addr != null;
+          addresses.add(addr.getAddress().getHostAddress()
+              + ":" + addr.getPort());
+        });
+    sb.append(String.join(",", addresses));
     return sb.append(")").toString();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/RemoteEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/RemoteEditLog.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.protocol;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ComparisonChain;
+import java.util.function.Function;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 
 public class RemoteEditLog implements Comparable<RemoteEditLog> {
@@ -85,13 +85,10 @@ public class RemoteEditLog implements Comparable<RemoteEditLog> {
    * Guava <code>Function</code> which applies {@link #getStartTxId()} 
    */
   public static final Function<RemoteEditLog, Long> GET_START_TXID =
-    new Function<RemoteEditLog, Long>() {
-      @Override
-      public Long apply(RemoteEditLog log) {
+      log -> {
         if (null == log) {
           return HdfsServerConstants.INVALID_TXID;
         }
         return log.getStartTxId();
-      }
-    };
+      };
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
@@ -37,9 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAccumulator;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -304,15 +302,11 @@ public abstract class HATestUtil {
   public static <P extends FailoverProxyProvider<?>> void
       setFailoverConfigurations(Configuration conf, String logicalName,
       List<InetSocketAddress> nnAddresses, Class<P> classFPP) {
-    setFailoverConfigurations(conf, logicalName,
-        Iterables.transform(nnAddresses, new Function<InetSocketAddress, String>() {
-
-          // transform the inet address to a simple string
-          @Override
-          public String apply(InetSocketAddress addr) {
-            return "hdfs://" + addr.getHostName() + ":" + addr.getPort();
-          }
-        }), classFPP);
+    final List<String> addresses = new ArrayList();
+    nnAddresses.forEach(
+        addr -> addresses.add(
+            "hdfs://" + addr.getHostName() + ":" + addr.getPort()));
+    setFailoverConfigurations(conf, logicalName, addresses, classFPP);
   }
 
   public static <P extends FailoverProxyProvider<?>>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestFileInputFormat.java
@@ -23,8 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-
-import javax.annotation.Nullable;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 
@@ -55,8 +54,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -403,13 +400,10 @@ public class TestFileInputFormat {
       List<FileStatus> fetchedStatuses, final FileSystem localFs) {
     Assert.assertEquals(expectedPaths.size(), fetchedStatuses.size());
 
-    Iterable<Path> fqExpectedPaths = Iterables.transform(expectedPaths,
-        new Function<Path, Path>() {
-          @Override
-          public Path apply(Path input) {
-            return localFs.makeQualified(input);
-          }
-        });
+    Iterable<Path> fqExpectedPaths =
+        expectedPaths.stream().map(
+            input -> localFs.makeQualified(input)).collect(Collectors.toList());
+
 
     Set<Path> expectedPathSet = Sets.newHashSet(fqExpectedPaths);
     for (FileStatus fileStatus : fetchedStatuses) {
@@ -424,13 +418,10 @@ public class TestFileInputFormat {
 
 
   private void verifySplits(List<String> expected, List<InputSplit> splits) {
-    Iterable<String> pathsFromSplits = Iterables.transform(splits,
-        new Function<InputSplit, String>() {
-          @Override
-          public String apply(@Nullable InputSplit input) {
-            return ((FileSplit) input).getPath().toString();
-          }
-        });
+    Iterable<String> pathsFromSplits =
+        splits.stream().map(
+            input-> ((FileSplit) input).getPath().toString())
+            .collect(Collectors.toList());
 
     Set<String> expectedSet = Sets.newHashSet(expected);
     for (String splitPathString : pathsFromSplits) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/GetApplicationsRequestPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/GetApplicationsRequestPBImpl.java
@@ -22,7 +22,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.Range;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
@@ -35,8 +35,6 @@ import org.apache.hadoop.yarn.proto.YarnProtos.YarnApplicationStateProto;
 import org.apache.hadoop.yarn.proto.YarnServiceProtos.GetApplicationsRequestProto;
 import org.apache.hadoop.yarn.proto.YarnServiceProtos.GetApplicationsRequestProtoOrBuilder;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import org.apache.hadoop.thirdparty.protobuf.TextFormat;
 
 @Private
@@ -88,13 +86,10 @@ public class GetApplicationsRequestPBImpl extends GetApplicationsRequest {
     }
     if (applicationStates != null && !applicationStates.isEmpty()) {
       builder.clearApplicationStates();
-      builder.addAllApplicationStates(Iterables.transform(applicationStates,
-          new Function<YarnApplicationState, YarnApplicationStateProto>() {
-            @Override
-            public YarnApplicationStateProto apply(YarnApplicationState input) {
-              return ProtoUtils.convertToProtoFormat(input);
-            }
-          }));
+      builder.addAllApplicationStates(
+          applicationStates.stream().map(
+              input -> ProtoUtils.convertToProtoFormat(input)
+          ).collect(Collectors.toList()));
     }
     if (applicationTags != null && !applicationTags.isEmpty()) {
       builder.clearApplicationTags();


### PR DESCRIPTION
- I have added a rule to prevent import of Guava `Function`, `Multimaps` and `ImmutableListMultimap`
- I added a new package `org.apache.hadoop.util.noguava` that will be the place holder for all utilities that we need to replace Guava API