### PR TITLE
HADOOP-16966. ABFS: change rest version to 2019-12-12

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -62,7 +62,7 @@ public class AbfsClient implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   private final URL baseUrl;
   private final SharedKeyCredentials sharedKeyCredentials;
-  private final String xMsVersion = "2018-11-09";
+  private final String xMsVersion = "2019-12-12";
   private final ExponentialRetryPolicy retryPolicy;
   private final String filesystem;
   private final AbfsConfiguration abfsConfiguration;


### PR DESCRIPTION
The PR changes the RestVersion to 2019-12-12 while sending requests from ABFS Driver. The change was tested with namespace and non namespace account in production. Whats missing? Documentation for the appendblob directories config parameter as the backend tenants are not enabled/right release is not present.

Here are the test results:

namespace enabled
Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
Tests run: 447, Failures: 0, Errors: 0, Skipped: 42
Tests run: 207, Failures: 0, Errors: 0, Skipped: 24

non namespace enabled:
Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
Tests run: 447, Failures: 0, Errors: 0, Skipped: 245
Tests run: 207, Failures: 0, Errors: 0, Skipped: 24