### PR TITLE
YARN-10344. Sync netty versions in hadoop-yarn-csi.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -66,6 +66,18 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <version>${grpc.version}</version>
+            <exclusions>
+                <!-- Contained in netty-all. skip -->
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http2</artifactId>
+                </exclusion>
+                <!-- Contained in netty-all. skip -->
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler-proxy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YARN-10344

Before:
```
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-yarn-csi ---
[INFO] org.apache.hadoop:hadoop-yarn-csi:jar:3.3.0
[INFO] +- com.google.guava:guava:jar:20.0:compile
[INFO] +- com.google.protobuf:protobuf-java:jar:3.6.1:compile
[INFO] +- io.netty:netty-all:jar:4.1.50.Final:compile
[INFO] +- io.grpc:grpc-core:jar:1.26.0:compile
[INFO] |  +- io.grpc:grpc-api:jar:1.26.0:compile (version selected from constraint [1.26.0,1.26.0])
[INFO] |  |  +- io.grpc:grpc-context:jar:1.26.0:compile
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.3.3:compile
[INFO] |  |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.2.4:compile
[INFO] |  +- com.google.android:annotations:jar:4.1.1.4:compile
[INFO] |  +- io.perfmark:perfmark-api:jar:0.19.0:compile
[INFO] |  +- io.opencensus:opencensus-api:jar:0.24.0:compile
[INFO] |  \- io.opencensus:opencensus-contrib-grpc-metrics:jar:0.24.0:compile
[INFO] +- io.grpc:grpc-protobuf:jar:1.26.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-common-protos:jar:1.12.0:compile
[INFO] |  \- io.grpc:grpc-protobuf-lite:jar:1.26.0:compile
[INFO] +- io.grpc:grpc-stub:jar:1.26.0:compile
[INFO] +- io.grpc:grpc-netty:jar:1.26.0:compile
[INFO] |  +- io.netty:netty-codec-http2:jar:4.1.42.Final:compile (version selected from constraint [4.1.42.Final,4.1.42.Final])
[INFO] |  |  +- io.netty:netty-common:jar:4.1.42.Final:compile
[INFO] |  |  +- io.netty:netty-buffer:jar:4.1.42.Final:compile
[INFO] |  |  +- io.netty:netty-transport:jar:4.1.42.Final:compile
[INFO] |  |  |  \- io.netty:netty-resolver:jar:4.1.42.Final:compile
[INFO] |  |  +- io.netty:netty-codec:jar:4.1.42.Final:compile
[INFO] |  |  +- io.netty:netty-handler:jar:4.1.42.Final:compile
[INFO] |  |  \- io.netty:netty-codec-http:jar:4.1.42.Final:compile
[INFO] |  \- io.netty:netty-handler-proxy:jar:4.1.42.Final:compile
[INFO] |     \- io.netty:netty-codec-socks:jar:4.1.42.Final:compile
(snip)
```

After:
```
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-yarn-csi ---
[INFO] org.apache.hadoop:hadoop-yarn-csi:jar:3.4.0-SNAPSHOT
[INFO] +- com.google.guava:guava:jar:20.0:compile
[INFO] +- com.google.protobuf:protobuf-java:jar:3.6.1:compile
[INFO] +- io.netty:netty-all:jar:4.1.50.Final:compile
[INFO] +- io.grpc:grpc-core:jar:1.26.0:compile
[INFO] |  +- io.grpc:grpc-api:jar:1.26.0:compile (version selected from constraint [1.26.0,1.26.0])
[INFO] |  |  +- io.grpc:grpc-context:jar:1.26.0:compile
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.3.3:compile
[INFO] |  |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.2.4:compile
[INFO] |  +- com.google.android:annotations:jar:4.1.1.4:compile
[INFO] |  +- io.perfmark:perfmark-api:jar:0.19.0:compile
[INFO] |  +- io.opencensus:opencensus-api:jar:0.24.0:compile
[INFO] |  \- io.opencensus:opencensus-contrib-grpc-metrics:jar:0.24.0:compile
[INFO] +- io.grpc:grpc-protobuf:jar:1.26.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-common-protos:jar:1.12.0:compile
[INFO] |  \- io.grpc:grpc-protobuf-lite:jar:1.26.0:compile
[INFO] +- io.grpc:grpc-stub:jar:1.26.0:compile
[INFO] +- io.grpc:grpc-netty:jar:1.26.0:compile
(snip)
```