### PR TITLE
HADOOP-17120. Fix failure of docker image creation due to pip2 install error.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -157,7 +157,8 @@ RUN apt-get -q update && apt-get -q install -y bats
 ####
 RUN pip2 install \
     configparser==4.0.2 \
-    pylint==1.9.2
+    pylint==1.9.2 \
+    isort==4.3.21
 
 ####
 # Install dateutil.parser


### PR DESCRIPTION
Since [isort 5.x does not support Python 2](https://github.com/timothycrosley/isort/blob/master/CHANGELOG.md#500-penny---july-4-2020), I pinned the version of isort to the latest of 4.x.