### PR TITLE
HDFS-15462. Add fs.viewfs.overload.scheme.target.ofs.impl to core-default.xml

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -968,6 +968,14 @@
 </property>
 
 <property>
+  <name>fs.viewfs.overload.scheme.target.ofs.impl</name>
+  <value>org.apache.hadoop.fs.ozone.RootedOzoneFileSystem</value>
+  <description>The RootedOzoneFileSystem for view file system overload scheme
+    when child file system and ViewFSOverloadScheme's schemes are ofs.
+  </description>
+</property>
+
+<property>
   <name>fs.viewfs.overload.scheme.target.o3fs.impl</name>
   <value>org.apache.hadoop.fs.ozone.OzoneFileSystem</value>
   <description>The OzoneFileSystem for view file system overload scheme when

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestCommonConfigurationFields.java
@@ -133,6 +133,7 @@ public class TestCommonConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.hdfs.impl");
     xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.http.impl");
     xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.https.impl");
+    xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.ofs.impl");
     xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.o3fs.impl");
     xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.oss.impl");
     xmlPropsToSkipCompare.add("fs.viewfs.overload.scheme.target.s3a.impl");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15462

HDFS-15394 added existing FS implementations in core-default.xml except ofs. Let's add ofs to core-default as well.