### PR TITLE
HADOOP-17126. implement un-guava Precondition checkNotNull

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/unguava/Validate.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/unguava/Validate.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.unguava;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * <p>This class replaces {@code guava.Preconditions} which provides helpers
+ * to validate the following conditions:
+ * <ul>
+ *   <li>An invalid {@code null} obj causes a {@link NullPointerException}.</li>
+ *   <li>An invalid argument causes an {@link IllegalArgumentException}.</li>
+ *   <li>An invalid state causes an {@link IllegalStateException}.</li>
+ *   <li>An invalid index causes an {@link IndexOutOfBoundsException}.</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public final class Validate {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(Validate.class);
+
+  public static final String VALIDATE_IS_NOT_NULL_EX_MESSAGE =
+      "The argument object is NULL";
+
+  private Validate() {
+  }
+
+  /**
+   * <p>Validate that the specified argument is not {@code null},
+   * throwing a NPE exception otherwise.
+   *
+   * <p>The message of the exception is
+   * &quot;The validated object is null&quot;.</p>
+   *
+   * @param <T> the object type
+   * @param obj  the object to check
+   * @return the validated object
+   * @throws NullPointerException if the object is {@code null}
+   * @see #checkNotNull(Object, Object)
+   */
+  public static <T> T checkNotNull(final T obj) {
+    return checkNotNull(obj, VALIDATE_IS_NOT_NULL_EX_MESSAGE);
+  }
+
+  /**
+   * <p>Validate that the specified argument is not {@code null},
+   * throwing a NPE exception otherwise.
+   *
+   * <p>The message of the exception is {@code errorMessage}.</p>
+   *
+   * @param <T> the object type
+   * @param obj  the object to check
+   * @param errorMessage  the message associated with the NPE
+   * @return the validated object
+   * @throws NullPointerException if the object is {@code null}
+   * @see #checkNotNull(Object, String, Object...)
+   */
+  public static <T> T checkNotNull(final T obj,
+      final Object errorMessage) {
+    if (obj == null) {
+      throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    return obj;
+  }
+
+  /**
+   * <p>Validate that the specified argument is not {@code null},
+   * throwing a NPE exception otherwise.
+   *
+   * <p>The message of the exception is {@code String.format(f, m)}.</p>
+   *
+   * @param <T> the object type
+   * @param obj  the object to check
+   * @param message  the {@link String#format(String, Object...)}
+   *                 exception message if valid. Otherwise,
+   *                 the message is {@link #VALIDATE_IS_NOT_NULL_EX_MESSAGE}
+   * @param values  the optional values for the formatted exception message
+   * @return the validated object
+   * @throws NullPointerException if the object is {@code null}
+   * @see #checkNotNull(Object, Supplier)
+   */
+  public static <T> T checkNotNull(final T obj, final String message,
+      final Object... values) {
+    // Deferring the evaluation of the message is a tradeoff between the cost
+    // of constructing lambda vs constructing a string object.
+    // Using lambda would allocate an object on every all:
+    //       return checkNotNull(obj, () -> String.format(message, values));
+    if (obj == null) {
+      String msg = VALIDATE_IS_NOT_NULL_EX_MESSAGE;
+      try {
+        msg = String.format(message, values);
+      } catch (Exception e) {
+        LOG.debug("Error formatting message: {}", e.getMessage());
+      }
+      throw new NullPointerException(msg);
+    }
+    return obj;
+  }
+
+  /**
+   * <p>Validate that the specified argument is not {@code null},
+   * throwing a NPE exception otherwise.
+   *
+   * <p>The message of the exception is {@code msgSupplier.get()}.</p>
+   *
+   * @param <T> the object type
+   * @param obj  the object to check
+   * @param msgSupplier  the {@link Supplier#get()} set the
+   *                 exception message if valid. Otherwise,
+   *                 the message is {@link #VALIDATE_IS_NOT_NULL_EX_MESSAGE}
+   * @return the validated object (never {@code null} for method chaining)
+   * @throws NullPointerException if the object is {@code null}
+   */
+  public static <T> T checkNotNull(final T obj,
+      final Supplier<String> msgSupplier) {
+    if (obj == null) {
+      String msg = VALIDATE_IS_NOT_NULL_EX_MESSAGE;
+      try {
+        // note that we can get NPE evaluating the message itself;
+        // but we do not want this to override the actual NPE.
+        msg = msgSupplier.get();
+      } catch (Exception e) {
+        // ideally we want to log the error to capture. This may cause log files
+        // to bloat. On the other hand, swallowing the exception may hide a bug
+        // in the caller. Debug level is a good compromise between the two
+        // concerns.
+        LOG.debug("Error formatting message: {}", e.getMessage());
+      }
+      throw new NullPointerException(msg);
+    }
+    return obj;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/unguava/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/unguava/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util.unguava;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/unguava/TestValidate.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/unguava/TestValidate.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util.unguava;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.test.LambdaTestUtils;
+
+public class TestValidate {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(TestValidate.class);
+
+  private static final String NON_NULL_STRING = "NON_NULL_OBJECT";
+  private static final String NON_INT_STRING = "NOT_INT";
+  private static final String EXPECTED_ERROR_MSG = "Expected-Error-MSG";
+  private static final String EXPECTED_ERROR_MSG_ARGS =
+      EXPECTED_ERROR_MSG + " %s number %d";
+  private static final String NULL_FORMATTER = null;
+
+  private String errorMessage;
+
+  @Test
+  public void testCheckNotNullSuccess() {
+    Validate.checkNotNull(NON_NULL_STRING);
+    // null supplier
+    Validate.checkNotNull(NON_NULL_STRING, null);
+    // ill-formated string supplier
+    Validate.checkNotNull(NON_NULL_STRING, ()-> String.format("%d",
+        NON_INT_STRING));
+    // null pattern to string formatter
+    Validate.checkNotNull(NON_NULL_STRING, NULL_FORMATTER, null, 1);
+    // null arguments to string formatter
+    Validate.checkNotNull(NON_NULL_STRING, EXPECTED_ERROR_MSG_ARGS,
+        null, null);
+    // illegal format exception
+    Validate.checkNotNull(NON_NULL_STRING, "message %d %d",
+        NON_INT_STRING, 1);
+    // insufficient arguments
+    Validate.checkNotNull(NON_NULL_STRING, EXPECTED_ERROR_MSG_ARGS,
+        NON_INT_STRING);
+    // null format in string supplier
+    Validate.checkNotNull(NON_NULL_STRING,
+        () -> String.format(NULL_FORMATTER, NON_INT_STRING));
+  }
+
+  @Test
+  public void testCheckNotNullFailure() throws Exception {
+    // failure without message
+    LambdaTestUtils.intercept(NullPointerException.class,
+        Validate.VALIDATE_IS_NOT_NULL_EX_MESSAGE,
+        () -> Validate.checkNotNull(null));
+
+    // failure with message
+    errorMessage = EXPECTED_ERROR_MSG;
+    LambdaTestUtils.intercept(NullPointerException.class,
+        errorMessage,
+        () -> Validate.checkNotNull(null, errorMessage));
+
+    // failure with Null message
+    LambdaTestUtils.intercept(NullPointerException.class,
+        null,
+        () -> Validate.checkNotNull(null, errorMessage));
+
+    // failure with message format
+    errorMessage = EXPECTED_ERROR_MSG + " %s";
+    String arg = "NPE";
+    String expectedMSG = String.format(errorMessage, arg);
+    LambdaTestUtils.intercept(NullPointerException.class,
+        expectedMSG,
+        () -> Validate.checkNotNull(null, errorMessage, arg));
+
+    // failure with multiple arg message format
+    errorMessage = EXPECTED_ERROR_MSG_ARGS;
+    expectedMSG =
+        String.format(errorMessage, arg, 1);
+    LambdaTestUtils.intercept(NullPointerException.class,
+        expectedMSG,
+        () -> Validate.checkNotNull(null, errorMessage, arg, 1));
+
+    // illegal format will be thrown if the case is not handled correctly
+    LambdaTestUtils.intercept(NullPointerException.class,
+        Validate.VALIDATE_IS_NOT_NULL_EX_MESSAGE,
+        () -> Validate.checkNotNull(null, errorMessage, 1, NON_INT_STRING));
+
+    // illegal format will be thrown for insufficient Insufficient Args
+    LambdaTestUtils.intercept(NullPointerException.class,
+        Validate.VALIDATE_IS_NOT_NULL_EX_MESSAGE,
+        () -> Validate.checkNotNull(null, errorMessage, NON_NULL_STRING));
+
+    // illegal format in supplier
+    LambdaTestUtils.intercept(NullPointerException.class,
+        Validate.VALIDATE_IS_NOT_NULL_EX_MESSAGE,
+        () -> Validate.checkNotNull(null,
+            () -> String.format(errorMessage, 1, NON_INT_STRING)));
+
+    // insufficient arguments in string Supplier
+    LambdaTestUtils.intercept(NullPointerException.class,
+        Validate.VALIDATE_IS_NOT_NULL_EX_MESSAGE,
+        () -> Validate.checkNotNull(null,
+            () -> String.format(errorMessage, NON_NULL_STRING)));
+
+    // null formatter
+    LambdaTestUtils.intercept(NullPointerException.class,
+        Validate.VALIDATE_IS_NOT_NULL_EX_MESSAGE,
+        () -> Validate.checkNotNull(null,
+            () -> String.format(NULL_FORMATTER, NON_NULL_STRING)));
+  }
+}


### PR DESCRIPTION
## NOTICE

As part In order to replace Guava Preconditions, we need to implement our own versions of the API.
This PR is to create `checkNotNull` in a new package dubbed `unguava`.
This is splitting the PR that was opened previously #2134
 
**The plan is as follows**

- create a new `package org.apache.hadoop.util.unguava`;
- create `class Validate`
- implement  `org.apache.hadoop.util.unguava.Validate`  with the following interface
  - `checkNotNull(final T obj)`
  - `checkNotNull(final T reference, final Object errorMessage)`
  - `checkNotNull(final T obj, final String message, final Object... values)`
  - `checkNotNull(final T obj,final Supplier<String> msgSupplier)`
- `guava.preconditions` used `String.lenientformat` which suppressed exceptions caused by string formatting of the exception message . So, in order to avoid changing the behavior, the implementation catches exceptions triggered by building the message (IllegalFormat, InsufficientArg, NullPointer..etc)
- After merging the new class, we can replace `guava.Preconditions.checkNotNull` by `unguava.Validate.checkNotNull`
- We need the change to go into trunk, 3.1, 3.2, and 3.3
 
Similar Jiras will be created to implement `checkState`, `checkArgument`, `checkIndex`
