### PR TITLE
HADOOP-16866. Upgrade spotbugs to 4.0.6.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -98,7 +98,7 @@
     <zookeeper.version>3.5.6</zookeeper.version>
     <curator.version>4.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
-    <spotbugs.version>3.1.0-RC1</spotbugs.version>
+    <spotbugs.version>4.0.6</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
     <guava.version>27.0-jre</guava.version>


### PR DESCRIPTION
We are using spotbufs 3.1.0-RC1. Newer released versions could be available now. The changes described on the [migration guide](https://spotbugs.readthedocs.io/en/stable/migration.html) seems to be not so disruptive.
