### PR TITLE
HDFS-15476 Make AsyncStream executor private

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/async_stream.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/async_stream.h
@@ -39,10 +39,11 @@ typedef boost::asio::const_buffers_1   ConstBuffer;
  * Threading model: async_read_some and async_write_some are not thread-safe.
  */
 class AsyncStream  {
-public:
+private:
   using executor_type = boost::asio::system_executor;
   executor_type executor_;
 
+public:
   virtual void async_read_some(const MutableBuffer &buf,
           std::function<void (const boost::system::error_code & error,
                                  std::size_t bytes_transferred) > handler) = 0;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/async_stream.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/async_stream.h
@@ -39,11 +39,9 @@ typedef boost::asio::const_buffers_1   ConstBuffer;
  * Threading model: async_read_some and async_write_some are not thread-safe.
  */
 class AsyncStream  {
-private:
-  using executor_type = boost::asio::system_executor;
-  executor_type executor_;
-
 public:
+  using executor_type = boost::asio::system_executor;
+
   virtual void async_read_some(const MutableBuffer &buf,
           std::function<void (const boost::system::error_code & error,
                                  std::size_t bytes_transferred) > handler) = 0;
@@ -55,6 +53,10 @@ public:
   executor_type get_executor() {
       return executor_;
   }
+
+private:
+  executor_type executor_;
+
 };
 
 }


### PR DESCRIPTION
The executor_ member of the AsyncStream class is public, but there is a getter get_executor() that returns this executor_ member. This member should be private.