### PR TITLE
HADOOP-15702. ABFS: Made max size and time out configurable for ITestAbfsReadWriteAndSeek

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -42,8 +42,8 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_MAX_RETRY_ATTEMPTS = 30;
   public static final int DEFAULT_CUSTOM_TOKEN_FETCH_RETRY_COUNT = 3;
 
-  private static final int ONE_KB = 1024;
-  private static final int ONE_MB = ONE_KB * ONE_KB;
+  public static final int ONE_KB = 1024;
+  public static final int ONE_MB = ONE_KB * ONE_KB;
 
   // Default upload and download buffer size
   public static final int DEFAULT_WRITE_BUFFER_SIZE = 8 * ONE_MB;  // 8 MB

--- a/hadoop-tools/hadoop-azure/src/site/markdown/testing_azure.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/testing_azure.md
@@ -293,6 +293,8 @@ Only a few properties can be set this way; more will be added.
 |-----------|-------------|
 | `fs.azure.scale.test.huge.filesize`| Size for huge file uploads |
 | `fs.azure.scale.test.huge.huge.partitionsize`| Size for partitions in huge file uploads |
+| `fs.azure.scale.test.readwriteseek.timeout.mins`| To set the timeout for the scale tests in ITestAbfsReadWriteAndSeek. Specify the value in minutes. By default the timeout will be 30 minutes. |
+| `fa.azure.scale.test.readwriteseek.max.size.mb'| To set the largest file size to run the scale test in ITestAbfsReadWriteAndSeek. Specify the value in MBs. By default this will be 100 MB |
 
 The file and partition sizes are numeric values with a k/m/g/t/p suffix depending
 on the desired size. For example: 128M, 128m, 2G, 2G, 4T or even 1P.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -49,6 +49,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.toHuman;
 @RunWith(Parameterized.class)
 public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
   private static final Path TEST_PATH = new Path("/testfile");
+  private static final int SIXTY = 60;
 
   @Parameterized.Parameters(name = "Size={0}")
   public static Iterable<Object[]> sizes() {
@@ -91,7 +92,7 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     if (timeout < 0) {
       timeout = super.getTestTimeoutMillis();
     } else {
-      timeout *= 60 * 1000;
+      timeout *= SIXTY * 1000;
     }
     return timeout;
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -49,6 +49,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
   @Test
   public void testEnsureFileCreatedImmediately() throws Exception {
+    AbfsConfiguration abfsconf = getConfiguration();
     final AzureBlobFileSystem fs = getFileSystem();
     FSDataOutputStream out = fs.create(TEST_FILE_PATH);
     try {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/constants/TestConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/constants/TestConfigurationKeys.java
@@ -58,5 +58,8 @@ public final class TestConfigurationKeys {
   public static final String TEST_CONTAINER_PREFIX = "abfs-testcontainer-";
   public static final int TEST_TIMEOUT = 15 * 60 * 1000;
 
+  public static final String SCALETEST_READ_WRITE_SEEK_TIMEOUT_IN_MINS = "fs.azure.scale.test.readwriteseek.timeout.mins";
+  public static final String SCALETEST_READ_WRITE_SEEK_MAX_SIZE_MB = "fa.azure.scale.test.readwriteseek.max.size.mb";
+
   private TestConfigurationKeys() {}
 }


### PR DESCRIPTION
Making ITestAbfsReadWriteAndSeek timeout configurable
Making max size configurable for ITestAbfsReadWriteAndSeek scale test
using the nanotimer to measure & print time effective bandwidth of writes, reads.

**Driver test results using accounts in Central India**
mvn -T 1C -Dparallel-tests=abfs -Dscale -DtestsThreadCount=8 clean verify

**Account with HNS Support**
[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 447, Failures: 0, Errors: 0, Skipped: 75
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 24

**Account without HNS support**
[INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 447, Failures: 0, Errors: 0, Skipped: 249
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 24