### PR TITLE
HADOOP-17136 ITestS3ADirectoryPerformance.testListOperations failing because of HADOOP-17022

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
@@ -114,7 +114,7 @@ public class ITestS3ADirectoryPerformance extends S3AScaleTestBase {
           listStatusCalls,
           getFileStatusCalls);
       if (!fs.hasMetadataStore()) {
-        assertEquals(listRequests.toString(), 2, listRequests.diff());
+        assertEquals(listRequests.toString(), 1, listRequests.diff());
       }
       reset(metadataRequests,
           listRequests,


### PR DESCRIPTION
Re ran the failed test. It is passing now. 
