### PR TITLE
YARN-10358. Fix findbugs warnings in hadoop-yarn-project on branch-2.10.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
+++ b/hadoop-yarn-project/hadoop-yarn/dev-support/findbugs-exclude.xml
@@ -641,4 +641,16 @@
     <Bug pattern="EQ_OVERRIDING_EQUALS_NOT_SYMMETRIC" />
   </Match>
 
+  <!-- Ignore WMI_WRONG_MAP_ITERATOR for EnumMap -->
+  <Match>
+    <Class name="org.apache.hadoop.yarn.state.StateMachineFactory" />
+    <Method name="generateStateGraph" />
+    <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
+  </Match>
+
+  <Match>
+    <Class name="org.apache.hadoop.yarn.server.timelineservice.storage.common.ColumnRWHelper" />
+    <Method name="readResultsWithTimestamps" />
+    <Bug pattern="BX_UNBOXING_IMMEDIATELY_REBOXED" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Please refer to the comments of [YARN-10358](https://issues.apache.org/jira/browse/YARN-10358) for description.