### PR TITLE
YARN-10367. Failed to get nodejs 10.21.0 when building docker image

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -140,6 +140,7 @@ RUN pip2 install python-dateutil==2.7.3
 ###
 # Install node.js 10.x for web UI framework (4.2.6 ships with Xenial)
 ###
+# hadolint ignore=DL3008
 RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -138,10 +138,10 @@ RUN pip2 install \
 RUN pip2 install python-dateutil==2.7.3
 
 ###
-# Install node.js 10.21.0 for web UI framework (4.2.6 ships with Xenial)
+# Install node.js 10.x for web UI framework (4.2.6 ships with Xenial)
 ###
 RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=10.21.0-1nodesource1 \
+    && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g bower@1.8.8

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -141,10 +141,10 @@ RUN pip2 install \
 RUN pip2 install python-dateutil==2.7.3
 
 ###
-# Install node.js 10.21.0 for web UI framework (4.2.6 ships with Xenial)
+# Install node.js 10.x for web UI framework (4.2.6 ships with Xenial)
 ###
 RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=10.21.0-1nodesource1 \
+    && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g bower@1.8.8

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -143,6 +143,7 @@ RUN pip2 install python-dateutil==2.7.3
 ###
 # Install node.js 10.x for web UI framework (4.2.6 ships with Xenial)
 ###
+# hadolint ignore=DL3008
 RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YARN-10367

Install the latest 10.x version of nodejs in the docker image.