### PR TITLE
HADOOP-17167 Skipping ITestS3AEncryptionWithDefaultS3Settings.testEncryptionOverRename

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -35,6 +35,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
+import static org.apache.hadoop.fs.s3a.EncryptionTestUtils.AWS_KMS_SSE_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_KMS;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 
@@ -105,6 +106,23 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
   @Ignore
   @Test
   public void testEncryption() throws Throwable {
+  }
+
+  /**
+   * Skipping if the test bucket is not configured with
+   * aws:kms encryption algorithm.
+   */
+  @Override
+  public void testEncryptionOverRename() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    Path path = path(getMethodName() + "find-encryption-algo");
+    ContractTestUtils.touch(fs, path);
+    String sseAlgorithm = fs.getObjectMetadata(path).getSSEAlgorithm();
+    if(StringUtils.isBlank(sseAlgorithm) ||
+            !sseAlgorithm.equals(AWS_KMS_SSE_ALGORITHM)) {
+      skip("Test bucket is not configured with " + AWS_KMS_SSE_ALGORITHM);
+    }
+    super.testEncryptionOverRename();
   }
 
   @Test


### PR DESCRIPTION
Tested by running this test only against ap-south-1 bucket configured with all three encryption algo.