### PR TITLE
HDFS-15499. Clean up httpfs/pom.xml to remove aws-java-sdk-s3 exclusion

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
@@ -119,10 +119,6 @@
           <artifactId>servlet-api-2.5</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-s3</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.eclipse.jdt</groupId>
           <artifactId>core</artifactId>
         </exclusion>
@@ -152,10 +148,6 @@
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>servlet-api-2.5</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-s3</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.jdt</groupId>


### PR DESCRIPTION
This was based on discussion that we need to update the s3 to bundle for dependencies after HADOOP-14040. However, when I checked it now, I did not find `aws-java-sdk-s3` included in the httpfs module
```
$ mvn clean dependency:tree -Dverbose | grep aws
$ echo $?
1
$
```

The reason is that, hadoop-common and hadoop-hdfs modules do not include this aws s3 sdk any longer. So this PR is to clean that up to avoid confusion.
