### PR TITLE
HADOOP-17164. UGI loginUserFromKeytab doesn't set the last login time

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -644,6 +644,15 @@ public class UserGroupInformation {
   }
 
   /**
+   * Set the last login time for logged in user
+   *
+   * @param loginTime the number of milliseconds since the beginning of time
+   */
+  private void setLastLogin(long loginTime) {
+    user.setLastLogin(loginTime);
+  }
+
+  /**
    * Create a UserGroupInformation for the given subject.
    * This does not change the subject or acquire new credentials.
    * @param subject the user's subject
@@ -1096,6 +1105,7 @@ public class UserGroupInformation {
       metrics.loginSuccess.add(Time.now() - start);
       loginUser = new UserGroupInformation(subject);
       loginUser.setLogin(login);
+      loginUser.setLastLogin(start);
       loginUser.setAuthenticationMethod(AuthenticationMethod.KERBEROS);
     } catch (LoginException le) {
       if (start > 0) {


### PR DESCRIPTION
See #2178 for related change for Hadoop 3.x