### PR TITLE
HDFS-15496. Add UI for deleted snapshots

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/SnapshotInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/SnapshotInfo.java
@@ -82,19 +82,34 @@ public class SnapshotInfo {
   }
 
   public static class Bean {
-    private final String snapshotID;
+    private final int snapshotID;
+    private final String snapshotName;
     private final String snapshotDirectory;
     private final long modificationTime;
+    private final short permission;
+    private final String owner;
+    private final String group;
+    private final String status;
 
-    public Bean(String snapshotID, String snapshotDirectory,
-        long modificationTime) {
+    public Bean(int snapshotID, String snapshotName, String snapshotDirectory,
+        long modificationTime, short permission, String owner, String group,
+                boolean isMarkedAsDeleted) {
       this.snapshotID = snapshotID;
+      this.snapshotName = snapshotName;
       this.snapshotDirectory = snapshotDirectory;
       this.modificationTime = modificationTime;
+      this.permission = permission;
+      this.owner = owner;
+      this.group = group;
+      this.status = isMarkedAsDeleted ? "DELETED" : "ACTIVE";
     }
 
-    public String getSnapshotID() {
+    public int getSnapshotID() {
       return snapshotID;
+    }
+
+    public String getSnapshotName() {
+      return snapshotName;
     }
 
     public String getSnapshotDirectory() {
@@ -103,6 +118,22 @@ public class SnapshotInfo {
 
     public long getModificationTime() {
       return modificationTime;
+    }
+
+    public short getPermission() {
+      return permission;
+    }
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public String getGroup() {
+      return group;
+    }
+
+    public String getStatus() {
+      return status;
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotManager.java
@@ -746,16 +746,22 @@ public class SnapshotManager implements SnapshotStatsMXBean {
         d.getDirectorySnapshottableFeature().getNumSnapshots(),
         d.getDirectorySnapshottableFeature().getSnapshotQuota(),
         d.getModificationTime(),
-        Short.valueOf(Integer.toOctalString(
-            d.getFsPermissionShort())),
+        Short.parseShort(Integer.toOctalString(d.getFsPermissionShort())),
         d.getUserName(),
         d.getGroupName());
   }
 
   public static SnapshotInfo.Bean toBean(Snapshot s) {
+    Snapshot.Root dir = s.getRoot();
     return new SnapshotInfo.Bean(
-        s.getRoot().getLocalName(), s.getRoot().getFullPathName(),
-        s.getRoot().getModificationTime());
+        s.getId(),
+        dir.getLocalName(), dir.getFullPathName(),
+        dir.getModificationTime(),
+        Short.parseShort(Integer.toOctalString(dir.getFsPermissionShort())),
+        dir.getUserName(),
+        dir.getGroupName(),
+        dir.isMarkedAsDeleted()
+        );
   }
 
   private List<INodeDirectory> getSnapshottableDirsForGc() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -285,15 +285,25 @@
   <thead>
     <tr>
       <th>Snapshot ID</th>
+      <th>Snapshot Name</th>
       <th>Snapshot Directory</th>
       <th>Modification Time</th>
+      <th>Permission</th>
+      <th>Owner</th>
+      <th>Group</th>
+      <th>Status</th>
     </tr>
   </thead>
   {#Snapshots}
   <tr>
     <td>{snapshotID}</td>
+    <td>{snapshotName}</td>
     <td>{snapshotDirectory}</td>
     <td>{modificationTime|date_tostring}</td>
+    <td>{permission|helper_to_permission}</td>
+    <td>{owner}</td>
+    <td>{group}</td>
+    <td>{status}</td>
   </tr>
   {/Snapshots}
 </table>


### PR DESCRIPTION
This patch adds a few additional columns to snapshots table in Namenode UI including the snapshot deletion status as shown in the screen-shot below.

<img width="1184" alt="Screen Shot 2020-08-10 at 7 33 51 PM" src="https://user-images.githubusercontent.com/1051198/89851520-84777580-db41-11ea-90bf-c168f9932fb2.png">


https://issues.apache.org/jira/browse/HDFS-15496
