### PR TITLE
HADOOP-16915. ABFS: Ignoring the test ITestAzureBlobFileSystemRandomRead.testRandomReadPerformance

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -23,6 +23,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -412,6 +413,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
   }
 
   @Test
+  @Ignore("HADOOP-16915")
   public void testRandomReadPerformance() throws Exception {
     Assume.assumeFalse("This test does not support namespace enabled account",
             this.getFileSystem().getIsNamespaceEnabled());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -413,7 +413,13 @@ public class ITestAzureBlobFileSystemRandomRead extends
   }
 
   @Test
-  @Ignore("HADOOP-16915")
+  @Ignore("ABFS accounts are primarily for customers to use with HNS property enabled. A non-HNS enabled ABFS account" +
+          "will not provide much value add in comparison to WASB account. The test case" +
+          "ITestAzureBlobFileSystemRandomRead#testRandomReadPerformance that tries to compare non-HNS to WASB" +
+          "performance hence isn't significant and can deviate in the perf in minor ways over time. Non-HNS not being a" +
+          "primary use case for ABFS, ignoring this test which currently fails randomly as it crosses test perf" +
+          "threshold." +
+          "https://issues.apache.org/jira/browse/HADOOP-16915")
   public void testRandomReadPerformance() throws Exception {
     Assume.assumeFalse("This test does not support namespace enabled account",
             this.getFileSystem().getIsNamespaceEnabled());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -413,13 +413,17 @@ public class ITestAzureBlobFileSystemRandomRead extends
   }
 
   @Test
-  @Ignore("ABFS accounts are primarily for customers to use with HNS property enabled. A non-HNS enabled ABFS account" +
-          "will not provide much value add in comparison to WASB account. The test case" +
-          "ITestAzureBlobFileSystemRandomRead#testRandomReadPerformance that tries to compare non-HNS to WASB" +
-          "performance hence isn't significant and can deviate in the perf in minor ways over time. Non-HNS not being a" +
-          "primary use case for ABFS, ignoring this test which currently fails randomly as it crosses test perf" +
-          "threshold." +
-          "https://issues.apache.org/jira/browse/HADOOP-16915")
+  @Ignore(
+      "ABFS accounts are primarily for customers to use with HNS property "
+          + "enabled. A non-HNS enabled ABFS account will not provide much "
+          + "value add in comparison to WASB account. The test case "
+          + "ITestAzureBlobFileSystemRandomRead#testRandomReadPerformance "
+          + "that tries to compare non-HNS to WASB performance hence isn't "
+          + "significant and can deviate in the perf in minor ways over time."
+          + " Non-HNS not being a primary use case for ABFS, ignoring this "
+          + "test which currently fails randomly as it crosses test perf "
+          + "threshold."
+          + "https://issues.apache.org/jira/browse/HADOOP-16915")
   public void testRandomReadPerformance() throws Exception {
     Assume.assumeFalse("This test does not support namespace enabled account",
             this.getFileSystem().getIsNamespaceEnabled());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -413,17 +413,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
   }
 
   @Test
-  @Ignore(
-      "ABFS accounts are primarily for customers to use with HNS property "
-          + "enabled. A non-HNS enabled ABFS account will not provide much "
-          + "value add in comparison to WASB account. The test case "
-          + "ITestAzureBlobFileSystemRandomRead#testRandomReadPerformance "
-          + "that tries to compare non-HNS to WASB performance hence isn't "
-          + "significant and can deviate in the perf in minor ways over time."
-          + " Non-HNS not being a primary use case for ABFS, ignoring this "
-          + "test which currently fails randomly as it crosses test perf "
-          + "threshold."
-          + "https://issues.apache.org/jira/browse/HADOOP-16915")
+  @Ignore("HADOOP-16915")
   public void testRandomReadPerformance() throws Exception {
     Assume.assumeFalse("This test does not support namespace enabled account",
             this.getFileSystem().getIsNamespaceEnabled());


### PR DESCRIPTION
HADOOP-16915. ABFS: Ignoring the test ITestAzureBlobFileSystemRandomRead.testRandomReadPerformance

ABFS accounts are primarily for customers to use with HNS property enabled. A non-HNS enabled ABFS account will not provide much value add in comparison to WASB account. The test case ITestAzureBlobFileSystemRandomRead#testRandomReadPerformance that tries to compare non-HNS to WASB performance hence isn't significant and can deviate in the perf in minor ways over time. Non-HNS not being a primary use case for ABFS, ignoring this test which currently fails randomly as it crosses test perf threshold.