### PR TITLE
HADOOP-17194. Adding Context class for AbfsClient in ABFS

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -85,6 +85,7 @@ import org.apache.hadoop.fs.azurebfs.oauth2.IdentityTransformerInterface;
 import org.apache.hadoop.fs.azurebfs.services.AbfsAclHelper;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClientContext;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClientContextBuilder;
 import org.apache.hadoop.fs.azurebfs.services.AbfsCounters;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsInputStream;
@@ -1216,6 +1217,17 @@ public class AzureBlobFileSystemStore implements Closeable {
     return isKeyForDirectorySet(key, azureAtomicRenameDirSet);
   }
 
+  /**
+   * A on-off operation to initialize AbfsClient for AzureBlobFileSystem
+   * Operations.
+   *
+   * @param uri            Uniform resource identifier for Abfs.
+   * @param fileSystemName Name of the fileSystem being used.
+   * @param accountName    Name of the account being used to access Azure
+   *                       data store.
+   * @param isSecure       Tells if https is being used or http.
+   * @throws IOException
+   */
   private void initializeClient(URI uri, String fileSystemName,
       String accountName, boolean isSecure)
       throws IOException {
@@ -1280,7 +1292,7 @@ public class AzureBlobFileSystemStore implements Closeable {
    * @return an instance of AbfsClientContext.
    */
   private AbfsClientContext populateAbfsClientContext() {
-    return new AbfsClientContext()
+    return new AbfsClientContextBuilder()
         .withExponentialRetryPolicy(
             new ExponentialRetryPolicy(abfsConfiguration.getMaxIoRetries()))
         .withAbfsCounters(abfsCounters)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -77,15 +77,13 @@ public class AbfsClient implements Closeable {
 
   private AbfsClient(final URL baseUrl, final SharedKeyCredentials sharedKeyCredentials,
                     final AbfsConfiguration abfsConfiguration,
-                    final ExponentialRetryPolicy exponentialRetryPolicy,
-                    final AbfsPerfTracker abfsPerfTracker,
-                    final AbfsCounters abfsCounters) {
+                    final AbfsClientContext abfsClientContext) {
     this.baseUrl = baseUrl;
     this.sharedKeyCredentials = sharedKeyCredentials;
     String baseUrlString = baseUrl.toString();
     this.filesystem = baseUrlString.substring(baseUrlString.lastIndexOf(FORWARD_SLASH) + 1);
     this.abfsConfiguration = abfsConfiguration;
-    this.retryPolicy = exponentialRetryPolicy;
+    this.retryPolicy = abfsClientContext.getExponentialRetryPolicy();
     this.accountName = abfsConfiguration.getAccountName().substring(0, abfsConfiguration.getAccountName().indexOf(AbfsHttpConstants.DOT));
     this.authType = abfsConfiguration.getAuthType(accountName);
 
@@ -105,29 +103,23 @@ public class AbfsClient implements Closeable {
     }
 
     this.userAgent = initializeUserAgent(abfsConfiguration, sslProviderName);
-    this.abfsPerfTracker = abfsPerfTracker;
-    this.abfsCounters = abfsCounters;
+    this.abfsPerfTracker = abfsClientContext.getAbfsPerfTracker();
+    this.abfsCounters = abfsClientContext.getAbfsCounters();
   }
 
   public AbfsClient(final URL baseUrl, final SharedKeyCredentials sharedKeyCredentials,
                     final AbfsConfiguration abfsConfiguration,
-                    final ExponentialRetryPolicy exponentialRetryPolicy,
                     final AccessTokenProvider tokenProvider,
-                    final AbfsPerfTracker abfsPerfTracker,
-                    final AbfsCounters abfsCounters) {
-    this(baseUrl, sharedKeyCredentials, abfsConfiguration,
-        exponentialRetryPolicy, abfsPerfTracker, abfsCounters);
+                    final AbfsClientContext abfsClientContext) {
+    this(baseUrl, sharedKeyCredentials, abfsConfiguration, abfsClientContext);
     this.tokenProvider = tokenProvider;
   }
 
   public AbfsClient(final URL baseUrl, final SharedKeyCredentials sharedKeyCredentials,
                     final AbfsConfiguration abfsConfiguration,
-                    final ExponentialRetryPolicy exponentialRetryPolicy,
                     final SASTokenProvider sasTokenProvider,
-                    final AbfsPerfTracker abfsPerfTracker,
-                    final AbfsCounters abfsCounters) {
-    this(baseUrl, sharedKeyCredentials, abfsConfiguration,
-        exponentialRetryPolicy, abfsPerfTracker, abfsCounters);
+                    final AbfsClientContext abfsClientContext) {
+    this(baseUrl, sharedKeyCredentials, abfsConfiguration, abfsClientContext);
     this.sasTokenProvider = sasTokenProvider;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -28,7 +28,7 @@ public class AbfsClientContext {
   private final AbfsPerfTracker abfsPerfTracker;
   private final AbfsCounters abfsCounters;
 
-  public AbfsClientContext(
+  AbfsClientContext(
       ExponentialRetryPolicy exponentialRetryPolicy,
       AbfsPerfTracker abfsPerfTracker,
       AbfsCounters abfsCounters) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -24,34 +24,17 @@ package org.apache.hadoop.fs.azurebfs.services;
  */
 public class AbfsClientContext {
 
-  private ExponentialRetryPolicy exponentialRetryPolicy;
-  private AbfsPerfTracker abfsPerfTracker;
-  private AbfsCounters abfsCounters;
+  private final ExponentialRetryPolicy exponentialRetryPolicy;
+  private final AbfsPerfTracker abfsPerfTracker;
+  private final AbfsCounters abfsCounters;
 
-  public AbfsClientContext withExponentialRetryPolicy(
-      final ExponentialRetryPolicy exponentialRetryPolicy) {
+  public AbfsClientContext(
+      ExponentialRetryPolicy exponentialRetryPolicy,
+      AbfsPerfTracker abfsPerfTracker,
+      AbfsCounters abfsCounters) {
     this.exponentialRetryPolicy = exponentialRetryPolicy;
-    return this;
-  }
-
-  public AbfsClientContext withAbfsPerfTracker(
-      final AbfsPerfTracker abfsPerfTracker) {
     this.abfsPerfTracker = abfsPerfTracker;
-    return this;
-  }
-
-  public AbfsClientContext withAbfsCounters(final AbfsCounters abfsCounters) {
     this.abfsCounters = abfsCounters;
-    return this;
-  }
-
-  /**
-   * Build the context and get the instance with the properties selected.
-   *
-   * @return an instance of AbfsClientContext.
-   */
-  public AbfsClientContext build() {
-    return this;
   }
 
   public ExponentialRetryPolicy getExponentialRetryPolicy() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+/**
+ * Class to hold extra configurations for AbfsClient and further classes
+ * inside AbfsClient.
+ */
+public class AbfsClientContext {
+
+  private ExponentialRetryPolicy exponentialRetryPolicy;
+  private AbfsPerfTracker abfsPerfTracker;
+  private AbfsCounters abfsCounters;
+
+  public AbfsClientContext withExponentialRetryPolicy(
+      final ExponentialRetryPolicy exponentialRetryPolicy) {
+    this.exponentialRetryPolicy = exponentialRetryPolicy;
+    return this;
+  }
+
+  public AbfsClientContext withAbfsPerfTracker(
+      final AbfsPerfTracker abfsPerfTracker) {
+    this.abfsPerfTracker = abfsPerfTracker;
+    return this;
+  }
+
+  public AbfsClientContext withAbfsCounters(final AbfsCounters abfsCounters) {
+    this.abfsCounters = abfsCounters;
+    return this;
+  }
+
+  /**
+   * Build the context and get the instance with the properties selected.
+   *
+   * @return an instance of AbfsClientContext.
+   */
+  public AbfsClientContext build() {
+    return this;
+  }
+
+  public ExponentialRetryPolicy getExponentialRetryPolicy() {
+    return exponentialRetryPolicy;
+  }
+
+  public AbfsPerfTracker getAbfsPerfTracker() {
+    return abfsPerfTracker;
+  }
+
+  public AbfsCounters getAbfsCounters() {
+    return abfsCounters;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+/**
+ * A builder for AbfsClientContext class with different options to select and
+ * build from.
+ */
+public class AbfsClientContextBuilder {
+
+  private ExponentialRetryPolicy exponentialRetryPolicy;
+  private AbfsPerfTracker abfsPerfTracker;
+  private AbfsCounters abfsCounters;
+
+  public AbfsClientContextBuilder withExponentialRetryPolicy(
+      final ExponentialRetryPolicy exponentialRetryPolicy) {
+    this.exponentialRetryPolicy = exponentialRetryPolicy;
+    return this;
+  }
+
+  public AbfsClientContextBuilder withAbfsPerfTracker(
+      final AbfsPerfTracker abfsPerfTracker) {
+    this.abfsPerfTracker = abfsPerfTracker;
+    return this;
+  }
+
+  public AbfsClientContextBuilder withAbfsCounters(final AbfsCounters abfsCounters) {
+    this.abfsCounters = abfsCounters;
+    return this;
+  }
+
+  /**
+   * Build the context and get the instance with the properties selected.
+   *
+   * @return an instance of AbfsClientContext.
+   */
+  public AbfsClientContext build() {
+    //validate the values
+    return new AbfsClientContext(exponentialRetryPolicy, abfsPerfTracker,
+        abfsCounters);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -103,7 +103,7 @@ public final class TestAbfsClient {
 
   private String getUserAgentString(AbfsConfiguration config,
       boolean includeSSLProvider) throws MalformedURLException {
-    AbfsClientContext abfsClientContext = new AbfsClientContext();
+    AbfsClientContext abfsClientContext = new AbfsClientContextBuilder().build();
     AbfsClient client = new AbfsClient(new URL("https://azure.com"), null,
         config, (AccessTokenProvider) null, abfsClientContext);
     String sslProviderName = null;
@@ -259,7 +259,7 @@ public final class TestAbfsClient {
         abfsConfig);
 
     AbfsClientContext abfsClientContext =
-        new AbfsClientContext().withAbfsPerfTracker(tracker)
+        new AbfsClientContextBuilder().withAbfsPerfTracker(tracker)
                                 .withExponentialRetryPolicy(
                                     new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()))
                                 .build();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -103,8 +103,9 @@ public final class TestAbfsClient {
 
   private String getUserAgentString(AbfsConfiguration config,
       boolean includeSSLProvider) throws MalformedURLException {
+    AbfsClientContext abfsClientContext = new AbfsClientContext();
     AbfsClient client = new AbfsClient(new URL("https://azure.com"), null,
-        config, null, (AccessTokenProvider) null, null, null);
+        config, (AccessTokenProvider) null, abfsClientContext);
     String sslProviderName = null;
     if (includeSSLProvider) {
       sslProviderName = DelegatingSSLSocketFactory.getDefaultFactory()
@@ -257,6 +258,12 @@ public final class TestAbfsClient {
         abfsConfig.getAccountName(),
         abfsConfig);
 
+    AbfsClientContext abfsClientContext =
+        new AbfsClientContext().withAbfsPerfTracker(tracker)
+                                .withExponentialRetryPolicy(
+                                    new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()))
+                                .build();
+
     // Create test AbfsClient
     AbfsClient testClient = new AbfsClient(
         baseAbfsClientInstance.getBaseUrl(),
@@ -267,11 +274,10 @@ public final class TestAbfsClient {
             abfsConfig.getStorageAccountKey())
             : null),
         abfsConfig,
-        new ExponentialRetryPolicy(abfsConfig.getMaxIoRetries()),
         (currentAuthType == AuthType.OAuth
             ? abfsConfig.getTokenProvider()
             : null),
-        tracker, null);
+        abfsClientContext);
 
     return testClient;
   }


### PR DESCRIPTION
Tested on: mvn -T 1C -Dparallel-tests=abfs clean verify
Region: East US

```
[INFO] Results:
[INFO]
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
```
```
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[INFO]
[ERROR] Tests run: 451, Failures: 0, Errors: 12, Skipped: 61
```
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 206, Failures: 0, Errors: 0, Skipped: 29
```

The errors are being discussed in HADOOP-17203(https://issues.apache.org/jira/browse/HADOOP-17203).