### PR TITLE
HADOOP-16966. ABFS: Upgrade store REST API version to 2019-12-12

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -62,7 +62,7 @@ public class AbfsClient implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   private final URL baseUrl;
   private final SharedKeyCredentials sharedKeyCredentials;
-  private final String xMsVersion = "2018-11-09";
+  private final String xMsVersion = "2019-12-12";
   private final ExponentialRetryPolicy retryPolicy;
   private final String filesystem;
   private final AbfsConfiguration abfsConfiguration;


### PR DESCRIPTION
Store REST API version on the backend clusters has been upgraded to 2019-12-12. This Jira will align the Driver requests to reflect this latest API version.

Test results from accounts in East US2 region:
```
With Namespace enabled account:  
----------------------------------------
1. With Authentication Type: OAuth
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 451, Failures: 0, Errors: 0, Skipped: 74
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 140

2. With Authentication Type: SharedKey
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 451, Failures: 0, Errors: 0, Skipped: 41
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 24

With Namespace not-enabled account:  
----------------------------------------
1. With Authentication Type: OAuth
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 451, Failures: 0, Errors: 0, Skipped: 249
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 140

2. With Authentication Type: SharedKey
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 451, Failures: 0, Errors: 0, Skipped: 245
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 24
```