### PR TITLE
HADOOP-17206. Add python2 to required package on CentOS 8 for building documentation.

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -436,6 +436,9 @@ Building on CentOS 8
   $ sudo dnf group install --with-optional 'Development Tools'
   $ sudo dnf install java-1.8.0-openjdk-devel maven
 
+* Install python2 for building documentation.
+  $ sudo dnf install python2
+
 * Install Protocol Buffers v3.7.1.
   $ git clone https://github.com/protocolbuffers/protobuf
   $ cd protobuf


### PR DESCRIPTION
`mvn site` fails without python2.

```
[INFO] --- exec-maven-plugin:1.3.1:exec (shelldocs) @ hadoop-common ---
/usr/bin/env: ‘python2’: No such file or directory
```

shelldocs.py and releasedocmaker.py requires python2.

```
$ grep -r python2 patchprocess
patchprocess/apache-yetus-0.10.0/lib/shelldocs/shelldocs/__init__.py:#!/usr/bin/env python2
patchprocess/apache-yetus-0.10.0/lib/shelldocs/shelldocs.py:#!/usr/bin/env python2
patchprocess/apache-yetus-0.10.0/lib/releasedocmaker/releasedocmaker/__init__.py:#!/usr/bin/env python2
patchprocess/apache-yetus-0.10.0/lib/releasedocmaker/releasedocmaker/utils.py:#!/usr/bin/env python2
patchprocess/apache-yetus-0.10.0/lib/releasedocmaker/releasedocmaker.py:#!/usr/bin/env python2
patchprocess/apache-yetus-0.10.0/lib/precommit/test-patch-docker/Dockerfile:    python2.7 \
```
