### PR TITLE
YARN-8746 fix overview in ui2  doesn't display GPU usage info when us…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/ClusterMetricsInfo.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.ParentQueue;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
 
 @XmlRootElement(name = "clusterMetrics")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -133,6 +134,11 @@ public class ClusterMetricsInfo {
     } else {
       this.totalMB = availableMB + allocatedMB;
       this.totalVirtualCores = availableVirtualCores + allocatedVirtualCores;
+    }
+    if (rs instanceof FairScheduler) {
+      FairScheduler fs = (FairScheduler) rs;
+      totalUsedResourcesAcrossPartition = new ResourceInfo(fs.getQueueManager().getRootQueue().getResourceUsage());
+      totalClusterResourcesAcrossPartition = new ResourceInfo(fs.getClusterResource());
     }
     this.activeNodes = clusterMetrics.getNumActiveNMs();
     this.lostNodes = clusterMetrics.getNumLostNMs();


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/YARN-8746
When using fair scheduler, GPU related information isn't displayed because the "metrics" api doesn't return any GPU related usage information( has run yarn on GPU per [this |https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-site/UsingGpus.html).]  The hadoop versions after 3.1.1 are all affected