### PR TITLE
HADOOP-17223 update org.apache.httpcomponents:httpclient to 4.5.12 and httpcore to 4.4.13

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -75,7 +75,7 @@
     <jackson2.databind.version>2.10.3</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
-    <httpclient.version>4.5.12</httpclient.version>
+    <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.13</httpcore.version>
 
     <!-- SLF4J/LOG4J version -->

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -76,7 +76,7 @@
 
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.12</httpclient.version>
-    <httpcore.version>4.4.10</httpcore.version>
+    <httpcore.version>4.4.13</httpcore.version>
 
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.30</slf4j.version>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -75,7 +75,7 @@
     <jackson2.databind.version>2.10.3</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
-    <httpclient.version>4.5.6</httpclient.version>
+    <httpclient.version>4.5.12</httpclient.version>
     <httpcore.version>4.4.10</httpcore.version>
 
     <!-- SLF4J/LOG4J version -->


### PR DESCRIPTION
Update the dependencies for org.apache.httpcomponent
- org.apache.httpcomponents:httpclient from 4.5.6 to 4.5.12
- org.apache.httpcomponents:httpcore from 4.4.10 to 4.4.13

Jira - https://issues.apache.org/jira/browse/HADOOP-17223