### PR TITLE
Hadoop-17215. ABFS: Disable default create overwrite

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -577,7 +577,9 @@ public class AbfsConfiguration{
     return this.azureAtomicDirs;
   }
 
-  public boolean isDefaultCreateOverwriteDisabled() { return this.disableDefaultCreateOverwrite; }
+  public boolean isDefaultCreateOverwriteDisabled() {
+    return this.disableDefaultCreateOverwrite;
+  }
 
   public String getAppendBlobDirs() {
     return this.azureAppendBlobDirs;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -181,6 +181,10 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_FS_AZURE_ATOMIC_RENAME_DIRECTORIES)
   private String azureAtomicDirs;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE,
+      DefaultValue = DEFAULT_FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE)
+  private boolean disableDefaultCreateOverwrite;
+
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_APPEND_BLOB_KEY,
       DefaultValue = DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES)
   private String azureAppendBlobDirs;
@@ -572,6 +576,8 @@ public class AbfsConfiguration{
   public String getAzureAtomicRenameDirs() {
     return this.azureAtomicDirs;
   }
+
+  public boolean isDefaultCreateOverwriteDisabled() { return this.disableDefaultCreateOverwrite; }
 
   public String getAppendBlobDirs() {
     return this.azureAppendBlobDirs;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -181,9 +181,9 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_FS_AZURE_ATOMIC_RENAME_DIRECTORIES)
   private String azureAtomicDirs;
 
-  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE,
-      DefaultValue = DEFAULT_FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE)
-  private boolean disableDefaultCreateOverwrite;
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_ENABLE_CONDITIONAL_CREATE_OVERWRITE,
+      DefaultValue = DEFAULT_FS_AZURE_ENABLE_CONDITIONAL_CREATE_OVERWRITE)
+  private boolean enableConditionalCreateOverwrite;
 
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_APPEND_BLOB_KEY,
       DefaultValue = DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES)
@@ -577,8 +577,8 @@ public class AbfsConfiguration{
     return this.azureAtomicDirs;
   }
 
-  public boolean isDefaultCreateOverwriteDisabled() {
-    return this.disableDefaultCreateOverwrite;
+  public boolean isConditionalCreateOverwriteEnabled() {
+    return this.enableConditionalCreateOverwrite;
   }
 
   public String getAppendBlobDirs() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -67,6 +67,10 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ENABLE_AUTOTHROTTLING = "fs.azure.enable.autothrottling";
   public static final String FS_AZURE_ALWAYS_USE_HTTPS = "fs.azure.always.use.https";
   public static final String FS_AZURE_ATOMIC_RENAME_KEY = "fs.azure.atomic.rename.key";
+  /** HDFS FS defaults overwrite behaviour to true which leads to race conditions at backend with parallel operations
+   * issued to same path. This config provides a means to override the default overwrite flag.
+   */
+  public static final String FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE = "fs.azure.disable.default.create.overwrite";
   /** Provides a config to provide comma separated path prefixes on which Appendblob based files are created
    *  Default is empty. **/
   public static final String FS_AZURE_APPEND_BLOB_KEY = "fs.azure.appendblob.directories";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -67,12 +67,10 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ENABLE_AUTOTHROTTLING = "fs.azure.enable.autothrottling";
   public static final String FS_AZURE_ALWAYS_USE_HTTPS = "fs.azure.always.use.https";
   public static final String FS_AZURE_ATOMIC_RENAME_KEY = "fs.azure.atomic.rename.key";
-  /** HDFS FS defaults overwrite behaviour to true which can lead to race
-   * conditions at times at backend with parallel operations issued to same path.
-   * Hence in ABFS driver the overwrite default behaviour is being set to false.
-   * This is added as a config to provide relief for any contigencies.
+  /** This config ensures that during create overwrite an existing file will be
+   *  overwritten only if there is a match on the eTag of existing file.
    */
-  public static final String FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE = "fs.azure.disable.default.create.overwrite";
+  public static final String FS_AZURE_ENABLE_CONDITIONAL_CREATE_OVERWRITE = "fs.azure.enable.conditional.create.overwrite";
   /** Provides a config to provide comma separated path prefixes on which Appendblob based files are created
    *  Default is empty. **/
   public static final String FS_AZURE_APPEND_BLOB_KEY = "fs.azure.appendblob.directories";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -67,8 +67,10 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ENABLE_AUTOTHROTTLING = "fs.azure.enable.autothrottling";
   public static final String FS_AZURE_ALWAYS_USE_HTTPS = "fs.azure.always.use.https";
   public static final String FS_AZURE_ATOMIC_RENAME_KEY = "fs.azure.atomic.rename.key";
-  /** HDFS FS defaults overwrite behaviour to true which leads to race conditions at backend with parallel operations
-   * issued to same path. This config provides a means to override the default overwrite flag.
+  /** HDFS FS defaults overwrite behaviour to true which can lead to race
+   * conditions at times at backend with parallel operations issued to same path.
+   * Hence in ABFS driver the overwrite default behaviour is being set to false.
+   * This is added as a config to provide relief for any contigencies.
    */
   public static final String FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE = "fs.azure.disable.default.create.overwrite";
   /** Provides a config to provide comma separated path prefixes on which Appendblob based files are created

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -70,6 +70,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_AZURE_SKIP_USER_GROUP_METADATA_DURING_INITIALIZATION = false;
 
   public static final String DEFAULT_FS_AZURE_ATOMIC_RENAME_DIRECTORIES = "/hbase";
+  public static final boolean DEFAULT_FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE = true;
   public static final String DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES = "";
 
   public static final int DEFAULT_READ_AHEAD_QUEUE_DEPTH = -1;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -70,7 +70,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_AZURE_SKIP_USER_GROUP_METADATA_DURING_INITIALIZATION = false;
 
   public static final String DEFAULT_FS_AZURE_ATOMIC_RENAME_DIRECTORIES = "/hbase";
-  public static final boolean DEFAULT_FS_AZURE_DISABLE_DEFAULT_CREATE_OVERWRITE = true;
+  public static final boolean DEFAULT_FS_AZURE_ENABLE_CONDITIONAL_CREATE_OVERWRITE = true;
   public static final String DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES = "";
 
   public static final int DEFAULT_READ_AHEAD_QUEUE_DEPTH = -1;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/ConcurrentWriteOperationDetectedException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/ConcurrentWriteOperationDetectedException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.contracts.exceptions;
+
+/**
+ * Thrown when a concurrent write operation is detected.
+ */
+@org.apache.hadoop.classification.InterfaceAudience.Public
+@org.apache.hadoop.classification.InterfaceStability.Evolving
+public class ConcurrentWriteOperationDetectedException
+    extends AzureBlobFileSystemException {
+
+  public ConcurrentWriteOperationDetectedException(String message) {
+    super(message);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -324,7 +324,7 @@ public class AbfsClient implements Closeable {
         try {
           op = getPathStatus(path, false);
         } catch (AbfsRestOperationException ex) {
-          if (e.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+          if (ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
             // Is a parallel access case, as file which was found to be
             // present went missing by this request.
             throw new ConcurrentWriteOperationDetectedException(
@@ -342,7 +342,7 @@ public class AbfsClient implements Closeable {
           op = createPathImpl(path, abfsUriQueryBuilder, true, permission,
               umask, eTag);
         } catch (AbfsRestOperationException ex) {
-          if (e.getStatusCode() == HttpURLConnection.HTTP_PRECON_FAILED) {
+          if (ex.getStatusCode() == HttpURLConnection.HTTP_PRECON_FAILED) {
             // Is a parallel access case, as file with eTag was just queried
             // and precondition failure can happen only when another file with
             // different etag got created.
@@ -361,7 +361,8 @@ public class AbfsClient implements Closeable {
     return op;
   }
 
-  private AbfsRestOperation createPathImpl(final String path,
+  @VisibleForTesting
+  public AbfsRestOperation createPathImpl(final String path,
       AbfsUriQueryBuilder abfsUriQueryBuilder,
       final boolean overwrite,
       final String permission,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
@@ -110,15 +110,16 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
     connectionsMade++;
     requestsSent++;
 
+
     try (AbfsOutputStream out = createAbfsOutputStreamWithFlushEnabled(fs,
         sendRequestPath)) {
-      boolean createOverwriteNeedsAdditionalRequest = false;
-      if (fs.getAbfsStore()
-          .getAbfsConfiguration()
-          .isDefaultCreateOverwriteDisabled()) {
-        // if the default overwrite=true behaviour is disabled by config,
-        // the re-create here will need 2 requests.
-        createOverwriteNeedsAdditionalRequest = true;
+
+      // Is a file overwrite case
+      long createRequestCalls = 1;
+      long createTriggeredGFSForETag = 0;
+      if (this.getConfiguration().isDefaultCreateOverwriteDisabled()) {
+        createRequestCalls += 1;
+        createTriggeredGFSForETag = 1;
       }
 
       for (int i = 0; i < LARGE_OPERATIONS; i++) {
@@ -149,22 +150,20 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
        * wrote each time).
        *
        */
-      long expectedConnectionsMade = connectionsMade + 1
-          + (createOverwriteNeedsAdditionalRequest ? 1 : 0);
-      long expectedSendRequests = requestsSent + 1
-          + (createOverwriteNeedsAdditionalRequest ? 1 : 0);
 
+      connectionsMade += createRequestCalls + createTriggeredGFSForETag;
+      requestsSent += createRequestCalls;
       if (fs.getAbfsStore().isAppendBlobKey(fs.makeQualified(sendRequestPath).toString())) {
         // no network calls are made for hflush in case of appendblob
         assertAbfsStatistics(CONNECTIONS_MADE,
-            expectedConnectionsMade + LARGE_OPERATIONS, metricMap);
+            connectionsMade + LARGE_OPERATIONS, metricMap);
         assertAbfsStatistics(SEND_REQUESTS,
-            expectedSendRequests + LARGE_OPERATIONS, metricMap);
+            requestsSent + LARGE_OPERATIONS, metricMap);
       } else {
         assertAbfsStatistics(CONNECTIONS_MADE,
-            expectedConnectionsMade + LARGE_OPERATIONS * 2, metricMap);
+            connectionsMade + LARGE_OPERATIONS * 2, metricMap);
         assertAbfsStatistics(SEND_REQUESTS,
-            expectedSendRequests + LARGE_OPERATIONS * 2, metricMap);
+            requestsSent + LARGE_OPERATIONS * 2, metricMap);
       }
       assertAbfsStatistics(AbfsStatistic.BYTES_SENT,
           bytesSent + LARGE_OPERATIONS * (testNetworkStatsString.getBytes().length),
@@ -250,13 +249,20 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
     try {
 
       /*
-       * Creating a file and writing buffer into it. Also recording the
-       * buffer for future read() call.
+       * Creating a file and writing buffer into it.
+       * This is a file recreate, so it will trigger
+       * 2 extra calls if create overwrite is off by default.
+       * Also recording the buffer for future read() call.
        * This creating outputStream and writing requires 2 *
        * (LARGE_OPERATIONS) get requests.
        */
       StringBuilder largeBuffer = new StringBuilder();
       out = fs.create(getResponsePath);
+
+      long createRequestCalls = 1;
+      if (this.getConfiguration().isDefaultCreateOverwriteDisabled()) {
+        createRequestCalls += 2;
+      }
 
       for (int i = 0; i < LARGE_OPERATIONS; i++) {
         out.write(testResponseString.getBytes());
@@ -282,7 +288,8 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
        *
        * get_response : get_responses(Last assertion) + 1
        * (OutputStream) + 2 * LARGE_OPERATIONS(Writing and flushing
-       * LARGE_OPERATIONS times) + 1(open()) + 1(read()).
+       * LARGE_OPERATIONS times) + 1(open()) + 1(read()) +
+       * 1 (createOverwriteTriggeredGetForeTag).
        *
        * bytes_received : bytes_received(Last assertion) + LARGE_OPERATIONS *
        * bytes wrote each time (bytes_received is equal to bytes wrote in the
@@ -298,7 +305,8 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
             getResponses + 3 + LARGE_OPERATIONS, metricMap);
       } else {
         assertAbfsStatistics(AbfsStatistic.GET_RESPONSES,
-            getResponses + 3 + 2 * LARGE_OPERATIONS, metricMap);
+            getResponses + 2 + createRequestCalls + 2 * LARGE_OPERATIONS,
+            metricMap);
       }
 
     } finally {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
@@ -117,7 +117,7 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
       // Is a file overwrite case
       long createRequestCalls = 1;
       long createTriggeredGFSForETag = 0;
-      if (this.getConfiguration().isDefaultCreateOverwriteDisabled()) {
+      if (this.getConfiguration().isConditionalCreateOverwriteEnabled()) {
         createRequestCalls += 1;
         createTriggeredGFSForETag = 1;
       }
@@ -260,7 +260,7 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
       out = fs.create(getResponsePath);
 
       long createRequestCalls = 1;
-      if (this.getConfiguration().isDefaultCreateOverwriteDisabled()) {
+      if (this.getConfiguration().isConditionalCreateOverwriteEnabled()) {
         createRequestCalls += 2;
       }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
@@ -236,9 +236,9 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
 
       // Testing that bytes received is equal to bytes sent.
       long bytesSend = metricMap.get(AbfsStatistic.BYTES_SENT.getStatName());
-      //bytesReceived = assertAbfsStatistics(AbfsStatistic.BYTES_RECEIVED,
-        //  bytesSend,
-          //metricMap);
+      bytesReceived = assertAbfsStatistics(AbfsStatistic.BYTES_RECEIVED,
+          bytesSend,
+          metricMap);
 
     } finally {
       IOUtils.cleanupWithLogger(LOG, out, in);
@@ -289,9 +289,9 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
        * File).
        *
        */
-      //assertAbfsStatistics(AbfsStatistic.BYTES_RECEIVED,
-       //   bytesReceived + LARGE_OPERATIONS * (testResponseString.getBytes().length),
-          //metricMap);
+      assertAbfsStatistics(AbfsStatistic.BYTES_RECEIVED,
+          bytesReceived + LARGE_OPERATIONS * (testResponseString.getBytes().length),
+          metricMap);
       if (fs.getAbfsStore().isAppendBlobKey(fs.makeQualified(getResponsePath).toString())) {
         // no network calls are made for hflush in case of appendblob
         assertAbfsStatistics(AbfsStatistic.GET_RESPONSES,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -35,9 +35,26 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.test.GenericTestUtils;
 
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.ConcurrentWriteOperationDetectedException;
+import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
+import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
+import org.apache.hadoop.fs.azurebfs.services.AbfsUriQueryBuilder;
+
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertIsFile;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-
 import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.CONNECTIONS_MADE;
 
 /**
@@ -285,5 +302,152 @@ public class ITestAzureBlobFileSystemCreate extends
         CONNECTIONS_MADE,
         totalConnectionMadeBeforeTest + createRequestCount,
         fs.getInstrumentationMap());
+  }
+
+  /**
+   * Test negative scenarios with Create overwrite=false as default
+   * With create overwrite=true ending in 3 calls:
+   * A. Create overwrite=false
+   * B. GFS
+   * C. Create overwrite=true
+   *
+   * Scn1: A fails with HTTP409, leading to B which fails with HTTP404,
+   *        detect parallel access
+   * Scn2: A fails with HTTP409, leading to B which fails with HTTP500,
+   *        fail create with HTTP500
+   * Scn3: A fails with HTTP409, leading to B and then C,
+   *        which fails with HTTP412, detect parallel access
+   * Scn4: A fails with HTTP409, leading to B and then C,
+   *        which fails with HTTP500, fail create with HTTP500
+   * Scn5: A fails with HTTP500, fail create with HTTP500
+   */
+  @Test
+  public void testNegativeScenariosForCreateOverwriteDisabled()
+      throws Throwable {
+
+    final AzureBlobFileSystem currentFs = getFileSystem();
+    Configuration config = new Configuration(this.getRawConfiguration());
+    config.set("fs.azure.disable.default.create.overwrite",
+        Boolean.toString(true));
+
+    final AzureBlobFileSystem fs =
+        (AzureBlobFileSystem) FileSystem.newInstance(currentFs.getUri(),
+            config);
+
+    // Get mock AbfsClient with current config
+    org.apache.hadoop.fs.azurebfs.services.AbfsClient
+        mockClient
+        = org.apache.hadoop.fs.azurebfs.services.TestAbfsClient.getMockAbfsClient(
+        fs.getAbfsStore().getClient(),
+        fs.getAbfsStore().getAbfsConfiguration());
+
+    AbfsRestOperation successOp = mock(
+        AbfsRestOperation.class);
+    AbfsHttpOperation http200Op = mock(
+        AbfsHttpOperation.class);
+    when(http200Op.getStatusCode()).thenReturn(HTTP_OK);
+    when(successOp.getResult()).thenReturn(http200Op);
+
+    AbfsRestOperationException conflictResponseEx
+        = getMockAbfsRestOperationException(HTTP_CONFLICT);
+    AbfsRestOperationException serverErrorResponseEx
+        = getMockAbfsRestOperationException(HTTP_INTERNAL_ERROR);
+    AbfsRestOperationException fileNotFoundResponseEx
+        = getMockAbfsRestOperationException(HTTP_NOT_FOUND);
+    AbfsRestOperationException preConditionResponseEx
+        = getMockAbfsRestOperationException(HTTP_PRECON_FAILED);
+
+    doThrow(conflictResponseEx) // Scn1: GFS fails with Http404
+        .doThrow(conflictResponseEx) // Scn2: GFS fails with Http500
+        .doThrow(
+            conflictResponseEx) // Scn3: create overwrite=true fails with Http412
+        .doThrow(
+            conflictResponseEx) // Scn4: create overwrite=true fails with Http500
+        .doThrow(
+            serverErrorResponseEx) // Scn5: create overwrite=false fails with Http500
+        .when(mockClient)
+        .createPathImpl(any(String.class), any(
+            AbfsUriQueryBuilder.class),
+            eq(false), any(String.class), any(String.class), eq(null));
+
+    doThrow(fileNotFoundResponseEx) // Scn1: GFS fails with Http404
+        .doThrow(serverErrorResponseEx) // Scn2: GFS fails with Http500
+        .doReturn(successOp) // Scn3: create overwrite=true fails with Http412
+        .doReturn(successOp) // Scn4: create overwrite=true fails with Http500
+        .when(mockClient)
+        .getPathStatus(any(String.class), eq(false));
+
+    doThrow(
+        preConditionResponseEx) // Scn3: create overwrite=true fails with Http412
+        .doThrow(
+            serverErrorResponseEx) // Scn4: create overwrite=true fails with Http500
+        .when(mockClient)
+        .createPathImpl(any(String.class), any(
+            AbfsUriQueryBuilder.class),
+            eq(true), any(String.class), any(String.class), eq(null));
+
+    when(mockClient.createPath(any(String.class), eq(true), eq(true),
+        any(String.class),
+        any(String.class), eq(false))).thenCallRealMethod();
+
+    // Scn1: GFS fails with Http404
+    // Sequence of events expected:
+    // 1. create overwrite=false - fail with conflict
+    // 2. GFS - fail with File Not found
+    // Create will fail with ConcurrentWriteOperationDetectedException
+    intercept(
+        ConcurrentWriteOperationDetectedException.class,
+        () ->
+            mockClient.createPath("someTestPath", true, true, "0644", "0022",
+                false));
+
+    // Scn2: GFS fails with Http500
+    // Sequence of events expected:
+    // 1. create overwrite=false - fail with conflict
+    // 2. GFS - fail with Server error
+    // Create will fail with 500
+    intercept(
+        AbfsRestOperationException.class,
+        () ->
+            mockClient.createPath("someTestPath", true, true, "0644", "0022",
+                false));
+
+    // Scn3: create overwrite=true fails with Http412
+    // Sequence of events expected:
+    // 1. create overwrite=false - fail with conflict
+    // 2. GFS - pass
+    // 3. create overwrite=true - fail with Pre-Condition
+    // Create will fail with ConcurrentWriteOperationDetectedException
+    intercept(
+        ConcurrentWriteOperationDetectedException.class,
+        () ->
+            mockClient.createPath("someTestPath", true, true, "0644", "0022",
+                false));
+
+    // Scn4: create overwrite=true fails with Http500
+    // Sequence of events expected:
+    // 1. create overwrite=false - fail with conflict
+    // 2. GFS - pass
+    // 3. create overwrite=true - fail with Server error
+    // Create will fail with 500
+    intercept(
+        AbfsRestOperationException.class,
+        () ->
+            mockClient.createPath("someTestPath", true, true, "0644", "0022",
+                false));
+
+    // Scn5: create overwrite=false fails with Http500
+    // Sequence of events expected:
+    // 1. create overwrite=false - fail with server error
+    // Create will fail with 500
+    intercept(
+        AbfsRestOperationException.class,
+        () ->
+            mockClient.createPath("someTestPath", true, true, "0644", "0022",
+                false));
+  }
+
+  private AbfsRestOperationException getMockAbfsRestOperationException(int status) {
+    return new AbfsRestOperationException(status, "", "", new Exception());
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -33,10 +33,10 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.ConcurrentWriteOperationDetectedException;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
@@ -434,7 +434,8 @@ public class ITestAzureBlobFileSystemCreate extends
       final String fieldName,
       Object fieldObject) throws Exception {
 
-    Field abfsClientField = AzureBlobFileSystemStore.class.getDeclaredField(fieldName);
+    Field abfsClientField = AzureBlobFileSystemStore.class.getDeclaredField(
+        fieldName);
     abfsClientField.setAccessible(true);
     Field modifiersField = Field.class.getDeclaredField("modifiers");
     modifiersField.setAccessible(true);
@@ -446,8 +447,10 @@ public class ITestAzureBlobFileSystemCreate extends
 
   private <E extends Throwable> void validateCreateFileException(final Class<E> exceptionClass, final AzureBlobFileSystemStore abfsStore)
       throws Exception {
-    FsPermission permission = new FsPermission(0644);
-    FsPermission umask = new FsPermission(0022);
+    FsPermission permission = new FsPermission(FsAction.ALL, FsAction.ALL,
+        FsAction.ALL);
+    FsPermission umask = new FsPermission(FsAction.NONE, FsAction.NONE,
+        FsAction.NONE);
     Path testPath = new Path("testFile");
     intercept(
         exceptionClass,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -218,8 +218,8 @@ public class ITestAzureBlobFileSystemCreate extends
    * 3. create overwrite=true of a file that doesnt pre-exist
    * 4. create overwrite=true of a file that pre-exists
    * matches the expectation when run against both combinations of
-   * fs.azure.disable.default.create.overwrite=true and
-   * fs.azure.disable.default.create.overwrite=false
+   * fs.azure.enable.conditional.create.overwrite=true and
+   * fs.azure.enable.conditional.create.overwrite=false
    * @throws Throwable
    */
   @Test
@@ -228,12 +228,12 @@ public class ITestAzureBlobFileSystemCreate extends
     testCreateFileOverwrite(false);
   }
 
-  public void testCreateFileOverwrite(boolean defaultDisableCreateOverwrite)
+  public void testCreateFileOverwrite(boolean enableConditionalCreateOverwrite)
       throws Throwable {
     final AzureBlobFileSystem currentFs = getFileSystem();
     Configuration config = new Configuration(this.getRawConfiguration());
-    config.set("fs.azure.disable.default.create.overwrite",
-        Boolean.toString(defaultDisableCreateOverwrite));
+    config.set("fs.azure.enable.conditional.create.overwrite",
+        Boolean.toString(enableConditionalCreateOverwrite));
 
     final AzureBlobFileSystem fs =
         (AzureBlobFileSystem) FileSystem.newInstance(currentFs.getUri(),
@@ -288,7 +288,7 @@ public class ITestAzureBlobFileSystemCreate extends
     // Case 4: Overwrite - File pre-exists
     fs.create(overwriteFilePath, true);
 
-    if (defaultDisableCreateOverwrite) {
+    if (enableConditionalCreateOverwrite) {
       // Three requests will be sent to server to create path,
       // 1. create without overwrite
       // 2. GetFileStatus to get eTag
@@ -327,7 +327,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
     final AzureBlobFileSystem currentFs = getFileSystem();
     Configuration config = new Configuration(this.getRawConfiguration());
-    config.set("fs.azure.disable.default.create.overwrite",
+    config.set("fs.azure.enable.conditional.create.overwrite",
         Boolean.toString(true));
 
     final AzureBlobFileSystem fs =

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -232,7 +232,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
     // Case 2: Not Overwrite - File pre-exists
     intercept(FileAlreadyExistsException.class,
-        () -> fs.create(nonOverwriteFile,false));
+        () -> fs.create(nonOverwriteFile, false));
 
     // One request to server to create path should be issued
     createRequestCount++;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -194,6 +194,17 @@ public class ITestAzureBlobFileSystemCreate extends
         });
   }
 
+  /**
+   * Tests if the number of connections made for:
+   * 1. create overwrite=false of a file that doesnt pre-exist
+   * 2. create overwrite=false of a file that pre-exists
+   * 3. create overwrite=true of a file that doesnt pre-exist
+   * 4. create overwrite=true of a file that pre-exists
+   * matches the expectation when run against both combinations of
+   * fs.azure.disable.default.create.overwrite=true and
+   * fs.azure.disable.default.create.overwrite=false
+   * @throws Throwable
+   */
   @Test
   public void testDefaultCreateOverwriteFileTest() throws Throwable {
     testCreateFileOverwrite(true);
@@ -261,9 +272,11 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.create(overwriteFilePath, true);
 
     if (defaultDisableCreateOverwrite) {
-      // Two requests will be sent to server to create path, one without overwrite
-      // and another with overwrite should be issued.
-      createRequestCount += 2;
+      // Three requests will be sent to server to create path,
+      // 1. create without overwrite
+      // 2. GetFileStatus to get eTag
+      // 3. create with overwrite
+      createRequestCount += 3;
     } else {
       createRequestCount++;
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -47,6 +47,10 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     assertMkdirs(fs, path);
   }
 
+  /**
+   * Test mkdir for possible values of fs.azure.disable.default.create.overwrite
+   * @throws Exception
+   */
   @Test
   public void testCreateRoot() throws Exception {
     assertMkdirs(getFileSystem(), new Path("/"));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -47,15 +47,15 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     assertMkdirs(fs, path);
   }
 
-  /**
-   * Test mkdir for possible values of fs.azure.disable.default.create.overwrite
-   * @throws Exception
-   */
   @Test
   public void testCreateRoot() throws Exception {
     assertMkdirs(getFileSystem(), new Path("/"));
   }
 
+  /**
+   * Test mkdir for possible values of fs.azure.disable.default.create.overwrite
+   * @throws Exception
+   */
   @Test
   public void testDefaultCreateOverwriteDirTest() throws Throwable {
     // the config fs.azure.disable.default.create.overwrite should have no

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -18,11 +18,17 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
+import java.util.UUID;
+
 import org.junit.Test;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertMkdirs;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.CONNECTIONS_MADE;
 
 /**
  * Test mkdir operation.
@@ -44,5 +50,55 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
   @Test
   public void testCreateRoot() throws Exception {
     assertMkdirs(getFileSystem(), new Path("/"));
+  }
+
+  @Test
+  public void testDefaultCreateOverwriteDirTest() throws Throwable {
+    // the config fs.azure.disable.default.create.overwrite should have no
+    // effect on mkdirs
+    testCreateDirOverwrite(true);
+    testCreateDirOverwrite(false);
+  }
+
+  public void testCreateDirOverwrite(boolean defaultDisableCreateOverwrite)
+      throws Throwable {
+    final AzureBlobFileSystem currentFs = getFileSystem();
+    Configuration config = new Configuration(this.getRawConfiguration());
+    config.set("fs.azure.disable.default.create.overwrite",
+        Boolean.toString(defaultDisableCreateOverwrite));
+
+    final AzureBlobFileSystem fs =
+        (AzureBlobFileSystem) FileSystem.newInstance(currentFs.getUri(),
+            config);
+
+    long totalConnectionMadeBeforeTest = fs.getInstrumentationMap()
+        .get(CONNECTIONS_MADE.getStatName());
+
+    int mkdirRequestCount = 0;
+    final Path dirPath = new Path("/DirPath_"
+        + UUID.randomUUID().toString());
+
+    // Case 1: Dir does not pre-exist
+    fs.mkdirs(dirPath);
+
+    // One request to server
+    mkdirRequestCount++;
+
+    assertAbfsStatistics(
+        CONNECTIONS_MADE,
+        totalConnectionMadeBeforeTest + mkdirRequestCount,
+        fs.getInstrumentationMap());
+
+    // Case 2: Dir pre-exists
+    // Mkdir on existing Dir path will not lead to failure
+    fs.mkdirs(dirPath);
+
+    // One request to server
+    mkdirRequestCount++;
+
+    assertAbfsStatistics(
+        CONNECTIONS_MADE,
+        totalConnectionMadeBeforeTest + mkdirRequestCount,
+        fs.getInstrumentationMap());
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -64,12 +64,12 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     testCreateDirOverwrite(false);
   }
 
-  public void testCreateDirOverwrite(boolean defaultDisableCreateOverwrite)
+  public void testCreateDirOverwrite(boolean enableConditionalCreateOverwrite)
       throws Throwable {
     final AzureBlobFileSystem currentFs = getFileSystem();
     Configuration config = new Configuration(this.getRawConfiguration());
-    config.set("fs.azure.disable.default.create.overwrite",
-        Boolean.toString(defaultDisableCreateOverwrite));
+    config.set("fs.azure.enable.conditional.create.overwrite",
+        Boolean.toString(enableConditionalCreateOverwrite));
 
     final AzureBlobFileSystem fs =
         (AzureBlobFileSystem) FileSystem.newInstance(currentFs.getUri(),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -283,8 +283,7 @@ public final class TestAbfsClient {
   }
 
   public static AbfsClient getMockAbfsClient(AbfsClient baseAbfsClientInstance,
-      AbfsConfiguration abfsConfig)
-      throws IOException, NoSuchFieldException, IllegalAccessException {
+      AbfsConfiguration abfsConfig) throws Exception {
     AuthType currentAuthType = abfsConfig.getAuthType(
         abfsConfig.getAccountName());
 
@@ -310,56 +309,46 @@ public final class TestAbfsClient {
     when(client.createDefaultHeaders()).thenCallRealMethod();
 
     // override baseurl
-    Field abfsConfigurationField = AbfsClient.class.getDeclaredField("abfsConfiguration");
-    abfsConfigurationField.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
-    modifiersField.setAccessible(true);
-    modifiersField.setInt(abfsConfigurationField,
-        abfsConfigurationField.getModifiers()
-            & ~java.lang.reflect.Modifier.FINAL);
-    abfsConfigurationField.set(client, abfsConfig);
+    client = TestAbfsClient.setAbfsClientField(client, "abfsConfiguration",
+        abfsConfig);
 
     // override baseurl
-    Field baseUrlField = AbfsClient.class.getDeclaredField("baseUrl");
-    baseUrlField.setAccessible(true);
-    modifiersField.setAccessible(true);
-    modifiersField.setInt(baseUrlField, baseUrlField.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
-    baseUrlField.set(client, baseAbfsClientInstance.getBaseUrl());
+    client = TestAbfsClient.setAbfsClientField(client, "baseUrl",
+        baseAbfsClientInstance.getBaseUrl());
 
     // override auth provider
     if (currentAuthType == AuthType.SharedKey) {
-      Field sharedKeyCredsField = AbfsClient.class.getDeclaredField(
-          "sharedKeyCredentials");
-      sharedKeyCredsField.setAccessible(true);
-      modifiersField.setInt(sharedKeyCredsField,
-          sharedKeyCredsField.getModifiers()
-              & ~java.lang.reflect.Modifier.FINAL);
-      sharedKeyCredsField.set(client, new SharedKeyCredentials(
-          abfsConfig.getAccountName().substring(0,
-              abfsConfig.getAccountName().indexOf(DOT)),
-          abfsConfig.getStorageAccountKey()));
+      client = TestAbfsClient.setAbfsClientField(client, "sharedKeyCredentials",
+          new SharedKeyCredentials(
+              abfsConfig.getAccountName().substring(0,
+                  abfsConfig.getAccountName().indexOf(DOT)),
+              abfsConfig.getStorageAccountKey()));
     } else {
-      Field tokenProviderField = AbfsClient.class.getDeclaredField(
-          "tokenProvider");
-      tokenProviderField.setAccessible(true);
-      modifiersField.setInt(tokenProviderField,
-          tokenProviderField.getModifiers()
-              & ~java.lang.reflect.Modifier.FINAL);
-      tokenProviderField.set(client, abfsConfig.getTokenProvider());
+      client = TestAbfsClient.setAbfsClientField(client, "tokenProvider",
+          abfsConfig.getTokenProvider());
     }
 
     // override user agent
     String userAgent = "APN/1.0 Azure Blob FS/3.4.0-SNAPSHOT (PrivateBuild "
         + "JavaJRE 1.8.0_252; Linux 5.3.0-59-generic/amd64; openssl-1.0; "
         + "UNKNOWN/UNKNOWN) MSFT";
-    Field userAgentField = AbfsClient.class.getDeclaredField(
-        "userAgent");
-    userAgentField.setAccessible(true);
-    modifiersField.setInt(userAgentField,
-        userAgentField.getModifiers()
-            & ~java.lang.reflect.Modifier.FINAL);
-    userAgentField.set(client, userAgent);
+    client = TestAbfsClient.setAbfsClientField(client, "userAgent", userAgent);
 
+    return client;
+  }
+
+  private static AbfsClient setAbfsClientField(
+      final AbfsClient client,
+      final String fieldName,
+      Object fieldObject) throws Exception {
+
+    Field field = AbfsClient.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(field,
+        field.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+    field.set(client, fieldObject);
     return client;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -310,9 +310,18 @@ public final class TestAbfsClient {
     when(client.createDefaultHeaders()).thenCallRealMethod();
 
     // override baseurl
+    Field abfsConfigurationField = AbfsClient.class.getDeclaredField("abfsConfiguration");
+    abfsConfigurationField.setAccessible(true);
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(abfsConfigurationField,
+        abfsConfigurationField.getModifiers()
+            & ~java.lang.reflect.Modifier.FINAL);
+    abfsConfigurationField.set(client, abfsConfig);
+
+    // override baseurl
     Field baseUrlField = AbfsClient.class.getDeclaredField("baseUrl");
     baseUrlField.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
     modifiersField.setAccessible(true);
     modifiersField.setInt(baseUrlField, baseUrlField.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
     baseUrlField.set(client, baseAbfsClientInstance.getBaseUrl());


### PR DESCRIPTION
Filesystem Create APIs that do not accept an argument for overwrite flag end up defaulting it to true. 

We are observing that request count of creates with overwrite=true is more and primarily because of the default setting of the flag is true of the called Create API. When a create with overwrite ends up timing out, we have observed that it could lead to race conditions between the first create and retried one running almost parallel.

To avoid this scenario for create with overwrite=true request, ABFS driver will always attempt to create without overwrite. If the create fails due to fileAlreadyPresent, it will fetch the ETag of the current file and then resend the request with overwrite=true with condition to overwrite only if ETag matches. 

This change will be guarded with a config if for any reason this behaviour needs to be reverted.

Tests for file and directory creations with and without overwrite along with file pre-existing or not combinations have been tested.