### PR TITLE
HADOOP-17230. Fix JAVA_HOME with spaces

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/conf/hadoop-env.cmd
+++ b/hadoop-common-project/hadoop-common/src/main/conf/hadoop-env.cmd
@@ -24,6 +24,9 @@
 @rem The java implementation to use.  Required.
 set JAVA_HOME=%JAVA_HOME%
 
+@rem In case path contains spaces, convert JAVA_HOME to short paths
+for %%I in ("%JAVA_HOME%") do set JAVA_HOME=%%~sI
+
 @rem The jsvc implementation to use. Jsvc is required to run secure datanodes.
 @rem set JSVC_HOME=%JSVC_HOME%
 


### PR DESCRIPTION
Windows users with default Java install location (c:\Program Files\Java) get errors when running Hadoop due to a space in the path. The fix converts the JAVA_HOME environment variable to the dos (short) path equivalent. 