### PR TITLE
HDFS-15471. TestHDFSContractMultipartUploader failing

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
@@ -807,12 +807,17 @@ public abstract class AbstractContractMultipartUploaderTest extends
 
     // now upload part 2.
     complete(file, upload2, partHandles2);
-    // and await the visible length to match
-    eventually(timeToBecomeConsistentMillis(),
-        () -> verifyFileLength(file, size2),
-        new LambdaTestUtils.ProportionalRetryInterval(
-            CONSISTENCY_INTERVAL,
-            timeToBecomeConsistentMillis()));
+
+    // and await the visible length to match, if this FS is not
+    // consistent.
+    final int consistencyDelay = timeToBecomeConsistentMillis();
+    if (consistencyDelay > 0) {
+      eventually(consistencyDelay,
+          () -> verifyFileLength(file, size2),
+          new LambdaTestUtils.ProportionalRetryInterval(
+              CONSISTENCY_INTERVAL,
+              consistencyDelay));
+    }
 
     verifyContents(file, digest2, size2);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/contract/hdfs/TestHDFSContractMultipartUploader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/contract/hdfs/TestHDFSContractMultipartUploader.java
@@ -35,7 +35,7 @@ public class TestHDFSContractMultipartUploader extends
     AbstractContractMultipartUploaderTest {
 
   protected static final Logger LOG =
-      LoggerFactory.getLogger(AbstractContractMultipartUploaderTest.class);
+      LoggerFactory.getLogger(TestHDFSContractMultipartUploader.class);
 
   @BeforeClass
   public static void createCluster() throws IOException {


### PR DESCRIPTION
Contributed by Steve Loughran
(Also: broken by Steve Loughran)

PR includes a minor change to the HDFS Code to ensure yetus is happy; main
change is that the eventually() clause is skipped on a consistent store,
because it is not needed.

