### PR TITLE
HADOOP-17234. Add .asf.yaml to allow Github to Jira integration.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+github:
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+notifications:
+  commits:      common-commits@hadoop.apache.org
+  issues:       common-issues@hadoop.apache.org
+  pullrequests: common-issues@hadoop.apache.org
+  jira_options: link label worklog


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17234
