### PR TITLE
HDFS-15546. Remove duplicate initializeGenericKeys method when creating DFSZKFailoverController

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSZKFailoverController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSZKFailoverController.java
@@ -158,7 +158,7 @@ public class DFSZKFailoverController extends ZKFailoverController {
           "You may run zkfc on the node other than namenode.";
       throw new HadoopIllegalArgumentException(msg);
     }
-    NameNode.initializeGenericKeys(localNNConf, nsId, nnId);
+
     DFSUtil.setGenericConf(localNNConf, nsId, nnId, ZKFC_CONF_KEYS);
     
     NNHAServiceTarget localTarget = new NNHAServiceTarget(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSZKFailoverController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSZKFailoverController.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.tools;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_BIND_HOST_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMESERVICE_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -60,6 +61,7 @@ import java.util.function.Supplier;
 public class TestDFSZKFailoverController extends ClientBaseWithFixes {
   private static final String LOCALHOST_SERVER_ADDRESS = "127.0.0.1";
   private static final String WILDCARD_ADDRESS = "0.0.0.0";
+  private static final String NAMESERVICE_ID = "ns1";
   private Configuration conf;
   private MiniDFSCluster cluster;
   private TestContext ctx;
@@ -226,9 +228,11 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     DFSZKFailoverController zkfc = DFSZKFailoverController.create(
         conf);
     String addr = zkfc.getRpcAddressToBindTo().getHostString();
+    String nameserviceId = conf.get(DFS_NAMESERVICE_ID);
 
     assertEquals("Bind address " + addr + " is not wildcard.",
         addr, WILDCARD_ADDRESS);
+    assertEquals(nameserviceId, NAMESERVICE_ID);
   }
 
   /**


### PR DESCRIPTION
…ng DFSZKFailoverController

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
