### PR TITLE
HADOOP-17023 Tune S3AFileSystem.listStatus() api.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
@@ -76,7 +76,7 @@ public class Listing extends AbstractStoreOperation {
 
   private static final Logger LOG = S3AFileSystem.LOG;
 
-  public static final FileStatusAcceptor ACCEPT_ALL_BUT_S3N =
+  static final FileStatusAcceptor ACCEPT_ALL_BUT_S3N =
       new AcceptAllButS3nDirs();
 
   private final ListingOperationCallbacks listingOperationCallbacks;
@@ -96,11 +96,24 @@ public class Listing extends AbstractStoreOperation {
    * @param acceptor the file status acceptor
    * @return the file status iterator
    */
-  public ProvidedFileStatusIterator createProvidedFileStatusIterator(
+  ProvidedFileStatusIterator createProvidedFileStatusIterator(
       S3AFileStatus[] fileStatuses,
       PathFilter filter,
       FileStatusAcceptor acceptor) {
     return new ProvidedFileStatusIterator(fileStatuses, filter, acceptor);
+  }
+
+  /**
+   * Create a FileStatus iterator against a provided list of file status.
+   * @param fileStatuses array of file status.
+   * @return
+   */
+  @VisibleForTesting
+  public static ProvidedFileStatusIterator toProvidedFileStatusIterator(
+          S3AFileStatus[] fileStatuses) {
+    return new ProvidedFileStatusIterator(fileStatuses,
+            ACCEPT_ALL,
+            Listing.ACCEPT_ALL_BUT_S3N);
   }
 
   /**
@@ -367,7 +380,7 @@ public class Listing extends AbstractStoreOperation {
     S3ListRequest request = createListObjectsRequest(key, "/");
     LOG.debug("listStatus: doing listObjects for directory {}", key);
 
-    Listing.FileStatusListingIterator filesItr = createFileStatusListingIterator(
+    FileStatusListingIterator filesItr = createFileStatusListingIterator(
             path,
             request,
             ACCEPT_ALL,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Listing.java
@@ -106,7 +106,7 @@ public class Listing extends AbstractStoreOperation {
   /**
    * Create a FileStatus iterator against a provided list of file status.
    * @param fileStatuses array of file status.
-   * @return
+   * @return the file status iterator.
    */
   @VisibleForTesting
   public static ProvidedFileStatusIterator toProvidedFileStatusIterator(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2704,18 +2704,17 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
     // Here we have a directory which may or may not be empty.
     // So we update the metastore and return.
-    RemoteIterator<S3AFileStatus> combinedRes = S3Guard.dirListingUnion(
+    return S3Guard.dirListingUnion(
             metadataStore,
             path,
             statusesAssumingNonEmptyDir.getLeft(),
             statusesAssumingNonEmptyDir.getMiddle(),
             allowAuthoritative(path),
-            ttlTimeProvider,
-            p -> listing.createProvidedFileStatusIterator(
+            ttlTimeProvider, p ->
+                    listing.createProvidedFileStatusIterator(
                     dirMetaToStatuses(statusesAssumingNonEmptyDir.getMiddle()),
                     ACCEPT_ALL,
                     Listing.ACCEPT_ALL_BUT_S3N));
-    return combinedRes;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
@@ -1414,6 +1415,30 @@ public final class S3AUtils {
     }
     LOG.debug("Using User-Agent: {}", userAgent);
     awsConf.setUserAgentPrefix(userAgent);
+  }
+
+  /**
+   * Convert the data of an iterator of {@link S3AFileStatus} to
+   * an array. Given tombstones are filtered out. If the iterator
+   * does return any item, an empty array is returned.
+   * @param iterator a non-null iterator
+   * @param tombstones
+   * @return a possibly-empty array of file status entries
+   * @throws IOException
+   */
+  public static S3AFileStatus[] iteratorToStatuses(
+      RemoteIterator<S3AFileStatus> iterator, Set<Path> tombstones)
+      throws IOException {
+    List<FileStatus> statuses = new ArrayList<>();
+
+    while (iterator.hasNext()) {
+      S3AFileStatus status = iterator.next();
+      if (!tombstones.contains(status.getPath())) {
+        statuses.add(status);
+      }
+    }
+
+    return statuses.toArray(new S3AFileStatus[0]);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -177,6 +177,77 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
   }
 
   @Test
+  public void testCostOfListStatusOnFile() throws Throwable {
+    describe("Performing listStatus() on a file");
+    Path file = path(getMethodName() + ".txt");
+    S3AFileSystem fs = getFileSystem();
+    touch(fs, file);
+    verifyMetrics(() ->
+            fs.listStatus(file),
+            whenRaw(LIST_STATUS_LIST_OP
+                    .plus(GET_FILE_STATUS_ON_FILE)),
+            whenAuthoritative(LIST_STATUS_LIST_OP),
+            whenNonauth(LIST_STATUS_LIST_OP));
+//    resetMetricDiffs();
+//    fs.listStatus(file);
+//    if (!fs.hasMetadataStore()) {
+//      metadataRequests.assertDiffEquals(1);
+//    }
+//    listRequests.assertDiffEquals(1);
+  }
+
+  @Test
+  public void testCostOfListStatusOnEmptyDir() throws Throwable {
+    describe("Performing listStatus() on an empty dir");
+    Path dir = path(getMethodName());
+    S3AFileSystem fs = getFileSystem();
+    fs.mkdirs(dir);
+    verifyMetrics(() ->
+            fs.listStatus(dir),
+            whenRaw(LIST_STATUS_LIST_OP
+            .plus(GET_FILE_STATUS_ON_EMPTY_DIR)),
+            whenAuthoritative(NO_IO),
+            whenNonauth(LIST_STATUS_LIST_OP));
+//    resetMetricDiffs();
+//    fs.listStatus(dir);
+//    if (!fs.hasMetadataStore()) {
+//      verifyOperationCount(2, 1);
+//    } else {
+//      if (fs.allowAuthoritative(dir)) {
+//        verifyOperationCount(0, 0);
+//      } else {
+//        verifyOperationCount(0, 1);
+//      }
+//    }
+  }
+
+  @Test
+  public void testCostOfListStatusOnNonEmptyDir() throws Throwable {
+    describe("Performing listStatus() on a non empty dir");
+    Path dir = path(getMethodName());
+    S3AFileSystem fs = getFileSystem();
+    fs.mkdirs(dir);
+    Path file = new Path(dir, "file.txt");
+    touch(fs, file);
+    verifyMetrics(() ->
+            fs.listStatus(dir),
+            whenRaw(LIST_STATUS_LIST_OP),
+            whenAuthoritative(NO_IO),
+            whenNonauth(LIST_STATUS_LIST_OP));
+//    resetMetricDiffs();
+//    fs.listStatus(dir);
+//    if (!fs.hasMetadataStore()) {
+//      verifyOperationCount(0, 1);
+//    } else {
+//      if (fs.allowAuthoritative(dir)) {
+//        verifyOperationCount(0, 0);
+//      } else {
+//        verifyOperationCount(0, 1);
+//      }
+//    }
+  }
+
+  @Test
   public void testCostOfGetFileStatusOnFile() throws Throwable {
     describe("performing getFileStatus on a file");
     Path simpleFile = file(methodPath());
@@ -406,8 +477,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
     fs.globStatus(basePath.suffix("/*"));
     // 2 head + 1 list from getFileStatus on path,
     // plus 1 list to match the glob pattern
-    verifyRaw(GET_FILE_STATUS_ON_DIR
-        .plus(LIST_OPERATION),
+    verifyRaw(LIST_STATUS_LIST_OP,
         () -> fs.globStatus(basePath.suffix("/*")));
   }
 
@@ -426,8 +496,7 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
     // unguarded: 2 head + 1 list from getFileStatus on path,
     // plus 1 list to match the glob pattern
     // no additional operations from symlink resolution
-    verifyRaw(GET_FILE_STATUS_ON_DIR
-        .plus(LIST_OPERATION),
+    verifyRaw(LIST_STATUS_LIST_OP,
         () -> fs.globStatus(basePath.suffix("/*")));
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -188,12 +188,6 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
                     .plus(GET_FILE_STATUS_ON_FILE)),
             whenAuthoritative(LIST_STATUS_LIST_OP),
             whenNonauth(LIST_STATUS_LIST_OP));
-//    resetMetricDiffs();
-//    fs.listStatus(file);
-//    if (!fs.hasMetadataStore()) {
-//      metadataRequests.assertDiffEquals(1);
-//    }
-//    listRequests.assertDiffEquals(1);
   }
 
   @Test
@@ -208,17 +202,6 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
             .plus(GET_FILE_STATUS_ON_EMPTY_DIR)),
             whenAuthoritative(NO_IO),
             whenNonauth(LIST_STATUS_LIST_OP));
-//    resetMetricDiffs();
-//    fs.listStatus(dir);
-//    if (!fs.hasMetadataStore()) {
-//      verifyOperationCount(2, 1);
-//    } else {
-//      if (fs.allowAuthoritative(dir)) {
-//        verifyOperationCount(0, 0);
-//      } else {
-//        verifyOperationCount(0, 1);
-//      }
-//    }
   }
 
   @Test
@@ -234,17 +217,6 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
             whenRaw(LIST_STATUS_LIST_OP),
             whenAuthoritative(NO_IO),
             whenNonauth(LIST_STATUS_LIST_OP));
-//    resetMetricDiffs();
-//    fs.listStatus(dir);
-//    if (!fs.hasMetadataStore()) {
-//      verifyOperationCount(0, 1);
-//    } else {
-//      if (fs.allowAuthoritative(dir)) {
-//        verifyOperationCount(0, 0);
-//      } else {
-//        verifyOperationCount(0, 1);
-//      }
-//    }
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -35,18 +35,40 @@ import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
 import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+import org.apache.hadoop.fs.s3a.impl.ContextAccessors;
+import org.apache.hadoop.fs.s3a.impl.ListingOperationCallbacks;
+import org.apache.hadoop.fs.s3a.impl.OperationCallbacks;
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.s3a.impl.StoreContextBuilder;
+import org.apache.hadoop.fs.s3a.impl.TestPartialDeleteFailures;
+import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
+import org.apache.hadoop.fs.s3a.s3guard.DirListingMetadata;
+import org.apache.hadoop.fs.s3a.s3guard.ITtlTimeProvider;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStore;
 import org.apache.hadoop.fs.s3a.s3guard.MetadataStoreCapabilities;
+import org.apache.hadoop.fs.s3a.s3guard.PathMetadata;
+import org.apache.hadoop.fs.s3a.s3guard.RenameTracker;
+import org.apache.hadoop.fs.s3a.s3guard.S3Guard;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.retry.RetryPolicies;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.service.ServiceOperations;
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.apache.hadoop.util.ReflectionUtils;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.amazonaws.services.s3.transfer.model.CopyResult;
+import javax.annotation.Nullable;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -61,12 +83,15 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -895,6 +920,49 @@ public final class S3ATestUtils {
   }
 
   /**
+   * Create mock implementation of store context.
+   * @param multiDelete
+   * @param store
+   * @param accessors
+   * @return
+   * @throws URISyntaxException
+   * @throws IOException
+   */
+  public static StoreContext createMockStoreContext(
+          boolean multiDelete,
+          OperationTrackingStore store,
+          ContextAccessors accessors)
+          throws URISyntaxException, IOException {
+    URI name = new URI("s3a://bucket");
+    Configuration conf = new Configuration();
+    return new StoreContextBuilder().setFsURI(name)
+        .setBucket("bucket")
+        .setConfiguration(conf)
+        .setUsername("alice")
+        .setOwner(UserGroupInformation.getCurrentUser())
+        .setExecutor(BlockingThreadPoolExecutorService.newInstance(
+            4,
+            4,
+            10, TimeUnit.SECONDS,
+            "s3a-transfer-shared"))
+        .setExecutorCapacity(DEFAULT_EXECUTOR_CAPACITY)
+        .setInvoker(
+            new Invoker(RetryPolicies.TRY_ONCE_THEN_FAIL, Invoker.LOG_EVENT))
+        .setInstrumentation(new S3AInstrumentation(name))
+        .setStorageStatistics(new S3AStorageStatistics())
+        .setInputPolicy(S3AInputPolicy.Normal)
+        .setChangeDetectionPolicy(
+            ChangeDetectionPolicy.createPolicy(ChangeDetectionPolicy.Mode.None,
+                ChangeDetectionPolicy.Source.ETag, false))
+        .setMultiObjectDeleteEnabled(multiDelete)
+        .setMetadataStore(store)
+        .setUseListV1(false)
+        .setContextAccessors(accessors)
+        .setTimeProvider(new S3Guard.TtlTimeProvider(conf))
+        .build();
+  }
+
+  /**
    * Helper class to do diffs of metrics.
    */
   public static final class MetricDiff {
@@ -1471,5 +1539,294 @@ public final class S3ATestUtils {
         path,
         needEmptyDirectoryFlag,
         probes);
+  }
+
+  public static class MinimalOperationCallbacks
+          implements OperationCallbacks {
+    @Override
+    public S3ObjectAttributes createObjectAttributes(
+            Path path,
+            String eTag,
+            String versionId,
+            long len) {
+      return null;
+    }
+
+    @Override
+    public S3ObjectAttributes createObjectAttributes(
+            S3AFileStatus fileStatus) {
+      return null;
+    }
+
+    @Override
+    public S3AReadOpContext createReadContext(
+            FileStatus fileStatus) {
+      return null;
+    }
+
+    @Override
+    public void finishRename(
+            Path sourceRenamed,
+            Path destCreated)
+            throws IOException {
+
+    }
+
+    @Override
+    public void deleteObjectAtPath(
+            Path path,
+            String key,
+            boolean isFile,
+            BulkOperationState operationState)
+            throws IOException {
+
+    }
+
+    @Override
+    public RemoteIterator<S3ALocatedFileStatus> listFilesAndEmptyDirectories(
+            Path path,
+            S3AFileStatus status,
+            boolean collectTombstones,
+            boolean includeSelf)
+            throws IOException {
+      return null;
+    }
+
+    @Override
+    public CopyResult copyFile(
+            String srcKey,
+            String destKey,
+            S3ObjectAttributes srcAttributes,
+            S3AReadOpContext readContext)
+            throws IOException {
+      return null;
+    }
+
+    @Override
+    public DeleteObjectsResult removeKeys(
+            List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+            boolean deleteFakeDir,
+            List<Path> undeletedObjectsOnFailure,
+            BulkOperationState operationState,
+            boolean quiet)
+            throws MultiObjectDeleteException, AmazonClientException,
+            IOException {
+      return null;
+    }
+
+    @Override
+    public boolean allowAuthoritative(Path p) {
+      return false;
+    }
+
+    @Override
+    public RemoteIterator<S3AFileStatus> listObjects(
+            Path path,
+            String key)
+            throws IOException {
+      return null;
+    }
+  }
+
+  /**
+   * MetadataStore which tracks what is deleted and added.
+   */
+  public static class OperationTrackingStore implements MetadataStore {
+
+    private final List<Path> deleted = new ArrayList<>();
+
+    private final List<Path> created = new ArrayList<>();
+
+    @Override
+    public void initialize(final FileSystem fs,
+        ITtlTimeProvider ttlTimeProvider) {
+    }
+
+    @Override
+    public void initialize(final Configuration conf,
+        ITtlTimeProvider ttlTimeProvider) {
+    }
+
+    @Override
+    public void forgetMetadata(final Path path) {
+    }
+
+    @Override
+    public PathMetadata get(final Path path) {
+      return null;
+    }
+
+    @Override
+    public PathMetadata get(final Path path,
+        final boolean wantEmptyDirectoryFlag) {
+      return null;
+    }
+
+    @Override
+    public DirListingMetadata listChildren(final Path path) {
+      return null;
+    }
+
+    @Override
+    public void put(final PathMetadata meta) {
+      put(meta, null);
+    }
+
+    @Override
+    public void put(final PathMetadata meta,
+        final BulkOperationState operationState) {
+      created.add(meta.getFileStatus().getPath());
+    }
+
+    @Override
+    public void put(final Collection<? extends PathMetadata> metas,
+        final BulkOperationState operationState) {
+      metas.stream().forEach(meta -> put(meta, null));
+    }
+
+    @Override
+    public void put(final DirListingMetadata meta,
+        final List<Path> unchangedEntries,
+        final BulkOperationState operationState) {
+      created.add(meta.getPath());
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void delete(final Path path,
+        final BulkOperationState operationState) {
+      deleted.add(path);
+    }
+
+    @Override
+    public void deletePaths(final Collection<Path> paths,
+        @Nullable final BulkOperationState operationState)
+            throws IOException {
+      deleted.addAll(paths);
+    }
+
+    @Override
+    public void deleteSubtree(final Path path,
+        final BulkOperationState operationState) {
+
+    }
+
+    @Override
+    public void move(@Nullable final Collection<Path> pathsToDelete,
+        @Nullable final Collection<PathMetadata> pathsToCreate,
+        @Nullable final BulkOperationState operationState) {
+    }
+
+    @Override
+    public void prune(final PruneMode pruneMode, final long cutoff) {
+    }
+
+    @Override
+    public long prune(final PruneMode pruneMode,
+        final long cutoff,
+        final String keyPrefix) {
+      return 0;
+    }
+
+    @Override
+    public BulkOperationState initiateBulkWrite(
+        final BulkOperationState.OperationType operation,
+        final Path dest) {
+      return null;
+    }
+
+    @Override
+    public void setTtlTimeProvider(ITtlTimeProvider ttlTimeProvider) {
+    }
+
+    @Override
+    public Map<String, String> getDiagnostics() {
+      return null;
+    }
+
+    @Override
+    public void updateParameters(final Map<String, String> parameters) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public List<Path> getDeleted() {
+      return deleted;
+    }
+
+    public List<Path> getCreated() {
+      return created;
+    }
+
+    @Override
+    public RenameTracker initiateRenameOperation(
+        final StoreContext storeContext,
+        final Path source,
+        final S3AFileStatus sourceStatus,
+        final Path dest) {
+      throw new UnsupportedOperationException("unsupported");
+    }
+
+    @Override
+    public void addAncestors(final Path qualifiedPath,
+        @Nullable final BulkOperationState operationState) {
+
+    }
+  }
+
+  public static class MinimalListingOperationCallbacks
+          implements ListingOperationCallbacks {
+    @Override
+    public CompletableFuture<S3ListResult> listObjectsAsync(
+            S3ListRequest request)
+            throws IOException {
+      return null;
+    }
+
+    @Override
+    public CompletableFuture<S3ListResult> continueListObjectsAsync(
+            S3ListRequest request,
+            S3ListResult prevResult)
+            throws IOException {
+      return null;
+    }
+
+    @Override
+    public S3ALocatedFileStatus toLocatedFileStatus(
+            S3AFileStatus status) throws IOException {
+      return null;
+    }
+
+    @Override
+    public S3ListRequest createListObjectsRequest(
+            String key,
+            String delimiter) {
+      return null;
+    }
+
+    @Override
+    public long getDefaultBlockSize(Path path) {
+      return 0;
+    }
+
+    @Override
+    public int getMaxKeys() {
+      return 0;
+    }
+
+    @Override
+    public ITtlTimeProvider getUpdatedTtlTimeProvider() {
+      return null;
+    }
+
+    @Override
+    public boolean allowAuthoritative(Path p) {
+      return false;
+    }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.fs.s3a.impl.OperationCallbacks;
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 import org.apache.hadoop.fs.s3a.impl.StoreContextBuilder;
-import org.apache.hadoop.fs.s3a.impl.TestPartialDeleteFailures;
 import org.apache.hadoop.fs.s3a.s3guard.BulkOperationState;
 import org.apache.hadoop.fs.s3a.s3guard.DirListingMetadata;
 import org.apache.hadoop.fs.s3a.s3guard.ITtlTimeProvider;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/OperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/OperationCost.java
@@ -107,12 +107,10 @@ public final class OperationCost {
       new OperationCost(0, 1);
 
   /** listFiles always does a LIST. */
-  public static final OperationCost LIST_FILES_LIST_OP =
-      new OperationCost(0, 1);
+  public static final OperationCost LIST_FILES_LIST_OP = LIST_OPERATION;
 
   /** listStatus always does a LIST. */
-  public static final OperationCost LIST_STATUS_LIST_OP =
-          new OperationCost(0, 1);
+  public static final OperationCost LIST_STATUS_LIST_OP = LIST_OPERATION;
   /**
    * Metadata cost of a copy operation, as used during rename.
    * This happens even if the store is guarded.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/OperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/OperationCost.java
@@ -110,6 +110,9 @@ public final class OperationCost {
   public static final OperationCost LIST_FILES_LIST_OP =
       new OperationCost(0, 1);
 
+  /** listStatus always does a LIST. */
+  public static final OperationCost LIST_STATUS_LIST_OP =
+          new OperationCost(0, 1);
   /**
    * Metadata cost of a copy operation, as used during rename.
    * This happens even if the store is guarded.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
@@ -141,9 +141,9 @@ public class TestS3Guard extends Assert {
             S3Guard.dirListingUnion(
                     ms, DIR_PATH, itr, dirMeta,
                     false, timeProvider,
-                    s3AFileStatuses ->
-                            toProvidedFileStatusIterator(
-                                    dirMetaToStatuses(dirMeta))),
+              s3AFileStatuses ->
+                      toProvidedFileStatusIterator(
+                              dirMetaToStatuses(dirMeta))),
             new HashSet<>());
     // the listing returns the new status
     Assertions.assertThat(find(result2, MS_FILE_1))
@@ -183,9 +183,9 @@ public class TestS3Guard extends Assert {
     RemoteIterator<S3AFileStatus> resultItr = S3Guard
             .dirListingUnion(ms, DIR_PATH, storeItr, dirMeta,
                     true, timeProvider,
-                    s3AFileStatuses ->
-                            toProvidedFileStatusIterator(
-                                    dirMetaToStatuses(dirMeta)));
+              s3AFileStatuses ->
+                      toProvidedFileStatusIterator(
+                              dirMetaToStatuses(dirMeta)));
 
     S3AFileStatus[] result = S3AUtils.iteratorToStatuses(
             resultItr, new HashSet<>());
@@ -215,9 +215,9 @@ public class TestS3Guard extends Assert {
     FileStatus[] result2 = S3AUtils.iteratorToStatuses(
             S3Guard.dirListingUnion(ms, DIR_PATH, itr, dirMeta,
                     true, timeProvider,
-                    s3AFileStatuses ->
-                            toProvidedFileStatusIterator(
-                                    dirMetaToStatuses(dirMeta))),
+              s3AFileStatuses ->
+                      toProvidedFileStatusIterator(
+                              dirMetaToStatuses(dirMeta))),
             new HashSet<>());
 
     // but the result of the listing contains the old entry

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3Guard.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.s3a.s3guard;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,20 +41,17 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.apache.hadoop.fs.s3a.Listing;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
-import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.Tristate;
-import org.apache.hadoop.fs.s3a.impl.ContextAccessors;
 import org.apache.hadoop.service.launcher.LauncherExitCodes;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_METADATASTORE_METADATA_TTL;
 import static org.apache.hadoop.fs.s3a.Constants.METADATASTORE_METADATA_TTL;
-import static org.apache.hadoop.fs.s3a.S3AUtils.ACCEPT_ALL;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.createMockStoreContext;
+import static org.apache.hadoop.fs.s3a.Listing.toProvidedFileStatusIterator;
+import static org.apache.hadoop.fs.s3a.s3guard.S3Guard.dirMetaToStatuses;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -81,11 +77,6 @@ public class TestS3Guard extends Assert {
 
   private ITtlTimeProvider timeProvider;
 
-  private static final ContextAccessors CONTEXT_ACCESSORS
-          = new MinimalContextAccessor();
-
-  private Listing listing;
-
   @Before
   public void setUp() throws Exception {
     final Configuration conf = new Configuration(false);
@@ -93,11 +84,6 @@ public class TestS3Guard extends Assert {
     ms.initialize(conf, new S3Guard.TtlTimeProvider(conf));
     timeProvider = new S3Guard.TtlTimeProvider(
         DEFAULT_METADATASTORE_METADATA_TTL);
-    listing = new Listing(new S3ATestUtils.MinimalListingOperationCallbacks(),
-            createMockStoreContext(
-                    true,
-                    new S3ATestUtils.OperationTrackingStore(),
-                    CONTEXT_ACCESSORS));
   }
 
   @After
@@ -126,16 +112,14 @@ public class TestS3Guard extends Assert {
     List<S3AFileStatus> s3Listing = Arrays.asList(
         s1Status,
         s2Status);
-    RemoteIterator<S3AFileStatus> storeItr =
-            listing.createProvidedFileStatusIterator(
-                    s3Listing.toArray(new S3AFileStatus[0]),
-                    ACCEPT_ALL,
-                    Listing.ACCEPT_ALL_BUT_S3N);
-
-    RemoteIterator<S3AFileStatus> resultItr = S3Guard
-            .dirListingUnion(ms, DIR_PATH, storeItr, dirMeta,
-                    false, timeProvider, listing);
-    S3AFileStatus[] result = S3AUtils.iteratorToStatuses(resultItr, new HashSet<>());
+    RemoteIterator<S3AFileStatus> storeItr = toProvidedFileStatusIterator(
+            s3Listing.toArray(new S3AFileStatus[0]));
+    RemoteIterator<S3AFileStatus> resultItr = S3Guard.dirListingUnion(
+            ms, DIR_PATH, storeItr, dirMeta, false,
+            timeProvider, s3AFileStatuses ->
+                    toProvidedFileStatusIterator(dirMetaToStatuses(dirMeta)));
+    S3AFileStatus[] result = S3AUtils.iteratorToStatuses(
+            resultItr, new HashSet<>());
 
     assertEquals("listing length", 4, result.length);
     assertContainsPaths(result, MS_FILE_1, MS_FILE_2, S3_FILE_3, S3_DIR_4);
@@ -151,14 +135,15 @@ public class TestS3Guard extends Assert {
         1, null, "tag2", "ver2");
     S3AFileStatus[] f1Statuses = new S3AFileStatus[1];
     f1Statuses[0] = f1Status2;
-    RemoteIterator<S3AFileStatus> itr = listing.
-            createProvidedFileStatusIterator(
-                    f1Statuses,
-                    ACCEPT_ALL,
-                    Listing.ACCEPT_ALL_BUT_S3N);
+    RemoteIterator<S3AFileStatus> itr = toProvidedFileStatusIterator(
+            f1Statuses);
     FileStatus[] result2 = S3AUtils.iteratorToStatuses(
-            S3Guard.dirListingUnion(ms, DIR_PATH, itr, dirMeta,
-                    false, timeProvider, listing),
+            S3Guard.dirListingUnion(
+                    ms, DIR_PATH, itr, dirMeta,
+                    false, timeProvider,
+                    s3AFileStatuses ->
+                            toProvidedFileStatusIterator(
+                                    dirMetaToStatuses(dirMeta))),
             new HashSet<>());
     // the listing returns the new status
     Assertions.assertThat(find(result2, MS_FILE_1))
@@ -193,16 +178,17 @@ public class TestS3Guard extends Assert {
     ITtlTimeProvider timeProvider = new S3Guard.TtlTimeProvider(
         DEFAULT_METADATASTORE_METADATA_TTL);
 
-    RemoteIterator<S3AFileStatus> storeItr =
-            listing.createProvidedFileStatusIterator(
-                    s3Listing.toArray(new S3AFileStatus[0]),
-                    ACCEPT_ALL,
-                    Listing.ACCEPT_ALL_BUT_S3N);
+    RemoteIterator<S3AFileStatus> storeItr = toProvidedFileStatusIterator(
+            s3Listing.toArray(new S3AFileStatus[0]));
     RemoteIterator<S3AFileStatus> resultItr = S3Guard
             .dirListingUnion(ms, DIR_PATH, storeItr, dirMeta,
-                    true, timeProvider, listing);
+                    true, timeProvider,
+                    s3AFileStatuses ->
+                            toProvidedFileStatusIterator(
+                                    dirMetaToStatuses(dirMeta)));
 
-    S3AFileStatus[] result = S3AUtils.iteratorToStatuses(resultItr, new HashSet<>());
+    S3AFileStatus[] result = S3AUtils.iteratorToStatuses(
+            resultItr, new HashSet<>());
     assertEquals("listing length", 4, result.length);
     assertContainsPaths(result, MS_FILE_1, MS_FILE_2, S3_FILE_3, S3_DIR_4);
 
@@ -224,15 +210,14 @@ public class TestS3Guard extends Assert {
         1, null, "tag2", "ver2");
     S3AFileStatus[] f1Statuses = new S3AFileStatus[1];
     f1Statuses[0] = s1Status2;
-    RemoteIterator<S3AFileStatus> itr = listing.
-            createProvidedFileStatusIterator(
-                    f1Statuses,
-                    ACCEPT_ALL,
-                    Listing.ACCEPT_ALL_BUT_S3N);
-
+    RemoteIterator<S3AFileStatus> itr =
+            toProvidedFileStatusIterator(f1Statuses);
     FileStatus[] result2 = S3AUtils.iteratorToStatuses(
             S3Guard.dirListingUnion(ms, DIR_PATH, itr, dirMeta,
-                    true, timeProvider, listing),
+                    true, timeProvider,
+                    s3AFileStatuses ->
+                            toProvidedFileStatusIterator(
+                                    dirMetaToStatuses(dirMeta))),
             new HashSet<>());
 
     // but the result of the listing contains the old entry
@@ -537,32 +522,5 @@ public class TestS3Guard extends Assert {
           100, System.currentTimeMillis(), p, 1, null, null, null);
     }
     return fileStatus;
-  }
-
-  private static class MinimalContextAccessor implements ContextAccessors {
-    @Override
-    public Path keyToPath(String key) {
-      return null;
-    }
-
-    @Override
-    public String pathToKey(Path path) {
-      return null;
-    }
-
-    @Override
-    public File createTempFile(String prefix, long size) throws IOException {
-      return null;
-    }
-
-    @Override
-    public String getBucketLocation() throws IOException {
-      return null;
-    }
-
-    @Override
-    public Path makeQualified(Path path) {
-      return null;
-    }
   }
 }


### PR DESCRIPTION
S3AFileSystem.listStatus() to perform list operations
directly and then fallback to head checks for files

Tested using ap-south-1 bucket in following modes along with scale tests:
1) Raw s3.
2) Auth S3guard.
3) Non auth s3guard. 
All good.
