### PR TITLE
HDFS-15539. When disallowing snapshot on a dir, throw exception if its trash root is not empty	

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -2068,6 +2068,12 @@ public class DistributedFileSystem extends FileSystem
     new FileSystemLinkResolver<Void>() {
       @Override
       public Void doCall(final Path p) throws IOException {
+        String ssTrashRoot =
+            new Path(p, FileSystem.TRASH_PREFIX).toUri().getPath();
+        if (dfs.exists(ssTrashRoot)) {
+          throw new IOException("Found trash root under path " + p + ". "
+              + "Please remove or move the trash root and then try again.");
+        }
         dfs.disallowSnapshot(getPathName(p));
         return null;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -2259,6 +2259,7 @@ public class TestDistributedFileSystem {
       assertEquals(trashRootsAfter2.size() + 1, trashRootsAfter3.size());
 
       // Cleanup
+      dfs.delete(new Path(testDir, FileSystem.TRASH_PREFIX), true);
       dfs.disallowSnapshot(testDir);
       dfs.delete(testDir, true);
     } finally {
@@ -2313,6 +2314,7 @@ public class TestDistributedFileSystem {
       assertEquals(trashRoots, trashRootsAfter);
 
       // Cleanup
+      dfs.delete(new Path(testDir, FileSystem.TRASH_PREFIX), true);
       dfs.disallowSnapshot(testDir);
       dfs.delete(testDir, true);
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -2445,7 +2445,7 @@ public class TestDistributedFileSystem {
 
   @Test
   public void testDisallowSnapshotShouldThrowWhenTrashRootExists()
-      throws IOException {
+      throws Exception {
     Configuration conf = getTestConfiguration();
     MiniDFSCluster cluster =
         new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
@@ -2459,12 +2459,8 @@ public class TestDistributedFileSystem {
       Path testDirTrashRoot = new Path(testDir, FileSystem.TRASH_PREFIX);
       dfs.mkdirs(testDirTrashRoot);
       // Try disallowing snapshot, should throw
-      try {
-        dfs.disallowSnapshot(testDir);
-        fail("Should have thrown IOException when trash root exists inside "
-            + "snapshot root when disallowing snapshot on it.");
-      } catch (IOException ignored) {
-      }
+      LambdaTestUtils.intercept(IOException.class,
+          () -> dfs.disallowSnapshot(testDir));
       // Remove the trash root and try again, should pass this time
       dfs.delete(testDirTrashRoot, true);
       dfs.disallowSnapshot(testDir);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15539

I initially intended to put the logic in `SnapshotManager#resetSnapshottable`.
But later I figured it makes more sense to put the check on the client side instead:
1. Trash is more of a client-side concept.
2. As a result of (1), it is much cleaner to add the check on the client than on the server side.