### PR TITLE
HADOOP-17208. LoadBalanceKMSClientProvider#deleteKey should invalidat…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/LoadBalancingKMSClientProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/LoadBalancingKMSClientProvider.java
@@ -502,6 +502,7 @@ public class LoadBalancingKMSClientProvider extends KeyProvider implements
         return null;
       }
     }, nextIdx(), false);
+    invalidateCache(name);
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/ValueQueue.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/ValueQueue.java
@@ -299,19 +299,18 @@ public class ValueQueue <E> {
    * @param keyName the key to drain the Queue for
    */
   public void drain(String keyName) {
+    Runnable e;
+    while ((e = queue.deleteByName(keyName)) != null) {
+      executor.remove(e);
+    }
+    writeLock(keyName);
     try {
-      Runnable e;
-      while ((e = queue.deleteByName(keyName)) != null) {
-        executor.remove(e);
+      LinkedBlockingQueue kq = keyQueues.getIfPresent(keyName);
+      if (kq != null) {
+        kq.clear();
       }
-      writeLock(keyName);
-      try {
-        keyQueues.get(keyName).clear();
-      } finally {
-        writeUnlock(keyName);
-      }
-    } catch (ExecutionException ex) {
-      //NOP
+    } finally {
+      writeUnlock(keyName);
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17208

Proposed Fix:
Send invalidCache to all KMS provider instances upon delete to ensure the server side key cache is drained upon deletion.
Also fix a NPE when invalidCache for a key that has been deleted. 

How is it tested:
Tested with RangerKMS with 3 instances. 