### PR TITLE
HADOOP-17229. No updation of bytes received counter value after response failure occurs in ABFS

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -249,8 +249,8 @@ public class AbfsRestOperation {
       httpOperation.processResponse(buffer, bufferOffset, bufferLength);
       incrementCounter(AbfsStatistic.GET_RESPONSES, 1);
       //Only increment bytesReceived counter when the status code is 2XX.
-      if (httpOperation.getStatusCode() >= HttpURLConnection.HTTP_OK &&
-          httpOperation.getStatusCode() <= HttpURLConnection.HTTP_PARTIAL) {
+      if (httpOperation.getStatusCode() >= HttpURLConnection.HTTP_OK
+          && httpOperation.getStatusCode() <= HttpURLConnection.HTTP_PARTIAL) {
         incrementCounter(AbfsStatistic.BYTES_RECEIVED,
             httpOperation.getBytesReceived());
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -248,8 +248,10 @@ public class AbfsRestOperation {
 
       httpOperation.processResponse(buffer, bufferOffset, bufferLength);
       incrementCounter(AbfsStatistic.GET_RESPONSES, 1);
-      incrementCounter(AbfsStatistic.BYTES_RECEIVED,
-          httpOperation.getBytesReceived());
+      if (httpOperation.getStatusCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+        incrementCounter(AbfsStatistic.BYTES_RECEIVED,
+            httpOperation.getBytesReceived());
+      }
     } catch (IOException ex) {
       if (ex instanceof UnknownHostException) {
         LOG.warn(String.format("Unknown host name: %s. Retrying to resolve the host name...", httpOperation.getUrl().getHost()));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -248,7 +248,9 @@ public class AbfsRestOperation {
 
       httpOperation.processResponse(buffer, bufferOffset, bufferLength);
       incrementCounter(AbfsStatistic.GET_RESPONSES, 1);
-      if (httpOperation.getStatusCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+      //Only increment bytesReceived counter when the status code is 2XX.
+      if (httpOperation.getStatusCode() >= HttpURLConnection.HTTP_OK &&
+          httpOperation.getStatusCode() <= HttpURLConnection.HTTP_PARTIAL) {
         incrementCounter(AbfsStatistic.BYTES_RECEIVED,
             httpOperation.getBytesReceived());
       }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
@@ -291,4 +292,31 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
     }
   }
 
+  /**
+   * Testing bytes_received counter value when a response failure occurs.
+   */
+  @Test
+  public void testAbfsHttpResponseFailure() throws IOException {
+    describe("Test to check the values of bytes received counter when a "
+        + "response is failed");
+
+    AzureBlobFileSystem fs = getFileSystem();
+    Path responseFailurePath = path(getMethodName());
+    Map<String, Long> metricMap;
+    FSDataOutputStream out = null;
+
+    try {
+      //create an empty file
+      out = fs.create(responseFailurePath);
+      //Re-creating the file again on same path with false overwrite, this
+      // would cause a response failure with status code 409.
+      out = fs.create(responseFailurePath, false);
+    } catch (FileAlreadyExistsException faee) {
+      metricMap = fs.getInstrumentationMap();
+      // Assert after catching the 409 error to check the counter values.
+      assertAbfsStatistics(AbfsStatistic.BYTES_RECEIVED, 0, metricMap);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, out);
+    }
+  }
 }


### PR DESCRIPTION
After a response failure at the moment, there is an increment to the bytes_received counter value which shouldn't increment.

Test-run: mvn -T 1C -Dparallel-tests=abfs clean verify
```
[INFO] Results:
[INFO]
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
```

```
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:82->setTestUserFs:104 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemDelete.testDeleteIdempotencyTriggerHttp404:223 » NoSuchField
[ERROR]   ITestAzureBlobFileSystemRename.testRenameIdempotencyTriggerHttpNotFound:225->testRenameIdempotencyTriggerChecks:236 » NoSuchField
[INFO]
[ERROR] Tests run: 452, Failures: 0, Errors: 14, Skipped: 61
```
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 206, Failures: 0, Errors: 0, Skipped: 29
```
Not really sure about these two failures, seeing these in trunk as well.
```
[ERROR]   ITestAzureBlobFileSystemDelete.testDeleteIdempotencyTriggerHttp404:223 » NoSuchField
[ERROR]   ITestAzureBlobFileSystemRename.testRenameIdempotencyTriggerHttpNotFound:225->testRenameIdempotencyTriggerChecks:236 » NoSuchField
```
Others are already in a Jira: HADOOP-17203.