### PR TITLE
HADOOP-16984 Add support to read history files from the done directory

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/jobhistory/JHAdminConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/jobhistory/JHAdminConfig.java
@@ -102,6 +102,17 @@ public class JHAdminConfig {
       MR_HISTORY_PREFIX + "intermediate-user-done-dir.permissions";
   public static final short
       DEFAULT_MR_HISTORY_INTERMEDIATE_USER_DONE_DIR_PERMISSIONS = 0770;
+
+  /**
+   * Scan for history files to read from done dir every X ms.
+   */
+  public static final String MR_HISTORY_READ_ONLY_INTERVAL_MS =
+      MR_HISTORY_PREFIX + "read-only.interval-ms";
+  public static final long DEFAULT_MR_HISTORY_READ_ONLY_INTERVAL_MS =
+      60 * 1000l; //60 seconds
+  /** Setting to check path pattern for history files in done directory */
+  public static final String MR_HISTORY_READ_ONLY_DIR_PATTERN =
+      MR_HISTORY_PREFIX + "read-only.dir-pattern";
   
   /** Size of the job list cache.*/
   public static final String MR_HISTORY_JOBLIST_CACHE_SIZE =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/pom.xml
@@ -70,10 +70,6 @@
       <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-all</artifactId>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/pom.xml
@@ -70,6 +70,10 @@
       <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-all</artifactId>
     </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/HistoryFileManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/HistoryFileManager.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -47,6 +48,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
@@ -74,8 +76,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.SystemClock;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * This class provides a way to interact with history files in a thread safe
@@ -578,6 +582,9 @@ public class HistoryFileManager extends AbstractService {
    */
   private int maxTasksForLoadedJob = -1;
 
+  private String readOnlyDirectoryPattern;
+  private FileSystem readOnlyDirFs;
+
   public HistoryFileManager() {
     super(HistoryFileManager.class.getName());
   }
@@ -594,7 +601,12 @@ public class HistoryFileManager extends AbstractService {
     long maxFSWaitTime = conf.getLong(
         JHAdminConfig.MR_HISTORY_MAX_START_WAIT_TIME,
         JHAdminConfig.DEFAULT_MR_HISTORY_MAX_START_WAIT_TIME);
-    createHistoryDirs(SystemClock.getInstance(), 10 * 1000, maxFSWaitTime);
+
+    readOnlyDirectoryPattern = conf.get(JHAdminConfig.MR_HISTORY_READ_ONLY_DIR_PATTERN, "");
+
+    if (!isReadOnlyMode()) {
+      createHistoryDirs(SystemClock.getInstance(), 10 * 1000, maxFSWaitTime);
+    }
 
     maxTasksForLoadedJob = conf.getInt(
         JHAdminConfig.MR_HS_LOADED_JOBS_TASKS_MAX,
@@ -611,10 +623,13 @@ public class HistoryFileManager extends AbstractService {
         JHAdminConfig.MR_HISTORY_DATESTRING_CACHE_SIZE,
         JHAdminConfig.DEFAULT_MR_HISTORY_DATESTRING_CACHE_SIZE));
 
-    int numMoveThreads = conf.getInt(
-        JHAdminConfig.MR_HISTORY_MOVE_THREAD_COUNT,
-        JHAdminConfig.DEFAULT_MR_HISTORY_MOVE_THREAD_COUNT);
-    moveToDoneExecutor = createMoveToDoneThreadPool(numMoveThreads);
+    if (!isReadOnlyMode()) {
+      int numMoveThreads = conf.getInt(
+          JHAdminConfig.MR_HISTORY_MOVE_THREAD_COUNT,
+          JHAdminConfig.DEFAULT_MR_HISTORY_MOVE_THREAD_COUNT);
+      moveToDoneExecutor = createMoveToDoneThreadPool(numMoveThreads);
+    }
+
     super.serviceInit(conf);
   }
 
@@ -782,6 +797,14 @@ public class HistoryFileManager extends AbstractService {
   @SuppressWarnings("unchecked")
   void initExisting() throws IOException {
     LOG.info("Initializing Existing Jobs...");
+    if (isReadOnlyMode()) {
+      Path readOnlyPath = new Path(readOnlyDirectoryPattern);
+      readOnlyDirFs = readOnlyPath.getFileSystem(conf);
+      scanDoneDirectoryInit();
+
+      return;
+    }
+
     List<FileStatus> timestampedDirList = findTimestampedDirectories();
     // Sort first just so insertion is in a consistent order
     Collections.sort(timestampedDirList);
@@ -894,6 +917,10 @@ public class HistoryFileManager extends AbstractService {
       FileContext fc) throws IOException {
     return scanDirectory(path, fc, JobHistoryUtils.getHistoryFileFilter());
   }
+
+  protected boolean isReadOnlyMode() {
+    return !(readOnlyDirectoryPattern.isEmpty());
+  }
   
   /**
    * Finds all history directories with a timestamp component by scanning the
@@ -905,6 +932,74 @@ public class HistoryFileManager extends AbstractService {
     List<FileStatus> fsList = JobHistoryUtils.localGlobber(doneDirFc,
         doneDirPrefixPath, DONE_BEFORE_SERIAL_TAIL);
     return fsList;
+  }
+
+  /**
+   * Scans the file system to find history files for jobs executed yesterday, today and the next day
+   *
+   * @throws IOException
+   *           if there was a error while scanning
+   */
+  void scanDoneDirectoryUpdate() throws IOException {
+    DateTime today = DateTime.now();
+    DateTime previousDay = today.minusDays(1);
+    DateTime nextDay = today.plusDays(1);
+
+    StringBuilder scanDatesPattern = new StringBuilder("{")
+        .append(JobHistoryUtils.timestampDirectoryComponent(previousDay.getMillis()))
+        .append(",")
+        .append(JobHistoryUtils.timestampDirectoryComponent(today.getMillis()))
+        .append(",")
+        .append(JobHistoryUtils.timestampDirectoryComponent(nextDay.getMillis()))
+        .append("}");
+
+    scanDoneDirectory(new Path(readOnlyDirectoryPattern, scanDatesPattern + "/*/*"));
+  }
+
+  /**
+   * Scans the file system to find all the existing history files
+   *
+   * @throws IOException
+   *           if there was a error while scanning
+   */
+  void scanDoneDirectoryInit() throws IOException {
+    scanDoneDirectory(new Path(readOnlyDirectoryPattern, "*/*/*/*/*"));
+  }
+
+  private void scanDoneDirectory(Path pathPattern) throws IOException {
+
+    List<FileStatus> fileStatusList = Arrays.asList(
+        readOnlyDirFs.globStatus(pathPattern, JobHistoryUtils.getHistoryFileFilter()));
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Found " + fileStatusList.size() + " files");
+    }
+
+    for (FileStatus fs : fileStatusList) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("scanning file: "+ fs.getPath());
+      }
+
+      try {
+        JobIndexInfo jobIndexInfo =
+            FileNameIndexUtils.getIndexInfo(fs.getPath().getName());
+        String confFileName =
+            JobHistoryUtils.getIntermediateConfFileName(jobIndexInfo.getJobId());
+        String summaryFileName =
+            JobHistoryUtils.getIntermediateSummaryFileName(jobIndexInfo.getJobId());
+        HistoryFileInfo fileInfo =
+            createHistoryFileInfo(
+                fs.getPath(),
+                new Path(fs.getPath().getParent(), confFileName),
+                new Path(fs.getPath().getParent(), summaryFileName),
+                jobIndexInfo,
+                false);
+
+        jobListCache.addIfAbsent(fileInfo);
+      } catch (Exception ex) {
+        LOG.error("Found exception while looking for history files in " + fs.getPath(), ex);
+      }
+    }
   }
 
   /**
@@ -1061,7 +1156,12 @@ public class HistoryFileManager extends AbstractService {
   }
 
   public Collection<HistoryFileInfo> getAllFileInfo() throws IOException {
-    scanIntermediateDirectory();
+    if (isReadOnlyMode()) {
+      scanDoneDirectoryUpdate();
+    } else {
+      scanIntermediateDirectory();
+    }
+
     return jobListCache.values();
   }
 
@@ -1071,8 +1171,12 @@ public class HistoryFileManager extends AbstractService {
     if (fileInfo != null) {
       return fileInfo;
     }
-    // OK so scan the intermediate to be sure we did not lose it that way
-    scanIntermediateDirectory();
+    if (isReadOnlyMode()) {
+      scanDoneDirectoryUpdate();
+    } else {
+      // OK so scan the intermediate to be sure we did not lose it that way
+      scanIntermediateDirectory();
+    }
     fileInfo = jobListCache.get(jobId);
     if (fileInfo != null) {
       return fileInfo;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
@@ -70,6 +70,8 @@ public class JobHistory extends AbstractService implements HistoryContext {
   // Time interval for the move thread.
   private long moveThreadInterval;
 
+  private long readOnlyModeScanInterval;
+
   private Configuration conf;
 
   private ScheduledThreadPoolExecutor scheduledExecutor = null;
@@ -92,6 +94,10 @@ public class JobHistory extends AbstractService implements HistoryContext {
     moveThreadInterval = conf.getLong(
         JHAdminConfig.MR_HISTORY_MOVE_INTERVAL_MS,
         JHAdminConfig.DEFAULT_MR_HISTORY_MOVE_INTERVAL_MS);
+
+    readOnlyModeScanInterval = conf.getLong(
+        JHAdminConfig.MR_HISTORY_READ_ONLY_INTERVAL_MS,
+        JHAdminConfig.DEFAULT_MR_HISTORY_READ_ONLY_INTERVAL_MS);
 
     hsManager = createHistoryFileManager();
     hsManager.init(conf);
@@ -132,11 +138,17 @@ public class JobHistory extends AbstractService implements HistoryContext {
         new ThreadFactoryBuilder().setNameFormat("Log Scanner/Cleaner #%d")
             .build());
 
-    scheduledExecutor.scheduleAtFixedRate(new MoveIntermediateToDoneRunnable(),
-        moveThreadInterval, moveThreadInterval, TimeUnit.MILLISECONDS);
+    if (hsManager.isReadOnlyMode()) {
+        scheduledExecutor.scheduleAtFixedRate(new ScanDoneDirectoryRunnable(),
+            readOnlyModeScanInterval, readOnlyModeScanInterval, TimeUnit.MILLISECONDS);
+    } else {
+        scheduledExecutor.scheduleAtFixedRate(new MoveIntermediateToDoneRunnable(),
+            moveThreadInterval, moveThreadInterval, TimeUnit.MILLISECONDS);
 
-    // Start historyCleaner
-    scheduleHistoryCleaner();
+        // Start historyCleaner
+        scheduleHistoryCleaner();
+    }
+
     super.serviceStart();
   }
 
@@ -192,6 +204,19 @@ public class JobHistory extends AbstractService implements HistoryContext {
         hsManager.scanIntermediateDirectory();
       } catch (IOException e) {
         LOG.error("Error while scanning intermediate done dir ", e);
+      }
+    }
+  }
+
+  private class ScanDoneDirectoryRunnable implements Runnable {
+    @Override
+    public void run() {
+      try {
+        LOG.info("Starting scan of history files in done directory");
+        hsManager.scanDoneDirectoryUpdate();
+        LOG.info("Completed scan of history files in done directory");
+      } catch (IOException e) {
+        LOG.error("Error while scanning done dir ", e);
       }
     }
   }


### PR DESCRIPTION
Currently history server implementation moves files from intermediate to done directory. We would like to add an additional server that can function as an alternate read only history server. To support it we would need to provide a functionality to read from done directory only. This will be a useful feature for multi cluster environments. https://github.com/apache/hadoop/pull/2028

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
