### PR TITLE
HDFS-15558: ViewDistributedFileSystem#recoverLease should call super.recoverLease when there are no mounts configured

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
@@ -266,6 +266,10 @@ public class ViewDistributedFileSystem extends DistributedFileSystem {
 
   @Override
   public boolean recoverLease(final Path f) throws IOException {
+    if (this.vfs == null) {
+      return super.recoverLease(f);
+    }
+
     ViewFileSystemOverloadScheme.MountPathInfo<FileSystem> mountPathInfo =
         this.vfs.getMountPathInfo(f, getConf());
     checkDFS(mountPathInfo.getTargetFs(), "recoverLease");
@@ -286,6 +290,9 @@ public class ViewDistributedFileSystem extends DistributedFileSystem {
   @Override
   public FSDataInputStream open(PathHandle fd, int bufferSize)
       throws IOException {
+    if (this.vfs == null) {
+      return super.open(fd, bufferSize);
+    }
     return this.vfs.open(fd, bufferSize);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestLeaseRecovery.java
@@ -280,8 +280,22 @@ public class TestLeaseRecovery {
    */
   @Test
   public void testLeaseRecoveryAndAppend() throws Exception {
+    testLeaseRecoveryAndAppend(new Configuration());
+  }
+
+  /**
+   * Recover the lease on a file and append file from another client with
+   * ViewDFS enabled.
+   */
+  @Test
+  public void testLeaseRecoveryAndAppendWithViewDFS() throws Exception {
     Configuration conf = new Configuration();
-    try{
+    conf.set("fs.hdfs.impl", ViewDistributedFileSystem.class.getName());
+    testLeaseRecoveryAndAppend(conf);
+  }
+
+  private void testLeaseRecoveryAndAppend(Configuration conf) throws Exception {
+    try {
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
     Path file = new Path("/testLeaseRecovery");
     DistributedFileSystem dfs = cluster.getFileSystem();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestViewDistributedFileSystem.java
@@ -17,9 +17,13 @@
  */
 package org.apache.hadoop.hdfs;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathHandle;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.test.Whitebox;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -43,5 +47,24 @@ public class TestViewDistributedFileSystem extends TestDistributedFileSystem{
                     ViewDistributedFileSystem.class), "threadData");
     data.set(null);
     super.testStatistics();
+  }
+
+  @Test
+  public void testOpenWithPathHandle() throws Exception {
+    Configuration conf = getTestConfiguration();
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+      FileSystem fileSys = cluster.getFileSystem();
+      Path openTestPath = new Path("/testOpen");
+      fileSys.create(openTestPath).close();
+      PathHandle pathHandle =
+          fileSys.getPathHandle(fileSys.getFileStatus(openTestPath));
+      fileSys.open(pathHandle, 1024).close();
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15558
