### PR TITLE
HADOOP-17245. Add OzoneFileSystem classes to core-default.xml.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3988,25 +3988,9 @@
   </property>
 
   <property>
-    <name>fs.ofs.impl</name>
-    <value>org.apache.hadoop.fs.ozone.RootedOzoneFileSystem</value>
-    <description>
-      The implementation class of the Rooted OzoneFileSystem
-    </description>
-  </property>
-
-  <property>
-    <name>fs.o3fs.impl</name>
-    <value>org.apache.hadoop.fs.ozone.OzoneFileSystem</value>
-    <description>
-      The implementation class of the OzoneFileSystem
-    </description>
-  </property>
-
-  <property>
     <name>fs.AbstractFileSystem.o3fs.impl</name>
     <value>org.apache.hadoop.fs.ozone.OzFs</value>
-    <description>The AbstractFileSystem for o3fs uri</description>
+    <description>The AbstractFileSystem for Ozone FileSystem o3fs uri</description>
   </property>
 
 </configuration>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3979,4 +3979,12 @@
       ThreadGroup approach is preferred for better performance.
     </description>
   </property>
+
+  <property>
+    <name>fs.AbstractFileSystem.ofs.impl</name>
+    <value>org.apache.hadoop.fs.ozone.RootedOzFs</value>
+    <description>The AbstractFileSystem for Rooted Ozone
+      FileSystem</description>
+  </property>
+
 </configuration>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3984,7 +3984,29 @@
     <name>fs.AbstractFileSystem.ofs.impl</name>
     <value>org.apache.hadoop.fs.ozone.RootedOzFs</value>
     <description>The AbstractFileSystem for Rooted Ozone
-      FileSystem</description>
+      FileSystem ofs uri</description>
+  </property>
+
+  <property>
+    <name>fs.ofs.impl</name>
+    <value>org.apache.hadoop.fs.ozone.RootedOzoneFileSystem</value>
+    <description>
+      The implementation class of the Rooted OzoneFileSystem
+    </description>
+  </property>
+
+  <property>
+    <name>fs.o3fs.impl</name>
+    <value>org.apache.hadoop.fs.ozone.OzoneFileSystem</value>
+    <description>
+      The implementation class of the OzoneFileSystem
+    </description>
+  </property>
+
+  <property>
+    <name>fs.AbstractFileSystem.o3fs.impl</name>
+    <value>org.apache.hadoop.fs.ozone.OzFs</value>
+    <description>The AbstractFileSystem for o3fs uri</description>
   </property>
 
 </configuration>


### PR DESCRIPTION
Add RootedOzoneFs to core-default similar to other filesystems.

Added o3fs also which is missing.
https://issues.apache.org/jira/browse/HADOOP-17245


