### PR TITLE
HADOOP-17246. Fix build the hadoop-build Docker image failed

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -129,6 +129,8 @@ ENV PATH "${PATH}:/opt/protobuf/bin"
 # https://github.com/PyCQA/pylint/issues/2294
 ####
 RUN pip2 install \
+    astroid==1.6.6 \
+    isort==4.3.21 \
     configparser==4.0.2 \
     pylint==1.9.2
 

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -132,6 +132,8 @@ ENV PATH "${PATH}:/opt/protobuf/bin"
 # https://github.com/PyCQA/pylint/issues/2294
 ####
 RUN pip2 install \
+    astroid==1.6.6 \
+    isort==4.3.21 \
     configparser==4.0.2 \
     pylint==1.9.2
 


### PR DESCRIPTION
When I build the docker-build image under macOS, it failed caused by:
```
    ----------------------------------------
Command "/usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-vKHcWu/isort/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-odL0bY-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-vKHcWu/isort/
You are using pip version 8.1.1, however version 20.2.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/bash -o pipefail -c pip2 install     configparser==4.0.2     pylint==1.9.2' returned a non-zero code: 1
```
https://issues.apache.org/jira/browse/HADOOP-17246