### PR TITLE
HADOOP-17249. Upgrade jackson-databind to 2.9.10.6 on branch-2.10.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -74,8 +74,8 @@
 
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.10.3</jackson2.version>
-    <jackson2.databind.version>2.10.3</jackson2.databind.version>
+    <jackson2.version>2.9.10</jackson2.version>
+    <jackson2.databind.version>2.9.10.6</jackson2.databind.version>
 
     <!-- SLF4J version -->
     <slf4j.version>1.7.25</slf4j.version>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -74,8 +74,8 @@
 
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.9.10</jackson2.version>
-    <jackson2.databind.version>2.9.10.5</jackson2.databind.version>
+    <jackson2.version>2.10.3</jackson2.version>
+    <jackson2.databind.version>2.10.3</jackson2.databind.version>
 
     <!-- SLF4J version -->
     <slf4j.version>1.7.25</slf4j.version>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -243,7 +243,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -243,7 +243,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>2.4.3</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
This is backporting [HADOOP-16905](https://issues.apache.org/jira/browse/HADOOP-16905) to branch-2.10. I used the same version of jackson-databind and maven-shade-plugin used in the current trunk.

maven-shade-plugin must be updated to 3.2.0 or above to fix error on creating jar of hadoop-yarn-server-applicationhistoryservice.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:2.4.3:shade (default) on project hadoop-yarn-server-applicationhistoryservice: Error creating shaded jar: null: IllegalArgumentException -> [Help 1]
```