### PR TITLE
HADOOP-17113, HADOOP-17158. Adding ReadAhead Counters and fixing ITestAbfsInputStreamStatistics#testReadAheadCounters

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -70,6 +70,8 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
 
   /** Stream statistics. */
   private final AbfsInputStreamStatistics streamStatistics;
+  private long bytesFromReadAhead; // bytes read from readAhead; for testing
+  private long bytesFromRemoteRead; // bytes read remotely; for testing
 
   public AbfsInputStream(
           final AbfsClient client,
@@ -235,6 +237,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
 
       // try reading from buffers first
       receivedBytes = ReadBufferManager.getBufferManager().getBlock(this, position, length, b);
+      bytesFromReadAhead += receivedBytes;
       if (receivedBytes > 0) {
         incrementReadOps();
         LOG.debug("Received data from read ahead, not doing remote read");
@@ -302,6 +305,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       throw new IOException("Unexpected Content-Length");
     }
     LOG.debug("HTTP request read bytes = {}", bytesRead);
+    bytesFromRemoteRead += bytesRead;
     return (int) bytesRead;
   }
 
@@ -501,6 +505,26 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
   @VisibleForTesting
   public AbfsInputStreamStatistics getStreamStatistics() {
     return streamStatistics;
+  }
+
+  /**
+   * Getter for bytes read from readAhead buffer that fills asynchronously.
+   *
+   * @return value of the counter in long.
+   */
+  @VisibleForTesting
+  public long getBytesFromReadAhead() {
+    return bytesFromReadAhead;
+  }
+
+  /**
+   * Getter for bytes read remotely from the data store.
+   *
+   * @return value of the counter in long.
+   */
+  @VisibleForTesting
+  public long getBytesFromRemoteRead() {
+    return bytesFromRemoteRead;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -238,6 +238,9 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       if (receivedBytes > 0) {
         incrementReadOps();
         LOG.debug("Received data from read ahead, not doing remote read");
+        if (streamStatistics != null) {
+          streamStatistics.readAheadBytesRead(receivedBytes);
+        }
         return receivedBytes;
       }
 
@@ -292,6 +295,9 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       throw new IOException(ex);
     }
     long bytesRead = op.getResult().getBytesReceived();
+    if (streamStatistics != null) {
+      streamStatistics.remoteBytesRead(bytesRead);
+    }
     if (bytesRead > Integer.MAX_VALUE) {
       throw new IOException("Unexpected Content-Length");
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
@@ -85,6 +85,18 @@ public interface AbfsInputStreamStatistics {
   void remoteReadOperation();
 
   /**
+   * Records the bytes read from readAhead buffer.
+   * @param bytes the bytes to be incremented.
+   */
+  void readAheadBytesRead(long bytes);
+
+  /**
+   * Records bytes read remotely after nothing from readAheadBuffer was read.
+   * @param bytes the bytes to be incremented.
+   */
+  void remoteBytesRead(long bytes);
+
+  /**
    * Makes the string of all the AbfsInputStream statistics.
    * @return the string with all the statistics.
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
@@ -33,6 +33,8 @@ public class AbfsInputStreamStatisticsImpl
   private long readOperations;
   private long bytesReadFromBuffer;
   private long remoteReadOperations;
+  private long readAheadBytesRead;
+  private long remoteBytesRead;
 
   /**
    * Seek backwards, incrementing the seek and backward seek counters.
@@ -129,6 +131,30 @@ public class AbfsInputStreamStatisticsImpl
   }
 
   /**
+   * Total bytes read from readAhead buffer during a read operation.
+   *
+   * @param bytes the bytes to be incremented.
+   */
+  @Override
+  public void readAheadBytesRead(long bytes) {
+    if (bytes > 0) {
+      readAheadBytesRead += bytes;
+    }
+  }
+
+  /**
+   * Total bytes read remotely after nothing was read from readAhead buffer.
+   *
+   * @param bytes the bytes to be incremented.
+   */
+  @Override
+  public void remoteBytesRead(long bytes) {
+    if (bytes > 0) {
+      remoteBytesRead += bytes;
+    }
+  }
+
+  /**
    * {@inheritDoc}
    *
    * Increment the counter when a remote read operation occurs.
@@ -178,6 +204,14 @@ public class AbfsInputStreamStatisticsImpl
     return remoteReadOperations;
   }
 
+  public long getReadAheadBytesRead() {
+    return readAheadBytesRead;
+  }
+
+  public long getRemoteBytesRead() {
+    return remoteBytesRead;
+  }
+
   /**
    * String operator describes all the current statistics.
    * <b>Important: there are no guarantees as to the stability
@@ -199,6 +233,8 @@ public class AbfsInputStreamStatisticsImpl
     sb.append(", ReadOperations=").append(readOperations);
     sb.append(", bytesReadFromBuffer=").append(bytesReadFromBuffer);
     sb.append(", remoteReadOperations=").append(remoteReadOperations);
+    sb.append(", readAheadBytesRead=").append(readAheadBytesRead);
+    sb.append(", remoteBytesRead=").append(remoteBytesRead);
     sb.append('}');
     return sb.toString();
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
@@ -41,9 +41,6 @@ public class ITestAbfsInputStreamStatistics
   private static final int ONE_MB = 1024 * 1024;
   private static final int ONE_KB = 1024;
   private static final int CUSTOM_BLOCK_BUFFER_SIZE = 4 * 1024;
-  private static final int CUSTOM_READ_AHEAD_BUFFER_SIZE = 8 * CUSTOM_BLOCK_BUFFER_SIZE;
-  private static final int THREAD_SLEEP_10_SECONDS = 10;
-  private static final int TIMEOUT_30_SECONDS = 30000;
   private byte[] defBuffer = new byte[ONE_MB];
 
   public ITestAbfsInputStreamStatistics() throws Exception {
@@ -295,8 +292,8 @@ public class ITestAbfsInputStreamStatistics
   /**
    * Testing readAhead counters in AbfsInputStream with 30 seconds timeout.
    */
-  @Test(timeout = TIMEOUT_30_SECONDS)
-  public void testReadAheadCounters() throws IOException, InterruptedException {
+  @Test
+  public void testReadAheadCounters() throws IOException {
     describe("Test to check correct values for readAhead counters in "
         + "AbfsInputStream");
 
@@ -335,45 +332,34 @@ public class ITestAbfsInputStreamStatistics
           (AbfsInputStreamStatisticsImpl) in.getStreamStatistics();
 
       /*
-       * Since, readAhead is done in background threads. Sometimes, the
-       * threads aren't finished in the background and could result in
-       * inaccurate results. So, we wait till we have the accurate values
-       * with a limit of 30 seconds as that's when the test times out.
-       *
-       */
-      while (stats.getRemoteBytesRead() < CUSTOM_READ_AHEAD_BUFFER_SIZE
-          || stats.getReadAheadBytesRead() < CUSTOM_BLOCK_BUFFER_SIZE) {
-        Thread.sleep(THREAD_SLEEP_10_SECONDS);
-      }
-
-      /*
        * Verifying the counter values of readAheadBytesRead and remoteBytesRead.
        *
        * readAheadBytesRead : Since, we read 1KBs 5 times, that means we go
        * from 0 to 5KB in the file. The bufferSize is set to 4KB, and since
        * we have 8 blocks of readAhead buffer. We would have 8 blocks of 4KB
        * buffer. Our read is till 5KB, hence readAhead would ideally read 2
-       * blocks of 4KB which is equal to 8KB. But, sometimes to get more than
-       * one block from readAhead buffer we might have to wait for background
+       * blocks of 4KB which is equal to 8KB. But, sometimes to get blocks
+       * from readAhead buffer we might have to wait for background
        * threads to fill the buffer and hence we might do remote read which
-       * would be faster. Therefore, readAheadBytesRead would be equal to or
-       * greater than 4KB.
+       * would be faster. Therefore, readAheadBytesRead would be greater than
+       * or equal to the value of bytesFromReadAhead at the point we measure it.
        *
        * remoteBytesRead : Since, the bufferSize is set to 4KB and the number
        * of blocks or readAheadQueueDepth is equal to 8. We would read 8 * 4
        * KB buffer on the first read, which is equal to 32KB. But, if we are not
        * able to read some bytes that were in the buffer after doing
        * readAhead, we might use remote read again. Thus, the bytes read
-       * remotely could also be greater than 32Kb.
+       * remotely would be greater than or equal to the bytesFromRemoteRead
+       * value that we measure at some point of the operation.
        *
        */
       Assertions.assertThat(stats.getReadAheadBytesRead()).describedAs(
           "Mismatch in readAheadBytesRead counter value")
-          .isGreaterThanOrEqualTo(CUSTOM_BLOCK_BUFFER_SIZE);
+          .isGreaterThanOrEqualTo(in.getBytesFromReadAhead());
 
       Assertions.assertThat(stats.getRemoteBytesRead()).describedAs(
           "Mismatch in remoteBytesRead counter value")
-          .isGreaterThanOrEqualTo(CUSTOM_READ_AHEAD_BUFFER_SIZE);
+          .isGreaterThanOrEqualTo(in.getBytesFromRemoteRead());
 
     } finally {
       IOUtils.cleanupWithLogger(LOG, out, in);


### PR DESCRIPTION
Backport for both HADOOP-17113(#2154) and HADOOP-17158(#2272)
Tested by: mvn -T 1C -Dparallel-tests=abfs clean verify
Region: East US

```
[INFO] Results:
[INFO]
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0
```
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 451, Failures: 0, Errors: 0, Skipped: 71
```
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 206, Failures: 0, Errors: 0, Skipped: 29
```
