### PR TITLE
HADOOP-17181. Fix transient stream read failures in FileSystem contract tests

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractSeekTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractSeekTest.java
@@ -317,7 +317,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
 
     int v = 256;
     byte[] readBuffer = new byte[v];
-    assertEquals(v, instream.read(128, readBuffer, 0, v));
+    instream.readFully(128, readBuffer, 0, v);
     //have gone back
     assertEquals(40000, instream.getPos());
     //content is the same too
@@ -572,8 +572,7 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
 
     // now read the entire file in one go
     byte[] fullFile = new byte[TEST_FILE_LEN];
-    assertEquals(TEST_FILE_LEN,
-        instream.read(0, fullFile, 0, fullFile.length));
+    instream.readFully(0, fullFile, 0, fullFile.length);
     assertEquals(0, instream.getPos());
 
     // now read past the end of the file

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
@@ -137,7 +137,8 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
           throws IOException {
     byte[] streamData = new byte[length];
     assertEquals("failed to read expected number of bytes from "
-            + "stream", length, stream.read(streamData));
+            + "stream. This may be transient",
+        length, stream.read(streamData));
     byte[] validateFileBytes;
     if (startIndex == 0 && length == fileBytes.length) {
       validateFileBytes = fileBytes;


### PR DESCRIPTION
* Fixes Seek test to readFully
* Doesn't do this to the unbuffer test as it changes the test too much.
  Instead just note in error that this may be transient

