### PR TITLE
HDFS-15552. Let DeadNode Detector also work for EC cases

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -278,6 +278,7 @@ public class DFSStripedInputStream extends DFSInputStream {
           // re-fetch the block in case the block has been moved
           fetchBlockAt(block.getStartOffset());
           addToLocalDeadNodes(dnInfo.info);
+          dfsClient.addNodeToDeadNodeDetector(this, dnInfo.info);
         }
       }
       if (reader != null) {


### PR DESCRIPTION
Use detector to deal with dead nodes under EC to avoid reading failures
Refer: [JIRA URL](https://issues.apache.org/jira/browse/HDFS-15552)

NOTE: This pr's `unit-test` is not ready for review, I'll finish it soon
