### PR TITLE
HADOOP-17255. JavaKeyStoreProvider fails to create a new key if the keystore is HDFS

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/JavaKeyStoreProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/JavaKeyStoreProvider.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -104,6 +105,7 @@ public class JavaKeyStoreProvider extends KeyProvider {
   private final Path path;
   private final FileSystem fs;
   private FsPermission permissions;
+  private FileContext context;
   private KeyStore keyStore;
   private char[] password;
   private boolean changed = false;
@@ -131,6 +133,7 @@ public class JavaKeyStoreProvider extends KeyProvider {
     this.uri = uri;
     path = ProviderUtils.unnestUri(uri);
     fs = path.getFileSystem(conf);
+    context = FileContext.getFileContext(conf);
     locateKeystore();
     ReadWriteLock lock = new ReentrantReadWriteLock(true);
     readLock = lock.readLock();
@@ -639,10 +642,7 @@ public class JavaKeyStoreProvider extends KeyProvider {
 
   private void renameOrFail(Path src, Path dest)
       throws IOException {
-    if (!fs.rename(src, dest)) {
-      throw new IOException("Rename unsuccessful : "
-          + String.format("'%s' to '%s'", src, dest));
-    }
+    context.rename(src, dest, org.apache.hadoop.fs.Options.Rename.NONE);
   }
 
   @Override


### PR DESCRIPTION
Use the new rename API in JavaKeyStoreProvider#renameOrFail.

JIRA: https://issues.apache.org/jira/browse/HADOOP-17255