### PR TITLE
HADOOP-17195. ABFS Store thread pool for stream IO.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -158,9 +158,9 @@ public class AbfsConfiguration{
       DefaultValue = AZURE_BLOCK_LOCATION_HOST_DEFAULT)
   private String azureBlockLocationHost;
 
-  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_CONCURRENT_CONNECTION_VALUE_OUT,
-      MinValue = 1,
-      DefaultValue = MAX_CONCURRENT_WRITE_THREADS)
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MAX_THREADS,
+      MinValue = -256,
+      DefaultValue = -4)
   private int maxConcurrentWriteThreads;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LIST_MAX_RESULTS,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -58,6 +58,11 @@ public final class ConfigurationKeys {
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
   public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";
+
+  /**
+   * Thread pool max size. Negative == multiply by core count.
+   */
+  public static final String AZURE_MAX_THREADS = "fs.azure.threads.max";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_OUT = "fs.azure.concurrentRequestCount.out";
   public static final String AZURE_CONCURRENT_CONNECTION_VALUE_IN = "fs.azure.concurrentRequestCount.in";
   public static final String AZURE_TOLERATE_CONCURRENT_APPEND = "fs.azure.io.read.tolerate.concurrent.append";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamContext.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import com.google.common.util.concurrent.ListeningExecutorService;
+
 /**
  * Class to hold extra output stream configs.
  */
@@ -36,6 +38,8 @@ public class AbfsOutputStreamContext extends AbfsStreamContext {
   private int writeMaxConcurrentRequestCount;
 
   private int maxWriteRequestsToQueue;
+
+  private ListeningExecutorService executorService;
 
   public AbfsOutputStreamContext(final long sasTokenRenewPeriodForStreamsInSeconds) {
     super(sasTokenRenewPeriodForStreamsInSeconds);
@@ -87,6 +91,12 @@ public class AbfsOutputStreamContext extends AbfsStreamContext {
     return this;
   }
 
+  public AbfsOutputStreamContext withExecutorService(
+      final ListeningExecutorService _executorService) {
+    executorService = _executorService;
+    return this;
+  }
+
   public int getWriteBufferSize() {
     return writeBufferSize;
   }
@@ -113,5 +123,9 @@ public class AbfsOutputStreamContext extends AbfsStreamContext {
 
   public int getMaxWriteRequestsToQueue() {
     return this.maxWriteRequestsToQueue;
+  }
+
+  public ListeningExecutorService getExecutorService() {
+    return executorService;
   }
 }


### PR DESCRIPTION

This is the successor to #2179

1. ABFS Store creates a single threadpool, configurable with fixed size or multiple of cores
1. each output stream is given its own semaphored pool which limits the access that stream has to the pool

To actually defend against OOMs the per-stream queue length is what needs to be managed; looking at the patch it still has the problem of #2179: you need one buffer per pending upload in the the pools.

Ultimately the S3A Connector fixed this by going to disk buffering by default. A more performant design might be to have a blocking byte buffer factory which limits the #of buffers which the streams can request, so putting an upper bound on the amount of memory which a single ABFS store instance can demand. 


