### PR TITLE
HDFS-15563. Incorrect getTrashRoot return value when a non-snapshottable dir prefix matches the path of a snapshottable dir

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -3168,6 +3168,9 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     }
     for (SnapshottableDirectoryStatus dirStatus : dirStatusList) {
       String currDir = dirStatus.getFullPath().toString();
+      if (!currDir.endsWith(Path.SEPARATOR)) {
+        currDir += Path.SEPARATOR;
+      }
       if (path.toUri().getPath().startsWith(currDir)) {
         return currDir;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -2172,9 +2172,19 @@ public class TestDistributedFileSystem {
       String testDirStr = testDir.toUri().getPath();
       assertTrue(trAfterAllowSnapshotStr.startsWith(testDirStr));
 
+      // test2Dir has the same prefix as testDir, but not snapshottable
+      Path test2Dir = new Path("/ssgtr/test12/");
+      Path file1path = new Path(test2Dir, "file-1");
+      trAfterAllowSnapshot = dfs.getTrashRoot(file1path);
+      trAfterAllowSnapshotStr = trAfterAllowSnapshot.toUri().getPath();
+      // The trash root should not be in the snapshot root
+      assertFalse(trAfterAllowSnapshotStr.startsWith(testDirStr));
+      assertTrue(trBeforeAllowSnapshotStr.startsWith(homeDirStr));
+
       // Cleanup
       dfs.disallowSnapshot(testDir);
       dfs.delete(testDir, true);
+      dfs.delete(test2Dir, true);
     } finally {
       if (cluster != null) {
         cluster.shutdown();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15563

This may impact clusters with `dfs.namenode.snapshot.trashroot.enabled` is set to `true`.