### PR TITLE
HDFS-15568. namenode start failed to start when dfs.namenode.max.snapshot.limit set.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -508,6 +508,10 @@ public class FSDirectory implements Closeable {
     return namesystem;
   }
 
+  /**
+   * Indicates whether the image loading is complete or not.
+   * @return true if image loading is complete, false otherwise
+   */
   public boolean isImageLoaded() {
     return namesystem.isImageLoaded();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -508,6 +508,10 @@ public class FSDirectory implements Closeable {
     return namesystem;
   }
 
+  public boolean isImageLoaded() {
+    return namesystem.isImageLoaded();
+  }
+
   /**
    * Parse configuration setting dfs.namenode.protected.directories to
    * retrieve the set of protected directories.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeDirectory.java
@@ -283,12 +283,11 @@ public class INodeDirectory extends INodeWithAdditionalFields
    * @param name Name of the snapshot.
    * @param mtime The snapshot creation time set by Time.now().
    */
-  public Snapshot addSnapshot(int id, String name,
-      final LeaseManager leaseManager, final boolean captureOpenFiles,
-      int maxSnapshotLimit, long mtime)
+  public Snapshot addSnapshot(SnapshotManager snapshotManager, String name,
+      final LeaseManager leaseManager, long mtime)
       throws SnapshotException {
-    return getDirectorySnapshottableFeature().addSnapshot(this, id, name,
-        leaseManager, captureOpenFiles, maxSnapshotLimit, mtime);
+    return getDirectorySnapshottableFeature().addSnapshot(this,
+        snapshotManager, name, leaseManager, mtime);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/DirectorySnapshottableFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/DirectorySnapshottableFeature.java
@@ -172,28 +172,26 @@ public class DirectorySnapshottableFeature extends DirectoryWithSnapshotFeature 
   /**
    * Add a snapshot.
    * @param snapshotRoot Root of the snapshot.
+   * @param snapshotManager SnapshotManager Instance.
    * @param name Name of the snapshot.
    * @param leaseManager
-   * @param captureOpenFiles
    * @throws SnapshotException Throw SnapshotException when there is a snapshot
    *           with the same name already exists or snapshot quota exceeds
    */
-  public Snapshot addSnapshot(INodeDirectory snapshotRoot, int id, String name,
-      final LeaseManager leaseManager, final boolean captureOpenFiles,
-      int maxSnapshotLimit, long now)
+  public Snapshot addSnapshot(INodeDirectory snapshotRoot,
+                              SnapshotManager snapshotManager, String name,
+                              final LeaseManager leaseManager, long now)
       throws SnapshotException {
+    int id = snapshotManager.getSnapshotCounter();
     //check snapshot quota
     final int n = getNumSnapshots();
     if (n + 1 > snapshotQuota) {
       throw new SnapshotException("Failed to add snapshot: there are already "
           + n + " snapshot(s) and the snapshot quota is "
           + snapshotQuota);
-    } else if (n + 1 > maxSnapshotLimit) {
-      throw new SnapshotException(
-          "Failed to add snapshot: there are already " + n
-              + " snapshot(s) and the max snapshot limit is "
-              + maxSnapshotLimit);
     }
+    snapshotManager.checkSnapshotLimit(snapshotManager.
+        getMaxSnapshotLimit(), n);
     final Snapshot s = new Snapshot(id, name, snapshotRoot);
     final byte[] nameBytes = s.getRoot().getLocalNameBytes();
     final int i = searchSnapshot(nameBytes);
@@ -210,7 +208,7 @@ public class DirectorySnapshottableFeature extends DirectoryWithSnapshotFeature 
     snapshotRoot.updateModificationTime(now, Snapshot.CURRENT_STATE_ID);
     s.getRoot().setModificationTime(now, Snapshot.CURRENT_STATE_ID);
 
-    if (captureOpenFiles) {
+    if (snapshotManager.captureOpenFiles()) {
       try {
         Set<INodesInPath> openFilesIIP =
             leaseManager.getINodeWithLeases(snapshotRoot);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/DirectorySnapshottableFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/DirectorySnapshottableFeature.java
@@ -190,8 +190,7 @@ public class DirectorySnapshottableFeature extends DirectoryWithSnapshotFeature 
           + n + " snapshot(s) and the snapshot quota is "
           + snapshotQuota);
     }
-    snapshotManager.checkSnapshotLimit(snapshotManager.
-        getMaxSnapshotLimit(), n);
+    snapshotManager.checkPerDirectorySnapshotLimit(n);
     final Snapshot s = new Snapshot(id, name, snapshotRoot);
     final byte[] nameBytes = s.getRoot().getLocalNameBytes();
     final int i = searchSnapshot(nameBytes);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotManager.java
@@ -473,7 +473,7 @@ public class SnapshotManager implements SnapshotStatsMXBean {
   }
 
   void checkPerDirectorySnapshotLimit(int n) throws SnapshotException {
-        checkSnapshotLimit(maxSnapshotLimit, n, "per directory");
+    checkSnapshotLimit(maxSnapshotLimit, n, "per directory");
   }
 
   void checkSnapshotLimit(int limit, int snapshotCount, String type)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
@@ -148,47 +148,53 @@ public class TestSnapshotManager {
             DFS_NAMENODE_SNAPSHOT_MAX_LIMIT, numSnapshots);
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_FILESYSTEM_LIMIT,
         numSnapshots * 2);
-    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).
-        numDataNodes(0).build();
-    cluster.waitActive();
-    DistributedFileSystem hdfs = cluster.getFileSystem();
-    hdfs.mkdirs(snapshottableDir);
-    hdfs.allowSnapshot(snapshottableDir);
-    for (int i = 0; i < numSnapshots; i++) {
-      hdfs.createSnapshot(snapshottableDir, "s" + i);
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).
+          numDataNodes(0).build();
+      cluster.waitActive();
+      DistributedFileSystem hdfs = cluster.getFileSystem();
+      hdfs.mkdirs(snapshottableDir);
+      hdfs.allowSnapshot(snapshottableDir);
+      for (int i = 0; i < numSnapshots; i++) {
+        hdfs.createSnapshot(snapshottableDir, "s" + i);
+      }
+      LambdaTestUtils.intercept(SnapshotException.class,
+          "snapshot limit",
+          () -> hdfs.createSnapshot(snapshottableDir, "s5"));
+
+      // now change max snapshot directory limit to 2 and restart namenode
+      cluster.getNameNode().getConf().setInt(DFSConfigKeys.
+          DFS_NAMENODE_SNAPSHOT_MAX_LIMIT, 2);
+      cluster.restartNameNodes();
+      SnapshotManager snapshotManager = cluster.getNamesystem().
+          getSnapshotManager();
+
+      // make sure edits of all previous 5 create snapshots are replayed
+      Assert.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
+
+      // make sure namenode has the new snapshot limit configured as 2
+      Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+
+      // Any new snapshot creation should still fail
+      LambdaTestUtils.intercept(SnapshotException.class,
+          "snapshot limit", () -> hdfs.createSnapshot(snapshottableDir, "s5"));
+      // now change max snapshot FS limit to 2 and restart namenode
+      cluster.getNameNode().getConf().setInt(DFSConfigKeys.
+          DFS_NAMENODE_SNAPSHOT_FILESYSTEM_LIMIT, 2);
+      cluster.restartNameNodes();
+      snapshotManager = cluster.getNamesystem().
+          getSnapshotManager();
+      // make sure edits of all previous 5 create snapshots are replayed
+      Assert.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
+
+      // make sure namenode has the new snapshot limit configured as 2
+      Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
-    LambdaTestUtils.intercept(SnapshotException.class,
-        "snapshot limit",
-        () -> hdfs.createSnapshot(snapshottableDir, "s5"));
-
-    // now change max snapshot directory limit to 2 and restart namenode
-    cluster.getNameNode().getConf().setInt(DFSConfigKeys.
-        DFS_NAMENODE_SNAPSHOT_MAX_LIMIT, 2);
-    cluster.restartNameNodes();
-    SnapshotManager snapshotManager = cluster.getNamesystem().
-        getSnapshotManager();
-
-    // make sure edits of all previous 5 create snapshots are replayed
-    Assert.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
-
-    // make sure namenode has the new snapshot limit configured as 2
-    Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
-
-    // Any new snapshot creation should still fail
-    LambdaTestUtils.intercept(SnapshotException.class,
-        "snapshot limit", () -> hdfs.createSnapshot(snapshottableDir, "s5"));
-    // now change max snapshot FS limit to 2 and restart namenode
-    cluster.getNameNode().getConf().setInt(DFSConfigKeys.
-        DFS_NAMENODE_SNAPSHOT_FILESYSTEM_LIMIT, 2);
-    cluster.restartNameNodes();
-    snapshotManager = cluster.getNamesystem().
-        getSnapshotManager();
-    // make sure edits of all previous 5 create snapshots are replayed
-    Assert.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
-
-    // make sure namenode has the new snapshot limit configured as 2
-    Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
-    cluster.shutdown();
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
@@ -69,7 +69,7 @@ public class TestSnapshotManager {
     conf.setInt(DFSConfigKeys.
             DFS_NAMENODE_SNAPSHOT_MAX_LIMIT,
         testMaxSnapshotIDLimit);
-    testMaxSnapshotLimit(testMaxSnapshotIDLimit,"max snapshot limit" ,
+    testMaxSnapshotLimit(testMaxSnapshotIDLimit,"file system snapshot limit" ,
         conf, testMaxSnapshotIDLimit * 2);
   }
 
@@ -84,6 +84,7 @@ public class TestSnapshotManager {
     SnapshotManager sm = spy(new SnapshotManager(conf, fsdir));
     doReturn(ids).when(sm).getSnapshottableRoot(any());
     doReturn(maxSnapID).when(sm).getMaxSnapshotID();
+    doReturn(true).when(fsdir).isImageLoaded();
 
     // Create testMaxSnapshotLimit snapshots. These should all succeed.
     //

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
@@ -153,8 +153,7 @@ public class TestSnapshotManager {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);
     hdfs.allowSnapshot(snapshottableDir);
-    int i = 0;
-    for (; i < numSnapshots; i++) {
+    for (int i = 0; i < numSnapshots; i++) {
       hdfs.createSnapshot(snapshottableDir, "s" + i);
     }
     LambdaTestUtils.intercept(SnapshotException.class,
@@ -176,8 +175,7 @@ public class TestSnapshotManager {
 
     // Any new snapshot creation should still fail
     LambdaTestUtils.intercept(SnapshotException.class,
-        "snapshot limit",
-        () -> hdfs.createSnapshot(snapshottableDir, "s5"));
+        "snapshot limit", () -> hdfs.createSnapshot(snapshottableDir, "s5"));
     // now change max snapshot FS limit to 2 and restart namenode
     cluster.getNameNode().getConf().setInt(DFSConfigKeys.
         DFS_NAMENODE_SNAPSHOT_FILESYSTEM_LIMIT, 2);
@@ -189,6 +187,7 @@ public class TestSnapshotManager {
 
     // make sure namenode has the new snapshot limit configured as 2
     Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+    cluster.shutdown();
   }
 
 }


### PR DESCRIPTION

please see https://issues.apache.org/jira/browse/HDFS-15568
