### PR TITLE
HADOOP-17261. s3a rename() needs s3:deleteObjectVersion permission

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
@@ -215,10 +215,9 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
    * This method must only be called from the primary thread.
    * @param path path to the object
    * @param key key of the object.
-   * @param version object version.
    */
-  private void queueToDelete(Path path, String key, String version) {
-    LOG.debug("Queueing to delete {}@{}", path, version);
+  private void queueToDelete(Path path, String key) {
+    LOG.debug("Queueing to delete {}", path);
     pathsToDelete.add(path);
     keysToDelete.add(new DeleteObjectsRequest.KeyVersion(key));
   }
@@ -228,28 +227,26 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
    * <p></p>
    * no-op if the list is empty.
    * <p></p>
-   * See {@link #queueToDelete(Path, String, String)} for
+   * See {@link #queueToDelete(Path, String)} for
    * details on safe use of this method.
    *
    * @param markersToDelete markers
    */
   private void queueToDelete(
       List<DirMarkerTracker.Marker> markersToDelete) {
-    markersToDelete.forEach(m ->
-        queueToDelete(m));
+    markersToDelete.forEach(this::queueToDelete);
   }
 
   /**
    * Queue a single marker for deletion.
    * <p></p>
-   * See {@link #queueToDelete(Path, String, String)} for
+   * See {@link #queueToDelete(Path, String)} for
    * details on safe use of this method.
    *
    * @param marker markers
    */
   private void queueToDelete(final DirMarkerTracker.Marker marker) {
-    queueToDelete(marker.getPath(), marker.getKey(),
-        marker.getStatus().getVersionId());
+    queueToDelete(marker.getPath(), marker.getKey());
   }
 
   /**
@@ -451,7 +448,7 @@ Are   * @throws IOException failure
         Path childDestPath = storeContext.keyToPath(newDestKey);
 
         // mark the source file for deletion on a successful copy.
-        queueToDelete(childSourcePath, key, child.getVersionId());
+        queueToDelete(childSourcePath, key);
           // now begin the single copy
         CompletableFuture<Path> copy = initiateCopy(child, key,
             childSourcePath, newDestKey, childDestPath);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
@@ -218,9 +218,9 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
    * @param version object version.
    */
   private void queueToDelete(Path path, String key, String version) {
-    LOG.debug("Queueing to delete {}", path);
+    LOG.debug("Queueing to delete {}@{}", path, version);
     pathsToDelete.add(path);
-    keysToDelete.add(new DeleteObjectsRequest.KeyVersion(key, version));
+    keysToDelete.add(new DeleteObjectsRequest.KeyVersion(key));
   }
 
   /**
@@ -418,6 +418,7 @@ Are   * @throws IOException failure
     while (iterator.hasNext()) {
       // get the next entry in the listing.
       S3ALocatedFileStatus child = iterator.next();
+      LOG.debug("To rename {}", child);
       // convert it to an S3 key.
       String k = storeContext.pathToKey(child.getPath());
       // possibly adding a "/" if it represents directory and it does


### PR DESCRIPTION
Stop using the versionId when building the list of files
to delete as the rename progresses


Testing: manual. For anyone wishing to replicate the problem on an unpatched release

1. Have a versioned bucket.
1. Latest version of cloudstore now allows you to create a set of session keys from an IAM role and json file, printing them as env vars and hadoop config options
1.  You need S3Guard enabled and the files to have been created individually by a client through S3Guard (i.e. the entries not discovered through listing). Then S3Guard caches the version ID in the DB, which is then used when deleting the object.
1. mkdir src/; touchz src/file1 file2
2. mv src dst

if that works, try renaming back.
