### PR TITLE
HDFS-15585: ViewDFS#getDelegationToken should not throw UnsupportedOperationException.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
@@ -1032,15 +1032,24 @@ public class ViewDistributedFileSystem extends DistributedFileSystem {
     return super.getDefaultPort();
   }
 
+  /**
+   * If no mount points configured, it works same as
+   * {@link DistributedFileSystem#getDelegationToken(String)}. If
+   * there are mount points configured and if default fs(linkFallback)
+   * configured, then it will return default fs delegation token. Otherwise
+   * it will return null.
+   */
   @Override
   public Token<DelegationTokenIdentifier> getDelegationToken(String renewer)
       throws IOException {
     if (this.vfs == null) {
       return super.getDelegationToken(renewer);
     }
-    //Let applications call getDelegationTokenIssuers and get respective
-    // delegation tokens from child fs.
-    throw new UnsupportedOperationException();
+
+    if (defaultDFS != null) {
+      return defaultDFS.getDelegationToken(renewer);
+    }
+    return null;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestViewDistributedFileSystem.java
@@ -76,7 +76,7 @@ public class TestViewDistributedFileSystem extends TestDistributedFileSystem{
     Configuration conf = getTestConfiguration();
     MiniDFSCluster cluster = null;
     try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
       URI defaultUri =
           URI.create(conf.get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY));
       ConfigUtil.addLinkFallback(conf, defaultUri.getHost(), defaultUri);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15585