### PR TITLE
HADOOP-17258. Make MagicS3GuardCommitter overwrite the existing pendingSet file if exists

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/magic/MagicS3GuardCommitter.java
@@ -221,7 +221,8 @@ public class MagicS3GuardCommitter extends AbstractS3ACommitter {
         CommitConstants.PENDINGSET_SUFFIX);
     LOG.info("Saving work of {} to {}", taskAttemptID, taskOutcomePath);
     try {
-      pendingSet.save(getDestFS(), taskOutcomePath, false);
+      // We will overwrite if there exists a pendingSet file already
+      pendingSet.save(getDestFS(), taskOutcomePath, true);
     } catch (IOException e) {
       LOG.warn("Failed to save task commit data to {} ",
           taskOutcomePath, e);


### PR DESCRIPTION
For [HADOOP-17258](https://issues.apache.org/jira/browse/HADOOP-17258), this PR aims to make `MagicS3GuardCommitter` overwrite the existing pendingSet file instead of failure.