### PR TITLE
MAPREDUCE-7282: remove v2 commit algorithm for correctness reasons.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -589,10 +589,9 @@ public class FileOutputCommitter extends PathOutputCommitter {
 
       if (taskAttemptDirStatus != null) {
         Path committedTaskPath = getCommittedTaskPath(context);
-        if (fs.exists(committedTaskPath)) {
-           if (!fs.delete(committedTaskPath, true)) {
-             throw new IOException("Could not delete " + committedTaskPath);
-           }
+        if (fs.exists(committedTaskPath)
+            && !fs.delete(committedTaskPath, true)) {
+          throw new IOException("Could not delete " + committedTaskPath);
         }
         if (!fs.rename(taskAttemptPath, committedTaskPath)) {
           throw new IOException("Could not rename " + taskAttemptPath + " to "
@@ -698,7 +697,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
               " to " + committedTaskPath);
         }
       } else {
-          LOG.warn(attemptId+" had no output to recover.");
+        LOG.warn(attemptId + " had no output to recover.");
       }
     } else {
       LOG.warn("Output Path is null in recoverTask()");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -1562,7 +1562,7 @@
 
 <property>
   <name>mapreduce.fileoutputcommitter.algorithm.version</name>
-  <value>21/value>
+  <value>1</value>
   <description>The file output committer algorithm version.
 
   There have been two algorithm versions in Hadoop, "1" and "2".

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -1562,10 +1562,18 @@
 
 <property>
   <name>mapreduce.fileoutputcommitter.algorithm.version</name>
-  <value>2</value>
-  <description>The file output committer algorithm version
-  valid algorithm version number: 1 or 2
-  default to 2, which is the original algorithm
+  <value>21/value>
+  <description>The file output committer algorithm version.
+
+  There have been two algorithm versions in Hadoop, "1" and "2".
+
+  The version 2 algorithm has been disabled as task commits
+  were not atomic. If the first task attempt failed partway
+  through the task commit, the output directory may end up
+  with data from that failed commit, as well as the data
+  from any subsequent attempts.
+
+  See https://issues.apache.org/jira/browse/MAPREDUCE-7282
 
   In algorithm version 1,
 
@@ -1585,32 +1593,58 @@
   $joboutput/, then it will delete $joboutput/_temporary/
   and write $joboutput/_SUCCESS
 
-  It has a performance regression, which is discussed in MAPREDUCE-4815.
+  It has a performance limitation, which is discussed in MAPREDUCE-4815.
+
   If a job generates many files to commit then the commitJob
   method call at the end of the job can take minutes.
   the commit is single-threaded and waits until all
   tasks have completed before commencing.
 
-  algorithm version 2 will change the behavior of commitTask,
+  The algorithm version 2 changed the behavior of commitTask,
   recoverTask, and commitJob.
 
-  1. commitTask will rename all files in
+  1. commitTask renamed all files in
   $joboutput/_temporary/$appAttemptID/_temporary/$taskAttemptID/
   to $joboutput/
 
-  2. recoverTask actually doesn't require to do anything, but for
+  2. recoverTask didn't do anything, but for
   upgrade from version 1 to version 2 case, it will check if there
   are any files in
   $joboutput/_temporary/($appAttemptID - 1)/$taskID/
   and rename them to $joboutput/
 
-  3. commitJob can simply delete $joboutput/_temporary and write
+  3. commitJob deleted $joboutput/_temporary and wrotew
   $joboutput/_SUCCESS
 
-  This algorithm will reduce the output commit time for
-  large jobs by having the tasks commit directly to the final
-  output directory as they were completing and commitJob had
-  very little to do.
+  This algorithm reduced the output commit time for large jobs
+  as the work of renaming files to their destination took place
+  incrementally as tasks committed. However, it has a key flaw
+
+  Task Attempt Commit is not atomic. If a task attempt ID 1 failed
+  partway through the rename, a second task attempt would be
+  scheduled.
+
+  - If task attempts 1 and 2 generated files with different names,
+    then those files from task 1 with different names which were
+    already renamed into the destination, would still be present.
+    They would not be overwritten by the second attempt.
+
+  - If task attempt 1 was still executing -even though the job
+    driver considered it to have failed- then a race condition
+    could arise where the output contained a mix of both task
+    attempts.
+
+  The applications which use these committers, including MapReduce,
+  and Apache Spark expect task attempts to be atomic -this
+  commit algorithm is not compatible.
+
+  Note:
+  * the Apache Hadoop S3A commit algorithms do have atomic task
+    commit and are safe.
+  * The Amazon "EMRFS S3-optimized Committer" completes its
+    multipart uploads in task commit, so has the same
+    limitation as for algorithm v2.
+  https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-committer-multipart.html
   </description>
 </property>
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
@@ -161,16 +161,6 @@ public class TestFileOutputCommitter {
     testRecoveryInternal(1, 1);
   }
 
-  @Test
-  public void testRecoveryV2() throws Exception {
-    testRecoveryInternal(2, 2);
-  }
-
-  @Test
-  public void testRecoveryUpgradeV1V2() throws Exception {
-    testRecoveryInternal(1, 2);
-  }
-
   private void validateContent(Path dir) throws IOException {
     File fdir = new File(dir.toUri().getPath());
     File expectedFile = new File(fdir, partFile);
@@ -213,12 +203,6 @@ public class TestFileOutputCommitter {
   public void testCommitterWithFailureV1() throws Exception {
     testCommitterWithFailureInternal(1, 1);
     testCommitterWithFailureInternal(1, 2);
-  }
-
-  @Test
-  public void testCommitterWithFailureV2() throws Exception {
-    testCommitterWithFailureInternal(2, 1);
-    testCommitterWithFailureInternal(2, 2);
   }
 
   private void testCommitterWithFailureInternal(int version, int maxAttempts) throws Exception {
@@ -267,11 +251,6 @@ public class TestFileOutputCommitter {
   @Test
   public void testCommitterWithDuplicatedCommitV1() throws Exception {
     testCommitterWithDuplicatedCommitInternal(1);
-  }
-
-  @Test
-  public void testCommitterWithDuplicatedCommitV2() throws Exception {
-    testCommitterWithDuplicatedCommitInternal(2);
   }
 
   private void testCommitterWithDuplicatedCommitInternal(int version) throws
@@ -355,11 +334,6 @@ public class TestFileOutputCommitter {
     testCommitterInternal(1);
   }
 
-  @Test
-  public void testCommitterV2() throws Exception {
-    testCommitterInternal(2);
-  }
-
   private void testMapFileOutputCommitterInternal(int version)
       throws Exception {
     JobConf conf = new JobConf();
@@ -398,18 +372,8 @@ public class TestFileOutputCommitter {
   }
 
   @Test
-  public void testMapFileOutputCommitterV2() throws Exception {
-    testMapFileOutputCommitterInternal(2);
-  }
-
-  @Test
   public void testMapOnlyNoOutputV1() throws Exception {
     testMapOnlyNoOutputInternal(1);
-  }
-
-  @Test
-  public void testMapOnlyNoOutputV2() throws Exception {
-    testMapOnlyNoOutputInternal(2);
   }
 
   private void testMapOnlyNoOutputInternal(int version) throws Exception {
@@ -475,11 +439,6 @@ public class TestFileOutputCommitter {
   @Test
   public void testAbortV1() throws Exception {
     testAbortInternal(1);
-  }
-
-  @Test
-  public void testAbortV2() throws Exception {
-    testAbortInternal(2);
   }
 
   public static class FakeFileSystem extends RawLocalFileSystem {
@@ -560,10 +519,6 @@ public class TestFileOutputCommitter {
     testFailAbortInternal(1);
   }
 
-  @Test
-  public void testFailAbortV2() throws Exception {
-    testFailAbortInternal(2);
-  }
   public static String slurp(File f) throws IOException {
     int len = (int) f.length();
     byte[] buf = new byte[len];

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -209,16 +209,6 @@ public class TestFileOutputCommitter {
     testRecoveryInternal(1, 1);
   }
 
-  @Test
-  public void testRecoveryV2() throws Exception {
-    testRecoveryInternal(2, 2);
-  }
-
-  @Test
-  public void testRecoveryUpgradeV1V2() throws Exception {
-    testRecoveryInternal(1, 2);
-  }
-
   private void validateContent(Path dir) throws IOException {
     validateContent(new File(dir.toUri().getPath()));
   }
@@ -270,9 +260,6 @@ public class TestFileOutputCommitter {
     conf.setInt(
         FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
-    conf.setBoolean(
-        FileOutputCommitter.FILEOUTPUTCOMMITTER_TASK_CLEANUP_ENABLED,
-        taskCleanup);
     JobContext jContext = new JobContextImpl(conf, taskID.getJobID());
     TaskAttemptContext tContext = new TaskAttemptContextImpl(conf, taskID);
     FileOutputCommitter committer = new FileOutputCommitter(outDir, tContext);
@@ -322,23 +309,8 @@ public class TestFileOutputCommitter {
   }
 
   @Test
-  public void testCommitterV2() throws Exception {
-    testCommitterInternal(2, false);
-  }
-
-  @Test
-  public void testCommitterV2TaskCleanupEnabled() throws Exception {
-    testCommitterInternal(2, true);
-  }
-
-  @Test
   public void testCommitterWithDuplicatedCommitV1() throws Exception {
     testCommitterWithDuplicatedCommitInternal(1);
-  }
-
-  @Test
-  public void testCommitterWithDuplicatedCommitV2() throws Exception {
-    testCommitterWithDuplicatedCommitInternal(2);
   }
 
   private void testCommitterWithDuplicatedCommitInternal(int version) throws
@@ -387,12 +359,6 @@ public class TestFileOutputCommitter {
   public void testCommitterWithFailureV1() throws Exception {
     testCommitterWithFailureInternal(1, 1);
     testCommitterWithFailureInternal(1, 2);
-  }
-
-  @Test
-  public void testCommitterWithFailureV2() throws Exception {
-    testCommitterWithFailureInternal(2, 1);
-    testCommitterWithFailureInternal(2, 2);
   }
 
   private void testCommitterWithFailureInternal(int version, int maxAttempts)
@@ -471,11 +437,6 @@ public class TestFileOutputCommitter {
   @Test
   public void testCommitterRepeatableV1() throws Exception {
     testCommitterRetryInternal(1);
-  }
-
-  @Test
-  public void testCommitterRepeatableV2() throws Exception {
-    testCommitterRetryInternal(2);
   }
 
   // retry committer for 2 times.
@@ -578,11 +539,6 @@ public class TestFileOutputCommitter {
   }
 
   @Test
-  public void testMapFileOutputCommitterV2() throws Exception {
-    testMapFileOutputCommitterInternal(2);
-  }
-
-  @Test
   public void testInvalidVersionNumber() throws IOException {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -637,11 +593,6 @@ public class TestFileOutputCommitter {
   @Test
   public void testAbortV1() throws IOException, InterruptedException {
     testAbortInternal(1);
-  }
-
-  @Test
-  public void testAbortV2() throws IOException, InterruptedException {
-    testAbortInternal(2);
   }
 
   public static class FakeFileSystem extends RawLocalFileSystem {
@@ -718,11 +669,6 @@ public class TestFileOutputCommitter {
   @Test
   public void testFailAbortV1() throws Exception {
     testFailAbortInternal(1);
-  }
-
-  @Test
-  public void testFailAbortV2() throws Exception {
-    testFailAbortInternal(2);
   }
 
   static class RLFS extends RawLocalFileSystem {
@@ -821,11 +767,6 @@ public class TestFileOutputCommitter {
   @Test
   public void testConcurrentCommitTaskWithSubDirV1() throws Exception {
     testConcurrentCommitTaskWithSubDir(1);
-  }
-
-  @Test
-  public void testConcurrentCommitTaskWithSubDirV2() throws Exception {
-    testConcurrentCommitTaskWithSubDir(2);
   }
 
   public static String slurp(File f) throws IOException {


### PR DESCRIPTION
* All jobs requsting v2 algorithm are WARNED and then switched to v1.
* the v2 codepaths in file output committer have been removed, even
  though some of the method names "rename or merge" are unchanged.

This patch doesn't fix those tests which will fail; I have
those changed and will submit after a Yetus run, to show what breaks/
is fixed

