### PR TITLE
HADOOP-17267: Add debug-level logs in Filesystem#close

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -621,9 +621,7 @@ public abstract class FileSystem extends Configured
    * @throws IOException a problem arose closing one or more filesystem.
    */
   public static void closeAll() throws IOException {
-    if (LOGGER.isDebugEnabled()) {
-      debugLogFileSystemClose("closeAll", "");
-    }
+    debugLogFileSystemClose("closeAll", "");
     CACHE.closeAll();
   }
 
@@ -635,19 +633,20 @@ public abstract class FileSystem extends Configured
    */
   public static void closeAllForUGI(UserGroupInformation ugi)
       throws IOException {
-    if (LOGGER.isDebugEnabled()) {
-      debugLogFileSystemClose("closeAllForUGI", "UGI: " + ugi);
-    }
+    debugLogFileSystemClose("closeAllForUGI", "UGI: " + ugi);
     CACHE.closeAll(ugi);
   }
 
   private static void debugLogFileSystemClose(String methodName,
       String additionalInfo) {
-    Throwable throwable = new Throwable().fillInStackTrace();
-    LOGGER.debug("FileSystem.{}() by method: {}); {}", methodName,
-        throwable.getStackTrace()[2], additionalInfo);
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("FileSystem.{}() full stack trace:", methodName, throwable);
+    if (LOGGER.isDebugEnabled()) {
+      Throwable throwable = new Throwable().fillInStackTrace();
+      LOGGER.debug("FileSystem.{}() by method: {}); {}", methodName,
+          throwable.getStackTrace()[2], additionalInfo);
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("FileSystem.{}() full stack trace:", methodName,
+            throwable);
+      }
     }
   }
 
@@ -2586,11 +2585,9 @@ public abstract class FileSystem extends Configured
    */
   @Override
   public void close() throws IOException {
-    if (LOGGER.isDebugEnabled()) {
-      debugLogFileSystemClose("close", "Key: " + key + "; URI: " + getUri()
-          + "; Object Identity Hash: "
-          + Integer.toHexString(System.identityHashCode(this)));
-    }
+    debugLogFileSystemClose("close", "Key: " + key + "; URI: " + getUri()
+        + "; Object Identity Hash: "
+        + Integer.toHexString(System.identityHashCode(this)));
     // delete all files that were marked as delete-on-exit.
     processDeleteOnExit();
     CACHE.remove(this.key, this);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -634,17 +634,18 @@ public abstract class FileSystem extends Configured
    * @throws IOException a problem arose closing one or more filesystem.
    */
   public static void closeAllForUGI(UserGroupInformation ugi)
-  throws IOException {
+      throws IOException {
     if (LOGGER.isDebugEnabled()) {
       debugLogFileSystemClose("closeAllForUGI", "UGI: " + ugi);
     }
     CACHE.closeAll(ugi);
   }
 
-  private static void debugLogFileSystemClose(String methodName, String additionalInfo) {
+  private static void debugLogFileSystemClose(String methodName,
+      String additionalInfo) {
     Throwable throwable = new Throwable().fillInStackTrace();
-    LOGGER.debug("FileSystem.{}() by method: {}); {}", methodName, throwable.getStackTrace()[2],
-        additionalInfo);
+    LOGGER.debug("FileSystem.{}() by method: {}); {}", methodName,
+        throwable.getStackTrace()[2], additionalInfo);
     if (LOGGER.isTraceEnabled()) {
       LOGGER.trace("FileSystem.{}() full stack trace:", methodName, throwable);
     }
@@ -2587,7 +2588,8 @@ public abstract class FileSystem extends Configured
   public void close() throws IOException {
     if (LOGGER.isDebugEnabled()) {
       debugLogFileSystemClose("close", "Key: " + key + "; URI: " + getUri()
-          + "; Object Identity Hash: " + Integer.toHexString(System.identityHashCode(this)));
+          + "; Object Identity Hash: "
+          + Integer.toHexString(System.identityHashCode(this)));
     }
     // delete all files that were marked as delete-on-exit.
     processDeleteOnExit();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -621,6 +621,9 @@ public abstract class FileSystem extends Configured
    * @throws IOException a problem arose closing one or more filesystem.
    */
   public static void closeAll() throws IOException {
+    if (LOGGER.isDebugEnabled()) {
+      debugLogFileSystemClose("closeAll", null);
+    }
     CACHE.closeAll();
   }
 
@@ -632,7 +635,19 @@ public abstract class FileSystem extends Configured
    */
   public static void closeAllForUGI(UserGroupInformation ugi)
   throws IOException {
+    if (LOGGER.isDebugEnabled()) {
+      debugLogFileSystemClose("closeAllForUGI", "UGI: " + ugi.toString());
+    }
     CACHE.closeAll(ugi);
+  }
+
+  private static void debugLogFileSystemClose(String methodName, String additionalInfo) {
+    StackTraceElement callingMethod = new Throwable().fillInStackTrace().getStackTrace()[2];
+    LOGGER.debug(
+        "FileSystem." + methodName + "() called by method: "
+            + callingMethod.getClassName() + "." + callingMethod.getMethodName()
+            + "(" + callingMethod.getFileName() + ":" + callingMethod.getLineNumber() + "); "
+            + (additionalInfo != null ? additionalInfo : ""));
   }
 
   /**
@@ -2570,6 +2585,10 @@ public abstract class FileSystem extends Configured
    */
   @Override
   public void close() throws IOException {
+    if (LOGGER.isDebugEnabled()) {
+      debugLogFileSystemClose("close", "Key: " + this.key + "; Object Identity Hash: "
+              + Integer.toHexString(System.identityHashCode(this)));
+    }
     // delete all files that were marked as delete-on-exit.
     processDeleteOnExit();
     CACHE.remove(this.key, this);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -622,7 +622,7 @@ public abstract class FileSystem extends Configured
    */
   public static void closeAll() throws IOException {
     if (LOGGER.isDebugEnabled()) {
-      debugLogFileSystemClose("closeAll", null);
+      debugLogFileSystemClose("closeAll", "");
     }
     CACHE.closeAll();
   }
@@ -636,18 +636,19 @@ public abstract class FileSystem extends Configured
   public static void closeAllForUGI(UserGroupInformation ugi)
   throws IOException {
     if (LOGGER.isDebugEnabled()) {
-      debugLogFileSystemClose("closeAllForUGI", "UGI: " + ugi.toString());
+      debugLogFileSystemClose("closeAllForUGI", "UGI: " + ugi);
     }
     CACHE.closeAll(ugi);
   }
 
   private static void debugLogFileSystemClose(String methodName, String additionalInfo) {
     StackTraceElement callingMethod = new Throwable().fillInStackTrace().getStackTrace()[2];
-    LOGGER.debug(
-        "FileSystem." + methodName + "() called by method: "
-            + callingMethod.getClassName() + "." + callingMethod.getMethodName()
-            + "(" + callingMethod.getFileName() + ":" + callingMethod.getLineNumber() + "); "
-            + (additionalInfo != null ? additionalInfo : ""));
+    LOGGER.debug("FileSystem.{}() called by method: {}.{}({}:{}); {}", methodName, callingMethod.getClassName(),
+            callingMethod.getMethodName(), callingMethod.getFileName(), callingMethod.getLineNumber(), additionalInfo);
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("FileSystem.{}() full stack trace:", methodName, new Throwable().fillInStackTrace());
+    }
+    
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -642,13 +642,12 @@ public abstract class FileSystem extends Configured
   }
 
   private static void debugLogFileSystemClose(String methodName, String additionalInfo) {
-    StackTraceElement callingMethod = new Throwable().fillInStackTrace().getStackTrace()[2];
-    LOGGER.debug("FileSystem.{}() called by method: {}.{}({}:{}); {}", methodName, callingMethod.getClassName(),
-            callingMethod.getMethodName(), callingMethod.getFileName(), callingMethod.getLineNumber(), additionalInfo);
+    Throwable throwable = new Throwable().fillInStackTrace();
+    LOGGER.debug("FileSystem.{}() by method: {}); {}", methodName, throwable.getStackTrace()[2],
+        additionalInfo);
     if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("FileSystem.{}() full stack trace:", methodName, new Throwable().fillInStackTrace());
+      LOGGER.trace("FileSystem.{}() full stack trace:", methodName, throwable);
     }
-    
   }
 
   /**
@@ -2587,8 +2586,8 @@ public abstract class FileSystem extends Configured
   @Override
   public void close() throws IOException {
     if (LOGGER.isDebugEnabled()) {
-      debugLogFileSystemClose("close", "Key: " + this.key + "; Object Identity Hash: "
-              + Integer.toHexString(System.identityHashCode(this)));
+      debugLogFileSystemClose("close", "Key: " + key + "; URI: " + getUri()
+          + "; Object Identity Hash: " + Integer.toHexString(System.identityHashCode(this)));
     }
     // delete all files that were marked as delete-on-exit.
     processDeleteOnExit();


### PR DESCRIPTION
HDFS reuses the same cached FileSystem object across the file system. If the client calls FileSystem.close(), closeAllForUgi(), or closeAll() (if it applies to the instance) anywhere in the system it purges the cache of that FS instance, and trying to use the instance results in an IOException: FileSystem closed.

It would be a great help to clients to see where and when a given FS instance was closed. I.e. in close(), closeAllForUgi(), or closeAll(), it would be great to see a DEBUG-level log of
- calling method name, class, file name/line number
- FileSystem object's identity hash (FileSystem.close() only)