### PR TITLE
HDFS-15596: ViewHDFS#create(f, permission, cflags, bufferSize, replication, blockSize, progress, checksumOpt) should not be restricted to DFS only.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
@@ -376,7 +376,6 @@ public class ViewDistributedFileSystem extends DistributedFileSystem {
   }
 
   @Override
-  //DFS specific API
   public FSDataOutputStream create(final Path f, final FsPermission permission,
       final EnumSet<CreateFlag> cflags, final int bufferSize,
       final short replication, final long blockSize,
@@ -387,12 +386,8 @@ public class ViewDistributedFileSystem extends DistributedFileSystem {
           .create(f, permission, cflags, bufferSize, replication, blockSize,
               progress, checksumOpt);
     }
-    ViewFileSystemOverloadScheme.MountPathInfo<FileSystem> mountPathInfo =
-        this.vfs.getMountPathInfo(f, getConf());
-    checkDFS(mountPathInfo.getTargetFs(), "create");
-    return mountPathInfo.getTargetFs()
-        .create(mountPathInfo.getPathOnTarget(), permission, cflags, bufferSize,
-            replication, blockSize, progress, checksumOpt);
+    return vfs.create(f, permission, cflags, bufferSize, replication, blockSize,
+        progress, checksumOpt);
   }
 
   void checkDFS(FileSystem fs, String methodName) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15596