### PR TITLE
HADOOP-17282. libzstd-dev should be used instead of libzstd1-dev on Ubuntu 18.04 or higher.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get -q update \
         libsnappy-dev \
         libssl-dev \
         libtool \
-        libzstd1-dev \
+        libzstd-dev \
         locales \
         make \
         maven \

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -64,7 +64,7 @@ RUN apt-get -q update \
         libsnappy-dev \
         libssl-dev \
         libtool \
-        libzstd1-dev \
+        libzstd-dev \
         locales \
         make \
         maven \


### PR DESCRIPTION
libzstd1-dev is a transitional package on Ubuntu 18.04. It is better to use libzstd-dev instead of libzstd1-dev in the Dockerfile (dev-support/docker/Dockerfile).

I have tested this patch in a docker container, and the results are as follows:

1. zstd version

```
hadoop@ac937c1afb72:~/hadoop$ sudo apt search libzstd
Sorting... Done
Full Text Search... Done
libzstd-dev/bionic-updates,bionic-security,now 1.3.3+dfsg-2ubuntu1.1 amd64 [installed]
  fast lossless compression algorithm -- development files
libzstd1/bionic-updates,bionic-security,now 1.3.3+dfsg-2ubuntu1.1 amd64 [installed]
  fast lossless compression algorithm
libzstd1-dev/bionic-updates,bionic-security 1.3.3+dfsg-2ubuntu1.1 amd64
  transitional package for libzstd-dev
```

2. Is zstd enabled?

The result of `cd hadoop-common-project/hadoop-common; mvn test -Dtest=TestZStandard*` is shown below.

```
[INFO] --- maven-surefire-plugin:3.0.0-M1:test (default-test) @ hadoop-common ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.467 s - in org.apache.hadoop.io.compress.zstd.TestZStandardCompressorDecompressor
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
```