### PR TITLE
MAPREDUCE-7289. Fix wrong comment in LongLong.java

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/math/LongLong.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/math/LongLong.java
@@ -44,7 +44,7 @@ class LongLong {
     return d0 & mask;
   }
 
-  /** Shift right operation (<<). */
+  /** Shift right operation (>>). */
   long shiftRight(int n) {
     return (d1 << (BITS_PER_LONG - n)) + (d0 >>> n);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MAPREDUCE-7288
