### PR TITLE
HADOOP-17281 Implement FileSystem.listStatusIterator() in S3AFileSystem

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -2229,7 +2229,9 @@ public abstract class FileSystem extends Configured
     @Override
     @SuppressWarnings("unchecked")
     public T next() throws IOException {
-      Preconditions.checkState(hasNext(), "No more items in iterator");
+      if (!hasNext()) {
+        throw new NoSuchElementException("No more items in iterator");
+      }
       if (i == entries.getEntries().length) {
         fetchMore();
       }

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -295,19 +295,23 @@ The atomicity and consistency constraints are as for
 `listStatus(Path, PathFilter)`.
 
 ### `RemoteIterator<FileStatus> listStatusIterator(Path p)`
+
 Return an iterator enumerating the `FileStatus` entries under
 a path. This is similar to `listStatus(Path)` except the fact that
 rather than returning an entire list, an iterator is returned.
-The result is exactly the same as listStatus, provided no other caller 
-updates the directory during the listing. Having said that, this does
-not guarantee atomicity if other callers are adding/deleting the files 
+The result is exactly the same as `listStatus(Path)`, provided no other
+caller updates the directory during the listing. Having said that, this does
+not guarantee atomicity if other callers are adding/deleting the files
 inside the directory while listing is being performed. Different filesystems
-may provide a more efficient implementation, for example S3A does the 
+may provide a more efficient implementation, for example S3A does the
 listing in pages and fetches the next pages asynchronously while a
-page is getting processed. 
+page is getting processed.
 
-Callers should prefer using listStatusIterator over listStatus as it 
-is incremental in nature. 
+Note that now since the initial listing is async, bucket/path existence
+exception may show up later during next() call.
+
+Callers should prefer using listStatusIterator over listStatus as it
+is incremental in nature.
 
 ### `FileStatus[] listStatus(Path[] paths)`
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -294,6 +294,20 @@ any optimizations.
 The atomicity and consistency constraints are as for
 `listStatus(Path, PathFilter)`.
 
+### `RemoteIterator<FileStatus> listStatusIterator(Path p)`
+Return an iterator enumerating the `FileStatus` entries under
+a path. This is similar to `listStatus(Path)` except the fact that
+rather than returning an entire list, an iterator is returned.
+The result is exactly the same as listStatus, provided no other caller 
+updates the directory during the listing. Having said that, this does
+not guarantee atomicity if other callers are adding/deleting the files 
+inside the directory while listing is being performed. Different filesystems
+may provide a more efficient implementation, for example S3A does the 
+listing in pages and fetches the next pages asynchronously while a
+page is getting processed. 
+
+Callers should prefer using listStatusIterator over listStatus as it 
+is incremental in nature. 
 
 ### `FileStatus[] listStatus(Path[] paths)`
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
@@ -384,9 +384,9 @@ public abstract class AbstractContractGetFileStatusTest extends
     Assertions.assertThat(statusList)
             .describedAs(msg)
             .hasSize(1);
-    Assertions.assertThat(statusList.get(0).getPath().toString())
+    Assertions.assertThat(statusList.get(0).getPath())
             .describedAs("path returned should match with the input path")
-            .isEqualTo(f.toString());
+            .isEqualTo(f);
     Assertions.assertThat(statusList.get(0).isFile())
             .describedAs("path returned should be a file")
             .isEqualTo(true);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -22,13 +22,16 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
+import org.assertj.core.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.RemoteIterator;
@@ -245,11 +248,10 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
         fileList.size() <= statuses.length);
     List<FileStatus> statusList = (List<FileStatus>) iteratorToList(
             fs.listStatusIterator(root));
-    String listStatusItrRes = join(statusList, "\n");
-    assertEquals("listStatus(/) vs listStatusIterator(/) with \n"
-                    + "listStatus =" + listStatusResult
-                    +" listLocatedStatus = " + listStatusItrRes,
-            statuses.length, statusList.size());
+    Assertions.assertThat(statusList)
+            .describedAs("Result of listStatus(/) and listStatusIterator(/)" +
+                    "must match")
+            .hasSameElementsAs(Arrays.stream(statuses).collect(Collectors.toList()));
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -39,6 +39,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.deleteChildren;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dumpStats;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.iteratorToList;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.listChildren;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.toList;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.treeWalk;
@@ -242,6 +243,13 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
             + "listStatus = " + listStatusResult
             + "listFiles = " + listFilesResult,
         fileList.size() <= statuses.length);
+    List<FileStatus> statusList = (List<FileStatus>) iteratorToList(
+            fs.listStatusIterator(root));
+    String listStatusItrRes = join(statusList, "\n");
+    assertEquals("listStatus(/) vs listStatusIterator(/) with \n"
+                    + "listStatus =" + listStatusResult
+                    +" listLocatedStatus = " + listStatusItrRes,
+            statuses.length, statusList.size());
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -249,9 +249,10 @@ public abstract class AbstractContractRootDirectoryTest extends AbstractFSContra
     List<FileStatus> statusList = (List<FileStatus>) iteratorToList(
             fs.listStatusIterator(root));
     Assertions.assertThat(statusList)
-            .describedAs("Result of listStatus(/) and listStatusIterator(/)" +
-                    "must match")
-            .hasSameElementsAs(Arrays.stream(statuses).collect(Collectors.toList()));
+            .describedAs("Result of listStatus(/) and listStatusIterator(/)"
+                    + " must match")
+            .hasSameElementsAs(Arrays.stream(statuses)
+                    .collect(Collectors.toList()));
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -1462,9 +1462,9 @@ public class ContractTestUtils extends Assert {
    * @return the file status entries as a list.
    * @throws IOException
    */
-  public static List<? extends FileStatus> iteratorToList(
-          RemoteIterator<? extends FileStatus> iterator) throws IOException {
-    ArrayList<FileStatus> list = new ArrayList<>();
+  public static <T extends FileStatus> List<T> iteratorToList(
+          RemoteIterator<T> iterator) throws IOException {
+    List<T> list = new ArrayList<>();
     while (iterator.hasNext()) {
       list.add(iterator.next());
     }
@@ -1486,14 +1486,15 @@ public class ContractTestUtils extends Assert {
    * @throws IOException IO problems
    */
   @SuppressWarnings("InfiniteLoopStatement")
-  public static List<? extends FileStatus> iteratorToListThroughNextCallsAlone(
-          RemoteIterator<? extends FileStatus> iterator) throws IOException {
-    ArrayList<FileStatus> list = new ArrayList<>();
+  public static <T extends FileStatus> List<T> iteratorToListThroughNextCallsAlone(
+          RemoteIterator<T> iterator) throws IOException {
+    List<T> list = new ArrayList<>();
     try {
       while (true) {
         list.add(iterator.next());
       }
-    } catch (NoSuchElementException expected) {
+    } catch (NoSuchElementException | IllegalStateException expected) {
+      // DirListingIterator.next() throws IllegalStateException
       // ignored
     }
     return list;
@@ -1520,7 +1521,8 @@ public class ContractTestUtils extends Assert {
       while (true) {
         list.add(iterator.next());
       }
-    } catch (NoSuchElementException expected) {
+    } catch (NoSuchElementException | IllegalStateException expected) {
+      // DirListingIterator.next() throws IllegalStateException
       // ignored
     }
     return list;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -1493,8 +1493,7 @@ public class ContractTestUtils extends Assert {
       while (true) {
         list.add(iterator.next());
       }
-    } catch (NoSuchElementException | IllegalStateException expected) {
-      // DirListingIterator.next() throws IllegalStateException
+    } catch (NoSuchElementException expected) {
       // ignored
     }
     return list;
@@ -1521,8 +1520,7 @@ public class ContractTestUtils extends Assert {
       while (true) {
         list.add(iterator.next());
       }
-    } catch (NoSuchElementException | IllegalStateException expected) {
-      // DirListingIterator.next() throws IllegalStateException
+    } catch (NoSuchElementException expected) {
       // ignored
     }
     return list;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -1455,6 +1455,52 @@ public class ContractTestUtils extends Assert {
 
   /**
    * Convert a remote iterator over file status results into a list.
+   * The utility equivalents in commons collection and guava cannot be
+   * used here, as this is a different interface, one whose operators
+   * can throw IOEs.
+   * @param iterator input iterator
+   * @return the file status entries as a list.
+   * @throws IOException
+   */
+  public static List<? extends FileStatus> iteratorToList(
+          RemoteIterator<? extends FileStatus> iterator) throws IOException {
+    ArrayList<FileStatus> list = new ArrayList<>();
+    while (iterator.hasNext()) {
+      list.add(iterator.next());
+    }
+    return list;
+  }
+
+
+  /**
+   * Convert a remote iterator over file status results into a list.
+   * This uses {@link RemoteIterator#next()} calls only, expecting
+   * a raised {@link NoSuchElementException} exception to indicate that
+   * the end of the listing has been reached. This iteration strategy is
+   * designed to verify that the implementation of the remote iterator
+   * generates results and terminates consistently with the {@code hasNext/next}
+   * iteration. More succinctly "verifies that the {@code next()} operator
+   * isn't relying on {@code hasNext()} to always be called during an iteration.
+   * @param iterator input iterator
+   * @return the status entries as a list.
+   * @throws IOException IO problems
+   */
+  @SuppressWarnings("InfiniteLoopStatement")
+  public static List<? extends FileStatus> iteratorToListThroughNextCallsAlone(
+          RemoteIterator<? extends FileStatus> iterator) throws IOException {
+    ArrayList<FileStatus> list = new ArrayList<>();
+    try {
+      while (true) {
+        list.add(iterator.next());
+      }
+    } catch (NoSuchElementException expected) {
+      // ignored
+    }
+    return list;
+  }
+
+  /**
+   * Convert a remote iterator over file status results into a list.
    * This uses {@link RemoteIterator#next()} calls only, expecting
    * a raised {@link NoSuchElementException} exception to indicate that
    * the end of the listing has been reached. This iteration strategy is
@@ -1602,7 +1648,7 @@ public class ContractTestUtils extends Assert {
      * @param results results of the listFiles/listStatus call.
      * @throws IOException IO problems during the iteration.
      */
-    public TreeScanResults(RemoteIterator<LocatedFileStatus> results)
+    public TreeScanResults(RemoteIterator<? extends FileStatus> results)
         throws IOException {
       while (results.hasNext()) {
         add(results.next());

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -1107,6 +1107,7 @@ public class DistributedFileSystem extends FileSystem
     }
 
     HdfsFileStatus[] partialListing = thisListing.getPartialListing();
+
     if (!thisListing.hasMore()) { // got all entries of the directory
       FileStatus[] stats = new FileStatus[partialListing.length];
       for (int i = 0; i < partialListing.length; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -1107,7 +1107,6 @@ public class DistributedFileSystem extends FileSystem
     }
 
     HdfsFileStatus[] partialListing = thisListing.getPartialListing();
-
     if (!thisListing.hasMore()) { // got all entries of the directory
       FileStatus[] stats = new FileStatus[partialListing.length];
       for (int i = 0; i < partialListing.length; i++) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2644,6 +2644,30 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   }
 
   /**
+   * Override subclass such that we benefit for async listing done
+   * in {@code S3AFileSystem}. See {@code Listing#ObjectListingIterator}.
+   * {@inheritDoc}
+   *
+   */
+  @Override
+  public RemoteIterator<FileStatus> listStatusIterator(Path p)
+          throws FileNotFoundException, IOException {
+    RemoteIterator<S3AFileStatus> listStatusItr = once("listStatus",
+            p.toString(), () -> innerListStatus(p));
+    return new RemoteIterator<FileStatus>() {
+      @Override
+      public boolean hasNext() throws IOException {
+        return listStatusItr.hasNext();
+      }
+
+      @Override
+      public FileStatus next() throws IOException {
+        return listStatusItr.next();
+      }
+    };
+  }
+
+  /**
    * List the statuses of the files/directories in the given path if the path is
    * a directory.
    *

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
@@ -239,9 +239,9 @@ public class ITestS3ADirectoryPerformance extends S3AScaleTestBase {
         listUsingListStatusItr.add(lsItr.next().getPath().toString());
         Thread.sleep(eachFileProcessingTime);
       }
-      timeUsingListStatusItr.end("listing %d files using listStatusIterator() api with " +
-                      "batch size of %d including %dms of processing time" +
-                      " for each file",
+      timeUsingListStatusItr.end("listing %d files using " +
+                      "listStatusIterator() api with batch size of %d " +
+                      "including %dms of processing time for each file",
               numOfPutRequests, batchSize, eachFileProcessingTime);
       Assertions.assertThat(listUsingListStatusItr)
               .describedAs("Listing results using listStatusIterator() must" +

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
@@ -231,6 +231,24 @@ public class ITestS3ADirectoryPerformance extends S3AScaleTestBase {
                       "match with original list of files")
               .hasSameElementsAs(originalListOfFiles)
               .hasSize(numOfPutRequests);
+      // Validate listing using listStatusIterator().
+      NanoTimer timeUsingListStatusItr = new NanoTimer();
+      RemoteIterator<FileStatus> lsItr = fs.listStatusIterator(dir);
+      List<String> listUsingListStatusItr = new ArrayList<>();
+      while (lsItr.hasNext()) {
+        listUsingListStatusItr.add(lsItr.next().getPath().toString());
+        Thread.sleep(eachFileProcessingTime);
+      }
+      timeUsingListStatusItr.end("listing %d files using listStatusIterator() api with " +
+                      "batch size of %d including %dms of processing time" +
+                      " for each file",
+              numOfPutRequests, batchSize, eachFileProcessingTime);
+      Assertions.assertThat(listUsingListStatusItr)
+              .describedAs("Listing results using listStatusIterator() must" +
+                      "match with original list of files")
+              .hasSameElementsAs(originalListOfFiles)
+              .hasSize(numOfPutRequests);
+
     } finally {
       executorService.shutdown();
     }


### PR DESCRIPTION
Ran the new test using ap-south-1 bucket. 

O/P- 
`(ContractTestUtils.java:end(1847)) - Duration of listing 1000 files using listFiles() api with batch size of 10 including 10ms of processing time for each file: 12,223,848,028 nS
2020-10-01 12:19:28,811 [JUnit-testMultiPagesListingPerformanceAndCorrectness] INFO  contract.ContractTestUtils (ContractTestUtils.java:end(1847)) - Duration of listing 1000 files using listStatus() api with batch size of 10 including 10ms of processing time for each file: 15,988,037,357 nS
2020-10-01 12:19:41,050 [JUnit-testMultiPagesListingPerformanceAndCorrectness] INFO  contract.ContractTestUtils (ContractTestUtils.java:end(1847)) - Duration of listing 1000 files using listStatusIterator() api with batch size of 10 including 10ms of processing time for each file: 12,214,813,052 nS`

From the logs we can see that time taken using listStatusIterator() and listFiles() matches and is less than listStatus().