### PR TITLE
HADOOP-17295 Move dedicated pre-logging statements into existing logg…

### DIFF
--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/impl/zk/CuratorService.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/client/impl/zk/CuratorService.java
@@ -573,9 +573,9 @@ public class CuratorService extends CompositeService
     }
 
     try {
-      RegistrySecurity.AclListInfo aclInfo =
-          new RegistrySecurity.AclListInfo(acls);
       if (LOG.isDebugEnabled()) {
+        RegistrySecurity.AclListInfo aclInfo =
+                new RegistrySecurity.AclListInfo(acls);
         LOG.debug("Creating path {} with mode {} and ACL {}",
             path, mode, aclInfo);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -486,12 +486,11 @@ class BPServiceActor implements Runnable {
 
       cmd = bpNamenode.cacheReport(bpRegistration, bpid, blockIds);
       long sendTime = monotonicNow();
-      long createCost = createTime - startTime;
       long sendCost = sendTime - createTime;
       dn.getMetrics().addCacheReport(sendCost);
       if (LOG.isDebugEnabled()) {
         LOG.debug("CacheReport of " + blockIds.size()
-            + " block(s) took " + createCost + " msecs to generate and "
+            + " block(s) took " + (createTime - startTime) + " msecs to generate and "
             + sendCost + " msecs for RPC and NN processing");
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
@@ -566,11 +566,10 @@ public class DefaultContainerExecutor extends ContainerExecutor {
   @Override
   public boolean signalContainer(ContainerSignalContext ctx)
       throws IOException {
-    String user = ctx.getUser();
     String pid = ctx.getPid();
     Signal signal = ctx.getSignal();
     LOG.debug("Sending signal {} to pid {} as user {}",
-        signal.getValue(), pid, user);
+        signal.getValue(), pid, ctx.getUser());
     if (!containerIsAlive(pid)) {
       return false;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
@@ -573,8 +573,8 @@ public class WindowsSecureContainerExecutor extends DefaultContainerExecutor {
   @Override
   protected String[] getRunCommand(String command, String groupId,
       String userName, Path pidFile, Configuration conf) {
-    File f = new File(command);
     if (LOG.isDebugEnabled()) {
+      File f = new File(command);
       LOG.debug(String.format("getRunCommand: %s exists:%b", 
           command, f.exists()));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsHandlerImpl.java
@@ -470,8 +470,8 @@ class CGroupsHandlerImpl implements CGroupsHandler {
   * Utility routine to print first line from cgroup tasks file
   */
   private void logLineFromTasksFile(File cgf) {
-    String str;
     if (LOG.isDebugEnabled()) {
+      String str;
       try (BufferedReader inl =
           new BufferedReader(new InputStreamReader(new FileInputStream(cgf
               + "/tasks"), "UTF-8"))) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/util/CgroupsLCEResourcesHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/util/CgroupsLCEResourcesHandler.java
@@ -245,8 +245,8 @@ public class CgroupsLCEResourcesHandler implements LCEResourcesHandler {
    * Utility routine to print first line from cgroup tasks file
    */
   private void logLineFromTasksFile(File cgf) {
-    String str;
     if (LOG.isDebugEnabled()) {
+      String str;
       try (BufferedReader inl =
             new BufferedReader(new InputStreamReader(new FileInputStream(cgf
               + "/tasks"), "UTF-8"))) {


### PR DESCRIPTION
I find some cases where some pre-processing statements dedicated to logging calls are not guarded by existing logging guards. Most of them are easy to fix. And I create this PR to fix them.

These issues are detected by a static analysis tool wrote by myself. This tool can extract all the dedicated statements for each debug-logging calls (i.e., the results of these statements are only used by debug-logging calls). Because I realize that debug logs will incur overhead in production, such as string concatenation and method calls in the parameters of logging calls. And I want to perform a systematic evaluation for the overhead of debugging logging calls in production.