### PR TITLE
HADOOP-17293. Aways probe S3 when opening/getFileStatus on non-auth paths

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2990,6 +2990,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
               tombstones,
               needEmptyDirectoryFlag);
         } catch (FileNotFoundException fne) {
+          LOG.trace("File Not Found from probes for {}", key, fne);
           s3AFileStatus = null;
         }
         if (s3AFileStatus == null) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2980,55 +2980,30 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         // a file has been found in a non-auth path and the caller has not said
         // they only care about directories
         LOG.debug("Metadata for {} found in the non-auth metastore.", path);
-        // If the timestamp of the pm is close to "now", we don't need to
-        // bother with a check of S3. that means:
-        // one of : status modtime is close to now,
-        //  or pm.getLastUpdated() == now
+        final long msModTime = pm.getFileStatus().getModificationTime();
 
-        // get the time in which a status modtime is considered valid
-        // in a non-auth metastore
-        long validTime =
-            ttlTimeProvider.getNow() - ttlTimeProvider.getMetadataTtl();
-        final long msModTime = msStatus.getModificationTime();
+        S3AFileStatus s3AFileStatus;
+        try {
+          s3AFileStatus = s3GetFileStatus(path,
+              key,
+              probes,
+              tombstones,
+              needEmptyDirectoryFlag);
+        } catch (FileNotFoundException fne) {
+          s3AFileStatus = null;
+        }
+        if (s3AFileStatus == null) {
+          LOG.warn("Failed to find file {}. Either it is not yet visible, or "
+              + "it has been deleted.", path);
+        } else {
+          final long s3ModTime = s3AFileStatus.getModificationTime();
 
-        if (msModTime < validTime) {
-          LOG.debug("Metastore entry of {} is out of date, probing S3", path);
-          try {
-            S3AFileStatus s3AFileStatus = s3GetFileStatus(path,
-                key,
-                probes,
-                tombstones,
-                needEmptyDirectoryFlag);
-            // if the new status is more current than that in the metastore,
-            // it means S3 has changed and the store needs updating
-            final long s3ModTime = s3AFileStatus.getModificationTime();
-
-            if (s3ModTime > msModTime) {
-              // there's new data in S3
-              LOG.debug("S3Guard metadata for {} is outdated;"
-                      + " s3modtime={}; msModTime={} updating metastore",
-                  path, s3ModTime, msModTime);
-              // add to S3Guard
-              S3Guard.putAndReturn(metadataStore, s3AFileStatus,
-                  ttlTimeProvider);
-            } else {
-              // the modtime of the data is the same as/older than the s3guard
-              // value either an old object has been found, or the existing one
-              // was retrieved in both cases -refresh the S3Guard entry so the
-              // record's TTL is updated.
-              S3Guard.refreshEntry(metadataStore, pm, s3AFileStatus,
-                  ttlTimeProvider);
-            }
-            // return the value
-            // note that the checks for empty dir status below can be skipped
-            // because the call to s3GetFileStatus include the checks there
-            return s3AFileStatus;
-          } catch (FileNotFoundException fne) {
-            // the attempt to refresh the record failed because there was
-            // no entry. Either it is a new file not visible, or it
-            // has been deleted (and therefore S3Guard is out of sync with S3)
-            LOG.warn("Failed to find file {}. Either it is not yet visible, or "
-                + "it has been deleted.", path);
+          if(s3ModTime > msModTime) {
+            LOG.debug("S3Guard metadata for {} is outdated;"
+                + " s3modtime={}; msModTime={} updating metastore",
+                path, s3ModTime, msModTime);
+            return S3Guard.putAndReturn(metadataStore, s3AFileStatus,
+                ttlTimeProvider);
           }
         }
       }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -92,7 +92,8 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
         whenRaw(FILE_STATUS_FILE_PROBE
             .plus(LIST_LOCATED_STATUS_LIST_OP)),
         whenAuthoritative(LIST_LOCATED_STATUS_LIST_OP),
-        whenNonauth(LIST_LOCATED_STATUS_LIST_OP));
+        whenNonauth(LIST_LOCATED_STATUS_LIST_OP
+            .plus(S3GUARD_NONAUTH_FILE_STATUS_PROBE)));
   }
 
   @Test
@@ -187,7 +188,8 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
             whenRaw(LIST_STATUS_LIST_OP
                     .plus(GET_FILE_STATUS_ON_FILE)),
             whenAuthoritative(LIST_STATUS_LIST_OP),
-            whenNonauth(LIST_STATUS_LIST_OP));
+            whenNonauth(LIST_STATUS_LIST_OP
+                .plus(S3GUARD_NONAUTH_FILE_STATUS_PROBE)));
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
@@ -326,7 +326,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
    * @return a number >= 0.
    */
   private int getFileStatusHeadCount() {
-    return authMode ? 0 : 0;
+    return authMode ? 0 : 1;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/OperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/OperationCost.java
@@ -154,6 +154,13 @@ public final class OperationCost {
   public static final OperationCost CREATE_FILE_NO_OVERWRITE =
       FILE_STATUS_ALL_PROBES;
 
+  /**
+   * S3Guard in non-auth mode always attempts a single file
+   * status call.
+   */
+  public static final OperationCost S3GUARD_NONAUTH_FILE_STATUS_PROBE =
+      FILE_STATUS_FILE_PROBE;
+
   /** Expected HEAD count. */
   private final int head;
 


### PR DESCRIPTION

This reverts changes in HADOOP-13230 to use S3Guard TTL in choosing when
to issue a HEAD request; fixing tests to compensate.

New operation cost constant, S3GUARD_NONAUTH_FILE_STATUS_PROBE for
use in cost tests.

Change-Id: Ie00279eb94f105d7fc99c7d3342eaf7002fef347

testing in progress: S3 London + S3Guard + markers keep and delete