### PR TITLE
HDFS-15614. Initialize snapshot trash root during NameNode startup if enabled

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2033,10 +2033,6 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return sw.toString();
   }
 
-  public boolean getIsSnapshotTrashRootEnabled() {
-    return isSnapshotTrashRootEnabled;
-  }
-
   @VisibleForTesting
   public FsServerDefaults getServerDefaults() throws StandbyException {
     checkOperation(OperationCategory.READ);
@@ -8535,13 +8531,6 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
    * directories. Create them if not.
    */
   void checkAndProvisionSnapshotTrashRoots() throws IOException {
-    if (haEnabled) {
-      if (!inActiveState()) {
-        LOG.warn("HA is enabled. But the current NameNode is not active. "
-            + "Skipping the check.");
-        return;
-      }
-    }
     SnapshottableDirectoryStatus[] dirStatusList = getSnapshottableDirListing();
     if (dirStatusList == null) {
       return;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -388,6 +388,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       "dfs.namenode.snapshot.trashroot.enabled";
   public static final boolean DFS_NAMENODE_SNAPSHOT_TRASHROOT_ENABLED_DEFAULT
       = false;
+  private static final FsPermission SHARED_TRASH_PERMISSION =
+      new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL, true);
 
   private final MetricsRegistry registry = new MetricsRegistry("FSNamesystem");
   @Metric final MutableRatesWithAggregation detailedLockHoldTimeMetrics =
@@ -2029,6 +2031,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     metaSave(pw);
     pw.flush();
     return sw.toString();
+  }
+
+  public boolean getIsSnapshotTrashRootEnabled() {
+    return isSnapshotTrashRootEnabled;
   }
 
   @VisibleForTesting
@@ -8522,6 +8528,39 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       throw e;
     }
     logAuditEvent(true, operationName, src);
+  }
+
+  /**
+   * Check if snapshot roots are created for all existing snapshottable
+   * directories. Create them if not.
+   */
+  void checkAndProvisionSnapshotTrashRoots() throws IOException {
+    if (haEnabled) {
+      if (!inActiveState()) {
+        LOG.warn("HA is enabled. But the current NameNode is not active. "
+            + "Skipping the check.");
+        return;
+      }
+    }
+    SnapshottableDirectoryStatus[] dirStatusList = getSnapshottableDirListing();
+    if (dirStatusList == null) {
+      return;
+    }
+    for (SnapshottableDirectoryStatus dirStatus : dirStatusList) {
+      String currDir = dirStatus.getFullPath().toString();
+      if (!currDir.endsWith(Path.SEPARATOR)) {
+        currDir += Path.SEPARATOR;
+      }
+      String trashPath = currDir + FileSystem.TRASH_PREFIX;
+      HdfsFileStatus fileStatus = getFileInfo(trashPath, false, false, false);
+      if (fileStatus == null) {
+        LOG.info("Trash doesn't exist for snapshottable directory {}. "
+            + "Creating trash at {}", currDir, trashPath);
+        PermissionStatus permissionStatus = new PermissionStatus(getRemoteUser()
+            .getShortUserName(), null, SHARED_TRASH_PERMISSION);
+        mkdirs(trashPath, permissionStatus, false);
+      }
+    }
   }
 
   private Supplier<String> getLockReportInfoSupplier(String src) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -781,6 +781,10 @@ public class NameNode extends ReconfigurableBase implements
       }
     }
 
+    if (namesystem.getIsSnapshotTrashRootEnabled()) {
+      namesystem.checkAndProvisionSnapshotTrashRoots();
+    }
+
     startCommonServices(conf);
     startMetricsLogger(conf);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -781,10 +781,6 @@ public class NameNode extends ReconfigurableBase implements
       }
     }
 
-    if (namesystem.getIsSnapshotTrashRootEnabled()) {
-      namesystem.checkAndProvisionSnapshotTrashRoots();
-    }
-
     startCommonServices(conf);
     startMetricsLogger(conf);
   }
@@ -2019,6 +2015,9 @@ public class NameNode extends ReconfigurableBase implements
     public void startActiveServices() throws IOException {
       try {
         namesystem.startActiveServices();
+        if (namesystem.isSnapshotTrashRootEnabled()) {
+          namesystem.checkAndProvisionSnapshotTrashRoots();
+        }
         startTrashEmptier(getConf());
       } catch (Throwable t) {
         doImmediateShutdown(t);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -623,6 +623,10 @@ public class MiniDFSCluster implements AutoCloseable {
       this.startOpt = startOpt;
       this.conf = conf;
     }
+
+    public void setConf(Configuration conf) {
+      this.conf = conf;
+    }
     
     public void setStartOpt(StartupOption startOpt) {
       this.startOpt = startOpt;
@@ -2183,6 +2187,17 @@ public class MiniDFSCluster implements AutoCloseable {
    */
   public synchronized void restartNameNode(int nnIndex) throws IOException {
     restartNameNode(nnIndex, true);
+  }
+
+  /**
+   * Update an existing NameNode's configuration.
+   */
+  public void setNameNodeConf(int nnIndex, Configuration conf) {
+    NameNodeInfo info = getNN(nnIndex);
+    if (info == null) {
+      throw new RuntimeException("Invalid nnIndex!");
+    }
+    info.setConf(conf);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -2192,12 +2192,12 @@ public class MiniDFSCluster implements AutoCloseable {
   /**
    * Update an existing NameNode's configuration.
    */
-  public void setNameNodeConf(int nnIndex, Configuration conf) {
+  public void setNameNodeConf(int nnIndex, Configuration nnConf) {
     NameNodeInfo info = getNN(nnIndex);
     if (info == null) {
       throw new RuntimeException("Invalid nnIndex!");
     }
-    info.setConf(conf);
+    info.setConf(nnConf);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.hdfs.client.HdfsAdmin.TRASH_PERMISSION;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_CONTEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1618,7 +1619,7 @@ public class TestDistributedFileSystem {
       cluster.waitActive();
       DistributedFileSystem dfs = cluster.getFileSystem();
       FsServerDefaults fsServerDefaults = dfs.getServerDefaults();
-      Assert.assertNotNull(fsServerDefaults);
+      assertNotNull(fsServerDefaults);
     } finally {
       cluster.shutdown();
     }
@@ -2490,6 +2491,45 @@ public class TestDistributedFileSystem {
       dfs.delete(testDirTrashRoot, true);
       dfs.disallowSnapshot(testDir);
       // Cleanup
+      dfs.delete(testDir, true);
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testNameNodeCreateSnapshotTrashRootOnStartup()
+      throws Exception {
+    // Start NN with dfs.namenode.snapshot.trashroot.enabled=false
+    Configuration conf = getTestConfiguration();
+    conf.setBoolean("dfs.namenode.snapshot.trashroot.enabled", false);
+    MiniDFSCluster cluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    try {
+      final DistributedFileSystem dfs = cluster.getFileSystem();
+      final Path testDir = new Path("/disallowss/test2/");
+      final Path file0path = new Path(testDir, "file-0");
+      dfs.create(file0path).close();
+      dfs.allowSnapshot(testDir);
+      // .Trash won't be created right now since snapshot trash is disabled
+      final Path trashRoot = new Path(testDir, FileSystem.TRASH_PREFIX);
+      assertFalse(dfs.exists(trashRoot));
+      // Set dfs.namenode.snapshot.trashroot.enabled=true
+      conf.setBoolean("dfs.namenode.snapshot.trashroot.enabled", true);
+      cluster.setNameNodeConf(0, conf);
+      cluster.restartNameNode(0);
+      // Check .Trash existence, should be created now
+      assertTrue(dfs.exists(trashRoot));
+      // Check permission
+      FileStatus trashRootStatus = dfs.getFileStatus(trashRoot);
+      assertNotNull(trashRootStatus);
+      assertEquals(TRASH_PERMISSION, trashRootStatus.getPermission());
+
+      // Cleanup
+      dfs.delete(trashRoot, true);
+      dfs.disallowSnapshot(testDir);
       dfs.delete(testDir, true);
     } finally {
       if (cluster != null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15614

Added `checkAndProvisionSnapshotTrashRoots` in `FSNamesystem`. Triggered in `NameNode` on startup if `dfs.namenode.snapshot.trashroot.enabled` set to `true`.

UT added in `TestDistributedFileSystem`.

The logic is ready for review.
~~I am considering adding another UT for HA case.~~ Now that we put the check in `startActiveServices()` it shouldn't be a problem anymore. Thanks @bshashikant for the suggestion.