### PR TITLE
HADOOP-17269. [JDK 11] Upgrade SpotBugs to 4.1.3 to fix false-positive warnings

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -98,7 +98,7 @@
     <zookeeper.version>3.5.6</zookeeper.version>
     <curator.version>4.2.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
-    <spotbugs.version>4.0.6</spotbugs.version>
+    <spotbugs.version>4.1.3</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
     <guava.version>27.0-jre</guava.version>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17269

Manually tested with Java 11.0.7

```
$ mvn install -DskipTests -DskipShade
$ mvn findbugs:findbugs -pl hadoop-common-project/hadoop-common
(snip)
[INFO] Fork Value is true
     [java] SLF4J: No SLF4J providers were found.
     [java] SLF4J: Defaulting to no-operation (NOP) logger implementation
     [java] SLF4J: See http://www.slf4j.org/codes.html#noProviders for further details.
[INFO] Done FindBugs Analysis....
```