### PR TITLE
HDFS-15620. RBF: Fix test failures after HADOOP-17281

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/pom.xml
@@ -114,6 +114,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/web/TestRouterWebHDFSContractRootDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/web/TestRouterWebHDFSContractRootDirectory.java
@@ -71,4 +71,9 @@ public class TestRouterWebHDFSContractRootDirectory extends
   public void testRmEmptyRootDirRecursive() {
     // It doesn't apply because we still have the mount points here
   }
+
+  @Override
+  public void testSimpleRootListing() {
+    // It doesn't apply because DFSRouter dosn't support LISTSTATUS_BATCH.
+  }
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15620

* Add assertj to test dependency
* Skip testSimpleRootListing in TestRouterWebHDFSContractRootDirectory