### PR TITLE
HADOOP-17304. KMS ACL: Allow DeleteKey Operation to Invalidate Cache.

### DIFF
--- a/hadoop-common-project/hadoop-kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMS.java
+++ b/hadoop-common-project/hadoop-kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMS.java
@@ -57,6 +57,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.crypto.key.kms.server.KMSACLs.INVALIDATE_CACHE_TYPES;
 import static org.apache.hadoop.util.KMSUtil.checkNotEmpty;
 import static org.apache.hadoop.util.KMSUtil.checkNotNull;
 
@@ -80,9 +81,6 @@ public class KMS {
   static final Logger LOG = LoggerFactory.getLogger(KMS.class);
 
   private static final int MAX_NUM_PER_BATCH = 10000;
-  // Allow both ROLLOVER and DELETE to invalidate cache.
-  private static final EnumSet<KMSACLs.Type> INVALIDATE_CACHE_TYPES =
-      EnumSet.of(KMSACLs.Type.ROLLOVER, KMSACLs.Type.DELETE);
 
   public KMS() throws Exception {
     provider = KMSWebApp.getKeyProvider();

--- a/hadoop-common-project/hadoop-kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSACLs.java
+++ b/hadoop-common-project/hadoop-kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/KMSACLs.java
@@ -70,6 +70,10 @@ public class KMSACLs implements Runnable, KeyACLs {
 
   public static final int RELOADER_SLEEP_MILLIS = 1000;
 
+  // Allow both ROLLOVER and DELETE to invalidate cache.
+  public static final EnumSet<KMSACLs.Type> INVALIDATE_CACHE_TYPES =
+      EnumSet.of(KMSACLs.Type.ROLLOVER, KMSACLs.Type.DELETE);
+
   private volatile Map<Type, AccessControlList> acls;
   private volatile Map<Type, AccessControlList> blacklistedAcls;
   @VisibleForTesting


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17304

Adding ACL check to allow both DeleteKey and RollOverKey to invalidate cache. 

The test case has been covered by TestKMS#testAcls. 
