### PR TITLE
HADOOP-16878. FileUtil.copy() to throw IOException if the source and destination are the same

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -398,6 +398,12 @@ public class FileUtil {
                              Configuration conf) throws IOException {
     Path src = srcStatus.getPath();
     dst = checkDest(src.getName(), dstFS, dst, overwrite);
+
+    if (srcFS.makeQualified(src).equals(dstFS.makeQualified(dst))) {
+      throw new PathOperationException("Source (" + src + ") and destination " +
+          "(" + dst + ") are equal in the copy command.");
+    }
+
     if (srcStatus.isDirectory()) {
       checkDependencies(srcFS, src, dstFS, dst);
       if (!dstFS.mkdirs(dst)) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
@@ -34,6 +34,7 @@ import java.io.PrintStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -175,7 +176,20 @@ public class TestFsShellCopy {
     checkPut(dirPath, targetDir, true);
   }
 
-  
+  @Test
+  public void testCopyBetweenFsEqualPath() throws Exception {
+    Path testRoot = new Path(testRootDir, "testPutFile");
+    lfs.delete(testRoot, true);
+    lfs.mkdirs(testRoot);
+
+    Path filePath = new Path(testRoot, "sameSourceTarget");
+    lfs.create(filePath).close();
+    final FileStatus status = lfs.getFileStatus(filePath);
+    LambdaTestUtils.intercept(PathOperationException.class, () ->
+        FileUtil.copy(lfs, status, lfs, filePath, false, true, conf)
+    );
+  }
+
   private void checkPut(Path srcPath, Path targetDir, boolean useWindowsPath)
   throws Exception {
     lfs.delete(targetDir, true);


### PR DESCRIPTION
Backport to branch-3.3
https://issues.apache.org/jira/browse/HADOOP-16878
