### PR TITLE
HADOOP-16649. hadoop_add_param function : change regexp test by iterative equality test

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1126,6 +1126,8 @@ function hadoop_validate_classname
 ## @param        envvar
 ## @param        checkstring
 ## @param        appendstring
+
+
 function hadoop_add_param
 {
   #
@@ -1136,19 +1138,29 @@ function hadoop_add_param
   #
   # doing it this way allows us to support all sorts of
   # different syntaxes, just so long as they are space
-  # delimited
+  # delimited.
   #
-  if [[ ! ${!1} =~ $2 ]] ; then
-    #shellcheck disable=SC2140
+  # testing with string regexp fails (see HADOOP-16649) : we' ll test equality on each string instead.
+
+  accepted=true
+  for s in $(echo "${!1}" | tr ' ' '\n'); do
+    if [  $2 = $s ] ; then
+      accepted=false
+      hadoop_debug " $s already contains $2"
+    fi
+  done
+
+  if [ $accepted == true ]; then
     eval "$1"="'${!1} $3'"
     if [[ ${!1:0:1} = ' ' ]]; then
       #shellcheck disable=SC2140
       eval "$1"="'${!1# }'"
     fi
-    hadoop_debug "$1 accepted $3"
+    hadoop_debug "$1 accepted $2 - $3"
   else
-    hadoop_debug "$1 declined $3"
+    hadoop_debug "skipped! "
   fi
+
 }
 
 ## @description  Register the given `shellprofile` to the Hadoop

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1135,28 +1135,43 @@ function hadoop_add_param
   # $1 is what we are adding to
   # $2 is the name of what we want to add (key)
   # $3 is the key+value of what we're adding
-  #
+  #hadoop_finalize_hadoop_heap
   # doing it this way allows us to support all sorts of
   # different syntaxes, just so long as they are space
   # delimited.
   #
   # testing with string regexp fails (see HADOOP-16649) : we' ll test equality on each string instead.
+  # reject if either key is already present in form of "-key[=]*" or value is already present
 
   accepted=true
-  for s in $(echo "${!1}" | tr ' ' '\n'); do
-    if [  $2 = $s ] ; then
-      accepted=false
-      hadoop_debug " $s already contains $2"
-    fi
-  done
 
+  if [[ ${3:0:1} == "-" ]]; then
+    # first char of value is a - (ex: -Xmx1024), we search for presence of "key (ex: -Xmx)
+    for s in $(echo "${!1}" | tr ' ' '\n'); do
+      key="${s%=*}"
+      if [[ $key =~ -$2 ]] ; then {
+          accepted=false
+          hadoop_debug "${!1} already contains key $2 ($key) of value $3"
+          }
+     fi
+    done
+  else
+      for s in $(echo "${!1}" | tr ' ' '\n'); do
+      # first char of value is NOT a - : we search for presence of value (ex: hadoop-azure)
+      if  [[ "$3" = "$s" ]]  ; then
+        accepted=false
+        hadoop_debug "${!1}  already contains value $3"
+      fi
+    done
+  fi
   if [ $accepted == true ]; then
+    hadoop_debug "'${!1}' accepted new key '$2', value '$3'"
     eval "$1"="'${!1} $3'"
     if [[ ${!1:0:1} = ' ' ]]; then
       #shellcheck disable=SC2140
       eval "$1"="'${!1# }'"
     fi
-    hadoop_debug "$1 accepted $2 - $3"
+    hadoop_debug "new string : '${!1}'"
   else
     hadoop_debug "skipped! "
   fi

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1166,10 +1166,11 @@ function hadoop_add_param
   fi
   if [ $accepted == true ]; then
     hadoop_debug "'${!1}' accepted new key '$2', value '$3'"
-    eval "$1"="$(echo \"${!1} $3\")"
+    eval "$1"="\"${!1} $3\""
     if [[ ${!1:0:1} = ' ' ]]; then
       #shellcheck disable=SC2140
-      eval "$1"="'${!1# }'"
+      eval "$1"="\"${!1# }\""
+
     fi
     hadoop_debug "new string : '${!1}'"
   else

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1166,7 +1166,7 @@ function hadoop_add_param
   fi
   if [ $accepted == true ]; then
     hadoop_debug "'${!1}' accepted new key '$2', value '$3'"
-    eval "$1"="'${!1} $3'"
+    eval "$1"="$(echo \"${!1} $3\")"
     if [[ ${!1:0:1} = ' ' ]]; then
       #shellcheck disable=SC2140
       eval "$1"="'${!1# }'"

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1166,6 +1166,7 @@ function hadoop_add_param
   fi
   if [ $accepted == true ]; then
     hadoop_debug "'${!1}' accepted new key '$2', value '$3'"
+    #shellcheck disable=SC2140
     eval "$1"="\"${!1} $3\""
     if [[ ${!1:0:1} = ' ' ]]; then
       #shellcheck disable=SC2140

--- a/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_add_param.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_add_param.bats
@@ -47,3 +47,20 @@ load hadoop-functions_test_helper
   echo ">${testvar}<"
   [ "${testvar}" = "foo bar baz" ]
 }
+
+
+@test "hadoop_add_param (HADOOP-16649 a)" {
+  hadoop_add_param testvar hadoop-azure-datalake hadoop-azure-datalake
+  hadoop_add_param testvar hadoop-azure hadoop-azure
+
+  echo ">${testvar}<"
+  [ "${testvar}" = "hadoop-azure-datalake hadoop-azure" ]
+}
+@test "hadoop_add_param (HADOOP-16649 b)" {
+  hadoop_add_param testvar hadoop-azure hadoop-azure
+  hadoop_add_param testvar hadoop-azure-datalake hadoop-azure-datalake
+
+  echo ">${testvar}<"
+  [ "${testvar}" = "hadoop-azure hadoop-azure-datalake" ]
+}
+

--- a/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_add_param.bats
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/hadoop_add_param.bats
@@ -56,11 +56,21 @@ load hadoop-functions_test_helper
   echo ">${testvar}<"
   [ "${testvar}" = "hadoop-azure-datalake hadoop-azure" ]
 }
+
+
 @test "hadoop_add_param (HADOOP-16649 b)" {
   hadoop_add_param testvar hadoop-azure hadoop-azure
   hadoop_add_param testvar hadoop-azure-datalake hadoop-azure-datalake
 
   echo ">${testvar}<"
   [ "${testvar}" = "hadoop-azure hadoop-azure-datalake" ]
+}
+
+@test "hadoop_add_param (HADOOP-16649 c )" {
+  hadoop_add_param testvar Xmx -Xmx2048
+  hadoop_add_param testvar Xmx -Xmx128
+  hadoop_add_param testvar Xms -Xms32
+  echo ">${testvar}<"
+  [ "${testvar}" = "-Xmx2048 -Xms32" ]
 }
 


### PR DESCRIPTION
The bug HADOOP-16649 is due to a regexp test : hadoop-azure is detected as already present when hadoop-azure-datalake is present.
This PR contains an update for hadoop_add_param function to address the problem, and the corresponding  bats test.