### PR TITLE
HADOOP-17309. Javadoc warnings and errors are ignored in the precommit jobs

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1880,6 +1880,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
+            <doclint>all</doclint>
             <additionalOptions>
                 <additionalOption>-Xmaxwarns 10000</additionalOption>
             </additionalOptions>


### PR DESCRIPTION
Set doclint option explicitly in maven-javadoc-plugin.

JIRA: https://issues.apache.org/jira/browse/HADOOP-17309
