### PR TITLE
HADOOP-17305 Fix ITestCustomSigner to work with s3 compatible endpoints

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
@@ -133,11 +133,7 @@ public class ITestCustomSigner extends AbstractS3ATestBase {
   }
 
   private String determineRegion(String bucketName) throws IOException {
-    AmazonS3 s3 = AmazonS3ClientBuilder.standard().withCredentials(
-        new SimpleAWSCredentialsProvider(null, createConfiguration()))
-        .withForceGlobalBucketAccessEnabled(true).withRegion("us-east-1")
-        .build();
-    String region = s3.getBucketLocation(bucketName);
+    String region = getFileSystem().getBucketLocation(bucketName);
     return fixBucketRegion(region);
   }
 


### PR DESCRIPTION
Re ran the failing test with s3 and gcs endpoints. All good.