### PR TITLE
HADOOP-17315. Use shaded guava in ClientCache.java

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -121,9 +121,7 @@
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="IllegalImport">
           <property name="regexp" value="true"/>
-          <property name="illegalPkgs" value="^sun\.[^.]+"/>
-          <property name="illegalClasses"
-            value="^com\.google\.common\.base\.(Optional|Function|Predicate|Supplier), ^com\.google\.common\.collect\.(ImmutableListMultimap)"/>
+          <property name="illegalPkgs" value="^sun\.[^.]+, ^com\.google\.common\.[^.]+"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ClientCache.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ClientCache.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.ObjectWritable;
 import org.apache.hadoop.io.Writable;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 /* Cache a client using its socket factory as the hash key */
 @InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce"})


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17315

- Ran "mvn clean process-sources" to update the source code via maven-replacer-plugin.