### PR TITLE
HADOOP-17319. Update the checkstyle config to ban some guava functions.

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -122,6 +122,7 @@
         <module name="IllegalImport">
           <property name="regexp" value="true"/>
           <property name="illegalPkgs" value="^sun\.[^.]+, ^com\.google\.common\.[^.]+"/>
+          <property name="illegalClasses" value="^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.base\.(Optional|Function|Predicate|Supplier), ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.collect\.(ImmutableListMultimap)"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17319