### PR TITLE
YARN-10469.  YARN-UI2 The accuracy of the percentage values in the same chart on the YARN 'Cluster OverView' page are inconsistent

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/components/app-usage-donut-chart.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/components/app-usage-donut-chart.js
@@ -48,7 +48,7 @@ export default BaseUsageDonutChart.extend({
 
     usageByApps.push({
       label: "Available",
-      value: avail.toFixed(4)
+      value: avail.toFixed(2)
     });
 
     this.colors = ColorUtils.getColors(usageByApps.length, ["others", "good"], true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/components/queue-usage-donut-chart.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/components/queue-usage-donut-chart.js
@@ -51,7 +51,7 @@ export default BaseUsageDonutChart.extend({
 
     usageByQueues.push({
       label: "Available",
-      value: avail.toFixed(4)
+      value: avail.toFixed(2)
     });
 
     this.colors = ColorUtils.getColors(usageByQueues.length, ["others", "good"], true);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YARN-10469

Ensure the accuracy of the percentage values in the same chart on the YARN 'Cluster OverView' page are consistent
just a small improvement.

**before modified, the cluster overview page shows like this:**
![reproduce](https://user-images.githubusercontent.com/52202080/96862914-b2116100-1498-11eb-8c47-9c80e66917f9.png)

**After modified, the manual test results are as follows:**
![fixed](https://user-images.githubusercontent.com/52202080/96862575-3a433680-1498-11eb-9d1f-178c5b2c7116.png)



