### PR TITLE
HADOOP-17201. eliminate double retry around delete/finishedWrite

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperationHelper.java
@@ -478,9 +478,7 @@ public class WriteOperationHelper implements WriteOperations {
   @Retries.RetryTranslated
   public PutObjectResult putObject(PutObjectRequest putObjectRequest)
       throws IOException {
-    return retry("Writing Object",
-        putObjectRequest.getKey(), true,
-        () -> owner.putObjectDirect(putObjectRequest));
+    return owner.putObjectDirect(putObjectRequest);
   }
 
   /**
@@ -492,10 +490,7 @@ public class WriteOperationHelper implements WriteOperations {
   @Retries.RetryTranslated
   public UploadResult uploadObject(PutObjectRequest putObjectRequest)
       throws IOException {
-    // no retry; rely on xfer manager logic
-    return retry("Writing Object",
-        putObjectRequest.getKey(), true,
-        () -> owner.executePut(putObjectRequest, null));
+    return owner.executePut(putObjectRequest, null);
   }
 
   /**


### PR DESCRIPTION

make putObject & putObjectDirect retrying everywhere, update @RetryPolicy
annotation, and make sure callers are not attempting to retry the methods

test failure related to inconistent s3 client creating too many throttle events for the retrier to handle...need to look @ my settings to see if I've turned off the AWS SDK retries there

```
[ERROR] Tests run: 17, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 60.785 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.commit.ITestCommitOperations
[ERROR] testCommitEmptyFile(org.apache.hadoop.fs.s3a.commit.ITestCommitOperations)  Time elapsed: 3.289 s  <<< ERROR!
com.amazonaws.AmazonServiceException: throttled count = 1 (Service: null; Status Code: 503; Error Code: null; Request ID: null)
	at org.apache.hadoop.fs.s3a.InconsistentAmazonS3Client.maybeFail(InconsistentAmazonS3Client.java:571)
	at org.apache.hadoop.fs.s3a.InconsistentAmazonS3Client.maybeFail(InconsistentAmazonS3Client.java:586)
	at org.apache.hadoop.fs.s3a.InconsistentAmazonS3Client.putObject(InconsistentAmazonS3Client.java:226)
	at com.amazonaws.services.s3.transfer.internal.UploadCallable.uploadInOneChunk(UploadCallable.java:131)
	at com.amazonaws.services.s3.transfer.internal.UploadCallable.call(UploadCallable.java:123)
	at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:143)
	at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:48)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```