### PR TITLE
HADOOP-17324. Don't relocate org.bouncycastle in shaded client jars

### DIFF
--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -143,6 +143,8 @@
                         <exclude>org/w3c/dom/**/*</exclude>
                         <exclude>org/xml/sax/*</exclude>
                         <exclude>org/xml/sax/**/*</exclude>
+                        <exclude>org/bouncycastle/*</exclude>
+                        <exclude>org/bouncycastle/**/*</exclude>
                       </excludes>
                     </relocation>
                     <relocation>

--- a/hadoop-client-modules/hadoop-client-check-test-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hadoop-client-modules/hadoop-client-check-test-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -43,6 +43,8 @@ allowed_expr+="|^org/apache/hadoop/"
 allowed_expr+="|^META-INF/"
 #   * whatever under the "webapps" directory; for things shipped by yarn
 allowed_expr+="|^webapps/"
+#   * Resources files used by Hadoop YARN mini cluster
+allowed_expr+="|^TERMINAL/"
 #   * Hadoop's default configuration files, which have the form
 #     "_module_-default.xml"
 allowed_expr+="|^[^-]*-default.xml$"
@@ -54,6 +56,8 @@ allowed_expr+="|^org.apache.hadoop.application-classloader.properties$"
 #   * Used by JavaSandboxLinuxContainerRuntime as a default, loaded
 #     from root, so can't relocate. :(
 allowed_expr+="|^java.policy$"
+#   * Used by javax.annotation
+allowed_expr+="|^jndi.properties$"
 # * allowing native libraries from rocksdb. Leaving native libraries as it is.
 allowed_expr+="|^librocksdbjni-linux32.so"
 allowed_expr+="|^librocksdbjni-linux64.so"

--- a/hadoop-client-modules/hadoop-client-integration-tests/pom.xml
+++ b/hadoop-client-modules/hadoop-client-integration-tests/pom.xml
@@ -75,6 +75,27 @@
           <artifactId>hadoop-client-minicluster</artifactId>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+          <version>1.1.1</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseMiniCluster.java
+++ b/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseMiniCluster.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
 
 import org.apache.hadoop.conf.Configuration;
 
@@ -43,10 +44,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
 import org.apache.hadoop.hdfs.web.WebHdfsConstants;
-
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Ensure that we can perform operations against the shaded minicluster
@@ -91,9 +89,7 @@ public class ITUseMiniCluster {
     if (cluster != null) {
       cluster.close();
     }
-    if (yarnCluster != null) {
-      yarnCluster.stop();
-    }
+    IOUtils.cleanupWithLogger(LOG, yarnCluster);
   }
 
   @Test

--- a/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseMiniCluster.java
+++ b/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseMiniCluster.java
@@ -44,6 +44,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
 import org.apache.hadoop.hdfs.web.WebHdfsConstants;
 
+import org.apache.hadoop.yarn.server.MiniYARNCluster;
+
+import static org.junit.Assert.assertTrue;
+
 /**
  * Ensure that we can perform operations against the shaded minicluster
  * given the API and runtime jars by performing some simple smoke tests.
@@ -54,6 +58,7 @@ public class ITUseMiniCluster {
       LoggerFactory.getLogger(ITUseMiniCluster.class);
 
   private MiniDFSCluster cluster;
+  private MiniYARNCluster yarnCluster;
 
   private static final String TEST_PATH = "/foo/bar/cats/dee";
   private static final String FILENAME = "test.file";
@@ -73,12 +78,21 @@ public class ITUseMiniCluster {
         .numDataNodes(3)
         .build();
     cluster.waitActive();
+
+    conf.set("yarn.scheduler.capacity.root.queues", "default");
+    conf.setInt("yarn.scheduler.capacity.root.default.capacity", 100);
+    yarnCluster = new MiniYARNCluster(getClass().getName(), 1, 1, 1, 1);
+    yarnCluster.init(conf);
+    yarnCluster.start();
   }
 
   @After
   public void clusterDown() {
     if (cluster != null) {
       cluster.close();
+    }
+    if (yarnCluster != null) {
+      yarnCluster.stop();
     }
   }
 

--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -678,10 +678,8 @@
                       <exclude>junit:junit</exclude>
                       <exclude>com.google.code.findbugs:jsr305</exclude>
                       <exclude>log4j:log4j</exclude>
-                      <exclude>org.eclipse.jetty.websocket:*</exclude>
-                      <exclude>javax.websocket:javax.websocket-api</exclude>
-                      <exclude>javax.annotation:javax.annotation-api</exclude>
-                      <exclude>org.eclipse.jetty:jetty-jndi</exclude>
+                      <exclude>org.eclipse.jetty.websocket:websocket-common</exclude>
+                      <exclude>org.eclipse.jetty.websocket:websocket-api</exclude>
                       <!-- We need a filter that matches just those things that are included in the above artiacts -->
                       <!-- Leave bouncycastle unshaded because it's signed with a special Oracle certificate so it can be a custom JCE security provider -->
                       <exclude>org.bouncycastle:*</exclude>
@@ -731,13 +729,6 @@
                         <exclude>testdata/*</exclude>
                       </excludes>
                     </filter>
-                    <!-- Skip terminal html and javascript -->
-                    <filter>
-                      <artifact>org.apache.hadoop:hadoop-yarn-server-nodemanager:*</artifact>
-                      <excludes>
-                        <exclude>TERMINAL/**/*</exclude>
-                      </excludes>
-                    </filter>
 
                     <!-- Mockito tries to include its own unrelocated copy of hamcrest. :( -->
                     <filter>
@@ -780,6 +771,13 @@
                     <filter>
                       <!-- skip jetty license info already incorporated into LICENSE/NOTICE -->
                       <artifact>org.eclipse.jetty:*</artifact>
+                      <excludes>
+                        <exclude>about.html</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <!-- skip jetty license info already incorporated into LICENSE/NOTICE -->
+                      <artifact>org.eclipse.jetty.websocket:*</artifact>
                       <excludes>
                         <exclude>about.html</exclude>
                       </excludes>
@@ -974,6 +972,13 @@
                     </relocation>
                     <relocation>
                       <pattern>javax/websocket/</pattern>
+                      <shadedPattern>${shaded.dependency.prefix}.javax.websocket.</shadedPattern>
+                      <excludes>
+                        <exclude>**/pom.xml</exclude>
+                      </excludes>
+                    </relocation>
+                    <relocation>
+                      <pattern>javax/annotation/</pattern>
                       <shadedPattern>${shaded.dependency.prefix}.javax.websocket.</shadedPattern>
                       <excludes>
                         <exclude>**/pom.xml</exclude>

--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -881,6 +881,8 @@
                         <exclude>org/w3c/dom/**/*</exclude>
                         <exclude>org/xml/sax/*</exclude>
                         <exclude>org/xml/sax/**/*</exclude>
+                        <exclude>org/bouncycastle/*</exclude>
+                        <exclude>org/bouncycastle/**/*</exclude>
                       </excludes>
                     </relocation>
                     <relocation>

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -267,6 +267,8 @@
                         <exclude>org/w3c/dom/**/*</exclude>
                         <exclude>org/xml/sax/*</exclude>
                         <exclude>org/xml/sax/**/*</exclude>
+                        <exclude>org/bouncycastle/*</exclude>
+                        <exclude>org/bouncycastle/**/*</exclude>
                       </excludes>
                     </relocation>
                     <relocation>


### PR DESCRIPTION
In [HADOOP-15832](https://issues.apache.org/jira/browse/HADOOP-15832) we excluded org.bouncycastle from the shaded client jars but still relocate them to `org.apache.hadoop.shaded`. This breaks any downstream application that wants to use `MiniYARNCluster` from `hadoop-client-minicluster` since there is no way to bring its own org.bouncycastle test dependency. 

```
Error:  Caused by: sbt.ForkMain$ForkError: java.lang.ClassNotFoundException: org.apache.hadoop.shaded.org.bouncycastle.operator.OperatorCreationException
Error:  	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
Error:  	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
Error:  	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
Error:  	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
Error:  	at org.apache.hadoop.yarn.server.resourcemanager.ResourceManager$RMActiveServices.serviceInit(ResourceManager.java:862)
Error:  	at org.apache.hadoop.service.AbstractService.init(AbstractService.java:164)
Error:  	at org.apache.hadoop.yarn.server.resourcemanager.ResourceManager.createAndInitActiveServices(ResourceManager.java:1296)
Error:  	at org.apache.hadoop.yarn.server.resourcemanager.ResourceManager.serviceInit(ResourceManager.java:339)
Error:  	at org.apache.hadoop.service.AbstractService.init(AbstractService.java:164)
Error:  	at org.apache.hadoop.yarn.server.MiniYARNCluster.initResourceManager(MiniYARNCluster.java:353)
Error:  	at org.apache.hadoop.yarn.server.MiniYARNCluster.access$200(MiniYARNCluster.java:127)
Error:  	at org.apache.hadoop.yarn.server.MiniYARNCluster$ResourceManagerWrapper.serviceInit(MiniYARNCluster.java:488)
Error:  	at org.apache.hadoop.service.AbstractService.init(AbstractService.java:164)
Error:  	at org.apache.hadoop.service.CompositeService.serviceInit(CompositeService.java:109)
Error:  	at org.apache.hadoop.yarn.server.MiniYARNCluster.serviceInit(MiniYARNCluster.java:321)
Error:  	at org.apache.hadoop.service.AbstractService.init(AbstractService.java:164)
Error:  	at org.apache.spark.deploy.yarn.BaseYarnClusterSuite.beforeAll(BaseYarnClusterSuite.scala:94)
Error:  	at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
Error:  	at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
Error:  	at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
Error:  	at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:61)
Error:  	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:318)
Error:  	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:513)
Error:  	at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:413)
Error:  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
Error:  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
Error:  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
Error:  	at java.lang.Thread.run(Thread.java:748)
```

This fixes the issue by excluding org.bouncycastle from relocation.