### PR TITLE
HADOOP-17320. Update apache/hadoop:3 to 3.3.0 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.git
+.gitignore
+build
+build.sh
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-3.2.0/hadoop-3.2.0.tar.gz
+ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $HADOOP_URL -O hadoop.tar.gz && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -17,11 +17,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 mkdir -p build
-if [ ! -d "$DIR/build/apache-rat-0.12" ]; then
-   wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
+   wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
 	cd $DIR/build
 	tar zvxf apache-rat.tar.gz
 	cd -
 fi
-java -jar $DIR/build/apache-rat-0.12/apache-rat-0.12.jar $DIR -e public -e apache-rat-0.12 -e .git -e .gitignore
+java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e public -e apache-rat-0.13 -e .git -e .gitignore
 docker build -t apache/hadoop:3 .

--- a/config
+++ b/config
@@ -18,6 +18,9 @@ CORE-SITE.XML_fs.defaultFS=hdfs://namenode
 HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:8020
 HDFS-SITE.XML_dfs.replication=1
 MAPRED-SITE.XML_mapreduce.framework.name=yarn
+MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
 YARN-SITE.XML_yarn.resourcemanager.hostname=resourcemanager
 YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Update to Hadoop 3.3.0 release.
2. And some misc updates/improvements for the docker build:
   * Use current Apache Rat 0.13 in `build.sh` as 0.12 is now available only in archive.
   * Add `.dockerignore` to speed up build (avoid sending `.git` etc. to the Docker daemon).
   * Let git ignore `build` dir (created by `build.sh`).
   * Add some MapReduce-related env to docker config to allow running MR examples.

https://issues.apache.org/jira/browse/HADOOP-17320

## How was this patch tested?

Built the new image locally:

```
$ ./build.sh
...
Successfully built 2adf1981fb31
Successfully tagged apache/hadoop:3
```

and tested it with the included sample Docker Compose cluster:

```
$ docker-compose up -d --scale datanode=3 --scale nodemanager=3
$ docker-compose exec resourcemanager yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.3.0.jar pi 3 3
...
Job Finished in 26.524 seconds
Estimated value of Pi is 3.55555555555555555556
```