### PR TITLE
HDFS-15657. RBF: TestRouter#testNamenodeHeartBeatEnableDefault fails by BindException

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -268,7 +268,7 @@ public class TestRouter {
   }
 
   /**
-   * Check the default value of dfs.federation.router.namenode.heartbeat.enable
+   * Check the default value of dfs.federation.router.heartbeat.enable
    * when it isn't explicitly defined.
    * @param enable value for dfs.federation.router.heartbeat.enable.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -274,18 +274,31 @@ public class TestRouter {
    */
   private void checkNamenodeHeartBeatEnableDefault(boolean enable)
       throws IOException {
-    final Router router = new Router();
-    try {
+    try (Router router = new Router()) {
+      // Use default config
       Configuration config = new HdfsConfiguration();
-      config.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE, enable);
+      // bind to any available port
+      config.set(RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY, "0.0.0.0");
+      config.set(RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY, "127.0.0.1:0");
+      config.set(RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_KEY, "127.0.0.1:0");
+      config.set(RBFConfigKeys.DFS_ROUTER_ADMIN_BIND_HOST_KEY, "0.0.0.0");
+      config.set(RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_KEY, "127.0.0.1:0");
+      config.set(RBFConfigKeys.DFS_ROUTER_HTTPS_ADDRESS_KEY, "127.0.0.1:0");
+      config.set(RBFConfigKeys.DFS_ROUTER_HTTP_BIND_HOST_KEY, "0.0.0.0");
+
+      if (enable) {
+        // We don't set the parameter explicitly to verify
+        // the default behavior. The default value should be true.
+      } else {
+        config.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE, false);
+      }
+
       router.init(config);
       if (enable) {
         assertNotNull(router.getNamenodeHeartbeatServices());
       } else {
         assertNull(router.getNamenodeHeartbeatServices());
       }
-    } finally {
-      router.close();
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -268,7 +268,7 @@ public class TestRouter {
   }
 
   /**
-   * Check the default value of dfs.federation.router.heartbeat.enable
+   * Check the default value of dfs.federation.router.namenode.heartbeat.enable
    * when it isn't explicitly defined.
    * @param enable value for dfs.federation.router.heartbeat.enable.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -286,14 +286,11 @@ public class TestRouter {
       config.set(RBFConfigKeys.DFS_ROUTER_HTTPS_ADDRESS_KEY, "127.0.0.1:0");
       config.set(RBFConfigKeys.DFS_ROUTER_HTTP_BIND_HOST_KEY, "0.0.0.0");
 
+      config.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE, enable);
+      router.init(config);
       if (enable) {
-        // We don't explicitly set the parameter to verify
-        // the default behavior. The default value should be true.
-        router.init(config);
         assertNotNull(router.getNamenodeHeartbeatServices());
       } else {
-        config.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE, false);
-        router.init(config);
         assertNull(router.getNamenodeHeartbeatServices());
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -287,16 +287,13 @@ public class TestRouter {
       config.set(RBFConfigKeys.DFS_ROUTER_HTTP_BIND_HOST_KEY, "0.0.0.0");
 
       if (enable) {
-        // We don't set the parameter explicitly to verify
+        // We don't explicitly set the parameter to verify
         // the default behavior. The default value should be true.
-      } else {
-        config.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE, false);
-      }
-
-      router.init(config);
-      if (enable) {
+        router.init(config);
         assertNotNull(router.getNamenodeHeartbeatServices());
       } else {
+        config.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE, false);
+        router.init(config);
         assertNull(router.getNamenodeHeartbeatServices());
       }
     }


### PR DESCRIPTION
- Use any available port to avoid BindException (main fix)
- Use try-with-resources for Router
- ~According to the javadoc, this test case is to verify the default behavior. Don't set the default value (true) explicitly to verify the default behavior.~

JIRA: https://issues.apache.org/jira/browse/HDFS-15657