### PR TITLE
HADOOP-17311. ABFS: Logs should redact SAS signature

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -87,7 +87,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
               "Operation failed: \"%1$s\", %2$s, HEAD, %3$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
-              abfsHttpOperation.getSignatureMaskedUrlStr());
+              abfsHttpOperation.getSignatureMaskedUrl());
     }
 
     return String.format(
@@ -95,7 +95,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
             abfsHttpOperation.getStatusDescription(),
             abfsHttpOperation.getStatusCode(),
             abfsHttpOperation.getMethod(),
-            abfsHttpOperation.getSignatureMaskedUrlStr(),
+            abfsHttpOperation.getSignatureMaskedUrl(),
             abfsHttpOperation.getStorageErrorCode(),
             // Remove break line to ensure the request id and timestamp can be shown in console.
             abfsHttpOperation.getStorageErrorMessage().replaceAll("\\n", " "));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -87,7 +87,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
               "Operation failed: \"%1$s\", %2$s, HEAD, %3$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
-              abfsHttpOperation.getUrl().toString());
+              abfsHttpOperation.getSignatureMaskedUrlStr());
     }
 
     return String.format(
@@ -95,7 +95,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
             abfsHttpOperation.getStatusDescription(),
             abfsHttpOperation.getStatusCode(),
             abfsHttpOperation.getMethod(),
-            abfsHttpOperation.getUrl().toString(),
+            abfsHttpOperation.getSignatureMaskedUrlStr(),
             abfsHttpOperation.getStorageErrorCode(),
             // Remove break line to ensure the request id and timestamp can be shown in console.
             abfsHttpOperation.getStorageErrorMessage().replaceAll("\\n", " "));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
@@ -158,7 +158,6 @@ public class AbfsHttpOperation implements AbfsPerfLoggable {
   // Returns a trace message for the request
   @Override
   public String toString() {
-    final String urlStr = url.toString();
     final StringBuilder sb = new StringBuilder();
     sb.append(statusCode);
     sb.append(",");
@@ -512,11 +511,14 @@ public class AbfsHttpOperation implements AbfsPerfLoggable {
   }
 
   public static String getSignatureMaskedUrl(String url) {
-    final int qpStrIdx = url.indexOf(SIGNATURE_QUERY_PARAM_KEY);
+    int qpStrIdx = url.indexOf('?' + SIGNATURE_QUERY_PARAM_KEY);
+    if (qpStrIdx == -1) {
+      qpStrIdx = url.indexOf('&' + SIGNATURE_QUERY_PARAM_KEY);
+    }
     if (qpStrIdx == -1) {
       return url;
     }
-    final int sigStartIdx = qpStrIdx + SIGNATURE_QUERY_PARAM_KEY.length();
+    final int sigStartIdx = qpStrIdx + SIGNATURE_QUERY_PARAM_KEY.length() + 1;
     final int ampIdx = url.indexOf("&", sigStartIdx);
     final int sigEndIndex = (ampIdx != -1) ? ampIdx : url.length();
     String signature = url.substring(sigStartIdx, sigEndIndex);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsIoUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsIoUtils.java
@@ -58,6 +58,9 @@ public final class AbfsIoUtils {
         if (key.contains("Cookie")) {
           values = "*cookie info*";
         }
+        if (key.equals("sig")) {
+          values = "XXXX";
+        }
         LOG.debug("  {}={}",
             key,
             values);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -261,6 +261,10 @@ public class AbfsRestOperation {
       }
       LOG.warn("Unknown host name: %s. Retrying to resolve the host name...",
           hostname);
+      if (!client.getRetryPolicy().shouldRetry(retryCount, -1)) {
+        throw new InvalidAbfsRestOperationException(ex);
+      }
+      return false;
     } catch (IOException ex) {
       if (LOG.isDebugEnabled()) {
         if (httpOperation != null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -255,8 +255,12 @@ public class AbfsRestOperation {
             httpOperation.getBytesReceived());
       }
     } catch (UnknownHostException ex) {
+      String hostname = null;
+      if (httpOperation != null) {
+        hostname = httpOperation.getHost();
+      }
       LOG.warn("Unknown host name: %s. Retrying to resolve the host name...",
-          httpOperation.getHost());
+          hostname);
     } catch (IOException ex) {
       if (LOG.isDebugEnabled()) {
         if (httpOperation != null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -254,13 +254,10 @@ public class AbfsRestOperation {
         incrementCounter(AbfsStatistic.BYTES_RECEIVED,
             httpOperation.getBytesReceived());
       }
+    } catch (UnknownHostException ex) {
+      LOG.warn("Unknown host name: %s. Retrying to resolve the host name...",
+          httpOperation.getHost());
     } catch (IOException ex) {
-      if (ex instanceof UnknownHostException) {
-        LOG.warn(String.format(
-            "Unknown host name: %s. Retrying to resolve the host name...",
-            httpOperation.getHost()));
-      }
-
       if (LOG.isDebugEnabled()) {
         if (httpOperation != null) {
           LOG.debug("HttpRequestFailure: " + httpOperation.toString(), ex);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -256,7 +256,9 @@ public class AbfsRestOperation {
       }
     } catch (IOException ex) {
       if (ex instanceof UnknownHostException) {
-        LOG.warn(String.format("Unknown host name: %s. Retrying to resolve the host name...", httpOperation.getUrl().getHost()));
+        LOG.warn(String.format(
+            "Unknown host name: %s. Retrying to resolve the host name...",
+            httpOperation.getHost()));
       }
 
       if (LOG.isDebugEnabled()) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
@@ -55,6 +55,7 @@ import static org.apache.hadoop.fs.permission.AclEntryScope.ACCESS;
 import static org.apache.hadoop.fs.permission.AclEntryScope.DEFAULT;
 import static org.apache.hadoop.fs.permission.AclEntryType.GROUP;
 import static org.apache.hadoop.fs.permission.AclEntryType.USER;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
  * Test Perform Authorization Check operation
@@ -403,19 +404,10 @@ public class ITestAzureBlobFileSystemDelegationSAS extends AbstractAbfsIntegrati
   }
 
   @Test
-  public void testSignatureMaskOnExceptionMessage() {
-    final AzureBlobFileSystem fs;
-    String msg = null;
-    try {
-      fs = getFileSystem();
-      AbfsRestOperation abfsHttpRestOperation = fs.getAbfsClient()
-          .renamePath("testABC/test.xt", "testABC/abc.txt", null);
-    } catch (IOException e) {
-      msg = e.getMessage();
-    }
-    Assertions.assertThat(msg.substring(msg.indexOf("sig=")))
-        .describedAs("Signature query param should be masked")
-        .startsWith("sig=XXXX");
+  public void testSignatureMaskOnExceptionMessage() throws Exception {
+    intercept(IOException.class, "sig=XXXX",
+        () -> getFileSystem().getAbfsClient()
+            .renamePath("testABC/test.xt", "testABC/abc.txt", null));
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -39,6 +39,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.extensions.MockDelegationSASTokenProvider;
+import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
+import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclEntryScope;
@@ -381,4 +383,39 @@ public class ITestAzureBlobFileSystemDelegationSAS extends AbstractAbfsIntegrati
 
     assertArrayEquals(propertyValue, fs.getXAttr(reqPath, propertyName));
   }
+
+  @Test
+  public void testSignatureMask() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    String src = "/testABC/test.xt";
+    fs.create(new Path(src));
+    AbfsRestOperation abfsHttpRestOperation = fs.getAbfsClient()
+        .renamePath(src, "/testABC" + "/abc.txt", null);
+    AbfsHttpOperation result = abfsHttpRestOperation.getResult();
+    String url = result.getSignatureMaskedUrlStr();
+    String encodedUrl = result.getSignatureMaskedEncodedUrlStr();
+    Assertions.assertThat(url.substring(url.indexOf("sig=")))
+        .describedAs("Signature query param should be masked")
+        .startsWith("sig=XXXX");
+    Assertions.assertThat(encodedUrl.substring(encodedUrl.indexOf("sig%3D")))
+        .describedAs("Signature query param should be masked")
+        .startsWith("sig%3DXXXX");
+  }
+
+  @Test
+  public void testSignatureMaskOnExceptionMessage() {
+    final AzureBlobFileSystem fs;
+    String msg = null;
+    try {
+      fs = getFileSystem();
+      AbfsRestOperation abfsHttpRestOperation = fs.getAbfsClient()
+          .renamePath("testABC/test.xt", "testABC/abc.txt", null);
+    } catch (IOException e) {
+      msg = e.getMessage();
+    }
+    Assertions.assertThat(msg.substring(msg.indexOf("sig=")))
+        .describedAs("Signature query param should be masked")
+        .startsWith("sig=XXXX");
+  }
+
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
@@ -393,8 +393,8 @@ public class ITestAzureBlobFileSystemDelegationSAS extends AbstractAbfsIntegrati
     AbfsRestOperation abfsHttpRestOperation = fs.getAbfsClient()
         .renamePath(src, "/testABC" + "/abc.txt", null);
     AbfsHttpOperation result = abfsHttpRestOperation.getResult();
-    String url = result.getSignatureMaskedUrlStr();
-    String encodedUrl = result.getSignatureMaskedEncodedUrlStr();
+    String url = result.getSignatureMaskedUrl();
+    String encodedUrl = result.getSignatureMaskedEncodedUrl();
     Assertions.assertThat(url.substring(url.indexOf("sig=")))
         .describedAs("Signature query param should be masked")
         .startsWith("sig=XXXX");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsHttpOperation.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation.getAbfsHttpOperationWithFixedResult;
+
+public class TestAbfsHttpOperation {
+
+  @Test
+  public void testForURLs()
+      throws MalformedURLException, UnsupportedEncodingException {
+    testIfMaskedSuccessfully("Where sig is the only query param"
+        ,"http://www.testurl.net?sig=abcd"
+        ,"http://www.testurl.net?sig=XXXX");
+
+    testIfMaskedSuccessfully("Where sig is the first query param"
+        ,"http://www.testurl.net?sig=abcd&abc=xyz"
+        ,"http://www.testurl.net?sig=XXXX&abc=xyz");
+
+    testIfMaskedSuccessfully("Where sig is neither first nor last query param"
+        ,"http://www.testurl.net?lmn=abc&sig=abcd&abc=xyz"
+        ,"http://www.testurl.net?lmn=abc&sig=XXXX&abc=xyz");
+
+    testIfMaskedSuccessfully("Where sig is the last query param"
+        ,"http://www.testurl.net?abc=xyz&sig=abcd"
+        ,"http://www.testurl.net?abc=xyz&sig=XXXX");
+
+    testIfMaskedSuccessfully("Where sig query param is not present"
+        ,"http://www.testurl.net?abc=xyz"
+        ,"http://www.testurl.net?abc=xyz");
+  }
+
+  private void testIfMaskedSuccessfully(String scenario, String url,
+      String expectedMaskedUrl)
+      throws MalformedURLException, UnsupportedEncodingException {
+    AbfsHttpOperation abfsHttpOperation = getAbfsHttpOperationWithFixedResult(
+        new URL(url), "GET", 200);
+
+    Assertions.assertThat(abfsHttpOperation.getSignatureMaskedUrlStr())
+        .describedAs(url+" ("+scenario+") after masking should be: "+expectedMaskedUrl)
+        .isEqualToIgnoringCase(expectedMaskedUrl);
+
+    final String expectedMaskedEncodedUrl =
+        URLEncoder.encode(expectedMaskedUrl, "UTF-8");
+    Assertions.assertThat(abfsHttpOperation.getSignatureMaskedEncodedUrlStr())
+        .describedAs(url+" ("+scenario+") after masking and encoding should "
+            + "be: "+expectedMaskedEncodedUrl)
+        .isEqualToIgnoringCase(expectedMaskedEncodedUrl);
+  }
+
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsHttpOperation.java
@@ -20,53 +20,71 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLEncoder;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import static org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation.getAbfsHttpOperationWithFixedResult;
-
 public class TestAbfsHttpOperation {
 
   @Test
-  public void testForURLs()
+  public void testMaskingAndEncoding()
       throws MalformedURLException, UnsupportedEncodingException {
-    testIfMaskedSuccessfully("Where sig is the only query param"
+    testIfMaskAndEncodeSuccessful("Where sig is the only query param"
         ,"http://www.testurl.net?sig=abcd"
         ,"http://www.testurl.net?sig=XXXX");
 
-    testIfMaskedSuccessfully("Where sig is the first query param"
+    testIfMaskAndEncodeSuccessful("Where sig is the first query param"
         ,"http://www.testurl.net?sig=abcd&abc=xyz"
         ,"http://www.testurl.net?sig=XXXX&abc=xyz");
 
-    testIfMaskedSuccessfully("Where sig is neither first nor last query param"
+    testIfMaskAndEncodeSuccessful("Where sig is neither first nor last query param"
         ,"http://www.testurl.net?lmn=abc&sig=abcd&abc=xyz"
         ,"http://www.testurl.net?lmn=abc&sig=XXXX&abc=xyz");
 
-    testIfMaskedSuccessfully("Where sig is the last query param"
+    testIfMaskAndEncodeSuccessful("Where sig is the last query param"
         ,"http://www.testurl.net?abc=xyz&sig=abcd"
         ,"http://www.testurl.net?abc=xyz&sig=XXXX");
 
-    testIfMaskedSuccessfully("Where sig query param is not present"
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present"
         ,"http://www.testurl.net?abc=xyz"
         ,"http://www.testurl.net?abc=xyz");
+
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present but mysig"
+        ,"http://www.testurl.net?abc=xyz&mysig=qwerty"
+        ,"http://www.testurl.net?abc=xyz&mysig=qwerty");
+
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present but sigmy"
+        ,"http://www.testurl.net?abc=xyz&sigmy=qwerty"
+        ,"http://www.testurl.net?abc=xyz&sigmy=qwerty");
+
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present but a "
+            + "value sig"
+        ,"http://www.testurl.net?abc=xyz&mnop=sig"
+        ,"http://www.testurl.net?abc=xyz&mnop=sig");
+
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present but a "
+            + "value ends with sig"
+        ,"http://www.testurl.net?abc=xyz&mnop=abcsig"
+        ,"http://www.testurl.net?abc=xyz&mnop=abcsig");
+
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present but a "
+            + "value starts with sig"
+        ,"http://www.testurl.net?abc=xyz&mnop=sigabc"
+        ,"http://www.testurl.net?abc=xyz&mnop=sigabc");
   }
 
-  private void testIfMaskedSuccessfully(String scenario, String url,
+  private void testIfMaskAndEncodeSuccessful(String scenario, String url,
       String expectedMaskedUrl)
-      throws MalformedURLException, UnsupportedEncodingException {
-    AbfsHttpOperation abfsHttpOperation = getAbfsHttpOperationWithFixedResult(
-        new URL(url), "GET", 200);
+      throws UnsupportedEncodingException {
 
-    Assertions.assertThat(abfsHttpOperation.getSignatureMaskedUrlStr())
+    Assertions.assertThat(AbfsHttpOperation.getSignatureMaskedUrl(url))
         .describedAs(url+" ("+scenario+") after masking should be: "+expectedMaskedUrl)
         .isEqualToIgnoringCase(expectedMaskedUrl);
 
     final String expectedMaskedEncodedUrl =
         URLEncoder.encode(expectedMaskedUrl, "UTF-8");
-    Assertions.assertThat(abfsHttpOperation.getSignatureMaskedEncodedUrlStr())
+    Assertions.assertThat(AbfsHttpOperation.encodedUrlStr(expectedMaskedUrl))
         .describedAs(url+" ("+scenario+") after masking and encoding should "
             + "be: "+expectedMaskedEncodedUrl)
         .isEqualToIgnoringCase(expectedMaskedEncodedUrl);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsHttpOperation.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,64 +30,66 @@ public class TestAbfsHttpOperation {
   @Test
   public void testMaskingAndEncoding()
       throws MalformedURLException, UnsupportedEncodingException {
-    testIfMaskAndEncodeSuccessful("Where sig is the only query param"
-        ,"http://www.testurl.net?sig=abcd"
-        ,"http://www.testurl.net?sig=XXXX");
+    testIfMaskAndEncodeSuccessful("Where sig is the only query param",
+        "http://www.testurl.net?sig=abcd", "http://www.testurl.net?sig=XXXX");
 
-    testIfMaskAndEncodeSuccessful("Where sig is the first query param"
-        ,"http://www.testurl.net?sig=abcd&abc=xyz"
-        ,"http://www.testurl.net?sig=XXXX&abc=xyz");
+    testIfMaskAndEncodeSuccessful("Where sig is the first query param",
+        "http://www.testurl.net?sig=abcd&abc=xyz",
+        "http://www.testurl.net?sig=XXXX&abc=xyz");
 
-    testIfMaskAndEncodeSuccessful("Where sig is neither first nor last query param"
-        ,"http://www.testurl.net?lmn=abc&sig=abcd&abc=xyz"
-        ,"http://www.testurl.net?lmn=abc&sig=XXXX&abc=xyz");
+    testIfMaskAndEncodeSuccessful(
+        "Where sig is neither first nor last query param",
+        "http://www.testurl.net?lmn=abc&sig=abcd&abc=xyz",
+        "http://www.testurl.net?lmn=abc&sig=XXXX&abc=xyz");
 
-    testIfMaskAndEncodeSuccessful("Where sig is the last query param"
-        ,"http://www.testurl.net?abc=xyz&sig=abcd"
-        ,"http://www.testurl.net?abc=xyz&sig=XXXX");
+    testIfMaskAndEncodeSuccessful("Where sig is the last query param",
+        "http://www.testurl.net?abc=xyz&sig=abcd",
+        "http://www.testurl.net?abc=xyz&sig=XXXX");
 
-    testIfMaskAndEncodeSuccessful("Where sig query param is not present"
-        ,"http://www.testurl.net?abc=xyz"
-        ,"http://www.testurl.net?abc=xyz");
+    testIfMaskAndEncodeSuccessful("Where sig query param is not present",
+        "http://www.testurl.net?abc=xyz", "http://www.testurl.net?abc=xyz");
 
-    testIfMaskAndEncodeSuccessful("Where sig query param is not present but mysig"
-        ,"http://www.testurl.net?abc=xyz&mysig=qwerty"
-        ,"http://www.testurl.net?abc=xyz&mysig=qwerty");
+    testIfMaskAndEncodeSuccessful(
+        "Where sig query param is not present but mysig",
+        "http://www.testurl.net?abc=xyz&mysig=qwerty",
+        "http://www.testurl.net?abc=xyz&mysig=qwerty");
 
-    testIfMaskAndEncodeSuccessful("Where sig query param is not present but sigmy"
-        ,"http://www.testurl.net?abc=xyz&sigmy=qwerty"
-        ,"http://www.testurl.net?abc=xyz&sigmy=qwerty");
+    testIfMaskAndEncodeSuccessful(
+        "Where sig query param is not present but sigmy",
+        "http://www.testurl.net?abc=xyz&sigmy=qwerty",
+        "http://www.testurl.net?abc=xyz&sigmy=qwerty");
 
-    testIfMaskAndEncodeSuccessful("Where sig query param is not present but a "
-            + "value sig"
-        ,"http://www.testurl.net?abc=xyz&mnop=sig"
-        ,"http://www.testurl.net?abc=xyz&mnop=sig");
+    testIfMaskAndEncodeSuccessful(
+        "Where sig query param is not present but a " + "value sig",
+        "http://www.testurl.net?abc=xyz&mnop=sig",
+        "http://www.testurl.net?abc=xyz&mnop=sig");
 
-    testIfMaskAndEncodeSuccessful("Where sig query param is not present but a "
-            + "value ends with sig"
-        ,"http://www.testurl.net?abc=xyz&mnop=abcsig"
-        ,"http://www.testurl.net?abc=xyz&mnop=abcsig");
+    testIfMaskAndEncodeSuccessful(
+        "Where sig query param is not present but a " + "value ends with sig",
+        "http://www.testurl.net?abc=xyz&mnop=abcsig",
+        "http://www.testurl.net?abc=xyz&mnop=abcsig");
 
-    testIfMaskAndEncodeSuccessful("Where sig query param is not present but a "
-            + "value starts with sig"
-        ,"http://www.testurl.net?abc=xyz&mnop=sigabc"
-        ,"http://www.testurl.net?abc=xyz&mnop=sigabc");
+    testIfMaskAndEncodeSuccessful(
+        "Where sig query param is not present but a " + "value starts with sig",
+        "http://www.testurl.net?abc=xyz&mnop=sigabc",
+        "http://www.testurl.net?abc=xyz&mnop=sigabc");
   }
 
-  private void testIfMaskAndEncodeSuccessful(String scenario, String url,
-      String expectedMaskedUrl)
+  private void testIfMaskAndEncodeSuccessful(final String scenario,
+      final String url, final String expectedMaskedUrl)
       throws UnsupportedEncodingException {
 
     Assertions.assertThat(AbfsHttpOperation.getSignatureMaskedUrl(url))
-        .describedAs(url+" ("+scenario+") after masking should be: "+expectedMaskedUrl)
-        .isEqualToIgnoringCase(expectedMaskedUrl);
+        .describedAs(url + " (" + scenario + ") after masking should be: "
+            + expectedMaskedUrl).isEqualTo(expectedMaskedUrl);
 
-    final String expectedMaskedEncodedUrl =
-        URLEncoder.encode(expectedMaskedUrl, "UTF-8");
+    final String expectedMaskedEncodedUrl = URLEncoder
+        .encode(expectedMaskedUrl, "UTF-8");
     Assertions.assertThat(AbfsHttpOperation.encodedUrlStr(expectedMaskedUrl))
-        .describedAs(url+" ("+scenario+") after masking and encoding should "
-            + "be: "+expectedMaskedEncodedUrl)
-        .isEqualToIgnoringCase(expectedMaskedEncodedUrl);
+        .describedAs(
+            url + " (" + scenario + ") after masking and encoding should "
+                + "be: " + expectedMaskedEncodedUrl)
+        .isEqualTo(expectedMaskedEncodedUrl);
   }
 
 }


### PR DESCRIPTION
Masking SAS signatures from logs

HNS-OAuth
========================
[INFO] Results:
[INFO] 
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
[INFO] Results:
[INFO] 
[WARNING] Tests run: 459, Failures: 0, Errors: 0, Skipped: 66
[INFO] Results:
[INFO] 
[WARNING] Tests run: 208, Failures: 0, Errors: 0, Skipped: 24

HNS-SharedKey
========================
[INFO] Results:
[INFO] 
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
[INFO] Results:
[INFO] 
[WARNING] Tests run: 459, Failures: 0, Errors: 0, Skipped: 24
[INFO] Results:
[INFO] 
[WARNING] Tests run: 208, Failures: 0, Errors: 0, Skipped: 16

NonHNS-SharedKey
========================
[INFO] Results:
[INFO] 
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
[INFO] Results:
[INFO] 
[WARNING] Tests run: 459, Failures: 0, Errors: 0, Skipped: 247
[INFO] Results:
[INFO] 
[WARNING] Tests run: 208, Failures: 0, Errors: 0, Skipped: 16