### PR TITLE
HDFS-15643. EC: Fix checksum computation in case of native encoders.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockChecksumReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockChecksumReconstructor.java
@@ -87,7 +87,7 @@ public abstract class StripedBlockChecksumReconstructor
 
         // step3: calculate checksum
         checksumDataLen += checksumWithTargetOutput(
-            targetBuffer.array(), toReconstructLen);
+            getBufferArray(targetBuffer), toReconstructLen);
 
         updatePositionInBlock(toReconstructLen);
         requestedLen -= toReconstructLen;
@@ -140,7 +140,7 @@ public abstract class StripedBlockChecksumReconstructor
     // case-2) length of data bytes which is less than bytesPerCRC
     if (requestedLen <= toReconstructLen) {
       int remainingLen = Math.toIntExact(requestedLen);
-      outputData = Arrays.copyOf(targetBuffer.array(), remainingLen);
+      outputData = Arrays.copyOf(outputData, remainingLen);
 
       int partialLength = remainingLen % getChecksum().getBytesPerChecksum();
 
@@ -206,5 +206,20 @@ public abstract class StripedBlockChecksumReconstructor
 
   public long getChecksumDataLen() {
     return checksumDataLen;
+  }
+
+  /**
+   * Gets an array corresponding the buffer.
+   * @param buffer the input buffer.
+   * @return the array with content of the buffer.
+   */
+  private static byte[] getBufferArray(ByteBuffer buffer) {
+    byte[] buff = new byte[buffer.remaining()];
+    if (buffer.hasArray()) {
+      buff = buffer.array();
+    } else {
+      buffer.slice().get(buff);
+    }
+    return buff;
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15643

This is the reason for failure of TestFileChecksum when ISA-L is loaded
