### PR TITLE
HADOOP-17311. ABFS: Read small files completely

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -100,6 +100,11 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_WRITE_BUFFER_SIZE)
   private int writeBufferSize;
 
+  @BooleanConfigurationValidatorAnnotation(
+      ConfigurationKey = AZURE_READ_SMALL_FILES_COMPLETELY,
+      DefaultValue = DEFAULT_AZURE_READ_SMALL_FILES_COMPLETELY)
+  private boolean readSmallFilesCompletely;
+
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_READ_BUFFER_SIZE,
       MinValue = MIN_BUFFER_SIZE,
       MaxValue = MAX_BUFFER_SIZE,
@@ -517,6 +522,10 @@ public class AbfsConfiguration{
     return this.writeBufferSize;
   }
 
+  public boolean readSmallFilesCompletely() {
+    return this.readSmallFilesCompletely;
+  }
+
   public int getReadBufferSize() {
     return this.readBufferSize;
   }
@@ -907,4 +916,8 @@ public class AbfsConfiguration{
     return authority;
   }
 
+  @VisibleForTesting
+  public void setReadSmallFilesCompletely(boolean readSmallFilesCompletely) {
+    this.readSmallFilesCompletely = readSmallFilesCompletely;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -853,7 +853,7 @@ public class AbfsConfiguration{
   }
 
   @VisibleForTesting
-  void setReadBufferSize(int bufferSize) {
+  public void setReadBufferSize(int bufferSize) {
     this.readBufferSize = bufferSize;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1218,7 +1218,7 @@ public class AzureBlobFileSystem extends FileSystem {
   }
 
   @VisibleForTesting
-  AzureBlobFileSystemStore getAbfsStore() {
+  public AzureBlobFileSystemStore getAbfsStore() {
     return abfsStore;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -644,6 +644,7 @@ public class AzureBlobFileSystemStore implements Closeable {
             .withReadAheadQueueDepth(abfsConfiguration.getReadAheadQueueDepth())
             .withTolerateOobAppends(abfsConfiguration.getTolerateOobAppends())
             .withStreamStatistics(new AbfsInputStreamStatisticsImpl())
+            .withReadSmallFilesCompletely(abfsConfiguration.readSmallFilesCompletely())
             .build();
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -55,6 +55,7 @@ public final class ConfigurationKeys {
   public static final String AZURE_WRITE_MAX_CONCURRENT_REQUESTS = "fs.azure.write.max.concurrent.requests";
   public static final String AZURE_WRITE_MAX_REQUESTS_TO_QUEUE = "fs.azure.write.max.requests.to.queue";
   public static final String AZURE_WRITE_BUFFER_SIZE = "fs.azure.write.request.size";
+  public static final String AZURE_READ_SMALL_FILES_COMPLETELY = "fs.azure.read.small.files.completely";
   public static final String AZURE_READ_BUFFER_SIZE = "fs.azure.read.request.size";
   public static final String AZURE_BLOCK_SIZE_PROPERTY_NAME = "fs.azure.block.size";
   public static final String AZURE_BLOCK_LOCATION_HOST_PROPERTY_NAME = "fs.azure.block.location.impersonatedhost";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -56,6 +56,7 @@ public final class FileSystemConfigurations {
   // Default upload and download buffer size
   public static final int DEFAULT_WRITE_BUFFER_SIZE = 8 * ONE_MB;  // 8 MB
   public static final int APPENDBLOB_MAX_WRITE_BUFFER_SIZE = 4 * ONE_MB;  // 4 MB
+  public static final boolean DEFAULT_AZURE_READ_SMALL_FILES_COMPLETELY = true;
   public static final int DEFAULT_READ_BUFFER_SIZE = 4 * ONE_MB;  // 4 MB
   public static final int MIN_BUFFER_SIZE = 16 * ONE_KB;  // 16 KB
   public static final int MAX_BUFFER_SIZE = 100 * ONE_MB;  // 100 MB

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -50,8 +50,8 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_AZURE_OAUTH_TOKEN_FETCH_RETRY_MAX_BACKOFF_INTERVAL = SIXTY_SECONDS;
   public static final int DEFAULT_AZURE_OAUTH_TOKEN_FETCH_RETRY_DELTA_BACKOFF = 2;
 
-  private static final int ONE_KB = 1024;
-  private static final int ONE_MB = ONE_KB * ONE_KB;
+  public static final int ONE_KB = 1024;
+  public static final int ONE_MB = ONE_KB * ONE_KB;
 
   // Default upload and download buffer size
   public static final int DEFAULT_WRITE_BUFFER_SIZE = 8 * ONE_MB;  // 8 MB

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -76,6 +76,8 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
   private long bytesFromReadAhead; // bytes read from readAhead; for testing
   private long bytesFromRemoteRead; // bytes read remotely; for testing
 
+  private final boolean readSmallFilesCompletely;
+
   public AbfsInputStream(
           final AbfsClient client,
           final Statistics statistics,
@@ -95,6 +97,8 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     this.cachedSasToken = new CachedSASToken(
         abfsInputStreamContext.getSasTokenRenewPeriodForStreamsInSeconds());
     this.streamStatistics = abfsInputStreamContext.getStreamStatistics();
+    this.readSmallFilesCompletely = abfsInputStreamContext
+        .readSmallFilesCompletely();
   }
 
   public String getPath() {
@@ -172,7 +176,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
         return -1;
       }
 
-      if (contentLength <= SLURP_FILE_SIZE) {
+      if (readSmallFilesCompletely && contentLength <= bufferSize) {
         if (slurpFullFile() < 0) {
           return -1;
         }
@@ -586,5 +590,10 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       sb.append("}");
     }
     return sb.toString();
+  }
+
+  @VisibleForTesting
+  long getFcursor() {
+    return this.fCursor;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamContext.java
@@ -31,6 +31,8 @@ public class AbfsInputStreamContext extends AbfsStreamContext {
 
   private AbfsInputStreamStatistics streamStatistics;
 
+  private boolean readSmallFilesCompletely;
+
   public AbfsInputStreamContext(final long sasTokenRenewPeriodForStreamsInSeconds) {
     super(sasTokenRenewPeriodForStreamsInSeconds);
   }
@@ -60,6 +62,12 @@ public class AbfsInputStreamContext extends AbfsStreamContext {
     return this;
   }
 
+  public AbfsInputStreamContext withReadSmallFilesCompletely
+      (final boolean readSmallFilesCompletely) {
+    this.readSmallFilesCompletely = readSmallFilesCompletely;
+    return this;
+  }
+
   public AbfsInputStreamContext build() {
     // Validation of parameters to be done here.
     return this;
@@ -79,5 +87,9 @@ public class AbfsInputStreamContext extends AbfsStreamContext {
 
   public AbfsInputStreamStatistics getStreamStatistics() {
     return streamStatistics;
+  }
+
+  public boolean readSmallFilesCompletely() {
+    return this.readSmallFilesCompletely;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.util.Random;
+
+import org.junit.Test;
+import org.assertj.core.api.Assertions;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_KB;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsInputStream.SLURP_FILE_SIZE;
+
+public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
+
+  public ITestAbfsInputStream() throws Exception {
+  }
+
+  @Test
+  public void testSmallFilesAreReadCompletely() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    for (int i = 1; i <= 4; i++) {
+      final int readBufferSize = i * ONE_KB;
+      final int fileSize = i * ONE_MB;
+      fs.getAbfsStore().getAbfsConfiguration()
+          .setReadBufferSize(readBufferSize);
+      final Path testFilePath = path(methodName.getMethodName() + i);
+      final byte[] iBuffer = getRandomBytesArray(fileSize);
+      try (FSDataOutputStream oStream = fs.create(testFilePath)) {
+        oStream.write(iBuffer);
+        oStream.flush();
+      }
+      try (FSDataInputStream iStream = fs.open(testFilePath)) {
+        byte[] b = new byte[ONE_KB];
+        iStream.read(0, b, 0, ONE_KB);
+        AbfsInputStream abfsIStream = (AbfsInputStream) iStream
+            .getWrappedStream();
+        Assertions.assertThat(abfsIStream.getBuffer().length).describedAs(
+            "Entire file should have been read as the file size is "
+                + "less than SLURP_FILE_SIZE (" + SLURP_FILE_SIZE + ")")
+            .isEqualTo(fileSize);
+      }
+    }
+  }
+
+  @Test
+  public void testBigFilesAreNotReadCompletely() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    for (int i = 5; i <= 8; i++) {
+      final int readBufferSize = i * ONE_KB;
+      final int fileSize = i * ONE_MB;
+      fs.getAbfsStore().getAbfsConfiguration()
+          .setReadBufferSize(readBufferSize);
+      final Path testFilePath = path(methodName.getMethodName() + i);
+      final byte[] iBuffer = getRandomBytesArray(fileSize);
+      try (FSDataOutputStream oStream = fs.create(testFilePath)) {
+        oStream.write(iBuffer);
+        oStream.flush();
+      }
+      try (FSDataInputStream iStream = fs.open(testFilePath)) {
+        byte[] b = new byte[ONE_KB];
+        iStream.read(0, b, 0, ONE_KB);
+        AbfsInputStream abfsIStream = (AbfsInputStream) iStream
+            .getWrappedStream();
+        Assertions.assertThat(abfsIStream.getBuffer().length)
+            .describedAs("It is expected to read only first "
+                + "AZURE_READ_BUFFER_SIZE ("+ readBufferSize + ") bytes")
+            .isEqualTo(readBufferSize);
+      }
+    }
+  }
+
+  private byte[] getRandomBytesArray(int length) {
+    final byte[] b = new byte[length];
+    new Random().nextBytes(b);
+    return b;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,11 +18,14 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Random;
 
 import org.junit.Test;
 import org.assertj.core.api.Assertions;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
@@ -31,7 +34,6 @@ import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_KB;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
-import static org.apache.hadoop.fs.azurebfs.services.AbfsInputStream.SLURP_FILE_SIZE;
 
 public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
 
@@ -39,57 +41,123 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  public void testSmallFilesAreReadCompletely() throws Exception {
+  public void testSmallFilesAreReadCompletelyByDefault() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
+    final int bufferSize = 4 * ONE_MB;
+    fs.getAbfsStore().getAbfsConfiguration().setReadBufferSize(bufferSize);
     for (int i = 1; i <= 4; i++) {
-      final int readBufferSize = i * ONE_KB;
       final int fileSize = i * ONE_MB;
-      fs.getAbfsStore().getAbfsConfiguration()
-          .setReadBufferSize(readBufferSize);
-      final Path testFilePath = path(methodName.getMethodName() + i);
-      final byte[] iBuffer = getRandomBytesArray(fileSize);
-      try (FSDataOutputStream oStream = fs.create(testFilePath)) {
-        oStream.write(iBuffer);
-        oStream.flush();
-      }
-      try (FSDataInputStream iStream = fs.open(testFilePath)) {
-        byte[] b = new byte[ONE_KB];
-        iStream.read(0, b, 0, ONE_KB);
-        AbfsInputStream abfsIStream = (AbfsInputStream) iStream
-            .getWrappedStream();
-        Assertions.assertThat(abfsIStream.getBuffer().length).describedAs(
-            "Entire file should have been read as the file size is "
-                + "less than SLURP_FILE_SIZE (" + SLURP_FILE_SIZE + ")")
-            .isEqualTo(fileSize);
-      }
+      final Path testFilePath = createFileOfSize(fs,
+          methodName.getMethodName() + i, fileSize);
+      final long bytesRead = readOneKBAndGetFcursor(fs, testFilePath);
+      assertFileReadCompletely(bytesRead,fileSize,bufferSize);
     }
   }
 
   @Test
-  public void testBigFilesAreNotReadCompletely() throws Exception {
+  public void testSmallFilesAreReadCompletelyWithConfigOn() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    for (int i = 5; i <= 8; i++) {
-      final int readBufferSize = i * ONE_KB;
+    final int bufferSize = 4 * ONE_MB;
+    fs.getAbfsStore().getAbfsConfiguration().setReadBufferSize(bufferSize);
+    fs.getAbfsStore().getAbfsConfiguration().setReadSmallFilesCompletely(true);
+    for (int i = 1; i <= 4; i++) {
       final int fileSize = i * ONE_MB;
-      fs.getAbfsStore().getAbfsConfiguration()
-          .setReadBufferSize(readBufferSize);
-      final Path testFilePath = path(methodName.getMethodName() + i);
-      final byte[] iBuffer = getRandomBytesArray(fileSize);
-      try (FSDataOutputStream oStream = fs.create(testFilePath)) {
-        oStream.write(iBuffer);
-        oStream.flush();
-      }
-      try (FSDataInputStream iStream = fs.open(testFilePath)) {
-        byte[] b = new byte[ONE_KB];
-        iStream.read(0, b, 0, ONE_KB);
-        AbfsInputStream abfsIStream = (AbfsInputStream) iStream
-            .getWrappedStream();
-        Assertions.assertThat(abfsIStream.getBuffer().length)
-            .describedAs("It is expected to read only first "
-                + "AZURE_READ_BUFFER_SIZE ("+ readBufferSize + ") bytes")
-            .isEqualTo(readBufferSize);
-      }
+      final Path testFilePath = createFileOfSize(fs,
+          methodName.getMethodName() + i, fileSize);
+      final long bytesRead = readOneKBAndGetFcursor(fs, testFilePath);
+      assertFileReadCompletely(bytesRead,fileSize,bufferSize);
     }
+  }
+
+  @Test
+  public void testBigFilesAreNotReadCompletelyWithConfigOn() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.getAbfsStore().getAbfsConfiguration().setReadBufferSize(4 * ONE_MB);
+    fs.getAbfsStore().getAbfsConfiguration().setReadSmallFilesCompletely(true);
+    for (int i = 5; i <= 8; i++) {
+      final Path testFilePath = createFileOfSize(fs,
+          methodName.getMethodName() + i, i * ONE_MB);
+      final long bytesRead = readOneKBAndGetFcursor(fs, testFilePath);
+      assertFileNotReadCompletely(bytesRead, ONE_KB);
+    }
+  }
+
+  @Test
+  public void testSmallFilesAreReadNotCompletelyWithConfigOff() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    final int bufferSize = 4 * ONE_MB;
+    fs.getAbfsStore().getAbfsConfiguration().setReadBufferSize(bufferSize);
+    fs.getAbfsStore().getAbfsConfiguration().setReadSmallFilesCompletely(false);
+    for (int i = 1; i <= 4; i++) {
+      final int fileSize = i * ONE_MB;
+      final Path testFilePath = createFileOfSize(fs,
+          methodName.getMethodName() + i, fileSize);
+      final long bytesRead = readOneKBAndGetFcursor(fs, testFilePath);
+      assertFileNotReadCompletely(bytesRead, ONE_KB);
+    }
+  }
+
+  @Test
+  public void testBigFilesAreNotReadCompletelyWithConfigOff() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.getAbfsStore().getAbfsConfiguration().setReadBufferSize(4 * ONE_MB);
+    fs.getAbfsStore().getAbfsConfiguration().setReadSmallFilesCompletely(false);
+    for (int i = 5; i <= 8; i++) {
+      final Path testFilePath = createFileOfSize(fs,
+          methodName.getMethodName() + i, i * ONE_MB);
+      final long bytesRead = readOneKBAndGetFcursor(fs, testFilePath);
+      assertFileNotReadCompletely(bytesRead, ONE_KB);
+    }
+  }
+
+  private void assertFileReadCompletely(final long bytesRead,
+      final int fileSize, final int bufferSize){
+    Assertions.assertThat(bytesRead)
+        .describedAs("Entire file should have been read as the file size ("
+            +fileSize+") <= the buffer size (" + bufferSize + ")")
+        .isEqualTo(fileSize);
+  }
+
+  private void assertFileNotReadCompletely(final long bytesRead,
+      final int readLength){
+    Assertions.assertThat(bytesRead)
+        .describedAs("It is expected to read only the requested length ("
+            + readLength + ") bytes")
+        .isEqualTo(readLength);
+  }
+
+  private Path createFileOfSize(final FileSystem fs, final String fileName,
+      final int fileSize) throws IOException {
+    final Path testFilePath = path(fileName);
+    final byte[] iBuffer = getRandomBytesArray(fileSize);
+    try (FSDataOutputStream oStream = fs.create(testFilePath)) {
+      oStream.write(iBuffer);
+      oStream.flush();
+    }
+    return testFilePath;
+  }
+
+  private long readOneKBAndGetFcursor(final FileSystem fs,
+      final Path testFilePath)
+      throws IOException, NoSuchFieldException, IllegalAccessException {
+    try (FSDataInputStream iStream = fs.open(testFilePath)) {
+      AbfsInputStream abfsIStream = (AbfsInputStream) iStream
+          .getWrappedStream();
+      setIStreamForNonSequentialReadCondition(abfsIStream);
+      final int length = ONE_KB;
+      byte[] b = new byte[length];
+      iStream.read(0, b, 0, length);
+      return abfsIStream.getFcursor();
+    }
+  }
+
+  private void setIStreamForNonSequentialReadCondition(
+      AbfsInputStream abfsIStream)
+      throws IllegalAccessException, NoSuchFieldException {
+    Field fCursorAfterLastReadField = abfsIStream.getClass()
+        .getDeclaredField("fCursorAfterLastRead");
+    fCursorAfterLastReadField.setAccessible(true);
+    fCursorAfterLastReadField.setLong(abfsIStream, -2L);
   }
 
   private byte[] getRandomBytesArray(int length) {


### PR DESCRIPTION
Files that are of size smaller than the read buffer size can be considered as small files. In case of such files it would be better to read the full file into the AbfsInputStream buffer.

**Driver test results using accounts in Central India**
mvn -T 1C -Dparallel-tests=abfs -Dscale -DtestsThreadCount=8 clean verify

HNS-OAuth
========================
[INFO] Results:
[INFO] 
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
[INFO] Results:
[INFO] 
[WARNING] Tests run: 462, Failures: 0, Errors: 0, Skipped: 64
[INFO] Results:
[INFO] 
[WARNING] Tests run: 208, Failures: 0, Errors: 0, Skipped: 24

HNS-SharedKey
========================
[INFO] Results:
[INFO] 
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
[INFO] Results:
[INFO] 
[WARNING] Tests run: 462, Failures: 0, Errors: 0, Skipped: 24
[INFO] Results:
[INFO] 
[WARNING] Tests run: 208, Failures: 0, Errors: 0, Skipped: 16

NonHNS-SharedKey
========================
[INFO] Results:
[INFO] 
[INFO] Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
[INFO] Results:
[INFO] 
[WARNING] Tests run: 462, Failures: 0, Errors: 0, Skipped: 245
[INFO] Results:
[INFO] 
[WARNING] Tests run: 208, Failures: 0, Errors: 0, Skipped: 16