### PR TITLE
HDFS-15667. Audit log record the unexpected allowed result when delete

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3321,7 +3321,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       throw e;
     }
     getEditLog().logSync();
-    logAuditEvent(true, operationName, src);
+    logAuditEvent(ret, operationName, src);
     if (toRemovedBlocks != null) {
       removeBlocks(toRemovedBlocks); // Incremental deletion of blocks
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
@@ -51,6 +51,7 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_ALWAYS_USE_KEY;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import org.mockito.Mockito;
 
@@ -1211,7 +1212,7 @@ public class TestAuditLoggerWithCommands {
     fileSys = DFSTestUtil.getFileSystemAs(user1, conf);
     boolean result = fileSys.delete(srcDir, true);
     fileSys.close();
-    assertTrue(result == false);
+    assertFalse(result);
     String aceDeletePattern =
         ".*allowed=false.*ugi=theDoctor.*cmd=delete.*";
     verifyAuditLogs(aceDeletePattern);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
@@ -1215,7 +1215,7 @@ public class TestAuditLoggerWithCommands {
     String aceDeletePattern =
         ".*allowed=false.*ugi=theDoctor.*cmd=delete.*";
     verifyAuditLogs(aceDeletePattern);
-  }  
+  }
 
   private void verifyAuditRestoreFailedStorageACE(
       FSNamesystem fsNamesystem, String arg) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
@@ -1205,6 +1205,18 @@ public class TestAuditLoggerWithCommands {
     }
   }
 
+  @Test
+  public void testDeleteRoot() throws Exception {
+    Path srcDir = new Path("/");
+    fileSys = DFSTestUtil.getFileSystemAs(user1, conf);
+    boolean result = fileSys.delete(srcDir, true);
+    fileSys.close();
+    assertTrue(result == false);
+    String aceDeletePattern =
+        ".*allowed=false.*ugi=theDoctor.*cmd=delete.*";
+    verifyAuditLogs(aceDeletePattern);
+  }  
+
   private void verifyAuditRestoreFailedStorageACE(
       FSNamesystem fsNamesystem, String arg) throws IOException {
     String operationName = fsNamesystem.getFailedStorageCommand(arg);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15667

![image](https://user-images.githubusercontent.com/17329931/98193169-817cfd00-1f57-11eb-9eb1-9da3c5887b9c.png)

![image](https://user-images.githubusercontent.com/17329931/98193241-ac675100-1f57-11eb-9d79-4bd31dfaf5ee.png)

![image](https://user-images.githubusercontent.com/17329931/98193377-ffd99f00-1f57-11eb-823d-26e34d0fe3b0.png)


The file disallow to be deleted, but record a `allowed=true` into auditlog, that is confusing me.