### PR TITLE
HADOOP-17363. ABFS: Fix Oauth 2.0 username-password authentication issues

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -676,7 +676,9 @@ public class AbfsConfiguration{
           String authEndpoint = getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ENDPOINT);
           String username = getPasswordString(FS_AZURE_ACCOUNT_OAUTH_USER_NAME);
           String password = getPasswordString(FS_AZURE_ACCOUNT_OAUTH_USER_PASSWORD);
-          tokenProvider = new UserPasswordTokenProvider(authEndpoint, username, password);
+          String clientId = getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
+          String clientSecret = getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_SECRET);
+          tokenProvider = new UserPasswordTokenProvider(authEndpoint, username, password, clientId, clientSecret);
           LOG.trace("UserPasswordTokenProvider initialized");
         } else if (tokenProviderClass == MsiTokenProvider.class) {
           String authEndpoint = getTrimmedPasswordString(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/UserPasswordTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/UserPasswordTokenProvider.java
@@ -35,22 +35,30 @@ public class UserPasswordTokenProvider extends AccessTokenProvider {
 
   private final String password;
 
+  private final String clientId;
+
+  private final String clientSecret;
+
   private static final Logger LOG = LoggerFactory.getLogger(AccessTokenProvider.class);
 
   public UserPasswordTokenProvider(final String authEndpoint,
-                                   final String username, final String password) {
+                                   final String username, final String password,
+                                   final String clientId, final String clientSecret) {
     Preconditions.checkNotNull(authEndpoint, "authEndpoint");
     Preconditions.checkNotNull(username, "username");
     Preconditions.checkNotNull(password, "password");
+    Preconditions.checkNotNull(clientId, "clientId");
 
     this.authEndpoint = authEndpoint;
     this.username = username;
     this.password = password;
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
   }
 
   @Override
   protected AzureADToken refreshToken() throws IOException {
     LOG.debug("AADToken: refreshing user-password based token");
-    return AzureADAuthenticator.getTokenUsingClientCreds(authEndpoint, username, password);
+    return AzureADAuthenticator.getTokenUsingUserCreds(authEndpoint, username, password, clientId, clientSecret);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -467,6 +467,20 @@ An OAuth 2.0 endpoint, username and password are provided in the configuration/J
   password for account
   </description>
 </property>
+<property>
+  <name>fs.azure.account.oauth2.client.id</name>
+  <value></value>
+  <description>
+  Client ID
+  </description>
+</property>
+<property>
+  <name>fs.azure.account.oauth2.client.secret</name>
+  <value></value>
+  <description>
+  Optional Secret
+  </description>
+</property>
 ```
 
 ### <a name="oauth-refresh-token"></a> OAuth 2.0: Refresh Token


### PR DESCRIPTION
https://hadoop.apache.org/docs/current/hadoop-azure/abfs.html

I have tried OAuth 2.0 authentication with the username and password written above.
However, it failed with the following exception.

~~~
Exception in thread "main" HTTP Error 400; url='https://login.microsoftonline.com/3070a5de-410e-4885-XXXX-XXXXXXXXXXXX/oauth2/token' AADToken: HTTP connection to https://login.microsoftonline.com/3070a5de-410e-4885-XXXX-XXXXXXXXXXXX/oauth2/token failed for getting token from AzureAD.; requestId='187c97a4-82a0-4b36-b764-XXXXXXXXXXXX'; contentType='application/json; charset=utf-8'; response '{"error":"unauthorized_client","error_description":"AADSTS700016: Application with identifier 'jiro' was not found in the directory '3070a5de-410e-4885-XXXX-XXXXXXXXXXXX'. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You may have sent your authentication request to the wrong tenant.\r\nTrace ID: 187c97a4-82a0-4b36-b764-a3b8b1c45201\r\nCorrelation ID: 4eb4a71e-2eef-4788-9c8c-24f4c84f6981\r\nTimestamp: 2020-11-07 11:49:21Z","error_codes":[700016],"timestamp":"2020-11-07 11:49:21Z","trace_id":"187c97a4-82a0-4b36-b764-a3b8b1c45201","correlation_id":"4eb4a71e-2eef-4788-9c8c-24f4c84f6981","error_uri":"https://login.microsoftonline.com/error?code=700016"}'org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator$HttpException: HTTP Error 400; url='https://login.microsoftonline.com/3070a5de-410e-4885-b6cd-95fe759ced2b/oauth2/token' AADToken: HTTP connection to https://login.microsoftonline.com/3070a5de-410e-4885-XXXX-XXXXXXXXXXXX/oauth2/token failed for getting token from AzureAD.; requestId='187c97a4-82a0-4b36-b764-XXXXXXXXXXXX'; contentType='application/json; charset=utf-8'; response '{"error":"unauthorized_client","error_description":"AADSTS700016: Application with identifier 'jiro' was not found in the directory '3070a5de-410e-4885-XXXX-XXXXXXXXXXXX'. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You may have sent your authentication request to the wrong tenant.\r\nTrace ID: 187c97a4-82a0-4b36-b764-a3b8b1c45201\r\nCorrelation ID: 4eb4a71e-2eef-4788-9c8c-24f4c84f6981\r\nTimestamp: 2020-11-07 11:49:21Z","error_codes":[700016],"timestamp":"2020-11-07 11:49:21Z","trace_id":"187c97a4-82a0-4b36-b764-a3b8b1c45201","correlation_id":"4eb4a71e-2eef-4788-9c8c-24f4c84f6981","error_uri":"https://login.microsoftonline.com/error?code=700016"}'
	at org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation.executeHttpOperation(AbfsRestOperation.java:215)
	at org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation.execute(AbfsRestOperation.java:134)
	at org.apache.hadoop.fs.azurebfs.services.AbfsClient.createPath(AbfsClient.java:293)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.createDirectory(AzureBlobFileSystemStore.java:445)
	at org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.mkdirs(AzureBlobFileSystem.java:409)
	at org.apache.hadoop.fs.FileSystem.mkdirs(FileSystem.java:2355)
	at com.sample.HelloWorld.main(HelloWorld.java:116)
Caused by: org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator$HttpException: HTTP Error 400; url='https://login.microsoftonline.com/3070a5de-410e-XXXX-XXXXXXXXXXXX/oauth2/token' AADToken: HTTP connection to https://login.microsoftonline.com/3070a5de-410e-4885-XXXX-XXXXXXXXXXXX/oauth2/token failed for getting token from AzureAD.; requestId='187c97a4-82a0-4b36-b764-a3b8b1c45201'; contentType='application/json; charset=utf-8'; response '{"error":"unauthorized_client","error_description":"AADSTS700016: Application with identifier 'jiro' was not found in the directory '3070a5de-410e-4885-XXXX-XXXXXXXXXXXX'. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You may have sent your authentication request to the wrong tenant.\r\nTrace ID: 187c97a4-82a0-4b36-b764-a3b8b1c45201\r\nCorrelation ID: 4eb4a71e-2eef-4788-9c8c-24f4c84f6981\r\nTimestamp: 2020-11-07 11:49:21Z","error_codes":[700016],"timestamp":"2020-11-07 11:49:21Z","trace_id":"187c97a4-82a0-4b36-b764-a3b8b1c45201","correlation_id":"4eb4a71e-2eef-4788-9c8c-24f4c84f6981","error_uri":"https://login.microsoftonline.com/error?code=700016"}'
	at org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.getTokenSingleCall(AzureADAuthenticator.java:394)
	at org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.getTokenCall(AzureADAuthenticator.java:291)
	at org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.getTokenCall(AzureADAuthenticator.java:273)
	at org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator.getTokenUsingClientCreds(AzureADAuthenticator.java:96)
	at org.apache.hadoop.fs.azurebfs.oauth2.UserPasswordTokenProvider.refreshToken(UserPasswordTokenProvider.java:54)
	at org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider.getToken(AccessTokenProvider.java:50)
	at org.apache.hadoop.fs.azurebfs.services.AbfsClient.getAccessToken(AbfsClient.java:670)
	at org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation.executeHttpOperation(AbfsRestOperation.java:168)
	... 6 more
~~~

The cause of the error seems to be that UserPasswordTokenProvider is calling getTokenUsingClientCreds() for the service principal.

https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth-ropc

I checked the API specifications of Azure and fixed the cause of this error.