### PR TITLE
HADOOP-17369. Bump up snappy-java to 1.1.8.1.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -143,7 +143,7 @@
     <metrics.version>3.2.4</metrics.version>
     <netty3.version>3.10.6.Final</netty3.version>
     <netty4.version>4.1.50.Final</netty4.version>
-    <snappy-java.version>1.1.7.7</snappy-java.version>
+    <snappy-java.version>1.1.8.1</snappy-java.version>
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17369