### PR TITLE
HADOOP-17370. Upgrade commons-compress to 1.20

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -286,7 +286,7 @@ net.minidev:accessors-smart:1.2
 net.minidev:json-smart:2.3
 org.apache.avro:avro:1.7.7
 org.apache.commons:commons-collections4:4.2
-org.apache.commons:commons-compress:1.19
+org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-configuration2:2.1.1
 org.apache.commons:commons-csv:1.0
 org.apache.commons:commons-digester:1.8.1

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -118,7 +118,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-compress.version>1.19</commons-compress.version>
+    <commons-compress.version>1.20</commons-compress.version>
     <commons-csv.version>1.0</commons-csv.version>
     <commons-io.version>2.5</commons-io.version>
     <commons-lang3.version>3.7</commons-lang3.version>


### PR DESCRIPTION
This PR aims to upgrade commons-compress to 1.20 to bring the following fix.

- https://commons.apache.org/proper/commons-compress/security-reports.html
