### PR TITLE
HADOOP-17373. hadoop-client-integration-tests doesn't work when building with skipShade

### DIFF
--- a/hadoop-client-modules/hadoop-client-integration-tests/pom.xml
+++ b/hadoop-client-modules/hadoop-client-integration-tests/pom.xml
@@ -180,6 +180,12 @@
           <scope>test</scope>
           <type>test-jar</type>
         </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-tests</artifactId>
+          <scope>test</scope>
+          <type>test-jar</type>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
