### PR TITLE
HADOOP-17379. AbstractS3ATokenIdentifier to set issue date == now.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
@@ -25,7 +25,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
@@ -24,6 +24,8 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -140,6 +142,7 @@ public abstract class AbstractS3ATokenIdentifier
       final URI uri) {
     super(kind, owner, renewer, realUser);
     this.uri = requireNonNull(uri);
+    initializeIssueDate();
   }
 
   /**
@@ -164,6 +167,13 @@ public abstract class AbstractS3ATokenIdentifier
    */
   protected AbstractS3ATokenIdentifier(final Text kind) {
     super(kind);
+    initializeIssueDate();
+  }
+
+  private void initializeIssueDate() {
+    Clock clock = Clock.systemDefaultZone();
+    long now = clock.millis();
+    setIssueDate(now);
   }
 
   public String getBucket() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
@@ -38,6 +38,7 @@ import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.SESSI
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests related to S3A DT support.
@@ -56,6 +57,14 @@ public class TestS3ADelegationTokenSupport {
     AbstractS3ATokenIdentifier identifier
         = new SessionTokenIdentifier();
     assertEquals(SESSION_TOKEN_KIND, identifier.getKind());
+  }
+
+  @Test
+  public void testSessionTokenIssueDate() throws Throwable {
+    AbstractS3ATokenIdentifier identifier
+        = new SessionTokenIdentifier();
+    assertEquals(SESSION_TOKEN_KIND, identifier.getKind());
+    assertTrue("issue date is not set", identifier.getIssueDate() > 0L);
   }
 
   @Test
@@ -90,6 +99,7 @@ public class TestS3ADelegationTokenSupport {
         UserGroupInformation.AuthenticationMethod.TOKEN,
         decodedUser.getAuthenticationMethod());
     assertEquals("origin", decoded.getOrigin());
+    assertEquals("issue date", identifier.getIssueDate(), decoded.getIssueDate());
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
@@ -99,7 +99,8 @@ public class TestS3ADelegationTokenSupport {
         UserGroupInformation.AuthenticationMethod.TOKEN,
         decodedUser.getAuthenticationMethod());
     assertEquals("origin", decoded.getOrigin());
-    assertEquals("issue date", identifier.getIssueDate(), decoded.getIssueDate());
+    assertEquals("issue date", identifier.getIssueDate(),
+        decoded.getIssueDate());
   }
 
   @Test


### PR DESCRIPTION
This patch ensures that all token identifiers extending AbstractS3ATokenIdentifier to have issue date as the time the identifier instance is created.