### PR TITLE
HADOOP-17343. Upgrade AWS SDK to 1.11.901

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -215,7 +215,7 @@ com.aliyun:aliyun-java-sdk-ecs:4.2.0
 com.aliyun:aliyun-java-sdk-ram:3.0.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.4.1
-com.amazonaws:aws-java-sdk-bundle:1.11.563
+com.amazonaws:aws-java-sdk-bundle:1.11.901
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1
 com.fasterxml.jackson.core:jackson-annotations:2.9.9

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -186,7 +186,7 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.11.563</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.901</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
     <jasmine-maven-plugin.version>2.1</jasmine-maven-plugin.version>


### PR DESCRIPTION
Upgrade the AWS SDK to the latest release

Includes the changes to the manual steps of the regression testing needed to test directory marker support

Tested AWS London (v4 signing only, BTW)

* Integration tests ( -Dparallel-tests -DtestsThreadCount=4 -Dmarkers=keep -Ds3guard -Ddynamo  -Dfs.s3a.directory.marker.audit=true) with review of all output files. 
* Downstream spark build and run through spark-cloud-integration suite
* Manual commands from the testing document

