### PR TITLE
HADOOP-17385. ITestS3ADeleteCost.testDirMarkersFileCreation failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -4951,6 +4951,15 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   }
 
   /**
+   * This is purely for testing, as it force initializes all static
+   * initializers. See HADOOP-17385 for details.
+   */
+  @InterfaceAudience.Private
+  public static void initializeClass() {
+    LOG.debug("Initialize S3A class");
+  }
+
+  /**
    * The implementation of context accessors.
    */
   private class ContextAccessorsImpl implements ContextAccessors {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/S3AContract.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/S3AContract.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractBondedFSContract;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 
 /**
@@ -53,6 +54,9 @@ public class S3AContract extends AbstractBondedFSContract {
    */
   public S3AContract(Configuration conf, boolean addContractResource) {
     super(conf);
+    // Force deprecated key load through the
+    // static initializers. See: HADOOP-17385
+    S3AFileSystem.initializeClass();
     //insert the base features
     if (addContractResource) {
       addConfResource(CONTRACT_XML);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -61,7 +61,7 @@ public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
     // our tests start adding/removing options. See HADOOP-16626.
     FileSystem.getLocal(new Configuration());
     // instantiate an S3A FS here here to force deprecated key load through the
-    // static initializers. See: HADOOP-17835
+    // static initializers. See: HADOOP-17385
     new S3AFileSystem();
     super.setup();
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -60,6 +60,9 @@ public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
     // filesystems which add default configuration resources to do it before
     // our tests start adding/removing options. See HADOOP-16626.
     FileSystem.getLocal(new Configuration());
+    // instantiate an S3A FS here here to force deprecated key load through the
+    // static initializers. See: HADOOP-17835
+    new S3AFileSystem();
     super.setup();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -60,9 +60,9 @@ public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
     // filesystems which add default configuration resources to do it before
     // our tests start adding/removing options. See HADOOP-16626.
     FileSystem.getLocal(new Configuration());
-    // instantiate an S3A FS here here to force deprecated key load through the
+    // Force deprecated key load through the
     // static initializers. See: HADOOP-17385
-    new S3AFileSystem();
+    S3AFileSystem.initializeClass();
     super.setup();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.Tristate;
+import org.apache.hadoop.fs.s3a.impl.DirectoryPolicy;
+import org.apache.hadoop.fs.s3a.impl.DirectoryPolicyImpl;
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;
@@ -140,6 +142,14 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
     isKeeping = isKeepingMarkers();
 
     isDeleting = !isKeeping;
+
+    // check that the FS has the expected state
+    DirectoryPolicy markerPolicy = fs.getDirectoryMarkerPolicy();
+    Assertions.assertThat(markerPolicy.getMarkerPolicy())
+        .describedAs("Marker policy for filesystem %s", fs)
+        .isEqualTo(isKeepingMarkers()
+            ? DirectoryPolicy.MarkerPolicy.Keep
+            : DirectoryPolicy.MarkerPolicy.Delete);
 
     // insert new metrics so as to keep the list sorted
     costValidator = OperationCostValidator.builder(getFileSystem())

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.Tristate;
 import org.apache.hadoop.fs.s3a.impl.DirectoryPolicy;
-import org.apache.hadoop.fs.s3a.impl.DirectoryPolicyImpl;
 import org.apache.hadoop.fs.s3a.impl.StatusProbeEnum;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3ADeleteCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3ADeleteCost.java
@@ -267,6 +267,7 @@ public class ITestS3ADeleteCost extends AbstractS3ACostTest {
 
     verifyMetrics(() -> {
       file(new Path(srcDir, "source.txt"));
+      LOG.info("Metrics: {}\n{}", getMetricSummary(), getFileSystem());
       return "after touch(fs, srcFilePath) " + getMetricSummary();
     },
         with(DIRECTORIES_CREATED, 0),


### PR DESCRIPTION
The addition of deprecated S3A configuration options in HADOOP-17318
triggered a reload of default (xml resource) configurations, which breaks
tests which fail if there's a per-bucket setting inconsistent with test
setup.

Creating an S3AFS instance before creating the Configuration() instance
for test runs gets that reload out the way before test setup takes
place.

Along with the fix, extra changes in the failing test suite to fail
fast when marker policy isn't as expected, and to log FS state better.

Testing: S3 London with marker policy forced to override (which is why this specific test failed)

