### PR TITLE
HADOOP-14650. Upgrade javax.servlet.jsp:jsp-api to 2.1.1

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -807,7 +807,7 @@
       <dependency>
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>jsp-api</artifactId>
-        <version>2.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>


### PR DESCRIPTION
`javax.servlet.jsp:jsp-api:2.1` directly contains the classes of `javax.el:el-api`. This results in duplicate classes on the classpath in projects that pull in both of these dependencies.

`javax.servlet.jsp:jsp-api:2.1.1` depends on `javax.el:el-api` instead of directly containing the classes, which avoids these issues.

See:
- https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api/2.1
- https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api/2.1.1