### PR TITLE
HDFS-15672. TestBalancerWithMultipleNameNodes#testBalancingBlockpoolsWithBlockPoolPolicy fails on trunk.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
@@ -146,15 +146,16 @@ public class TestBalancerWithMultipleNameNodes {
   }
 
   /* wait for one heartbeat */
-  static void wait(final ClientProtocol[] clients,
+  static void wait(final Suite suite,
       long expectedUsedSpace, long expectedTotalSpace) throws IOException {
     LOG.info("WAIT expectedUsedSpace=" + expectedUsedSpace
         + ", expectedTotalSpace=" + expectedTotalSpace);
-    for(int n = 0; n < clients.length; n++) {
+    suite.cluster.triggerHeartbeats();
+    for(int n = 0; n < suite.clients.length; n++) {
       int i = 0;
       for(boolean done = false; !done; ) {
-        final long[] s = clients[n].getStats();
-        done = s[0] == expectedTotalSpace && s[1] == expectedUsedSpace;
+        final long[] s = suite.clients[n].getStats();
+        done = s[0] == expectedTotalSpace && s[1] >= expectedUsedSpace;
         if (!done) {
           sleep(100L);
           if (++i % 100 == 0) {
@@ -172,7 +173,7 @@ public class TestBalancerWithMultipleNameNodes {
     LOG.info("BALANCER 0: totalUsed=" + totalUsed
         + ", totalCapacity=" + totalCapacity
         + ", avg=" + avg);
-    wait(s.clients, totalUsed, totalCapacity);
+    wait(s, totalUsed, totalCapacity);
     LOG.info("BALANCER 1");
 
     // get storage reports for relevant blockpools so that we can compare
@@ -186,7 +187,7 @@ public class TestBalancerWithMultipleNameNodes {
     Assert.assertEquals(ExitStatus.SUCCESS.getExitCode(), r);
 
     LOG.info("BALANCER 2");
-    wait(s.clients, totalUsed, totalCapacity);
+    wait(s, totalUsed, totalCapacity);
     LOG.info("BALANCER 3");
 
     int i = 0;
@@ -530,7 +531,7 @@ public class TestBalancerWithMultipleNameNodes {
 
       LOG.info("RUN_TEST 2: create files");
       // fill up the cluster to be 30% full
-      final long totalUsed = (totalCapacity * s.replication)*3/10;
+      final long totalUsed = totalCapacity * 3 / 10;
       final long size = (totalUsed/nNameNodes)/s.replication;
       for(int n = 0; n < nNameNodes; n++) {
         createFile(s, n, size);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15672

The setting of testBalancingBlockpoolsWithBlockPoolPolicy is

* 2 NameNodes (2 name spaces)
* 4 DataNodes (with 500 bytes capacity per node)
* blocksize = 100, replication factor = 2
* creating 300 bytes file on both name spaces (6 blocks total)
* add 2 DataNodes (with 500 bytes capacity per node)
* running balancer

If one of the DataNode is chosen for all 6 blocks, no free space is available. The error causes retry of block creation.

```
2020-11-18 06:01:36,648 [DataXceiver for client DFSClient_NONMAPREDUCE_1983766438_12 at /127.0.0.1:46158 [Receiving block BP-631108559-172.31.197.233-1605679293748:blk_1073741827_1003]] ERROR datanode.DataNode (DataXceiver.java:run(324)) - host1.foo.com:43495:DataXceiver error processing WRITE_BLOCK operation  src: /127.0.0.1:46158 dst: /127.0.0.1:43495
java.io.IOException: Creating block, no free space available
```

The garbage breaks assertion about total used space.

```
2020-11-18 06:01:37,361 [Listener at localhost/43281] INFO  balancer.Balancer (TestBalancerWithMultipleNameNodes.java:runBalancer(172)) - BALANCER 0: totalUsed=1200, totalCapacity=3000, avg=40.0
2020-11-18 06:01:37,361 [Listener at localhost/43281] INFO  balancer.Balancer (TestBalancerWithMultipleNameNodes.java:wait(151)) - WAIT expectedUsedSpace=1200, expectedTotalSpace=3000
...(snip)
2020-11-18 06:01:47,372 [Listener at localhost/43281] WARN  balancer.Balancer (TestBalancerWithMultipleNameNodes.java:wait(161)) - WAIT i=100, s=[3000, 1300]
```