### PR TITLE
HADOOP-17388. AbstractS3ATokenIdentifier to issue date in UTC

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/AbstractS3ATokenIdentifier.java
@@ -24,7 +24,6 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
-import java.time.Clock;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -32,6 +31,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
+import org.apache.hadoop.util.Time;
 
 import static java.util.Objects.requireNonNull;
 
@@ -170,9 +170,7 @@ public abstract class AbstractS3ATokenIdentifier
   }
 
   private void initializeIssueDate() {
-    Clock clock = Clock.systemDefaultZone();
-    long now = clock.millis();
-    setIssueDate(now);
+    setIssueDate(Time.now());
   }
 
   public String getBucket() {


### PR DESCRIPTION
In HADOOP-17379, I missed to set issue date as local timezone sensitive, whereas we actually set issue date in UTC.

https://github.com/apache/hadoop/blob/07050339e0a41a7d4b89b852ffdd7aa315a9184b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java#L418-L439

This PR fixes the issue.