### PR TITLE
HADOOP-17325. WASB: Test failure in trunk

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -655,9 +655,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
       // because the mock container does not exist, this call is expected to fail.
       intercept(IllegalArgumentException.class,
               "java.net.UnknownHostException",
-              () -> {
-                fs0.getCanonicalServiceName();
-              });
+              () -> fs0.getCanonicalServiceName());
 
       conf.setBoolean(RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME, true);
       FileSystem fs1 = FileSystem.newInstance(defaultUri, conf);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/InMemoryBlockBlobStore.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/InMemoryBlockBlobStore.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * A simple memory key-value store to help mock the Windows Azure Storage

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/InMemoryBlockBlobStore.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/InMemoryBlockBlobStore.java
@@ -25,6 +25,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertNotNull;
+
 /**
  * A simple memory key-value store to help mock the Windows Azure Storage
  * implementation for unit testing.
@@ -163,7 +166,10 @@ public class InMemoryBlockBlobStore {
 
   @SuppressWarnings("unchecked")
   public synchronized HashMap<String, String> getMetadata(String key) {
-    return (HashMap<String, String>) blobs.get(key).metadata.clone();
+    Entry entry = requireNonNull(blobs.get(key), "entry for " + key);
+    return (HashMap<String, String>) requireNonNull(entry.metadata,
+        "metadata for " + key)
+        .clone();
   }
 
   public synchronized HashMap<String, String> getContainerMetadata() {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/MockStorageInterface.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/MockStorageInterface.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/MockStorageInterface.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/MockStorageInterface.java
@@ -139,9 +139,10 @@ public class MockStorageInterface extends StorageInterface {
 
   private static URI convertKeyToEncodedUri(String key) {
     try {
-      URI unEncodedURI = new URI(key);
-      return new URIBuilder().setPath(unEncodedURI.getRawPath())
-          .setScheme(unEncodedURI.getScheme()).build();
+     Path p = new Path(key);
+     URI unEncodedURI = p.toUri();
+     return new URIBuilder().setPath(unEncodedURI.getPath())
+         .setScheme(unEncodedURI.getScheme()).build();
     } catch (URISyntaxException e) {
       int i = e.getIndex();
       String details;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobMetadata.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobMetadata.java
@@ -202,8 +202,10 @@ public class TestBlobMetadata extends AbstractWasbTestWithTimeout {
     Path selfishFile = new Path("/noOneElse");
     fs.create(selfishFile, justMe, true, 4096, fs.getDefaultReplication(),
         fs.getDefaultBlockSize(), null).close();
+    String mockUri = AzureBlobStorageTestAccount.toMockUri(selfishFile);
+    assertNotNull("converted URI", mockUri);
     HashMap<String, String> metadata = backingStore
-        .getMetadata(AzureBlobStorageTestAccount.toMockUri(selfishFile));
+        .getMetadata(mockUri);
     assertNotNull(metadata);
     String storedPermission = metadata.get("hdi_permission");
     assertEquals(getExpectedPermissionString("rw-------"), storedPermission);


### PR DESCRIPTION
Contributed by Ayush Saxena and Steve Loughran

Change-Id: I6d70b6f69f11c61bedd9b20ad2113150d2c25857

### Testing

trying to get wasb test setup against a storage account without http support. Looks like fs.azure.secure.mode=true will do this. Maybe it should become the default

lets see what yetus says.