### PR TITLE
HDFS-15690. Add lz4-java as test dependency

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -219,6 +219,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>assertj-core</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HDFS-15690 for details.

` TestFSImage.testNativeCompression` failed with `java.lang.NoClassDefFoundError: net/jpountz/lz4/LZ4Factory`:

https://ci-hadoop.apache.org/job/PreCommit-HDFS-Build/305/testReport/junit/org.apache.hadoop.hdfs.server.namenode/TestFSImage/testNativeCompression/

We need to have lz4-java as test dependency.

