### PR TITLE
YARN-10499. TestRouterWebServiceREST fails (#2490). Contributed by Akira Ajisaka

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
@@ -181,6 +181,10 @@ public class CSMappingPlacementRule extends PlacementRule {
       return;
     }
     Set<String> groupsSet = groups.getGroupsSet(user);
+    if (groupsSet.isEmpty()) {
+      LOG.warn("There are no groups for user {}", user);
+      return;
+    }
     String secondaryGroup = null;
     Iterator<String> it = groupsSet.iterator();
     String primaryGroup = it.next();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
@@ -183,6 +183,7 @@ public class CSMappingPlacementRule extends PlacementRule {
     Set<String> groupsSet = groups.getGroupsSet(user);
     if (groupsSet.isEmpty()) {
       LOG.warn("There are no groups for user {}", user);
+      vctx.putExtraDataset("groups", groupsSet);
       return;
     }
     String secondaryGroup = null;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
@@ -155,6 +155,7 @@ public class TestRouterWebServicesREST {
   /** The number of concurrent submissions for multi-thread test. */
   private static final int NUM_THREADS_TESTS = 100;
 
+
   private static String userName = "test";
 
   private static JavaProcess rm;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
@@ -155,7 +155,6 @@ public class TestRouterWebServicesREST {
   /** The number of concurrent submissions for multi-thread test. */
   private static final int NUM_THREADS_TESTS = 100;
 
-
   private static String userName = "test";
 
   private static JavaProcess rm;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YARN-10499

In the test, the groupSet is empty and `it.next()` throws NoSuchElementException.
If the groupSet is empty, skip checking the set.