### PR TITLE
HADOOP-17396. ABFS: testRenameFileOverExistingFile Fails after Contract test update

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRename.java
@@ -38,6 +38,11 @@ public class ITestAbfsFileSystemContractRename extends AbstractContractRenameTes
   public void setup() throws Exception {
     binding.setup();
     super.setup();
+    // Base rename contract test class re-uses the test folder
+    // This leads to failures when the test is re-run as same ABFS test
+    // containers are re-used for test run and creation of source and
+    // destination test paths fail, as they are already present.
+    binding.getFileSystem().delete(binding.getTestPath(), true);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/resources/azure-test.xml
+++ b/hadoop-tools/hadoop-azure/src/test/resources/azure-test.xml
@@ -38,6 +38,11 @@
     <value>false</value>
   </property>
 
+  <property>
+    <name>fs.contract.rename-returns-false-if-dest-exists</name>
+    <value>true</value>
+  </property>
+
   <!--====================  ABFS CONFIGURATION ====================-->
   <!-- SEE relevant section in "site/markdown/testing_azure.md"-->
 


### PR DESCRIPTION
Post updates to rename on existing file test, ABFS contract test is having failure. Updates were made in the AbstractContractTest class in https://issues.apache.org/jira/browse/HADOOP-17365.

To align to test expectation of no exception but a false return from rename, ABFS tests need config "fs.contract.rename-returns-false-if-dest-exists" set to true. 

Also the abstract class was reusing a static test folder path.  Hence on test re-run, where same storage container is used, source and destination path creations will fail with FileAlreadyExists, leading to test failures. This is also fixed.

[Test results pasted at the end of conversation tab].