### PR TITLE
HADOOP-17397. ABFS: SAS Test updates for version and permission update

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/DelegationSASGenerator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/DelegationSASGenerator.java
@@ -88,7 +88,7 @@ public class DelegationSASGenerator extends SASGenerator {
         break;
       case SASTokenProvider.SET_ACL_OPERATION:
       case SASTokenProvider.SET_PERMISSION_OPERATION:
-        sp = "p";
+        sp = "op";
         break;
       case SASTokenProvider.SET_OWNER_OPERATION:
         sp = "o";

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/ServiceSASGenerator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/ServiceSASGenerator.java
@@ -38,7 +38,7 @@ public class ServiceSASGenerator extends SASGenerator {
 
   public String getContainerSASWithFullControl(String accountName, String containerName) {
     String sp = "rcwdl";
-    String sv = AuthenticationVersion.Nov18.toString();
+    String sv = AuthenticationVersion.Feb20.toString();
     String sr = "c";
     String st = ISO_8601_FORMATTER.format(Instant.now().minus(FIVE_MINUTES));
     String se = ISO_8601_FORMATTER.format(Instant.now().plus(ONE_DAY));


### PR DESCRIPTION
Below updates are made:
1. Upgrading the SAS version in Service SAS generator to Feb20 which is the latest server supported version (test code)
2. Updating the permission in Delegation SAS to "op" from "p" for ACL operation as identities added as suoid/saoid added by tests are not owners of test path (Again test code).
Relevant public documentation: https://docs.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#specify-a-signed-object-id-for-a-security-principal-preview

Tests were re-run. Test results posted at end of conversation tab.