### PR TITLE
HADOOP-17398. Skipping network I/O in S3A getFileStatus(/) breaks some tests

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
@@ -282,16 +282,24 @@ public final class MarkerTool extends S3GuardTool {
     }
     FileSystem fs = path.getFileSystem(getConf());
     boolean nonAuth = command.getOpt(OPT_NONAUTH);
-    ScanResult result = execute(
-        new ScanArgsBuilder()
-            .withSourceFS(fs)
-            .withPath(path)
-            .withDoPurge(clean)
-            .withMinMarkerCount(expectedMin)
-            .withMaxMarkerCount(expectedMax)
-            .withLimit(limit)
-            .withNonAuth(nonAuth)
-            .build());
+    ScanResult result;
+    try {
+      result = execute(
+              new ScanArgsBuilder()
+                      .withSourceFS(fs)
+                      .withPath(path)
+                      .withDoPurge(clean)
+                      .withMinMarkerCount(expectedMin)
+                      .withMaxMarkerCount(expectedMax)
+                      .withLimit(limit)
+                      .withNonAuth(nonAuth)
+                      .build());
+    } catch (UnknownStoreException ex) {
+      // bucket doesn't exist.
+      // replace the stack trace with an error code.
+      throw new ExitUtil.ExitException(EXIT_NOT_FOUND,
+              ex.toString(), ex);
+    }
     if (verbose) {
       dumpFileSystemStatistics(out);
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABucketExistence.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABucketExistence.java
@@ -62,8 +62,10 @@ public class ITestS3ABucketExistence extends AbstractS3ATestBase {
 
     Path root = new Path(uri);
 
-    expectUnknownStore(
-        () -> fs.getFileStatus(root));
+    //See HADOOP-17323.
+    assertTrue("root path should always exist", fs.exists(root));
+    assertTrue("getFileStatus on root should always return a directory",
+            fs.getFileStatus(root).isDirectory());
 
     expectUnknownStore(
         () -> fs.listStatus(root));


### PR DESCRIPTION
Re-ran failed tests. No failures.
Ran tests using ap-south-1 bucket for raw and s3guard config. No failures.

CC @steveloughran 