### PR TITLE
HADOOP-17399. lz4 sources missing for native Visual Studio project

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/native.vcxproj
+++ b/hadoop-common-project/hadoop-common/src/main/native/native.vcxproj
@@ -128,10 +128,6 @@
   <ItemGroup>
     <ClCompile Include="src\org\apache\hadoop\io\compress\zlib\ZlibCompressor.c" Condition="Exists('$(ZLIB_HOME)')" />
     <ClCompile Include="src\org\apache\hadoop\io\compress\zlib\ZlibDecompressor.c" Condition="Exists('$(ZLIB_HOME)')" />
-    <ClCompile Include="src\org\apache\hadoop\io\compress\lz4\lz4.c" />
-    <ClCompile Include="src\org\apache\hadoop\io\compress\lz4\lz4hc.c" />
-    <ClCompile Include="src\org\apache\hadoop\io\compress\lz4\Lz4Compressor.c" />
-    <ClCompile Include="src\org\apache\hadoop\io\compress\lz4\Lz4Decompressor.c" />
     <ClCompile Include="src\org\apache\hadoop\io\nativeio\file_descriptor.c" />
     <ClCompile Include="src\org\apache\hadoop\io\nativeio\NativeIO.c" />
     <ClCompile Include="src\org\apache\hadoop\security\JniBasedUnixGroupsMappingWin.c" />


### PR DESCRIPTION
* The sources for lz4 do not exist for native
  vcxproj for Visual Studio on the Windows
  platform. Hence, removing the corresponding
  source references.