### PR TITLE
MAPREDUCE-7311. Clear filesystem statistics after tests in TestTaskProgressReporter

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
@@ -324,5 +324,6 @@ public class TestTaskProgressReporter {
     reporter.resetDoneFlag();
     t.join();
     Assert.assertEquals(failFast, threadExited);
+    FileSystem.clearStatistics();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.checkpoint.TaskCheckpointID;
 import org.apache.hadoop.util.ExitUtil;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -177,6 +178,11 @@ public class TestTaskProgressReporter {
       taskLimitIsChecked = true;
       super.checkTaskLimits();
     }
+  }
+
+  @After
+  public void cleanup() {
+    FileSystem.clearStatistics();
   }
 
   @Test(timeout=60000)
@@ -324,6 +330,5 @@ public class TestTaskProgressReporter {
     reporter.resetDoneFlag();
     t.join();
     Assert.assertEquals(failFast, threadExited);
-    FileSystem.clearStatistics();
   }
 }


### PR DESCRIPTION
The test `org.apache.hadoop.mapred.TestTaskProgressReporter.testBytesWrittenRespectingLimit` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Details
---
Running `TestTaskProgressReporter.testBytesWrittenRespectingLimit` twice would result in the second run failing with the following assertion:
```
Assert.assertEquals(failFast, threadExited)
```
The root cause for this is that when`testBytesWrittenRespectingLimit` writes some bytes on the local file system, some counters are being incremented. The problem is that, after the test is done, the counter is not reset. With this polluted shared state, assumptions are broken, resulting in test failure in the second run.

The fix is to invoke `FileSystem.clearStatistics()` to reset the counter(among others statistics) when the test finishes.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

Jira link: [MAPREDUCE-7311](https://issues.apache.org/jira/browse/MAPREDUCE-7311)