### PR TITLE
HDFS-15677. TestRouterRpcMultiDestination#testGetCachedDatanodeReportfails on trunk.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -233,9 +233,13 @@ public class TestRouterRpc {
 
     // We decrease the DN heartbeat expire interval to make them dead faster
     cluster.getCluster().getNamesystem(0).getBlockManager()
-        .getDatanodeManager().setHeartbeatExpireInterval(5000);
+        .getDatanodeManager().setHeartbeatInterval(1);
     cluster.getCluster().getNamesystem(1).getBlockManager()
-        .getDatanodeManager().setHeartbeatExpireInterval(5000);
+        .getDatanodeManager().setHeartbeatInterval(1);
+    cluster.getCluster().getNamesystem(0).getBlockManager()
+        .getDatanodeManager().setHeartbeatExpireInterval(3000);
+    cluster.getCluster().getNamesystem(1).getBlockManager()
+        .getDatanodeManager().setHeartbeatExpireInterval(3000);
   }
 
   @AfterClass
@@ -1859,7 +1863,7 @@ public class TestRouterRpc {
         }
         return datanodeReport.length == dn.length;
       }
-    }, 500, 5 * 1000);
+    }, 100, 10 * 1000);
 
     // The cache should be updated now
     final DatanodeInfo[] datanodeReport3 =


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15677

Since heartbeatExpireInterval and assertion timeout of DN removal has the same value (5000 ms), the test fails intermittently. Updating the heartbeatExpireInterval and assertion timeout worked for me.