### PR TITLE
HDFS-15702. Fix intermittent falilure of TestDecommission#testAllocAndIBRWhileDecommission.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
@@ -976,6 +976,8 @@ public class TestDecommission extends AdminStatesBaseTest {
   @Test(timeout=120000)
   public void testAllocAndIBRWhileDecommission() throws IOException {
     LOG.info("Starting test testAllocAndIBRWhileDecommission");
+    getConf().setLong(DFSConfigKeys.DFS_BLOCKREPORT_INTERVAL_MSEC_KEY,
+        DFSConfigKeys.DFS_BLOCKREPORT_INTERVAL_MSEC_DEFAULT);
     startCluster(1, 6);
     getCluster().waitActive();
     FSNamesystem ns = getCluster().getNamesystem(0);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15702

dfs.blockreport.intervalMsec is set to 1000 in the TestDecommission. While the testAllocAndIBRWhileDecommission tries to stop IBRs by DataNodeTestUtils#pauseIBR, IBR still can be sent in the code path of FBR (BPServiceActor#blockReport). Avoiding FBR (except for the 1st BR) by setting dfs.blockreport.intervalMsec to enough long value should fix the issue. The testAllocAndIBRWhileDecommission does not depend on FBR.

The test failure can not be reproduced in 100 runs after applying the patch on my local.

```
for i in `seq 100` ; do echo $i && mvn test -DignoreTestFailure=false -Dtest=TestDecommission#testAllocAndIBRWhileDecommission || break ; done
```
