### PR TITLE
YARN-10491: Fix deprecation warnings in SLSWebApp.java

### DIFF
--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
@@ -20,12 +20,11 @@ package org.apache.hadoop.yarn.sls.web;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -56,7 +55,6 @@ import com.codahale.metrics.MetricRegistry;
 @Unstable
 public class SLSWebApp extends HttpServlet {
   private static final long serialVersionUID = 1905162041950251407L;
-  private static final Charset UTF8 = StandardCharsets.UTF_8;
   private transient Server server;
   private transient SchedulerWrapper wrapper;
   private transient MetricRegistry metrics;
@@ -97,11 +95,11 @@ public class SLSWebApp extends HttpServlet {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       simulateInfoTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.info.html.template"), UTF8);
+          cl.getResourceAsStream("html/simulate.info.html.template"), StandardCharsets.UTF_8);
       simulateTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.html.template"), UTF8);
+          cl.getResourceAsStream("html/simulate.html.template"), StandardCharsets.UTF_8);
       trackTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/track.html.template"), UTF8);
+          cl.getResourceAsStream("html/track.html.template"), StandardCharsets.UTF_8);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
@@ -24,6 +24,8 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -54,7 +56,7 @@ import com.codahale.metrics.MetricRegistry;
 @Unstable
 public class SLSWebApp extends HttpServlet {
   private static final long serialVersionUID = 1905162041950251407L;
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
   private transient Server server;
   private transient SchedulerWrapper wrapper;
   private transient MetricRegistry metrics;

--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
@@ -54,6 +54,7 @@ import com.codahale.metrics.MetricRegistry;
 @Unstable
 public class SLSWebApp extends HttpServlet {
   private static final long serialVersionUID = 1905162041950251407L;
+  private static final Charset UTF8 = Charset.forName("UTF-8");
   private transient Server server;
   private transient SchedulerWrapper wrapper;
   private transient MetricRegistry metrics;
@@ -94,11 +95,11 @@ public class SLSWebApp extends HttpServlet {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       simulateInfoTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.info.html.template"));
+          cl.getResourceAsStream("html/simulate.info.html.template"), UTF8);
       simulateTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.html.template"));
+          cl.getResourceAsStream("html/simulate.html.template"), UTF8);
       trackTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/track.html.template"));
+          cl.getResourceAsStream("html/track.html.template"), UTF8);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
@@ -24,7 +24,6 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
@@ -56,7 +55,6 @@ import com.codahale.metrics.MetricRegistry;
 @Unstable
 public class SLSWebApp extends HttpServlet {
   private static final long serialVersionUID = 1905162041950251407L;
-  private static final Charset UTF8 = StandardCharsets.UTF_8;
   private transient Server server;
   private transient SchedulerWrapper wrapper;
   private transient MetricRegistry metrics;
@@ -97,11 +95,11 @@ public class SLSWebApp extends HttpServlet {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       simulateInfoTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.info.html.template"), UTF8);
+          cl.getResourceAsStream("html/simulate.info.html.template"), StandardCharsets.UTF_8);
       simulateTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.html.template"), UTF8);
+          cl.getResourceAsStream("html/simulate.html.template"), StandardCharsets.UTF_8);
       trackTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/track.html.template"), UTF8);
+          cl.getResourceAsStream("html/track.html.template"), StandardCharsets.UTF_8);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/web/SLSWebApp.java
@@ -24,6 +24,7 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
@@ -55,6 +56,7 @@ import com.codahale.metrics.MetricRegistry;
 @Unstable
 public class SLSWebApp extends HttpServlet {
   private static final long serialVersionUID = 1905162041950251407L;
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
   private transient Server server;
   private transient SchedulerWrapper wrapper;
   private transient MetricRegistry metrics;
@@ -95,11 +97,11 @@ public class SLSWebApp extends HttpServlet {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       simulateInfoTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.info.html.template"), StandardCharsets.UTF_8);
+          cl.getResourceAsStream("html/simulate.info.html.template"), UTF8);
       simulateTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/simulate.html.template"), StandardCharsets.UTF_8);
+          cl.getResourceAsStream("html/simulate.html.template"), UTF8);
       trackTemplate = IOUtils.toString(
-          cl.getResourceAsStream("html/track.html.template"), StandardCharsets.UTF_8);
+          cl.getResourceAsStream("html/track.html.template"), UTF8);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
@@ -28,14 +28,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashMap;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class TestSLSWebApp {
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   @Test
   public void testSimulateInfoPageHtmlTemplate() throws Exception {
     String simulateInfoTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.info.html.template"), StandardCharsets.UTF_8);
+            new File("src/main/html/simulate.info.html.template"), UTF8);
 
     Map<String, Object> simulateInfoMap = new HashMap<>();
     simulateInfoMap.put("Number of racks", 10);
@@ -73,7 +75,7 @@ public class TestSLSWebApp {
   @Test
   public void testSimulatePageHtmlTemplate() throws Exception {
     String simulateTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.html.template"), StandardCharsets.UTF_8);
+            new File("src/main/html/simulate.html.template"), UTF8);
 
     Set<String> queues = new HashSet<String>();
     queues.add("sls_queue_1");
@@ -97,7 +99,7 @@ public class TestSLSWebApp {
   @Test
   public void testTrackPageHtmlTemplate() throws Exception {
     String trackTemplate = FileUtils.readFileToString(
-            new File("src/main/html/track.html.template"), StandardCharsets.UTF_8);
+            new File("src/main/html/track.html.template"), UTF8);
     String trackedQueueInfo = "";
     Set<String> trackedQueues = new HashSet<String>();
     trackedQueues.add("sls_queue_1");

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
@@ -28,16 +28,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashMap;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class TestSLSWebApp {
-  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   @Test
   public void testSimulateInfoPageHtmlTemplate() throws Exception {
     String simulateInfoTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.info.html.template"), UTF8);
+            new File("src/main/html/simulate.info.html.template"), StandardCharsets.UTF_8);
 
     Map<String, Object> simulateInfoMap = new HashMap<>();
     simulateInfoMap.put("Number of racks", 10);
@@ -75,7 +73,7 @@ public class TestSLSWebApp {
   @Test
   public void testSimulatePageHtmlTemplate() throws Exception {
     String simulateTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.html.template"), UTF8);
+            new File("src/main/html/simulate.html.template"), StandardCharsets.UTF_8);
 
     Set<String> queues = new HashSet<String>();
     queues.add("sls_queue_1");
@@ -99,7 +97,7 @@ public class TestSLSWebApp {
   @Test
   public void testTrackPageHtmlTemplate() throws Exception {
     String trackTemplate = FileUtils.readFileToString(
-            new File("src/main/html/track.html.template"), UTF8);
+            new File("src/main/html/track.html.template"), StandardCharsets.UTF_8);
     String trackedQueueInfo = "";
     Set<String> trackedQueues = new HashSet<String>();
     trackedQueues.add("sls_queue_1");

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
@@ -23,21 +23,19 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashMap;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 public class TestSLSWebApp {
-  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   @Test
   public void testSimulateInfoPageHtmlTemplate() throws Exception {
     String simulateInfoTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.info.html.template"), UTF8);
+            new File("src/main/html/simulate.info.html.template"), StandardCharsets.UTF_8);
 
     Map<String, Object> simulateInfoMap = new HashMap<>();
     simulateInfoMap.put("Number of racks", 10);
@@ -75,7 +73,7 @@ public class TestSLSWebApp {
   @Test
   public void testSimulatePageHtmlTemplate() throws Exception {
     String simulateTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.html.template"), UTF8);
+            new File("src/main/html/simulate.html.template"), StandardCharsets.UTF_8);
 
     Set<String> queues = new HashSet<String>();
     queues.add("sls_queue_1");
@@ -99,7 +97,7 @@ public class TestSLSWebApp {
   @Test
   public void testTrackPageHtmlTemplate() throws Exception {
     String trackTemplate = FileUtils.readFileToString(
-            new File("src/main/html/track.html.template"), UTF8);
+            new File("src/main/html/track.html.template"), StandardCharsets.UTF_8);
     String trackedQueueInfo = "";
     Set<String> trackedQueues = new HashSet<String>();
     trackedQueues.add("sls_queue_1");

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
@@ -30,11 +30,12 @@ import java.util.Set;
 import java.util.HashMap;
 
 public class TestSLSWebApp {
+  private static final Charset UTF8 = Charset.forName("UTF-8");
 
   @Test
   public void testSimulateInfoPageHtmlTemplate() throws Exception {
     String simulateInfoTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.info.html.template"));
+            new File("src/main/html/simulate.info.html.template"), UTF8);
 
     Map<String, Object> simulateInfoMap = new HashMap<>();
     simulateInfoMap.put("Number of racks", 10);
@@ -72,7 +73,7 @@ public class TestSLSWebApp {
   @Test
   public void testSimulatePageHtmlTemplate() throws Exception {
     String simulateTemplate = FileUtils.readFileToString(
-            new File("src/main/html/simulate.html.template"));
+            new File("src/main/html/simulate.html.template"), UTF8);
 
     Set<String> queues = new HashSet<String>();
     queues.add("sls_queue_1");
@@ -96,7 +97,7 @@ public class TestSLSWebApp {
   @Test
   public void testTrackPageHtmlTemplate() throws Exception {
     String trackTemplate = FileUtils.readFileToString(
-            new File("src/main/html/track.html.template"));
+            new File("src/main/html/track.html.template"), UTF8);
     String trackedQueueInfo = "";
     Set<String> trackedQueues = new HashSet<String>();
     trackedQueues.add("sls_queue_1");

--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/web/TestSLSWebApp.java
@@ -28,9 +28,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashMap;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class TestSLSWebApp {
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   @Test
   public void testSimulateInfoPageHtmlTemplate() throws Exception {


### PR DESCRIPTION
What? :: Fix deprecation warnings in SLSWebApp.java & TestSLSWebApp.java

------
toString(URI uri) Deprecated. 
> Use toString(URI, Charset) instead.
------
readFileToString(File file) Deprecated. 
> Use readFileToString(File, Charset) instead.
------

@aajisaka Can you please review this?

Thanks!