### PR TITLE
HADOOP-17413. ABFS: Release elastic byte buffer pool at close

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -85,7 +85,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
    * blocks. After the data is sent to the service, the buffer is returned
    * back to the queue
    */
-  private final ElasticByteBufferPool byteBufferPool
+  private ElasticByteBufferPool byteBufferPool
           = new ElasticByteBufferPool();
 
   private final Statistics statistics;
@@ -297,6 +297,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable, StreamCa
       bufferIndex = 0;
       closed = true;
       writeOperations.clear();
+      byteBufferPool = null;
       if (!threadExecutor.isShutdown()) {
         threadExecutor.shutdownNow();
       }


### PR DESCRIPTION
Each AbfsOutputStream holds on to an instance of elastic bytebuffer pool. This instance needs to be released so that the memory can be given back to JVM's available memory pool. 

For testing, existing tests were re-run. 