### PR TITLE
YARN-10520. Deprecated the residual nested class for the LCEResourceHandler

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutor.java
@@ -725,6 +725,7 @@ public class TestLinuxContainerExecutor {
     verify(lce, times(1)).getLocalResources(container);
   }
 
+  @Deprecated
   private static class TestResourceHandler implements LCEResourcesHandler {
     static Set<ContainerId> postExecContainers = new HashSet<ContainerId>();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/util/TestCgroupsLCEResourcesHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/util/TestCgroupsLCEResourcesHandler.java
@@ -126,12 +126,14 @@ public class TestCgroupsLCEResourcesHandler {
     FileUtils.deleteQuietly(cgroupDir);
   }
 
+  @Deprecated
   static class MockLinuxContainerExecutor extends LinuxContainerExecutor {
     @Override
     public void mountCgroups(List<String> x, String y) {
     }
   }
 
+  @Deprecated
   static class CustomCgroupsLCEResourceHandler extends
       CgroupsLCEResourcesHandler {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-10520