### PR TITLE
HDFS-15718. Optimize hdfs token op writeLock.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -571,9 +571,14 @@ extends AbstractDelegationTokenIdentifier>
     DataInputStream in = new DataInputStream(buf);
     TokenIdent id = createIdentifier();
     id.readFields(in);
-    LOG.info("Token cancellation requested for identifier: "
-        + formatTokenId(id));
-    
+    return cancelToken(id, canceller);
+  }
+
+  public synchronized TokenIdent cancelToken(TokenIdent id, String canceller)
+      throws IOException {
+    LOG.info("Token cancellation requested for identifier: {}",
+        formatTokenId(id));
+
     if (id.getUser() == null) {
       throw new InvalidToken("Token with no owner " + formatTokenId(id));
     }
@@ -582,8 +587,8 @@ extends AbstractDelegationTokenIdentifier>
     HadoopKerberosName cancelerKrbName = new HadoopKerberosName(canceller);
     String cancelerShortName = cancelerKrbName.getShortName();
     if (!canceller.equals(owner)
-        && (renewer == null || renewer.toString().isEmpty() || !cancelerShortName
-            .equals(renewer.toString()))) {
+        && (renewer == null || renewer.toString().isEmpty()
+            || !cancelerShortName.equals(renewer.toString()))) {
       throw new AccessControlException(canceller
           + " is not authorized to cancel the token " + formatTokenId(id));
     }
@@ -595,7 +600,7 @@ extends AbstractDelegationTokenIdentifier>
     removeStoredToken(id);
     return id;
   }
-  
+
   /**
    * Convert the byte[] to a secret key
    * @param key the byte[] to create the secret key from

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -65,7 +65,8 @@ public class TestDelegationToken {
     public TestDelegationTokenIdentifier() {
     }
 
-    public TestDelegationTokenIdentifier(Text owner, Text renewer, Text realUser) {
+    public TestDelegationTokenIdentifier(Text owner, Text renewer,
+        Text realUser) {
       super(owner, renewer, realUser);
     }
 


### PR DESCRIPTION
Token operations are acquiring the fsn write lock. Like lease renewal and token expiration, the read lock is sufficient because the namesystem is not mutated.
@daryn-sharp suggested to improve performance by substituting writeLock with readLock.

CC: @jbrennan333 
