### PR TITLE
HADOOP-17425. Bump up snappy-java to 1.1.8.2

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -143,7 +143,7 @@
     <metrics.version>3.2.4</metrics.version>
     <netty3.version>3.10.6.Final</netty3.version>
     <netty4.version>4.1.50.Final</netty4.version>
-    <snappy-java.version>1.1.8.1</snappy-java.version>
+    <snappy-java.version>1.1.8.2</snappy-java.version>
     <lz4-java.version>1.7.1</lz4-java.version>
 
     <!-- Maven protoc compiler -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17425

1.1.8.2 includes:

- Support Apple Silicon (M1, Mac-aarch64)
- Fixed the pure-java Snappy fallback logic when no native library for your platform is found.

