### PR TITLE
YARN-10529 Fix the wrong attemptId displayed on the graph-view tab in the YARN-UI2 page

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/utils/converter.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/utils/converter.js
@@ -24,7 +24,7 @@ export default {
     if (containerId) {
       var arr = containerId.split('_');
       var attemptId = ["appattempt", arr[1],
-        arr[2], this.padding(arr[3], 6)];
+        arr[2], this.padding(arr[4], 6)];
       return attemptId.join('_');
     }
   },


### PR DESCRIPTION
## NOTICE
JIRA: https://issues.apache.org/jira/browse/YARN-10529


manual test works well:

![Graph View ApptemptID shows ok](https://user-images.githubusercontent.com/52202080/101938486-5f456180-3c1e-11eb-9172-e725a39d6db7.png)
