### PR TITLE
[YARN-10545] Improve the readability of diagnostics log in yarn-ui2 web page.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-app/info.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-app/info.hbs
@@ -42,7 +42,7 @@
         <div class="panel-heading">
           Diagnostics
         </div>
-        <div class="panel-body">{{model.app.diagnostics}}</div>
+        <div class="panel-body" style="white-space: pre-wrap;">{{model.app.diagnostics}}</div>
       </div>
     {{else}}
       <div class="panel panel-default">


### PR DESCRIPTION
fix this 
https://issues.apache.org/jira/browse/YARN-10545

manual test works well:
![Diagnostics shows ok](https://user-images.githubusercontent.com/52202080/102918820-9f300280-44c2-11eb-81f1-485e991e39ff.png)
