### PR TITLE
HADOOP-17432. [JDK 16] KerberosUtil#getOidInstance is broken by JEP 396

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosUtil.java
@@ -85,15 +85,15 @@ public class KerberosUtil {
   public static Oid getOidInstance(String oidName)
       throws NoSuchFieldException {
     switch (oidName) {
-      case "GSS_SPNEGO_MECH_OID":
-        return GSS_SPNEGO_MECH_OID;
-      case "GSS_KRB5_MECH_OID":
-        return GSS_KRB5_MECH_OID;
-      case "NT_GSS_KRB5_PRINCIPAL":
-        return NT_GSS_KRB5_PRINCIPAL_OID;
-      default:
-        throw new NoSuchFieldException(
-            "oidName: " + oidName + " is not supported.");
+    case "GSS_SPNEGO_MECH_OID":
+      return GSS_SPNEGO_MECH_OID;
+    case "GSS_KRB5_MECH_OID":
+      return GSS_KRB5_MECH_OID;
+    case "NT_GSS_KRB5_PRINCIPAL":
+      return NT_GSS_KRB5_PRINCIPAL_OID;
+    default:
+      throw new NoSuchFieldException(
+          "oidName: " + oidName + " is not supported.");
     }
   }
 

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosUtil.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.util.PlatformName.IBM_JAVA;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -73,21 +72,29 @@ public class KerberosUtil {
     }
   }
 
-  public static Oid getOidInstance(String oidName) 
-      throws ClassNotFoundException, GSSException, NoSuchFieldException,
-      IllegalAccessException {
-    Class<?> oidClass;
-    if (IBM_JAVA) {
-      if ("NT_GSS_KRB5_PRINCIPAL".equals(oidName)) {
-        // IBM JDK GSSUtil class does not have field for krb5 principal oid
-        return new Oid("1.2.840.113554.1.2.2.1");
-      }
-      oidClass = Class.forName("com.ibm.security.jgss.GSSUtil");
-    } else {
-      oidClass = Class.forName("sun.security.jgss.GSSUtil");
+  @Deprecated
+  /**
+   * Returns the Oid instance from string oidName.
+   * Use {@link GSS_SPNEGO_MECH_OID}, {@link GSS_KRB5_MECH_OID},
+   * or {@link NT_GSS_KRB5_PRINCIPAL_OID} instead.
+   *
+   * @return Oid instance
+   * @param oidName The oid Name
+   * @throws NoSuchFieldException if the input is not supported.
+   */
+  public static Oid getOidInstance(String oidName)
+      throws NoSuchFieldException {
+    switch (oidName) {
+      case "GSS_SPNEGO_MECH_OID":
+        return GSS_SPNEGO_MECH_OID;
+      case "GSS_KRB5_MECH_OID":
+        return GSS_KRB5_MECH_OID;
+      case "NT_GSS_KRB5_PRINCIPAL":
+        return NT_GSS_KRB5_PRINCIPAL_OID;
+      default:
+        throw new NoSuchFieldException(
+            "oidName: " + oidName + " is not supported.");
     }
-    Field oidField = oidClass.getDeclaredField(oidName);
-    return (Oid)oidField.get(oidClass);
   }
 
   /**

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosUtil.java
@@ -72,7 +72,6 @@ public class KerberosUtil {
     }
   }
 
-  @Deprecated
   /**
    * Returns the Oid instance from string oidName.
    * Use {@link GSS_SPNEGO_MECH_OID}, {@link GSS_KRB5_MECH_OID},
@@ -82,6 +81,7 @@ public class KerberosUtil {
    * @param oidName The oid Name
    * @throws NoSuchFieldException if the input is not supported.
    */
+  @Deprecated
   public static Oid getOidInstance(String oidName)
       throws NoSuchFieldException {
     switch (oidName) {

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestKerberosAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestKerberosAuthenticationHandler.java
@@ -301,11 +301,10 @@ public class TestKerberosAuthenticationHandler
         GSSContext gssContext = null;
         try {
           String servicePrincipal = KerberosTestUtils.getServerPrincipal();
-          Oid oid =
-              KerberosUtil.getOidInstance("NT_GSS_KRB5_PRINCIPAL");
+          Oid oid = KerberosUtil.NT_GSS_KRB5_PRINCIPAL_OID;
           GSSName serviceName = gssManager.createName(servicePrincipal,
               oid);
-          oid = KerberosUtil.getOidInstance("GSS_KRB5_MECH_OID");
+          oid = KerberosUtil.GSS_KRB5_MECH_OID;
           gssContext = gssManager.createContext(serviceName, oid, null,
                                                   GSSContext.DEFAULT_LIFETIME);
           gssContext.requestCredDeleg(true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/HttpUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/HttpUtil.java
@@ -72,8 +72,6 @@ public class HttpUtil {
           @Override
           public String run() throws Exception {
             try {
-              // This Oid for Kerberos GSS-API mechanism.
-              Oid mechOid = KerberosUtil.getOidInstance("GSS_KRB5_MECH_OID");
               GSSManager manager = GSSManager.getInstance();
               // GSS name for server
               GSSName serverName = manager.createName("HTTP@" + server,
@@ -81,8 +79,9 @@ public class HttpUtil {
               // Create a GSSContext for authentication with the service.
               // We're passing client credentials as null since we want them to
               // be read from the Subject.
+              // We're passing Oid as null to use the default.
               GSSContext gssContext = manager.createContext(
-                  serverName.canonicalize(mechOid), mechOid, null,
+                  serverName.canonicalize(null), null, null,
                   GSSContext.DEFAULT_LIFETIME);
               gssContext.requestMutualAuth(true);
               gssContext.requestCredDeleg(true);
@@ -95,9 +94,8 @@ public class HttpUtil {
               LOG.debug("Got valid challenge for host {}", serverName);
               return new String(BASE_64_CODEC.encode(outToken),
                   StandardCharsets.US_ASCII);
-            } catch (GSSException | IllegalAccessException
-                | NoSuchFieldException | ClassNotFoundException e) {
-              LOG.error("Error: {}", e);
+            } catch (GSSException e) {
+              LOG.error("Error: ", e);
               throw new AuthenticationException(e);
             }
           }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/HttpUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/HttpUtil.java
@@ -30,12 +30,10 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
-import org.ietf.jgss.Oid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/util/YarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/util/YarnClientUtils.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.conf.HAUtil;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -39,7 +38,6 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
-import org.ietf.jgss.Oid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/util/YarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/util/YarnClientUtils.java
@@ -222,8 +222,6 @@ public abstract class YarnClientUtils {
           @Override
           public String run() throws Exception {
             try {
-              // This Oid for Kerberos GSS-API mechanism.
-              Oid mechOid = KerberosUtil.getOidInstance("GSS_KRB5_MECH_OID");
               GSSManager manager = GSSManager.getInstance();
               // GSS name for server
               GSSName serverName = manager.createName("HTTP@" + server,
@@ -231,8 +229,9 @@ public abstract class YarnClientUtils {
               // Create a GSSContext for authentication with the service.
               // We're passing client credentials as null since we want them to
               // be read from the Subject.
+              // We're passing Oid as null to use the default.
               GSSContext gssContext = manager.createContext(
-                  serverName.canonicalize(mechOid), mechOid, null,
+                  serverName.canonicalize(null), null, null,
                   GSSContext.DEFAULT_LIFETIME);
               gssContext.requestMutualAuth(true);
               gssContext.requestCredDeleg(true);
@@ -245,8 +244,7 @@ public abstract class YarnClientUtils {
               LOG.debug("Got valid challenge for host {}", serverName);
               return new String(BASE_64_CODEC.encode(outToken),
                   StandardCharsets.US_ASCII);
-            } catch (GSSException | IllegalAccessException
-                | NoSuchFieldException | ClassNotFoundException e) {
+            } catch (GSSException e) {
               LOG.error("Error: ", e);
               throw new AuthenticationException(e);
             }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17432

- Removed the use of JDK internal APIs
- Deprecated KerberosUtil#getOidInstance
- Use the default OID in Hadoop

TestAltKerberosAuthenticationHandler passed in JDK 16-ea+28.

```
[INFO] Running org.apache.hadoop.security.authentication.server.TestAltKerberosAuthenticationHandler
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.761 s - in org.apache.hadoop.security.authentication.server.TestAltKerberosAuthenticationHandler
```