### PR TITLE
HADOOP-17444. ADLS Gen1: Updating gen1 SDK version from 2.3.6 to 2.3.9

### DIFF
--- a/hadoop-tools/hadoop-azure-datalake/pom.xml
+++ b/hadoop-tools/hadoop-azure-datalake/pom.xml
@@ -33,7 +33,7 @@
     <minimalJsonVersion>0.9.1</minimalJsonVersion>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <azure.data.lake.store.sdk.version>2.3.6</azure.data.lake.store.sdk.version>
+    <azure.data.lake.store.sdk.version>2.3.9</azure.data.lake.store.sdk.version>
   </properties>
   <build>
     <plugins>
@@ -166,5 +166,12 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.openssl</groupId>
+      <artifactId>wildfly-openssl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
Updating gen1 SDK version from 2.3.6 to 2.3.9

**Before the change**

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAdlContractRenameLive>AbstractContractRenameTest.testRenameFileOverExistingFile:131->Assert.fail:88 expected rename(/test/source-256.txt, /test/dest-512.txt) to be rejected with exception, but got false
[ERROR]   TestAdlContractRenameLive.testRenameFileUnderFile:46 Expecting org.apache.hadoop.security.AccessControlException with text Parent path is not a folder. but got : "void"
[ERROR] Errors: 
[ERROR]   TestAdlContractGetFileStatusLive>AbstractContractGetFileStatusTest.testComplexDirActions:153->AbstractContractGetFileStatusTest.checkListStatusIteratorComplexDir:196 » NoClassDefFound
[ERROR]   TestAdlContractGetFileStatusLive>AbstractContractGetFileStatusTest.testListStatusIteratorFile:363->AbstractContractGetFileStatusTest.validateListingForFile:384 » NoClassDefFound
[ERROR]   TestAdlContractRootDirLive>AbstractContractRootDirectoryTest.testSimpleRootListing:251 » NoClassDefFound
[INFO] 
[ERROR] Tests run: 893, Failures: 2, Errors: 3, Skipped: 3

**After the change**

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAdlContractRenameLive>AbstractContractRenameTest.testRenameFileOverExistingFile:131->Assert.fail:88 expected rename(/test/source-256.txt, dest-512.txt) to be rejected with exception, but got false
[ERROR]   TestAdlContractRenameLive.testRenameFileUnderFile:46 Expecting org.apache.hadoop.security.AccessControlException with text Parent path is not a folder. but got : "void"
[ERROR] Errors: 
[ERROR]   TestAdlContractGetFileStatusLive>AbstractContractGetFileStatusTest.testComplexDirActions:153->AbstractContractGetFileStatusTest.checkListStatusIteratorComplexDir:196 » NoClassDefFound
[ERROR]   TestAdlContractGetFileStatusLive>AbstractContractGetFileStatusTest.testListStatusIteratorFile:363->AbstractContractGetFileStatusTest.validateListingForFile:384 » NoClassDefFound
[ERROR]   TestAdlContractRootDirLive>AbstractContractRootDirectoryTest.testSimpleRootListing:251 » NoClassDefFound
[INFO] 
[ERROR] Tests run: 893, Failures: 2, Errors: 3, Skipped: 3