### PR TITLE
HDFS-13579. Fix potential OutOfMemory error in DatanodeHttpServer.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -346,8 +346,8 @@ public class DatanodeHttpServer implements Closeable {
 
   @Override
   public void close() throws IOException {
-    bossGroup.shutdownGracefully();
     workerGroup.shutdownGracefully();
+    bossGroup.shutdownGracefully();
     if (sslFactory != null) {
       sslFactory.destroy();
     }


### PR DESCRIPTION
bossGroups.shutdownGracefully() closes its child workerGroups,
so if the workerGroups.shutdownGracefully() is called after
closing bossGroups, it launches the threads again and that may cause
OOM. To fix this issue, close workerGroups before closing bossGroups.

JIRA: https://issues.apache.org/jira/browse/HDFS-13579