### PR TITLE
HDFS-15732 EC client will not retry get block token when block token …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -267,8 +267,7 @@ public class DFSStripedInputStream extends DFSInputStream {
               + " : " + e);
           dfsClient.clearDataEncryptionKey();
           retry.refetchEncryptionKey();
-        } else if (retry.shouldRefetchToken() &&
-            tokenRefetchNeeded(e, dnInfo.addr)) {
+        } else if (retry.shouldRefetchToken()) {
           fetchBlockAt(block.getStartOffset());
           retry.refetchToken();
         } else {


### PR DESCRIPTION
Since client side will not identify the InvalidToken error because of the SASL negotiation, always refetch token  when encountered error for the first time.
