### PR TITLE
HADOOP-17438. Increase docker memory limit in Jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
                         # changing these to higher values may cause problems
                         # with other jobs on systemd-enabled machines
                         YETUS_ARGS+=("--proclimit=5500")
-                        YETUS_ARGS+=("--dockermemlimit=20g")
+                        YETUS_ARGS+=("--dockermemlimit=22g")
 
                         # -1 findbugs issues that show up prior to the patch being applied
                         YETUS_ARGS+=("--findbugs-strict-precheck")


### PR DESCRIPTION
This change to increase the memory limit from 20g to 22g.
The last commit is needed to trigger the tests and increase the timeout. It should be skipped before merging.
