### PR TITLE
 HDFS-15739. Add missing Javadoc for a param in DFSNetworkTopology

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/DFSNetworkTopology.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/DFSNetworkTopology.java
@@ -173,6 +173,7 @@ public class DFSNetworkTopology extends NetworkTopology {
    * @param scope the scope where we look for node.
    * @param excludedScope the scope where the node must NOT be from.
    * @param excludedNodes the returned node must not be in this set
+   * @param type the storage type we search for
    * @return a node with required storage type
    */
   @VisibleForTesting


### PR DESCRIPTION
Only add missing Javadoc for a param in method chooseRandomWithStorageType of DFSNetworkTopology.java.