### PR TITLE
HDFS-15743. Fix -Pdist build failure of hadoop-hdfs-native-client.

### DIFF
--- a/dev-support/bin/dist-copynativelibs
+++ b/dev-support/bin/dist-copynativelibs
@@ -164,7 +164,7 @@ fi
 
 # Windows doesn't have a LIB_DIR, everything goes into bin
 
-if [[ -d "${BIN_DIR}" ]] ; then
+if [[ -d "${BIN_DIR}" && $(ls -A "${BIN_DIR}") ]] ; then
   mkdir -p "${TARGET_BIN_DIR}"
   cd "${BIN_DIR}"  || exit 1
   ${TAR} ./* | (cd "${TARGET_BIN_DIR}"/ || exit 1; ${UNTAR})


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-15743

`-Pdist` build failed in hadoop-hdfs-native-client on calling dev-support/bin/dist-copynativelibs.

```
[DEBUG] Executing command line: [bash, /home/centos/srcs/hadoop/hadoop-project-dist/../dev-support/bin/dist-copynativelibs, --version=3.4.0-SNAPSHOT, --builddir=/home/centos/srcs/hadoop/hadoop-hdfs-project/hadoop-hdfs-native-client/target, --artifactid=hadoop-hdfs-native-client, --isalbundle=false, --isallib=, --openssllib=, --opensslbinbundle=false, --openssllibbundle=false, --snappylib=, --snappylibbundle=false, --zstdbinbundle=false, --zstdlib=, --zstdlibbundle=false]
tar: ./*: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
```

The cause is empty target/bin dir (and the code for Windows platform) based on debug output by `set -x`. 

```
+ [[ -d /home/centos/srcs/hadoop/hadoop-hdfs-project/hadoop-hdfs-native-client/target/bin ]]
+ mkdir -p /home/centos/srcs/hadoop/hadoop-hdfs-project/hadoop-hdfs-native-client/target/hadoop-hdfs-native-client-3.4.0-SNAPSHOT/bin
+ cd /home/centos/srcs/hadoop/hadoop-hdfs-project/hadoop-hdfs-native-client/target/bin
+ tar cf - './*'
tar: ./*: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
```

I guess target/bin is created or emptied by recent commit. Adding empty dir check to the conditional worked for me.