### PR TITLE
YARN-10546: Limit application resource reservation on nodes for non-n…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -330,6 +330,13 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
       "reservation-policy";
 
   @Private
+  /** Ratio of nodes available for an app to make an reservation on. */
+  // Default no limit.
+  public static final String RESERVABLE_NODES
+      =  PREFIX  + "reservable-nodes";
+  public static final float DEFAULT_RESERVABLE_NODES = 1.0f;
+
+  @Private
   public static final String RESERVATION_AGENT_NAME = "reservation-agent";
 
   @Private
@@ -803,6 +810,16 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public boolean getReservationContinueLook() {
     return getBoolean(RESERVE_CONT_LOOK_ALL_NODES,
         DEFAULT_RESERVE_CONT_LOOK_ALL_NODES);
+  }
+
+  public float getReservableNodes() {
+    float reservableNodes =
+        getFloat( RESERVABLE_NODES, DEFAULT_RESERVABLE_NODES);
+    return reservableNodes;
+  }
+
+  public void setReservableNodes(float reservableNodes) {
+    setFloat(RESERVABLE_NODES, reservableNodes);
   }
   
   private static String getAclKey(QueueACL acl) {


### PR DESCRIPTION
Just as fixed in [YARN-4270 ](https://issues.apache.org/jira/browse/YARN-4270) about FairScheduler.

The capacityScheduler should also fixed it.

It is a big problem in production cluster, when it happended.

Also we should support fs convert to cs to support it.

Options
