### PR TITLE
HADOOP-17451. IOStatistics test failures in S3A code.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StorageStatisticsFromIOStatistics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/StorageStatisticsFromIOStatistics.java
@@ -67,23 +67,46 @@ public class StorageStatisticsFromIOStatistics
   public Iterator<LongStatistic> getLongStatistics() {
     final Set<Map.Entry<String, Long>> counters = counters()
         .entrySet();
-    return counters.stream().map(e ->
-        new StorageStatistics.LongStatistic(e.getKey(), e.getValue()))
-        .collect(Collectors.toSet()).iterator();
+    final Set<LongStatistic> statisticSet = counters.stream().map(
+        this::toLongStatistic)
+        .collect(Collectors.toSet());
+
+    // add the gauges
+    gauges().entrySet().forEach(entry ->
+        statisticSet.add(toLongStatistic(entry)));
+    return statisticSet.iterator();
+  }
+
+  /**
+   * Convert a counter/gauge entry to a long statistics.
+   * @param e entry
+   * @return statistic
+   */
+  private LongStatistic toLongStatistic(final Map.Entry<String, Long> e) {
+    return new LongStatistic(e.getKey(), e.getValue());
   }
 
   private Map<String, Long> counters() {
     return ioStatistics.counters();
   }
 
+  private Map<String, Long> gauges() {
+    return ioStatistics.gauges();
+  }
+
   @Override
   public Long getLong(final String key) {
-    return counters().get(key);
+    Long l = counters().get(key);
+    if (l == null) {
+      l = gauges().get(key);
+    }
+    return l;
   }
 
   @Override
   public boolean isTracked(final String key) {
-    return counters().containsKey(key);
+    return counters().containsKey(key)
+        || gauges().containsKey(key);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -64,10 +64,8 @@ import org.apache.hadoop.metrics2.lib.MutableQuantiles;
 import java.io.Closeable;
 import java.net.URI;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -183,20 +181,6 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
   private final IOStatisticsStore instanceIOStatistics;
 
   /**
-   * Gauges to create.
-   * <p></p>
-   * All statistics which are not gauges or quantiles
-   * are registered as counters.
-   */
-  private static final Statistic[] GAUGES_TO_CREATE = {
-      OBJECT_PUT_REQUESTS_ACTIVE,
-      OBJECT_PUT_BYTES_PENDING,
-      STREAM_WRITE_BLOCK_UPLOADS_ACTIVE,
-      STREAM_WRITE_BLOCK_UPLOADS_PENDING,
-      STREAM_WRITE_BLOCK_UPLOADS_BYTES_PENDING,
-  };
-
-  /**
    * Construct the instrumentation for a filesystem.
    * @param name URI of filesystem.
    */
@@ -211,10 +195,6 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     // create the builder
     IOStatisticsStoreBuilder storeBuilder = iostatisticsStore();
 
-    // add the gauges
-    List<Statistic> gauges = Arrays.asList(GAUGES_TO_CREATE);
-    gauges.forEach(this::gauge);
-
     // declare all counter statistics
     EnumSet.allOf(Statistic.class).stream()
         .filter(statistic ->
@@ -222,6 +202,14 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
         .forEach(stat -> {
           counter(stat);
           storeBuilder.withCounters(stat.getSymbol());
+        });
+    // declare all gauge statistics
+    EnumSet.allOf(Statistic.class).stream()
+        .filter(statistic ->
+            statistic.getType() == StatisticTypeEnum.TYPE_GAUGE)
+        .forEach(stat -> {
+          gauge(stat);
+          storeBuilder.withGauges(stat.getSymbol());
         });
 
     // and durations
@@ -1352,15 +1340,13 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
       this.filesystemStatistics = filesystemStatistics;
       IOStatisticsStore st = iostatisticsStore()
           .withCounters(
-              StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS,
+              STREAM_WRITE_BLOCK_UPLOADS.getSymbol(),
               STREAM_WRITE_BYTES.getSymbol(),
               STREAM_WRITE_EXCEPTIONS.getSymbol(),
-              StreamStatisticNames.STREAM_WRITE_BLOCK_UPLOADS_BYTES_PENDING,
-              STREAM_WRITE_TOTAL_TIME.getSymbol(),
+              STREAM_WRITE_EXCEPTIONS_COMPLETING_UPLOADS.getSymbol(),
               STREAM_WRITE_QUEUE_DURATION.getSymbol(),
               STREAM_WRITE_TOTAL_DATA.getSymbol(),
-              STREAM_WRITE_EXCEPTIONS.getSymbol(),
-              STREAM_WRITE_EXCEPTIONS_COMPLETING_UPLOADS.getSymbol())
+              STREAM_WRITE_TOTAL_TIME.getSymbol())
           .withGauges(
               STREAM_WRITE_BLOCK_UPLOADS_PENDING.getSymbol(),
               STREAM_WRITE_BLOCK_UPLOADS_BYTES_PENDING.getSymbol())
@@ -1470,7 +1456,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public void bytesTransferred(long byteCount) {
       bytesUploaded.addAndGet(byteCount);
-      incrementGauge(STREAM_WRITE_BLOCK_UPLOADS_BYTES_PENDING, -byteCount);
+      incAllGauges(STREAM_WRITE_BLOCK_UPLOADS_BYTES_PENDING, -byteCount);
     }
 
     @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
@@ -699,8 +699,8 @@ public class ITestPartialRenamesDeletes extends AbstractS3ATestBase {
     if (multiDelete) {
       // multi-delete status checks
       deleteVerbCount.assertDiffEquals("Wrong delete request count", 0);
-      bulkDeleteVerbCount.assertDiffEquals("Wrong count of delete operations in "
-          + iostats, 1);
+      bulkDeleteVerbCount.assertDiffEquals(
+          "Wrong count of delete operations in " + iostats, 1);
       MultiObjectDeleteException mde = extractCause(
           MultiObjectDeleteException.class, ex);
       List<MultiObjectDeleteSupport.KeyPath> undeletedKeyPaths =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestPartialRenamesDeletes.java
@@ -76,6 +76,7 @@ import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.removeUndel
 import static org.apache.hadoop.fs.s3a.impl.MultiObjectDeleteSupport.toPathList;
 import static org.apache.hadoop.fs.s3a.test.ExtraAssertions.assertFileCount;
 import static org.apache.hadoop.fs.s3a.test.ExtraAssertions.extractCause;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsSourceToString;
 import static org.apache.hadoop.io.IOUtils.cleanupWithLogger;
 import static org.apache.hadoop.test.LambdaTestUtils.eval;
 
@@ -683,7 +684,8 @@ public class ITestPartialRenamesDeletes extends AbstractS3ATestBase {
           readOnlyFiles.size());
       rejectionCount.assertDiffEquals("Wrong rejection count",
           readOnlyFiles.size());
-      reset(rejectionCount, deleteVerbCount, deleteObjectCount);
+      reset(rejectionCount, deleteVerbCount, deleteObjectCount,
+          bulkDeleteVerbCount);
     }
     // all the files are still there? (avoid in scale test due to cost)
     if (!scaleTest) {
@@ -692,9 +694,13 @@ public class ITestPartialRenamesDeletes extends AbstractS3ATestBase {
 
     describe("Trying to delete upper-level directory");
     ex = expectDeleteForbidden(basePath);
+    String iostats = ioStatisticsSourceToString(roleFS);
+
     if (multiDelete) {
       // multi-delete status checks
-      deleteVerbCount.assertDiffEquals("Wrong delete count", 1);
+      deleteVerbCount.assertDiffEquals("Wrong delete request count", 0);
+      bulkDeleteVerbCount.assertDiffEquals("Wrong count of delete operations in "
+          + iostats, 1);
       MultiObjectDeleteException mde = extractCause(
           MultiObjectDeleteException.class, ex);
       List<MultiObjectDeleteSupport.KeyPath> undeletedKeyPaths =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
@@ -475,7 +475,7 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
 
   /**
    * Execute a closure expecting a specific number of HEAD/LIST calls
-   * on <i>raw</i> S3 stores only.
+   * on <i>raw</i> S3 stores only. The operation is always evaluated.
    * @param cost expected cost
    * @param eval closure to evaluate
    * @param <T> return type of closure
@@ -484,7 +484,8 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
   protected <T> T verifyRaw(
       OperationCost cost,
       Callable<T> eval) throws Exception {
-    return verifyMetrics(eval, whenRaw(cost));
+    return verifyMetrics(eval,
+        whenRaw(cost), OperationCostValidator.always());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3ADeleteCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3ADeleteCost.java
@@ -121,17 +121,21 @@ public class ITestS3ADeleteCost extends AbstractS3ACostTest {
         with(DIRECTORIES_DELETED, 0),
         with(FILES_DELETED, 1),
 
+        // a single DELETE call is made to delete the object
+        with(OBJECT_DELETE_REQUEST, DELETE_OBJECT_REQUEST),
+
         // keeping: create no parent dirs or delete parents
         withWhenKeeping(DIRECTORIES_CREATED, 0),
-        withWhenKeeping(OBJECT_DELETE_OBJECTS, DELETE_OBJECT_REQUEST),
+        withWhenKeeping(OBJECT_BULK_DELETE_REQUEST, 0),
 
         // deleting: create a parent and delete any of its parents
         withWhenDeleting(DIRECTORIES_CREATED, 1),
-        // two objects will be deleted
-        withWhenDeleting(OBJECT_DELETE_OBJECTS,
-            DELETE_OBJECT_REQUEST
-                + DELETE_MARKER_REQUEST)
+        // a bulk delete for all parents is issued.
+        // the number of objects in it depends on the depth of the tree;
+        // don't worry about that
+        withWhenDeleting(OBJECT_BULK_DELETE_REQUEST, DELETE_MARKER_REQUEST)
     );
+
     // there is an empty dir for a parent
     S3AFileStatus status = verifyRawInnerGetFileStatus(dir, true,
         StatusProbeEnum.ALL, GET_FILE_STATUS_ON_DIR);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
@@ -23,18 +23,21 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.AbstractS3ATestBase;
 import org.apache.hadoop.fs.s3a.S3AInputStream;
-import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
+import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
+import org.assertj.core.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupGaugeStatistic;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToString;
 
 /**
  * Base class for scale tests; here is where the common scale configuration
@@ -184,17 +187,15 @@ public class S3AScaleTestBase extends AbstractS3ATestBase {
   }
 
   /**
-   * Get the gauge value of a statistic. Raises an assertion if
+   * Get the gauge value of a statistic from the
+   * IOStatistics of the filesystem. Raises an assertion if
    * there is no such gauge.
    * @param statistic statistic to look up
    * @return the value.
    */
   public long gaugeValue(Statistic statistic) {
-    S3AInstrumentation instrumentation = getFileSystem().getInstrumentation();
-    MutableGaugeLong gauge = instrumentation.lookupGauge(statistic.getSymbol());
-    assertNotNull("No gauge " + statistic
-        + " in " + instrumentation.dump("", " = ", "\n", true), gauge);
-    return gauge.value();
+    return lookupGaugeStatistic(getFileSystem().getIOStatistics(),
+        statistic.getSymbol());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.s3a.S3AInputStream;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
-import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
@@ -26,10 +26,8 @@ import org.apache.hadoop.fs.s3a.S3AInputStream;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
-import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
-import org.assertj.core.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +35,6 @@ import java.io.InputStream;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupGaugeStatistic;
-import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToString;
 
 /**
  * Base class for scale tests; here is where the common scale configuration


### PR DESCRIPTION
Fixing tests which fail intermittently based on configs and
in the case of the HugeFile tests, only in bulk runs when existing
FS instances meant statistic probes sometimes ended up probing those
of a previous FS.

Fixes:

* HADOOP-17451. HugeFile upload tests
* HADOOP-17456. ITestPartialRenamesDeletes.testPartialDirDelete failure
* HADOOP-17455. ITestS3ADeleteCost failure

---------

Testing: s3 london with ` -Dparallel-tests -DtestsThreadCount=6 -Dscale -Dmarkers=keep -Ds3guard -Ddynamo`

no test failures!