### PR TITLE
HADOOP-17272. ABFS Streams to support IOStatistics API

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -286,6 +286,78 @@ public final class StreamStatisticNames {
   public static final String STREAM_WRITE_TOTAL_DATA
       = "stream_write_total_data";
 
+  /**
+   * Number of bytes to upload from an OutputStream.
+   */
+  public static final String BYTES_TO_UPLOAD
+      = "bytes_upload";
+
+  /**
+   * Number of bytes uploaded successfully to the object store.
+   */
+  public static final String BYTES_UPLOAD_SUCCESSFUL
+      = "bytes_upload_successfully";
+
+  /**
+   * Number of bytes failed to upload to the object store.
+   */
+  public static final String BYTES_UPLOAD_FAILED
+      = "bytes_upload_failed";
+
+  /**
+   * Total time spent on waiting for a task to complete.
+   */
+  public static final String TIME_SPENT_ON_TASK_WAIT
+    = "time_spent_task_wait";
+
+  /**
+   * Number of task queue shrunk operations.
+   */
+  public static final String QUEUE_SHRUNK_OPS
+    = "queue_shrunk_ops";
+
+  /**
+   * Number of times current buffer is written to the service.
+   */
+  public static final String WRITE_CURRENT_BUFFER_OPERATIONS
+    = "write_current_buffer_ops";
+
+  /**
+   * Total time spent on completing a PUT request.
+   */
+  public static final String TIME_SPENT_ON_PUT_REQUEST
+    = "time_spent_on_put_request";
+
+  /**
+   * Number of seeks in buffer.
+   */
+  public static final String SEEK_IN_BUFFER
+      = "seek_in_buffer";
+
+  /**
+   * Number of bytes read from the buffer.
+   */
+  public static final String BYTES_READ_BUFFER
+      = "bytes_read_buffer";
+
+  /**
+   * Total number of remote read operations performed.
+   */
+  public static final String REMOTE_READ_OP
+  = "remote_read_op";
+
+  /**
+   * Total number of bytes read from readAhead.
+   */
+  public static final String READ_AHEAD_BYTES_READ
+    = "read_ahead_bytes_read";
+
+  /**
+   * Total number of bytes read from remote operations.
+   */
+  public static final String REMOTE_BYTES_READ
+    = "remote_bytes_read";
+
   private StreamStatisticNames() {
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -308,25 +308,25 @@ public final class StreamStatisticNames {
    * Total time spent on waiting for a task to complete.
    */
   public static final String TIME_SPENT_ON_TASK_WAIT
-    = "time_spent_task_wait";
+      = "time_spent_task_wait";
 
   /**
    * Number of task queue shrunk operations.
    */
   public static final String QUEUE_SHRUNK_OPS
-    = "queue_shrunk_ops";
+      = "queue_shrunk_ops";
 
   /**
    * Number of times current buffer is written to the service.
    */
   public static final String WRITE_CURRENT_BUFFER_OPERATIONS
-    = "write_current_buffer_ops";
+      = "write_current_buffer_ops";
 
   /**
    * Total time spent on completing a PUT request.
    */
   public static final String TIME_SPENT_ON_PUT_REQUEST
-    = "time_spent_on_put_request";
+      = "time_spent_on_put_request";
 
   /**
    * Number of seeks in buffer.
@@ -344,19 +344,19 @@ public final class StreamStatisticNames {
    * Total number of remote read operations performed.
    */
   public static final String REMOTE_READ_OP
-  = "remote_read_op";
+      = "remote_read_op";
 
   /**
    * Total number of bytes read from readAhead.
    */
   public static final String READ_AHEAD_BYTES_READ
-    = "read_ahead_bytes_read";
+      = "read_ahead_bytes_read";
 
   /**
    * Total number of bytes read from remote operations.
    */
   public static final String REMOTE_BYTES_READ
-    = "remote_bytes_read";
+      = "remote_bytes_read";
 
   private StreamStatisticNames() {
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
@@ -73,35 +73,7 @@ public enum AbfsStatistic {
   READ_THROTTLES("read_throttles",
       "Total number of times a read operation is throttled."),
   WRITE_THROTTLES("write_throttles",
-      "Total number of times a write operation is throttled."),
-
-  //OutputStream statistics.
-  BYTES_TO_UPLOAD("bytes_upload",
-      "Total bytes to upload."),
-  BYTES_UPLOAD_SUCCESSFUL("bytes_upload_successfully",
-      "Total bytes uploaded successfully."),
-  BYTES_UPLOAD_FAILED("bytes_upload_failed",
-      "Total bytes failed to upload."),
-  TIME_SPENT_ON_TASK_WAIT("time_spent_task_wait",
-      "Total time spent on waiting for a task."),
-  QUEUE_SHRUNK_OPS("queue_shrunk_ops",
-      "Total number of times blocking queue was shrunk."),
-  WRITE_CURRENT_BUFFER_OPERATIONS("write_current_buffer_ops",
-      "Total number of times the current buffer is written to the service."),
-  TIME_SPENT_ON_PUT_REQUEST("time_spent_on_put_request",
-      "Total time spent on a put request."),
-
-  //InputStream statistics.
-  SEEK_IN_BUFFER("seek_in_buffer",
-      "Total number of seek operations performed in the buffer."),
-  BYTES_READ_BUFFER("bytes_read_buffer",
-      "Total number of bytes read from the buffer."),
-  REMOTE_READ_OP("remote_read_op",
-      "Total number of remote read operations performed."),
-  READ_AHEAD_BYTES_READ("read_ahead_bytes_read",
-      "Total number of bytes from readAhead."),
-  REMOTE_BYTES_READ("remote_bytes_read",
-      "Total number of bytes read from remote operations.");
+      "Total number of times a write operation is throttled.");
 
   private String statName;
   private String statDescription;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
@@ -73,7 +73,35 @@ public enum AbfsStatistic {
   READ_THROTTLES("read_throttles",
       "Total number of times a read operation is throttled."),
   WRITE_THROTTLES("write_throttles",
-      "Total number of times a write operation is throttled.");
+      "Total number of times a write operation is throttled."),
+
+  //OutputStream statistics.
+  BYTES_TO_UPLOAD("bytes_upload",
+      "Total bytes to upload."),
+  BYTES_UPLOAD_SUCCESSFUL("bytes_upload_successfully",
+      "Total bytes uploaded successfully."),
+  BYTES_UPLOAD_FAILED("bytes_upload_failed",
+      "Total bytes failed to upload."),
+  TIME_SPENT_ON_TASK_WAIT("time_spent_task_wait",
+      "Total time spent on waiting for a task."),
+  QUEUE_SHRUNK_OPS("queue_shrunk_ops",
+      "Total number of times blocking queue was shrunk."),
+  WRITE_CURRENT_BUFFER_OPERATIONS("write_current_buffer_ops",
+      "Total number of times the current buffer is written to the service."),
+  TIME_SPENT_ON_PUT_REQUEST("time_spent_on_put_request",
+      "Total time spent on a put request."),
+
+  //InputStream statistics.
+  SEEK_IN_BUFFER("seek_in_buffer",
+      "Total number of seek operations performed in the buffer."),
+  BYTES_READ_BUFFER("bytes_read_buffer",
+      "Total number of bytes read from the buffer."),
+  REMOTE_READ_OP("remote_read_op",
+      "Total number of remote read operations performed."),
+  READ_AHEAD_BYTES_READ("read_ahead_bytes_read",
+      "Total number of bytes from readAhead."),
+  REMOTE_BYTES_READ("remote_bytes_read",
+      "Total number of bytes read from remote operations.");
 
   private String statName;
   private String statDescription;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
@@ -20,12 +20,13 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
  * Interface for statistics for the AbfsInputStream.
  */
 @InterfaceStability.Unstable
-public interface AbfsInputStreamStatistics {
+public interface AbfsInputStreamStatistics extends IOStatisticsSource {
   /**
    * Seek backwards, incrementing the seek and backward seek counters.
    *

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatistics.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.IOStatistics;
 
 /**
  * Interface for statistics for the AbfsInputStream.
@@ -73,11 +74,8 @@ public interface AbfsInputStreamStatistics {
 
   /**
    * A {@code read(byte[] buf, int off, int len)} operation has started.
-   *
-   * @param pos starting position of the read.
-   * @param len length of bytes to read.
    */
-  void readOperationStarted(long pos, long len);
+  void readOperationStarted();
 
   /**
    * Records a successful remote read operation.
@@ -95,6 +93,12 @@ public interface AbfsInputStreamStatistics {
    * @param bytes the bytes to be incremented.
    */
   void remoteBytesRead(long bytes);
+
+  /**
+   * Get the IOStatisticsStore instance from AbfsInputStreamStatistics.
+   * @return instance of IOStatisticsStore which extends IOStatistics.
+   */
+  IOStatistics getIOStatistics();
 
   /**
    * Makes the string of all the AbfsInputStream statistics.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
@@ -18,23 +18,50 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.hadoop.fs.azurebfs.AbfsStatistic;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.*;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
+
 /**
  * Stats for the AbfsInputStream.
  */
 public class AbfsInputStreamStatisticsImpl
-    implements AbfsInputStreamStatistics {
-  private long seekOperations;
-  private long forwardSeekOperations;
-  private long backwardSeekOperations;
-  private long bytesRead;
-  private long bytesSkippedOnSeek;
-  private long bytesBackwardsOnSeek;
-  private long seekInBuffer;
-  private long readOperations;
-  private long bytesReadFromBuffer;
-  private long remoteReadOperations;
-  private long readAheadBytesRead;
-  private long remoteBytesRead;
+    implements AbfsInputStreamStatistics, IOStatisticsSource {
+
+  private final IOStatisticsStore ioStatisticsStore = iostatisticsStore()
+      .withCounters(
+          STREAM_READ_SEEK_OPERATIONS,
+          STREAM_READ_SEEK_FORWARD_OPERATIONS,
+          STREAM_READ_SEEK_BACKWARD_OPERATIONS,
+          STREAM_READ_BYTES,
+          STREAM_READ_SEEK_BYTES_SKIPPED,
+          STREAM_READ_OPERATIONS,
+          STREAM_READ_SEEK_BYTES_BACKWARDS,
+          getStatName(SEEK_IN_BUFFER),
+          getStatName(BYTES_READ_BUFFER),
+          getStatName(REMOTE_READ_OP),
+          getStatName(READ_AHEAD_BYTES_READ),
+          getStatName(REMOTE_BYTES_READ)
+          )
+      .withDurationTracking(StoreStatisticNames.ACTION_HTTP_GET_REQUEST)
+      .build();
+
+  private final AtomicLong bytesRead =
+      ioStatisticsStore.getCounterReference(STREAM_READ_BYTES);
+  private final AtomicLong readOps =
+      ioStatisticsStore.getCounterReference(STREAM_READ_OPERATIONS);
+  private final AtomicLong seekOps =
+      ioStatisticsStore.getCounterReference(STREAM_READ_SEEK_OPERATIONS);
 
   /**
    * Seek backwards, incrementing the seek and backward seek counters.
@@ -44,9 +71,9 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void seekBackwards(long negativeOffset) {
-    seekOperations++;
-    backwardSeekOperations++;
-    bytesBackwardsOnSeek -= negativeOffset;
+    seekOps.incrementAndGet();
+    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_BACKWARD_OPERATIONS);
+    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_BYTES_BACKWARDS, negativeOffset);
   }
 
   /**
@@ -58,11 +85,9 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void seekForwards(long skipped) {
-    seekOperations++;
-    forwardSeekOperations++;
-    if (skipped > 0) {
-      bytesSkippedOnSeek += skipped;
-    }
+    seekOps.incrementAndGet();
+    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_FORWARD_OPERATIONS);
+    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_BYTES_SKIPPED, skipped);
   }
 
   /**
@@ -90,9 +115,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void bytesRead(long bytes) {
-    if (bytes > 0) {
-      bytesRead += bytes;
-    }
+    bytesRead.addAndGet(bytes);
   }
 
   /**
@@ -104,9 +127,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void bytesReadFromBuffer(long bytes) {
-    if (bytes > 0) {
-      bytesReadFromBuffer += bytes;
-    }
+    ioStatisticsStore.incrementCounter(getStatName(BYTES_READ_BUFFER), bytes);
   }
 
   /**
@@ -116,18 +137,15 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void seekInBuffer() {
-    seekInBuffer++;
+    ioStatisticsStore.incrementCounter(getStatName(SEEK_IN_BUFFER));
   }
 
   /**
    * A {@code read(byte[] buf, int off, int len)} operation has started.
-   *
-   * @param pos starting position of the read.
-   * @param len length of bytes to read.
    */
   @Override
-  public void readOperationStarted(long pos, long len) {
-    readOperations++;
+  public void readOperationStarted() {
+    readOps.incrementAndGet();
   }
 
   /**
@@ -137,9 +155,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void readAheadBytesRead(long bytes) {
-    if (bytes > 0) {
-      readAheadBytesRead += bytes;
-    }
+    ioStatisticsStore.incrementCounter(getStatName(READ_AHEAD_BYTES_READ), bytes);
   }
 
   /**
@@ -149,9 +165,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void remoteBytesRead(long bytes) {
-    if (bytes > 0) {
-      remoteBytesRead += bytes;
-    }
+    ioStatisticsStore.incrementCounter(getStatName(REMOTE_BYTES_READ), bytes);
   }
 
   /**
@@ -161,55 +175,97 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void remoteReadOperation() {
-    remoteReadOperations++;
+    ioStatisticsStore.incrementCounter(getStatName(REMOTE_READ_OP));
   }
 
+  /**
+   * Getter for IOStatistics instance used.
+   * @return IOStatisticsStore instance which extends IOStatistics.
+   */
+  @Override
+  public IOStatistics getIOStatistics() {
+    return ioStatisticsStore;
+  }
+
+  @VisibleForTesting
   public long getSeekOperations() {
-    return seekOperations;
+    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_OPERATIONS);
   }
 
+  @VisibleForTesting
   public long getForwardSeekOperations() {
-    return forwardSeekOperations;
+    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_FORWARD_OPERATIONS);
   }
 
+  @VisibleForTesting
   public long getBackwardSeekOperations() {
-    return backwardSeekOperations;
+    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_BACKWARD_OPERATIONS);
   }
 
+  @VisibleForTesting
   public long getBytesRead() {
-    return bytesRead;
+    return ioStatisticsStore.counters().get(STREAM_READ_BYTES);
   }
 
+  @VisibleForTesting
   public long getBytesSkippedOnSeek() {
-    return bytesSkippedOnSeek;
+    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_BYTES_SKIPPED);
   }
 
+  @VisibleForTesting
   public long getBytesBackwardsOnSeek() {
-    return bytesBackwardsOnSeek;
+    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_BYTES_BACKWARDS);
   }
 
+  @VisibleForTesting
   public long getSeekInBuffer() {
-    return seekInBuffer;
+    return ioStatisticsStore.counters().get(getStatName(SEEK_IN_BUFFER));
+
   }
 
+  @VisibleForTesting
   public long getReadOperations() {
-    return readOperations;
+    return ioStatisticsStore.counters().get(STREAM_READ_OPERATIONS);
   }
 
+  @VisibleForTesting
   public long getBytesReadFromBuffer() {
-    return bytesReadFromBuffer;
+    return ioStatisticsStore.counters().get(getStatName(BYTES_READ_BUFFER));
   }
 
+  @VisibleForTesting
   public long getRemoteReadOperations() {
-    return remoteReadOperations;
+    return ioStatisticsStore.counters().get(getStatName(REMOTE_READ_OP));
   }
 
+  @VisibleForTesting
   public long getReadAheadBytesRead() {
-    return readAheadBytesRead;
+    return ioStatisticsStore.counters().get(getStatName(READ_AHEAD_BYTES_READ));
   }
 
+  @VisibleForTesting
   public long getRemoteBytesRead() {
-    return remoteBytesRead;
+    return ioStatisticsStore.counters().get(getStatName(REMOTE_BYTES_READ));
+  }
+
+  /**
+   * Getter for the mean value of the time taken to complete a HTTP GET
+   * request by AbfsInputStream.
+   * @return mean value.
+   */
+  @VisibleForTesting
+  public double getActionHttpGetRequest() {
+    return ioStatisticsStore.meanStatistics().
+        get(StoreStatisticNames.ACTION_HTTP_GET_REQUEST + StoreStatisticNames.SUFFIX_MEAN).mean();
+  }
+
+  /**
+   * Method to get Statistic name from the enum class.
+   * @param statistic AbfsStatistic to get the name of.
+   * @return String value of AbfsStatistic name.
+   */
+  private String getStatName(AbfsStatistic statistic) {
+    return statistic.getStatName();
   }
 
   /**
@@ -223,18 +279,7 @@ public class AbfsInputStreamStatisticsImpl
   public String toString() {
     final StringBuilder sb = new StringBuilder(
         "StreamStatistics{");
-    sb.append(", SeekOperations=").append(seekOperations);
-    sb.append(", ForwardSeekOperations=").append(forwardSeekOperations);
-    sb.append(", BackwardSeekOperations=").append(backwardSeekOperations);
-    sb.append(", BytesSkippedOnSeek=").append(bytesSkippedOnSeek);
-    sb.append(", BytesBackwardsOnSeek=").append(bytesBackwardsOnSeek);
-    sb.append(", seekInBuffer=").append(seekInBuffer);
-    sb.append(", BytesRead=").append(bytesRead);
-    sb.append(", ReadOperations=").append(readOperations);
-    sb.append(", bytesReadFromBuffer=").append(bytesReadFromBuffer);
-    sb.append(", remoteReadOperations=").append(remoteReadOperations);
-    sb.append(", readAheadBytesRead=").append(readAheadBytesRead);
-    sb.append(", remoteBytesRead=").append(remoteBytesRead);
+    sb.append(ioStatisticsStore.toString());
     sb.append('}');
     return sb.toString();
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStreamStatisticsImpl.java
@@ -21,12 +21,12 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.SUFFIX_MEAN;
-import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
 /**
@@ -37,18 +37,18 @@ public class AbfsInputStreamStatisticsImpl
 
   private final IOStatisticsStore ioStatisticsStore = iostatisticsStore()
       .withCounters(
-          STREAM_READ_SEEK_OPERATIONS,
-          STREAM_READ_SEEK_FORWARD_OPERATIONS,
-          STREAM_READ_SEEK_BACKWARD_OPERATIONS,
-          STREAM_READ_BYTES,
-          STREAM_READ_SEEK_BYTES_SKIPPED,
-          STREAM_READ_OPERATIONS,
-          STREAM_READ_SEEK_BYTES_BACKWARDS,
-          SEEK_IN_BUFFER,
-          BYTES_READ_BUFFER,
-          REMOTE_READ_OP,
-          READ_AHEAD_BYTES_READ,
-          REMOTE_BYTES_READ
+          StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS,
+          StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS,
+          StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS,
+          StreamStatisticNames.STREAM_READ_BYTES,
+          StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED,
+          StreamStatisticNames.STREAM_READ_OPERATIONS,
+          StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS,
+          StreamStatisticNames.SEEK_IN_BUFFER,
+          StreamStatisticNames.BYTES_READ_BUFFER,
+          StreamStatisticNames.REMOTE_READ_OP,
+          StreamStatisticNames.READ_AHEAD_BYTES_READ,
+          StreamStatisticNames.REMOTE_BYTES_READ
           )
       .withDurationTracking(ACTION_HTTP_GET_REQUEST)
       .build();
@@ -57,11 +57,11 @@ public class AbfsInputStreamStatisticsImpl
    * cost of the map lookup on every increment.
    */
   private final AtomicLong bytesRead =
-      ioStatisticsStore.getCounterReference(STREAM_READ_BYTES);
+      ioStatisticsStore.getCounterReference(StreamStatisticNames.STREAM_READ_BYTES);
   private final AtomicLong readOps =
-      ioStatisticsStore.getCounterReference(STREAM_READ_OPERATIONS);
+      ioStatisticsStore.getCounterReference(StreamStatisticNames.STREAM_READ_OPERATIONS);
   private final AtomicLong seekOps =
-      ioStatisticsStore.getCounterReference(STREAM_READ_SEEK_OPERATIONS);
+      ioStatisticsStore.getCounterReference(StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS);
 
   /**
    * Seek backwards, incrementing the seek and backward seek counters.
@@ -72,8 +72,8 @@ public class AbfsInputStreamStatisticsImpl
   @Override
   public void seekBackwards(long negativeOffset) {
     seekOps.incrementAndGet();
-    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_BACKWARD_OPERATIONS);
-    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_BYTES_BACKWARDS, negativeOffset);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS, negativeOffset);
   }
 
   /**
@@ -86,8 +86,8 @@ public class AbfsInputStreamStatisticsImpl
   @Override
   public void seekForwards(long skipped) {
     seekOps.incrementAndGet();
-    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_FORWARD_OPERATIONS);
-    ioStatisticsStore.incrementCounter(STREAM_READ_SEEK_BYTES_SKIPPED, skipped);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED, skipped);
   }
 
   /**
@@ -127,7 +127,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void bytesReadFromBuffer(long bytes) {
-    ioStatisticsStore.incrementCounter(BYTES_READ_BUFFER, bytes);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.BYTES_READ_BUFFER, bytes);
   }
 
   /**
@@ -137,7 +137,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void seekInBuffer() {
-    ioStatisticsStore.incrementCounter(SEEK_IN_BUFFER);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.SEEK_IN_BUFFER);
   }
 
   /**
@@ -155,7 +155,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void readAheadBytesRead(long bytes) {
-    ioStatisticsStore.incrementCounter(READ_AHEAD_BYTES_READ, bytes);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.READ_AHEAD_BYTES_READ, bytes);
   }
 
   /**
@@ -165,7 +165,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void remoteBytesRead(long bytes) {
-    ioStatisticsStore.incrementCounter(REMOTE_BYTES_READ, bytes);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.REMOTE_BYTES_READ, bytes);
   }
 
   /**
@@ -175,7 +175,7 @@ public class AbfsInputStreamStatisticsImpl
    */
   @Override
   public void remoteReadOperation() {
-    ioStatisticsStore.incrementCounter(REMOTE_READ_OP);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.REMOTE_READ_OP);
   }
 
   /**
@@ -189,63 +189,63 @@ public class AbfsInputStreamStatisticsImpl
 
   @VisibleForTesting
   public long getSeekOperations() {
-    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_OPERATIONS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS);
   }
 
   @VisibleForTesting
   public long getForwardSeekOperations() {
-    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_FORWARD_OPERATIONS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_SEEK_FORWARD_OPERATIONS);
   }
 
   @VisibleForTesting
   public long getBackwardSeekOperations() {
-    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_BACKWARD_OPERATIONS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_SEEK_BACKWARD_OPERATIONS);
   }
 
   @VisibleForTesting
   public long getBytesRead() {
-    return ioStatisticsStore.counters().get(STREAM_READ_BYTES);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_BYTES);
   }
 
   @VisibleForTesting
   public long getBytesSkippedOnSeek() {
-    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_BYTES_SKIPPED);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_SEEK_BYTES_SKIPPED);
   }
 
   @VisibleForTesting
   public long getBytesBackwardsOnSeek() {
-    return ioStatisticsStore.counters().get(STREAM_READ_SEEK_BYTES_BACKWARDS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_SEEK_BYTES_BACKWARDS);
   }
 
   @VisibleForTesting
   public long getSeekInBuffer() {
-    return ioStatisticsStore.counters().get(SEEK_IN_BUFFER);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.SEEK_IN_BUFFER);
 
   }
 
   @VisibleForTesting
   public long getReadOperations() {
-    return ioStatisticsStore.counters().get(STREAM_READ_OPERATIONS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.STREAM_READ_OPERATIONS);
   }
 
   @VisibleForTesting
   public long getBytesReadFromBuffer() {
-    return ioStatisticsStore.counters().get(BYTES_READ_BUFFER);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.BYTES_READ_BUFFER);
   }
 
   @VisibleForTesting
   public long getRemoteReadOperations() {
-    return ioStatisticsStore.counters().get(REMOTE_READ_OP);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.REMOTE_READ_OP);
   }
 
   @VisibleForTesting
   public long getReadAheadBytesRead() {
-    return ioStatisticsStore.counters().get(READ_AHEAD_BYTES_READ);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.READ_AHEAD_BYTES_READ);
   }
 
   @VisibleForTesting
   public long getRemoteBytesRead() {
-    return ioStatisticsStore.counters().get(REMOTE_BYTES_READ);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.REMOTE_BYTES_READ);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
 
@@ -46,6 +45,7 @@ import org.apache.hadoop.fs.azurebfs.utils.CachedSASToken;
 import org.apache.hadoop.fs.statistics.DurationTracker;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.io.ElasticByteBufferPool;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
 
@@ -53,7 +54,6 @@ import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
 
-import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
 import static org.apache.hadoop.io.IOUtils.wrapException;
 import static org.apache.hadoop.fs.azurebfs.contracts.services.AppendRequestParameters.Mode.APPEND_MODE;
 import static org.apache.hadoop.fs.azurebfs.contracts.services.AppendRequestParameters.Mode.FLUSH_CLOSE_MODE;
@@ -441,7 +441,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
     final Future<Void> job =
         completionService.submit(IOStatisticsBinding
             .trackDurationOfCallable((IOStatisticsStore) ioStatistics,
-                TIME_SPENT_ON_PUT_REQUEST,
+                StreamStatisticNames.TIME_SPENT_ON_PUT_REQUEST,
                 () -> {
                   AbfsPerfTracker tracker = client.getAbfsPerfTracker();
                   try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatistics.java
@@ -21,12 +21,13 @@ package org.apache.hadoop.fs.azurebfs.services;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.statistics.DurationTracker;
 import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
  * Interface for {@link AbfsOutputStream} statistics.
  */
 @InterfaceStability.Unstable
-public interface AbfsOutputStreamStatistics {
+public interface AbfsOutputStreamStatistics extends IOStatisticsSource {
 
   /**
    * Number of bytes to be uploaded.
@@ -51,6 +52,7 @@ public interface AbfsOutputStreamStatistics {
 
   /**
    * Time spent in waiting for tasks to be completed in the blocking queue.
+   * @return instance of the DurationTracker that tracks the time for waiting.
    */
   DurationTracker timeSpentTaskWait();
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatistics.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.IOStatistics;
 
 /**
  * Interface for {@link AbfsOutputStream} statistics.
@@ -49,11 +51,8 @@ public interface AbfsOutputStreamStatistics {
 
   /**
    * Time spent in waiting for tasks to be completed in the blocking queue.
-   *
-   * @param start millisecond at which the wait for task to be complete begins.
-   * @param end   millisecond at which the wait is completed for the task.
    */
-  void timeSpentTaskWait(long start, long end);
+  DurationTracker timeSpentTaskWait();
 
   /**
    * Number of times task queue is shrunk.
@@ -64,6 +63,12 @@ public interface AbfsOutputStreamStatistics {
    * Number of times buffer is written to the service after a write operation.
    */
   void writeCurrentBuffer();
+
+  /**
+   * Get the IOStatisticsStore instance from AbfsOutputStreamStatistics.
+   * @return instance of IOStatisticsStore which extends IOStatistics.
+   */
+  IOStatistics getIOStatistics();
 
   /**
    * Method to form a string of all AbfsOutputStream statistics and their

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatisticsImpl.java
@@ -18,32 +18,41 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.hadoop.fs.azurebfs.AbfsStatistic;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.*;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
+
 /**
  * OutputStream statistics implementation for Abfs.
  */
 public class AbfsOutputStreamStatisticsImpl
-    implements AbfsOutputStreamStatistics {
-  private long bytesToUpload;
-  private long bytesUploadSuccessful;
-  private long bytesUploadFailed;
-  /**
-   * Counter to get the total time spent while waiting for tasks to complete
-   * in the blocking queue inside the thread executor.
-   */
-  private long timeSpentOnTaskWait;
-  /**
-   * Counter to get the total number of queue shrink operations done {@code
-   * AbfsOutputStream#shrinkWriteOperationQueue()} by AbfsOutputStream to
-   * remove the write operations which were successfully done by
-   * AbfsOutputStream from the task queue.
-   */
-  private long queueShrunkOps;
-  /**
-   * Counter to get the total number of times the current buffer is written
-   * to the service {@code AbfsOutputStream#writeCurrentBufferToService()} via
-   * AbfsClient and appended to the data store by AbfsRestOperation.
-   */
-  private long writeCurrentBufferOperations;
+    implements AbfsOutputStreamStatistics, IOStatisticsSource {
+
+  private final IOStatisticsStore ioStatisticsStore = iostatisticsStore()
+      .withCounters(
+          getStatName(BYTES_TO_UPLOAD),
+          getStatName(BYTES_UPLOAD_SUCCESSFUL),
+          getStatName(BYTES_UPLOAD_FAILED),
+          getStatName(QUEUE_SHRUNK_OPS),
+          getStatName(WRITE_CURRENT_BUFFER_OPERATIONS)
+      )
+      .withDurationTracking(
+          getStatName(TIME_SPENT_ON_PUT_REQUEST),
+          getStatName(TIME_SPENT_ON_TASK_WAIT)
+      )
+      .build();
+  private final AtomicLong bytesUpload =
+      ioStatisticsStore.getCounterReference(getStatName(BYTES_TO_UPLOAD));
 
   /**
    * Records the need to upload bytes and increments the total bytes that
@@ -53,9 +62,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void bytesToUpload(long bytes) {
-    if (bytes > 0) {
-      bytesToUpload += bytes;
-    }
+    bytesUpload.addAndGet(bytes);
   }
 
   /**
@@ -66,9 +73,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void uploadSuccessful(long bytes) {
-    if (bytes > 0) {
-      bytesUploadSuccessful += bytes;
-    }
+    ioStatisticsStore.incrementCounter(getStatName(BYTES_UPLOAD_SUCCESSFUL), bytes);
   }
 
   /**
@@ -78,9 +83,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void uploadFailed(long bytes) {
-    if (bytes > 0) {
-      bytesUploadFailed += bytes;
-    }
+    ioStatisticsStore.incrementCounter(getStatName(BYTES_UPLOAD_FAILED), bytes);
   }
 
   /**
@@ -96,14 +99,10 @@ public class AbfsOutputStreamStatisticsImpl
    * This time spent while waiting for the task to be completed is being
    * recorded in this counter.
    *
-   * @param startTime time(in milliseconds) before the wait for task to be
-   *                  completed is begin.
-   * @param endTime   time(in milliseconds) after the wait for the task to be
-   *                  completed is done.
    */
   @Override
-  public void timeSpentTaskWait(long startTime, long endTime) {
-    timeSpentOnTaskWait += endTime - startTime;
+  public DurationTracker timeSpentTaskWait() {
+    return ioStatisticsStore.trackDuration(getStatName(TIME_SPENT_ON_TASK_WAIT));
   }
 
   /**
@@ -114,7 +113,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void queueShrunk() {
-    queueShrunkOps++;
+    ioStatisticsStore.incrementCounter(getStatName(QUEUE_SHRUNK_OPS));
   }
 
   /**
@@ -125,31 +124,68 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void writeCurrentBuffer() {
-    writeCurrentBufferOperations++;
+    ioStatisticsStore.incrementCounter(getStatName(WRITE_CURRENT_BUFFER_OPERATIONS));
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * A getter for IOStatisticsStore instance which extends IOStatistics.
+   *
+   * @return IOStatisticsStore instance.
+   */
+  @Override
+  public IOStatistics getIOStatistics() {
+    return ioStatisticsStore;
+  }
+
+  @VisibleForTesting
   public long getBytesToUpload() {
-    return bytesToUpload;
+    return ioStatisticsStore.counters().get(getStatName(BYTES_TO_UPLOAD));
   }
 
+  @VisibleForTesting
   public long getBytesUploadSuccessful() {
-    return bytesUploadSuccessful;
+    return ioStatisticsStore.counters().get(getStatName(BYTES_UPLOAD_SUCCESSFUL));
   }
 
+  @VisibleForTesting
   public long getBytesUploadFailed() {
-    return bytesUploadFailed;
+    return ioStatisticsStore.counters().get(getStatName(BYTES_UPLOAD_FAILED));
   }
 
+  @VisibleForTesting
   public long getTimeSpentOnTaskWait() {
-    return timeSpentOnTaskWait;
+    return ioStatisticsStore.counters().get(getStatName(TIME_SPENT_ON_TASK_WAIT));
   }
 
+  @VisibleForTesting
   public long getQueueShrunkOps() {
-    return queueShrunkOps;
+    return ioStatisticsStore.counters().get(getStatName(QUEUE_SHRUNK_OPS));
   }
 
+  @VisibleForTesting
   public long getWriteCurrentBufferOperations() {
-    return writeCurrentBufferOperations;
+    return ioStatisticsStore.counters().get(getStatName(WRITE_CURRENT_BUFFER_OPERATIONS));
+  }
+
+  /**
+   * Getter for mean value of time taken to complete a PUT request by
+   * AbfsOutputStream.
+   * @return mean value.
+   */
+  @VisibleForTesting
+  public double getTimeSpentOnPutRequest() {
+    return ioStatisticsStore.meanStatistics().get(getStatName(TIME_SPENT_ON_PUT_REQUEST) + StoreStatisticNames.SUFFIX_MEAN).mean();
+  }
+
+  /**
+   * Method to get Statistic name from the enum class.
+   * @param statistic AbfsStatistic to get the name of.
+   * @return String value of AbfsStatistic name.
+   */
+  private String getStatName(AbfsStatistic statistic) {
+    return statistic.getStatName();
   }
 
   /**
@@ -160,16 +196,7 @@ public class AbfsOutputStreamStatisticsImpl
   @Override public String toString() {
     final StringBuilder outputStreamStats = new StringBuilder(
         "OutputStream Statistics{");
-    outputStreamStats.append(", bytes_upload=").append(bytesToUpload);
-    outputStreamStats.append(", bytes_upload_successfully=")
-        .append(bytesUploadSuccessful);
-    outputStreamStats.append(", bytes_upload_failed=")
-        .append(bytesUploadFailed);
-    outputStreamStats.append(", time_spent_task_wait=")
-        .append(timeSpentOnTaskWait);
-    outputStreamStats.append(", queue_shrunk_ops=").append(queueShrunkOps);
-    outputStreamStats.append(", write_current_buffer_ops=")
-        .append(writeCurrentBufferOperations);
+    outputStreamStats.append(ioStatisticsStore.toString());
     outputStreamStats.append("}");
     return outputStreamStats.toString();
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatisticsImpl.java
@@ -20,12 +20,12 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.hadoop.fs.statistics.DurationTracker;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatisticsImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStreamStatisticsImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.hadoop.fs.statistics.DurationTracker;
@@ -27,7 +28,6 @@ import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
-import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
 /**
@@ -38,15 +38,15 @@ public class AbfsOutputStreamStatisticsImpl
 
   private final IOStatisticsStore ioStatisticsStore = iostatisticsStore()
       .withCounters(
-          BYTES_TO_UPLOAD,
-          BYTES_UPLOAD_SUCCESSFUL,
-          BYTES_UPLOAD_FAILED,
-          QUEUE_SHRUNK_OPS,
-          WRITE_CURRENT_BUFFER_OPERATIONS
+          StreamStatisticNames.BYTES_TO_UPLOAD,
+          StreamStatisticNames.BYTES_UPLOAD_SUCCESSFUL,
+          StreamStatisticNames.BYTES_UPLOAD_FAILED,
+          StreamStatisticNames.QUEUE_SHRUNK_OPS,
+          StreamStatisticNames.WRITE_CURRENT_BUFFER_OPERATIONS
       )
       .withDurationTracking(
-          TIME_SPENT_ON_PUT_REQUEST,
-          TIME_SPENT_ON_TASK_WAIT
+          StreamStatisticNames.TIME_SPENT_ON_PUT_REQUEST,
+          StreamStatisticNames.TIME_SPENT_ON_TASK_WAIT
       )
       .build();
 
@@ -54,11 +54,11 @@ public class AbfsOutputStreamStatisticsImpl
    * cost of the map lookup on every increment.
    */
   private final AtomicLong bytesUpload =
-      ioStatisticsStore.getCounterReference(BYTES_TO_UPLOAD);
+      ioStatisticsStore.getCounterReference(StreamStatisticNames.BYTES_TO_UPLOAD);
   private final AtomicLong bytesUploadedSuccessfully =
-      ioStatisticsStore.getCounterReference(BYTES_UPLOAD_SUCCESSFUL);
+      ioStatisticsStore.getCounterReference(StreamStatisticNames.BYTES_UPLOAD_SUCCESSFUL);
   private final AtomicLong writeCurrentBufferOps =
-      ioStatisticsStore.getCounterReference(WRITE_CURRENT_BUFFER_OPERATIONS);
+      ioStatisticsStore.getCounterReference(StreamStatisticNames.WRITE_CURRENT_BUFFER_OPERATIONS);
 
   /**
    * Records the need to upload bytes and increments the total bytes that
@@ -89,7 +89,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void uploadFailed(long bytes) {
-    ioStatisticsStore.incrementCounter(BYTES_UPLOAD_FAILED, bytes);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.BYTES_UPLOAD_FAILED, bytes);
   }
 
   /**
@@ -108,7 +108,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public DurationTracker timeSpentTaskWait() {
-    return ioStatisticsStore.trackDuration(TIME_SPENT_ON_TASK_WAIT);
+    return ioStatisticsStore.trackDuration(StreamStatisticNames.TIME_SPENT_ON_TASK_WAIT);
   }
 
   /**
@@ -119,7 +119,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @Override
   public void queueShrunk() {
-    ioStatisticsStore.incrementCounter(QUEUE_SHRUNK_OPS);
+    ioStatisticsStore.incrementCounter(StreamStatisticNames.QUEUE_SHRUNK_OPS);
   }
 
   /**
@@ -147,32 +147,32 @@ public class AbfsOutputStreamStatisticsImpl
 
   @VisibleForTesting
   public long getBytesToUpload() {
-    return ioStatisticsStore.counters().get(BYTES_TO_UPLOAD);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.BYTES_TO_UPLOAD);
   }
 
   @VisibleForTesting
   public long getBytesUploadSuccessful() {
-    return ioStatisticsStore.counters().get(BYTES_UPLOAD_SUCCESSFUL);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.BYTES_UPLOAD_SUCCESSFUL);
   }
 
   @VisibleForTesting
   public long getBytesUploadFailed() {
-    return ioStatisticsStore.counters().get(BYTES_UPLOAD_FAILED);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.BYTES_UPLOAD_FAILED);
   }
 
   @VisibleForTesting
   public long getTimeSpentOnTaskWait() {
-    return ioStatisticsStore.counters().get(TIME_SPENT_ON_TASK_WAIT);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.TIME_SPENT_ON_TASK_WAIT);
   }
 
   @VisibleForTesting
   public long getQueueShrunkOps() {
-    return ioStatisticsStore.counters().get(QUEUE_SHRUNK_OPS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.QUEUE_SHRUNK_OPS);
   }
 
   @VisibleForTesting
   public long getWriteCurrentBufferOperations() {
-    return ioStatisticsStore.counters().get(WRITE_CURRENT_BUFFER_OPERATIONS);
+    return ioStatisticsStore.counters().get(StreamStatisticNames.WRITE_CURRENT_BUFFER_OPERATIONS);
   }
 
   /**
@@ -182,7 +182,7 @@ public class AbfsOutputStreamStatisticsImpl
    */
   @VisibleForTesting
   public double getTimeSpentOnPutRequest() {
-    return ioStatisticsStore.meanStatistics().get(TIME_SPENT_ON_PUT_REQUEST + StoreStatisticNames.SUFFIX_MEAN).mean();
+    return ioStatisticsStore.meanStatistics().get(StreamStatisticNames.TIME_SPENT_ON_PUT_REQUEST + StoreStatisticNames.SUFFIX_MEAN).mean();
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
@@ -389,6 +389,7 @@ public class ITestAbfsInputStreamStatistics
       AbfsInputStreamStatisticsImpl abfsInputStreamStatistics =
           (AbfsInputStreamStatisticsImpl) abfsInputStream.getStreamStatistics();
 
+      LOG.info("AbfsInputStreamStats info: {}", abfsInputStreamStatistics.toString());
       Assertions.assertThat(
           abfsInputStreamStatistics.getActionHttpGetRequest())
           .describedAs("Mismatch in time taken by a GET request")

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
@@ -139,10 +139,9 @@ public class ITestAbfsInputStreamStatistics
        * forwardSeekOps - Since we are doing a forward seek inside a loop
        * for OPERATION times, total forward seeks would be OPERATIONS.
        *
-       * bytesBackwardsOnSeek - Since we are doing backward seeks from end of
-       * file in a ONE_MB file each time, this would mean the bytes from
-       * backward seek would be OPERATIONS * ONE_MB. Since this is backward
-       * seek this value is expected be to be negative.
+       * negativeBytesBackwardsOnSeek - Since we are doing backward seeks from
+       * end of file in a ONE_MB file each time, this would mean the bytes from
+       * backward seek would be OPERATIONS * ONE_MB.
        *
        * bytesSkippedOnSeek - Since, we move from start to end in seek, but
        * our fCursor(position of cursor) always remain at end of file, this
@@ -160,7 +159,7 @@ public class ITestAbfsInputStreamStatistics
       assertEquals("Mismatch in forwardSeekOps value", OPERATIONS,
           stats.getForwardSeekOperations());
       assertEquals("Mismatch in bytesBackwardsOnSeek value",
-          -1 * OPERATIONS * ONE_MB, stats.getBytesBackwardsOnSeek());
+          OPERATIONS * ONE_MB, stats.getBytesBackwardsOnSeek());
       assertEquals("Mismatch in bytesSkippedOnSeek value",
           0, stats.getBytesSkippedOnSeek());
       assertEquals("Mismatch in seekInBuffer value", 2 * OPERATIONS,
@@ -363,6 +362,39 @@ public class ITestAbfsInputStreamStatistics
 
     } finally {
       IOUtils.cleanupWithLogger(LOG, out, in);
+    }
+  }
+
+  /**
+   * Testing time taken by AbfsInputStream to complete a GET request.
+   */
+  @Test
+  public void testActionHttpGetRequest() throws IOException {
+    describe("Test to check the correct value of Time taken by http get "
+        + "request in AbfsInputStream");
+    AzureBlobFileSystem fs = getFileSystem();
+    AzureBlobFileSystemStore abfss = fs.getAbfsStore();
+    Path actionHttpGetRequestPath = path(getMethodName());
+    AbfsInputStream abfsInputStream = null;
+    AbfsOutputStream abfsOutputStream = null;
+    try {
+      abfsOutputStream = createAbfsOutputStreamWithFlushEnabled(fs,
+          actionHttpGetRequestPath);
+      abfsOutputStream.write('a');
+      abfsOutputStream.hflush();
+
+      abfsInputStream =
+          abfss.openFileForRead(actionHttpGetRequestPath, fs.getFsStatistics());
+      abfsInputStream.read();
+      AbfsInputStreamStatisticsImpl abfsInputStreamStatistics =
+          (AbfsInputStreamStatisticsImpl) abfsInputStream.getStreamStatistics();
+
+      Assertions.assertThat(
+          abfsInputStreamStatistics.getActionHttpGetRequest())
+          .describedAs("Mismatch in time taken by a GET request")
+          .isGreaterThan(0.0);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, abfsInputStream, abfsOutputStream);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsOutputStreamStatistics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.IOException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.Path;
@@ -31,6 +32,7 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStreamStatisticsImpl;
  */
 public class ITestAbfsOutputStreamStatistics
     extends AbstractAbfsIntegrationTest {
+
   private static final int OPERATIONS = 10;
 
   public ITestAbfsOutputStreamStatistics() throws Exception {
@@ -216,6 +218,31 @@ public class ITestAbfsOutputStreamStatistics
       assertEquals("Mismatch in write current buffer operations",
           OPERATIONS,
           abfsOutputStreamStatistics.getWriteCurrentBufferOperations());
+    }
+  }
+
+  /**
+   * Test to check correct value of time spent on a PUT request in
+   * AbfsOutputStream.
+   */
+  @Test
+  public void testAbfsOutputStreamDurationTrackerPutRequest() throws IOException {
+    describe("Testing to check if DurationTracker for PUT request is working "
+        + "correctly.");
+    AzureBlobFileSystem fs = getFileSystem();
+    Path pathForPutRequest = path(getMethodName());
+
+    try(AbfsOutputStream outputStream =
+        createAbfsOutputStreamWithFlushEnabled(fs, pathForPutRequest)) {
+      outputStream.write('a');
+      outputStream.hflush();
+
+      AbfsOutputStreamStatisticsImpl abfsOutputStreamStatistics =
+          getAbfsOutputStreamStatistics(outputStream);
+
+     Assertions.assertThat(abfsOutputStreamStatistics.getTimeSpentOnPutRequest())
+          .describedAs("Mismatch in timeSpentOnPutRequest DurationTracker")
+          .isGreaterThan(0.0);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsOutputStreamStatistics.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
@@ -34,6 +36,8 @@ public class ITestAbfsOutputStreamStatistics
     extends AbstractAbfsIntegrationTest {
 
   private static final int OPERATIONS = 10;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ITestAbfsOutputStreamStatistics.class);
 
   public ITestAbfsOutputStreamStatistics() throws Exception {
   }
@@ -239,8 +243,8 @@ public class ITestAbfsOutputStreamStatistics
 
       AbfsOutputStreamStatisticsImpl abfsOutputStreamStatistics =
           getAbfsOutputStreamStatistics(outputStream);
-
-     Assertions.assertThat(abfsOutputStreamStatistics.getTimeSpentOnPutRequest())
+      LOG.info("AbfsOutputStreamStats info: {}", abfsOutputStreamStatistics.toString());
+      Assertions.assertThat(abfsOutputStreamStatistics.getTimeSpentOnPutRequest())
           .describedAs("Mismatch in timeSpentOnPutRequest DurationTracker")
           .isGreaterThan(0.0);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsOutputStreamStatistics.java
@@ -94,17 +94,11 @@ public class TestAbfsOutputStreamStatistics
     assertEquals("Mismatch in time spent on waiting for tasks to complete", 0,
         abfsOutputStreamStatistics.getTimeSpentOnTaskWait());
 
-    int smallRandomStartTime =
-        new Random().nextInt(LOW_RANGE_FOR_RANDOM_VALUE);
-    int smallRandomEndTime =
-        new Random().nextInt(LOW_RANGE_FOR_RANDOM_VALUE)
-            + smallRandomStartTime;
-    int smallDiff = smallRandomEndTime - smallRandomStartTime;
     abfsOutputStreamStatistics
-        .timeSpentTaskWait(smallRandomStartTime, smallRandomEndTime);
-    //Test for small random value of timeSpentWaitTask.
+        .timeSpentTaskWait();
+    //Test for one op call value of timeSpentWaitTask.
     assertEquals("Mismatch in time spent on waiting for tasks to complete",
-        smallDiff, abfsOutputStreamStatistics.getTimeSpentOnTaskWait());
+        1, abfsOutputStreamStatistics.getTimeSpentOnTaskWait());
 
     //Reset statistics for the next test.
     abfsOutputStreamStatistics = new AbfsOutputStreamStatisticsImpl();
@@ -113,23 +107,16 @@ public class TestAbfsOutputStreamStatistics
      * Entering multiple values for timeSpentTaskWait() to check the
      * summation is happening correctly. Also calculating the expected result.
      */
-    int expectedRandomDiff = 0;
     for (int i = 0; i < OPERATIONS; i++) {
-      int largeRandomStartTime =
-          new Random().nextInt(HIGH_RANGE_FOR_RANDOM_VALUE);
-      int largeRandomEndTime = new Random().nextInt(HIGH_RANGE_FOR_RANDOM_VALUE)
-          + largeRandomStartTime;
-      abfsOutputStreamStatistics
-          .timeSpentTaskWait(largeRandomStartTime, largeRandomEndTime);
-      expectedRandomDiff += largeRandomEndTime - largeRandomStartTime;
+       abfsOutputStreamStatistics.timeSpentTaskWait();
     }
 
     /*
-     * Test to check correct value of timeSpentTaskWait after multiple
-     * random values are passed in it.
+     * Test to check correct value of timeSpentTaskWait after OPERATIONS
+     * number of op calls.
      */
     assertEquals("Mismatch in time spent on waiting for tasks to complete",
-        expectedRandomDiff,
+        OPERATIONS,
         abfsOutputStreamStatistics.getTimeSpentOnTaskWait());
   }
 


### PR DESCRIPTION
Previously #2353, Had to close it due to parent branch closing and pushed in a new PR. Now the IOStatistics has been merged in trunk as 3 PRs(#2577, #2579, #2580). 

Tested using:  mvn -T 1C -Dparallel-tests=abfs clean verify
Region: East US

```
[INFO] Results:
[INFO]
[INFO] Tests run: 90, Failures: 0, Errors: 0, Skipped: 0
```
```
[INFO] Results:
[ERROR] Tests run: 500, Failures: 0, Errors: 8, Skipped: 67
```
[errors related to #2331]
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 255, Failures: 0, Errors: 0, Skipped: 77
```