### PR TITLE
HADOOP-17459. ADLS Gen1: Fixes for rename contract tests

### DIFF
--- a/hadoop-tools/hadoop-azure-datalake/src/test/java/org/apache/hadoop/fs/adl/live/TestAdlContractRenameLive.java
+++ b/hadoop-tools/hadoop-azure-datalake/src/test/java/org/apache/hadoop/fs/adl/live/TestAdlContractRenameLive.java
@@ -19,13 +19,9 @@
 
 package org.apache.hadoop.fs.adl.live;
 
-import org.junit.Test;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.apache.hadoop.security.AccessControlException;
-import org.apache.hadoop.test.LambdaTestUtils;
 
 /**
  * Test rename contract test cases on Adl file system.
@@ -37,14 +33,4 @@ public class TestAdlContractRenameLive extends AbstractContractRenameTest {
     return new AdlStorageContract(configuration);
   }
 
-  /**
-   * ADL throws an Access Control Exception rather than return false.
-   * This is caught and its error text checked, to catch regressions.
-   */
-  @Test
-  public void testRenameFileUnderFile() throws Exception {
-    LambdaTestUtils.intercept(AccessControlException.class,
-        "Parent path is not a folder.",
-        super::testRenameFileUnderFile);
-  }
 }

--- a/hadoop-tools/hadoop-azure-datalake/src/test/resources/adls.xml
+++ b/hadoop-tools/hadoop-azure-datalake/src/test/resources/adls.xml
@@ -39,6 +39,11 @@
   </property>
 
   <property>
+    <name>fs.contract.rename-returns-false-if-dest-exists</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <name>fs.contract.test.random-seek-count</name>
     <value>10</value>
   </property>


### PR DESCRIPTION
Fix the following test case failures which are failing after the contract test update in hadoop-common

[ERROR] Failures:
[ERROR] TestAdlContractRenameLive>AbstractContractRenameTest.testRenameFileOverExistingFile:131->Assert.fail:88 expected rename(/test/source-256.txt, /test/dest-512.txt) to be rejected with exception, but got false
[ERROR] TestAdlContractRenameLive.testRenameFileUnderFile:46 Expecting org.apache.hadoop.security.AccessControlException with text Parent path is not a folder. but got : "void"

Post updates to rename on existing file test, ADL contract test is having failure. Updates were made in the AbstractContractTest class in https://issues.apache.org/jira/browse/HADOOP-17365.

To align to test expectation of no exception but a false return from rename, ADL tests need config "fs.contract.rename-returns-false-if-dest-exists" set to true.

[Test results pasted at the end of conversation tab].