### PR TITLE
HADOOP-17462: Hadoop Client getRpcResponse May Return Wrong Result

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -330,7 +330,7 @@ public class Client implements AutoCloseable {
     Writable rpcResponse;       // null if rpc has error
     IOException error;          // exception, null if success
     final RPC.RpcKind rpcKind;      // Rpc EngineKind
-    boolean done;               // true when call is done
+    volatile boolean done;      // true when call is done
     private final Object externalHandler;
     private AlignmentContext alignmentContext;
 


### PR DESCRIPTION
The done variable is not marked as volatile so the thread which is checking its status is free to cache the value and never reload it even though it is expected to change by a different thread. The while loop may be stuck waiting for the change, but is always looking at a cached value. If that happens, timeout will occur and then return 'null'.

In previous versions of Hadoop, there was no time-out at this level, so it would cause endless loop. Really tough error to track down if it happens.