### PR TITLE
YARN-10566. Elapsed time should be measured monotonicNow

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/Client.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/Client.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
@@ -213,7 +214,7 @@ public class Client {
   private String rollingFilesPattern = "";
 
   // Start time for client
-  private long clientStartTime = System.currentTimeMillis();
+  private long clientStartTime = Time.monotonicNow();
   // Timeout threshold for client. Kill app after time interval expires.
   private long clientTimeout = 600000;
 
@@ -681,7 +682,7 @@ public class Client {
     isRunning.set(true);
     yarnClient.start();
     // set the client start time.
-    clientStartTime = System.currentTimeMillis();
+    clientStartTime = Time.monotonicNow();
 
     YarnClusterMetrics clusterMetrics = yarnClient.getYarnClusterMetrics();
     LOG.info("Got Cluster metric info from ASM" 
@@ -1179,7 +1180,7 @@ public class Client {
 
       // The value equal or less than 0 means no timeout
       if (clientTimeout > 0
-          && System.currentTimeMillis() > (clientStartTime + clientTimeout)) {
+          && Time.monotonicNow() > (clientStartTime + clientTimeout)) {
         LOG.info("Reached client specified timeout for application. " +
             "Killing application");
         needForceKill = true;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/src/main/java/org/apache/hadoop/yarn/applications/unmanagedamlauncher/UnmanagedAMLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/src/main/java/org/apache/hadoop/yarn/applications/unmanagedamlauncher/UnmanagedAMLauncher.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -385,7 +386,7 @@ public class UnmanagedAMLauncher {
   private ApplicationAttemptReport monitorCurrentAppAttempt(
       ApplicationId appId, YarnApplicationAttemptState attemptState)
       throws YarnException, IOException {
-    long startTime = System.currentTimeMillis();
+    long startTime = Time.monotonicNow();
     ApplicationAttemptId attemptId = null;
     while (true) {
       if (attemptId == null) {
@@ -409,7 +410,7 @@ public class UnmanagedAMLauncher {
         LOG.warn("Interrupted while waiting for current attempt of " + appId
             + " to reach " + attemptState);
       }
-      if (System.currentTimeMillis() - startTime > AM_STATE_WAIT_TIMEOUT_MS) {
+      if (Time.monotonicNow() - startTime > AM_STATE_WAIT_TIMEOUT_MS) {
         String errmsg =
             "Timeout for waiting current attempt of " + appId + " to reach "
                 + attemptState;
@@ -478,8 +479,8 @@ public class UnmanagedAMLauncher {
       // come back
       if (amCompleted) {
         if (foundAMCompletedTime == 0) {
-          foundAMCompletedTime = System.currentTimeMillis();
-        } else if ((System.currentTimeMillis() - foundAMCompletedTime)
+          foundAMCompletedTime = Time.monotonicNow();
+        } else if ((Time.monotonicNow() - foundAMCompletedTime)
             > AM_STATE_WAIT_TIMEOUT_MS) {
           LOG.warn("Waited " + AM_STATE_WAIT_TIMEOUT_MS/1000
               + " seconds after process completed for AppReport"

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/client/ServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/client/ServiceClient.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.UpdateApplicationTimeoutsRequest;
@@ -761,7 +762,7 @@ public class ServiceClient extends AppAdminClient implements SliderExitCodes,
         return EXIT_SUCCESS;
       }
       // Wait until the app is killed.
-      long startTime = System.currentTimeMillis();
+      long startTime = Time.monotonicNow();
       int pollCount = 0;
       while (true) {
         Thread.sleep(2000);
@@ -771,7 +772,7 @@ public class ServiceClient extends AppAdminClient implements SliderExitCodes,
           break;
         }
         // Forcefully kill after 10 seconds.
-        if ((System.currentTimeMillis() - startTime) > 10000) {
+        if ((Time.monotonicNow() - startTime) > 10000) {
           LOG.info("Stop operation timeout stopping, forcefully kill the app "
               + serviceName);
           yarnClient.killApplication(currentAppId,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.server.KerberosAuthenticationHandler;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.FailApplicationAttemptRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetAllResourceProfilesRequest;
@@ -336,7 +337,7 @@ public class YarnClientImpl extends YarnClient {
     rmClient.submitApplication(request);
 
     int pollCount = 0;
-    long startTime = System.currentTimeMillis();
+    long startTime = Time.monotonicNow();
     EnumSet<YarnApplicationState> waitingStates = 
                                  EnumSet.of(YarnApplicationState.NEW,
                                  YarnApplicationState.NEW_SAVING,
@@ -357,7 +358,7 @@ public class YarnClientImpl extends YarnClient {
           break;
         }
 
-        long elapsedMillis = System.currentTimeMillis() - startTime;
+        long elapsedMillis = Time.monotonicNow() - startTime;
         if (enforceAsyncAPITimeout() &&
             elapsedMillis >= asyncApiPollTimeoutMillis) {
           throw new YarnException("Timed out while waiting for application " +
@@ -554,7 +555,7 @@ public class YarnClientImpl extends YarnClient {
 
     try {
       int pollCount = 0;
-      long startTime = System.currentTimeMillis();
+      long startTime = Time.monotonicNow();
 
       while (true) {
         KillApplicationResponse response =
@@ -564,7 +565,7 @@ public class YarnClientImpl extends YarnClient {
           break;
         }
 
-        long elapsedMillis = System.currentTimeMillis() - startTime;
+        long elapsedMillis = Time.monotonicNow() - startTime;
         if (enforceAsyncAPITimeout()
             && elapsedMillis >= this.asyncApiPollTimeoutMillis) {
           throw new YarnException("Timed out while waiting for application "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestHedgingRequestRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestHedgingRequestRMFailoverProxyProvider.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.HAServiceProtocol;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
@@ -65,12 +66,12 @@ public class TestHedgingRequestRMFailoverProxyProvider {
       client.start();
 
       // Transition rm5 to active;
-      long start = System.currentTimeMillis();
+      long start = Time.monotonicNow();
       makeRMActive(cluster, 4);
 
       validateActiveRM(client);
 
-      long end = System.currentTimeMillis();
+      long end = Time.monotonicNow();
       System.out.println("Client call succeeded at " + end);
       // should return the response fast
       Assert.assertTrue(end - start <= 10000);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.service.Service.STATE;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
@@ -1781,7 +1782,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
       amClient.init(conf);
       amClient.start();
 
-      Long startTime = System.currentTimeMillis();
+      Long startTime = Time.monotonicNow();
       amClient.registerApplicationMaster("Host", 10000, "");
 
       org.apache.hadoop.security.token.Token<AMRMTokenIdentifier> amrmToken_1 =
@@ -1792,7 +1793,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
 
       // Wait for enough time and make sure the roll_over happens
       // At mean time, the old AMRMToken should continue to work
-      while (System.currentTimeMillis() - startTime <
+      while (Time.monotonicNow() - startTime <
           rollingIntervalSec * 1000) {
         amClient.allocate(0.1f);
         sleep(1000);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientOnRMRestart.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientOnRMRestart.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
@@ -432,7 +433,7 @@ public class TestAMRMClientOnRMRestart {
     // start first RM
     MyResourceManager2 rm1 = new MyResourceManager2(conf, memStore);
     rm1.start();
-    Long startTime = System.currentTimeMillis();
+    Long startTime = Time.monotonicNow();
     // Submit the application
     RMApp app = MockRMAppSubmitter.submitWithMemory(1024, rm1);
     rm1.drainEvents();
@@ -463,7 +464,7 @@ public class TestAMRMClientOnRMRestart {
 
     // Wait for enough time and make sure the roll_over happens
     // At mean time, the old AMRMToken should continue to work
-    while (System.currentTimeMillis() - startTime < rolling_interval_sec * 1000) {
+    while (Time.monotonicNow() - startTime < rolling_interval_sec * 1000) {
       amClient.allocate(0.1f);
       try {
         Thread.sleep(1000);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClient.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.server.KerberosAuthenticationHandler;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportResponse;
@@ -1067,9 +1068,9 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
 
       appId = createApp(rmClient, true);
       waitTillAccepted(rmClient, appId, true);
-      long start = System.currentTimeMillis();
+      long start = Time.monotonicNow();
       while (rmClient.getAMRMToken(appId) == null) {
-        if (System.currentTimeMillis() - start > 20 * 1000) {
+        if (Time.monotonicNow() - start > 20 * 1000) {
           Assert.fail("AMRM token is null");
         }
         Thread.sleep(100);
@@ -1088,9 +1089,9 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
             rmClient.start();
             ApplicationId appId = createApp(rmClient, true);
           waitTillAccepted(rmClient, appId, true);
-            long start = System.currentTimeMillis();
+            long start = Time.monotonicNow();
             while (rmClient.getAMRMToken(appId) == null) {
-              if (System.currentTimeMillis() - start > 20 * 1000) {
+              if (Time.monotonicNow() - start > 20 * 1000) {
                 Assert.fail("AMRM token is null");
               }
               Thread.sleep(100);
@@ -1150,10 +1151,10 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
   private void waitTillAccepted(YarnClient rmClient, ApplicationId appId,
       boolean unmanagedApplication)
     throws Exception {
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     ApplicationReport report = rmClient.getApplicationReport(appId);
     while (YarnApplicationState.ACCEPTED != report.getYarnApplicationState()) {
-      if (System.currentTimeMillis() - start > 20 * 1000) {
+      if (Time.monotonicNow() - start > 20 * 1000) {
         throw new Exception(
             "App '" + appId + "' time out, failed to reach ACCEPTED state");
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineV2ClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineV2ClientImpl.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthenticatedURL;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.CollectorInfo;
 import org.apache.hadoop.yarn.api.records.Token;
@@ -471,10 +472,10 @@ public class TimelineV2ClientImpl extends TimelineV2Client {
             // Try to drain the remaining entities to be published @ the max for
             // 2 seconds
             long timeTillweDrain =
-                System.currentTimeMillis() + drainTimeoutPeriod;
+                Time.monotonicNow() + drainTimeoutPeriod;
             while (!timelineEntityQueue.isEmpty()) {
               publishWithoutBlockingOnQueue(timelineEntityQueue.poll());
-              if (System.currentTimeMillis() > timeTillweDrain) {
+              if (Time.monotonicNow() > timeTillweDrain) {
                 // time elapsed stop publishing further....
                 if (!timelineEntityQueue.isEmpty()) {
                   LOG.warn("Time to drain elapsed! Remaining "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.util.ShutdownHookManager;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 
@@ -180,14 +181,14 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
     if (drainEventsOnStop) {
       blockNewEvents = true;
       LOG.info("AsyncDispatcher is draining to stop, ignoring any new events.");
-      long endTime = System.currentTimeMillis() + getConfig()
+      long endTime = Time.monotonicNow() + getConfig()
           .getLong(YarnConfiguration.DISPATCHER_DRAIN_EVENTS_TIMEOUT,
               YarnConfiguration.DEFAULT_DISPATCHER_DRAIN_EVENTS_TIMEOUT);
 
       synchronized (waitForDrained) {
         while (!isDrained() && eventHandlingThread != null
             && eventHandlingThread.isAlive()
-            && System.currentTimeMillis() < endTime) {
+            && Time.monotonicNow() < endTime) {
           waitForDrained.wait(100);
           LOG.info("Waiting for AsyncDispatcher to drain. Thread state is :" +
               eventHandlingThread.getState());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.service.ServiceStateException;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntities;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEvent;
@@ -365,7 +366,7 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
     entitiesPrep.addEntity(entityToStorePrep);
     store.put(entitiesPrep);
 
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     int num = 1000000;
 
     Log.getLog().info("Start test for " + num);
@@ -413,7 +414,7 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
       store.put(entities);
     }
 
-    long duration = System.currentTimeMillis() - start;
+    long duration = Time.monotonicNow() - start;
     Log.getLog().info("Duration for " + num + ": " + duration);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
@@ -450,7 +451,7 @@ public class UnmanagedApplicationManager {
       YarnApplicationAttemptState attemptState)
       throws YarnException, IOException {
 
-    long startTime = System.currentTimeMillis();
+    long startTime = Time.monotonicNow();
     ApplicationAttemptId appAttemptId = null;
     while (true) {
       if (appAttemptId == null) {
@@ -495,7 +496,7 @@ public class UnmanagedApplicationManager {
             + " to reach " + attemptState);
       }
 
-      if (System.currentTimeMillis() - startTime > AM_STATE_WAIT_TIMEOUT_MS) {
+      if (Time.monotonicNow() - startTime > AM_STATE_WAIT_TIMEOUT_MS) {
         throw new RuntimeException("Timeout for waiting current attempt of "
             + appId + " to reach " + attemptState);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/lib/TestZKClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/lib/TestZKClient.java
@@ -29,6 +29,7 @@ import java.net.Socket;
 import org.apache.hadoop.net.ServerSocketUtil;
 import org.junit.Assert;
 
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.lib.ZKClient;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
@@ -83,7 +84,7 @@ public class TestZKClient  {
   }
 
   public static boolean waitForServerDown(String hp, long timeout) {
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     while (true) {
       try {
         String host = hp.split(":")[0];
@@ -93,7 +94,7 @@ public class TestZKClient  {
         return true;
       }
 
-      if (System.currentTimeMillis() > start + timeout) {
+      if (Time.monotonicNow() > start + timeout) {
         break;
       }
       try {
@@ -107,7 +108,7 @@ public class TestZKClient  {
 
 
   public static boolean waitForServerUp(String hp, long timeout) {
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     while (true) {
       try {
         String host = hp.split(":")[0];
@@ -119,7 +120,7 @@ public class TestZKClient  {
         }
       } catch (IOException e) {
       }
-      if (System.currentTimeMillis() > start + timeout) {
+      if (Time.monotonicNow() > start + timeout) {
         break;
       }
       try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
@@ -33,6 +33,7 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.api.records.NMToken;
 import org.apache.hadoop.yarn.api.records.NodeReport;
@@ -215,14 +216,14 @@ public class TestLocalityMulticastAMRMProxyPolicy
     prepPolicyWithHeadroom(true);
 
     int numIterations = 1000;
-    long tstart = System.currentTimeMillis();
+    long tstart = Time.monotonicNow();
     for (int i = 0; i < numIterations; i++) {
       Map<SubClusterId, List<ResourceRequest>> response =
           ((FederationAMRMProxyPolicy) getPolicy()).splitResourceRequests(
               resourceRequests, new HashSet<SubClusterId>());
       validateSplit(response, resourceRequests);
     }
-    long tend = System.currentTimeMillis();
+    long tend = Time.monotonicNow();
 
     LOG.info("Performed " + numIterations + " policy invocations (and "
         + "validations) in " + (tend - tstart) + "ms");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.VersionUtil;
 import org.apache.hadoop.yarn.api.protocolrecords.SignalContainerRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -957,7 +958,7 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
           value = null;
         } finally {
           // Set last send time in heartbeat
-          lastSendMills = System.currentTimeMillis();
+          lastSendMills = Time.monotonicNow();
         }
       } else {
         // if value have not changed then no need to send
@@ -971,7 +972,7 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
      */
     public boolean isResyncIntervalElapsed() {
       long elapsedTimeSinceLastSync =
-          System.currentTimeMillis() - lastSendMills;
+          Time.monotonicNow() - lastSendMills;
       if (elapsedTimeSinceLastSync > resyncInterval) {
         return true;
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.protocolrecords.GetLocalizationStatusesRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetLocalizationStatusesResponse;
 import org.apache.hadoop.yarn.api.records.LocalizationStatus;
@@ -740,9 +741,10 @@ public class ContainerManagerImpl extends CompositeService implements
 
     LOG.info("Waiting for Applications to be Finished");
 
-    long waitStartTime = System.currentTimeMillis();
+    long waitStartTime = Time.monotonicNow();
     while (!applications.isEmpty()
-        && System.currentTimeMillis() - waitStartTime < waitForContainersOnShutdownMillis) {
+        && Time.monotonicNow() - waitStartTime
+            < waitForContainersOnShutdownMillis) {
       try {
         Thread.sleep(1000);
       } catch (InterruptedException ex) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestNodeStatusUpdater.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.service.Service.STATE;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.service.ServiceOperations;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.hadoop.yarn.api.protocolrecords.SignalContainerRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -872,7 +873,7 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
                        boolean useSocketTimeoutEx) {
       this.rmStartIntervalMS = rmStartIntervalMS;
       this.rmNeverStart = rmNeverStart;
-      this.waitStartTime = System.currentTimeMillis();
+      this.waitStartTime = Time.monotonicNow();
       this.useSocketTimeoutEx = useSocketTimeoutEx;
     }
 
@@ -880,7 +881,7 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
     public RegisterNodeManagerResponse registerNodeManager(
         RegisterNodeManagerRequest request) throws YarnException, IOException,
         IOException {
-      if (System.currentTimeMillis() - waitStartTime <= rmStartIntervalMS
+      if (Time.monotonicNow() - waitStartTime <= rmStartIntervalMS
           || rmNeverStart) {
         if (useSocketTimeoutEx) {
           throw new java.net.SocketTimeoutException(
@@ -1353,12 +1354,12 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
       }
     };
     nm.init(conf);
-    long waitStartTime = System.currentTimeMillis();
+    long waitStartTime = Time.monotonicNow();
     try {
       nm.start();
       Assert.fail("NM should have failed to start due to RM connect failure");
     } catch(Exception e) {
-      long t = System.currentTimeMillis();
+      long t = Time.monotonicNow();
       long duration = t - waitStartTime;
       boolean waitTimeValid = (duration >= nmRmConnectionWaitMs) &&
           (duration < (nmRmConnectionWaitMs + delta));
@@ -1398,12 +1399,12 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
       }
     };
     nm.init(conf);
-    long waitStartTime = System.currentTimeMillis();
+    long waitStartTime = Time.monotonicNow();
     try {
       nm.start();
       Assert.fail("NM should have failed to start due to RM connect failure");
     } catch(Exception e) {
-      long t = System.currentTimeMillis();
+      long t = Time.monotonicNow();
       long duration = t - waitStartTime;
       boolean waitTimeValid = (duration >= connectionWaitMs)
               && (duration < (connectionWaitMs + delta));
@@ -1432,7 +1433,7 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
     nm.init(conf);
     NodeStatusUpdater updater = nmWithUpdater.getUpdater();
     Assert.assertNotNull("Updater not yet created ", updater);
-    waitStartTime = System.currentTimeMillis();
+    waitStartTime = Time.monotonicNow();
     try {
       nm.start();
     } catch (Exception ex){
@@ -1440,7 +1441,7 @@ public class TestNodeStatusUpdater extends NodeManagerTestBase {
                 "after connecting to RM.", ex);
       throw ex;
     }
-    long duration = System.currentTimeMillis() - waitStartTime;
+    long duration = Time.monotonicNow() - waitStartTime;
     MyNodeStatusUpdater4 myUpdater = (MyNodeStatusUpdater4) updater;
     Assert.assertTrue("NM started before updater triggered",
                       myUpdater.isTriggered());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resourc
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
@@ -286,7 +288,7 @@ public class TestCGroupElasticMemoryController {
               10000,
               handler
           );
-      long start = System.currentTimeMillis();
+      long start = Time.monotonicNow();
       service.submit(() -> {
         try {
           Thread.sleep(2000);
@@ -294,7 +296,7 @@ public class TestCGroupElasticMemoryController {
           assertTrue("Wait interrupted.", false);
         }
         LOG.info(String.format("Calling process destroy in %d ms",
-            System.currentTimeMillis() - start));
+            Time.monotonicNow() - start));
         controller.stopListening();
         LOG.info("Called process destroy.");
       });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/TestNonAggregatingLogHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/TestNonAggregatingLogHandler.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.AccessControlException;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -534,10 +535,10 @@ public class TestNonAggregatingLogHandler {
   static void testDeletionServiceCall(DeletionService delService, String user,
       long timeout, Path... matchPaths) {
 
-    long verifyStartTime = System.currentTimeMillis();
+    long verifyStartTime = Time.monotonicNow();
     WantedButNotInvoked notInvokedException = null;
     boolean matched = false;
-    while (!matched && System.currentTimeMillis() < verifyStartTime + timeout) {
+    while (!matched && Time.monotonicNow() < verifyStartTime + timeout) {
       try {
         verify(delService, times(1)).delete(argThat(new FileDeletionMatcher(
             delService, user, null, Arrays.asList(matchPaths))));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.server.metrics.OpportunisticSchedulerMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed.CentralizedOpportunisticContainerAllocator;
 import org.slf4j.Logger;
@@ -240,7 +241,7 @@ public class OpportunisticContainerAllocatorAMService
         YarnConfiguration.
             DEFAULT_NM_CONTAINER_QUEUING_SORTING_NODES_INTERVAL_MS);
     this.cacheRefreshInterval = nodeSortInterval;
-    this.lastCacheUpdateTime = System.currentTimeMillis();
+    this.lastCacheUpdateTime = Time.monotonicNow();
     NodeQueueLoadMonitor.LoadComparator comparator =
         NodeQueueLoadMonitor.LoadComparator.valueOf(
             rmContext.getYarnConfiguration().get(
@@ -457,7 +458,7 @@ public class OpportunisticContainerAllocatorAMService
 
   @VisibleForTesting
   synchronized List<RemoteNode> getLeastLoadedNodes() {
-    long currTime = System.currentTimeMillis();
+    long currTime = Time.monotonicNow();
     if ((currTime - lastCacheUpdateTime > cacheRefreshInterval)
         || (cachedNodes == null)) {
       cachedNodes = convertToRemoteNodes(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/RMDelegatedNodeLabelsUpdater.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/RMDelegatedNodeLabelsUpdater.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -117,7 +118,7 @@ public class RMDelegatedNodeLabelsUpdater extends CompositeService {
 
       if (allNodesLabelUpdateInterval != DISABLE_DELEGATED_NODE_LABELS_UPDATE) {
         long elapsedTimeSinceLastUpdate =
-            System.currentTimeMillis() - lastAllNodesLabelUpdateMills;
+            Time.monotonicNow() - lastAllNodesLabelUpdateMills;
         if (elapsedTimeSinceLastUpdate > allNodesLabelUpdateInterval) {
           nodesToUpdateLabels =
               Collections.unmodifiableSet(rmContext.getRMNodes().keySet());
@@ -137,7 +138,7 @@ public class RMDelegatedNodeLabelsUpdater extends CompositeService {
         if (nodesToUpdateLabels != null && !nodesToUpdateLabels.isEmpty()) {
           updateNodeLabelsInternal(nodesToUpdateLabels);
           if (isUpdatingAllNodes) {
-            lastAllNodesLabelUpdateMills = System.currentTimeMillis();
+            lastAllNodesLabelUpdateMills = Time.monotonicNow();
           }
           synchronized (lock) {
             newlyRegisteredNodes.removeAll(nodesToUpdateLabels);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStoreTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStoreTestBase.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -150,7 +151,7 @@ public class RMStateStoreTestBase {
   }
 
   void waitNotify(TestDispatcher dispatcher) {
-    long startTime = System.currentTimeMillis();
+    long startTime = Time.monotonicNow();
     while(!dispatcher.notified) {
       synchronized (dispatcher) {
         try {
@@ -159,7 +160,7 @@ public class RMStateStoreTestBase {
           e.printStackTrace();
         }
       }
-      if(System.currentTimeMillis() - startTime > 1000*60) {
+      if (Time.monotonicNow() - startTime > 1000 * 60) {
         fail("Timed out attempt store notification");
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerOvercommit.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerOvercommit.java
@@ -257,7 +257,7 @@ public abstract class TestSchedulerOvercommit {
     assertMemory(scheduler, nmId, 4 * GB, 0);
 
     // Reducing to 2GB should kill the container
-    long t0 = Time.now();
+    long t0 = Time.monotonicNow();
     updateNodeResource(rm, nmId, 2 * GB, 2, 0);
     waitMemory(scheduler, nm, 2 * GB, 0 * GB, INTERVAL, 2 * INTERVAL);
 
@@ -269,7 +269,7 @@ public abstract class TestSchedulerOvercommit {
     assertContainerKilled(container.getId(), containerStatus);
 
     // It should kill the containers right away
-    assertTime(0, Time.now() - t0);
+    assertTime(0, Time.monotonicNow() - t0);
   }
 
   /**
@@ -285,7 +285,7 @@ public abstract class TestSchedulerOvercommit {
     final int timeout = (int)TimeUnit.SECONDS.toMillis(2);
 
     // Reducing to 2GB should first preempt the container
-    long t0 = Time.now();
+    long t0 = Time.monotonicNow();
     updateNodeResource(rm, nmId, 2 * GB, 2, timeout);
     waitMemory(scheduler, nm, 4 * GB, -2 * GB, INTERVAL, timeout);
 
@@ -307,7 +307,7 @@ public abstract class TestSchedulerOvercommit {
     assertContainerKilled(container.getId(), containerStatus);
 
     // Check how long it took to kill the container
-    assertTime(timeout, Time.now() - t0);
+    assertTime(timeout, Time.monotonicNow() - t0);
   }
 
   /**
@@ -339,8 +339,8 @@ public abstract class TestSchedulerOvercommit {
     updateNodeResource(rm, nmId, 4 * GB, 2, timeout);
     waitMemory(scheduler, nm, 4 * GB, 0, INTERVAL, timeout);
 
-    long t0 = Time.now();
-    while (Time.now() - t0 < TimeUnit.SECONDS.toMillis(2)) {
+    long t0 = Time.monotonicNow();
+    while (Time.monotonicNow() - t0 < TimeUnit.SECONDS.toMillis(2)) {
       nm.nodeHeartbeat(true);
       AllocateResponse allocation = am.schedule();
       assertNoPreemption(allocation.getPreemptionMessage());
@@ -505,7 +505,7 @@ public abstract class TestSchedulerOvercommit {
     assertMemory(scheduler, nmId, 5 * GB, 0);
 
     // reduce the resources again to trigger a preempt request to the AM for c2
-    long t0 = Time.now();
+    long t0 = Time.monotonicNow();
     updateNodeResource(rm, nmId, 3 * GB, 2, 2 * 1000);
     waitMemory(scheduler, nmId, 5 * GB, -2 * GB, 200, 5 * 1000);
 
@@ -533,7 +533,7 @@ public abstract class TestSchedulerOvercommit {
     ContainerStatus c2status = completedContainers.get(0);
     assertContainerKilled(c2.getId(), c2status);
 
-    assertTime(2000, Time.now() - t0);
+    assertTime(2000, Time.monotonicNow() - t0);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/activities/TestActivitiesManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/activities/TestActivitiesManager.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
@@ -460,9 +461,9 @@ public class TestActivitiesManager {
       Supplier<Void> supplier, int testingTimes) {
     long totalTime = 0;
     for (int i = 0; i < testingTimes; i++) {
-      long startTime = System.currentTimeMillis();
+      long startTime = Time.monotonicNow();
       supplier.get();
-      totalTime += System.currentTimeMillis() - startTime;
+      totalTime += Time.monotonicNow() - startTime;
     }
     System.out.println("#" + testingName + ", testing times : " + testingTimes
         + ", total cost time : " + totalTime + " ms, average cost time : "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Sets;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
@@ -80,8 +81,8 @@ public class CapacitySchedulerTestBase {
 
   protected void waitforNMRegistered(ResourceScheduler scheduler, int nodecount,
       int timesec) throws InterruptedException {
-    long start = System.currentTimeMillis();
-    while (System.currentTimeMillis() - start < timesec * 1000) {
+    long start = Time.monotonicNow();
+    while (Time.monotonicNow() - start < timesec * 1000) {
       if (scheduler.getNumClusterNodes() < nodecount) {
         Thread.sleep(100);
       } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacityScheduler.java
@@ -1450,7 +1450,7 @@ public class TestCapacityScheduler extends CapacitySchedulerTestBase {
     assertMemory(scheduler, nmId, 5 * GB, 0);
 
     // reduce the resources again to trigger a preempt request to the AM for c2
-    long t0 = Time.now();
+    long t0 = Time.monotonicNow();
     updateNodeResource(rm, nmId, 3 * GB, 2, 2 * 1000);
     waitMemory(scheduler, nmId, 5 * GB, -2 * GB, 200, 5 * 1000);
 
@@ -1475,7 +1475,7 @@ public class TestCapacityScheduler extends CapacitySchedulerTestBase {
     ContainerStatus c2status = completedContainers.get(0);
     assertContainerKilled(c2.getId(), c2status);
 
-    assertTime(2000, Time.now() - t0);
+    assertTime(2000, Time.monotonicNow() - t0);
 
     rm.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNodeLabelUpdate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNodeLabelUpdate.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -868,9 +869,9 @@ public class TestCapacitySchedulerNodeLabelUpdate {
 
   private long waitForResourceUpdate(MockRM rm, String queuename, long memory,
       String label, long timeout) throws InterruptedException {
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     long memorySize = 0;
-    while (System.currentTimeMillis() - start < timeout) {
+    while (Time.monotonicNow() - start < timeout) {
       CapacityScheduler scheduler =
           (CapacityScheduler) rm.getResourceScheduler();
       CSQueue queue = scheduler.getQueue(queuename);
@@ -886,9 +887,9 @@ public class TestCapacitySchedulerNodeLabelUpdate {
 
   private long waitForNodeLabelSchedulerEventUpdate(MockRM rm, String partition,
       long expectedNodeCount, long timeout) throws InterruptedException {
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     long size = 0;
-    while (System.currentTimeMillis() - start < timeout) {
+    while (Time.monotonicNow() - start < timeout) {
       CapacityScheduler scheduler = (CapacityScheduler) rm
           .getResourceScheduler();
       size = scheduler.getNodeTracker().getNodesPerPartition(partition).size();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestQueueManagementDynamicEditPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestQueueManagementDynamicEditPolicy.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity
@@ -116,8 +117,8 @@ public class TestQueueManagementDynamicEditPolicy extends
   private void waitForPolicyState(float expectedVal,
       GuaranteedOrZeroCapacityOverTimePolicy queueManagementPolicy, String
       nodeLabel, int timesec) throws InterruptedException {
-    long start = System.currentTimeMillis();
-    while (System.currentTimeMillis() - start < timesec * 1000) {
+    long start = Time.monotonicNow();
+    while (Time.monotonicNow() - start < timesec * 1000) {
       if (Math.abs(expectedVal - queueManagementPolicy
           .getAbsoluteActivatedChildQueueCapacity(nodeLabel)) > EPSILON) {
         Thread.sleep(100);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestAMRMTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestAMRMTokens.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
@@ -240,7 +241,7 @@ public class TestAMRMTokens {
     final MockRMWithAMS rm =
         new MockRMWithAMS(conf, containerManager);
     rm.start();
-    Long startTime = System.currentTimeMillis();
+    Long startTime = Time.monotonicNow();
     final Configuration conf = rm.getConfig();
     final YarnRPC rpc = YarnRPC.create(conf);
     ApplicationMasterProtocol rmClient = null;
@@ -290,7 +291,7 @@ public class TestAMRMTokens {
 
       // Wait for enough time and make sure the roll_over happens
       // At mean time, the old AMRMToken should continue to work
-      while(System.currentTimeMillis() - startTime < rolling_interval_sec*1000) {
+      while (Time.monotonicNow() - startTime < rolling_interval_sec * 1000) {
         rmClient.allocate(allocateRequest);
         Thread.sleep(500);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/main/java/org/apache/hadoop/yarn/server/sharedcachemanager/CleanerTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/main/java/org/apache/hadoop/yarn/server/sharedcachemanager/CleanerTask.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.sharedcache.SharedCacheUtil;
@@ -149,7 +150,7 @@ class CleanerTask implements Runnable {
           fs.globStatus(new Path(root, pattern));
       int numResources = resources == null ? 0 : resources.length;
       LOG.info("Processing " + numResources + " resources in the shared cache");
-      long beginMs = System.currentTimeMillis();
+      long beginMs = Time.monotonicNow();
       if (resources != null) {
         for (FileStatus resource : resources) {
           // check for interruption so it can abort in a timely manner in case
@@ -172,7 +173,7 @@ class CleanerTask implements Runnable {
           }
         }
       }
-      long endMs = System.currentTimeMillis();
+      long endMs = Time.monotonicNow();
       long durationMs = endMs - beginMs;
       LOG.info("Processed " + numResources + " resource(s) in " + durationMs +
           " ms.");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.conf.HAUtil;
@@ -507,9 +508,10 @@ public class MiniYARNCluster extends CompositeService {
     }
 
     private void waitForAppMastersToFinish(long timeoutMillis) throws InterruptedException {
-      long started = System.currentTimeMillis();
+      long started = Time.monotonicNow();
       synchronized (appMasters) {
-        while (!appMasters.isEmpty() && System.currentTimeMillis() - started < timeoutMillis) {
+        while (!appMasters.isEmpty()
+            && Time.monotonicNow() - started < timeoutMillis) {
           appMasters.wait(1000);
         }
       }


### PR DESCRIPTION
For Yarn module, Use `Time.monotonicNow()` instead of `System.currentTimeMillis()` to measure elapsed time.

