### PR TITLE
HADOOP-17463. use monotonicNow for elapsed time. 

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import sun.misc.Unsafe;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.Time;
 
 /**
  * JNI wrappers for various native IO-related calls not available in Java.
@@ -620,7 +621,7 @@ public class NativeIO {
         ? USER_ID_NAME_CACHE : GROUP_ID_NAME_CACHE;
       String name;
       CachedName cachedName = idNameCache.get(id);
-      long now = System.currentTimeMillis();
+      long now = Time.monotonicNow();
       if (cachedName != null && (cachedName.timestamp + cacheTimeout) > now) {
         name = cachedName.name;
       } else {
@@ -915,7 +916,7 @@ public class NativeIO {
     } else {
       long uid = POSIX.getUIDforFDOwnerforOwner(fd);
       CachedUid cUid = uidCache.get(uid);
-      long now = System.currentTimeMillis();
+      long now = Time.monotonicNow();
       if (cUid != null && (cUid.timestamp + cacheTimeout) > now) {
         return cUid.username;
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -508,7 +508,7 @@ public class Client implements AutoCloseable {
 
     /** Update lastActivity with the current time. */
     private void touch() {
-      lastActivity.set(Time.now());
+      lastActivity.set(Time.monotonicNow());
     }
 
     /**
@@ -1046,8 +1046,8 @@ public class Client implements AutoCloseable {
      */
     private synchronized boolean waitForWork() {
       if (calls.isEmpty() && !shouldCloseConnection.get()  && running.get())  {
-        long timeout = maxIdleTime-
-              (Time.now()-lastActivity.get());
+        long timeout = maxIdleTime -
+              (Time.monotonicNow() - lastActivity.get());
         if (timeout>0) {
           try {
             wait(timeout);
@@ -1077,7 +1077,7 @@ public class Client implements AutoCloseable {
      * since last I/O activity is equal to or greater than the ping interval
      */
     private synchronized void sendPing() throws IOException {
-      long curTime = Time.now();
+      long curTime = Time.monotonicNow();
       if ( curTime - lastActivity.get() >= pingInterval) {
         lastActivity.set(curTime);
         synchronized (ipcStreams.out) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine.java
@@ -202,7 +202,7 @@ public class ProtobufRpcEngine implements RpcEngine {
         throws ServiceException {
       long startTime = 0;
       if (LOG.isDebugEnabled()) {
-        startTime = Time.now();
+        startTime = Time.monotonicNow();
       }
       
       if (args.length != 2) { // RpcController + Message
@@ -257,7 +257,7 @@ public class ProtobufRpcEngine implements RpcEngine {
       }
 
       if (LOG.isDebugEnabled()) {
-        long callTime = Time.now() - startTime;
+        long callTime = Time.monotonicNow() - startTime;
         LOG.debug("Call: " + method.getName() + " took " + callTime + "ms");
       }
       

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
@@ -196,7 +196,7 @@ public class ProtobufRpcEngine2 implements RpcEngine {
         throws ServiceException {
       long startTime = 0;
       if (LOG.isDebugEnabled()) {
-        startTime = Time.now();
+        startTime = Time.monotonicNow();
       }
 
       if (args.length != 2) { // RpcController + Message
@@ -253,7 +253,7 @@ public class ProtobufRpcEngine2 implements RpcEngine {
       }
 
       if (LOG.isDebugEnabled()) {
-        long callTime = Time.now() - startTime;
+        long callTime = Time.monotonicNow() - startTime;
         LOG.debug("Call: " + method.getName() + " took " + callTime + "ms");
       }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RPC.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RPC.java
@@ -401,7 +401,7 @@ public class RPC {
                                int rpcTimeout,
                                RetryPolicy connectionRetryPolicy,
                                long timeout) throws IOException { 
-    long startTime = Time.now();
+    long startTime = Time.monotonicNow();
     IOException ioe;
     while (true) {
       try {
@@ -419,7 +419,7 @@ public class RPC {
         ioe = nrthe;
       }
       // check if timed out
-      if (Time.now()-timeout >= startTime) {
+      if (Time.monotonicNow() - timeout >= startTime) {
         throw ioe;
       }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSourceAdapter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSourceAdapter.java
@@ -160,9 +160,9 @@ class MetricsSourceAdapter implements DynamicMBean {
   private void updateJmxCache() {
     boolean getAllMetrics = false;
     synchronized(this) {
-      if (Time.now() - jmxCacheTS >= jmxCacheTTL) {
+      if (Time.monotonicNow() - jmxCacheTS >= jmxCacheTTL) {
         // temporarilly advance the expiry while updating the cache
-        jmxCacheTS = Time.now() + jmxCacheTTL;
+        jmxCacheTS = Time.monotonicNow() + jmxCacheTTL;
         // lastRecs might have been set to an object already by another thread.
         // Track the fact that lastRecs has been reset once to make sure refresh
         // is correctly triggered.
@@ -188,7 +188,7 @@ class MetricsSourceAdapter implements DynamicMBean {
         updateAttrCache(lastRecs);
         updateInfoCache(lastRecs);
       }
-      jmxCacheTS = Time.now();
+      jmxCacheTS = Time.monotonicNow();
       lastRecsCleared = true;
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -703,7 +703,7 @@ extends AbstractDelegationTokenIdentifier>
           / (60 * 1000) + " min(s)");
       try {
         while (running) {
-          long now = Time.now();
+          long now = Time.monotonicNow();
           if (lastMasterKeyUpdate + keyUpdateInterval < now) {
             try {
               rollMasterKey();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/AsyncDiskService.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/AsyncDiskService.java
@@ -128,12 +128,12 @@ public class AsyncDiskService {
   public synchronized boolean awaitTermination(long milliseconds) 
       throws InterruptedException {
 
-    long end = Time.now() + milliseconds;
+    long end = Time.monotonicNow() + milliseconds;
     for (Map.Entry<String, ThreadPoolExecutor> e:
         executors.entrySet()) {
       ThreadPoolExecutor executor = e.getValue();
       if (!executor.awaitTermination(
-          Math.max(end - Time.now(), 0),
+          Math.max(end - Time.monotonicNow(), 0),
           TimeUnit.MILLISECONDS)) {
         LOG.warn("AsyncDiskService awaitTermination timeout.");
         return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CacheableIPList.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CacheableIPList.java
@@ -48,7 +48,7 @@ public class CacheableIPList implements IPList {
     if (cacheTimeout < 0) {
       cacheExpiryTimeStamp = -1; // no automatic cache expiry.
     }else {
-      cacheExpiryTimeStamp = System.currentTimeMillis() + cacheTimeout;
+      cacheExpiryTimeStamp = Time.monotonicNow() + cacheTimeout;
     }
   }
 
@@ -63,10 +63,10 @@ public class CacheableIPList implements IPList {
   public boolean isIn(String ipAddress) {
     //is cache expired
     //Uses Double Checked Locking using volatile
-    if (cacheExpiryTimeStamp >= 0 && cacheExpiryTimeStamp < System.currentTimeMillis()) {
+    if (cacheExpiryTimeStamp >= 0 && cacheExpiryTimeStamp < Time.monotonicNow()) {
       synchronized(this) {
         //check if cache expired again
-        if (cacheExpiryTimeStamp < System.currentTimeMillis()) {
+        if (cacheExpiryTimeStamp < Time.monotonicNow()) {
           reset();
         }
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CacheableIPList.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CacheableIPList.java
@@ -63,7 +63,8 @@ public class CacheableIPList implements IPList {
   public boolean isIn(String ipAddress) {
     //is cache expired
     //Uses Double Checked Locking using volatile
-    if (cacheExpiryTimeStamp >= 0 && cacheExpiryTimeStamp < Time.monotonicNow()) {
+    if (cacheExpiryTimeStamp >= 0
+        && cacheExpiryTimeStamp < Time.monotonicNow()) {
       synchronized(this) {
         //check if cache expired again
         if (cacheExpiryTimeStamp < Time.monotonicNow()) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java
@@ -91,9 +91,9 @@ public final class ShutdownHookManager {
               LOG.info("Shutdown process invoked a second time: ignoring");
               return;
             }
-            long started = System.currentTimeMillis();
+            long started = Time.monotonicNow();
             int timeoutCount = MGR.executeShutdown();
-            long ended = System.currentTimeMillis();
+            long ended = Time.monotonicNow();
             LOG.debug(String.format(
                 "Completed shutdown in %.3f seconds; Timeouts: %d",
                 (ended-started)/1000.0, timeoutCount));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ThreadUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ThreadUtil.java
@@ -37,10 +37,10 @@ public class ThreadUtil {
    * @param millis the number of milliseconds for the current thread to sleep
    */
   public static void sleepAtLeastIgnoreInterrupts(long millis) {
-    long start = Time.now();
-    while (Time.now() - start < millis) {
+    long start = Time.monotonicNow();
+    while (Time.monotonicNow() - start < millis) {
       long timeToSleep = millis -
-          (Time.now() - start);
+          (Time.monotonicNow() - start);
       try {
         Thread.sleep(timeToSleep);
       } catch (InterruptedException ie) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestReconfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestReconfiguration.java
@@ -317,8 +317,8 @@ public class TestReconfiguration {
     }
     dummy.reconfigureProperty(PROP1, VAL2);
 
-    long endWait = Time.now() + 2000;
-    while (dummyThread.isAlive() && Time.now() < endWait) {
+    long endWait = Time.monotonicNow() + 2000;
+    while (dummyThread.isAlive() && Time.monotonicNow() < endWait) {
       try {
         Thread.sleep(50);
       } catch (InterruptedException ignore) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
@@ -870,7 +870,7 @@ public class TestTrash {
       
       writeFile(fs, myFile, 10);
       
-      start = Time.now();
+      start = Time.monotonicNow();
       
       try {
         retVal = shell.run(args);
@@ -882,7 +882,7 @@ public class TestTrash {
       
       assertTrue(retVal == 0);
       
-      long iterTime = Time.now() - start;
+      long iterTime = Time.monotonicNow() - start;
       // take median of the first 10 runs
       if(i<10) {
         if(i==0) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/ContractTestUtils.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.PathCapabilities;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.util.Time;
+
 import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
@@ -1394,13 +1396,13 @@ public class ContractTestUtils extends Assert {
    */
   public static FileStatus getFileStatusEventually(FileSystem fs, Path path,
       int timeout) throws IOException, InterruptedException {
-    long endTime = System.currentTimeMillis() + timeout;
+    long endTime = Time.monotonicNow() + timeout;
     FileStatus stat = null;
     do {
       try {
         stat = fs.getFileStatus(path);
       } catch (FileNotFoundException e) {
-        if (System.currentTimeMillis() > endTime) {
+        if (Time.monotonicNow() > endTime) {
           // timeout, raise an assert with more diagnostics
           assertPathExists(fs, "Path not found after " + timeout + " mS", path);
         } else {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ActiveStandbyElectorTestUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ActiveStandbyElectorTestUtil.java
@@ -37,7 +37,7 @@ public abstract class ActiveStandbyElectorTestUtil {
   public static void waitForActiveLockData(TestContext ctx,
       ZooKeeperServer zks, String parentDir, byte[] activeData)
       throws Exception {
-    long st = Time.now();
+    long st = Time.monotonicNow();
     long lastPrint = st;
     while (true) {
       if (ctx != null) {
@@ -52,17 +52,17 @@ public abstract class ActiveStandbyElectorTestUtil {
             Arrays.equals(activeData, data)) {
           return;
         }
-        if (Time.now() > lastPrint + LOG_INTERVAL_MS) {
+        if (Time.monotonicNow() > lastPrint + LOG_INTERVAL_MS) {
           LOG.info("Cur data: " + StringUtils.byteToHexString(data));
-          lastPrint = Time.now();
+          lastPrint = Time.monotonicNow();
         }
       } catch (NoNodeException nne) {
         if (activeData == null) {
           return;
         }
-        if (Time.now() > lastPrint + LOG_INTERVAL_MS) {
+        if (Time.monotonicNow() > lastPrint + LOG_INTERVAL_MS) {
           LOG.info("Cur data: no node");
-          lastPrint = Time.now();
+          lastPrint = Time.monotonicNow();
         }
       }
       Thread.sleep(50);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ClientBaseWithFixes.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ClientBaseWithFixes.java
@@ -130,11 +130,11 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
         @VisibleForTesting
         public synchronized void waitForConnected(long timeout)
             throws InterruptedException, TimeoutException {
-            long expire = Time.now() + timeout;
+            long expire = Time.monotonicNow() + timeout;
             long left = timeout;
             while(!connected && left > 0) {
                 wait(left);
-                left = expire - Time.now();
+                left = expire - Time.monotonicNow();
             }
             if (!connected) {
                 throw new TimeoutException("Did not connect");
@@ -144,11 +144,11 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
         @VisibleForTesting
         public synchronized void waitForDisconnected(long timeout)
             throws InterruptedException, TimeoutException {
-            long expire = Time.now() + timeout;
+            long expire = Time.monotonicNow() + timeout;
             long left = timeout;
             while(connected && left > 0) {
                 wait(left);
-                left = expire - Time.now();
+                left = expire - Time.monotonicNow();
             }
             if (connected) {
                 throw new TimeoutException("Did not disconnect");
@@ -268,7 +268,7 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
     }
 
     public static boolean waitForServerUp(String hp, long timeout) {
-        long start = Time.now();
+        long start = Time.monotonicNow();
         while (true) {
             try {
                 // if there are multiple hostports, just take the first one
@@ -283,7 +283,7 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
                 LOG.info("server " + hp + " not up " + e);
             }
 
-            if (Time.now() > start + timeout) {
+            if (Time.monotonicNow() > start + timeout) {
                 break;
             }
             try {
@@ -295,7 +295,7 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
         return false;
     }
     public static boolean waitForServerDown(String hp, long timeout) {
-        long start = Time.now();
+        long start = Time.monotonicNow();
         while (true) {
             try {
                 HostPort hpobj = parseHostPortList(hp).get(0);
@@ -304,7 +304,7 @@ public abstract class ClientBaseWithFixes extends ZKTestCase {
                 return true;
             }
 
-            if (Time.now() > start + timeout) {
+            if (Time.monotonicNow() > start + timeout) {
                 break;
             }
             try {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHealthMonitor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHealthMonitor.java
@@ -143,8 +143,8 @@ public class TestHealthMonitor {
 
   private void waitForState(HealthMonitor hm, State state)
       throws InterruptedException {
-    long st = Time.now();
-    while (Time.now() - st < 2000) {
+    long st = Time.monotonicNow();
+    while (Time.monotonicNow() - st < 2000) {
       if (hm.getHealthState() == state) {
         return;
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestZKFailoverController.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestZKFailoverController.java
@@ -472,9 +472,9 @@ public class TestZKFailoverController extends ClientBaseWithFixes {
     // Ask it to cede active for 3 seconds. It should respond promptly
     // (i.e. the RPC itself should not take 3 seconds!)
     ZKFCProtocol proxy = zkfc.getLocalTarget().getZKFCProxy(conf, 5000);
-    long st = Time.now();
+    long st = Time.monotonicNow();
     proxy.cedeActive(3000);
-    long et = Time.now();
+    long et = Time.monotonicNow();
     assertTrue("RPC to cedeActive took " + (et - st) + " ms",
         et - st < 1000);
 
@@ -486,7 +486,7 @@ public class TestZKFailoverController extends ClientBaseWithFixes {
     // After the prescribed 3 seconds, should go into STANDBY state,
     // since the other node in the cluster would have taken ACTIVE.
     cluster.waitForElectorState(0, ActiveStandbyElector.State.STANDBY);
-    long et2 = Time.now();
+    long et2 = Time.monotonicNow();
     assertTrue("Should take ~3 seconds to rejoin. Only took " + (et2 - et) +
         "ms before rejoining.",
         et2 - et > 2800);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestZKFailoverControllerStress.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestZKFailoverControllerStress.java
@@ -65,11 +65,11 @@ public class TestZKFailoverControllerStress extends ClientBaseWithFixes {
   @Test(timeout=(STRESS_RUNTIME_SECS + EXTRA_TIMEOUT_SECS) * 1000)
   public void testExpireBackAndForth() throws Exception {
     cluster.start();
-    long st = Time.now();
+    long st = Time.monotonicNow();
     long runFor = STRESS_RUNTIME_SECS * 1000;
 
     int i = 0;
-    while (Time.now() - st < runFor) {
+    while (Time.monotonicNow() - st < runFor) {
       // flip flop the services back and forth
       int from = i % 2;
       int to = (i + 1) % 2;
@@ -91,11 +91,11 @@ public class TestZKFailoverControllerStress extends ClientBaseWithFixes {
   @Test(timeout=(STRESS_RUNTIME_SECS + EXTRA_TIMEOUT_SECS) * 1000)
   public void testRandomExpirations() throws Exception {
     cluster.start();
-    long st = Time.now();
+    long st = Time.monotonicNow();
     long runFor = STRESS_RUNTIME_SECS * 1000;
 
     Random r = new Random();
-    while (Time.now() - st < runFor) {
+    while (Time.monotonicNow() - st < runFor) {
       cluster.getTestContext().checkException();
       int targetIdx = r.nextInt(2);
       ActiveStandbyElector target = cluster.getElector(targetIdx);
@@ -128,8 +128,8 @@ public class TestZKFailoverControllerStress extends ClientBaseWithFixes {
     // setting up the mock.
     cluster.start();
     
-    long st = Time.now();
-    while (Time.now() - st < runFor) {
+    long st = Time.monotonicNow();
+    while (Time.monotonicNow() - st < runFor) {
       cluster.getTestContext().checkException();
       serverFactory.closeAll();
       Thread.sleep(50);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeqFileComparison.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeqFileComparison.java
@@ -91,12 +91,12 @@ public class TestTFileSeqFileComparison {
   }
 
   public void startTime() throws IOException {
-    startTimeEpoch = Time.now();
+    startTimeEpoch = Time.monotonicNow();
     System.out.println(formatTime() + " Started timing.");
   }
 
   public void stopTime() throws IOException {
-    finishTimeEpoch = Time.now();
+    finishTimeEpoch = Time.monotonicNow();
     System.out.println(formatTime() + " Stopped timing.");
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/Timer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/Timer.java
@@ -30,11 +30,11 @@ public  class Timer {
   long finishTimeEpoch;
   
   public void startTime() throws IOException {
-    startTimeEpoch = Time.now();
+    startTimeEpoch = Time.monotonicNow();
   }
 
   public void stopTime() throws IOException {
-    finishTimeEpoch = Time.now();
+    finishTimeEpoch = Time.monotonicNow();
   }
 
   public long getIntervalMillis() throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestNativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/nativeio/TestNativeIO.java
@@ -131,8 +131,8 @@ public class TestNativeIO {
       Thread statter = new Thread() {
         @Override
         public void run() {
-          long et = Time.now() + 5000;
-          while (Time.now() < et) {
+          long et = Time.monotonicNow() + 5000;
+          while (Time.monotonicNow() < et) {
             try {
               NativeIO.POSIX.Stat stat = NativeIO.POSIX.getFstat(fos.getFD());
               assertEquals(System.getProperty("user.name"), stat.getOwner());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/MiniRPCBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/MiniRPCBenchmark.java
@@ -188,10 +188,10 @@ public class MiniRPCBenchmark {
   throws IOException {
     MiniProtocol client = null;
     try {
-      long start = Time.now();
+      long start = Time.monotonicNow();
       client = RPC.getProxy(MiniProtocol.class,
           MiniProtocol.versionID, addr, conf);
-      long end = Time.now();
+      long end = Time.monotonicNow();
       return end - start;
     } finally {
       RPC.stopProxy(client);
@@ -234,7 +234,7 @@ public class MiniRPCBenchmark {
       final Configuration conf, final InetSocketAddress addr) throws IOException {
     MiniProtocol client = null;
     try {
-      long start = Time.now();
+      long start = Time.monotonicNow();
       try {
         client = currentUgi.doAs(new PrivilegedExceptionAction<MiniProtocol>() {
           @Override
@@ -246,7 +246,7 @@ public class MiniRPCBenchmark {
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
-      long end = Time.now();
+      long end = Time.monotonicNow();
       return end - start;
     } finally {
       RPC.stopProxy(client);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.protobuf.TestProtos;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.TestProtobufRpcHandoffProto;
+import org.apache.hadoop.util.Time;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -76,7 +78,7 @@ public class TestProtoBufRpcServerHandoff {
     completionService.submit(new ClientInvocationCallable(client, 5000l));
     completionService.submit(new ClientInvocationCallable(client, 5000l));
 
-    long submitTime = System.currentTimeMillis();
+    long submitTime = Time.monotonicNow();
     Future<ClientInvocationCallable> future1 = completionService.take();
     Future<ClientInvocationCallable> future2 = completionService.take();
 
@@ -89,7 +91,7 @@ public class TestProtoBufRpcServerHandoff {
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
     Assert.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
-    Assert.assertTrue(System.currentTimeMillis() - submitTime < 7000l);
+    Assert.assertTrue(Time.monotonicNow() - submitTime < 7000l);
 
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
@@ -91,7 +91,7 @@ public class TestProtoBufRpcServerHandoff {
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
     Assert.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
-    Assert.assertTrue(Time.monotonicNow() - submitTime < 7000l);
+    Assert.assertTrue(Time.monotonicNow() - submitTime < 7000L);
 
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSocketFactory.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.SocksSocketFactory;
 import org.apache.hadoop.net.StandardSocketFactory;
+import org.apache.hadoop.util.Time;
+
 import org.junit.After;
 import org.junit.Test;
 import static org.junit.Assert.assertSame;
@@ -64,11 +66,11 @@ public class TestSocketFactory {
     serverRunnable = new ServerRunnable();
     serverThread = new Thread(serverRunnable);
     serverThread.start();
-    final long timeout = System.currentTimeMillis() + START_STOP_TIMEOUT_SEC * 1000;
+    final long timeout = Time.monotonicNow() + START_STOP_TIMEOUT_SEC * 1000;
     while (!serverRunnable.isReady()) {
       assertNull(serverRunnable.getThrowable());
       Thread.sleep(10);
-      if (System.currentTimeMillis() > timeout) {
+      if (Time.monotonicNow() > timeout) {
         fail("Server thread did not start properly in allowed time of "
             + START_STOP_TIMEOUT_SEC + " sec.");
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.service.ServiceOperations;
 import org.apache.hadoop.service.ServiceStateException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.JvmPauseMonitor;
+import org.apache.hadoop.util.Time;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -179,9 +180,9 @@ public class TestJvmMetrics {
 
     List<String> garbageStrings = new ArrayList<>();
 
-    long startTime = System.currentTimeMillis();
+    long startTime = Time.monotonicNow();
     // Run this for at least 1 sec for our monitor to collect enough data
-    while (System.currentTimeMillis() - startTime < 1000) {
+    while (Time.monotonicNow() - startTime < 1000) {
       for (int j = 0; j < 100000; j++) {
         garbageStrings.add(
             "Long string prefix just to fill memory with garbage " + j);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestDNS.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestDNS.java
@@ -72,9 +72,9 @@ public class TestDNS {
     String hostname1 = DNS.getDefaultHost(DEFAULT);
     assertNotNull(hostname1);
     String hostname2 = DNS.getDefaultHost(DEFAULT);
-    long t1 = Time.now();
+    long t1 = Time.monotonicNow();
     String hostname3 = DNS.getDefaultHost(DEFAULT);
-    long t2 = Time.now();
+    long t2 = Time.monotonicNow();
     assertEquals(hostname3, hostname2);
     assertEquals(hostname2, hostname1);
     long interval = t2 - t1;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSocketIOWithTimeout.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSocketIOWithTimeout.java
@@ -66,7 +66,7 @@ public class TestSocketIOWithTimeout {
     byte buf[] = new byte[PAGE_SIZE + 19];
     
     while (true) {
-      long start = Time.now();
+      long start = Time.monotonicNow();
       try {
         if (in != null) {
           in.read(buf);
@@ -74,7 +74,7 @@ public class TestSocketIOWithTimeout {
           out.write(buf);
         }
       } catch (SocketTimeoutException e) {
-        long diff = Time.now() - start;
+        long diff = Time.monotonicNow() - start;
         LOG.info("Got SocketTimeoutException as expected after " + 
                  diff + " millis : " + e.getMessage());
         assertTrue(Math.abs(expectedTimeout - diff) <=

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/TestServiceLifecycle.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/service/TestServiceLifecycle.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.service.LoggingStateChangeListener;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.service.ServiceStateChangeListener;
 import org.apache.hadoop.service.ServiceStateException;
+import org.apache.hadoop.util.Time;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -336,11 +338,11 @@ public class TestServiceLifecycle extends ServiceAssert {
     service.init(new Configuration());
     service.start();
     assertServiceInState(service, Service.STATE.STARTED);
-    long start = System.currentTimeMillis();
+    long start = Time.monotonicNow();
     synchronized (listener) {
       listener.wait(20000);
     }
-    long duration = System.currentTimeMillis() - start;
+    long duration = Time.monotonicNow() - start;
     assertEquals(Service.STATE.STOPPED, listener.notifyingState);
     assertServiceInState(service, Service.STATE.STOPPED);
     assertTrue("Duration of " + duration + " too long", duration < 10000);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -125,7 +125,7 @@ public final class LambdaTestUtils {
         "timeoutMillis must be >= 0");
     Preconditions.checkNotNull(timeoutHandler);
 
-    long endTime = Time.now() + timeoutMillis;
+    long endTime = Time.monotonicNow() + timeoutMillis;
     Throwable ex = null;
     boolean running = true;
     int iterations = 0;
@@ -146,7 +146,7 @@ public final class LambdaTestUtils {
         LOG.debug("eventually() iteration {}", iterations, e);
         ex = e;
       }
-      running = Time.now() < endTime;
+      running = Time.monotonicNow() < endTime;
       if (running) {
         int sleeptime = retry.call();
         if (sleeptime >= 0) {
@@ -241,7 +241,7 @@ public final class LambdaTestUtils {
       Callable<Integer> retry) throws Exception {
     Preconditions.checkArgument(timeoutMillis >= 0,
         "timeoutMillis must be >= 0");
-    long endTime = Time.now() + timeoutMillis;
+    long endTime = Time.monotonicNow() + timeoutMillis;
     Throwable ex;
     boolean running;
     int sleeptime;
@@ -259,7 +259,7 @@ public final class LambdaTestUtils {
         LOG.debug("evaluate() iteration {}", iterations, e);
         ex = e;
       }
-      running = Time.now() < endTime;
+      running = Time.monotonicNow() < endTime;
       if (running && (sleeptime = retry.call()) >= 0) {
         Thread.sleep(sleeptime);
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MultithreadedTestUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MultithreadedTestUtil.java
@@ -110,10 +110,10 @@ public abstract class MultithreadedTestUtil {
      * have thrown up an error.
      */
     public synchronized void waitFor(long millis) throws Exception {
-      long endTime = Time.now() + millis;
+      long endTime = Time.monotonicNow() + millis;
       while (shouldRun() &&
              finishedThreads.size() < testThreads.size()) {
-        long left = endTime - Time.now();
+        long left = endTime - Time.monotonicNow();
         if (left <= 0) break;
         checkException();
         wait(left);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestMultithreadedTestUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestMultithreadedTestUtil.java
@@ -48,9 +48,9 @@ public class TestMultithreadedTestUtil {
     }
     assertEquals(0, threadsRun.get());
     ctx.startThreads();
-    long st = Time.now();
+    long st = Time.monotonicNow();
     ctx.waitFor(30000);
-    long et = Time.now();
+    long et = Time.monotonicNow();
 
     // All threads should have run
     assertEquals(3, threadsRun.get());
@@ -70,7 +70,7 @@ public class TestMultithreadedTestUtil {
       }
     });
     ctx.startThreads();
-    long st = Time.now();
+    long st = Time.monotonicNow();
     try {
       ctx.waitFor(30000);
       fail("waitFor did not throw");
@@ -78,7 +78,7 @@ public class TestMultithreadedTestUtil {
       // expected
       assertEquals(FAIL_MSG, rte.getCause().getMessage());
     }
-    long et = Time.now();
+    long et = Time.monotonicNow();
     // Test shouldn't have waited the full 30 seconds, since
     // the thread throws faster than that
     assertTrue("Test took " + (et - st) + "ms",
@@ -95,7 +95,7 @@ public class TestMultithreadedTestUtil {
       }
     });
     ctx.startThreads();
-    long st = Time.now();
+    long st = Time.monotonicNow();
     try {
       ctx.waitFor(30000);
       fail("waitFor did not throw");
@@ -103,7 +103,7 @@ public class TestMultithreadedTestUtil {
       // expected
       assertEquals("my ioe", rte.getCause().getMessage());
     }
-    long et = Time.now();
+    long et = Time.monotonicNow();
     // Test shouldn't have waited the full 30 seconds, since
     // the thread throws faster than that
     assertTrue("Test took " + (et - st) + "ms",
@@ -122,10 +122,10 @@ public class TestMultithreadedTestUtil {
       }
     });
     ctx.startThreads();
-    long st = Time.now();
+    long st = Time.monotonicNow();
     ctx.waitFor(3000);
     ctx.stop();
-    long et = Time.now();
+    long et = Time.monotonicNow();
     long elapsed = et - st;
 
     // Test should have waited just about 3 seconds

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestGSet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestGSet.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class TestGSet {
   private static final Random ran = new Random();
-  private static final long starttime = Time.now();
+  private static final long START_TIME = Time.monotonicNow();
 
   private static void print(Object s) {
     System.out.print(s);
@@ -278,7 +278,7 @@ public class TestGSet {
     }
     println("DONE " + test.stat());
 
-    final long s = (Time.now() - starttime)/1000L;
+    final long s = (Time.monotonicNow() - START_TIME)/1000L;
     println("total time elapsed=" + s + "s\n");
   }
 
@@ -290,7 +290,7 @@ public class TestGSet {
     final IntData data;
 
     final String info;
-    final long starttime = Time.now();
+    private final long startTime = Time.monotonicNow();
     /** Determine the probability in {@link #check()}. */
     final int denominator;
     int iterate_count = 0;
@@ -418,7 +418,7 @@ public class TestGSet {
     }
 
     String stat() {
-      final long t = Time.now() - starttime;
+      final long t = Time.monotonicNow() - startTime;
       return String.format(" iterate=%5d, contain=%5d, time elapsed=%5d.%03ds",
           iterate_count, contain_count, t/1000, t%1000);
     }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/KMSBenchmark.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/KMSBenchmark.java
@@ -207,7 +207,7 @@ public class KMSBenchmark implements Tool {
         for (tIdx=0; tIdx < numThreads; tIdx++) {
           daemons.add(new StatsDaemon(tIdx, opsPerThread[tIdx], this));
         }
-        start = Time.now();
+        start = Time.monotonicNow();
         LOG.info("Starting "+numOpsRequired+" "+getOpName()+"(s).");
         for (StatsDaemon d : daemons) {
           d.start();
@@ -218,7 +218,7 @@ public class KMSBenchmark implements Tool {
             Thread.sleep(500);
           } catch (InterruptedException e) {}
         }
-        elapsedTime = Time.now() - start;
+        elapsedTime = Time.monotonicNow() - start;
         for (StatsDaemon d : daemons) {
           incrementStats(d.localNumOpsExecuted, d.localCumulativeTime);
           System.out.println(d.toString() + ": ops Exec = " +
@@ -429,14 +429,14 @@ public class KMSBenchmark implements Tool {
     @Override
     long executeOp(int daemonId, int inputIdx, String clientName)
             throws IOException {
-      long start = Time.now();
+      long start = Time.monotonicNow();
       try {
         eek = kp.generateEncryptedKey(encryptionKeyName);
       } catch (GeneralSecurityException e) {
         LOG.warn("failed to generate encrypted key", e);
       }
 
-      long end = Time.now();
+      long end = Time.monotonicNow();
       return end-start;
     }
 
@@ -500,13 +500,13 @@ public class KMSBenchmark implements Tool {
     @Override
     long executeOp(int daemonId, int inputIdx, String clientName)
         throws IOException {
-      long start = Time.now();
+      long start = Time.monotonicNow();
       try {
         kp.decryptEncryptedKey(eek);
       } catch (GeneralSecurityException e) {
         LOG.warn("failed to generate and/or decrypt key", e);
       }
-      long end = Time.now();
+      long end = Time.monotonicNow();
       return end - start;
     }
 


### PR DESCRIPTION
Replace both `System.currentTimeMillis()` and `Time.now()` with `Time.monotonicNow()` to measure elapsed time.
Code changes are minimal to reduce the size of the patch.
I intentionally left the check style errors in `hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ClientBaseWithFixes.java` because those would require reformatting the entire file, increasing the patch and confusing the reviewer.
