### PR TITLE
MAPREDUCE-7317. Add latency information in FileOutputCommitter.mergePaths.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -457,11 +457,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
       final Path to, JobContext context) throws IOException {
     try (DurationInfo d = new DurationInfo(LOG,
         false,
-        "Merged data from %s to %s", from.getPath(), to)) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Merging data from " + from + " to " + to);
-      }
-
+        "Merging data from %s to %s", from, to)) {
       reportProgress(context);
       FileStatus toStat;
       try {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.mapreduce.lib.output;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -454,7 +455,9 @@ public class FileOutputCommitter extends PathOutputCommitter {
    */
   private void mergePaths(FileSystem fs, final FileStatus from,
       final Path to, JobContext context) throws IOException {
+    long timeStartNs = -1L;
     if (LOG.isDebugEnabled()) {
+      timeStartNs = System.nanoTime();
       LOG.debug("Merging data from " + from + " to " + to);
     }
     reportProgress(context);
@@ -492,6 +495,12 @@ public class FileOutputCommitter extends PathOutputCommitter {
       } else {
         renameOrMerge(fs, from, to, context);
       }
+    }
+    if (LOG.isDebugEnabled() && timeStartNs > 0) {
+      long timeEndNs = System.nanoTime();
+      // use getPath() to reduce log message (another info would be available in previous log)
+      LOG.debug("Merged data from " + from.getPath() + " to " + to + " in " +
+          TimeUnit.MILLISECONDS.convert(timeEndNs - timeStartNs, TimeUnit.NANOSECONDS) + " ms");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -497,10 +497,10 @@ public class FileOutputCommitter extends PathOutputCommitter {
       }
     }
     if (LOG.isDebugEnabled() && timeStartNs > 0) {
-      long timeEndNs = System.nanoTime();
-      // use getPath() to reduce log message (another info would be available in previous log)
+      long elapsedMs = TimeUnit.MILLISECONDS.convert(
+          System.nanoTime() - timeStartNs, TimeUnit.NANOSECONDS);
       LOG.debug("Merged data from " + from.getPath() + " to " + to + " in " +
-          TimeUnit.MILLISECONDS.convert(timeEndNs - timeStartNs, TimeUnit.NANOSECONDS) + " ms");
+          elapsedMs + " ms");
     }
   }
 


### PR DESCRIPTION
This PR proposes to add latency information in FileOutputCommitter.mergePaths, so that we can trace how much latency specific directory takes to merge.

This information would provide some value on investigation when the commit in FileOutputCommitter takes huge time than expected. This class logged the call with from/to params in debug level which looks insufficient to trace the latency of specific directory due to recursive call.

No test added as there's nothing to test actually. Manual test done via adding below in log4j.properties

```
log4j.logger.org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter=DEBUG
```

and ran tests in TestFileOutputCommitter.

```
2021-01-18 16:14:03,475 DEBUG [main] output.FileOutputCommitter (FileOutputCommitter.java:mergePaths(461)) - Merging data from DeprecatedRawLocalFileStatus{path=file:/Users/jlim/WorkArea/JavaProjects/hadoop/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/target/test-dir/org.apache.hadoop.mapreduce.lib.output.TestFileOutputCommitter/_temporary/0/task_200707121733_0001_m_000000; isDirectory=true; modification_time=1610954043000; access_time=1610954043000; owner=; group=; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=false; isErasureCoded=false} to file:/Users/jlim/WorkArea/JavaProjects/hadoop/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/target/test-dir/org.apache.hadoop.mapreduce.lib.output.TestFileOutputCommitter
...
2021-01-18 16:14:03,476 DEBUG [main] output.FileOutputCommitter (FileOutputCommitter.java:mergePaths(502)) - Merged data from file:/.../hadoop/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/target/test-dir/org.apache.hadoop.mapreduce.lib.output.TestFileOutputCommitter/_temporary/0/task_200707121733_0001_m_000000 to file:/.../hadoop/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/target/test-dir/org.apache.hadoop.mapreduce.lib.output.TestFileOutputCommitter in 1 ms
```