### PR TITLE
HDFS-15783. Speed up BlockPlacementPolicyRackFaultTolerant#verifyBlockPlacement

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
@@ -237,14 +237,11 @@ public class BlockPlacementPolicyRackFaultTolerant extends BlockPlacementPolicyD
       // only one rack
       return new BlockPlacementStatusDefault(1, 1, 1);
     }
-    // 1. Check that all locations are different.
-    // 2. Count locations on different racks.
-    Set<String> racks = new TreeSet<>();
-    for (DatanodeInfo dn : locs) {
-      racks.add(dn.getNetworkLocation());
-    }
-    return new BlockPlacementStatusDefault(racks.size(), numberOfReplicas,
-        clusterMap.getNumOfRacks());
+    // Count locations on different racks.
+    final long rackCount = Arrays.stream(locs)
+        .map(DatanodeInfo::getNetworkLocation).distinct().count();
+    return new BlockPlacementStatusDefault(Math.toIntExact(rackCount),
+        numberOfReplicas, clusterMap.getNumOfRacks());
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
@@ -238,10 +238,12 @@ public class BlockPlacementPolicyRackFaultTolerant extends BlockPlacementPolicyD
       return new BlockPlacementStatusDefault(1, 1, 1);
     }
     // Count locations on different racks.
-    final long rackCount = Arrays.stream(locs)
-        .map(DatanodeInfo::getNetworkLocation).distinct().count();
-    return new BlockPlacementStatusDefault(Math.toIntExact(rackCount),
-        numberOfReplicas, clusterMap.getNumOfRacks());
+    Set<String> racks = new HashSet<>();
+    for (DatanodeInfo dn : locs) {
+      racks.add(dn.getNetworkLocation());
+    }
+    return new BlockPlacementStatusDefault(racks.size(), numberOfReplicas,
+        clusterMap.getNumOfRacks());
   }
 
   @Override


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15783

- Remove the usage of `TreeSet#add`, its time complexity is `O(logN)`.
- ~This fix is similar to https://issues.apache.org/jira/browse/HDFS-14102~