### PR TITLE
HADOOP-17467. fix concurrency bugs in netgroup cache

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NetgroupCache.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NetgroupCache.java
@@ -17,15 +17,17 @@
  */
 package org.apache.hadoop.security;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.Time;
 
 /**
  * Class that caches the netgroups and inverts group-to-user map
@@ -36,6 +38,12 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce"})
 @InterfaceStability.Unstable
 public class NetgroupCache {
+  /**
+   * a static lookup of all the groups that have been fetched.
+   * Note that a group with empty users won't be added.
+   */
+  private final static ConcurrentHashMap<String, Long> GROUPS_LOOKUP =
+      new ConcurrentHashMap<>();
   private static ConcurrentHashMap<String, Set<String>> userToNetgroupsMap =
     new ConcurrentHashMap<String, Set<String>>();
 
@@ -56,20 +64,33 @@ public class NetgroupCache {
   }
 
   /**
+   * Get netgroups for a given user
+   *
+   * @param user get groups for this user
+   * @param groups add user's netgroups into this set of groups
+   */
+  public static void getNetgroups(final String user,
+      Set<String> groups) {
+    Set<String> userGroups = userToNetgroupsMap.get(user);
+    //ConcurrentHashMap does not allow null values;
+    //So null value check can be used to check if the key exists
+    if (userGroups != null) {
+      groups.addAll(userGroups);
+    }
+  }
+
+  /**
    * Get the list of cached netgroups
    *
    * @return list of cached groups
    */
   public static List<String> getNetgroupNames() {
-    return new ArrayList<>(getGroups());
+    return Collections.unmodifiableList(
+        new ArrayList<>(getGroups()));
   }
 
   private static Set<String> getGroups() {
-    Set<String> allGroups = new HashSet<String> ();
-    for (Set<String> userGroups : userToNetgroupsMap.values()) {
-      allGroups.addAll(userGroups);
-    }
-    return allGroups;
+    return GROUPS_LOOKUP.keySet();
   }
 
   /**
@@ -79,7 +100,7 @@ public class NetgroupCache {
    * @return true if group is cached, false otherwise
    */
   public static boolean isCached(String group) {
-    return getGroups().contains(group);
+    return GROUPS_LOOKUP.containsKey(group);
   }
 
   /**
@@ -90,26 +111,88 @@ public class NetgroupCache {
   }
 
   /**
-   * Add group to cache
+   * Refresh the cached entries.
+   * This is done in two steps: clearing the map, then regenerating the values
+   * for each key.
+   *
+   * @param groupProvider the implementation that retrieves the users of the
+   *                      group. This could be a JNI.
+   * @throws IOException exception thrown getting users of a specific group.
+   */
+  public static void refreshCacheCB(NetgroupCacheProvider groupProvider)
+      throws IOException {
+    NetgroupCacheFaultInjector.get().checkPointResettingBeforeClearing();
+    clear();
+    for (String groupName : GROUPS_LOOKUP.keySet()) {
+      add(groupName, groupProvider);
+    }
+  }
+
+  /**
+   * clears the group-users mapping and clear the lookup.
+   */
+  @VisibleForTesting
+  protected static void clearDataForTesting() {
+    clear();
+    GROUPS_LOOKUP.clear();
+  }
+
+  /**
+   * Add group to cache.
    *
    * @param group name of the group to add to cache
    * @param users list of users for a given group
    */
   public static void add(String group, List<String> users) {
+    //TODO this method should be only visible for testing.
+    addInternal(group, users);
+  }
+
+  /**
+   * Add a group to cache using the provider implementation.
+   * Note that the group will not be added to the cache if an exception is
+   * thrown by the group provider implementation.
+   *
+   * @param group the netgroup value.
+   * @param groupProvider the implementation that fetches the group users.
+   * @throws IOException exception thrown fetching the users.
+   */
+  public static void add(String group,
+      NetgroupCacheProvider groupProvider) throws IOException {
+    List<String> groupUsers = groupProvider.getUsersForNetgroup(group);
+    addInternal(group, groupUsers);
+  }
+
+  /**
+   * Add group to cache.
+   *
+   * @param group name of the group to add to cache
+   * @param users list of users for a given group
+   */
+  private static void addInternal(String group, List<String> users) {
+    //TODO is it supposed to cache empty groups?
     for (String user : users) {
-      Set<String> userGroups = userToNetgroupsMap.get(user);
-      // ConcurrentHashMap does not allow null values; 
-      // So null value check can be used to check if the key exists
-      if (userGroups == null) {
-        //Generate a ConcurrentHashSet (backed by the keyset of the ConcurrentHashMap)
-        userGroups =
-            Collections.newSetFromMap(new ConcurrentHashMap<String,Boolean>());
-        Set<String> currentSet = userToNetgroupsMap.putIfAbsent(user, userGroups);
-        if (currentSet != null) {
-          userGroups = currentSet;
-        }
-      }
-      userGroups.add(group);
+      userToNetgroupsMap.computeIfAbsent(user,
+          userName -> ConcurrentHashMap.newKeySet()).add(group);
+    }
+    GROUPS_LOOKUP.put(group, Time.monotonicNow());
+    NetgroupCacheFaultInjector.get().checkPointPostAddingGroup(group);
+  }
+
+  /**
+   * An interface required to provide the netgroup cache with the key/value
+   * pairs.
+   */
+  public interface NetgroupCacheProvider {
+    default List<String> getUsersForNetgroup(String netgroup)
+        throws IOException {
+      return Collections.emptyList();
+    }
+
+    default boolean isCacheableGroup(String groupName) {
+      return (groupName.length() > 0
+          && groupName.charAt(0) == '@' // unix group, not caching
+          && !isCached(groupName));
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NetgroupCacheFaultInjector.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/NetgroupCacheFaultInjector.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security;
+
+/**
+ * Used for injecting faults in NetgroupCache.
+ * Calls into this are a no-op in production code.
+ */
+public class NetgroupCacheFaultInjector {
+  private static NetgroupCacheFaultInjector instance =
+      new NetgroupCacheFaultInjector();
+
+  public static NetgroupCacheFaultInjector get() {
+    return instance;
+  }
+
+  public static void set(NetgroupCacheFaultInjector injector) {
+    instance = injector;
+  }
+
+  public void checkPointResettingBeforeClearing() { }
+  public void checkPointPostAddingGroup(String group) { }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ShellBasedUnixGroupsNetgroupMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ShellBasedUnixGroupsNetgroupMapping.java
@@ -18,15 +18,16 @@
 package org.apache.hadoop.security;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-
+import org.apache.hadoop.security.NetgroupCache.NetgroupCacheProvider;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.ExitCodeException;
 
-import org.apache.hadoop.security.NetgroupCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce"})
 @InterfaceStability.Evolving
 public class ShellBasedUnixGroupsNetgroupMapping
-  extends ShellBasedUnixGroupsMapping {
+    extends ShellBasedUnixGroupsMapping implements NetgroupCacheProvider {
   
   private static final Logger LOG =
       LoggerFactory.getLogger(ShellBasedUnixGroupsNetgroupMapping.class);
@@ -57,14 +58,19 @@ public class ShellBasedUnixGroupsNetgroupMapping
     return groups;
   }
 
+  @Override
+  public Set<String> getGroupsSet(String user) throws IOException {
+    Set<String> groups = new LinkedHashSet<>(super.getGroupsSet(user));
+    NetgroupCache.getNetgroups(user, groups);
+    return groups;
+  }
+
   /**
    * Refresh the netgroup cache
    */
   @Override
   public void cacheGroupsRefresh() throws IOException {
-    List<String> groups = NetgroupCache.getNetgroupNames();
-    NetgroupCache.clear();
-    cacheGroupsAdd(groups);
+    NetgroupCache.refreshCacheCB(this);
   }
 
   /**
@@ -74,15 +80,9 @@ public class ShellBasedUnixGroupsNetgroupMapping
    */
   @Override
   public void cacheGroupsAdd(List<String> groups) throws IOException {
-    for(String group: groups) {
-      if(group.length() == 0) {
-        // better safe than sorry (should never happen)
-      } else if(group.charAt(0) == '@') {
-        if(!NetgroupCache.isCached(group)) {
-          NetgroupCache.add(group, getUsersForNetgroup(group));
-        }
-      } else {
-        // unix group, not caching
+    for (String group: groups) {
+      if (isCacheableGroup(group)) {
+        NetgroupCache.add(group, this);
       }
     }
   }
@@ -93,7 +93,8 @@ public class ShellBasedUnixGroupsNetgroupMapping
    * @param netgroup return users for this netgroup
    * @return list of users for a given netgroup
    */
-  protected List<String> getUsersForNetgroup(String netgroup) 
+  @Override
+  public List<String> getUsersForNetgroup(String netgroup)
     throws IOException {
 
     List<String> users = new LinkedList<String>();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestNetgroupCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestNetgroupCache.java
@@ -19,13 +19,32 @@ package org.apache.hadoop.security;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.security.NetgroupCache.NetgroupCacheProvider;
 
 public class TestNetgroupCache {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestNetgroupCache.class);
 
   private static final String USER1 = "user1";
   private static final String USER2 = "user2";
@@ -33,9 +52,20 @@ public class TestNetgroupCache {
   private static final String GROUP1 = "group1";
   private static final String GROUP2 = "group2";
 
+  /**
+   * Used to keep the original injector between tests.
+   */
+  private NetgroupCacheFaultInjector defaultCacheFaultInjector;
+
   @After
   public void teardown() {
-    NetgroupCache.clear();
+    NetgroupCache.clearDataForTesting();
+    NetgroupCacheFaultInjector.set(defaultCacheFaultInjector);
+  }
+
+  @Before
+  public void setup() {
+    defaultCacheFaultInjector = NetgroupCacheFaultInjector.get();
   }
 
   /**
@@ -109,6 +139,68 @@ public class TestNetgroupCache {
     verifyGroupMembership(USER3, 0, null);
   }
 
+  /**
+   * Testing that an emty group will still be added to the NetgroupCache Lookup.
+   * @throws Exception if failing.
+   */
+  @Test
+  public void testCachingEmptyGroups() throws Exception {
+    Map<String, Set<String>> groupToUsersMap = new HashMap<>();
+    // GROUP1 has no users. USER1 is assigned to Group2
+    groupToUsersMap.put(GROUP1, new LinkedHashSet<>());
+    groupToUsersMap.put(GROUP2, Collections.singleton(USER1));
+    NetgroupCacheProviderForTesting netgroupProvider =
+        new NetgroupCacheProviderForTesting(groupToUsersMap);
+    netgroupProvider.cacheGroupsAdd(Arrays.asList(GROUP1, GROUP2));
+    verifyGroupMembership(USER1, 1, GROUP2);
+    // now GROUP1 should not be cached be cause it is empty.
+    Assert.assertTrue(
+        NetgroupCache.getNetgroupNames()
+            .containsAll(groupToUsersMap.keySet()));
+  }
+  /**
+   * A unit test to inject a race refreshing/adding the groups caching.
+   *
+   * @throws Exception if the unit test fails, or the injector throws
+   *        an exception.
+   */
+  @Test
+  public void testMultiThreadedAccess() throws Exception {
+    int totalUsers = 100;
+    int totalGroups = 20;
+    List<String> usersList = new ArrayList<>();
+    List<String> groupList = new ArrayList<>();
+
+    Map<String, Set<String>> groupToUsersMap =
+        generateRandomMapping(groupList, totalGroups, usersList, totalUsers);
+    InjectRaceInNetgroupRefresh raceInjector =
+        new InjectRaceInNetgroupRefresh(totalGroups);
+    InjectRaceInNetgroupRefresh.set(raceInjector);
+    NetgroupCacheProviderForTesting netgroupProvider =
+        new NetgroupCacheProviderForTesting(groupToUsersMap);
+    int phaseACount = totalGroups / 2;
+    Thread cacheAppendRunner = new Thread(() -> {
+      // add the groups from 10-19 to the cache;
+      raceInjector.blockForPhaseClearing(phaseACount);
+      try {
+        netgroupProvider.cacheGroupsAdd(
+            groupList.subList(phaseACount, totalGroups));
+      } catch (IOException e) {
+        raceInjector.setFailure(e);
+        LOG.error("exception addGroupToCacheInBulk", e);
+      }
+    });
+    cacheAppendRunner.start();
+    // add the first 10 groups to the cache;
+    netgroupProvider.cacheGroupsAdd(groupList.subList(0, phaseACount));
+    NetgroupCache.refreshCacheCB(netgroupProvider);
+    // now we should have 20 groups in the bulkAdder
+    cacheAppendRunner.join();
+    Assert.assertNull(raceInjector.getFailure());
+    assertEquals(totalGroups,
+        NetgroupCache.getNetgroupNames().size());
+  }
+
   private void verifyGroupMembership(String user, int size, String group) {
     List<String> groups = new ArrayList<String>();
     NetgroupCache.getNetgroups(user, groups);
@@ -122,6 +214,144 @@ public class TestNetgroupCache {
         }
       }
       assertTrue(present);
+    }
+  }
+
+  /**
+   * Pick items randomly from a list of String.
+   *
+   * @param originalList list to select items from.
+   * @return a random selected set with size at least larger than half
+   *         the original set.
+   */
+  private static Set<String> getRandomElements(List<String> originalList) {
+    int cutOffElements =
+        Math.abs(ThreadLocalRandom.current().nextInt())
+            % (originalList.size() >> 1);
+    int numberOfElements = originalList.size() - cutOffElements;
+    Set<String> randomElements = new HashSet<>();
+    for (int i = 0; i < numberOfElements; i++) {
+      int rIndex =
+          Math.abs(ThreadLocalRandom.current().nextInt()) % originalList.size();
+      randomElements.add(originalList.get(rIndex));
+    }
+    return randomElements;
+  }
+
+  /**
+   * Generate a random map between groups and users.
+   *
+   * @param groupsList the list where groups are added.
+   * @param groupsCount number of groups generated.
+   * @param usersList the list of the users to test.
+   * @param usersCount the number of total users.
+   * @return map between groups and users with size groupsCount.
+   */
+  private static Map<String, Set<String>> generateRandomMapping(
+      List<String> groupsList, int groupsCount,
+      List<String> usersList, int usersCount) {
+    Map<String, Set<String>> groupToUsersMap = new HashMap<>();
+    for (int i = 1; i <= usersCount; i++) {
+      usersList.add(String.format("user-%03d", i));
+    }
+    for (int i = 1; i <= groupsCount; i++) {
+      String groupName = String.format("group-%03d", i);
+      groupsList.add(groupName);
+      groupToUsersMap.put(groupName, getRandomElements(usersList));
+    }
+    return groupToUsersMap;
+  }
+
+  /**
+   * A Class that injects a race between clearing the group lookups
+   * and fetching the group users.
+   */
+  static class InjectRaceInNetgroupRefresh extends NetgroupCacheFaultInjector {
+    private final Object signalLock = new Object();
+    private final int expectedGroupCount;
+    private final Set<String> addedGroups;
+    private final AtomicBoolean inClearingPhase;
+    private Throwable throwableFailure;
+
+    InjectRaceInNetgroupRefresh(int groupCount) {
+      expectedGroupCount = groupCount;
+      addedGroups = ConcurrentHashMap.newKeySet();
+      throwableFailure = null;
+      inClearingPhase = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void checkPointResettingBeforeClearing() {
+      inClearingPhase.set(true);
+      blockForGroupsToBeAdded(expectedGroupCount);
+    }
+
+    @Override
+    public void checkPointPostAddingGroup(String group) {
+      addedGroups.add(group);
+      synchronized (signalLock) {
+        signalLock.notifyAll();
+      }
+    }
+
+    public void blockForPhaseClearing(int groupCnt) {
+      while (!inClearingPhase.get()) {
+        blockForGroupsToBeAdded(groupCnt);
+      }
+    }
+
+    public void blockForGroupsToBeAdded(int groupCnt) {
+      try {
+        synchronized (signalLock) {
+          while (addedGroups.size() < groupCnt) {
+            signalLock.wait(1000);
+          }
+        }
+      } catch (InterruptedException e) {
+        throwableFailure = e;
+        LOG.error("Error waiting for count latch", e);
+      }
+    }
+
+    Throwable getFailure() {
+      return throwableFailure;
+    }
+
+    void setFailure(Throwable failure) {
+      if (throwableFailure == null) {
+        throwableFailure = failure;
+      }
+    }
+  }
+
+  /**
+   * Implementation for a class to test the Netgroup provider functionality.
+   */
+  static class NetgroupCacheProviderForTesting
+      implements NetgroupCacheProvider {
+    private final Map<String, Set<String>> groupUsersMap;
+
+    NetgroupCacheProviderForTesting(Map<String, Set<String>> groupUserLookup) {
+      groupUsersMap = groupUserLookup;
+    }
+
+    @Override
+    public List<String> getUsersForNetgroup(String netgroup)
+        throws IOException {
+      return new ArrayList<>(groupUsersMap.get(netgroup));
+    }
+
+    @Override
+    public boolean isCacheableGroup(String groupName) {
+      return !NetgroupCache.isCached(groupName);
+    }
+
+    public void cacheGroupsAdd(List<String> groups) throws IOException {
+      for (String group: groups) {
+        if (isCacheableGroup(group)) {
+          NetgroupCache.add(group, this);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- `cacheGroupsRefresh` introduces a race that could result in a group not being added correctly to the set of keys in the table. The code below shows that a concurrent thread that adds a group between lines 80-81 would not be accounted for.  

```java
78 @Override
79  public void cacheGroupsRefresh() throws IOException {
80    List<String> groups = NetgroupCache.getNetgroupNames();
81     NetgroupCache.clear();
82    cacheGroupsAdd(groups);
83  }
```
- getGroupSet is not implemented in JNIBased classes. As a result, the netgroup  data won't be retrieved from the NetgroupCache even after forcing a manual `refresh()`. This bug was introduced by [HADOOP-17079](https://issues.apache.org/jira/browse/HADOOP-17079)
- `NetgroupCache.isCached` is not threadSafe. The process of checking whether a group has been cached or not can be overwhelming given the number of users in the tables.
- In addition to the above fixed, I added a unit test to verify the code fails in concurrent environment.