### PR TITLE
HADOOP-17483. Remove option to enable/disable S3A magic committer . It is always on

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1872,16 +1872,6 @@
 </property>
 
 <property>
-  <name>fs.s3a.committer.magic.enabled</name>
-  <value>false</value>
-  <description>
-    Enable support in the filesystem for the S3 "Magic" committer.
-    When working with AWS S3, S3Guard must be enabled for the destination
-    bucket, as consistent metadata listings are required.
-  </description>
-</property>
-
-<property>
   <name>fs.s3a.committer.threads</name>
   <value>8</value>
   <description>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -449,13 +449,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       LOG.debug("Input fadvise policy = {}", inputPolicy);
       changeDetectionPolicy = ChangeDetectionPolicy.getPolicy(conf);
       LOG.debug("Change detection policy = {}", changeDetectionPolicy);
-      boolean magicCommitterEnabled = conf.getBoolean(
-          CommitConstants.MAGIC_COMMITTER_ENABLED,
-          CommitConstants.DEFAULT_MAGIC_COMMITTER_ENABLED);
-      LOG.debug("Filesystem support for magic committers {} enabled",
-          magicCommitterEnabled ? "is" : "is not");
-      committerIntegration = new MagicCommitIntegration(
-          this, magicCommitterEnabled);
+      committerIntegration = new MagicCommitIntegration(this);
 
       // instantiate S3 Select support
       selectBinding = new SelectBinding(writeHelper);
@@ -4203,9 +4197,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     sb.append(", authoritativeStore=").append(allowAuthoritativeMetadataStore);
     sb.append(", authoritativePath=").append(allowAuthoritativePaths);
     sb.append(", useListV1=").append(useListV1);
-    if (committerIntegration != null) {
-      sb.append(", magicCommitter=").append(isMagicCommitEnabled());
-    }
     sb.append(", boundedExecutor=").append(boundedThreadPool);
     sb.append(", unboundedExecutor=").append(unboundedThreadPool);
     sb.append(", credentials=").append(credentials);
@@ -4248,10 +4239,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
   /**
    * Is magic commit enabled?
-   * @return true if magic commit support is turned on.
+   * Now that it is always enabled, this method always returns
+   * {@code true}
+   * @return true, always.
    */
+  @Deprecated
   public boolean isMagicCommitEnabled() {
-    return committerIntegration.isMagicCommitEnabled();
+    return true;
   }
 
   /**
@@ -4737,8 +4731,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
     case CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER:
     case CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER_OLD:
-      // capability depends on FS configuration
-      return isMagicCommitEnabled();
+      return true;
 
     case SelectConstants.S3_SELECT_CAPABILITY:
       // select is only supported if enabled

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitConstants.java
@@ -69,6 +69,7 @@ public final class CommitConstants {
    * in the filesystem.
    * Value: {@value}.
    */
+  @Deprecated
   public static final String MAGIC_COMMITTER_ENABLED
       = MAGIC_COMMITTER_PREFIX + ".enabled";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitOperations.java
@@ -431,8 +431,6 @@ public class CommitOperations implements IOStatisticsSource {
         conf.getTrimmed(METADATASTORE_AUTHORITATIVE, "false"));
     successData.addDiagnostic(AUTHORITATIVE_PATH,
         conf.getTrimmed(AUTHORITATIVE_PATH, ""));
-    successData.addDiagnostic(MAGIC_COMMITTER_ENABLED,
-        conf.getTrimmed(MAGIC_COMMITTER_ENABLED, "false"));
 
     // now write
     Path markerPath = new Path(outputPath, _SUCCESS);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/CommitUtils.java
@@ -53,25 +53,8 @@ public final class CommitUtils {
    */
   public static void verifyIsMagicCommitPath(S3AFileSystem fs,
       Path path) throws PathCommitException {
-    verifyIsMagicCommitFS(fs);
     if (!fs.isMagicCommitPath(path)) {
       throw new PathCommitException(path, E_BAD_PATH);
-    }
-  }
-
-  /**
-   * Verify that an S3A FS instance is a magic commit FS.
-   * @param fs filesystem
-   * @throws PathCommitException if the FS isn't a magic commit FS.
-   */
-  public static void verifyIsMagicCommitFS(S3AFileSystem fs)
-      throws PathCommitException {
-    if (!fs.isMagicCommitEnabled()) {
-      // dump out details to console for support diagnostics
-      String fsUri = fs.getUri().toString();
-      LOG.error("{}: {}:\n{}", E_NORMAL_FS, fsUri, fs);
-      // then fail
-      throw new PathCommitException(fsUri, E_NORMAL_FS);
     }
   }
 
@@ -106,7 +89,6 @@ public final class CommitUtils {
       throws PathCommitException, IOException {
     S3AFileSystem s3AFS = verifyIsS3AFS(path.getFileSystem(conf), path);
     if (magicCommitRequired) {
-      verifyIsMagicCommitFS(s3AFS);
     }
     return s3AFS;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/InternalCommitterConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/InternalCommitterConstants.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.s3a.commit.staging.PartitionedStagingCommitterFactor
 import org.apache.hadoop.fs.s3a.commit.staging.StagingCommitterFactory;
 
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC;
-import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC_COMMITTER_ENABLED;
 
 /**
  * These are internal constants not intended for public use.
@@ -90,11 +89,6 @@ public final class InternalCommitterConstants {
   /** Error message for bad path: {@value}. */
   public static final String E_BAD_PATH
       = "Path does not represent a magic-commit path";
-
-  /** Error message if filesystem isn't magic: {@value}. */
-  public static final String E_NORMAL_FS
-      = "Filesystem does not have support for 'magic' committer enabled"
-      + " in configuration option " + MAGIC_COMMITTER_ENABLED;
 
   /** Error message if the dest FS isn't S3A: {@value}. */
   public static final String E_WRONG_FS

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/MagicCommitIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/MagicCommitIntegration.java
@@ -49,19 +49,17 @@ public class MagicCommitIntegration {
   private static final Logger LOG =
       LoggerFactory.getLogger(MagicCommitIntegration.class);
   private final S3AFileSystem owner;
-  private final boolean magicCommitEnabled;
+  private final boolean magicCommitEnabled = true;
 
   private final StoreContext storeContext;
 
   /**
    * Instantiate.
    * @param owner owner class
-   * @param magicCommitEnabled is magic commit enabled.
+   *
    */
-  public MagicCommitIntegration(S3AFileSystem owner,
-      boolean magicCommitEnabled) {
+  public MagicCommitIntegration(S3AFileSystem owner) {
     this.owner = owner;
-    this.magicCommitEnabled = magicCommitEnabled;
     this.storeContext = owner.createStoreContext();
   }
 
@@ -128,9 +126,7 @@ public class MagicCommitIntegration {
    * @return a list of elements, possibly empty
    */
   private List<String> finalDestination(List<String> elements) {
-    return magicCommitEnabled ?
-        MagicCommitPaths.finalDestination(elements)
-        : elements;
+    return MagicCommitPaths.finalDestination(elements);
   }
 
   /**
@@ -138,7 +134,7 @@ public class MagicCommitIntegration {
    * @return true if magic commit is turned on.
    */
   public boolean isMagicCommitEnabled() {
-    return magicCommitEnabled;
+    return true;
   }
 
   /**
@@ -158,7 +154,7 @@ public class MagicCommitIntegration {
    * @return true if writing path is to be uprated to a magic file write
    */
   private boolean isMagicCommitPath(List<String> elements) {
-    return magicCommitEnabled && isMagicFile(elements);
+    return isMagicFile(elements);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardTool.java
@@ -1385,15 +1385,6 @@ public abstract class S3GuardTool extends Configured implements Tool,
         printOption(out, "\tFile conflict resolution",
             FS_S3A_COMMITTER_STAGING_CONFLICT_MODE, DEFAULT_CONFLICT_MODE);
         break;
-      case COMMITTER_NAME_MAGIC:
-        printOption(out, "\tStore magic committer integration",
-            MAGIC_COMMITTER_ENABLED,
-            Boolean.toString(DEFAULT_MAGIC_COMMITTER_ENABLED));
-        if (!magic) {
-          println(out, "Warning: although the magic committer is enabled, "
-              + "the store does not support it");
-        }
-        break;
       default:
         println(out, "\tWarning: committer '%s' is unknown", committer);
       }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
@@ -71,8 +71,6 @@ public abstract class AbstractS3AMockTest {
     // test we don't issue request to AWS DynamoDB service.
     conf.setClass(S3_METADATA_STORE_IMPL, NullMetadataStore.class,
         MetadataStore.class);
-    // FS is always magic
-    conf.setBoolean(CommitConstants.MAGIC_COMMITTER_ENABLED, true);
     // use minimum multipart size for faster triggering
     conf.setLong(Constants.MULTIPART_SIZE, MULTIPART_MIN_SIZE);
     conf.setInt(Constants.S3A_BUCKET_PROBE, 1);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -165,11 +165,6 @@ public class MockS3AFileSystem extends S3AFileSystem {
     return conf;
   }
 
-  @Override
-  public boolean isMagicCommitEnabled() {
-    return true;
-  }
-
   /**
    * Make operation to set the s3 client public.
    * @param client client.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -93,7 +93,6 @@ import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3AUtils.propagateBucketOptions;
 import static org.apache.hadoop.test.LambdaTestUtils.eventually;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC_COMMITTER_ENABLED;
 import static org.junit.Assert.*;
 
 /**
@@ -628,9 +627,6 @@ public final class S3ATestUtils {
       conf.set(HADOOP_TMP_DIR, tmpDir);
     }
     conf.set(BUFFER_DIR, tmpDir);
-    // add this so that even on tests where the FS is shared,
-    // the FS is always "magic"
-    conf.setBoolean(MAGIC_COMMITTER_ENABLED, true);
 
     // directory marker policy
     String directoryRetention = getTestProperty(

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -555,7 +555,6 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
   public void testRestrictedCommitActions() throws Throwable {
     describe("Attempt commit operations against a path with restricted rights");
     Configuration conf = createAssumedRoleConfig();
-    conf.setBoolean(CommitConstants.MAGIC_COMMITTER_ENABLED, true);
     final int uploadPartSize = 5 * 1024 * 1024;
 
     ProgressCounter progress = new ProgressCounter();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractCommitITest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractCommitITest.java
@@ -110,14 +110,12 @@ public abstract class AbstractCommitITest extends AbstractS3ATestBase {
     Configuration conf = super.createConfiguration();
     String bucketName = getTestBucketName(conf);
     removeBucketOverrides(bucketName, conf,
-        MAGIC_COMMITTER_ENABLED,
         S3A_COMMITTER_FACTORY_KEY,
         FS_S3A_COMMITTER_NAME,
         FS_S3A_COMMITTER_STAGING_CONFLICT_MODE,
         FS_S3A_COMMITTER_STAGING_UNIQUE_FILENAMES,
         FAST_UPLOAD_BUFFER);
 
-    conf.setBoolean(MAGIC_COMMITTER_ENABLED, true);
     conf.setLong(MIN_MULTIPART_THRESHOLD, MULTIPART_MIN_SIZE);
     conf.setInt(MULTIPART_SIZE, MULTIPART_MIN_SIZE);
     conf.set(FAST_UPLOAD_BUFFER, FAST_UPLOAD_BUFFER_ARRAY);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
@@ -103,7 +103,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
   public void setup() throws Exception {
     FileSystem.closeAll();
     super.setup();
-    verifyIsMagicCommitFS(getFileSystem());
+    getFileSystem();
     // abort,; rethrow on failure
     setThrottling(HIGH_THROTTLE, STANDARD_FAILURE_LIMIT);
     progress = new ProgressCounter();
@@ -114,7 +114,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
   public void testCreateTrackerNormalPath() throws Throwable {
     S3AFileSystem fs = getFileSystem();
     MagicCommitIntegration integration
-        = new MagicCommitIntegration(fs, true);
+        = new MagicCommitIntegration(fs);
     String filename = "notdelayed.txt";
     Path destFile = methodPath(filename);
     String origKey = fs.pathToKey(destFile);
@@ -131,7 +131,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
   public void testCreateTrackerMagicPath() throws Throwable {
     S3AFileSystem fs = getFileSystem();
     MagicCommitIntegration integration
-        = new MagicCommitIntegration(fs, true);
+        = new MagicCommitIntegration(fs);
     String filename = "delayed.txt";
     Path destFile = methodPath(filename);
     String origKey = fs.pathToKey(destFile);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
@@ -24,14 +24,12 @@ import java.net.URI;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.commit.AbstractITCommitProtocol;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitter;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
-import org.apache.hadoop.fs.s3a.commit.CommitUtils;
 import org.apache.hadoop.fs.s3a.commit.CommitterFaultInjection;
 import org.apache.hadoop.fs.s3a.commit.CommitterFaultInjectionImpl;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -62,13 +60,6 @@ public class ITestMagicCommitProtocol extends AbstractITCommitProtocol {
   }
 
   @Override
-  protected Configuration createConfiguration() {
-    Configuration conf = super.createConfiguration();
-    conf.setBoolean(MAGIC_COMMITTER_ENABLED, true);
-    return conf;
-  }
-
-  @Override
   protected String getCommitterFactoryName() {
     return CommitConstants.S3A_COMMITTER_FACTORY;
   }
@@ -81,7 +72,7 @@ public class ITestMagicCommitProtocol extends AbstractITCommitProtocol {
   @Override
   public void setup() throws Exception {
     super.setup();
-    CommitUtils.verifyIsMagicCommitFS(getFileSystem());
+    getFileSystem();
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestS3AHugeMagicCommits.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestS3AHugeMagicCommits.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
@@ -35,7 +34,6 @@ import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 import org.apache.hadoop.fs.s3a.commit.CommitOperations;
-import org.apache.hadoop.fs.s3a.commit.CommitUtils;
 import org.apache.hadoop.fs.s3a.commit.files.PendingSet;
 import org.apache.hadoop.fs.s3a.commit.files.SinglePendingCommit;
 import org.apache.hadoop.fs.s3a.scale.AbstractSTestS3AHugeFiles;
@@ -83,21 +81,10 @@ public class ITestS3AHugeMagicCommits extends AbstractSTestS3AHugeFiles {
     return "ITestS3AHugeMagicCommits";
   }
 
-  /**
-   * Create the scale IO conf with the committer enabled.
-   * @return the configuration to use for the test FS.
-   */
-  @Override
-  protected Configuration createScaleConfiguration() {
-    Configuration conf = super.createScaleConfiguration();
-    conf.setBoolean(MAGIC_COMMITTER_ENABLED, true);
-    return conf;
-  }
-
   @Override
   public void setup() throws Exception {
     super.setup();
-    CommitUtils.verifyIsMagicCommitFS(getFileSystem());
+    getFileSystem();
 
     // set up the paths for the commit operation
     Path finalDirectory = new Path(getScaleTestDir(), "commit");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/terasort/ITestTerasortOnS3A.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/terasort/ITestTerasortOnS3A.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.util.ToolRunner;
 
 import static java.util.Optional.empty;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.lsR;
-import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC_COMMITTER_ENABLED;
 
 /**
  * Runs Terasort against S3A.
@@ -155,7 +154,6 @@ public class ITestTerasortOnS3A extends AbstractYarnClusterITest {
   @Override
   protected void applyCustomConfigOptions(JobConf conf) {
     // small sample size for faster runs
-    conf.setBoolean(MAGIC_COMMITTER_ENABLED, true);
     conf.setInt(TeraSortConfigKeys.SAMPLE_SIZE.key(),
         getSampleSizeForEachPartition());
     conf.setInt(TeraSortConfigKeys.NUM_PARTITIONS.key(),

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/AbstractS3GuardToolTestBase.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
-import org.apache.hadoop.fs.s3a.commit.CommitConstants;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.StringUtils;
@@ -61,7 +60,6 @@ import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_METASTORE_NULL;
 import static org.apache.hadoop.fs.s3a.Constants.S3_METADATA_STORE_IMPL;
 import static org.apache.hadoop.fs.s3a.S3AUtils.clearBucketOption;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.BucketInfo.IS_MARKER_AWARE;
-import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.E_BAD_STATE;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.INVALID_ARGUMENT;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.SUCCESS;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardToolTestHelper.exec;
@@ -590,16 +588,8 @@ public abstract class AbstractS3GuardToolTestBase extends AbstractS3ATestBase {
     String name = fs.getUri().toString();
     S3GuardTool.BucketInfo cmd = new S3GuardTool.BucketInfo(
         getConfiguration());
-    if (fs.hasPathCapability(fs.getWorkingDirectory(),
-        CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER)) {
-      // if the FS is magic, expect this to work
-      exec(cmd, S3GuardTool.BucketInfo.MAGIC_FLAG, name);
-    } else {
-      // if the FS isn't magic, expect the probe to fail
-      assertExitCode(E_BAD_STATE,
-          intercept(ExitUtil.ExitException.class,
-              () -> exec(cmd, S3GuardTool.BucketInfo.MAGIC_FLAG, name)));
-    }
+    // this must always work
+    exec(cmd, S3GuardTool.BucketInfo.MAGIC_FLAG, name);
   }
 
   /**


### PR DESCRIPTION


#2636 updated the docs; this is the code-side change to remove the option of disabling magic committer support in the FS

That was a safety check to stop people enabling it on inconsistent/unguarded buckets. We can stop worrying there.

Before anyone asks: what about inconsistent third party stores: every one else's has always been consistent.

tested: s3 london with `-Dparallel-tests -DtestsThreadCount=6 -Dmarkers=delete -Dtest=no -Dfs.s3a.directory.marker.audit=true -Dscale`

Looks like I skipped the unit tests there...lets see what yetus says