### PR TITLE
HADOOP-15710. ABFS checkException to map 403 to AccessDeniedException.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1117,7 +1117,8 @@ public class AzureBlobFileSystem extends FileSystem {
    * @param allowedErrorCodesList varargs list of error codes.
    * @throws IOException if the exception error code is not on the allowed list.
    */
-  private void checkException(final Path path,
+  @VisibleForTesting
+  static void checkException(final Path path,
                               final AzureBlobFileSystemException exception,
                               final AzureServiceErrorCode... allowedErrorCodesList) throws IOException {
     if (exception instanceof AbfsRestOperationException) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -32,13 +32,18 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.AUTHORIZATION_PERMISSION_MISS_MATCH;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assume.assumeTrue;
 
 /**
  * Verify the AbfsRestOperationException error message format.
  * */
-public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest{
+public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest {
+
+  private static final String E_UNAUTH
+      = AUTHORIZATION_PERMISSION_MISS_MATCH.getErrorCode();
+
   public ITestAbfsRestOperationException() throws Exception {
     super();
   }
@@ -56,7 +61,9 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
 
       Assert.assertEquals(4, errorFields.length);
       // Check status message, status code, HTTP Request Type and URL.
-      Assert.assertEquals("Operation failed: \"The specified path does not exist.\"", errorFields[0].trim());
+      Assert.assertEquals(
+          "Operation failed: \"The specified path does not exist.\"",
+          errorFields[0].trim());
       Assert.assertEquals("404", errorFields[1].trim());
       Assert.assertEquals("HEAD", errorFields[2].trim());
       Assert.assertTrue(errorFields[3].trim().startsWith("http"));
@@ -71,14 +78,16 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
 
       Assert.assertEquals(6, errorFields.length);
       // Check status message, status code, HTTP Request Type and URL.
-      Assert.assertEquals("Operation failed: \"The specified path does not exist.\"", errorFields[0].trim());
+      Assert.assertEquals(
+          "Operation failed: \"The specified path does not exist.\"",
+          errorFields[0].trim());
       Assert.assertEquals("404", errorFields[1].trim());
       Assert.assertEquals("GET", errorFields[2].trim());
       Assert.assertTrue(errorFields[3].trim().startsWith("http"));
       // Check storage error code and storage error message.
       Assert.assertEquals("PathNotFound", errorFields[4].trim());
       Assert.assertTrue(errorFields[5].contains("RequestId")
-              && errorFields[5].contains("Time"));
+          && errorFields[5].contains("Time"));
     }
   }
 
@@ -89,38 +98,43 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
     testWithDifferentCustomTokenFetchRetry(5);
   }
 
-  public void testWithDifferentCustomTokenFetchRetry(int numOfRetries) throws Exception {
+  public void testWithDifferentCustomTokenFetchRetry(int numOfRetries)
+      throws Exception {
     AzureBlobFileSystem fs = this.getFileSystem();
 
     Configuration config = new Configuration(this.getRawConfiguration());
     String accountName = config.get("fs.azure.abfs.account.name");
     // Setup to configure custom token provider
     config.set("fs.azure.account.auth.type." + accountName, "Custom");
-    config.set("fs.azure.account.oauth.provider.type." + accountName, "org.apache.hadoop.fs"
-        + ".azurebfs.oauth2.RetryTestTokenProvider");
-    config.set("fs.azure.custom.token.fetch.retry.count", Integer.toString(numOfRetries));
+    config.set("fs.azure.account.oauth.provider.type." + accountName,
+        "org.apache.hadoop.fs"
+            + ".azurebfs.oauth2.RetryTestTokenProvider");
+    config.set("fs.azure.custom.token.fetch.retry.count",
+        Integer.toString(numOfRetries));
     // Stop filesystem creation as it will lead to calls to store.
     config.set("fs.azure.createRemoteFileSystemDuringInitialization", "false");
 
     final AzureBlobFileSystem fs1 =
         (AzureBlobFileSystem) FileSystem.newInstance(fs.getUri(),
-        config);
+            config);
     RetryTestTokenProvider.ResetStatusToFirstTokenFetch();
 
     intercept(Exception.class,
-        ()-> {
+        () -> {
           fs1.getFileStatus(new Path("/"));
         });
 
     // Number of retries done should be as configured
     Assert.assertTrue(
         "Number of token fetch retries (" + RetryTestTokenProvider.reTryCount
-            + ") done, does not match with fs.azure.custom.token.fetch.retry.count configured (" + numOfRetries
+            + ") done, does not match with fs.azure.custom.token.fetch.retry.count configured ("
+            + numOfRetries
             + ")", RetryTestTokenProvider.reTryCount == numOfRetries);
   }
 
   @Test
   public void testPermissionDenied() throws Throwable {
+    describe("Verify that permission denial manifests as failures");
     final AzureBlobFileSystem fs = getFileSystem();
     assumeTrue(fs.getIsNamespaceEnabled());
     Path dir = new Path("testPermissionDenied");
@@ -129,8 +143,9 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
     // no permissions
     fs.setPermission(path, new FsPermission((short) 00000));
     fs.setPermission(dir, new FsPermission((short) 00000));
-    intercept(AccessDeniedException.class, () ->
+    intercept(AccessDeniedException.class, E_UNAUTH, () ->
         fs.delete(path, false));
-    intercept(AccessDeniedException.class, () ->
+    intercept(AccessDeniedException.class, E_UNAUTH, () ->
         ContractTestUtils.readUTF8(fs, path, -1));
-  }}
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -139,13 +139,15 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
     assumeTrue(fs.getIsNamespaceEnabled());
     Path dir = new Path("testPermissionDenied");
     Path path = new Path(dir, "file");
-    ContractTestUtils.writeTextFile(fs, path, "some text", true);
+    ContractTestUtils.writeTextFile(fs, path, "This should not be readable", true);
     // no permissions
     fs.setPermission(path, new FsPermission((short) 00000));
     fs.setPermission(dir, new FsPermission((short) 00000));
     intercept(AccessDeniedException.class, E_UNAUTH, () ->
-        fs.delete(path, false));
-    intercept(AccessDeniedException.class, E_UNAUTH, () ->
         ContractTestUtils.readUTF8(fs, path, -1));
+    intercept(AccessDeniedException.class, E_UNAUTH, () -> {
+      boolean d = fs.delete(path, false);
+      return "Expected delete to fail, but got " + d;
+    });
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsErrorTranslation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsErrorTranslation.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import java.io.FileNotFoundException;
+import java.net.HttpURLConnection;
+import java.nio.file.AccessDeniedException;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
+import org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.checkException;
+import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.AUTHORIZATION_PERMISSION_MISS_MATCH;
+import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.PATH_ALREADY_EXISTS;
+import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.PATH_NOT_FOUND;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+/**
+ * Test suite to verify exception conversion, filtering etc.
+ */
+public class TestAbfsErrorTranslation extends AbstractHadoopTestBase {
+
+  public static final Path PATH = new Path("abfs//store/path");
+
+  @Test
+  public void testConvert403ToAccessDenied() throws Throwable {
+    assertTranslated(HttpURLConnection.HTTP_FORBIDDEN,
+        AUTHORIZATION_PERMISSION_MISS_MATCH,
+        AccessDeniedException.class,
+        AUTHORIZATION_PERMISSION_MISS_MATCH.getErrorCode());
+  }
+
+  @Test
+  public void testConvert404ToFNFE() throws Throwable {
+    assertTranslated(HttpURLConnection.HTTP_NOT_FOUND,
+        PATH_NOT_FOUND,
+        FileNotFoundException.class,
+        PATH_NOT_FOUND.getErrorCode());
+  }
+
+  @Test
+  public void testConvert409ToFileAlreadyExistsException() throws Throwable {
+    assertTranslated(HttpURLConnection.HTTP_CONFLICT,
+        PATH_ALREADY_EXISTS,
+        FileAlreadyExistsException.class,
+        PATH_ALREADY_EXISTS.getErrorCode());
+  }
+
+  /**
+   * Assert that for a given status code and AzureServiceErrorCode, a specific
+   * exception class is raised.
+   * @param <E> type of exception
+   * @param httpStatus http status code
+   * @param exitCode AzureServiceErrorCode
+   * @param clazz class of raised exception
+   * @param expectedText text to expect in the exception
+   * @throws Exception any other exception than the one expected
+   */
+  private <E extends Throwable> void assertTranslated(
+      int httpStatus, AzureServiceErrorCode exitCode,
+      Class<E> clazz, String expectedText) throws Exception {
+    AbfsRestOperationException ex =
+        new AbfsRestOperationException(httpStatus, exitCode.getErrorCode(),
+            "", null);
+    intercept(clazz, expectedText, () -> {
+      checkException(PATH, ex);
+      return "expected exception translation from " + ex;
+    });
+  }
+
+}


### PR DESCRIPTION

This maps both 401 and 403 to AccessDeniedException.

The test does not work, because even though I'm removing permissions
from the file and parent dir, it's still opening.

Tested: Azure cardiff