### PR TITLE
HDFS-15791. Possible Resource Leak in FSImageFormatProtobuf

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
@@ -269,14 +269,20 @@ public final class FSImageFormatProtobuf {
                                                 String compressionCodec)
         throws IOException {
       FileInputStream fin = new FileInputStream(filename);
-      FileChannel channel = fin.getChannel();
-      channel.position(section.getOffset());
-      InputStream in = new BufferedInputStream(new LimitInputStream(fin,
-          section.getLength()));
+      try {
 
-      in = FSImageUtil.wrapInputStreamForCompression(conf,
-          compressionCodec, in);
-      return in;
+          FileChannel channel = fin.getChannel();
+          channel.position(section.getOffset());
+          InputStream in = new BufferedInputStream(new LimitInputStream(fin,
+                  section.getLength()));
+
+          in = FSImageUtil.wrapInputStreamForCompression(conf,
+                  compressionCodec, in);
+          return in;
+      } catch (IOException e) {
+          fin.close();
+          throw e;
+      }
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://issues.apache.org/jira/browse/HDFS-15791).