### PR TITLE
HADOOP-17496. Install a supported version of pip

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -113,10 +113,10 @@ RUN mkdir -p /opt/boost-library \
 ####
 # hadolint ignore=DL3003
 RUN mkdir -p /opt/pip \
-    && curl -L https://bootstrap.pypa.io/get-pip.py > get-pip.py \
+    && curl -L https://bootstrap.pypa.io/2.7/get-pip.py > get-pip.py \
     && mv get-pip.py /opt/pip \
     && cd /opt/pip \
-    && python2.7 get-pip.py \
+    && python2.7 get-pip.py "pip < 21.0" \
     && cd /root \
     && rm -rf /opt/pip
 

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -117,10 +117,10 @@ RUN mkdir -p /opt/boost-library \
 ####
 # hadolint ignore=DL3003
 RUN mkdir -p /opt/pip \
-    && curl -L https://bootstrap.pypa.io/get-pip.py > get-pip.py \
+    && curl -L https://bootstrap.pypa.io/2.7/get-pip.py > get-pip.py \
     && mv get-pip.py /opt/pip \
     && cd /opt/pip \
-    && python2.7 get-pip.py \
+    && python2.7 get-pip.py "pip < 21.0" \
     && cd /root \
     && rm -rf /opt/pip
 


### PR DESCRIPTION
* pip version 21 ended support for
  python 2.7. Thus we need to install
  a version of pip that supports
  python 2.7.
