### PR TITLE
HADOOP-17507. Add install notes GCC9, CMake 3.19

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -70,13 +70,11 @@ Installing required packages for clean install of Ubuntu 14.04 LTS Desktop:
   $ sudo apt-get -y install g++-9 gcc-9
   $ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 * CMake 3.19
-  $ mkdir -p /opt/cmake \
-    && curl -L https://cmake.org/files/v3.19/cmake-3.19.0.tar.gz > cmake-3.19.0.tar.gz \
-    && tar -zxvf cmake-3.19.0.tar.gz \
-    && cd cmake-3.19.0 \
-    && ./bootstrap \
-    && make -j$(nproc) \
-    && sudo make install
+  $ curl -L https://cmake.org/files/v3.19/cmake-3.19.0.tar.gz > cmake-3.19.0.tar.gz
+  $ tar -zxvf cmake-3.19.0.tar.gz && cd cmake-3.19.0
+  $ ./bootstrap
+  $ make -j$(nproc)
+  $ sudo make install
 * Protocol Buffers 3.7.1 (required to build native code)
   $ mkdir -p /opt/protobuf-3.7-src \
         && curl -L -s -S \
@@ -472,13 +470,11 @@ Building on CentOS 8
   $ source /opt/rh/gcc-toolset-9/enable
 
 * Install CMake 3.19
-  $ mkdir -p /opt/cmake \
-    && curl -L https://cmake.org/files/v3.19/cmake-3.19.0.tar.gz > cmake-3.19.0.tar.gz \
-    && tar -zxvf cmake-3.19.0.tar.gz \
-    && cd cmake-3.19.0 \
-    && ./bootstrap \
-    && make -j$(nproc) \
-    && sudo make install
+  $ curl -L https://cmake.org/files/v3.19/cmake-3.19.0.tar.gz > cmake-3.19.0.tar.gz
+  $ tar -zxvf cmake-3.19.0.tar.gz && cd cmake-3.19.0
+  $ ./bootstrap
+  $ make -j$(nproc)
+  $ sudo make install
 
 * Install boost.
   $ curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -63,6 +63,20 @@ Installing required packages for clean install of Ubuntu 14.04 LTS Desktop:
   $ sudo apt-get -y install maven
 * Native libraries
   $ sudo apt-get -y install build-essential autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev libsasl2-dev
+* GCC 9.3.0
+  $ sudo apt-get -y install software-properties-common
+  $ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  $ sudo apt-get update
+  $ sudo apt-get -y install g++-9 gcc-9
+  $ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+* CMake 3.19
+  $ mkdir -p /opt/cmake \
+    && curl -L https://cmake.org/files/v3.19/cmake-3.19.0.tar.gz > cmake-3.19.0.tar.gz \
+    && tar -zxvf cmake-3.19.0.tar.gz \
+    && cd cmake-3.19.0 \
+    && ./bootstrap \
+    && make -j$(nproc) \
+    && sudo make install
 * Protocol Buffers 3.7.1 (required to build native code)
   $ mkdir -p /opt/protobuf-3.7-src \
         && curl -L -s -S \
@@ -452,6 +466,19 @@ Building on CentOS 8
 
 * Install libraries provided by CentOS 8.
   $ sudo dnf install libtirpc-devel zlib-devel lz4-devel bzip2-devel openssl-devel cyrus-sasl-devel libpmem-devel
+
+* Install GCC 9.3.0
+  $ sudo dnf -y install gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+  $ source /opt/rh/gcc-toolset-9/enable
+
+* Install CMake 3.19
+  $ mkdir -p /opt/cmake \
+    && curl -L https://cmake.org/files/v3.19/cmake-3.19.0.tar.gz > cmake-3.19.0.tar.gz \
+    && tar -zxvf cmake-3.19.0.tar.gz \
+    && cd cmake-3.19.0 \
+    && ./bootstrap \
+    && make -j$(nproc) \
+    && sudo make install
 
 * Install boost.
   $ curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download


### PR DESCRIPTION
* Added instructions for Ubuntu 14.04 and
  Centos 8 regarding installation of GCC 9.3.0
  and CMake 3.19.
