### PR TITLE
YARN-9650. Set thread names for CapacityScheduler AsyncScheduleThread

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -199,6 +199,8 @@ public class CapacityScheduler extends
 
   private CSConfigurationProvider csConfProvider;
 
+  private int threadNum = 0;
+
   @Override
   public void setConf(Configuration conf) {
       yarnConf = conf;
@@ -634,6 +636,7 @@ public class CapacityScheduler extends
 
     public AsyncScheduleThread(CapacityScheduler cs) {
       this.cs = cs;
+      setName("CapacitySchedulerThread" + cs.threadNum++);
       setDaemon(true);
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -636,7 +636,7 @@ public class CapacityScheduler extends
 
     public AsyncScheduleThread(CapacityScheduler cs) {
       this.cs = cs;
-      setName("CapacitySchedulerThread" + cs.threadNum++);
+      setName("AsyncCapacitySchedulerThread" + cs.threadNum++);
       setDaemon(true);
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -152,8 +152,10 @@ public class TestCapacitySchedulerAsyncScheduling {
     rm.start();
 
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
-    for (CapacityScheduler.AsyncScheduleThread thread : cs.asyncSchedulerThreads) {
-      Assert.assertTrue(thread.getName().startsWith("AsyncCapacitySchedulerThread"));
+    for (CapacityScheduler
+        .AsyncScheduleThread thread : cs.asyncSchedulerThreads) {
+      Assert.assertTrue(thread.getName()
+          .startsWith("AsyncCapacitySchedulerThread"));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -131,28 +131,28 @@ public class TestCapacitySchedulerAsyncScheduling {
   }
 
   @Test(timeout = 300000)
-  public void testAsyncThreadNames() throws Exception{
+  public void testAsyncThreadNames() throws Exception {
     conf.setInt(
-            CapacitySchedulerConfiguration.SCHEDULE_ASYNCHRONOUSLY_MAXIMUM_THREAD,
-            1);
+        CapacitySchedulerConfiguration.SCHEDULE_ASYNCHRONOUSLY_MAXIMUM_THREAD,
+        1);
     conf.setInt(CapacitySchedulerConfiguration.SCHEDULE_ASYNCHRONOUSLY_PREFIX
-            + ".scheduling-interval-ms", 0);
-    final RMNodeLabelsManager mgr = new NullRMNodeLabelsManager();
-    mgr.init(conf);
+        + ".scheduling-interval-ms", 0);
+    final RMNodeLabelsManager mg = new NullRMNodeLabelsManager();
+    mg.init(conf);
 
     // inject node label manager
     MockRM rm = new MockRM(TestUtils.getConfigurationWithMultipleQueues(conf)) {
       @Override
       public RMNodeLabelsManager createNodeLabelManager() {
-        return mgr;
+        return mg;
       }
     };
 
-    rm.getRMContext().setNodeLabelManager(mgr);
+    rm.getRMContext().setNodeLabelManager(mg);
     rm.start();
 
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
-    for (CapacityScheduler.AsyncScheduleThread thread: cs.asyncSchedulerThreads) {
+    for (CapacityScheduler.AsyncScheduleThread thread : cs.asyncSchedulerThreads) {
       Assert.assertTrue(thread.getName().startsWith("AsyncCapacitySchedulerThread"));
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -136,7 +136,6 @@ public class TestCapacitySchedulerAsyncScheduling {
         numThreads);
     conf.setInt(CapacitySchedulerConfiguration.SCHEDULE_ASYNCHRONOUSLY_PREFIX
         + ".scheduling-interval-ms", 0);
-
     final RMNodeLabelsManager mgr = new NullRMNodeLabelsManager();
     mgr.init(conf);
 
@@ -187,7 +186,8 @@ public class TestCapacitySchedulerAsyncScheduling {
       ams.get(i).allocate("*", 1024, 20 * (i + 1), new ArrayList<>());
       totalAsked += 20 * (i + 1) * GB;
     }
-
+    //test name of thread
+    Assert.assertEquals(testThreadName(Thread.currentThread().getName(), "CapacitySchedulerThread", Thread.currentThread().getClass().toString()), true);
     // Wait for at most 15000 ms
     int waitTime = 15000; // ms
     while (waitTime > 0) {
@@ -1119,5 +1119,14 @@ public class TestCapacitySchedulerAsyncScheduling {
           ContainerId.newContainerId(am.getApplicationAttemptId(), cId),
           RMContainerState.RUNNING);
     }
+  }
+  public boolean testThreadName(String a, String b, String threadClass){
+    if(threadClass.endsWith("$AsyncScheduleThread")){
+      if(a.startsWith(b))
+        return true;
+      else
+        return false;
+    }
+    return true;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -153,7 +153,7 @@ public class TestCapacitySchedulerAsyncScheduling {
 
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
     for (CapacityScheduler.AsyncScheduleThread thread :
-      cs.asyncSchedulerThreads) {
+        cs.asyncSchedulerThreads) {
       Assert.assertTrue(thread.getName()
           .startsWith("AsyncCapacitySchedulerThread"));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -152,8 +152,8 @@ public class TestCapacitySchedulerAsyncScheduling {
     rm.start();
 
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
-    for (CapacityScheduler
-        .AsyncScheduleThread thread : cs.asyncSchedulerThreads) {
+    for (CapacityScheduler.AsyncScheduleThread thread :
+      cs.asyncSchedulerThreads) {
       Assert.assertTrue(thread.getName()
           .startsWith("AsyncCapacitySchedulerThread"));
     }


### PR DESCRIPTION
Set thread names for CapacityScheduler's AsyncThreads in CapacityScheduler.java
Used an integer to provide traceable names to the threads.
Linked Jira - https://issues.apache.org/jira/browse/YARN-9650
