### PR TITLE
HADOOP-16906. Add Abortable.abort() interface for streams to enable output stream to be terminated

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Abortable.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Abortable.java
@@ -20,8 +20,17 @@ package org.apache.hadoop.fs;
 
 import org.apache.hadoop.classification.InterfaceStability;
 
-/** FIXME: javadoc */
+/**
+ *  Stream that abort the upload.
+ */
 @InterfaceStability.Unstable
 public interface Abortable {
+
+  /**
+   * Abort the upload for the stream.
+   *
+   * This is to provide ability to cancel the write on stream; once stream is
+   * aborted, it should behave as the write was never happened.
+   */
   void abort();
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Abortable.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Abortable.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+/** FIXME: javadoc */
+@InterfaceStability.Unstable
+public interface Abortable {
+  void abort();
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
@@ -171,7 +171,6 @@ public class FSDataOutputStream extends DataOutputStream
     return IOStatisticsSupport.retrieveIOStatistics(wrappedStream);
   }
 
-  /** FIXME: javadoc */
   @Override
   public void abort() {
     try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.statistics.IOStatisticsSupport;
 @InterfaceStability.Stable
 public class FSDataOutputStream extends DataOutputStream
     implements Syncable, CanSetDropBehind, StreamCapabilities,
-      IOStatisticsSource {
+      IOStatisticsSource, Abortable {
   private final OutputStream wrappedStream;
 
   private static class PositionCache extends FilterOutputStream {
@@ -169,5 +169,16 @@ public class FSDataOutputStream extends DataOutputStream
   @Override
   public IOStatistics getIOStatistics() {
     return IOStatisticsSupport.retrieveIOStatistics(wrappedStream);
+  }
+
+  /** FIXME: javadoc */
+  @Override
+  public void abort() {
+    try {
+      ((Abortable)wrappedStream).abort();
+    } catch (ClassCastException e) {
+      throw new UnsupportedOperationException("the wrapped stream does " +
+          "not support aborting stream.");
+    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
@@ -76,7 +76,9 @@ public interface StreamCapabilities {
    */
   String IOSTATISTICS = "iostatistics";
 
-  /** FIXME: javadoc */
+  /**
+   * Stream abort() capability implemented by {@link Abortable#abort()}.
+   */
   String ABORTABLE = "abortable";
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/StreamCapabilities.java
@@ -76,6 +76,9 @@ public interface StreamCapabilities {
    */
   String IOSTATISTICS = "iostatistics";
 
+  /** FIXME: javadoc */
+  String ABORTABLE = "abortable";
+
   /**
    * Capabilities that a stream can support and be queried for.
    */

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -166,9 +166,11 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
     try {
       stream.write(data);
       stream.abort();
+      // the path should not exist
       ContractTestUtils.assertPathsDoNotExist(fs, "aborted file", dest);
     } finally {
       IOUtils.closeStream(stream);
+      // check the path doesn't exist "after" closing stream
       ContractTestUtils.assertPathsDoNotExist(fs, "aborted file", dest);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.s3a;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.statistics.BlockOutputStreamStatistics;
@@ -155,4 +156,20 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
     markAndResetDatablock(createFactory(getFileSystem()));
   }
 
+  @Test
+  public void testAbortAfterWrite() throws Throwable {
+    Path dest = path("testAbortAfterWrite");
+    describe(" testAbortAfterWrite");
+    FileSystem fs = getFileSystem();
+    FSDataOutputStream stream = fs.create(dest, true);
+    byte[] data = ContractTestUtils.dataset(16, 'a', 26);
+    try {
+      stream.write(data);
+      stream.abort();
+      ContractTestUtils.assertPathsDoNotExist(fs, "aborted file", dest);
+    } finally {
+      IOUtils.closeStream(stream);
+      ContractTestUtils.assertPathsDoNotExist(fs, "aborted file", dest);
+    }
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -89,14 +89,15 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
   public void testStreamClosedAfterAbort() throws Exception {
     stream.abort();
 
-    // This verification replaces testing various operations after calling abort:
-    // after calling abort, stream is closed like calling close().
+    // This verification replaces testing various operations after calling
+    // abort: after calling abort, stream is closed like calling close().
     intercept(IOException.class, () -> stream.checkOpen());
 
     // check that calling write() will call checkOpen() and throws exception
     doThrow(new StreamClosedException()).when(stream).checkOpen();
 
-    intercept(StreamClosedException.class, () -> stream.write(new byte[] {'a', 'b', 'c'}));
+    intercept(StreamClosedException.class,
+        () -> stream.write(new byte[] {'a', 'b', 'c'}));
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -83,6 +83,8 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
             "uploadId", 50000, 1024, inputStream, null, 0L));
   }
 
+  static class StreamClosedException extends IOException {}
+
   @Test
   public void testStreamClosedAfterAbort() throws Exception {
     stream.abort();
@@ -90,6 +92,11 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     // This verification replaces testing various operations after calling abort:
     // after calling abort, stream is closed like calling close().
     intercept(IOException.class, () -> stream.checkOpen());
+
+    // check that calling write() will call checkOpen() and throws exception
+    doThrow(new StreamClosedException()).when(stream).checkOpen();
+
+    intercept(StreamClosedException.class, () -> stream.write(new byte[] {'a', 'b', 'c'}));
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -82,4 +82,22 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
         () -> woh.newUploadPartRequest(key,
             "uploadId", 50000, 1024, inputStream, null, 0L));
   }
+
+  @Test
+  public void testStreamClosedAfterAbort() throws Exception {
+    stream.abort();
+
+    // This verification replaces testing various operations after calling abort:
+    // after calling abort, stream is closed like calling close().
+    intercept(IOException.class, () -> stream.checkOpen());
+  }
+
+  @Test
+  public void testCallingCloseAfterCallingAbort() throws Exception {
+    stream.abort();
+
+    // This shouldn't throw IOException like calling close() multiple times.
+    // This will ensure abort() can be called with try-with-resource.
+    stream.close();
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AMultipartUploadSizeLimits.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AMultipartUploadSizeLimits.java
@@ -22,7 +22,6 @@ import java.io.File;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;


### PR DESCRIPTION
NOTE: WIP. DO-NOT-MERGE.

No meaningful tests have been added, as I have no idea where I can add it, and how s3a has been tested
with integration test manner. (Tests in TestS3ABlockOutputStream only check simple things with mocking
everything, so can't do some write/upload test with it.)

I got some review comments from @steveloughran in my commit, and will reflect these review comments.

Once it's done I'll remove WIP.