### PR TITLE
HDFS-15808. Add metrics for FSNamesystem read/write lock hold long time

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4824,6 +4824,16 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return fsLock.getQueueLength();
   }
 
+  @Metric({"ReadLockWarning", "The number of time the read lock has been held for longer than the threshold"})
+  public long getNumOfReadLockWarnings() {
+    return fsLock.getNumOfReadLockWarnings();
+  }
+
+  @Metric({"WriteLockWarning", "The number of time the write lock has been held for longer than the threshold"})
+  public long getNumOfWriteLockWarnings() {
+    return fsLock.getNumOfWriteLockWarnings();
+  }
+
   int getNumberOfDatanodes(DatanodeReportType type) {
     readLock();
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4824,14 +4824,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return fsLock.getQueueLength();
   }
 
-  @Metric({"ReadLockWarning", "The number of time the read lock has been held for longer than the threshold"})
-  public long getNumOfReadLockWarnings() {
-    return fsLock.getNumOfReadLockWarnings();
+  @Metric({"ReadLockLongHoldCount", "The number of time the read lock has been held for longer than the threshold"})
+  public long getNumOfReadLockLongHold() {
+    return fsLock.getNumOfReadLockLongHold();
   }
 
-  @Metric({"WriteLockWarning", "The number of time the write lock has been held for longer than the threshold"})
-  public long getNumOfWriteLockWarnings() {
-    return fsLock.getNumOfWriteLockWarnings();
+  @Metric({"WriteLockLongHoldCount", "The number of time the write lock has been held for longer than the threshold"})
+  public long getNumOfWriteLockLongHold() {
+    return fsLock.getNumOfWriteLockLongHold();
   }
 
   int getNumberOfDatanodes(DatanodeReportType type) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4824,6 +4824,16 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return fsLock.getQueueLength();
   }
 
+  @Metric({"ReadLockLongHoldCount", "The number of time the read lock has been held for longer than the threshold"})
+  public long getNumOfReadLockLongHold() {
+    return fsLock.getNumOfReadLockLongHold();
+  }
+
+  @Metric({"WriteLockLongHoldCount", "The number of time the write lock has been held for longer than the threshold"})
+  public long getNumOfWriteLockLongHold() {
+    return fsLock.getNumOfWriteLockLongHold();
+  }
+
   int getNumberOfDatanodes(DatanodeReportType type) {
     readLock();
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4824,14 +4824,16 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return fsLock.getQueueLength();
   }
 
-  @Metric({"ReadLockLongHoldCount", "The number of time the read lock " +
-          "has been held for longer than the threshold"})
+  @Metric(value = {"ReadLockLongHoldCount", "The number of time " +
+          "the read lock has been held for longer than the threshold"},
+          type = Metric.Type.COUNTER)
   public long getNumOfReadLockLongHold() {
     return fsLock.getNumOfReadLockLongHold();
   }
 
-  @Metric({"WriteLockLongHoldCount", "The number of time the write lock " +
-          "has been held for longer than the threshold"})
+  @Metric(value = {"WriteLockLongHoldCount", "The number of time " +
+          "the write lock has been held for longer than the threshold"},
+          type = Metric.Type.COUNTER)
   public long getNumOfWriteLockLongHold() {
     return fsLock.getNumOfWriteLockLongHold();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4824,12 +4824,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return fsLock.getQueueLength();
   }
 
-  @Metric({"ReadLockLongHoldCount", "The number of time the read lock has been held for longer than the threshold"})
+  @Metric({"ReadLockLongHoldCount", "The number of time the read lock " +
+          "has been held for longer than the threshold"})
   public long getNumOfReadLockLongHold() {
     return fsLock.getNumOfReadLockLongHold();
   }
 
-  @Metric({"WriteLockLongHoldCount", "The number of time the write lock has been held for longer than the threshold"})
+  @Metric({"WriteLockLongHoldCount", "The number of time the write lock " +
+          "has been held for longer than the threshold"})
   public long getNumOfWriteLockLongHold() {
     return fsLock.getNumOfWriteLockLongHold();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
@@ -109,6 +109,10 @@ class FSNamesystemLock {
   private final AtomicReference<LockHeldInfo> longestReadLockHeldInfo =
       new AtomicReference<>(new LockHeldInfo());
   private LockHeldInfo longestWriteLockHeldInfo = new LockHeldInfo();
+  /** The number of time the read lock has been held for longer than the threshold. */
+  private final AtomicLong numReadLockLongHold = new AtomicLong(0);
+  /** The number of time the write lock has been held for longer than the threshold. */
+  private final AtomicLong numWriteLockLongHold = new AtomicLong(0);
 
   @VisibleForTesting
   static final String OP_NAME_OTHER = "OTHER";
@@ -182,6 +186,7 @@ class FSNamesystemLock {
     final long readLockIntervalMs =
         TimeUnit.NANOSECONDS.toMillis(readLockIntervalNanos);
     if (needReport && readLockIntervalMs >= this.readLockReportingThresholdMs) {
+      numReadLockLongHold.addAndGet(1);
       String lockReportInfo = null;
       boolean done = false;
       while (!done) {
@@ -298,6 +303,7 @@ class FSNamesystemLock {
     LogAction logAction = LogThrottlingHelper.DO_NOT_LOG;
     if (needReport &&
         writeLockIntervalMs >= this.writeLockReportingThresholdMs) {
+      numWriteLockLongHold.addAndGet(1);
       if (longestWriteLockHeldInfo.getIntervalMs() <= writeLockIntervalMs) {
         String lockReportInfo = lockReportInfoSupplier != null ? " (" +
             lockReportInfoSupplier.get() + ")" : "";
@@ -360,6 +366,24 @@ class FSNamesystemLock {
    */
   public int getQueueLength() {
     return coarseLock.getQueueLength();
+  }
+
+  /**
+   * Returns the number of time the read lock has been held for longer than the threshold.
+   *
+   * @return long - Number of time the read lock has been held for longer than the threshold
+   */
+  public long getNumOfReadLockLongHold() {
+    return numReadLockLongHold.get();
+  }
+
+  /**
+   * Returns the number of time the write lock has been held for longer than the threshold.
+   *
+   * @return long - Number of time the write lock has been held for longer than the threshold.
+   */
+  public long getNumOfWriteLockLongHold() {
+    return numWriteLockLongHold.get();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
@@ -109,6 +109,10 @@ class FSNamesystemLock {
   private final AtomicReference<LockHeldInfo> longestReadLockHeldInfo =
       new AtomicReference<>(new LockHeldInfo());
   private LockHeldInfo longestWriteLockHeldInfo = new LockHeldInfo();
+  /** The number of time the read lock has been held for longer than the threshold. */
+  private final AtomicLong numOfReadLockWarnings = new AtomicLong(0);
+  /** The number of time the write lock has been held for longer than the threshold. */
+  private final AtomicLong numOfWriteLockWarnings = new AtomicLong(0);
 
   @VisibleForTesting
   static final String OP_NAME_OTHER = "OTHER";
@@ -182,6 +186,7 @@ class FSNamesystemLock {
     final long readLockIntervalMs =
         TimeUnit.NANOSECONDS.toMillis(readLockIntervalNanos);
     if (needReport && readLockIntervalMs >= this.readLockReportingThresholdMs) {
+      numOfReadLockWarnings.addAndGet(1);
       String lockReportInfo = null;
       boolean done = false;
       while (!done) {
@@ -298,6 +303,7 @@ class FSNamesystemLock {
     LogAction logAction = LogThrottlingHelper.DO_NOT_LOG;
     if (needReport &&
         writeLockIntervalMs >= this.writeLockReportingThresholdMs) {
+      numOfWriteLockWarnings.addAndGet(1);
       if (longestWriteLockHeldInfo.getIntervalMs() <= writeLockIntervalMs) {
         String lockReportInfo = lockReportInfoSupplier != null ? " (" +
             lockReportInfoSupplier.get() + ")" : "";
@@ -360,6 +366,24 @@ class FSNamesystemLock {
    */
   public int getQueueLength() {
     return coarseLock.getQueueLength();
+  }
+
+  /**
+   * Returns the number of time the read lock has been held for longer than the threshold.
+   *
+   * @return long - Number of time the read lock has been held for longer than the threshold
+   */
+  public long getNumOfReadLockWarnings() {
+    return numOfReadLockWarnings.get();
+  }
+
+  /**
+   * Returns the number of time the write lock has been held for longer than the threshold.
+   *
+   * @return long - Number of time the write lock has been held for longer than the threshold.
+   */
+  public long getNumOfWriteLockWarnings() {
+    return numOfWriteLockWarnings.get();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
@@ -110,9 +110,9 @@ class FSNamesystemLock {
       new AtomicReference<>(new LockHeldInfo());
   private LockHeldInfo longestWriteLockHeldInfo = new LockHeldInfo();
   /** The number of time the read lock has been held for longer than the threshold. */
-  private final AtomicLong numOfReadLockWarnings = new AtomicLong(0);
+  private final AtomicLong numReadLockLongHold = new AtomicLong(0);
   /** The number of time the write lock has been held for longer than the threshold. */
-  private final AtomicLong numOfWriteLockWarnings = new AtomicLong(0);
+  private final AtomicLong numWriteLockLongHold = new AtomicLong(0);
 
   @VisibleForTesting
   static final String OP_NAME_OTHER = "OTHER";
@@ -186,7 +186,7 @@ class FSNamesystemLock {
     final long readLockIntervalMs =
         TimeUnit.NANOSECONDS.toMillis(readLockIntervalNanos);
     if (needReport && readLockIntervalMs >= this.readLockReportingThresholdMs) {
-      numOfReadLockWarnings.addAndGet(1);
+      numReadLockLongHold.addAndGet(1);
       String lockReportInfo = null;
       boolean done = false;
       while (!done) {
@@ -303,7 +303,7 @@ class FSNamesystemLock {
     LogAction logAction = LogThrottlingHelper.DO_NOT_LOG;
     if (needReport &&
         writeLockIntervalMs >= this.writeLockReportingThresholdMs) {
-      numOfWriteLockWarnings.addAndGet(1);
+      numWriteLockLongHold.addAndGet(1);
       if (longestWriteLockHeldInfo.getIntervalMs() <= writeLockIntervalMs) {
         String lockReportInfo = lockReportInfoSupplier != null ? " (" +
             lockReportInfoSupplier.get() + ")" : "";
@@ -373,8 +373,8 @@ class FSNamesystemLock {
    *
    * @return long - Number of time the read lock has been held for longer than the threshold
    */
-  public long getNumOfReadLockWarnings() {
-    return numOfReadLockWarnings.get();
+  public long getNumOfReadLockLongHold() {
+    return numReadLockLongHold.get();
   }
 
   /**
@@ -382,8 +382,8 @@ class FSNamesystemLock {
    *
    * @return long - Number of time the write lock has been held for longer than the threshold.
    */
-  public long getNumOfWriteLockWarnings() {
-    return numOfWriteLockWarnings.get();
+  public long getNumOfWriteLockLongHold() {
+    return numWriteLockLongHold.get();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
@@ -192,7 +192,7 @@ class FSNamesystemLock {
     final long readLockIntervalMs =
         TimeUnit.NANOSECONDS.toMillis(readLockIntervalNanos);
     if (needReport && readLockIntervalMs >= this.readLockReportingThresholdMs) {
-      numReadLockLongHold.addAndGet(1);
+      numReadLockLongHold.incrementAndGet();
       String lockReportInfo = null;
       boolean done = false;
       while (!done) {
@@ -309,7 +309,7 @@ class FSNamesystemLock {
     LogAction logAction = LogThrottlingHelper.DO_NOT_LOG;
     if (needReport &&
         writeLockIntervalMs >= this.writeLockReportingThresholdMs) {
-      numWriteLockLongHold.addAndGet(1);
+      numWriteLockLongHold.incrementAndGet();
       if (longestWriteLockHeldInfo.getIntervalMs() <= writeLockIntervalMs) {
         String lockReportInfo = lockReportInfoSupplier != null ? " (" +
             lockReportInfoSupplier.get() + ")" : "";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystemLock.java
@@ -109,9 +109,15 @@ class FSNamesystemLock {
   private final AtomicReference<LockHeldInfo> longestReadLockHeldInfo =
       new AtomicReference<>(new LockHeldInfo());
   private LockHeldInfo longestWriteLockHeldInfo = new LockHeldInfo();
-  /** The number of time the read lock has been held for longer than the threshold. */
+  /**
+   * The number of time the read lock
+   * has been held longer than the threshold.
+   */
   private final AtomicLong numReadLockLongHold = new AtomicLong(0);
-  /** The number of time the write lock has been held for longer than the threshold. */
+  /**
+   * The number of time the write lock
+   * has been held for longer than the threshold.
+   */
   private final AtomicLong numWriteLockLongHold = new AtomicLong(0);
 
   @VisibleForTesting
@@ -369,18 +375,22 @@ class FSNamesystemLock {
   }
 
   /**
-   * Returns the number of time the read lock has been held for longer than the threshold.
+   * Returns the number of time the read lock
+   * has been held longer than the threshold.
    *
-   * @return long - Number of time the read lock has been held for longer than the threshold
+   * @return long - Number of time the read lock
+   * has been held longer than the threshold
    */
   public long getNumOfReadLockLongHold() {
     return numReadLockLongHold.get();
   }
 
   /**
-   * Returns the number of time the write lock has been held for longer than the threshold.
+   * Returns the number of time the write lock
+   * has been held longer than the threshold.
    *
-   * @return long - Number of time the write lock has been held for longer than the threshold.
+   * @return long - Number of time the write lock
+   * has been held longer than the threshold.
    */
   public long getNumOfWriteLockLongHold() {
     return numWriteLockLongHold.get();


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15808

To monitor how often read/write locks exceed thresholds, we can add two metrics(ReadLockWarning/WriteLockWarning), which are exposed in JMX.