### PR TITLE
HADOOP-17509. Parallelize building of dependencies

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -131,6 +131,7 @@ RUN mkdir -p /opt/protobuf-src \
     && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
     && cd /opt/protobuf-src \
     && ./configure --prefix=/opt/protobuf \
+    && make -j$(nproc) \
     && make install \
     && cd /root \
     && rm -rf /opt/protobuf-src
@@ -183,7 +184,7 @@ RUN mkdir -p /opt/isa-l-src \
     && cd /opt/isa-l-src \
     && ./autogen.sh \
     && ./configure \
-    && make \
+    && make -j$(nproc) \
     && make install \
     && cd /root \
     && rm -rf /opt/isa-l-src

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -131,7 +131,7 @@ RUN mkdir -p /opt/protobuf-src \
     && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
     && cd /opt/protobuf-src \
     && ./configure --prefix=/opt/protobuf \
-    && make -j$(nproc) \
+    && make "-j$(nproc)" \
     && make install \
     && cd /root \
     && rm -rf /opt/protobuf-src
@@ -184,7 +184,7 @@ RUN mkdir -p /opt/isa-l-src \
     && cd /opt/isa-l-src \
     && ./autogen.sh \
     && ./configure \
-    && make -j$(nproc) \
+    && make "-j$(nproc)" \
     && make install \
     && cd /root \
     && rm -rf /opt/isa-l-src

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -135,6 +135,7 @@ RUN mkdir -p /opt/protobuf-src \
     && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
     && cd /opt/protobuf-src \
     && ./configure --prefix=/opt/protobuf \
+    && make -j$(nproc) \
     && make install \
     && cd /root \
     && rm -rf /opt/protobuf-src

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -135,7 +135,7 @@ RUN mkdir -p /opt/protobuf-src \
     && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
     && cd /opt/protobuf-src \
     && ./configure --prefix=/opt/protobuf \
-    && make -j$(nproc) \
+    && make "-j$(nproc)" \
     && make install \
     && cd /root \
     && rm -rf /opt/protobuf-src


### PR DESCRIPTION
* Added -j option to parallelize the
  building of Protocol buffers and Intel
  ISA-L dependencies.
