### PR TITLE
YARN-10335. Improve scheduling of containers based on node health

### DIFF
--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/nodemanager/NodeInfo.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/nodemanager/NodeInfo.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.yarn.api.records.NodeState;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceUtilization;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
 import org.apache.hadoop.yarn.server.api.records.OpportunisticContainersStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
@@ -70,10 +71,12 @@ public class NodeInfo {
     private List<ContainerId> toCleanUpContainers;
     private List<ApplicationId> toCleanUpApplications;
     private List<ApplicationId> runningApplications;
+    private NodeHealthDetails nodeHealthDetails;
 
     public FakeRMNodeImpl(NodeId nodeId, String nodeAddr, String httpAddress,
         Resource perNode, String rackName, String healthReport,
-        int cmdPort, String hostName, NodeState state) {
+        int cmdPort, String hostName, NodeState state,
+        NodeHealthDetails nodeHealthDetails) {
       this.nodeId = nodeId;
       this.nodeAddr = nodeAddr;
       this.httpAddress = httpAddress;
@@ -86,6 +89,7 @@ public class NodeInfo {
       toCleanUpApplications = new ArrayList<ApplicationId>();
       toCleanUpContainers = new ArrayList<ContainerId>();
       runningApplications = new ArrayList<ApplicationId>();
+      this.nodeHealthDetails = nodeHealthDetails;
     }
 
     public NodeId getNodeID() {
@@ -118,6 +122,11 @@ public class NodeInfo {
 
     public long getLastHealthReportTime() {
       return 0; 
+    }
+
+    @Override
+    public NodeHealthDetails getNodeHealthDetails() {
+      return this.nodeHealthDetails;
     }
 
     public Resource getTotalCapability() {
@@ -263,7 +272,7 @@ public class NodeInfo {
     
     return new FakeRMNodeImpl(nodeId, nodeAddr, httpAddress,
         resource, rackName, "Me good",
-        port, hostName, null);
+        port, hostName, null, null);
   }
   
   public static RMNode newNodeInfo(String rackName, String hostName,

--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/scheduler/RMNodeWrapper.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/scheduler/RMNodeWrapper.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.yarn.api.records.NodeState;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceUtilization;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
 import org.apache.hadoop.yarn.server.api.records.OpportunisticContainersStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
@@ -92,6 +93,11 @@ public class RMNodeWrapper implements RMNode {
   @Override
   public long getLastHealthReportTime() {
     return node.getLastHealthReportTime();
+  }
+
+  @Override
+  public NodeHealthDetails getNodeHealthDetails() {
+    return node.getNodeHealthDetails();
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1977,6 +1977,10 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_NM_CONTAINER_METRICS_UNREGISTER_DELAY_MS =
       10000;
 
+  /** The Service to check the health of the node. */
+  public static final String NM_HEALTH_CHECKER_SERVICE =
+      NM_PREFIX + "health-checker-service.class";
+
   /** Prefix for all node manager disk health checker configs. */
   private static final String NM_DISK_HEALTH_CHECK_PREFIX =
       "yarn.nodemanager.disk-health-checker.";
@@ -2091,6 +2095,17 @@ public class YarnConfiguration extends Configuration {
   /** Frequency of running node health script. */
   public static final String NM_HEALTH_CHECK_SCRIPT_INTERVAL_MS_TEMPLATE =
       NM_PREFIX + "health-checker.%s.interval-ms";
+
+  /** The health checker score file. */
+  public static final boolean DEFAULT_NM_HEALTH_CHECK_SCORE_ENABLED =
+      false;
+  public static final String NM_HEALTH_CHECK_SCORE_ENABLED =
+      NM_PREFIX + "health-checker.score-enabled";
+  public static final String NM_HEALTH_CHECK_SCORE_FILE =
+      NM_PREFIX + "health-checker.score-file";
+
+  public static final String NM_HEALTH_DETAILS_REPORTER_CLASS =
+      NM_PREFIX + "health-checker.reporter.class";
 
   /** The JVM options used on forking ContainerLocalizer process
       by container executor. */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/util/resource/ResourceUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/util/resource/ResourceUtils.java
@@ -465,7 +465,7 @@ public class ResourceUtils {
     return ris;
   }
 
-  private static void addResourcesFileToConf(String resourceFile,
+  public static void addResourcesFileToConf(String resourceFile,
       Configuration conf) {
     try {
       InputStream ris = getConfInputStream(resourceFile, conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_protos.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_protos.proto
@@ -823,6 +823,11 @@ message StringLocalResourceMapProto {
   optional LocalResourceProto value = 2;
 }
 
+message StringIntMapProto {
+  optional string key = 1;
+  optional int32 value = 2;
+}
+
 message StringStringMapProto {
   optional string key = 1;
   optional string value = 2;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ProtoUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ProtoUtils.java
@@ -81,6 +81,7 @@ import org.apache.hadoop.yarn.proto.YarnProtos.QueueACLProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.QueueStateProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.ReservationRequestInterpreterProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.ResourceProto;
+import org.apache.hadoop.yarn.proto.YarnProtos.StringIntMapProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.StringStringMapProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.TimedPlacementConstraintProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.YarnApplicationAttemptStateProto;
@@ -583,6 +584,34 @@ public class ProtoUtils {
       tmp.setKey(entry.getKey());
       tmp.setValue(entry.getValue());
       ret.add(tmp.build());
+    }
+    return ret;
+  }
+
+
+  public static List<YarnProtos.StringIntMapProto>
+      convertStringIntMapToProtoList(Map<String, Integer> stringIntMap) {
+    List<YarnProtos.StringIntMapProto> pList = new ArrayList<>();
+    if (stringIntMap != null && !stringIntMap.isEmpty()) {
+      StringIntMapProto.Builder pBuilder = StringIntMapProto.newBuilder();
+      for (Map.Entry<String, Integer> entry : stringIntMap.entrySet()) {
+        pBuilder.setKey(entry.getKey());
+        pBuilder.setValue(entry.getValue());
+        pList.add(pBuilder.build());
+      }
+    }
+    return pList;
+  }
+
+  public static Map<String, Integer> convertProtoListToStringIntMap(
+      List<StringIntMapProto> pList) {
+    Map<String, Integer> ret = new HashMap<>();
+    if (pList != null) {
+      for (StringIntMapProto p : pList) {
+        if (p.hasKey()) {
+          ret.put(p.getKey(), p.getValue());
+        }
+      }
     }
     return ret;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2479,6 +2479,14 @@
 
   <property>
     <description>
+      The Service class to check the health of the node.
+    </description>
+    <name>yarn.nodemanager.health-checker-service.class</name>
+    <value>org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl</value>
+  </property>
+
+  <property>
+    <description>
     Flag to enable NodeManager disk health checker
     </description>
     <name>yarn.nodemanager.disk-health-checker.enable</name>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/NodeHealthDetails.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/NodeHealthDetails.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.api.records;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.yarn.util.Records;
+
+import java.util.Map;
+import java.util.StringJoiner;
+
+/**
+ * {@code NodeHealthDetails} is a summary of the overall health score
+ * of the node.
+ * <p>
+ * It includes information such as:
+ * <ul>
+ *   <li>
+ *     In depth analysis of the health of the node. Even if the node is healthy
+ *     it gives out a score based on node resources.
+ *   </li>
+ *   <li>
+ *     Holds a map of information about the node resources.
+ *     Example: SSD, HDD etc.
+ *   </li>
+ * </ul>
+ *
+ */
+public abstract class NodeHealthDetails {
+
+  @Private
+  public static NodeHealthDetails newInstance(Integer overallScore,
+      Map<String, Integer> nodeResourceScore) {
+    NodeHealthDetails nodeHealthDetails = Records.newRecord(
+        NodeHealthDetails.class);
+    nodeHealthDetails.setOverallScore(overallScore);
+    nodeHealthDetails.setNodeResourceScores(nodeResourceScore);
+    return nodeHealthDetails;
+  }
+
+  @Private
+  public static NodeHealthDetails newInstance(Integer overallScore) {
+    NodeHealthDetails nodeHealthDetails = Records.newRecord(
+        NodeHealthDetails.class);
+    nodeHealthDetails.setOverallScore(overallScore);
+    return nodeHealthDetails;
+  }
+
+  /**
+   * Set the overall score of the node. This score is derived from node
+   * resources score.
+   * @param overallScore
+   */
+  @Private
+  public abstract void setOverallScore(Integer overallScore);
+
+  /**
+   * Holds a Map of the resources and its scores.
+   * @param nodeResourceScores
+   */
+  @Private
+  public abstract void setNodeResourceScores(
+      Map<String, Integer> nodeResourceScores);
+
+  /**
+   * @return the score of the node.
+   */
+  @Private
+  public abstract Integer getOverallScore();
+
+  /**
+   * @return Scores of each resources in the node.
+   */
+  @Private
+  public abstract Map<String, Integer> getNodeResourceScores();
+
+  @Override
+  public String toString() {
+    StringJoiner healthDetailsString = new StringJoiner(",", "[", "]");
+    healthDetailsString.add("Overall Score = " + this.getOverallScore());
+    this.getNodeResourceScores().forEach((key, value) ->
+        healthDetailsString.add(key + " = " + value));
+    return healthDetailsString.toString();
+  }
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/NodeHealthStatus.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/NodeHealthStatus.java
@@ -90,4 +90,22 @@ public abstract class NodeHealthStatus {
   @Private
   @Unstable
   public abstract void setLastHealthReportTime(long lastHealthReport);
+
+  /**
+   * Set the overall score of the Node.
+   * @param nodeHealthDetails contains the resources score and the total
+   *                          overall score of the node
+   */
+  @Private
+  @Unstable
+  public abstract void setNodeHealthDetails(NodeHealthDetails
+      nodeHealthDetails);
+
+  /**
+   * @return {@link NodeHealthDetails} Gives a detailed overall score
+   * of the node health resources.
+   */
+  @Public
+  @Stable
+  public abstract NodeHealthDetails getNodeHealthDetails();
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/impl/pb/NodeHealthDetailsPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/impl/pb/NodeHealthDetailsPBImpl.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.api.records.impl.pb;
+
+import org.apache.hadoop.yarn.api.records.impl.pb.ProtoUtils;
+import org.apache.hadoop.yarn.proto.YarnServerCommonProtos.NodeHealthDetailsProto;
+import org.apache.hadoop.yarn.proto.YarnServerCommonProtos.NodeHealthDetailsProtoOrBuilder;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class NodeHealthDetailsPBImpl extends NodeHealthDetails {
+  private NodeHealthDetailsProto proto = NodeHealthDetailsProto
+      .getDefaultInstance();
+  private NodeHealthDetailsProto.Builder builder = null;
+  private boolean viaProto = false;
+
+  public NodeHealthDetailsPBImpl() {
+    builder = NodeHealthDetailsProto.newBuilder();
+  }
+
+  public NodeHealthDetailsPBImpl(NodeHealthDetailsProto proto) {
+    this.proto = proto;
+    viaProto = true;
+  }
+  public NodeHealthDetailsProto getProto() {
+    mergeLocalToProto();
+    proto = viaProto ? proto : builder.build();
+    viaProto = true;
+    return proto;
+  }
+
+  private void mergeLocalToProto() {
+    if (viaProto) {
+      maybeInitBuilder();
+    }
+    proto = builder.build();
+    viaProto = true;
+  }
+
+  private void maybeInitBuilder() {
+    if (viaProto || builder == null) {
+      builder = NodeHealthDetailsProto.newBuilder(proto);
+    }
+    viaProto = false;
+  }
+
+  @Override
+  public void setOverallScore(Integer overallScore) {
+    maybeInitBuilder();
+    this.builder.setOverallScore(overallScore);
+  }
+
+  @Override
+  public Integer getOverallScore() {
+    NodeHealthDetailsProtoOrBuilder p =
+        this.viaProto ? this.proto : this.builder;
+    if (!p.hasOverallScore()) {
+      return null;
+    }
+    return (p.getOverallScore());
+  }
+
+  @Override
+  public void setNodeResourceScores(Map<String, Integer> nodeResourceScores) {
+    maybeInitBuilder();
+    this.builder.addAllNodeResourceScores(ProtoUtils
+        .convertStringIntMapToProtoList(nodeResourceScores));
+  }
+
+  @Override
+  public Map<String, Integer> getNodeResourceScores() {
+    NodeHealthDetailsProtoOrBuilder p =
+        this.viaProto ? this.proto : this.builder;
+    return p.getNodeResourceScoresCount() > 0 ?
+        ProtoUtils.convertProtoListToStringIntMap(
+            p.getNodeResourceScoresList()) : Collections.emptyMap();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/impl/pb/NodeHealthStatusPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/records/impl/pb/NodeHealthStatusPBImpl.java
@@ -18,8 +18,10 @@
 
 package org.apache.hadoop.yarn.server.api.records.impl.pb;
 
+import org.apache.hadoop.yarn.proto.YarnServerCommonProtos.NodeHealthDetailsProto;
 import org.apache.hadoop.yarn.proto.YarnServerCommonProtos.NodeHealthStatusProto;
 import org.apache.hadoop.yarn.proto.YarnServerCommonProtos.NodeHealthStatusProtoOrBuilder;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
 import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
 
 import org.apache.hadoop.thirdparty.protobuf.TextFormat;
@@ -30,6 +32,7 @@ public class NodeHealthStatusPBImpl extends NodeHealthStatus {
   private boolean viaProto = false;
   private NodeHealthStatusProto proto = NodeHealthStatusProto
       .getDefaultInstance();
+  private NodeHealthDetails nodeHealthDetails;
 
   public NodeHealthStatusPBImpl() {
     this.builder = NodeHealthStatusProto.newBuilder();
@@ -70,6 +73,7 @@ public class NodeHealthStatusPBImpl extends NodeHealthStatus {
   private void mergeLocalToProto() {
     if (this.viaProto)
       maybeInitBuilder();
+    mergeLocalToBuilder();
     this.proto = this.builder.build();
 
     this.viaProto = true;
@@ -80,6 +84,13 @@ public class NodeHealthStatusPBImpl extends NodeHealthStatus {
       this.builder = NodeHealthStatusProto.newBuilder(this.proto);
     }
     this.viaProto = false;
+  }
+
+  private void mergeLocalToBuilder() {
+    if(nodeHealthDetails != null) {
+      builder.setNodeHealthDetails(convertToProtoFormat(
+          nodeHealthDetails));
+    }
   }
 
   @Override
@@ -128,4 +139,36 @@ public class NodeHealthStatusPBImpl extends NodeHealthStatus {
     this.builder.setLastHealthReportTime((lastHealthReport));
   }
 
+  @Override
+  public void setNodeHealthDetails(
+      NodeHealthDetails nodeHealthDetails) {
+    maybeInitBuilder();
+    if(nodeHealthDetails == null) {
+      this.builder.clearNodeHealthDetails();
+    }
+    this.nodeHealthDetails = nodeHealthDetails;
+  }
+
+  @Override
+  public NodeHealthDetails getNodeHealthDetails() {
+    NodeHealthStatusProtoOrBuilder p =
+        this.viaProto ? this.proto : this.builder;
+    if(this.nodeHealthDetails != null) {
+      return this.nodeHealthDetails;
+    }
+    if(!p.hasNodeHealthDetails()) {
+      return null;
+    }
+    this.nodeHealthDetails = convertFromProtoFormat(p.getNodeHealthDetails());
+    return this.nodeHealthDetails;
+  }
+
+  private NodeHealthDetailsPBImpl convertFromProtoFormat(
+      NodeHealthDetailsProto p) {
+    return new NodeHealthDetailsPBImpl(p);
+  }
+
+  private NodeHealthDetailsProto convertToProtoFormat(NodeHealthDetails nhd) {
+    return ((NodeHealthDetailsPBImpl) nhd).getProto();
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/proto/yarn_server_common_protos.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/proto/yarn_server_common_protos.proto
@@ -58,10 +58,16 @@ message MasterKeyProto {
   optional bytes bytes = 2;
 }
 
+message NodeHealthDetailsProto {
+  optional int32 overall_score = 1;
+  repeated StringIntMapProto node_resource_scores = 2;
+}
+
 message NodeHealthStatusProto {
   optional bool is_node_healthy = 1;
   optional string health_report = 2;
   optional int64 last_health_report_time = 3;
+  optional NodeHealthDetailsProto node_health_details = 4;
 }
 
 message VersionProto {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.GenericOptionsParser;
@@ -62,6 +63,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.ResourcePluginManager;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.logaggregation.tracker.NMLogAggregationStatusTracker;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.nodelabels.ConfigurationNodeLabelsProvider;
@@ -85,6 +87,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +247,28 @@ public class NodeManager extends CompositeService
   protected NodeResourceMonitor createNodeResourceMonitor() {
     return new NodeResourceMonitorImpl(context);
   }
+
+  protected NodeHealthCheckerService createNodeHealthCheckerService(
+      Configuration conf) {
+
+    Class<?> clazz = conf.getClassByNameOrNull(conf.get(YarnConfiguration
+        .NM_HEALTH_CHECKER_SERVICE,
+        NodeHealthCheckerServiceImpl.class.getName()));
+    try {
+      if (clazz == null || !AbstractService.class.isAssignableFrom(clazz)) {
+        throw new RuntimeException(clazz + " does not implement "
+            + AbstractService.class);
+      }
+      Constructor<?> cons = clazz.getConstructor(
+          LocalDirsHandlerService.class);
+      return (NodeHealthCheckerService) cons.newInstance(dirsHandler);
+    } catch (Exception e) {
+      throw new YarnRuntimeException(
+          "Could not instantiate NodeHealthChecker Class: " + YarnConfiguration
+              .NM_HEALTH_CHECKER_SERVICE, e);
+    }
+  }
+
 
   protected ContainerManagerImpl createContainerManager(Context context,
       ContainerExecutor exec, DeletionService del,
@@ -410,7 +435,7 @@ public class NodeManager extends CompositeService
     // NodeManager level dispatcher
     this.dispatcher = createNMDispatcher();
 
-    this.nodeHealthChecker = new NodeHealthCheckerService(dirsHandler);
+    this.nodeHealthChecker = createNodeHealthCheckerService(conf);
     addService(nodeHealthChecker);
 
     ((NMContext)context).setContainerExecutor(exec);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
@@ -517,9 +517,12 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
     nodeHealthStatus.setIsNodeHealthy(healthChecker.isHealthy());
     nodeHealthStatus.setLastHealthReportTime(healthChecker
       .getLastHealthReportTime());
-    LOG.debug("Node's health-status : {}, {}",
+
+    healthChecker.updateNodeHealthDetails(nodeHealthStatus);
+    LOG.debug("Node's health-status : {}, {}, {}",
         nodeHealthStatus.getIsNodeHealthy(),
-        nodeHealthStatus.getHealthReport());
+        nodeHealthStatus.getHealthReport(),
+        nodeHealthStatus.getNodeHealthDetails());
     List<ContainerStatus> containersStatuses = getContainerStatuses();
     ResourceUtilization containersUtilization = getContainersUtilization();
     ResourceUtilization nodeUtilization = getNodeUtilization();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/FileBasedNodeHealthDetails.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/FileBasedNodeHealthDetails.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.health;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.yarn.util.resource.ResourceUtils.addResourcesFileToConf;
+
+/**
+ * This class provides the functionality of reading a score of the node from
+ * a xml file. The file is read only when the lastModified time is changed.
+ * This is the default implementation of {@link NodeHealthDetailsReporter}
+ * See {@link NodeHealthDetailsReporter}
+ */
+public class FileBasedNodeHealthDetails extends NodeHealthDetailsReporter
+    implements HealthReporter {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(FileBasedNodeHealthDetails.class);
+
+  private NodeHealthDetails nodeHealthDetails;
+  private long lastModified = -1;
+  private File resourceScoreFile;
+  private String nodeHealthScoreFilename;
+
+  private boolean isHealthy;
+  private String healthReport;
+
+
+
+  public FileBasedNodeHealthDetails(Configuration conf) {
+    this.nodeHealthDetails = NodeHealthDetails.newInstance(0);
+    nodeHealthScoreFilename = conf.get(
+        YarnConfiguration.NM_HEALTH_CHECK_SCORE_FILE);
+    resourceScoreFile = new File(nodeHealthScoreFilename);
+    this.isHealthy = true;
+    this.healthReport = "";
+  }
+
+  /**
+   * Reads the score of each resource and gives out a summation of overall
+   * score of the node from a xml file. The file is read only if the last
+   * modified value changes. Node Health Details needs to be enabled.
+   * Otherwise, the score is defaulted to 0.
+   */
+  @Override
+  public void updateNodeHealthDetails() {
+    try {
+      if (resourceScoreFile.lastModified() <= lastModified) {
+        LOG.debug("resourceScoreFile [{}] has not been modified " + "from last check",
+            resourceScoreFile);
+      } else {
+        HashMap<String, Integer> resourcesScore = new HashMap<>();
+        readXMLFile(nodeHealthScoreFilename, resourcesScore);
+
+        Integer overallScore =
+            resourcesScore.values().stream().reduce(0, Integer::sum);
+        nodeHealthDetails =
+            NodeHealthDetails.newInstance(overallScore, resourcesScore);
+
+        lastModified = resourceScoreFile.lastModified();
+        setNodeAsHealthy();
+      }
+    } catch (Exception e) {
+      LOG.error("Error reading Node Health Checker score file", e);
+      setNodeAsUnhealthy(e);
+    }
+
+  }
+
+  /**
+   * Reads the input xml file. The tags of the file leverages {
+   * @link Configuration} tags.
+   * @param filename The path of the file.
+   * @param map The resources map of the node. This will hold the score of each
+   *            property.
+   */
+  public void readXMLFile(String filename, Map<String, Integer> map) {
+    Configuration conf = new Configuration(false);
+    addResourcesFileToConf(filename, conf);
+    for (Map.Entry<String, String> entry : conf) {
+      String key = entry.getKey();
+      String score = entry.getValue();
+      Integer value = (score == null) ? null : Integer.parseInt(score);
+      map.put(key, value);
+    }
+
+  }
+
+  public void setNodeAsHealthy() {
+    this.isHealthy = true;
+    this.healthReport = "";
+  }
+
+  public void setNodeAsUnhealthy(Exception e) {
+    this.isHealthy = false;
+    this.healthReport = StringUtils.stringifyException(e);
+  }
+
+  @Override
+  public NodeHealthDetails getNodeHealthDetails() {
+    return nodeHealthDetails;
+  }
+
+  @Override
+  public boolean isHealthy() {
+    return this.isHealthy;
+  }
+
+  @Override
+  public String getHealthReport() {
+    return this.healthReport;
+  }
+
+  @Override
+  public long getLastHealthReportTime() {
+    return this.lastModified;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerService.java
@@ -18,102 +18,28 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.health;
 
-import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
-import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.CompositeService;
-import org.apache.hadoop.service.Service;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
 import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 /**
- * This class provides functionality of checking the health of a node and
- * reporting back to the service for which the health checker has been asked to
- * report.
- *
- * It is a {@link CompositeService}: every {@link Service} must be registered
- * first in serviceInit, and should also implement the {@link HealthReporter}
- * interface - otherwise an exception is thrown.
- *
- * Calling functions of HealthReporter merge its dependent
- * services' reports.
- *
+ * This class is the base class for all NodeHealthCheckerServices.
  * @see HealthReporter
  * @see LocalDirsHandlerService
  * @see TimedHealthReporterService
+ * @see NodeHealthCheckerServiceImpl
  */
-public class NodeHealthCheckerService extends CompositeService
+public abstract class NodeHealthCheckerService extends CompositeService
     implements HealthReporter {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(NodeHealthCheckerService.class);
-  private static final int MAX_SCRIPTS = 4;
 
-  private List<HealthReporter> reporters;
-  private LocalDirsHandlerService dirsHandler;
-  private ExceptionReporter exceptionReporter;
 
-  public static final String SEPARATOR = ";";
-
-  public NodeHealthCheckerService(
-      LocalDirsHandlerService dirHandlerService) {
-    super(NodeHealthCheckerService.class.getName());
-
-    this.reporters = new ArrayList<>();
-    this.dirsHandler = dirHandlerService;
-    this.exceptionReporter = new ExceptionReporter();
-  }
-
-  @Override
-  protected void serviceInit(Configuration conf) throws Exception {
-    reporters.add(exceptionReporter);
-    addHealthReporter(dirsHandler);
-    String[] configuredScripts = conf.getTrimmedStrings(
-        YarnConfiguration.NM_HEALTH_CHECK_SCRIPTS,
-        YarnConfiguration.DEFAULT_NM_HEALTH_CHECK_SCRIPTS);
-    if (configuredScripts.length > MAX_SCRIPTS) {
-      throw new IllegalArgumentException("Due to performance reasons " +
-          "running more than " + MAX_SCRIPTS + "scripts is not allowed.");
-    }
-    for (String configuredScript : configuredScripts) {
-      addHealthReporter(NodeHealthScriptRunner.newInstance(
-          configuredScript, conf));
-    }
-    super.serviceInit(conf);
-  }
-
-  /**
-   * Adds a {@link Service} implementing the {@link HealthReporter} interface,
-   * if that service has not been added to this {@link CompositeService} yet.
-   *
-   * @param service to add
-   * @throws Exception if not a {@link HealthReporter}
-   *         implementation is provided to this function
-   */
-  @VisibleForTesting
-  void addHealthReporter(Service service) throws Exception {
-    if (service != null) {
-      if (getServices().stream()
-          .noneMatch(x -> x.getName().equals(service.getName()))) {
-        if (!(service instanceof HealthReporter)) {
-          throw new Exception("Attempted to add service to " +
-              "NodeHealthCheckerService that does not implement " +
-              "HealthReporter.");
-        }
-        reporters.add((HealthReporter) service);
-        addService(service);
-      } else {
-        LOG.debug("Omitting duplicate service: {}.", service.getName());
-      }
-    }
+  public NodeHealthCheckerService(String name) {
+    super(name);
   }
 
   /**
@@ -121,44 +47,34 @@ public class NodeHealthCheckerService extends CompositeService
    *
    * @return the report string about the health of the node
    */
-  @Override
-  public String getHealthReport() {
-    ArrayList<String> reports = reporters.stream()
-        .map(reporter -> Strings.emptyToNull(reporter.getHealthReport()))
-        .collect(Collectors.toCollection(ArrayList::new));
-    return Joiner.on(SEPARATOR).skipNulls().join(reports);
-  }
+  public abstract String getHealthReport();
 
   /**
    * @return <em>true</em> if the node is healthy
    */
-  @Override
-  public boolean isHealthy() {
-    return reporters.stream().allMatch(HealthReporter::isHealthy);
-  }
-
-  /**
-   * @return when the last time the node health status is reported
-   */
-  @Override
-  public long getLastHealthReportTime() {
-    Optional<Long> max = reporters.stream()
-        .map(HealthReporter::getLastHealthReportTime).max(Long::compareTo);
-    return max.orElse(0L);
-  }
+  public abstract boolean isHealthy();
 
   /**
    * @return the disk handler
    */
-  public LocalDirsHandlerService getDiskHandler() {
-    return dirsHandler;
-  }
+  public abstract LocalDirsHandlerService getDiskHandler();
+
+  /**
+   * @return when the last time the node health status is reported
+   */
+  public abstract long getLastHealthReportTime();
+
+
+  /**
+   * Reads the score of each resource and gives out a overall score of
+   * the node. Node Health Details needs to be enabled otherwise the score
+   * is defaulted to 0.
+   */
+  public abstract void updateNodeHealthDetails(NodeHealthStatus status);
 
   /**
    * Propagating an exception to {@link ExceptionReporter}.
    * @param exception the exception to propagate
    */
-  public void reportException(Exception exception) {
-    exceptionReporter.reportException(exception);
-  }
+  public abstract void reportException(Exception exception);
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerServiceImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerServiceImpl.java
@@ -1,0 +1,218 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.hadoop.yarn.server.nodemanager.health;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.service.Service;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
+import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides functionality of checking the health of a node and
+ * reporting back to the service for which the health checker has been asked to
+ * report.
+ *
+ * It is a {@link CompositeService}: every {@link Service} must be registered
+ * first in serviceInit, and should also implement the {@link HealthReporter}
+ * interface - otherwise an exception is thrown.
+ *
+ * Calling functions of HealthReporter merge its dependent
+ * services' reports.
+ *
+ * @see HealthReporter
+ * @see LocalDirsHandlerService
+ * @see TimedHealthReporterService
+ */
+public class NodeHealthCheckerServiceImpl extends NodeHealthCheckerService {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(NodeHealthCheckerServiceImpl.class);
+  private static final int MAX_SCRIPTS = 4;
+
+  private List<HealthReporter> reporters;
+  private LocalDirsHandlerService dirsHandler;
+  private ExceptionReporter exceptionReporter;
+
+  public static final String SEPARATOR = ";";
+
+  private boolean nodeHealthScoreEnabled;
+  private NodeHealthDetailsReporter nodeHealthDetailsReporter;
+
+  public NodeHealthCheckerServiceImpl(
+      LocalDirsHandlerService dirHandlerService) {
+    super(NodeHealthCheckerServiceImpl.class.getName());
+
+    this.reporters = new ArrayList<>();
+    this.dirsHandler = dirHandlerService;
+    this.exceptionReporter = new ExceptionReporter();
+  }
+
+  @Override
+  protected void serviceInit(Configuration conf) throws Exception {
+    reporters.add(exceptionReporter);
+    addHealthReporter(dirsHandler);
+    String[] configuredScripts = conf.getTrimmedStrings(
+        YarnConfiguration.NM_HEALTH_CHECK_SCRIPTS,
+        YarnConfiguration.DEFAULT_NM_HEALTH_CHECK_SCRIPTS);
+    if (configuredScripts.length > MAX_SCRIPTS) {
+      throw new IllegalArgumentException("Due to performance reasons " +
+          "running more than " + MAX_SCRIPTS + "scripts is not allowed.");
+    }
+    for (String configuredScript : configuredScripts) {
+      addHealthReporter(NodeHealthScriptRunner.newInstance(
+          configuredScript, conf));
+    }
+
+    nodeHealthScoreEnabled = conf.getBoolean(
+        YarnConfiguration.NM_HEALTH_CHECK_SCORE_ENABLED,
+        YarnConfiguration.DEFAULT_NM_HEALTH_CHECK_SCORE_ENABLED);
+
+    if (nodeHealthScoreEnabled) {
+      addHealthDetailsReporter(conf);
+    }
+
+    super.serviceInit(conf);
+  }
+
+  /**
+   * Adds a {@link Service} implementing the {@link HealthReporter} interface,
+   * if that service has not been added to this {@link CompositeService} yet.
+   *
+   * @param service to add
+   * @throws Exception if not a {@link HealthReporter}
+   *         implementation is provided to this function
+   */
+  @VisibleForTesting
+  void addHealthReporter(Service service) throws Exception {
+    if (service != null) {
+      if (getServices().stream()
+          .noneMatch(x -> x.getName().equals(service.getName()))) {
+        if (!(service instanceof HealthReporter)) {
+          throw new Exception("Attempted to add service to " +
+              "NodeHealthCheckerService that does not implement " +
+              "HealthReporter.");
+        }
+        reporters.add((HealthReporter) service);
+        addService(service);
+      } else {
+        LOG.debug("Omitting duplicate service: {}.", service.getName());
+      }
+    }
+  }
+
+  /**
+   * Adds a {@link NodeHealthDetailsReporter} implementing the
+   * {@link HealthReporter} interface. This is added to the list of reporters.
+   *
+   * @param conf is required to fetch the class name
+   * @throws Exception if not a {@link HealthReporter}
+   *         implementation is provided to this function
+   */
+  @VisibleForTesting
+  void addHealthDetailsReporter(Configuration conf) throws Exception {
+    Class<?> clazz = conf.getClassByNameOrNull(conf.get(
+        YarnConfiguration.NM_HEALTH_DETAILS_REPORTER_CLASS,
+        FileBasedNodeHealthDetails.class.getName()));
+
+    try {
+      if (clazz == null || !HealthReporter.class.isAssignableFrom(clazz)) {
+        throw new Exception(clazz + " does not implement "
+            + HealthReporter.class);
+      }
+      Constructor<?> cons = clazz.getConstructor(
+          Configuration.class);
+      nodeHealthDetailsReporter = (NodeHealthDetailsReporter) cons.newInstance(conf);
+      reporters.add(nodeHealthDetailsReporter);
+    } catch (Exception e) {
+      throw new Exception("Attempted to add class to " +
+          "NodeHealthCheckerService that does not implement HealthReporter.");
+    }
+  }
+
+  /**
+   * Joining the health reports of the dependent services.
+   *
+   * @return the report string about the health of the node
+   */
+  @Override
+  public String getHealthReport() {
+    ArrayList<String> reports = reporters.stream()
+        .map(reporter -> Strings.emptyToNull(reporter.getHealthReport()))
+        .collect(Collectors.toCollection(ArrayList::new));
+    return Joiner.on(SEPARATOR).skipNulls().join(reports);
+  }
+
+  /**
+   * @return <em>true</em> if the node is healthy
+   */
+  @Override
+  public boolean isHealthy() {
+    return reporters.stream().allMatch(HealthReporter::isHealthy);
+  }
+
+  /**
+   * @return when the last time the node health status is reported
+   */
+  @Override
+  public long getLastHealthReportTime() {
+    Optional<Long> max = reporters.stream()
+        .map(HealthReporter::getLastHealthReportTime).max(Long::compareTo);
+    return max.orElse(0L);
+  }
+
+
+  @Override
+  public void updateNodeHealthDetails(NodeHealthStatus status) {
+
+    if (nodeHealthScoreEnabled) {
+      nodeHealthDetailsReporter.updateNodeHealthDetails();
+      status.setNodeHealthDetails(nodeHealthDetailsReporter
+          .getNodeHealthDetails());
+    }
+
+  }
+
+
+  /**
+   * @return the disk handler
+   */
+  public LocalDirsHandlerService getDiskHandler() {
+    return dirsHandler;
+  }
+
+  /**
+   * Propagating an exception to {@link ExceptionReporter}.
+   * @param exception the exception to propagate
+   */
+  public void reportException(Exception exception) {
+    exceptionReporter.reportException(exception);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthDetailsReporter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthDetailsReporter.java
@@ -16,19 +16,27 @@
  * limitations under the License.
  */
 
-import DS from 'ember-data';
+package org.apache.hadoop.yarn.server.nodemanager.health;
 
-export default DS.Model.extend({
-  totalVmemAllocatedContainersMB: DS.attr('number'),
-  totalPmemAllocatedContainersMB: DS.attr('number'),
-  totalVCoresAllocatedContainers: DS.attr('number'),
-  vmemCheckEnabled: DS.attr('boolean'),
-  pmemCheckEnabled: DS.attr('boolean'),
-  nodeHealthy: DS.attr('boolean'),
-  lastNodeUpdateTime: DS.attr('string'),
-  healthReport: DS.attr('string'),
-  nodeHealthDetails: DS.attr('string'),
-  nmStartupTime: DS.attr('string'),
-  nodeManagerBuildVersion: DS.attr('string'),
-  hadoopBuildVersion: DS.attr('string'),
-});
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
+
+/**
+ * Interface for providing the {@link NodeHealthDetails}. This is used to
+ * refresh the scores of the node and provide this information to the
+ * implementing class.
+ */
+public abstract class NodeHealthDetailsReporter implements HealthReporter {
+
+  /**
+   * Gets the updated {@link NodeHealthDetails}. This method should never
+   * return a null. The defaulted score is 0.
+   * @return nodeHealthDetails
+   */
+  public abstract NodeHealthDetails getNodeHealthDetails();
+
+  /**
+   * Refreshes the {@link NodeHealthDetails} when called upon.
+   */
+  public abstract void updateNodeHealthDetails();
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NodePage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/NodePage.java
@@ -83,6 +83,7 @@ public class NodePage extends NMView {
               info.getLastNodeUpdateTime()))
           .__("NodeHealthReport",
               info.getHealthReport())
+          .__("Node Health Details", info.getNodeHealthDetails())
           .__("NodeManager started on", new Date(
               info.getNMStartupTime()))
           .__("NodeManager Version:", info.getNMBuildVersion() +

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NodeInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/webapp/dao/NodeInfo.java
@@ -45,6 +45,7 @@ public class NodeInfo {
   protected long lastNodeUpdateTime;
   protected String resourceTypes;
   protected boolean nodeHealthy;
+  protected String nodeHealthDetails;
   protected String nodeManagerVersion;
   protected String nodeManagerBuildVersion;
   protected String nodeManagerVersionBuiltOn;
@@ -77,7 +78,9 @@ public class NodeInfo {
         .getLastHealthReportTime();
 
     this.healthReport = context.getNodeHealthStatus().getHealthReport();
-
+    this.nodeHealthDetails = context.getNodeHealthStatus()
+        .getNodeHealthDetails() == null ? "" : context.getNodeHealthStatus()
+        .getNodeHealthDetails().toString();
     this.nodeManagerVersion = YarnVersionInfo.getVersion();
     this.nodeManagerBuildVersion = YarnVersionInfo.getBuildVersion();
     this.nodeManagerVersionBuiltOn = YarnVersionInfo.getDate();
@@ -129,6 +132,10 @@ public class NodeInfo {
 
   public String getHealthReport() {
     return this.healthReport;
+  }
+
+  public String getNodeHealthDetails() {
+    return this.nodeHealthDetails;
   }
 
   public long getTotalVmemAllocated() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestEventFlow.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestEventFlow.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.yarn.server.nodemanager.NodeManager.NMContext;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.BaseContainerManagerTest;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.TestContainerManager;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.security.NMContainerTokenSecretManager;
@@ -106,7 +107,7 @@ public class TestEventFlow {
     Dispatcher dispatcher = new AsyncDispatcher();
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
     NodeHealthCheckerService healthChecker =
-        new NodeHealthCheckerService(dirsHandler);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
     healthChecker.init(conf);
     NodeManagerMetrics metrics = NodeManagerMetrics.create();
     NodeStatusUpdater nodeStatusUpdater =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.doNothing;
 
 import org.apache.hadoop.yarn.server.nodemanager.NodeResourceMonitorImpl;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +155,6 @@ public abstract class BaseContainerManagerTest {
   protected ContainerExecutor exec;
   protected DeletionService delSrvc;
   protected String user = "nobody";
-  protected NodeHealthCheckerService nodeHealthChecker;
   protected LocalDirsHandlerService dirsHandler;
   protected final long DUMMY_RM_IDENTIFIER = 1234;
   private NodeResourceMonitorImpl nodeResourceMonitor = mock(
@@ -170,6 +170,12 @@ public abstract class BaseContainerManagerTest {
   public void setNodeStatusUpdater(
       NodeStatusUpdater nodeStatusUpdater) {
     this.nodeStatusUpdater = nodeStatusUpdater;
+  }
+
+  public void setNodeHealthCheckerService(NodeHealthCheckerService nhcs,
+      Configuration yarnConfiguration) {
+    this.nodeHealthCheckerService = nhcs;
+    this.nodeHealthCheckerService.init(yarnConfiguration);
   }
 
   protected ContainerExecutor createContainerExecutor() {
@@ -208,7 +214,7 @@ public abstract class BaseContainerManagerTest {
 
     dirsHandler = new LocalDirsHandlerService();
     dirsHandler.init(conf);
-    nodeHealthCheckerService = new NodeHealthCheckerService(dirsHandler);
+    nodeHealthCheckerService = new NodeHealthCheckerServiceImpl(dirsHandler);
     nodeStatusUpdater = new NodeStatusUpdaterImpl(
         context, new AsyncDispatcher(), nodeHealthCheckerService, metrics) {
       @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
@@ -85,7 +85,6 @@ import org.apache.hadoop.yarn.server.nodemanager.ContainerExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
 import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
-import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
 import org.apache.hadoop.yarn.server.nodemanager.NodeManager.NMContext;
 import org.apache.hadoop.yarn.server.nodemanager.NodeStatusUpdater;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Application;
@@ -106,6 +105,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.Contai
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.ContainersMonitorImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.scheduler.ContainerScheduler;
 
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.TestNodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreService;
@@ -156,9 +156,8 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
     delSrvc.init(conf);
     exec = createContainerExecutor();
     dirsHandler = new LocalDirsHandlerService();
-    nodeHealthChecker = new NodeHealthCheckerService(dirsHandler);
-    nodeHealthChecker.init(conf);
-
+    setNodeHealthCheckerService(new NodeHealthCheckerServiceImpl(dirsHandler),
+        conf);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/health/TestFileBasedNodeHealthDetails.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/health/TestFileBasedNodeHealthDetails.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.health;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestFileBasedNodeHealthDetails {
+
+  private static final File TEST_ROOT_DIR = new File("target",
+      TestFileBasedNodeHealthDetails.class.getName() + "-localDir")
+      .getAbsoluteFile();
+  private File nodeHealthDetailsFile = new File(TEST_ROOT_DIR,
+      "nodeScore.xml");
+
+  private NodeHealthDetailsReporter nodeHealthDetailsReporter;
+  private Configuration conf;
+  @Before
+  public void setup() throws IOException {
+    writeNodeHealthScoreFile();
+    conf = new Configuration();
+    conf.set(YarnConfiguration.NM_HEALTH_CHECK_SCORE_FILE,
+        nodeHealthDetailsFile.getAbsolutePath());
+    nodeHealthDetailsReporter = new FileBasedNodeHealthDetails(conf);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (TEST_ROOT_DIR.exists()) {
+      FileContext.getLocalFSFileContext().delete(
+          new Path(TEST_ROOT_DIR.getAbsolutePath()), true);
+    }
+  }
+
+  private void writeNodeHealthScoreFile() throws IOException {
+    String xmlData = "<configuration>"
+        + "<property><name>resource1</name><value>35</value></property>"
+        + "<property><name>resource2</name><value>65</value></property>"
+        + "</configuration>";
+    FileUtils.writeStringToFile(nodeHealthDetailsFile, xmlData,
+        StandardCharsets.UTF_8);
+  }
+
+
+
+  /**
+   * Test NodeHealthDetails when its configured. The resourceScore file is
+   * {@link #nodeHealthDetailsFile}
+   */
+  @Test
+  public void testUpdateNodeHealthDetails() {
+
+    HashMap<String, Integer> resourcesScrore = new HashMap<>();
+    resourcesScrore.put("resource1", 35);
+    resourcesScrore.put("resource2", 65);
+    NodeHealthDetails nodeHealthDetails = NodeHealthDetails
+        .newInstance(100, resourcesScrore);
+
+    nodeHealthDetailsReporter.updateNodeHealthDetails();
+
+    assertEquals(100, (int) nodeHealthDetailsReporter.getNodeHealthDetails()
+        .getOverallScore());
+    assertEquals(nodeHealthDetailsReporter.getNodeHealthDetails().toString(),
+        nodeHealthDetails.toString());
+
+    nodeHealthDetailsReporter.updateNodeHealthDetails();
+    nodeHealthDetailsReporter.updateNodeHealthDetails();
+
+    // The value should not be changed.
+    assertEquals(100, (int) nodeHealthDetailsReporter.getNodeHealthDetails()
+        .getOverallScore());
+    assertEquals(nodeHealthDetailsReporter.getNodeHealthDetails().toString(),
+        nodeHealthDetails.toString());
+
+  }
+
+  @Test
+  public void testNodeHealthDetailsWhenDisabled() {
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.NM_HEALTH_CHECK_SCORE_FILE, "");
+    nodeHealthDetailsReporter = new FileBasedNodeHealthDetails(conf);
+
+    // Testing with the default conf. The score should return 0.
+    nodeHealthDetailsReporter.updateNodeHealthDetails();
+
+    assertEquals(0, (int) nodeHealthDetailsReporter.getNodeHealthDetails()
+        .getOverallScore());
+    assertEquals(nodeHealthDetailsReporter.getNodeHealthDetails().toString(),
+        "[Overall Score = 0]");
+
+  }
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/health/TestNodeHealthCheckerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/health/TestNodeHealthCheckerService.java
@@ -140,8 +140,9 @@ public class TestNodeHealthCheckerService {
     }
     nodeHealthScriptRunner = spy(nodeHealthScriptRunner);
     NodeHealthCheckerService nodeHealthChecker =
-        new NodeHealthCheckerService(dirsHandler);
-    nodeHealthChecker.addHealthReporter(nodeHealthScriptRunner);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
+    ((NodeHealthCheckerServiceImpl) nodeHealthChecker)
+        .addHealthReporter(nodeHealthScriptRunner);
     nodeHealthChecker.init(conf);
 
     doReturn(true).when(nodeHealthScriptRunner).isHealthy();
@@ -190,7 +191,7 @@ public class TestNodeHealthCheckerService {
         healthStatus.getIsNodeHealthy());
     Assert.assertTrue("Node script time out message not propagated",
         healthStatus.getHealthReport().equals(
-            Joiner.on(NodeHealthCheckerService.SEPARATOR).skipNulls().join(
+            Joiner.on(NodeHealthCheckerServiceImpl.SEPARATOR).skipNulls().join(
                 NodeHealthScriptRunner.NODE_HEALTH_SCRIPT_TIMED_OUT_MSG,
                 Strings.emptyToNull(
                     nodeHealthChecker.getDiskHandler()
@@ -230,8 +231,9 @@ public class TestNodeHealthCheckerService {
     Configuration conf = new Configuration();
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
     NodeHealthCheckerService nodeHealthChecker =
-        new NodeHealthCheckerService(dirsHandler);
-    nodeHealthChecker.addHealthReporter(customHealthReporter);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
+    ((NodeHealthCheckerServiceImpl) nodeHealthChecker)
+        .addHealthReporter(customHealthReporter);
     nodeHealthChecker.init(conf);
 
     assertThat(nodeHealthChecker.isHealthy()).isTrue();
@@ -246,7 +248,7 @@ public class TestNodeHealthCheckerService {
     Configuration conf = new Configuration();
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
     NodeHealthCheckerService nodeHealthChecker =
-        new NodeHealthCheckerService(dirsHandler);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
     nodeHealthChecker.init(conf);
     assertThat(nodeHealthChecker.isHealthy()).isTrue();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestContainerLogsPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestContainerLogsPage.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.launcher.ContainerLaunch;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.ContainerLogsPage.ContainersLogsBlock;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
@@ -78,9 +79,9 @@ import com.google.inject.Module;
 
 public class TestContainerLogsPage {
 
-  private NodeHealthCheckerService createNodeHealthCheckerService() {
+  private NodeHealthCheckerServiceImpl createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   @Test(timeout=30000)
@@ -90,7 +91,8 @@ public class TestContainerLogsPage {
     String logdirwithFile = absLogDir.toURI().toString();
     Configuration conf = new Configuration();
     conf.set(YarnConfiguration.NM_LOG_DIRS, logdirwithFile);
-    NodeHealthCheckerService healthChecker = createNodeHealthCheckerService();
+    NodeHealthCheckerService healthChecker =
+        createNodeHealthCheckerService();
     healthChecker.init(conf);
     LocalDirsHandlerService dirsHandler = healthChecker.getDiskHandler();
     NMContext nmContext = new NodeManager.NMContext(null, null, dirsHandler,
@@ -213,7 +215,8 @@ public class TestContainerLogsPage {
         "kerberos");
       UserGroupInformation.setConfiguration(conf);
 
-      NodeHealthCheckerService healthChecker = createNodeHealthCheckerService();
+      NodeHealthCheckerService healthChecker =
+          createNodeHealthCheckerService();
       healthChecker.init(conf);
       LocalDirsHandlerService dirsHandler = healthChecker.getDiskHandler();
       // Add an application and the corresponding containers

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMContainerWebSocket.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMContainerWebSocket.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.yarn.server.nodemanager.NodeManager;
 import org.apache.hadoop.yarn.server.nodemanager.ResourceView;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
@@ -104,7 +105,8 @@ public class TestNMContainerWebSocket {
     };
     conf.set(YarnConfiguration.NM_LOCAL_DIRS, TESTROOTDIR.getAbsolutePath());
     conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
-    NodeHealthCheckerService healthChecker = createNodeHealthCheckerService();
+    NodeHealthCheckerService healthChecker =
+        createNodeHealthCheckerService();
     healthChecker.init(conf);
     LocalDirsHandlerService dirsHandler = healthChecker.getDiskHandler();
     conf.set(YarnConfiguration.NM_WEBAPP_ADDRESS, webAddr);
@@ -118,9 +120,9 @@ public class TestNMContainerWebSocket {
     }
   }
 
-  private NodeHealthCheckerService createNodeHealthCheckerService() {
+  private NodeHealthCheckerServiceImpl createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServer.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
@@ -78,9 +79,9 @@ public class TestNMWebServer {
     FileUtil.fullyDelete(testLogDir);
   }
 
-  private NodeHealthCheckerService createNodeHealthCheckerService() {
+  private NodeHealthCheckerServiceImpl createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   private int startNMWebAppServer(String webAddr) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Ap
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.ApplicationState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AppsInfo;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
@@ -105,7 +106,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
       conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
       LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       dirsHandler = healthChecker.getDiskHandler();
       aclsManager = new ApplicationACLsManager(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.yarn.server.nodemanager.ResourceView;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.AuxServices;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceRecord;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
@@ -125,7 +126,7 @@ public class TestNMWebServicesAuxServices extends JerseyTestBase {
       conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
       LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       dirsHandler = healthChecker.getDiskHandler();
       ApplicationACLsManager aclsManager = new ApplicationACLsManager(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Ap
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
@@ -130,7 +131,7 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
       conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
       LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       dirsHandler = healthChecker.getDiskHandler();
       aclsManager = new ApplicationACLsManager(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebTerminal.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebTerminal.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
 import org.apache.hadoop.yarn.server.nodemanager.NodeManager;
 import org.apache.hadoop.yarn.server.nodemanager.ResourceView;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.junit.After;
 import org.junit.Before;
@@ -53,9 +54,9 @@ public class TestNMWebTerminal {
   private WebServer server;
   private int port;
 
-  private NodeHealthCheckerService createNodeHealthCheckerService() {
+  private NodeHealthCheckerServiceImpl createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   private int startNMWebAppServer(String webAddr) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMNMInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMNMInfo.java
@@ -96,6 +96,9 @@ public class RMNMInfo implements RMNMInfoBeans {
                         ni.getLastHealthReportTime());
         info.put("HealthReport",
                         ni.getHealthReport());
+      info.put("HealthDetails",
+          ni.getNodeHealthDetails() != null ?
+              ni.getNodeHealthDetails().toString() : "");
         info.put("NodeManagerVersion",
                 ni.getNodeManagerVersion());
         if(report != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNode.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceUtilization;
 import org.apache.hadoop.yarn.api.records.NodeAttribute;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
 import org.apache.hadoop.yarn.server.api.records.OpportunisticContainersStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 
@@ -85,12 +86,18 @@ public interface RMNode {
    * @return the latest health report received from this node.
    */
   public String getHealthReport();
-  
+
   /**
    * the time of the latest health report received from this node.
    * @return the time of the latest health report received from this node.
    */
   public long getLastHealthReportTime();
+
+  /**
+   * the overall health score received from this node.
+   * @return the overall health score of the node.
+   */
+  NodeHealthDetails getNodeHealthDetails();
 
   /**
    * the node manager version of the node received as part of the

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.apache.commons.collections.keyvalue.DefaultMapEntry;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,6 +133,7 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
 
   private String healthReport;
   private long lastHealthReportTime;
+  private NodeHealthDetails nodeHealthDetails;
   private String nodeManagerVersion;
   private Integer decommissioningTimeout;
 
@@ -513,7 +515,27 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       this.writeLock.unlock();
     }
   }
-  
+
+  public void setNodeHealthDetails(NodeHealthDetails nhd) {
+    this.writeLock.lock();
+
+    try {
+      this.nodeHealthDetails = nhd;
+    } finally {
+      this.writeLock.unlock();
+    }
+  }
+
+  public NodeHealthDetails getNodeHealthDetails() {
+    this.readLock.lock();
+
+    try {
+      return this.nodeHealthDetails;
+    } finally {
+      this.readLock.unlock();
+    }
+  }
+
   @Override
   public long getLastHealthReportTime() {
     this.readLock.lock();
@@ -922,6 +944,7 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
     rmNode.setHealthReport(remoteNodeHealthStatus.getHealthReport());
     rmNode.setLastHealthReportTime(remoteNodeHealthStatus
         .getLastHealthReportTime());
+    rmNode.setNodeHealthDetails(remoteNodeHealthStatus.getNodeHealthDetails());
     rmNode.setAggregatedContainersUtilization(statusEvent
         .getAggregatedContainersUtilization());
     rmNode.setNodeUtilization(statusEvent.getNodeUtilization());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockNodes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockNodes.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager;
 import org.apache.hadoop.yarn.resourcetypes.ResourceTypesTestHelper;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthDetails;
 import org.apache.hadoop.yarn.server.api.records.OpportunisticContainersStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo;
@@ -127,6 +128,7 @@ public class MockNodes {
     private ResourceUtilization nodeUtilization;
     private Resource physicalResource;
     private RMContext rmContext;
+    private NodeHealthDetails nodeHealthDetails;
 
     MockRMNodeImpl(NodeId nodeId, String nodeAddr, String httpAddress,
         Resource perNode, String rackName, String healthReport,
@@ -268,6 +270,11 @@ public class MockNodes {
     @Override
     public long getLastHealthReportTime() {
       return lastHealthReportTime;
+    }
+
+    @Override
+    public NodeHealthDetails getNodeHealthDetails() {
+      return nodeHealthDetails;
     }
 
     @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/NodeManagerRest.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/NodeManagerRest.md
@@ -99,6 +99,7 @@ Response Body:
     "pmemCheckEnabled": true,
     "lastNodeUpdateTime": 1485814574224,
     "nodeHealthy": true,
+    "nodeHealthDetails": "[Overall Score = 100,SSD = 100]",
     "nodeManagerVersion": "3.0.0",
     "nodeManagerBuildVersion": "3.0.0",
     "nodeManagerVersionBuiltOn": "2017-01-30T17:42Z",
@@ -140,6 +141,7 @@ Response Body:
     <pmemCheckEnabled>true</pmemCheckEnabled>
     <lastNodeUpdateTime>1485815774203</lastNodeUpdateTime>
     <nodeHealthy>true</nodeHealthy>
+    <nodeHealthDetails>[Overall Score = 100,SSD = 100]</nodeHealthDetails>
     <nodeManagerVersion>3.0.0</nodeManagerVersion>
     <nodeManagerBuildVersion>3.0.0</nodeManagerBuildVersion>
     <nodeManagerVersionBuiltOn>2017-01-30T17:42Z</nodeManagerVersionBuiltOn>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/serializers/yarn-node.js
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/serializers/yarn-node.js
@@ -37,6 +37,7 @@ export default DS.JSONAPISerializer.extend({
         nodeHealthy: payload.nodeHealthy,
         lastNodeUpdateTime: Converter.timeStampToDate(payload.lastNodeUpdateTime),
         healthReport: payload.healthReport || 'N/A',
+        nodeHealthDetails: payload.nodeHealthDetails || 'N/A',
         nmStartupTime: payload.nmStartupTime? Converter.timeStampToDate(payload.nmStartupTime) : '',
         nodeManagerBuildVersion: payload.nodeManagerBuildVersion,
         hadoopBuildVersion: payload.hadoopBuildVersion

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-node/info.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/yarn-node/info.hbs
@@ -67,6 +67,10 @@
                 <td>Node Health Report</td>
                 <td>{{model.node.healthReport}}</td>
               </tr>
+              <tr>
+                <td>Node Health Details</td>
+                <td>{{model.node.nodeHealthDetails}}</td>
+              </tr>
               {{#if model.node.nmStartupTime}}
                 <tr>
                   <td>Node Manager Start Time</td>


### PR DESCRIPTION
This PR aims to provide an interface to send out nodeHealthScore to Resource manager. This in turn can be used to improve scheduling of containers based on the score received from the nodemanagers. 

Linked Jira: [YARN-10335](https://issues.apache.org/jira/browse/YARN-10335)
