### PR TITLE
HADOOP-17510. Hadoop prints sensitive Cookie information.

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/AuthenticatedURL.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/AuthenticatedURL.java
@@ -153,7 +153,6 @@ public class AuthenticatedURL {
         cookieHeaders = new HashMap<>();
         cookieHeaders.put("Cookie", Arrays.asList(cookie.toString()));
       }
-      LOG.trace("Setting token value to {} ({})", authCookie, oldCookie);
     }
 
     private void setAuthCookieValue(String value) {


### PR DESCRIPTION
This patch will remove sensitive information logging (Cookies). Log message has no significance, so deleted the complete log message.
