### PR TITLE
HADOOP-17513. Checkstyle IllegalImport does not catch guava imports

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -121,7 +121,7 @@
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="IllegalImport">
           <property name="regexp" value="true"/>
-          <property name="illegalPkgs" value="^sun\.[^.]+, ^com\.google\.common\.[^.]+"/>
+          <property name="illegalPkgs" value="sun, com\.google\.common"/>
           <property name="illegalClasses" value="^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.base\.(Optional|Function|Predicate|Supplier), ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.collect\.(ImmutableListMultimap)"/>
         </module>
         <module name="RedundantImport"/>


### PR DESCRIPTION
[HADOOP-17513](https://issues.apache.org/jira/browse/HADOOP-17513)

Although YARN-10352 introduces `guava iterator import` in [TestCapacitySchedulerMultiNodes-L#28](https://github.com/apache/hadoop/commit/6fc26ad5392a2a61ace60b88ed931fed3859365d#diff-34d534eb66cd9af6d7c47a9f643d598b1ad4cef3453219457769e92fbd4a649dR28), it was committed to trunk without checkstyle errors.

According to [IllegalImportCheck#setIllegalPkgs ](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java), the packages regex should be the prefix of the package. The code automatically append "`\.*`" to the regex.

This PR is to fix the regex to match all `^com\.google\.common\..*`

CC: @aajisaka Can you please take a look to the changes and commit it to trunk?