### PR TITLE
HADOOP-17514. Remove trace subcommand from hadoop CLI.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop
@@ -44,7 +44,6 @@ function hadoop_usage
   hadoop_add_subcommand "kerbname" client "show auth_to_local principal conversion"
   hadoop_add_subcommand "key" client "manage keys via the KeyProvider"
   hadoop_add_subcommand "registrydns" daemon "run the registry DNS server"
-  hadoop_add_subcommand "trace" client "view and modify Hadoop tracing settings"
   hadoop_add_subcommand "version" client "print the version"
   hadoop_add_subcommand "kdiag" client "Diagnose Kerberos Problems"
   hadoop_add_subcommand "rbfbalance" client "move directories and files across router-based federation namespaces"
@@ -165,9 +164,6 @@ function hadoopcmd_case
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
       HADOOP_SECURE_CLASSNAME='org.apache.hadoop.registry.server.dns.PrivilegedRegistryDNSStarter'
       HADOOP_CLASSNAME='org.apache.hadoop.registry.server.dns.RegistryDNSServer'
-    ;;
-    trace)
-      HADOOP_CLASSNAME=org.apache.hadoop.tracing.TraceAdmin
     ;;
     version)
       HADOOP_CLASSNAME=org.apache.hadoop.util.VersionInfo

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop.cmd
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop.cmd
@@ -149,7 +149,7 @@ call :updatepath %HADOOP_BIN_PATH%
     exit /b
   )
 
-  set corecommands=fs version jar checknative conftest distch distcp daemonlog archive classpath credential kerbname key trace kdiag
+  set corecommands=fs version jar checknative conftest distch distcp daemonlog archive classpath credential kerbname key kdiag
   for %%i in ( %corecommands% ) do (
     if %hadoop-command% == %%i set corecommand=true  
   )
@@ -244,10 +244,6 @@ call :updatepath %HADOOP_BIN_PATH%
   set CLASS=org.apache.hadoop.crypto.key.KeyShell
   goto :eof
 
-:trace
-  set CLASS=org.apache.hadoop.tracing.TraceAdmin
-  goto :eof
-
 :updatepath
   set path_to_add=%*
   set current_path_comparable=%path%
@@ -318,7 +314,6 @@ call :updatepath %HADOOP_BIN_PATH%
   @echo   kerbname             show auth_to_local principal conversion
   @echo   kdiag                diagnose kerberos problems
   @echo   key                  manage keys via the KeyProvider
-  @echo   trace                view and modify Hadoop tracing settings
   @echo   daemonlog            get/set the log level for each daemon
   @echo  or
   @echo   CLASSNAME            run the class named CLASSNAME

--- a/hadoop-common-project/hadoop-common/src/site/markdown/CommandsManual.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/CommandsManual.md
@@ -240,10 +240,6 @@ Usage: `hadoop kms`
 
 Run KMS, the Key Management Server.
 
-### `trace`
-
-View and modify Hadoop tracing settings. See the [Tracing Guide](./Tracing.html).
-
 ### `version`
 
 Usage: `hadoop version`


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17514

TraceAdmin protocol and utility class were removed by [HADOOP-17424](https://issues.apache.org/jira/browse/HADOOP-17424).
