### PR TITLE
HADOOP-16767 Handle non-IO exceptions in reopen()

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -476,7 +476,7 @@ public class S3AInputStream extends FSInputStream implements CanSetReadahead {
           // and an abort is triggered, the initial attempt's statistics
           // aren't collected.
           streamStatistics.streamClose(false, drained);
-        } catch (IOException e) {
+        } catch (Exception e) {
           // exception escalates to an abort
           LOG.debug("When closing {} stream for {}", uri, reason, e);
           shouldAbort = true;


### PR DESCRIPTION
Contributed by Sergei Poganshev.

Catches Exception instead of IOException in closeStream() 
and so handle exceptions such as SdkClientException by 
aborting the wrapped stream. This will increase resilience
to failures, as any which occuring during stream closure
will be caught. Furthermore, because the
underlying HTTP connection is aborted, rather than closed,
it will not be recycled to cause problems on subsequent
operations.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
