### PR TITLE
HADOOP-17520. Downgrade missing DDB table to unguarded client

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentAmazonS3Client.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentAmazonS3Client.java
@@ -133,14 +133,16 @@ public class InconsistentAmazonS3Client extends AmazonS3Client {
 
   /**
    * Clear any accumulated inconsistency state. Used by tests to make paths
-   * visible again.
-   * @param fs S3AFileSystem under test
+   * visible again. No-op if the FS is null (for teardowns)
+   * @param fs S3AFileSystem under test; can be null.
    * @throws Exception on failure
    */
   public static void clearInconsistency(S3AFileSystem fs) throws Exception {
-    AmazonS3 s3 = fs.getAmazonS3ClientForTesting("s3guard");
-    InconsistentAmazonS3Client ic = InconsistentAmazonS3Client.castFrom(s3);
-    ic.clearInconsistency();
+    if (fs != null) {
+      AmazonS3 s3 = fs.getAmazonS3ClientForTesting("s3guard");
+      InconsistentAmazonS3Client ic = InconsistentAmazonS3Client.castFrom(s3);
+      ic.clearInconsistency();
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -685,7 +685,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
       metricsSystem.unregisterSource(metricsSourceName);
       metricsSourceActiveCounter--;
       int activeSources = metricsSourceActiveCounter;
-      if (activeSources == 0) {
+      if (activeSources == 0 && metricsSystem != null) {
         LOG.debug("Shutting down metrics publisher");
         metricsSystem.publishMetricsNow();
         metricsSystem.shutdown();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/S3Guard.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a.s3guard;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -124,10 +125,9 @@ public final class S3Guard {
           msClass.getSimpleName(), fs.getScheme());
       msInstance.initialize(fs, ttlTimeProvider);
       return msInstance;
-    } catch (FileNotFoundException e) {
-      // Don't log this exception as it means the table doesn't exist yet;
-      // rely on callers to catch and treat specially
-      throw e;
+    } catch (FileNotFoundException | AccessDeniedException e) {
+      // Downgrade.
+      return new NullMetadataStore();
     } catch (RuntimeException | IOException e) {
       String message = "Failed to instantiate metadata store " +
           conf.get(S3_METADATA_STORE_IMPL)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestAuthoritativePath.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestAuthoritativePath.java
@@ -53,6 +53,7 @@ public class ITestAuthoritativePath extends AbstractS3ATestBase {
 
   @Before
   public void setup() throws Exception {
+    setS3GuardRequired(true);
     super.setup();
 
     long timestamp = System.currentTimeMillis();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestLocatedFileStatusFetcher.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestLocatedFileStatusFetcher.java
@@ -141,6 +141,7 @@ public class ITestLocatedFileStatusFetcher extends AbstractS3ATestBase {
       final boolean s3guard) {
     this.name = name;
     this.s3guard = s3guard;
+    setS3GuardRequired(s3guard);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARemoteFileChanged.java
@@ -255,6 +255,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
     this.changeDetectionMode = changeDetectionMode;
     this.authMode = authMode;
     this.expectedExceptionInteractions = expectedExceptionInteractions;
+    setS3GuardRequired(authMode);
   }
 
   @Override
@@ -441,6 +442,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
    */
   @Test
   public void testOpenFileWithStatus() throws Throwable {
+    requireS3Guard();
     final Path testpath = path("testOpenFileWithStatus.dat");
     final byte[] dataset = TEST_DATA_BYTES;
     S3AFileStatus originalStatus =
@@ -1004,6 +1006,8 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
    * should result in {@link RemoteFileChangedException}.
    */
   private Path writeOutOfSyncFileVersion(String filename) throws IOException {
+    // skip if S3Guard is out of play.
+    requireS3Guard();
     final Path testpath = path(filename);
     final byte[] dataset = TEST_DATA_BYTES;
     S3AFileStatus originalStatus =
@@ -1453,7 +1457,7 @@ public class ITestS3ARemoteFileChanged extends AbstractS3ATestBase {
    * not have it.
    */
   private void requireS3Guard() {
-    Assume.assumeTrue("S3Guard must be enabled", fs.hasMetadataStore());
+    downgradeIfUnguarded(fs);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardCreate.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardCreate.java
@@ -32,6 +32,10 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
  */
 public class ITestS3GuardCreate extends AbstractS3ATestBase {
 
+   public ITestS3GuardCreate() {
+     setS3GuardRequired(true);
+   }
+
   /**
    * Test that ancestor creation during S3AFileSystem#create() is properly
    * accounted for in the MetadataStore.  This should be handled by the

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardEmptyDirs.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardEmptyDirs.java
@@ -59,6 +59,10 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.getStatusWithEmptyDirFlag;
  */
 public class ITestS3GuardEmptyDirs extends AbstractS3ATestBase {
 
+  public ITestS3GuardEmptyDirs() {
+    setS3GuardRequired(true);
+  }
+
   /**
    * Rename an empty directory, verify that the empty dir
    * marker moves in both S3Guard and in the S3A FS.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardListConsistency.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardListConsistency.java
@@ -66,6 +66,7 @@ public class ITestS3GuardListConsistency extends AbstractS3ATestBase {
 
   @Override
   public void setup() throws Exception {
+    setS3GuardRequired(true);
     super.setup();
     invoker = new Invoker(new S3ARetryPolicy(getConfiguration()),
         Invoker.NO_OP

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardOutOfBandOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardOutOfBandOperations.java
@@ -148,6 +148,7 @@ public class ITestS3GuardOutOfBandOperations extends AbstractS3ATestBase {
 
   public ITestS3GuardOutOfBandOperations(final boolean authoritative) {
     this.authoritative = authoritative;
+    setS3GuardRequired(true);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardTtl.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3GuardTtl.java
@@ -79,6 +79,7 @@ public class ITestS3GuardTtl extends AbstractS3ATestBase {
 
   public ITestS3GuardTtl(boolean authoritative) {
     this.authoritative = authoritative;
+    setS3GuardRequired(true);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -517,7 +517,6 @@ public final class S3ATestUtils {
       conf.setBoolean(METADATASTORE_AUTHORITATIVE, authoritative);
       conf.set(AUTHORITATIVE_PATH, "");
       conf.set(S3_METADATA_STORE_IMPL, implClass);
-      conf.setBoolean(S3GUARD_DDB_TABLE_CREATE_KEY, true);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestRestrictedReadAccess.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestRestrictedReadAccess.java
@@ -214,7 +214,7 @@ public class ITestRestrictedReadAccess extends AbstractS3ATestBase {
     this.s3guard = s3guard;
     this.authMode = authMode;
     this.guardedInAuthMode = s3guard && authMode;
-
+    setS3GuardRequired(s3guard);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -344,7 +344,8 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
         SERVER_SIDE_ENCRYPTION_ALGORITHM,
         SERVER_SIDE_ENCRYPTION_KEY,
         DELEGATION_TOKEN_ROLE_ARN,
-        DELEGATION_TOKEN_ENDPOINT);
+        DELEGATION_TOKEN_ENDPOINT,
+        S3GUARD_DDB_TABLE_CREATE_KEY);
     // this is done to make sure you cannot create an STS session no
     // matter how you pick up credentials.
     conf.set(DELEGATION_TOKEN_ENDPOINT, "http://localhost:8080/");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/AbstractS3ACostTest.java
@@ -53,7 +53,10 @@ import static org.apache.hadoop.test.AssertExtensions.dynamicDescription;
 /**
  * Abstract class for tests which make assertions about cost.
  * <p></p>
- * Factored out from {@code ITestS3AFileOperationCost}
+ * Factored out from {@code ITestS3AFileOperationCost}.
+ * When S3Guard is required, if the store falls back to
+ * being unguarded then the test will be skipped during
+ * setup.
  */
 public class AbstractS3ACostTest extends AbstractS3ATestBase {
 
@@ -106,6 +109,7 @@ public class AbstractS3ACostTest extends AbstractS3ATestBase {
     this.s3guard = s3guard;
     this.keepMarkers = keepMarkers;
     this.authoritative = authoritative;
+    setS3GuardRequired(s3guard);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardConcurrentOps.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardConcurrentOps.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_REGION_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_CAPACITY_READ_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_CAPACITY_WRITE_KEY;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeFilesystemHasMetadatastore;
 
 /**
  * Tests concurrent operations on S3Guard.
@@ -63,6 +64,12 @@ public class ITestS3GuardConcurrentOps extends AbstractS3ATestBase {
     conf.setInt(S3GUARD_DDB_TABLE_CAPACITY_READ_KEY, 0);
     conf.setInt(S3GUARD_DDB_TABLE_CAPACITY_WRITE_KEY, 0);
     return conf;
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    assumeFilesystemHasMetadatastore(getFileSystem());
   }
 
   private void failIfTableExists(DynamoDB db, String tableName) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardConcurrentOps.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardConcurrentOps.java
@@ -58,6 +58,10 @@ public class ITestS3GuardConcurrentOps extends AbstractS3ATestBase {
   @Rule
   public final Timeout timeout = new Timeout(5 * 60 * 1000);
 
+  public ITestS3GuardConcurrentOps() {
+    setS3GuardRequired(true);
+  }
+
   protected Configuration createConfiguration() {
     Configuration conf =  super.createConfiguration();
     //patch the read/write capacity

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardFsck.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardFsck.java
@@ -61,6 +61,7 @@ public class ITestS3GuardFsck extends AbstractS3ATestBase {
 
   @Before
   public void setup() throws Exception {
+    setS3GuardRequired(true);
     super.setup();
     S3AFileSystem fs = getFileSystem();
     // These test will fail if no ms

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolDynamoDB.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/ITestS3GuardToolDynamoDB.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.Init;
 import org.apache.hadoop.util.ExitUtil;
 
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_REGION_KEY;
+import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_CREATE_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_NAME_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.S3GUARD_DDB_TABLE_TAG;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBucketOverrides;
@@ -54,6 +55,7 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.setBucketOption;
 import static org.apache.hadoop.fs.s3a.s3guard.DynamoDBMetadataStore.*;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.*;
 import static org.apache.hadoop.fs.s3a.s3guard.S3GuardToolTestHelper.exec;
+import static org.apache.hadoop.fs.s3a.s3guard.S3GuardToolTestHelper.runS3GuardCommand;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -320,8 +322,10 @@ public class ITestS3GuardToolDynamoDB extends AbstractS3GuardToolTestBase {
 
   @Test
   public void testCLIFsckFailInitializeFs() throws Exception {
+    Configuration conf = new Configuration(getConfiguration());
+    conf.setBoolean(S3GUARD_DDB_TABLE_CREATE_KEY, true);
     intercept(UnknownStoreException.class,
-        () -> run(S3GuardTool.Fsck.NAME, "-check",
+        () -> runS3GuardCommand(conf, Fsck.NAME, "-check",
             "s3a://this-bucket-does-not-exist-" + UUID.randomUUID()));
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractITestS3AMetadataStoreScale.java
@@ -61,6 +61,10 @@ public abstract class AbstractITestS3AMetadataStoreScale extends
   static final Path BUCKET_ROOT = new Path("s3a://fake-bucket/");
   private ITtlTimeProvider ttlTimeProvider;
 
+  protected AbstractITestS3AMetadataStoreScale() {
+    setS3GuardRequired(true);
+  }
+
   @Before
   public void initialize() {
     ttlTimeProvider = new S3Guard.TtlTimeProvider(new Configuration());


### PR DESCRIPTION

If an s3a client starts up and cannot find/read the DDB table then it downgrades to being unguarded