### PR TITLE
MAPREDUCE-7141. Allow KMS generated spill encryption keys

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
@@ -24,7 +24,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,8 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.crypto.KeyGenerator;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -49,7 +46,6 @@ import org.apache.hadoop.mapreduce.Cluster.JobTrackerStatus;
 import org.apache.hadoop.mapreduce.ClusterMetrics;
 import org.apache.hadoop.mapreduce.CryptoUtils;
 import org.apache.hadoop.mapreduce.MRConfig;
-import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.QueueInfo;
 import org.apache.hadoop.mapreduce.TaskCompletionEvent;
@@ -57,7 +53,6 @@ import org.apache.hadoop.mapreduce.TaskTrackerInfo;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.checkpoint.TaskCheckpointID;
 import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
-import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.mapreduce.security.token.delegation.DelegationTokenIdentifier;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
 import org.apache.hadoop.mapreduce.split.JobSplit.TaskSplitMetaInfo;
@@ -89,8 +84,6 @@ public class LocalJobRunner implements ClientProtocol {
   /** The maximum number of reduce tasks to run in parallel in LocalJobRunner */
   public static final String LOCAL_MAX_REDUCES =
     "mapreduce.local.reduce.tasks.maximum";
-
-  public static final String INTERMEDIATE_DATA_ENCRYPTION_ALGO = "HmacSHA1";
 
   private FileSystem fs;
   private HashMap<JobID, Job> jobs = new HashMap<JobID, Job>();
@@ -195,26 +188,7 @@ public class LocalJobRunner implements ClientProtocol {
           profile.getURL().toString());
 
       jobs.put(id, this);
-
-      if (CryptoUtils.isEncryptedSpillEnabled(job)) {
-        try {
-          int keyLen = conf.getInt(
-              MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA_KEY_SIZE_BITS,
-              MRJobConfig
-                  .DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEY_SIZE_BITS);
-          KeyGenerator keyGen =
-              KeyGenerator.getInstance(INTERMEDIATE_DATA_ENCRYPTION_ALGO);
-          keyGen.init(keyLen);
-          Credentials creds =
-              UserGroupInformation.getCurrentUser().getCredentials();
-          TokenCache.setEncryptedSpillKey(keyGen.generateKey().getEncoded(),
-              creds);
-          UserGroupInformation.getCurrentUser().addCredentials(creds);
-        } catch (NoSuchAlgorithmException e) {
-          throw new IOException("Error generating encrypted spill key", e);
-        }
-      }
-
+      CryptoUtils.processEncryptedSpillKeyFromConf(job);
       this.start();
     }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
@@ -185,7 +185,10 @@ class JobSubmitter {
         TokenCache.setShuffleSecretKey(shuffleKey.getEncoded(),
             job.getCredentials());
       }
-      if (CryptoUtils.isEncryptedSpillEnabled(conf)) {
+      SpillKeyProvider spillKeyProvider =
+          CryptoUtils.initSpillKeyProvider(conf);
+      if (spillKeyProvider.isEncryptionEnabled()) {
+        spillKeyProvider.addEncryptedSpillKey(job.getCredentials());
         conf.setInt(MRJobConfig.MR_AM_MAX_ATTEMPTS, 1);
         LOG.warn("Max job attempts set to 1 since encrypted intermediate" +
                 "data spill is enabled");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
@@ -1216,6 +1216,21 @@ public interface MRJobConfig {
       "mapreduce.job.encrypted-intermediate-data";
   public static final boolean DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA = false;
 
+  String MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_CLASS =
+      "mapreduce.job.encrypted-intermediate-data.keyprovider.class";
+
+  String MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_KEY_NAME =
+      "mapreduce.job.encrypted-intermediate-data.keyprovider.key-name";
+
+  String DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_KEY_NAME =
+      "am-spill-key";
+
+  String MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_EDEK =
+      "mapreduce.job.encrypted-intermediate-data.keyprovider.edek";
+
+  String DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_EDEK =
+      "AMEncryptedSpillEdek";
+
   public static final String MR_ENCRYPTED_INTERMEDIATE_DATA_KEY_SIZE_BITS =
       "mapreduce.job.encrypted-intermediate-data-key-size-bits";
   public static final int DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEY_SIZE_BITS =
@@ -1225,6 +1240,12 @@ public interface MRJobConfig {
       "mapreduce.job.encrypted-intermediate-data.buffer.kb";
   public static final int DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_BUFFER_KB =
           128;
+
+  String MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_ALGORITHM =
+      "mapreduce.job.encrypted-intermediate-data.keyprovider.keygen.algorithm";
+
+  String DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_ALGORITHM =
+      "HmacSHA1";
 
   /**
    * The maximum number of resources a map reduce job is allowed to submit for

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillDefaultKeyProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillDefaultKeyProvider.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.KeyGenerator;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.Credentials;
+
+/**
+ * The implementation uses keygenerator to encrypt data spilled to disk.
+ */
+public class SpillDefaultKeyProvider extends SpillNullKeyProvider {
+
+  private int keyLength;
+  private String keyAlgo;
+
+  @Override
+  public void setConf(Configuration conf) {
+    super.setConf(conf);
+    if (conf == null) {
+      return;
+    }
+    setEncryptionEnabled(getConf().getBoolean(
+        MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA,
+        MRJobConfig.DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA));
+    setKeyLen(getConf().getInt(
+        MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA_KEY_SIZE_BITS,
+        MRJobConfig.DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEY_SIZE_BITS));
+    setKeyAlgo(getConf().get(
+        MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_ALGORITHM,
+        MRJobConfig
+            .DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_ALGORITHM));
+  }
+
+  @Override
+  public byte[] getEncryptionSpillKey(
+      Credentials credentials) throws IOException {
+    KeyGenerator keyGen;
+    try {
+      keyGen = KeyGenerator.getInstance(getKeyAlgo());
+      keyGen.init(getKeyLength());
+      return keyGen.generateKey().getEncoded();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IOException("Error generating encrypted spill key", e);
+    }
+  }
+
+  protected void setKeyLen(int length) {
+    keyLength = length;
+  }
+
+  public int getKeyLength() {
+    return keyLength;
+  }
+
+  protected void setKeyAlgo(String algo) {
+    keyAlgo = algo;
+  }
+
+  public String getKeyAlgo() {
+    return keyAlgo;
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillHdfsKMSKeyProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillHdfsKMSKeyProvider.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.key.KeyProvider;
+import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
+import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.EncryptedKeyVersion;
+import org.apache.hadoop.crypto.key.kms.KMSRESTConstants;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.util.JsonSerialization;
+import org.apache.hadoop.util.KMSUtil;
+
+/**
+ * Implementation that allows Allow KMS generated spill encryption keys.
+ */
+public class SpillHdfsKMSKeyProvider extends SpillNullKeyProvider {
+  private Text spillEdek;
+  private String kmsSpillKeyName;
+
+  @Override
+  public void setConf(Configuration conf) {
+    super.setConf(conf);
+    if (conf == null) {
+      return;
+    }
+    setEncryptionEnabled(conf.getBoolean(
+        MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA,
+        MRJobConfig.DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA));
+    spillEdek = new Text(getConf().get(
+        MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_EDEK,
+        MRJobConfig.DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_EDEK));
+    kmsSpillKeyName = getConf().get(
+        MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_KEY_NAME,
+        MRJobConfig
+            .DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_KEY_NAME);
+  }
+
+  @Override
+  public void addEncryptedSpillKey(Credentials credentials) throws IOException {
+    // assumes key provider is from DFS
+    KeyProvider keyProvider =
+        ((DistributedFileSystem) FileSystem.get(getConf())).getKeyProvider();
+    try (KeyProviderCryptoExtension keyProviderCryptoExtension =
+             KeyProviderCryptoExtension
+                 .createKeyProviderCryptoExtension(keyProvider)) {
+      KeyProviderCryptoExtension.EncryptedKeyVersion version =
+          keyProviderCryptoExtension.generateEncryptedKey(kmsSpillKeyName);
+      Map jsonLoad = KMSUtil.toJSON(version);
+      jsonLoad.put(KMSRESTConstants.NAME_FIELD,
+          version.getEncryptionKeyName());
+      byte[] encKeyVersionJSON =
+          JsonSerialization.writer().writeValueAsBytes(jsonLoad);
+      credentials.addSecretKey(spillEdek, encKeyVersionJSON);
+    } catch (GeneralSecurityException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public byte[] getEncryptionSpillKey(
+      Credentials credentials) throws IOException {
+    byte[] versionJson = credentials.getSecretKey(spillEdek);
+    // assumes key provider is from DFS
+    KeyProvider keyProvider =
+        ((DistributedFileSystem) FileSystem.get(getConf())).getKeyProvider();
+    Map jsonMap = JsonSerialization.mapReader().readValue(versionJson);
+    String keyName = (String) jsonMap.get(KMSRESTConstants.NAME_FIELD);
+    EncryptedKeyVersion kmsEDEK =
+        KMSUtil.parseJSONEncKeyVersion(keyName, jsonMap);
+    try (KeyProviderCryptoExtension keyProviderCryptoExtension =
+             KeyProviderCryptoExtension
+                 .createKeyProviderCryptoExtension(keyProvider)) {
+      KeyProvider.KeyVersion ek =
+          keyProviderCryptoExtension.decryptEncryptedKey(kmsEDEK);
+      return ek.getMaterial();
+    } catch (GeneralSecurityException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillKeyProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillKeyProvider.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce;
+
+import java.io.IOException;
+
+import org.apache.hadoop.security.Credentials;
+
+public interface SpillKeyProvider {
+  void addEncryptedSpillKey(Credentials credentials) throws IOException;
+  byte[] getEncryptionSpillKey(Credentials credentials) throws IOException;
+  boolean isEncryptionEnabled();
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillNullKeyProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/SpillNullKeyProvider.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapreduce;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.security.Credentials;
+
+/**
+ * The implementation that provides no encryption to date spilled to disk.
+ */
+public class SpillNullKeyProvider
+    extends Configured implements SpillKeyProvider {
+  private boolean encryptionEnabled;
+
+  @Override
+  public void setConf(Configuration conf) {
+    super.setConf(conf);
+    setEncryptionEnabled(false);
+  }
+
+  @Override
+  public void addEncryptedSpillKey(Credentials credentials)
+      throws IOException {
+    // do nothing
+  }
+
+  @Override
+  public byte[] getEncryptionSpillKey(Credentials credentials)
+      throws IOException {
+    return new byte[] {0};
+  }
+
+  @Override
+  public boolean isEncryptionEnabled() {
+    return encryptionEnabled;
+  }
+
+  public void setEncryptionEnabled(boolean encryptionEnabled) {
+    this.encryptionEnabled = encryptionEnabled;
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml
@@ -2086,6 +2086,14 @@
 </property>
 
 <property>
+  <name>mapreduce.job.encrypted-intermediate-data.keyprovider.class</name>
+  <value>org.apache.hadoop.mapreduce.SpillDefaultKeyProvider</value>
+  <description>Implementation that allows encryption for intermediate data.
+  Default is org.apache.hadoop.mapreduce.SpillDefaultKeyProvider which uses
+  keygenerator to encrypt the spilled data.</description>
+</property>
+
+<property>
   <name>mapreduce.job.encrypted-intermediate-data-key-size-bits</name>
   <value>128</value>
   <description>Mapreduce encrypt data key size default is 128</description>
@@ -2096,6 +2104,28 @@
   <value>128</value>
   <description>Buffer size for intermediate encrypt data in kb
   default is 128</description>
+</property>
+
+<property>
+  <name>mapreduce.job.encrypted-intermediate-data.keyprovider.keygen.algorithm</name>
+  <value>HmacSHA1</value>
+  <description>The algorithm used by the keygenerator for intermediate encrypt
+  data. Default is HmacSHA1.</description>
+</property>
+
+<property>
+  <name>mapreduce.job.encrypted-intermediate-data.keyprovider.key-name</name>
+  <value>am-spill-key</value>
+  <description>The name of the KMS-key loaded to encrypt the spilled data.
+  This is only used when KMS key provider is the implementation of the
+  intermediate data encryption. Default is am-spill-key.</description>
+</property>
+
+<property>
+  <name>mapreduce.job.encrypted-intermediate-data.keyprovider.edek</name>
+  <value>AMEncryptedSpillEdek</value>
+  <description>The encrypted key version of the Spilled data, when Spilled
+  KMS-Key-provider is enabled. Default is AMEncryptedSpillEdek.</description>
 </property>
 
 <property>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 import java.io.IOException;
 import java.util.Map;
@@ -43,6 +45,17 @@ import java.util.Properties;
  * The DFS filesystem is formated before the testcase starts and after it ends.
  */
 public abstract class ClusterMapReduceTestCase {
+  @Rule
+  public TestName testName = new TestName();
+
+  public String getTestName() {
+    return testName.getMethodName();
+  }
+
+  public MiniDFSCluster getDfsCluster() {
+    return dfsCluster;
+  }
+
   private MiniDFSCluster dfsCluster = null;
   private MiniMRCluster mrCluster = null;
 
@@ -80,7 +93,7 @@ public abstract class ClusterMapReduceTestCase {
       }
       dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2)
       .format(reformatDFS).racks(null).build();
-
+      dfsCluster.waitActive();
       ConfigurableMiniMRCluster.setConfiguration(props);
       //noinspection deprecation
       mrCluster = new ConfigurableMiniMRCluster(2,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRIntermediateDataEncryptionWithKMS.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRIntermediateDataEncryptionWithKMS.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.mapred;
+
+import java.io.File;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.key.JavaKeyStoreProvider;
+import org.apache.hadoop.crypto.key.KeyProvider;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileSystemTestHelper;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.SpillHdfsKMSKeyProvider;
+import org.apache.hadoop.mapreduce.SpillKeyProvider;
+
+/**
+ * {@inheritdoc}
+ * Extends {@link TestMRIntermediateDataEncryption} to test the intermediate
+ * encryption with KMS Key provider.
+ */
+public class TestMRIntermediateDataEncryptionWithKMS extends
+    TestMRIntermediateDataEncryption {
+  /**
+   * Initialized the parametrized JUnit test.
+   *
+   * @param testName    the name of the unit test to be executed.
+   * @param mappers     number of mappers in the tests.
+   * @param reducers    number of the reducers.
+   * @param uberEnabled boolean flag for isUber
+   */
+  public TestMRIntermediateDataEncryptionWithKMS(String testName, int mappers,
+      int reducers, boolean uberEnabled) {
+    super(testName, mappers, reducers, uberEnabled);
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  @Override
+  protected void setupSpillKeyProviderConf(JobConf jobConf) throws Exception {
+    super.setupSpillKeyProviderConf(jobConf);
+    String encryptionKeyName =
+        jobConf.get(
+            MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_KEY_NAME,
+            MRJobConfig
+                .DEFAULT_MR_ENCRYPTED_INTERMEDIATE_DATA_KEYPROVIDER_KEY_NAME);
+    try (KeyProvider keyProvider =
+             getDFSCluster().getNameNode().getNamesystem().getProvider()) {
+      KeyProvider.Options options = KeyProvider.options(jobConf);
+      if (keyProvider.getCurrentKey(encryptionKeyName) == null) {
+        keyProvider.createKey(encryptionKeyName, options);
+        keyProvider.flush();
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  @Override
+  protected Configuration setupClustersConf() {
+    Configuration conf = super.setupClustersConf();
+    FileSystemTestHelper fsHelper = new FileSystemTestHelper();
+    File kmsDir = new File(fsHelper.getTestRootDir()).getAbsoluteFile();
+    conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH,
+        getKeyProviderURI(kmsDir));
+    return conf;
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  @Override
+  protected Class<? extends SpillKeyProvider> getSpillKeyKlass() {
+    return SpillHdfsKMSKeyProvider.class;
+  }
+
+  private static String getKeyProviderURI(File testRootDir) {
+    return JavaKeyStoreProvider.SCHEME_NAME + "://file" +
+        new Path(testRootDir.toString(), "test.jks").toUri();
+  }
+}


### PR DESCRIPTION
[MAPREDUCE-7141: Allow KMS generated spill encryption keys](https://issues.apache.org/jira/browse/MAPREDUCE-7141)
Add KMS support to generate key for the encryption of the spilled data on disk. The feature improves fault tolerance to AM failures/re-runs and also gives another option to the client on how it wants the keys to be created.
The current implementation assumed that the KMS key can be retrieved from the DFS.

