### PR TITLE
HADOOP-16810. Increase entropy on precommit Linux VMs

### DIFF
--- a/dev-support/bin/hadoop.sh
+++ b/dev-support/bin/hadoop.sh
@@ -35,6 +35,8 @@ function personality_globals
   JIRA_ISSUE_RE='^(HADOOP|YARN|MAPREDUCE|HDFS)-[0-9]+$'
   #shellcheck disable=SC2034
   GITHUB_REPO_DEFAULT="apache/hadoop"
+  # mount urandom to increase entropy
+  DOCKER_EXTRAARGS=("-v" "/dev/urandom:/dev/random")
 
   HADOOP_HOMEBREW_DIR=${HADOOP_HOMEBREW_DIR:-$(brew --prefix 2>/dev/null)}
   if [[ -z "${HADOOP_HOMEBREW_DIR}" ]]; then

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRIntermediateDataEncryption.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRIntermediateDataEncryption.java
@@ -58,12 +58,7 @@ import static org.junit.Assert.*;
 public class TestMRIntermediateDataEncryption {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMRIntermediateDataEncryption.class);
-  /**
-   * Use urandom to avoid the YarnChild  process from hanging on low entropy
-   * systems.
-   */
-  private static final String JVM_SECURITY_EGD_OPT =
-      "-Djava.security.egd=file:/dev/./urandom";
+
   // Where MR job's input will reside.
   private static final Path INPUT_DIR = new Path("/test/input");
   // Where output goes.
@@ -114,14 +109,6 @@ public class TestMRIntermediateDataEncryption {
   public static void setupClass() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA, true);
-
-    // Set the jvm arguments.
-    conf.set(MRJobConfig.MR_AM_ADMIN_COMMAND_OPTS,
-        JVM_SECURITY_EGD_OPT);
-    final String childJVMOpts = JVM_SECURITY_EGD_OPT
-        + " " + conf.get("mapred.child.java.opts", " ");
-    conf.set("mapred.child.java.opts", childJVMOpts);
-
 
     // Start the mini-MR and mini-DFS clusters.
     dfsCluster = new MiniDFSCluster.Builder(conf)

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -87,10 +87,20 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
-docker run --rm=true $DOCKER_INTERACTIVE_RUN \
-  -v "${PWD}:${DOCKER_HOME_DIR}/hadoop${V_OPTS:-}" \
-  -w "${DOCKER_HOME_DIR}/hadoop" \
-  -v "${HOME}/.m2:${DOCKER_HOME_DIR}/.m2${V_OPTS:-}" \
-  -v "${HOME}/.gnupg:${DOCKER_HOME_DIR}/.gnupg${V_OPTS:-}" \
-  -u "${USER_ID}" \
+dockerargs=(--rm=true)
+dockerargs+=($DOCKER_INTERACTIVE_RUN)
+# use urandom to increase entropy
+dockerargs+=(-v "/dev/urandom:/dev/random${V_OPTS:-}")
+# mount current directory
+dockerargs+=(-v "${PWD}:${DOCKER_HOME_DIR}/hadoop${V_OPTS:-}")
+# mount maven directory
+dockerargs+=(-v "${HOME}/.m2:${DOCKER_HOME_DIR}/.m2${V_OPTS:-}")
+# mount gnu
+dockerargs+=(-v "${HOME}/.gnupg:${DOCKER_HOME_DIR}/.gnupg${V_OPTS:-}")
+# set work directory
+dockerargs+=(-w "${DOCKER_HOME_DIR}/hadoop")
+# set user
+dockerargs+=(-u "${USER_ID}")
+
+docker run "${dockerargs[@]}" \
   "hadoop-build-${USER_ID}" "$@"

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -87,7 +87,7 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
-dockerargs=(--rm=true)
+dockerargs=("--rm=true")
 dockerargs+=($DOCKER_INTERACTIVE_RUN)
 # use urandom to increase entropy
 dockerargs+=(-v "/dev/urandom:/dev/random${V_OPTS:-}")
@@ -101,6 +101,8 @@ dockerargs+=(-v "${HOME}/.gnupg:${DOCKER_HOME_DIR}/.gnupg${V_OPTS:-}")
 dockerargs+=(-w "${DOCKER_HOME_DIR}/hadoop")
 # set user
 dockerargs+=(-u "${USER_ID}")
+
+set -x
 
 docker run "${dockerargs[@]}" \
   "hadoop-build-${USER_ID}" "$@"

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -87,7 +87,7 @@ DOCKER_INTERACTIVE_RUN=${DOCKER_INTERACTIVE_RUN-"-i -t"}
 # within the container and use the result on your normal
 # system.  And this also is a significant speedup in subsequent
 # builds because the dependencies are downloaded only once.
-dockerargs=("--rm=true")
+dockerargs=(--rm=true)
 dockerargs+=($DOCKER_INTERACTIVE_RUN)
 # use urandom to increase entropy
 dockerargs+=(-v "/dev/urandom:/dev/random${V_OPTS:-}")
@@ -101,8 +101,6 @@ dockerargs+=(-v "${HOME}/.gnupg:${DOCKER_HOME_DIR}/.gnupg${V_OPTS:-}")
 dockerargs+=(-w "${DOCKER_HOME_DIR}/hadoop")
 # set user
 dockerargs+=(-u "${USER_ID}")
-
-set -x
 
 docker run "${dockerargs[@]}" \
   "hadoop-build-${USER_ID}" "$@"


### PR DESCRIPTION
[HADOOP-16810: Increase entropy to improve cryptographic randomness on precommit Linux VMs](https://issues.apache.org/jira/browse/HADOOP-16810)
In [my comment on MAPREDUCE-7079](https://issues.apache.org/jira/browse/MAPREDUCE-7079?focusedCommentId=17013234&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17013234)
This test case has been failing for ever.
 - When it timeout, MRAppMaster and some YarnChild processes remain running in the background. Therefore, the JVM running the tests fail due to OOM. No one notices that this unit test case has failed because the QA reports the unit tests that failed, but not timeout.
- It works for Mac OS X, but never works for Linux running on a virtual Box. It only works on the latter by disabling MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA.

In this PR:

- the `DOCKER_EXTRAARGS` are added to `hadoop.sh` to pass the random mount
- ~~the version 0.10.0 is not on the release page. So, this is upgrading the Yetus to a released version 0.13.0.~~
- adding the mount parameter to start `start-build-env.sh`
