### PR TITLE
HADOOP-17529. Upgrade os-maven-plugin to 1.7.0

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <protobuf.version>3.6.1</protobuf.version>
         <grpc.version>1.26.0</grpc.version>
-        <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This would enable support for RISC-V arch.

CC @trustin

https://issues.apache.org/jira/browse/HADOOP-17529