### PR TITLE
HADOOP-17529. Upgrade os-maven-plugin to 1.7.0

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -150,7 +150,7 @@
 
     <protobuf-compile.version>3.5.1</protobuf-compile.version>
     <grpc.version>1.10.0</grpc.version>
-    <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+    <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>


### PR DESCRIPTION
In favor of supporting RISC-V architecture.

CC @trustin

https://issues.apache.org/jira/browse/HADOOP-17529