### PR TITLE
HDFS-15836. RBF: Fix contract tests after HADOOP-13327

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/resources/contract/hdfs.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/resources/contract/hdfs.xml
@@ -111,4 +111,19 @@
     <value>true</value>
   </property>
 
+  <property>
+    <name>fs.contract.supports-hflush</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-hsync</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.metadata_updated_on_hsync</name>
+    <value>false</value>
+  </property>
+
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/resources/contract/webhdfs.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/resources/contract/webhdfs.xml
@@ -28,4 +28,19 @@
     <value>true</value>
   </property>
 
+  <property>
+    <name>fs.contract.supports-hflush</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-hsync</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.metadata_updated_on_hsync</name>
+    <value>false</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15836

Fix the following tests:
- TestRouterHDFSContractCreate
- TestRouterHDFSContractCreateSecure
- TestRouterWebHDFSContractCreate