### PR TITLE
HADOOP-17109. add guava BaseEncoding to illegalClasses

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -122,7 +122,7 @@
         <module name="IllegalImport">
           <property name="regexp" value="true"/>
           <property name="illegalPkgs" value="sun, com\.google\.common"/>
-          <property name="illegalClasses" value="^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.base\.(Optional|Function|Predicate|Supplier), ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.collect\.(ImmutableListMultimap)"/>
+          <property name="illegalClasses" value="^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.io\.BaseEncoding, ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.base\.(Optional|Function|Predicate|Supplier), ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.collect\.(ImmutableListMultimap)"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>


### PR DESCRIPTION
[HADOOP-17109: Replace Guava base64Url and base64 with Java8+ base64](https://issues.apache.org/jira/browse/HADOOP-17109)

The hadoop source code relies on `org.apache.commons.` for Base64. 
This PR is to add the `com.google.common.io.BaseEncoding` to illegal classes in order to prevent using the guava import in future commits.

- This PR only touches the checkstyle configuration.
- There are no occurrences of `com.google.common.io.BaseEncoding` in the code.