### PR TITLE
MAPREDUCE-7320. cleanup test data after ClusterMapReduceTestCase

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -230,6 +230,31 @@ public abstract class GenericTestUtils {
   }
 
   /**
+   * Creates a directory for the data/logs of the unit test.
+   * It first delete the directory if it exists.
+   *
+   * @param testClass the unit test class.
+   * @param defaultTargetRootDir the directory where the class directory is
+   *                             created.
+   * @return the Path of the root directory.
+   */
+  public static Path setupTestRootDir(Class<?> testClass,
+      String defaultTargetRootDir) {
+    // setup the test root directory
+    String targetTestDir =
+        System.getProperty(SYSPROP_TEST_DATA_DIR, defaultTargetRootDir);
+    Path testRootDirPath =
+        new Path(targetTestDir, testClass.getSimpleName());
+    System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
+        testRootDirPath.toString());
+    // delete the folder if it exists
+    File rootDir = clearTestRootDir();
+    // create the directory
+    rootDir.mkdirs();
+    return testRootDirPath;
+  }
+
+  /**
    * Get the (created) base directory for tests.
    * @return the absolute directory
    */
@@ -243,6 +268,18 @@ public abstract class GenericTestUtils {
     dir.mkdirs();
     assertExists(dir);
     return dir;
+  }
+
+  /**
+   * Cleans-up the root directory from the property
+   * {@link #SYSPROP_TEST_DATA_DIR}.
+   *
+   * @return the absolute file of the test root directory.
+   */
+  public static File clearTestRootDir() {
+    File testRootDir = getTestDir();
+    FileUtil.fullyDelete(testRootDir);
+    return testRootDir;
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
@@ -17,17 +17,14 @@
  */
 package org.apache.hadoop.mapred;
 
-import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -55,26 +52,14 @@ public abstract class ClusterMapReduceTestCase {
   private MiniDFSCluster dfsCluster = null;
   private MiniMRClientCluster mrCluster = null;
 
-  protected static void setupClassBase(String testClassName) throws Exception {
+  protected static void setupClassBase(Class<?> testClass) throws Exception {
     // setup the test root directory
-    testRootDir =
-        new Path(TEST_ROOT_DEFAULT_PATH, testClassName);
+    testRootDir = GenericTestUtils.setupTestRootDir(testClass,
+        TEST_ROOT_DEFAULT_PATH);
     System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
         testRootDir.toString());
   }
 
-  protected static void clearRootDirectory() throws Exception {
-    // delete the entire test directory
-    File rootDir = new File(testRootDir.toString());
-    FileContext.getLocalFSFileContext().delete(
-        new Path(rootDir.getAbsoluteFile().getPath()), true);
-  }
-
-  @AfterClass
-  public static void tearDownClass() throws Exception {
-    // delete the entire test directory
-    clearRootDirectory();
-  }
 
   /**
    * Creates Hadoop Cluster and DFS before a test case is run.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
@@ -17,12 +17,17 @@
  */
 package org.apache.hadoop.mapred;
 
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.GenericTestUtils;
+
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -43,8 +48,33 @@ import java.util.Properties;
  * The DFS filesystem is formated before the testcase starts and after it ends.
  */
 public abstract class ClusterMapReduceTestCase {
+  private static final String TEST_ROOT_DEFAULT_PATH =
+      System.getProperty("test.build.data", "target/test-dir");
+  private static Path testRootDir;
+
   private MiniDFSCluster dfsCluster = null;
-  private MiniMRCluster mrCluster = null;
+  private MiniMRClientCluster mrCluster = null;
+
+  protected static void setupClassBase(String testClassName) throws Exception {
+    // setup the test root directory
+    testRootDir =
+        new Path(TEST_ROOT_DEFAULT_PATH, testClassName);
+    System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
+        testRootDir.toString());
+  }
+
+  protected static void clearRootDirectory() throws Exception {
+    // delete the entire test directory
+    File rootDir = new File(testRootDir.toString());
+    FileContext.getLocalFSFileContext().delete(
+        new Path(rootDir.getAbsoluteFile().getPath()), true);
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    // delete the entire test directory
+    clearRootDirectory();
+  }
 
   /**
    * Creates Hadoop Cluster and DFS before a test case is run.
@@ -81,34 +111,7 @@ public abstract class ClusterMapReduceTestCase {
       dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2)
       .format(reformatDFS).racks(null).build();
 
-      ConfigurableMiniMRCluster.setConfiguration(props);
-      //noinspection deprecation
-      mrCluster = new ConfigurableMiniMRCluster(2,
-          getFileSystem().getUri().toString(), 1, conf);
-    }
-  }
-
-  private static class ConfigurableMiniMRCluster extends MiniMRCluster {
-    private static Properties config;
-
-    public static void setConfiguration(Properties props) {
-      config = props;
-    }
-
-    public ConfigurableMiniMRCluster(int numTaskTrackers, String namenode,
-                                     int numDir, JobConf conf)
-        throws Exception {
-      super(0,0, numTaskTrackers, namenode, numDir, null, null, null, conf);
-    }
-
-    public JobConf createJobConf() {
-      JobConf conf = super.createJobConf();
-      if (config != null) {
-        for (Map.Entry entry : config.entrySet()) {
-          conf.set((String) entry.getKey(), (String) entry.getValue());
-        }
-      }
-      return conf;
+      mrCluster = MiniMRClientClusterFactory.create(this.getClass(), 2, conf);
     }
   }
 
@@ -125,7 +128,7 @@ public abstract class ClusterMapReduceTestCase {
    */
   protected void stopCluster() throws Exception {
     if (mrCluster != null) {
-      mrCluster.shutdown();
+      mrCluster.stop();
       mrCluster = null;
     }
     if (dfsCluster != null) {
@@ -157,17 +160,13 @@ public abstract class ClusterMapReduceTestCase {
     return dfsCluster.getFileSystem();
   }
 
-  protected MiniMRCluster getMRCluster() {
-    return mrCluster;
-  }
-
   /**
    * Returns the path to the root directory for the testcase.
    *
    * @return path to the root directory for the testcase.
    */
   protected Path getTestRootDir() {
-    return new Path("x").getParent();
+    return testRootDir;
   }
 
   /**
@@ -194,8 +193,8 @@ public abstract class ClusterMapReduceTestCase {
    *
    * @return configuration that works on the testcase Hadoop instance
    */
-  protected JobConf createJobConf() {
-    return mrCluster.createJobConf();
+  protected JobConf createJobConf() throws IOException {
+    return new JobConf(mrCluster.getConfig());
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
@@ -63,7 +63,7 @@ public class TestBadRecords extends ClusterMapReduceTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    setupClassBase(TestBadRecords.class.getSimpleName());
+    setupClassBase(TestBadRecords.class);
   }
 
   public TestBadRecords() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.util.ReflectionUtils;
+
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -58,7 +60,12 @@ public class TestBadRecords extends ClusterMapReduceTestCase {
     Arrays.asList("hello08","hello10");
   
   private List<String> input;
-  
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestBadRecords.class.getSimpleName());
+  }
+
   public TestBadRecords() {
     input = new ArrayList<String>();
     for(int i=1;i<=10;i++) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
@@ -41,7 +41,7 @@ public class TestClusterMapReduceTestCase extends ClusterMapReduceTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    setupClassBase(TestClusterMapReduceTestCase.class.getSimpleName());
+    setupClassBase(TestClusterMapReduceTestCase.class);
   }
 
   public void _testMapReduce(boolean restart) throws Exception {
@@ -96,7 +96,6 @@ public class TestClusterMapReduceTestCase extends ClusterMapReduceTestCase {
       reader.close();
       assertEquals(4, counter);
     }
-
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -36,6 +38,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 public class TestClusterMapReduceTestCase extends ClusterMapReduceTestCase {
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestClusterMapReduceTestCase.class.getSimpleName());
+  }
+
   public void _testMapReduce(boolean restart) throws Exception {
     OutputStream os = getFileSystem().create(new Path(getInputDir(), "text.txt"));
     Writer wr = new OutputStreamWriter(os);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
@@ -29,11 +29,18 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class TestJobName extends ClusterMapReduceTestCase {
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestJobName.class.getSimpleName());
+  }
 
   @Test
   public void testComplexName() throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
@@ -39,7 +39,7 @@ public class TestJobName extends ClusterMapReduceTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    setupClassBase(TestJobName.class.getSimpleName());
+    setupClassBase(TestJobName.class);
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
@@ -37,7 +37,7 @@ public class TestMRCJCJobClient extends TestMRJobClient {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    setupClassBase(TestMRCJCJobClient.class.getSimpleName());
+    setupClassBase(TestMRCJCJobClient.class);
   }
 
   private String runJob() throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
@@ -29,10 +29,17 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TestMRJobClient;
 import org.apache.hadoop.mapreduce.tools.CLI;
 import org.apache.hadoop.util.Tool;
+
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 @Ignore
 public class TestMRCJCJobClient extends TestMRJobClient {
-  
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestMRCJCJobClient.class.getSimpleName());
+  }
+
   private String runJob() throws Exception {
     OutputStream os = getFileSystem().create(new Path(getInputDir(),
                         "text.txt"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,11 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMRJobClient.class);
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestMRJobClient.class.getSimpleName());
+  }
 
   private Job runJob(Configuration conf) throws Exception {
     String input = "hello1\nhello2\nhello3\n";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
@@ -66,7 +66,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    setupClassBase(TestMRJobClient.class.getSimpleName());
+    setupClassBase(TestMRJobClient.class);
   }
 
   private Job runJob(Configuration conf) throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.mapreduce.security.ssl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -35,7 +34,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -58,20 +56,8 @@ public class TestEncryptedShuffle {
   @BeforeClass
   public static void setUp() throws Exception {
     testRootDir =
-        new Path(TEST_ROOT_DEFAULT_PATH,
-            TestEncryptedShuffle.class.getSimpleName());
-    System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
-        testRootDir.toString());
-    File base = new File(testRootDir.toString());
-    FileUtil.fullyDelete(base);
-    base.mkdirs();
-  }
-
-  @AfterClass
-  public static void tearDownClass() throws Exception {
-    // delete the entire test directory
-    File rootDir = new File(testRootDir.toString());
-    FileUtil.fullyDelete(rootDir);
+        GenericTestUtils.setupTestRootDir(TestEncryptedShuffle.class,
+            TEST_ROOT_DEFAULT_PATH);
   }
 
   @Before

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingBadRecords.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingBadRecords.java
@@ -68,7 +68,7 @@ public class TestStreamingBadRecords extends ClusterMapReduceTestCase
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    setupClassBase(TestStreamingBadRecords.class.getSimpleName());
+    setupClassBase(TestStreamingBadRecords.class);
   }
 
   public TestStreamingBadRecords() throws IOException

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingBadRecords.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingBadRecords.java
@@ -31,13 +31,13 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.ClusterMapReduceTestCase;
 import org.apache.hadoop.mapred.Counters;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.SkipBadRecords;
 import org.apache.hadoop.mapred.Utils;
@@ -65,7 +65,12 @@ public class TestStreamingBadRecords extends ClusterMapReduceTestCase
   private static final String badReducer = 
     UtilTest.makeJavaCommand(BadApp.class, new String[]{"true"});
   private static final int INPUTSIZE=100;
-  
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestStreamingBadRecords.class.getSimpleName());
+  }
+
   public TestStreamingBadRecords() throws IOException
   {
     UtilTest utilTest = new UtilTest(getClass().getName());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
@@ -172,7 +172,7 @@ public class MiniYARNCluster extends CompositeService {
     this.numLocalDirs = numLocalDirs;
     this.numLogDirs = numLogDirs;
     this.enableAHS = enableAHS;
-    String testSubDir = testName.replace("$", "");
+    String testSubDir = testName.replace("$", "").concat("-yarn");
     File targetWorkDirRoot = GenericTestUtils.getTestDir();
     File targetWorkDir = new File(targetWorkDirRoot, testSubDir);
     try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
@@ -172,7 +173,8 @@ public class MiniYARNCluster extends CompositeService {
     this.numLogDirs = numLogDirs;
     this.enableAHS = enableAHS;
     String testSubDir = testName.replace("$", "");
-    File targetWorkDir = new File("target", testSubDir);
+    File targetWorkDirRoot = GenericTestUtils.getTestDir();
+    File targetWorkDir = new File(targetWorkDirRoot, testSubDir);
     try {
       FileContext.getLocalFSFileContext().delete(
           new Path(targetWorkDir.getAbsolutePath()), true);


### PR DESCRIPTION
[MAPREDUCE-7320: ClusterMapReduceTestCase does not clean directories](https://issues.apache.org/jira/browse/MAPREDUCE-7320)

Running Junits that extend ClusterMapReduceTestCase generate lots of directories and folders without cleaning them up.

This PR addresses cleaning up the clusters directories after finishing the unit tests.

- It touches `MiniYARNCluster.java` in order to change the base dir to `target/test-dir/$TEST_CLASS_NAME`
- test classes affected

  - TestMRJobClient,
  - TestStreamingBadRecords,
  - TestClusterMapReduceTestCase,
  - TestBadRecords.
  - TestMRCJCJobClient,
  - TestJobName

I tested the TestUnits that use `MiniYARNCluster.java` such as:

```bash
Class
    MiniYARNCluster

        TestOSSMiniYarnCluster  (3 usages found)
        TestMRTimelineEventHandling  (4 usages found)
        TestJobHistoryEventHandler  (3 usages found)
        TestHadoopArchiveLogs  (3 usages found)
        TestHadoopArchiveLogsRunner  (3 usages found)
        TestDynamometerInfra  (3 usages found)
        TestDSTimelineV10
        TestDSTimelineV20
        TestDSTimelineV15
        TestUnmanagedAMLauncher  (3 usages found)
        TestApplicationMasterServiceProtocolForTimelineV2
        TestFederationRMFailoverProxyProvider  (3 usages found)
        TestHedgingRequestRMFailoverProxyProvider  (4 usages found)
        TestNoHaRMFailoverProxyProvider  (5 usages found)
        TestRMFailover  (4 usages found)
        TestAMRMClient
        TestAMRMClientPlacementConstraints
        TestAMRMProxy  (5 usages found)
        TestNMClient  (3 usages found)
        TestOpportunisticContainerAllocationE2E  (3 usages found)
        TestYarnClient  (3 usages found)
        TestYarnClientWithReservation  (12 usages found)
        TestYarnCLI  (7 usages found)
        TestContainerManagerSecurity  (2 usages found)
        TestDiskFailures  (2 usages found)
        TestMiniYarnCluster  (9 usages found)
        TestMiniYARNClusterForHA  (2 usages found)
        TestMiniYarnClusterNodeUtilization  (3 usages found)
        TestEncryptedShuffle
```
