### PR TITLE
HDFS-15845. RBF: Router fails to start due to NoClassDefFoundError for hadoop-federation-balance.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/bin/hdfs
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/bin/hdfs
@@ -112,6 +112,7 @@ function hdfscmd_case
       HADOOP_CLASSNAME=org.apache.hadoop.hdfs.tools.DFSAdmin
     ;;
     dfsrouter)
+      hadoop_add_to_classpath_tools hadoop-federation-balance
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
       HADOOP_CLASSNAME='org.apache.hadoop.hdfs.server.federation.router.DFSRouter'
     ;;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15845