### PR TITLE
HADOOP-17537. ABFS: Correct assertion reversed in HADOOP-13327

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -326,7 +326,8 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
     try (FSDataOutputStream stream = getStreamAfterWrite(fs, testFilePath, buffer, true)) {
       assertHasStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
-          StreamCapabilities.HSYNC,
+          StreamCapabilities.HSYNC);
+      assertLacksStreamCapabilities(stream,
           StreamCapabilities.DROPBEHIND,
           StreamCapabilities.READAHEAD,
           StreamCapabilities.UNBUFFER);


### PR DESCRIPTION
HADOOP-13327 introduces, among other changes, functions to simplify assert for checking stream capabilities. This change fixes (originally) assertFalse statements whose logic has been reversed to assertTrue by the [PR](https://github.com/apache/hadoop/pull/2587/files).
