### PR TITLE
HADOOP-17538. Add kms-default.xml and httpfs-default.xml to site index.

### DIFF
--- a/hadoop-project/src/site/site.xml
+++ b/hadoop-project/src/site/site.xml
@@ -216,6 +216,8 @@
       <item name="hdfs-rbf-default.xml" href="hadoop-project-dist/hadoop-hdfs-rbf/hdfs-rbf-default.xml"/>
       <item name="mapred-default.xml" href="hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml"/>
       <item name="yarn-default.xml" href="hadoop-yarn/hadoop-yarn-common/yarn-default.xml"/>
+      <item name="kms-default.xml" href="hadoop-kms/kms-default.html"/>
+      <item name="httpfs-default.xml" href="hadoop-hdfs-httpfs/httpfs-default.html"/>
       <item name="Deprecated Properties" href="hadoop-project-dist/hadoop-common/DeprecatedProperties.html"/>
     </menu>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17538

While there are links to *-default.xml in the site index, kms-default.xml and httpfs-default.xml are not included. Adding them could be useful as a quick reference.

Since HTMLs are generated by XSL for hadoop-kms and hadoop-hdfs-httpfs on `mvn site`, just adding link to the .html should work.