### PR TITLE
MAPREDUCE-7320. organize test directories for ClusterMapReduceTestCase

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -230,6 +230,31 @@ public abstract class GenericTestUtils {
   }
 
   /**
+   * Creates a directory for the data/logs of the unit test.
+   * It first delete the directory if it exists.
+   *
+   * @param testClass the unit test class.
+   * @param defaultTargetRootDir the directory where the class directory is
+   *                             created.
+   * @return the Path of the root directory.
+   */
+  public static Path setupTestRootDir(Class<?> testClass,
+      String defaultTargetRootDir) {
+    // setup the test root directory
+    String targetTestDir =
+        System.getProperty(SYSPROP_TEST_DATA_DIR, defaultTargetRootDir);
+    Path testRootDirPath =
+        new Path(targetTestDir, testClass.getSimpleName());
+    System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
+        testRootDirPath.toString());
+    // delete the folder if it exists
+    File rootDir = clearTestRootDir();
+    // create the directory
+    rootDir.mkdirs();
+    return testRootDirPath;
+  }
+
+  /**
    * Get the (created) base directory for tests.
    * @return the absolute directory
    */
@@ -243,6 +268,18 @@ public abstract class GenericTestUtils {
     dir.mkdirs();
     assertExists(dir);
     return dir;
+  }
+
+  /**
+   * Cleans-up the root directory from the property
+   * {@link #SYSPROP_TEST_DATA_DIR}.
+   *
+   * @return the absolute file of the test root directory.
+   */
+  public static File clearTestRootDir() {
+    File testRootDir = getTestDir();
+    FileUtil.fullyDelete(testRootDir);
+    return testRootDir;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -231,27 +231,18 @@ public abstract class GenericTestUtils {
 
   /**
    * Creates a directory for the data/logs of the unit test.
-   * It first delete the directory if it exists.
+   * It first deletes the directory if it exists.
    *
    * @param testClass the unit test class.
-   * @param defaultTargetRootDir the directory where the class directory is
-   *                             created.
    * @return the Path of the root directory.
    */
-  public static Path setupTestRootDir(Class<?> testClass,
-      String defaultTargetRootDir) {
-    // setup the test root directory
-    String targetTestDir =
-        System.getProperty(SYSPROP_TEST_DATA_DIR, defaultTargetRootDir);
-    Path testRootDirPath =
-        new Path(targetTestDir, testClass.getSimpleName());
-    System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
-        testRootDirPath.toString());
-    // delete the folder if it exists
-    File rootDir = clearTestRootDir();
-    // create the directory
-    rootDir.mkdirs();
-    return testRootDirPath;
+  public static File setupTestRootDir(Class<?> testClass) {
+    File testRootDir = getTestDir(testClass.getSimpleName());
+    if (testRootDir.exists()) {
+      FileUtil.fullyDelete(testRootDir);
+    }
+    testRootDir.mkdirs();
+    return testRootDir;
   }
 
   /**
@@ -268,18 +259,6 @@ public abstract class GenericTestUtils {
     dir.mkdirs();
     assertExists(dir);
     return dir;
-  }
-
-  /**
-   * Cleans-up the root directory from the property
-   * {@link #SYSPROP_TEST_DATA_DIR}.
-   *
-   * @return the absolute file of the test root directory.
-   */
-  public static File clearTestRootDir() {
-    File testRootDir = getTestDir();
-    FileUtil.fullyDelete(testRootDir);
-    return testRootDir;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/JarFinder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/JarFinder.java
@@ -132,6 +132,10 @@ public class JarFinder {
    * @return path to the Jar containing the class.
    */
   public static String getJar(Class klass) {
+    return getJar(klass, null);
+  }
+
+  public static String getJar(Class klass, String testSubDir) {
     Preconditions.checkNotNull(klass, "klass");
     ClassLoader loader = klass.getClassLoader();
     if (loader != null) {
@@ -154,7 +158,9 @@ public class JarFinder {
             klassName = klassName.replace(".", "/") + ".class";
             path = path.substring(0, path.length() - klassName.length());
             File baseDir = new File(path);
-            File testDir = GenericTestUtils.getTestDir();
+            File testDir =
+                testSubDir == null ? GenericTestUtils.getTestDir()
+                    : GenericTestUtils.getTestDir(testSubDir);
             testDir = testDir.getAbsoluteFile();
             if (!testDir.exists()) {
               testDir.mkdirs();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -45,19 +46,16 @@ import java.util.Properties;
  * The DFS filesystem is formated before the testcase starts and after it ends.
  */
 public abstract class ClusterMapReduceTestCase {
-  private static final String TEST_ROOT_DEFAULT_PATH =
-      System.getProperty("test.build.data", "target/test-dir");
-  private static Path testRootDir;
+  private static File testRootDir;
+  private static File dfsFolder;
 
   private MiniDFSCluster dfsCluster = null;
   private MiniMRClientCluster mrCluster = null;
 
   protected static void setupClassBase(Class<?> testClass) throws Exception {
     // setup the test root directory
-    testRootDir = GenericTestUtils.setupTestRootDir(testClass,
-        TEST_ROOT_DEFAULT_PATH);
-    System.setProperty(GenericTestUtils.SYSPROP_TEST_DATA_DIR,
-        testRootDir.toString());
+    testRootDir = GenericTestUtils.setupTestRootDir(testClass);
+    dfsFolder = new File(testRootDir, "dfs");
   }
 
 
@@ -93,9 +91,9 @@ public abstract class ClusterMapReduceTestCase {
           conf.set((String) entry.getKey(), (String) entry.getValue());
         }
       }
-      dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2)
-      .format(reformatDFS).racks(null).build();
-
+      dfsCluster =
+          new MiniDFSCluster.Builder(conf, dfsFolder)
+              .numDataNodes(2).format(reformatDFS).racks(null).build();
       mrCluster = MiniMRClientClusterFactory.create(this.getClass(), 2, conf);
     }
   }
@@ -151,7 +149,7 @@ public abstract class ClusterMapReduceTestCase {
    * @return path to the root directory for the testcase.
    */
   protected Path getTestRootDir() {
-    return testRootDir;
+    return new Path(testRootDir.getPath());
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MiniMRClientClusterFactory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MiniMRClientClusterFactory.java
@@ -55,7 +55,8 @@ public class MiniMRClientClusterFactory {
     Path appJar = new Path(testRootDir, "MRAppJar.jar");
 
     // Copy MRAppJar and make it private.
-    Path appMasterJar = new Path(MiniMRYarnCluster.APPJAR);
+    Path appMasterJar =
+        new Path(MiniMRYarnCluster.copyAppJarIntoTestDir(identifier));
 
     fs.copyFromLocalFile(appMasterJar, appJar);
     fs.setPermission(appJar, new FsPermission("744"));
@@ -64,7 +65,7 @@ public class MiniMRClientClusterFactory {
 
     job.addFileToClassPath(appJar);
 
-    Path callerJar = new Path(JarFinder.getJar(caller));
+    Path callerJar = new Path(JarFinder.getJar(caller, identifier));
     Path remoteCallerJar = new Path(testRootDir, callerJar.getName());
     fs.copyFromLocalFile(callerJar, remoteCallerJar);
     fs.setPermission(remoteCallerJar, new FsPermission("744"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.util.ReflectionUtils;
+
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -58,7 +60,12 @@ public class TestBadRecords extends ClusterMapReduceTestCase {
     Arrays.asList("hello08","hello10");
   
   private List<String> input;
-  
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestBadRecords.class);
+  }
+
   public TestBadRecords() {
     input = new ArrayList<String>();
     for(int i=1;i<=10;i++) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -36,6 +38,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 public class TestClusterMapReduceTestCase extends ClusterMapReduceTestCase {
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestClusterMapReduceTestCase.class);
+  }
+
   public void _testMapReduce(boolean restart) throws Exception {
     OutputStream os = getFileSystem().create(new Path(getInputDir(), "text.txt"));
     Writer wr = new OutputStreamWriter(os);
@@ -88,7 +96,6 @@ public class TestClusterMapReduceTestCase extends ClusterMapReduceTestCase {
       reader.close();
       assertEquals(4, counter);
     }
-
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
@@ -29,11 +29,18 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class TestJobName extends ClusterMapReduceTestCase {
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestJobName.class);
+  }
 
   @Test
   public void testComplexName() throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
@@ -29,10 +29,17 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TestMRJobClient;
 import org.apache.hadoop.mapreduce.tools.CLI;
 import org.apache.hadoop.util.Tool;
+
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 @Ignore
 public class TestMRCJCJobClient extends TestMRJobClient {
-  
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestMRCJCJobClient.class);
+  }
+
   private String runJob() throws Exception {
     OutputStream os = getFileSystem().create(new Path(getInputDir(),
                         "text.txt"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,11 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMRJobClient.class);
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestMRJobClient.class);
+  }
 
   private Job runJob(Configuration conf) throws Exception {
     String input = "hello1\nhello2\nhello3\n";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.mapreduce.security.ssl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -31,37 +30,34 @@ import org.apache.hadoop.mapred.RunningJob;
 
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.Assert;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.net.URL;
 
 public class TestEncryptedShuffle {
 
-  private static final String BASEDIR =
-    System.getProperty("test.build.dir", "target/test-dir") + "/" +
-    TestEncryptedShuffle.class.getSimpleName();
-  
+  private static final String TEST_ROOT_DEFAULT_PATH =
+      System.getProperty("test.build.data", "target/test-dir");
+
+  private static Path testRootDir;
   private String classpathDir;
 
   @BeforeClass
   public static void setUp() throws Exception {
-    File base = new File(BASEDIR);
-    FileUtil.fullyDelete(base);
-    base.mkdirs();
+    testRootDir =
+        GenericTestUtils.setupTestRootDir(TestEncryptedShuffle.class,
+            TEST_ROOT_DEFAULT_PATH);
   }
 
   @Before
@@ -73,7 +69,7 @@ public class TestEncryptedShuffle {
   @After
   public void cleanUpMiniClusterSpecialConfig() throws Exception {
     new File(classpathDir, "core-site.xml").delete();
-    String keystoresDir = new File(BASEDIR).getAbsolutePath();
+    String keystoresDir = new File(testRootDir.toString()).getAbsolutePath();
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, classpathDir);
   }
 
@@ -82,7 +78,7 @@ public class TestEncryptedShuffle {
 
   private void startCluster(Configuration  conf) throws Exception {
     if (System.getProperty("hadoop.log.dir") == null) {
-      System.setProperty("hadoop.log.dir", "target/test-dir");
+      System.setProperty("hadoop.log.dir", testRootDir.toString());
     }
     conf.set("dfs.block.access.token.enable", "false");
     conf.set("dfs.permissions", "true");
@@ -129,7 +125,7 @@ public class TestEncryptedShuffle {
     throws Exception {
     try {
       Configuration conf = new Configuration();
-      String keystoresDir = new File(BASEDIR).getAbsolutePath();
+      String keystoresDir = new File(testRootDir.toString()).getAbsolutePath();
       String sslConfsDir =
         KeyStoreTestUtil.getClasspathDir(TestEncryptedShuffle.class);
       KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfsDir, conf,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.After;
 import org.junit.Before;
@@ -48,20 +49,19 @@ import java.io.Writer;
 public class TestEncryptedShuffle {
 
   private static File testRootDir;
-  private static File dfsFolder;
-  private String classpathDir;
 
   @BeforeClass
   public static void setUp() throws Exception {
     testRootDir =
         GenericTestUtils.setupTestRootDir(TestEncryptedShuffle.class);
-    dfsFolder = new File(testRootDir, "dfs");
   }
 
   @Before
   public void createCustomYarnClasspath() throws Exception {
     classpathDir = KeyStoreTestUtil.getClasspathDir(TestEncryptedShuffle.class);
     new File(classpathDir, "core-site.xml").delete();
+    dfsFolder = new File(testRootDir, String.format("dfs-%d",
+        Time.monotonicNow()));
   }
 
   @After
@@ -71,8 +71,10 @@ public class TestEncryptedShuffle {
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, classpathDir);
   }
 
+  private String classpathDir;
   private MiniDFSCluster dfsCluster = null;
   private MiniMRClientCluster mrCluster = null;
+  private File dfsFolder;
 
   private void startCluster(Configuration  conf) throws Exception {
     if (System.getProperty("hadoop.log.dir") == null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
@@ -47,17 +47,15 @@ import java.io.Writer;
 
 public class TestEncryptedShuffle {
 
-  private static final String TEST_ROOT_DEFAULT_PATH =
-      System.getProperty("test.build.data", "target/test-dir");
-
-  private static Path testRootDir;
+  private static File testRootDir;
+  private static File dfsFolder;
   private String classpathDir;
 
   @BeforeClass
   public static void setUp() throws Exception {
     testRootDir =
-        GenericTestUtils.setupTestRootDir(TestEncryptedShuffle.class,
-            TEST_ROOT_DEFAULT_PATH);
+        GenericTestUtils.setupTestRootDir(TestEncryptedShuffle.class);
+    dfsFolder = new File(testRootDir, "dfs");
   }
 
   @Before
@@ -69,7 +67,7 @@ public class TestEncryptedShuffle {
   @After
   public void cleanUpMiniClusterSpecialConfig() throws Exception {
     new File(classpathDir, "core-site.xml").delete();
-    String keystoresDir = new File(testRootDir.toString()).getAbsolutePath();
+    String keystoresDir = testRootDir.getAbsolutePath();
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, classpathDir);
   }
 
@@ -78,7 +76,7 @@ public class TestEncryptedShuffle {
 
   private void startCluster(Configuration  conf) throws Exception {
     if (System.getProperty("hadoop.log.dir") == null) {
-      System.setProperty("hadoop.log.dir", testRootDir.toString());
+      System.setProperty("hadoop.log.dir", testRootDir.getAbsolutePath());
     }
     conf.set("dfs.block.access.token.enable", "false");
     conf.set("dfs.permissions", "true");
@@ -88,7 +86,7 @@ public class TestEncryptedShuffle {
             YarnConfiguration.DEFAULT_YARN_CROSS_PLATFORM_APPLICATION_CLASSPATH))
         + File.pathSeparator + classpathDir;
     conf.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH, cp);
-    dfsCluster = new MiniDFSCluster.Builder(conf).build();
+    dfsCluster = new MiniDFSCluster.Builder(conf, dfsFolder).build();
     FileSystem fileSystem = dfsCluster.getFileSystem();
     fileSystem.mkdirs(new Path("/tmp"));
     fileSystem.mkdirs(new Path("/user"));
@@ -125,7 +123,7 @@ public class TestEncryptedShuffle {
     throws Exception {
     try {
       Configuration conf = new Configuration();
-      String keystoresDir = new File(testRootDir.toString()).getAbsolutePath();
+      String keystoresDir = testRootDir.getAbsolutePath();
       String sslConfsDir =
         KeyStoreTestUtil.getClasspathDir(TestEncryptedShuffle.class);
       KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfsDir, conf,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/MiniMRYarnCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/MiniMRYarnCluster.java
@@ -87,6 +87,10 @@ public class MiniMRYarnCluster extends MiniYARNCluster {
     super(testName, 1, noOfNMs, 4, 4, enableAHS);
   }
 
+  public static String copyAppJarIntoTestDir(String testSubdir) {
+    return JarFinder.getJar(LocalContainerLauncher.class, testSubdir);
+  }
+
   public static String getResolvedMRHistoryWebAppURLWithoutScheme(
       Configuration conf, boolean isSSLEnabled) {
     InetSocketAddress address = null;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/MiniMRYarnCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/MiniMRYarnCluster.java
@@ -78,6 +78,7 @@ public class MiniMRYarnCluster extends MiniYARNCluster {
     this(testName, 1);
   }
 
+  @SuppressWarnings("deprecation")
   public MiniMRYarnCluster(String testName, int noOfNMs) {
     this(testName, noOfNMs, false);
   }

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingBadRecords.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingBadRecords.java
@@ -31,13 +31,13 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.ClusterMapReduceTestCase;
 import org.apache.hadoop.mapred.Counters;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.SkipBadRecords;
 import org.apache.hadoop.mapred.Utils;
@@ -65,7 +65,12 @@ public class TestStreamingBadRecords extends ClusterMapReduceTestCase
   private static final String badReducer = 
     UtilTest.makeJavaCommand(BadApp.class, new String[]{"true"});
   private static final int INPUTSIZE=100;
-  
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setupClassBase(TestStreamingBadRecords.class);
+  }
+
   public TestStreamingBadRecords() throws IOException
   {
     UtilTest utilTest = new UtilTest(getClass().getName());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
@@ -171,8 +172,9 @@ public class MiniYARNCluster extends CompositeService {
     this.numLocalDirs = numLocalDirs;
     this.numLogDirs = numLogDirs;
     this.enableAHS = enableAHS;
-    String testSubDir = testName.replace("$", "");
-    File targetWorkDir = new File("target", testSubDir);
+    String testSubDir = testName.replace("$", "").concat("-yarn");
+    File targetWorkDirRoot = GenericTestUtils.getTestDir();
+    File targetWorkDir = new File(targetWorkDirRoot, testSubDir);
     try {
       FileContext.getLocalFSFileContext().delete(
           new Path(targetWorkDir.getAbsolutePath()), true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +44,7 @@ import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.conf.HAUtil;
@@ -173,11 +173,11 @@ public class MiniYARNCluster extends CompositeService {
     this.numLocalDirs = numLocalDirs;
     this.numLogDirs = numLogDirs;
     this.enableAHS = enableAHS;
-    String testSubDir = testName.replace("$", "").concat("-yarn");
-    File targetWorkDirRoot = GenericTestUtils.getTestDir(testName);
+    String yarnFolderName = String.format("yarn-%d", Time.monotonicNow());
+    File targetWorkDirRoot = GenericTestUtils.getTestDir(getName());
     // make sure that the folder exists
     targetWorkDirRoot.mkdirs();
-    File targetWorkDir = new File(targetWorkDirRoot, testSubDir);
+    File targetWorkDir = new File(targetWorkDirRoot, yarnFolderName);
     try {
       FileContext.getLocalFSFileContext().delete(
           new Path(targetWorkDir.getAbsolutePath()), true);
@@ -232,6 +232,7 @@ public class MiniYARNCluster extends CompositeService {
    * @param numLocalDirs the number of nm-local-dirs per nodemanager
    * @param numLogDirs the number of nm-log-dirs per nodemanager
    */
+  @SuppressWarnings("deprecation")
   public MiniYARNCluster(
       String testName, int numResourceManagers, int numNodeManagers,
       int numLocalDirs, int numLogDirs) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MiniYARNCluster.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -173,7 +174,9 @@ public class MiniYARNCluster extends CompositeService {
     this.numLogDirs = numLogDirs;
     this.enableAHS = enableAHS;
     String testSubDir = testName.replace("$", "").concat("-yarn");
-    File targetWorkDirRoot = GenericTestUtils.getTestDir();
+    File targetWorkDirRoot = GenericTestUtils.getTestDir(testName);
+    // make sure that the folder exists
+    targetWorkDirRoot.mkdirs();
     File targetWorkDir = new File(targetWorkDirRoot, testSubDir);
     try {
       FileContext.getLocalFSFileContext().delete(


### PR DESCRIPTION
[MAPREDUCE-7320: ClusterMapReduceTestCase does not clean directories](https://issues.apache.org/jira/browse/MAPREDUCE-7320)

Running Junits that extend ClusterMapReduceTestCase generate lots of directories and folders all over the place.

This PR addresses organizing the directories generated by the unit test, cleaning them up at the beginning of the execution if necessary.

- It touches `MiniYARNCluster.java` in order to change the base dir to `target/test-dir/$TEST_CLASS_NAME`
- test classes affected

  - TestMRJobClient,
  - TestStreamingBadRecords,
  - TestClusterMapReduceTestCase,
  - TestBadRecords.
  - TestMRCJCJobClient,
  - TestJobName

I tested the TestUnits that use `MiniYARNCluster.java` such as:

```bash
Class
    MiniYARNCluster

        TestOSSMiniYarnCluster  (3 usages found)
        TestMRTimelineEventHandling  (4 usages found)
        TestJobHistoryEventHandler  (3 usages found)
        TestHadoopArchiveLogs  (3 usages found)
        TestHadoopArchiveLogsRunner  (3 usages found)
        TestDynamometerInfra  (3 usages found)
        TestDSTimelineV10
        TestDSTimelineV20
        TestDSTimelineV15
        TestUnmanagedAMLauncher  (3 usages found)
        TestApplicationMasterServiceProtocolForTimelineV2
        TestFederationRMFailoverProxyProvider  (3 usages found)
        TestHedgingRequestRMFailoverProxyProvider  (4 usages found)
        TestNoHaRMFailoverProxyProvider  (5 usages found)
        TestRMFailover  (4 usages found)
        TestAMRMClient
        TestAMRMClientPlacementConstraints
        TestAMRMProxy  (5 usages found)
        TestNMClient  (3 usages found)
        TestOpportunisticContainerAllocationE2E  (3 usages found)
        TestYarnClient  (3 usages found)
        TestYarnClientWithReservation  (12 usages found)
        TestYarnCLI  (7 usages found)
        TestContainerManagerSecurity  (2 usages found)
        TestDiskFailures  (2 usages found)
        TestMiniYarnCluster  (9 usages found)
        TestMiniYARNClusterForHA  (2 usages found)
        TestMiniYarnClusterNodeUtilization  (3 usages found)
        TestEncryptedShuffle
```


MAPREDUCE-7320. fix TestEncryptedShuffle paths
MAPREDUCE-7320. move cleaning up root directory to setup
