### PR TITLE
HADOOP-13126 Add BrotliCodec based on Brotli4j library

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -232,6 +232,41 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>brotli4j</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-aarch64</artifactId>
+      <scope>provided</scope>
+      <version>${brotli4j.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-x86_64</artifactId>
+      <scope>provided</scope>
+      <version>${brotli4j.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-windows-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>compile</scope>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BrotliCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/BrotliCodec.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress;
+
+import com.aayushatharva.brotli4j.Brotli4jLoader;
+import com.aayushatharva.brotli4j.encoder.Encoder;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.io.compress.brotli.BrotliCompressor;
+import org.apache.hadoop.io.compress.brotli.BrotliDecompressor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * This class provides output and input streams for Brotli compression
+ * and decompression. It uses the native brotli library provided as a
+ * Maven dependency.
+ *
+ * Brotli compression does not support splittability!
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class BrotliCodec extends Configured implements CompressionCodec {
+
+  public static final String MODE_PROP = "compression.brotli.is-text";
+  public static final String QUALITY_LEVEL_PROP = "compression.brotli.quality";
+  public static final String LZ_WINDOW_SIZE_PROP = "compression.brotli.lzwin";
+  public static final Encoder.Mode DEFAULT_MODE = Encoder.Mode.GENERIC;
+  public static final int DEFAULT_QUALITY = -1;
+  public static final int DEFAULT_LZ_WINDOW_SIZE = -1;
+
+  static {
+    loadNatives();
+  }
+
+  public static void loadNatives() {
+    Brotli4jLoader.ensureAvailability();
+  }
+
+  @Override
+  public CompressionOutputStream createOutputStream(OutputStream out)
+      throws IOException {
+    return createOutputStream(out, createCompressor());
+  }
+
+  @Override
+  public CompressionOutputStream createOutputStream(OutputStream out,
+                                                    Compressor compressor)
+      throws IOException {
+    return new BrotliCompressorStream(out, compressor);
+  }
+
+  @Override
+  public Class<? extends Compressor> getCompressorType() {
+    return BrotliCompressor.class;
+  }
+
+  @Override
+  public Compressor createCompressor() {
+    return new BrotliCompressor(getConf());
+  }
+
+  @Override
+  public CompressionInputStream createInputStream(InputStream in)
+      throws IOException {
+    return createInputStream(in, createDecompressor());
+  }
+
+  @Override
+  public CompressionInputStream createInputStream(InputStream in,
+                                                  Decompressor decompressor)
+      throws IOException {
+    return new BrotliDecompressorStream(in, decompressor);
+  }
+
+  @Override
+  public Class<? extends Decompressor> getDecompressorType() {
+    return BrotliDecompressor.class;
+  }
+
+  @Override
+  public Decompressor createDecompressor() {
+    return new BrotliDecompressor();
+  }
+
+  @Override
+  public String getDefaultExtension() {
+    return ".br";
+  }
+
+  private static final class BrotliCompressorStream extends CompressorStream {
+    private BrotliCompressorStream(OutputStream out,
+                                   Compressor compressor,
+                                   int bufferSize) {
+      super(out, compressor, bufferSize);
+    }
+
+    private BrotliCompressorStream(OutputStream out,
+                                   Compressor compressor) {
+      super(out, compressor);
+    }
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      compressor.end();
+    }
+  }
+
+  private static final class BrotliDecompressorStream
+          extends DecompressorStream {
+
+    private BrotliDecompressorStream(InputStream in,
+                                     Decompressor decompressor,
+                                     int bufferSize)
+        throws IOException {
+      super(in, decompressor, bufferSize);
+    }
+
+    private BrotliDecompressorStream(InputStream in, Decompressor decompressor)
+        throws IOException {
+      super(in, decompressor);
+    }
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      decompressor.end();
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliCompressor.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress.brotli;
+
+import com.aayushatharva.brotli4j.encoder.Encoder;
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.Compressor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import static org.apache.hadoop.io.compress.BrotliCodec.DEFAULT_LZ_WINDOW_SIZE;
+import static org.apache.hadoop.io.compress.BrotliCodec.DEFAULT_MODE;
+import static org.apache.hadoop.io.compress.BrotliCodec.DEFAULT_QUALITY;
+import static org.apache.hadoop.io.compress.BrotliCodec.LZ_WINDOW_SIZE_PROP;
+import static org.apache.hadoop.io.compress.BrotliCodec.MODE_PROP;
+import static org.apache.hadoop.io.compress.BrotliCodec.QUALITY_LEVEL_PROP;
+
+public class BrotliCompressor implements Compressor {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(BrotliCompressor.class);
+
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocateDirect(0);
+
+  private final StackTraceElement[] stack;
+
+  private final Encoder.Parameters parameter = new Encoder.Parameters();
+
+  // Using a direct byte buffer as input prevents a JNI-side copy
+  private ByteBuffer inBuffer = ByteBuffer.allocateDirect(16384);
+  private ByteBuffer outBuffer = EMPTY_BUFFER;
+  private boolean compressing = false;
+  private boolean shouldFinish = false;
+  private boolean flushed = false;
+  private int totalBytesIn = 0;
+  private int totalBytesOut = 0;
+
+  public BrotliCompressor(Configuration conf) {
+    reinit(conf);
+    this.stack = Thread.currentThread().getStackTrace();
+  }
+
+  private boolean isOutputBufferEmpty() {
+    return outBuffer.position() == 0;
+  }
+
+  private boolean hasMoreOutput() {
+    return outBuffer.hasRemaining();
+  }
+
+  @Override
+  public void setInput(byte[] inBytes, int off, int len) {
+    Preconditions.checkState(isOutputBufferEmpty(),
+        "[BUG] setInput called with non-empty output buffer");
+    Preconditions.checkState(!compressing,
+        "[BUG] setInput called while compressing the input buffer");
+    Preconditions.checkState(inBuffer.remaining() > (inBuffer.capacity() >> 1),
+        "[BUG] setInput called with a full input buffer");
+    ensureCapacity(len);
+
+    // copy as much of the input as possible
+    int bytesToCopy = Math.min(len, inBuffer.remaining());
+    Preconditions.checkState(bytesToCopy == len,
+        "[BUG] Cannot copy the entire input");
+    inBuffer.put(inBytes, off, bytesToCopy);
+
+    // if the buffer is full, compress it and copy any remaining input
+    if (shouldFinish || inBuffer.remaining() <= (inBuffer.capacity() >> 1)) {
+      compress(shouldFinish);
+    }
+
+    this.totalBytesIn += len;
+  }
+
+  /**
+   * This checks that the given size is less than the current input buffer's
+   * capacity. If not, the capacity of the input buffer is increased. This
+   * ensures that an incoming buffer of size bytes can be handled by setInput,
+   * even if the input buffer is almost full.
+   */
+  private void ensureCapacity(int size) {
+    int targetCapacity = inBuffer.capacity() / 2;
+    if (targetCapacity > size) {
+      return;
+    }
+
+    // find a capacity that works for the current request
+    while (targetCapacity < size) {
+      targetCapacity *= 2;
+    }
+
+    // increase the input buffer size
+    ByteBuffer oldBuffer = inBuffer;
+    this.inBuffer = ByteBuffer.allocateDirect(targetCapacity * 2);
+    oldBuffer.flip(); // prepare for reading
+    inBuffer.put(oldBuffer);
+  }
+
+  /**
+   * Compresses and clears the input buffer. After this method is called, the
+   * output buffer must be read entirely before calling setInput again.
+   */
+  private void compress(boolean flush) {
+    if (!compressing) {
+      this.compressing = true;
+      inBuffer.flip(); // prepare for reading
+    }
+
+    ByteBuffer toCompress = inBuffer.duplicate();
+    int toRead = toCompress.remaining();
+
+    final byte[] compressed;
+    try {
+      byte[] dst = new byte[toRead];
+      toCompress.get(dst, 0, toRead);
+      compressed = Encoder.compress(dst, parameter);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    this.outBuffer.put(compressed);
+
+    inBuffer.position(toCompress.position());
+    if (!inBuffer.hasRemaining()) {
+      this.flushed = flush;
+      inBuffer.clear(); // prepare for writing
+      this.compressing = false;
+    }
+  }
+
+  @Override
+  public boolean needsInput() {
+    return !compressing && isOutputBufferEmpty();
+  }
+
+  @Override
+  public void setDictionary(byte[] b, int off, int len) {
+    // do nothing
+  }
+
+  @Override
+  public long getBytesRead() {
+    return totalBytesOut;
+  }
+
+  @Override
+  public long getBytesWritten() {
+    return totalBytesIn;
+  }
+
+  @Override
+  public void finish() {
+    this.shouldFinish = true;
+  }
+
+  @Override
+  public boolean finished() {
+    return shouldFinish && flushed && isOutputBufferEmpty() && !compressing;
+  }
+
+  @Override
+  public int compress(byte[] out, int off, int len) throws IOException {
+    int bytesCopied = 0;
+
+    if (isOutputBufferEmpty()) {
+      if (compressing) {
+        compress(shouldFinish);
+      } else if (shouldFinish && !flushed) {
+        compress(true);
+      }
+    }
+
+    if (hasMoreOutput()) {
+      int bytesToCopy = Math.min(len, outBuffer.position());
+      outBuffer.flip();
+      outBuffer.get(out, off, bytesToCopy);
+      bytesCopied += bytesToCopy;
+    }
+
+    totalBytesOut += bytesCopied;
+
+    return bytesCopied;
+  }
+
+  @Override
+  public void reset() {
+    end();
+    Preconditions.checkState(totalBytesIn == 0 ||
+        (flushed && !compressing && inBuffer.position() == 0),
+        "Reused without consuming all input");
+    Preconditions.checkState(isOutputBufferEmpty(),
+        "Reused without consuming all output");
+
+    this.inBuffer.clear();
+    this.outBuffer = EMPTY_BUFFER;
+    this.compressing = false;
+    this.shouldFinish = false;
+    this.flushed = false;
+    this.totalBytesIn = 0;
+    this.totalBytesOut = 0;
+  }
+
+  @Override
+  public void end() {
+    if (compressing || inBuffer.position() > 0) {
+      LOG.warn("Closed without consuming all input");
+    } else if (hasMoreOutput()) {
+      LOG.warn("Closed without consuming all output");
+    }
+  }
+
+  @Override
+  public void reinit(Configuration conf) {
+    this.parameter
+            .setMode(DEFAULT_MODE)
+            .setQuality(DEFAULT_QUALITY)
+            .setWindow(DEFAULT_LZ_WINDOW_SIZE);
+
+    if (conf != null) {
+      this.parameter
+          .setMode(Encoder.Mode.of(conf.get(MODE_PROP, DEFAULT_MODE.name())))
+          .setQuality(conf.getInt(QUALITY_LEVEL_PROP, DEFAULT_QUALITY))
+          .setWindow(conf.getInt(LZ_WINDOW_SIZE_PROP, DEFAULT_LZ_WINDOW_SIZE));
+    }
+    this.outBuffer = ByteBuffer.allocateDirect(16384);
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    super.finalize();
+
+    if (hasMoreOutput()) {
+      String trace = Joiner
+              .on("\n\t")
+              .join(Arrays.copyOfRange(stack, 1, stack.length));
+      LOG.warn("A compressor is being GC-ed without consuming all its output. "
+               + "Created at:\n\t{}", trace);
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliCompressor.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.io.compress.brotli;
 
 import com.aayushatharva.brotli4j.encoder.Encoder;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
-import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.Compressor;
 import org.slf4j.Logger;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliDecompressor.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress.brotli;
+
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+public class BrotliDecompressor implements Decompressor {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(BrotliDecompressor.class);
+
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+
+  private final ByteBuffer outBuffer;
+  private final StackTraceElement[] stack;
+
+  private ByteBuffer inBuffer = EMPTY_BUFFER;
+  private long totalBytesIn = 0;
+  private long totalBytesOut = 0;
+
+  public BrotliDecompressor() {
+    this.outBuffer = ByteBuffer.allocateDirect(16384);
+    outBuffer.limit(0); // must be empty
+    this.stack = Thread.currentThread().getStackTrace();
+  }
+
+  @Override
+  public void setInput(byte[] inBytes, int off, int len) {
+    Preconditions.checkState(isInputBufferEmpty(),
+             "[BUG] Cannot call setInput with existing unconsumed input.");
+    // this must use a ByteBuffer because not all of the bytes must be consumed
+    this.inBuffer = ByteBuffer.wrap(inBytes, off, len);
+    getMoreOutput();
+    totalBytesIn += len;
+  }
+
+  private void getMoreOutput() {
+    Preconditions.checkState(isOutputBufferEmpty(),
+              "[BUG] Cannot call getMoreOutput without consuming all output.");
+    outBuffer.clear();
+    try {
+      new BrotliDirectDecompressor().decompress(inBuffer, outBuffer);
+    } catch (IOException iox) {
+      throw new UncheckedIOException(iox);
+    }
+  }
+
+  @Override
+  public boolean needsInput() {
+    return isInputBufferEmpty() && !hasMoreOutput();
+  }
+
+  @Override
+  public void setDictionary(byte[] b, int off, int len) {
+    throw new UnsupportedOperationException(
+            "Brotli decompression does not support dictionaries");
+  }
+
+  @Override
+  public boolean needsDictionary() {
+    return false;
+  }
+
+  @Override
+  public boolean finished() {
+    return isInputBufferEmpty() && !hasMoreOutput();
+  }
+
+  @Override
+  public int decompress(byte[] out, int off, int len) {
+    int bytesCopied = 0;
+    int currentOffset = off;
+
+    if (isOutputBufferEmpty() && (hasMoreInput())) {
+      getMoreOutput();
+    }
+
+    while (bytesCopied < len && hasMoreOutput()) {
+      int bytesToCopy = Math.min(len - bytesCopied, outBuffer.position());
+      outBuffer.flip();
+      outBuffer.get(out, currentOffset, bytesToCopy);
+      currentOffset += bytesToCopy;
+
+      if (isOutputBufferEmpty() && (hasMoreInput())) {
+        getMoreOutput();
+      }
+
+      bytesCopied += bytesToCopy;
+    }
+
+    totalBytesOut += bytesCopied;
+
+    return bytesCopied;
+  }
+
+  @Override
+  public int getRemaining() {
+    int available = outBuffer.remaining();
+    if (available > 0) {
+      return available;
+    }
+    return 0;
+  }
+
+  @Override
+  public void reset() {
+    Preconditions.checkState(isOutputBufferEmpty(),
+              "Reused without consuming all output");
+    end();
+    outBuffer.limit(0);
+    this.inBuffer = EMPTY_BUFFER;
+    this.totalBytesIn = 0;
+    this.totalBytesOut = 0;
+  }
+
+  @Override
+  public void end() {
+    if (!isOutputBufferEmpty()) {
+      LOG.warn("Closed without consuming all output");
+    }
+  }
+
+  public long getTotalBytesIn() {
+    return totalBytesIn;
+  }
+
+  public long getTotalBytesOut() {
+    return totalBytesOut;
+  }
+
+  private boolean hasMoreOutput() {
+    return outBuffer.hasRemaining();
+  }
+
+  private boolean hasMoreInput() {
+    return inBuffer.hasRemaining();
+  }
+
+  private boolean isOutputBufferEmpty() {
+    return outBuffer.position() == 0;
+  }
+
+  private boolean isInputBufferEmpty() {
+    return inBuffer.position() == 0;
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    super.finalize();
+
+    String message = "A decompressor is being GC-ed without consuming all its ";
+    if (hasMoreInput()) {
+      message += "input";
+
+      if (hasMoreOutput()) {
+        message += " and output";
+      }
+    } else if (hasMoreOutput()) {
+      message += "output";
+    }
+
+    if (message.endsWith("put")) {
+      String trace = Joiner
+              .on("\n\t")
+              .join(Arrays.copyOfRange(stack, 1, stack.length));
+      LOG.warn("{}. Created at:\n\t{}", message, trace);
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliDecompressor.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.io.compress.brotli;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
-import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliDirectDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/BrotliDirectDecompressor.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress.brotli;
+
+import com.aayushatharva.brotli4j.decoder.Decoder;
+import com.aayushatharva.brotli4j.decoder.DecoderJNI;
+import com.aayushatharva.brotli4j.decoder.DirectDecompress;
+import org.apache.hadoop.io.compress.BrotliCodec;
+import org.apache.hadoop.io.compress.DirectDecompressor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class BrotliDirectDecompressor implements DirectDecompressor {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(BrotliDirectDecompressor.class);
+
+  static {
+    BrotliCodec.loadNatives();
+  }
+
+  @Override
+  public void decompress(ByteBuffer src, ByteBuffer dst) throws IOException {
+
+    int toRead = src.remaining();
+    byte[] compressed = new byte[toRead];
+    src.get(compressed, 0, toRead);
+    final DirectDecompress result = Decoder.decompress(compressed);
+    final DecoderJNI.Status status = result.getResultStatus();
+    if (status == DecoderJNI.Status.DONE) {
+      dst.put(result.getDecompressedData());
+      src.position(src.limit());
+    } else {
+      LOG.error("An error occurred while decompressing data: {}", status);
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/brotli/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.io.compress.brotli;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/brotli/TestBrotliCompressorDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/brotli/TestBrotliCompressorDecompressor.java
@@ -1,0 +1,69 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.hadoop.io.compress.brotli;
+
+import com.aayushatharva.brotli4j.encoder.Encoder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.compress.BrotliCodec;
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestBrotliCompressorDecompressor {
+
+  @Test
+  public void decompress() throws IOException {
+    BrotliCodec codec = new BrotliCodec();
+
+    Compressor compressor = codec.createCompressor();
+    Configuration config = new Configuration(false);
+    config.set(BrotliCodec.MODE_PROP, Encoder.Mode.TEXT.name());
+    compressor.reinit(config);
+
+    InputStream textStream = getClass().getResourceAsStream("/brotli/test_file.txt");
+    byte[] textBytes = new byte[textStream.available()];
+    IOUtils.readFully(textStream, textBytes, 0, textBytes.length);
+
+    compressor.setInput(textBytes, 0, textBytes.length);
+    compressor.finish();
+
+    byte[] compressed = new byte[textBytes.length];
+    int compressedBytes = compressor.compress(compressed, 0, compressed.length);
+    compressor.end();
+    assertTrue("Compressed size must be smaller than the input size",
+               compressedBytes < textBytes.length);
+
+    Decompressor decompressor = codec.createDecompressor();
+    decompressor.setInput(compressed, 0, compressedBytes);
+
+    byte[] result = new byte[textBytes.length];
+    int decompressedBytes = decompressor.decompress(result, 0, result.length);
+    decompressor.end();
+
+    assertEquals(textBytes.length, decompressedBytes);
+    assertEquals(new String(textBytes), new String(result));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/brotli/TestBrotliDirectDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/brotli/TestBrotliDirectDecompressor.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress.brotli;
+
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.compress.BrotliCodec;
+import org.apache.hadoop.io.compress.Compressor;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestBrotliDirectDecompressor {
+
+  @Test
+  public void decompress() throws IOException {
+    String input = "Hello Brotli";
+
+    BrotliCodec codec = new BrotliCodec();
+
+    Compressor compressor = codec.createCompressor();
+
+    byte[] uncompressed = input.getBytes(StandardCharsets.UTF_8);
+    compressor.setInput(uncompressed, 0, uncompressed.length);
+    compressor.finish();
+
+    byte[] compressed = new byte[/*(int) compressor.getBytesWritten()*/ 16];
+    int compressedBytes = compressor.compress(compressed, 0, compressed.length);
+    assertEquals(compressed.length, compressedBytes);
+
+
+    ByteBuffer src = ByteBuffer.wrap(compressed);
+    ByteBuffer dest = ByteBuffer.allocateDirect(16);
+    BrotliDirectDecompressor decompressor = new BrotliDirectDecompressor();
+    decompressor.decompress(src, dest);
+
+    assertFalse(src.hasRemaining());
+
+    dest.flip();
+    byte[] result = new byte[input.length()];
+    dest.get(result, 0, result.length);
+    assertEquals(input, new String(result));
+  }
+
+  @Test
+  public void decompressLongText() throws IOException {
+    InputStream textStream = getClass()
+        .getResourceAsStream("/brotli/test_file.txt");
+    byte[] textBytes = new byte[textStream.available()];
+    IOUtils.readFully(textStream, textBytes, 0, textBytes.length);
+    String input = new String(textBytes);
+
+    BrotliCodec codec = new BrotliCodec();
+
+    Compressor compressor = codec.createCompressor();
+
+    byte[] uncompressed = input.getBytes(StandardCharsets.UTF_8);
+    compressor.setInput(uncompressed, 0, uncompressed.length);
+    compressor.finish();
+
+    byte[] compressed = new byte[textBytes.length];
+    int compressedBytes = compressor.compress(compressed, 0, compressed.length);
+    compressor.end();
+    assertTrue("Compressed size must be smaller than the input size",
+               compressedBytes < textBytes.length);
+
+    ByteBuffer src = ByteBuffer.wrap(compressed, 0, compressedBytes);
+    ByteBuffer dest = ByteBuffer.allocateDirect(textBytes.length);
+    BrotliDirectDecompressor decompressor = new BrotliDirectDecompressor();
+    decompressor.decompress(src, dest);
+
+    assertFalse("There is more input to decompress", src.hasRemaining());
+
+    dest.flip();
+    byte[] result = new byte[textBytes.length];
+    dest.get(result, 0, result.length);
+    assertEquals(input, new String(result));
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/resources/brotli/test_file.txt
+++ b/hadoop-common-project/hadoop-common/src/test/resources/brotli/test_file.txt
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -65,6 +65,9 @@
     <!-- avro version -->
     <avro.version>1.9.2</avro.version>
 
+    <!-- Brotli4j version -->
+    <brotli4j.version>1.3.2</brotli4j.version>
+
     <!-- jersey version -->
     <jersey.version>1.19.4</jersey.version>
 


### PR DESCRIPTION
Adds BrotliCodec - a compression codec based on [Google Brotli](https://github.com/google/brotli)

This PR is a continuation on the work done by @rdblue at https://issues.apache.org/jira/browse/HADOOP-13126
In his patches it was based on [jbrotli](https://github.com/MeteoGroup/jbrotli) library but this library is not maintained since few years. My PR uses [Brotli4j](https://github.com/hyperxpro/Brotli4j)