### PR TITLE
HDFS-15862. Make TestViewfsWithNfs3.testNfsRenameSingleNN() idempotent

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
@@ -326,5 +326,7 @@ public class TestViewfsWithNfs3 {
     statusAfterRename =
         nn1.getRpcServer().getFileInfo("/user1/renameSingleNN");
     Assert.assertEquals(statusAfterRename, null);
+    testNfsRename(fromHandle, "renameSingleNNSucess",
+        fromHandle, "renameSingleNN", Nfs3Status.NFS3_OK);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
@@ -154,8 +154,6 @@ public class TestViewfsWithNfs3 {
     DFSTestUtil.createFile(viewFs, new Path("/hdfs2/write2"), 0, (short) 1, 0);
     DFSTestUtil.createFile(viewFs, new Path("/hdfs1/renameMultiNN"),
         0, (short) 1, 0);
-    DFSTestUtil.createFile(viewFs, new Path("/hdfs1/renameSingleNN"),
-        0, (short) 1, 0);
   }
 
   @AfterClass
@@ -307,6 +305,8 @@ public class TestViewfsWithNfs3 {
 
   @Test (timeout = 60000)
   public void testNfsRenameSingleNN() throws Exception {
+    DFSTestUtil.createFile(viewFs, new Path("/hdfs1/renameSingleNN"),
+            0, (short) 1, 0);
     HdfsFileStatus fromFileStatus = nn1.getRpcServer().getFileInfo("/user1");
     int fromNNId = Nfs3Utils.getNamenodeId(config, hdfs1.getUri());
     FileHandle fromHandle =
@@ -316,6 +316,10 @@ public class TestViewfsWithNfs3 {
         nn1.getRpcServer().getFileInfo("/user1/renameSingleNN");
     Assert.assertEquals(statusBeforeRename.isDirectory(), false);
 
+    Path successFilePath = new Path("/user1/renameSingleNNSucess");
+    if (hdfs1.exists(successFilePath)) {
+      hdfs1.delete(successFilePath, false);
+    }
     testNfsRename(fromHandle, "renameSingleNN",
         fromHandle, "renameSingleNNSucess", Nfs3Status.NFS3_OK);
 
@@ -326,7 +330,5 @@ public class TestViewfsWithNfs3 {
     statusAfterRename =
         nn1.getRpcServer().getFileInfo("/user1/renameSingleNN");
     Assert.assertEquals(statusAfterRename, null);
-    testNfsRename(fromHandle, "renameSingleNNSucess",
-        fromHandle, "renameSingleNN", Nfs3Status.NFS3_OK);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
@@ -317,9 +317,7 @@ public class TestViewfsWithNfs3 {
     Assert.assertEquals(statusBeforeRename.isDirectory(), false);
 
     Path successFilePath = new Path("/user1/renameSingleNNSucess");
-    if (hdfs1.exists(successFilePath)) {
-      hdfs1.delete(successFilePath, false);
-    }
+    hdfs1.delete(successFilePath, false);
     testNfsRename(fromHandle, "renameSingleNN",
         fromHandle, "renameSingleNNSucess", Nfs3Status.NFS3_OK);
 


### PR DESCRIPTION
The test `org.apache.hadoop.hdfs.nfs.nfs3.TestViewfsWithNfs3.testNfsRenameSingleNN` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Details

Running `TestViewfsWithNfs3.testNfsRenameSingleNN` twice would result in the second run failing with the a NullPointer exception:
```
[ERROR] Errors:
[ERROR] TestViewfsWithNfs3.testNfsRenameSingleNN:317 NullPointer
```

The reason for this is that the `/user1/renameSingleNN` file is created in `setup()`, but gets renamed in`testNfsRenameSingleNN`. When the second run of `testNfsRenameSingleNN` tries to get info of the file by its original name, it returns a NullPointer since the file no longer exists.

The fix for this is to rename the file back to the original when the test is done.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

Link to JIRA issue: https://issues.apache.org/jira/browse/HDFS-15862
