### PR TITLE
HADOOP-17471. ABFS to collect IOStatistics

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -317,6 +317,30 @@ public final class StoreStatisticNames {
       = "action_http_get_request";
 
   /**
+   * An HTTP DELETE request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_DELETE_REQUEST
+      = "action_http_delete_request";
+
+  /**
+   * An HTTP PUT request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_PUT_REQUEST
+      = "action_http_put_request";
+
+  /**
+   * An HTTP PATCH request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_PATCH_REQUEST
+      = "action_http_patch_request";
+
+  /**
+   * An HTTP POST request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_POST_REQUEST
+      = "action_http_post_request";
+
+  /**
    * An HTTP HEAD request was made: {@value}.
    */
   public static final String OBJECT_METADATA_REQUESTS

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsCountersImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsCountersImpl.java
@@ -231,14 +231,13 @@ public class AbfsCountersImpl implements AbfsCounters {
   }
 
   /**
-   * Tracks the duration for different types of HTTP requests.
+   * Tracks the duration of a statistic.
    *
-   * @param key name of the request that is mapped to the statistic name.
+   * @param key name of the statistic.
    * @return DurationTracker for that statistic.
    */
   @Override
-  public DurationTracker startRequest(String key) {
-    return ioStatisticsStore
-        .trackDuration(AbfsStatistic.getStatNameFromHttpCall(key));
+  public DurationTracker trackDuration(String key) {
+    return ioStatisticsStore.trackDuration(key);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsCountersImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsCountersImpl.java
@@ -19,24 +19,23 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.hadoop.fs.azurebfs.services.AbfsCounters;
-import org.apache.hadoop.metrics2.AbstractMetric;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsStoreBuilder;
 import org.apache.hadoop.metrics2.MetricStringBuilder;
-import org.apache.hadoop.metrics2.MetricsCollector;
-import org.apache.hadoop.metrics2.MetricsInfo;
-import org.apache.hadoop.metrics2.MetricsRecordBuilder;
-import org.apache.hadoop.metrics2.MetricsTag;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableMetric;
 
 import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.*;
+import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
 /**
  * Instrumentation of Abfs counters.
@@ -62,6 +61,8 @@ public class AbfsCountersImpl implements AbfsCounters {
   private final MetricsRegistry registry =
       new MetricsRegistry("abfsMetrics").setContext(CONTEXT);
 
+  private final IOStatisticsStore ioStatisticsStore;
+
   private static final AbfsStatistic[] STATISTIC_LIST = {
       CALL_CREATE,
       CALL_OPEN,
@@ -85,7 +86,17 @@ public class AbfsCountersImpl implements AbfsCounters {
       BYTES_SENT,
       BYTES_RECEIVED,
       READ_THROTTLES,
-      WRITE_THROTTLES
+      WRITE_THROTTLES,
+      SERVER_UNAVAILABLE
+  };
+
+  private static final AbfsStatistic[] DURATION_TRACKER_LIST = {
+      HTTP_HEAD_REQUEST,
+      HTTP_GET_REQUEST,
+      HTTP_DELETE_REQUEST,
+      HTTP_PUT_REQUEST,
+      HTTP_PATCH_REQUEST,
+      HTTP_POST_REQUEST
   };
 
   public AbfsCountersImpl(URI uri) {
@@ -95,9 +106,17 @@ public class AbfsCountersImpl implements AbfsCounters {
         fileSystemInstanceId.toString());
     registry.tag(METRIC_BUCKET, "Hostname from the FS URL", uri.getHost());
 
+    IOStatisticsStoreBuilder ioStatisticsStoreBuilder = iostatisticsStore();
+    // Declaring the counters.
     for (AbfsStatistic stats : STATISTIC_LIST) {
+      ioStatisticsStoreBuilder.withCounters(stats.getStatName());
       createCounter(stats);
     }
+    // Declaring the DurationTrackers.
+    for (AbfsStatistic durationStats : DURATION_TRACKER_LIST) {
+      ioStatisticsStoreBuilder.withDurationTracking(durationStats.getStatName());
+    }
+    ioStatisticsStore = ioStatisticsStoreBuilder.build();
   }
 
   /**
@@ -149,6 +168,7 @@ public class AbfsCountersImpl implements AbfsCounters {
    */
   @Override
   public void incrementCounter(AbfsStatistic statistic, long value) {
+    ioStatisticsStore.incrementCounter(statistic.getStatName(), value);
     MutableCounterLong counter = lookupCounter(statistic.getStatName());
     if (counter != null) {
       counter.incr(value);
@@ -189,98 +209,36 @@ public class AbfsCountersImpl implements AbfsCounters {
   /**
    * {@inheritDoc}
    *
-   * Creating a map of all the counters for testing.
+   * Map of all the counters for testing.
    *
-   * @return a map of the metrics.
+   * @return a map of the IOStatistics counters.
    */
   @VisibleForTesting
   @Override
   public Map<String, Long> toMap() {
-    MetricsToMap metricBuilder = new MetricsToMap(null);
-    registry.snapshot(metricBuilder, true);
-    return metricBuilder.getMap();
+    return ioStatisticsStore.counters();
   }
 
-  protected static class MetricsToMap extends MetricsRecordBuilder {
-    private final MetricsCollector parent;
-    private final Map<String, Long> map =
-        new HashMap<>();
+  /**
+   * Returning the instance of IOStatisticsStore used to collect the metrics
+   * in AbfsCounters.
+   *
+   * @return instance of IOStatistics.
+   */
+  @Override
+  public IOStatistics getIOStatistics() {
+    return ioStatisticsStore;
+  }
 
-    MetricsToMap(MetricsCollector parent) {
-      this.parent = parent;
-    }
-
-    @Override
-    public MetricsRecordBuilder tag(MetricsInfo info, String value) {
-      return this;
-    }
-
-    @Override
-    public MetricsRecordBuilder add(MetricsTag tag) {
-      return this;
-    }
-
-    @Override
-    public MetricsRecordBuilder add(AbstractMetric metric) {
-      return this;
-    }
-
-    @Override
-    public MetricsRecordBuilder setContext(String value) {
-      return this;
-    }
-
-    @Override
-    public MetricsRecordBuilder addCounter(MetricsInfo info, int value) {
-      return tuple(info, value);
-    }
-
-    @Override
-    public MetricsRecordBuilder addCounter(MetricsInfo info, long value) {
-      return tuple(info, value);
-    }
-
-    @Override
-    public MetricsRecordBuilder addGauge(MetricsInfo info, int value) {
-      return tuple(info, value);
-    }
-
-    @Override
-    public MetricsRecordBuilder addGauge(MetricsInfo info, long value) {
-      return tuple(info, value);
-    }
-
-    public MetricsToMap tuple(MetricsInfo info, long value) {
-      return tuple(info.name(), value);
-    }
-
-    public MetricsToMap tuple(String name, long value) {
-      map.put(name, value);
-      return this;
-    }
-
-    @Override
-    public MetricsRecordBuilder addGauge(MetricsInfo info, float value) {
-      return tuple(info, (long) value);
-    }
-
-    @Override
-    public MetricsRecordBuilder addGauge(MetricsInfo info, double value) {
-      return tuple(info, (long) value);
-    }
-
-    @Override
-    public MetricsCollector parent() {
-      return parent;
-    }
-
-    /**
-     * Get the map.
-     *
-     * @return the map of metrics.
-     */
-    public Map<String, Long> getMap() {
-      return map;
-    }
+  /**
+   * Tracks the duration for different types of HTTP requests.
+   *
+   * @param key name of the request that is mapped to the statistic name.
+   * @return DurationTracker for that statistic.
+   */
+  @Override
+  public DurationTracker startRequest(String key) {
+    return ioStatisticsStore
+        .trackDuration(AbfsStatistic.getStatNameFromHttpCall(key));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
@@ -18,7 +18,12 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.hadoop.fs.StorageStatistics.CommonStatisticNames;
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 
 /**
  * Statistic which are collected in Abfs.
@@ -73,10 +78,44 @@ public enum AbfsStatistic {
   READ_THROTTLES("read_throttles",
       "Total number of times a read operation is throttled."),
   WRITE_THROTTLES("write_throttles",
-      "Total number of times a write operation is throttled.");
+      "Total number of times a write operation is throttled."),
+  SERVER_UNAVAILABLE("server_unavailable",
+      "Total number of times HTTP 503 status code is received in response."),
+
+  // HTTP Duration Trackers
+  HTTP_HEAD_REQUEST(StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST,
+      "Time taken to complete a HEAD request",
+      AbfsHttpConstants.HTTP_METHOD_HEAD),
+  HTTP_GET_REQUEST(StoreStatisticNames.ACTION_HTTP_GET_REQUEST,
+      "Time taken to complete a GET request",
+      AbfsHttpConstants.HTTP_METHOD_GET),
+  HTTP_DELETE_REQUEST(StoreStatisticNames.ACTION_HTTP_DELETE_REQUEST,
+      "Time taken to complete a DELETE request",
+      AbfsHttpConstants.HTTP_METHOD_DELETE),
+  HTTP_PUT_REQUEST(StoreStatisticNames.ACTION_HTTP_PUT_REQUEST,
+      "Time taken to complete a PUT request",
+      AbfsHttpConstants.HTTP_METHOD_PUT),
+  HTTP_PATCH_REQUEST(StoreStatisticNames.ACTION_HTTP_PATCH_REQUEST,
+      "Time taken to complete a PATCH request",
+      AbfsHttpConstants.HTTP_METHOD_PATCH),
+  HTTP_POST_REQUEST(StoreStatisticNames.ACTION_HTTP_POST_REQUEST,
+      "Time taken to complete a POST request",
+      AbfsHttpConstants.HTTP_METHOD_POST);
 
   private String statName;
   private String statDescription;
+
+  //For http call stats only.
+  private String httpCall;
+  private static final Map<String, String> HTTP_CALL_TO_NAME_MAP = new HashMap<>();
+
+  static {
+    for (AbfsStatistic statistic : values()) {
+      if (statistic.getHttpCall() != null) {
+        HTTP_CALL_TO_NAME_MAP.put(statistic.getHttpCall(), statistic.getStatName());
+      }
+    }
+  }
 
   /**
    * Constructor of AbfsStatistic to set statistic name and description.
@@ -87,6 +126,19 @@ public enum AbfsStatistic {
   AbfsStatistic(String statName, String statDescription) {
     this.statName = statName;
     this.statDescription = statDescription;
+  }
+
+  /**
+   * Constructor for AbfsStatistic for HTTP durationTrackers.
+   *
+   * @param statName        Name of the statistic.
+   * @param statDescription Description of the statistic.
+   * @param httpCall        HTTP call associated with the stat name.
+   */
+  AbfsStatistic(String statName, String statDescription, String httpCall) {
+    this.statName = statName;
+    this.statDescription = statDescription;
+    this.httpCall = httpCall;
   }
 
   /**
@@ -105,5 +157,24 @@ public enum AbfsStatistic {
    */
   public String getStatDescription() {
     return statDescription;
+  }
+
+  /**
+   * Getter for http call for HTTP duration trackers.
+   *
+   * @return http call of a statistic.
+   */
+  public String getHttpCall() {
+    return httpCall;
+  }
+
+  /**
+   * Get the statistic name using the http call name.
+   *
+   * @param httpCall The HTTP call used to get the statistic name.
+   * @return Statistic name.
+   */
+  public static String getStatNameFromHttpCall(String httpCall) {
+    return HTTP_CALL_TO_NAME_MAP.get(httpCall);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsCounters.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsCounters.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.azurebfs.AbfsStatistic;
 import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
@@ -33,7 +34,7 @@ import org.apache.hadoop.fs.statistics.IOStatisticsSource;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-public interface AbfsCounters extends IOStatisticsSource {
+public interface AbfsCounters extends IOStatisticsSource, DurationTrackerFactory {
 
   /**
    * Increment a AbfsStatistic by a long value.
@@ -71,5 +72,6 @@ public interface AbfsCounters extends IOStatisticsSource {
    * @param key Name of the DurationTracker statistic.
    * @return an instance of DurationTracker.
    */
-  DurationTracker startRequest(String key);
+  @Override
+  DurationTracker trackDuration(String key);
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsCounters.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsCounters.java
@@ -25,13 +25,15 @@ import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTest
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.azurebfs.AbfsStatistic;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
  * An interface for Abfs counters.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-public interface AbfsCounters {
+public interface AbfsCounters extends IOStatisticsSource {
 
   /**
    * Increment a AbfsStatistic by a long value.
@@ -63,4 +65,11 @@ public interface AbfsCounters {
   @VisibleForTesting
   Map<String, Long> toMap();
 
+  /**
+   * Start a DurationTracker for a request.
+   *
+   * @param key Name of the DurationTracker statistic.
+   * @return an instance of DurationTracker.
+   */
+  DurationTracker startRequest(String key);
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -485,10 +485,8 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     AbfsPerfTracker tracker = client.getAbfsPerfTracker();
     try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker, "readRemote", "read")) {
       LOG.trace("Trigger client.read for path={} position={} offset={} length={}", path, position, offset, length);
-      op = IOStatisticsBinding.trackDuration((IOStatisticsStore) ioStatistics,
-          StoreStatisticNames.ACTION_HTTP_GET_REQUEST,
-          () -> client.read(path, position, b, offset, length,
-              tolerateOobAppends ? "*" : eTag, cachedSasToken.get()));
+      op = client.read(path, position, b, offset, length,
+          tolerateOobAppends ? "*" : eTag, cachedSasToken.get());
       cachedSasToken.update(op.getSasToken());
       if (streamStatistics != null) {
         streamStatistics.remoteReadOperation();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -39,9 +39,6 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemExc
 import org.apache.hadoop.fs.azurebfs.utils.CachedSASToken;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
-import org.apache.hadoop.fs.statistics.StoreStatisticNames;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -45,9 +45,6 @@ import org.apache.hadoop.fs.azurebfs.utils.CachedSASToken;
 import org.apache.hadoop.fs.statistics.DurationTracker;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
-import org.apache.hadoop.fs.statistics.StreamStatisticNames;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.FSExceptionMessages;
@@ -450,32 +447,29 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
       }
     }
     final Future<Void> job =
-        completionService.submit(IOStatisticsBinding
-            .trackDurationOfCallable((IOStatisticsStore) ioStatistics,
-                StreamStatisticNames.TIME_SPENT_ON_PUT_REQUEST,
-                () -> {
-                  AbfsPerfTracker tracker = client.getAbfsPerfTracker();
-                  try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
-                      "writeCurrentBufferToService", "append")) {
-                    AppendRequestParameters.Mode
-                        mode = APPEND_MODE;
-                    if (isFlush & isClose) {
-                      mode = FLUSH_CLOSE_MODE;
-                    } else if (isFlush) {
-                      mode = FLUSH_MODE;
-                    }
-                    AppendRequestParameters reqParams = new AppendRequestParameters(
-                        offset, 0, bytesLength, mode, false, leaseId);
-                    AbfsRestOperation op = client.append(path, bytes, reqParams,
-                        cachedSasToken.get());
-                    cachedSasToken.update(op.getSasToken());
-                    perfInfo.registerResult(op.getResult());
-                    byteBufferPool.putBuffer(ByteBuffer.wrap(bytes));
-                    perfInfo.registerSuccess(true);
-                    return null;
-                  }
-                })
-        );
+        completionService.submit(() -> {
+          AbfsPerfTracker tracker =
+              client.getAbfsPerfTracker();
+          try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
+              "writeCurrentBufferToService", "append")) {
+            AppendRequestParameters.Mode
+                mode = APPEND_MODE;
+            if (isFlush & isClose) {
+              mode = FLUSH_CLOSE_MODE;
+            } else if (isFlush) {
+              mode = FLUSH_MODE;
+            }
+            AppendRequestParameters reqParams = new AppendRequestParameters(
+                offset, 0, bytesLength, mode, false, leaseId);
+            AbfsRestOperation op = client.append(path, bytes, reqParams,
+                cachedSasToken.get());
+            cachedSasToken.update(op.getSasToken());
+            perfInfo.registerResult(op.getResult());
+            byteBufferPool.putBuffer(ByteBuffer.wrap(bytes));
+            perfInfo.registerSuccess(true);
+            return null;
+          }
+        });
 
     if (outputStreamStatistics != null) {
       if (job.isCancelled()) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -181,7 +182,7 @@ public class AbfsRestOperation {
     } catch (AzureBlobFileSystemException aze) {
       throw aze;
     } catch (IOException e) {
-      throw new RuntimeException("Error while tracking Duration of an "
+      throw new UncheckedIOException("Error while tracking Duration of an "
           + "AbfsRestOperation call", e);
     }
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -171,7 +171,6 @@ public class AbfsRestOperation {
    * Execute a AbfsRestOperation. Track the Duration of a request if
    * abfsCounters isn't null.
    *
-   * @throws AzureBlobFileSystemException
    */
   public void execute() throws AzureBlobFileSystemException {
     if (abfsCounters != null) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsDurationTrackers.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsDurationTrackers.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.services.AbfsInputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.io.IOUtils;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_DELETE_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_GET_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_HEAD_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_PUT_REQUEST;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.extractStatistics;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupMeanStatistic;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+
+public class ITestAbfsDurationTrackers extends AbstractAbfsIntegrationTest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ITestAbfsDurationTrackers.class);
+  private static final AbfsStatistic[] HTTP_DURATION_TRACKER_LIST = {
+      HTTP_HEAD_REQUEST,
+      HTTP_GET_REQUEST,
+      HTTP_DELETE_REQUEST,
+      HTTP_PUT_REQUEST,
+  };
+
+  public ITestAbfsDurationTrackers() throws Exception {
+  }
+
+  /**
+   * Test to check if DurationTrackers for Abfs HTTP calls work correctly and
+   * track the duration of the http calls.
+   */
+  @Test
+  public void testAbfsHttpCallsDurations() throws IOException {
+    describe("test to verify if the DurationTrackers for abfs http calls "
+        + "work as expected.");
+
+    AzureBlobFileSystem fs = getFileSystem();
+    Path testFilePath = path(getMethodName());
+
+    // Declaring output and input stream.
+    AbfsOutputStream out = null;
+    AbfsInputStream in = null;
+    try {
+      // PUT the file.
+      out = createAbfsOutputStreamWithFlushEnabled(fs, testFilePath);
+      out.write('a');
+      out.hflush();
+
+      // GET the file.
+      in = fs.getAbfsStore().openFileForRead(testFilePath, fs.getFsStatistics());
+      int res = in.read();
+      LOG.info("Result of Read: {}", res);
+
+      // DELETE the file.
+      fs.delete(testFilePath, false);
+
+      // extract the IOStatistics from the filesystem.
+      IOStatistics ioStatistics = extractStatistics(fs);
+      LOG.info(ioStatisticsToPrettyString(ioStatistics));
+      assertDurationTracker(ioStatistics);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, out, in);
+    }
+  }
+
+  /**
+   * A method to assert that all the DurationTrackers for the http calls are
+   * working correctly.
+   *
+   * @param ioStatistics the IOStatisticsSource in use.
+   */
+  private void assertDurationTracker(IOStatistics ioStatistics) {
+    for (AbfsStatistic abfsStatistic : HTTP_DURATION_TRACKER_LIST) {
+      Assertions.assertThat(lookupMeanStatistic(ioStatistics,
+          abfsStatistic.getStatName() + StoreStatisticNames.SUFFIX_MEAN).mean())
+          .describedAs("The DurationTracker Named " + abfsStatistic.getStatName()
+                  + " Doesn't match the expected value.")
+          .isGreaterThan(0.0);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
@@ -39,13 +39,12 @@ public class ITestAbfsStreamStatistics extends AbstractAbfsIntegrationTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestAbfsStreamStatistics.class);
 
-  private static final int LARGE_NUMBER_OF_OPS = 999999;
+  private static final int LARGE_NUMBER_OF_OPS = 99;
 
   /***
    * Testing {@code incrementReadOps()} in class {@code AbfsInputStream} and
    * {@code incrementWriteOps()} in class {@code AbfsOutputStream}.
    *
-   * @throws Exception
    */
   @Test
   public void testAbfsStreamOps() throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
@@ -95,9 +95,9 @@ public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
     AbfsCounters abfsCounters = new AbfsCountersImpl(getFileSystem().getUri());
     // Start dummy work for the DurationTrackers and start tracking.
     try (DurationTracker ignoredPatch =
-        abfsCounters.startRequest(AbfsHttpConstants.HTTP_METHOD_PATCH);
+        abfsCounters.trackDuration(AbfsStatistic.getStatNameFromHttpCall(AbfsHttpConstants.HTTP_METHOD_PATCH));
         DurationTracker ignoredPost =
-            abfsCounters.startRequest(AbfsHttpConstants.HTTP_METHOD_POST)
+            abfsCounters.trackDuration(AbfsStatistic.getStatNameFromHttpCall(AbfsHttpConstants.HTTP_METHOD_POST))
     ) {
       // Emulates doing some work.
       Thread.sleep(10);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
@@ -21,13 +21,31 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.services.AbfsCounters;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_PATCH_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_POST_REQUEST;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.extractStatistics;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupMeanStatistic;
 
 public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestAbfsNetworkStatistics.class);
   private static final int LARGE_OPERATIONS = 1000;
+  private static final AbfsStatistic[] HTTP_DURATION_TRACKER_LIST = {
+      HTTP_POST_REQUEST,
+      HTTP_PATCH_REQUEST
+  };
 
   public TestAbfsNetworkStatistics() throws Exception {
   }
@@ -63,5 +81,61 @@ public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
         metricMap);
     assertAbfsStatistics(AbfsStatistic.WRITE_THROTTLES, LARGE_OPERATIONS,
         metricMap);
+  }
+
+  /**
+   * Test to check if the DurationTrackers are tracking as expected whilst
+   * doing some work.
+   */
+  @Test
+  public void testAbfsNetworkDurationTrackers() throws IOException {
+    describe("Test to verify the actual values of DurationTrackers are "
+        + "greater than 0.0 while tracking some work.");
+
+    AbfsCounters abfsCounters = new AbfsCountersImpl(getFileSystem().getUri());
+    // Start dummy work for the DurationTrackers and start tracking.
+    try (DurationTracker ignoredPatch =
+        abfsCounters.startRequest(AbfsHttpConstants.HTTP_METHOD_PATCH);
+        DurationTracker ignoredPost =
+            abfsCounters.startRequest(AbfsHttpConstants.HTTP_METHOD_POST)
+    ) {
+      // Emulates doing some work.
+      Thread.sleep(10);
+      LOG.info("Execute some Http requests...");
+    } catch (InterruptedException e) {
+      throw new RuntimeException(
+          "Exception encountered while Thread tried to sleep", e);
+    }
+
+    // Extract the iostats from the abfsCounters instance.
+    IOStatistics ioStatistics = extractStatistics(abfsCounters);
+    // Asserting that the durationTrackers have mean > 0.0.
+    for (AbfsStatistic abfsStatistic : HTTP_DURATION_TRACKER_LIST) {
+      Assertions.assertThat(lookupMeanStatistic(ioStatistics,
+          abfsStatistic.getStatName() + StoreStatisticNames.SUFFIX_MEAN).mean())
+          .describedAs("The DurationTracker Named " + abfsStatistic.getStatName()
+                  + " Doesn't match the expected value")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  /**
+   * Test to check if abfs counter for HTTP 503 statusCode works correctly
+   * when incremented.
+   */
+  @Test
+  public void testAbfsHTTP503ErrorCounter() throws IOException {
+    describe("tests to verify the expected value of the HTTP 503 error "
+        + "counter is equal to number of times incremented.");
+
+    AbfsCounters abfsCounters = new AbfsCountersImpl(getFileSystem().getUri());
+    // Incrementing the server_unavailable counter.
+    for (int i = 0; i < LARGE_OPERATIONS; i++) {
+      abfsCounters.incrementCounter(AbfsStatistic.SERVER_UNAVAILABLE, 1);
+    }
+    // Getting the IOStatistics counter map from abfsCounters.
+    Map<String, Long> metricsMap = abfsCounters.toMap();
+    assertAbfsStatistics(AbfsStatistic.SERVER_UNAVAILABLE, LARGE_OPERATIONS,
+        metricsMap);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
@@ -88,7 +88,8 @@ public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
    * doing some work.
    */
   @Test
-  public void testAbfsNetworkDurationTrackers() throws IOException {
+  public void testAbfsNetworkDurationTrackers()
+      throws IOException, InterruptedException {
     describe("Test to verify the actual values of DurationTrackers are "
         + "greater than 0.0 while tracking some work.");
 
@@ -102,9 +103,6 @@ public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
       // Emulates doing some work.
       Thread.sleep(10);
       LOG.info("Execute some Http requests...");
-    } catch (InterruptedException e) {
-      throw new RuntimeException(
-          "Exception encountered while Thread tried to sleep", e);
     }
 
     // Extract the iostats from the abfsCounters instance.


### PR DESCRIPTION
Tested by: mvn -T 16 -Dparallel-tests=abfs clean verify
Region: East US

```
[INFO] Results:
[INFO]
[INFO] Tests run: 95, Failures: 0, Errors: 0, Skipped: 0
```

```
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testCheckAccessForNonExistentFile »  Unexp...
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionALL:293->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionEXECUTE:218->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionNONE:204->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionREAD:233->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionREADEXECUTE:263->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionWRITE:248->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testFsActionWRITEEXECUTE:278->checkPrerequisites:306->setTestUserFs:88->checkIfConfigIsSet:319 » IllegalArgument
[INFO]
[ERROR] Tests run: 512, Failures: 0, Errors: 8, Skipped: 67
```
Illegal argument due to not using oauth config for these tests.
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 256, Failures: 0, Errors: 0, Skipped: 77
```