### PR TITLE
YARN-10662. [JDK 11] TestTimelineReaderWebServicesHBaseStorage fails

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -206,6 +206,7 @@
     <junit.platform.version>1.5.1</junit.platform.version>
     <assertj.version>3.12.2</assertj.version>
     <jline.version>3.9.0</jline.version>
+    <jmockit.version>1.49</jmockit.version>
     <powermock.version>1.5.6</powermock.version>
     <solr.version>7.7.0</solr.version>
     <openssl-wildfly.version>1.0.7.Final</openssl-wildfly.version>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -326,7 +326,7 @@
     <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
-      <version>1.24</version>
+      <version>${jmockit.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -437,6 +437,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+            -Xmx2048m
+            -XX:+HeapDumpOnOutOfMemoryError
+          </argLine>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YARN-10662

- Upgrade jmockit to the latest version.
- Set argLine (reference: https://jmockit.github.io/tutorial/Introduction.html#runningTests)

Manually tested with AdoptOpenJDK 11.0.9.