### PR TITLE
HADOOP-17559. S3guard import OOM.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperations.java
@@ -705,8 +705,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
       LOG.info("Commit #2");
       writes.reset();
       commitContext.commitOrFail(commits.get(1));
-      assertPathExists("subdirectory", subdir);
-      assertPathExists("destFile2", destFile2);
+
       final String secondCommitContextString = commitContext.toString();
       LOG.info("Second Commit state {}", secondCommitContextString);
 
@@ -724,11 +723,11 @@ public class ITestCommitOperations extends AbstractCommitITest {
                 + "; second commit ancestors: " + secondCommitContextString,
             2);
       }
-
+      assertPathExists("subdirectory", subdir);
+      assertPathExists("destFile2", destFile2);
       LOG.info("Commit #3");
       writes.reset();
       commitContext.commitOrFail(commits.get(2));
-      assertPathExists("destFile3", destFile3);
       if (writesOnFirstCommit != 0) {
         // this file is in the same dir as destFile2, so only its entry
         // is added
@@ -737,6 +736,7 @@ public class ITestCommitOperations extends AbstractCommitITest {
                 + "first commit had " + writesOnFirstCommit,
             1);
       }
+      assertPathExists("destFile3", destFile3);
     }
     resetFailures();
   }


### PR DESCRIPTION
Remove all tracking of files from DDB AncestorState; dirs in import tool.

Reduces size of the cache to O(dirs).

Test change is to reduce brittleness to clock skew on loaded test runs;
removes an intermittent failure where the existence assert was triggering
a s3guard update -which then broke the assert about the number of writes

Change-Id: I9251f64beb0fec225b0b4ba71bc16f3e116bc758

