### PR TITLE
HADOOP-15880. Reduce redundant end logsegment rpc

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -1438,6 +1438,12 @@ public class FSEditLog implements LogsPurgeable {
    * Transitions from IN_SEGMENT state to BETWEEN_LOG_SEGMENTS state.
    */
   public synchronized void endCurrentLogSegment(boolean writeEndTxn) {
+
+    if (getLastWrittenTxId() == getSyncTxId()) {
+      LOG.info("No more edits after last sync: {}", getSyncTxId());
+      return;
+    }
+
     LOG.info("Ending log segment " + curSegmentTxId +
         ", " + getLastWrittenTxId());
     Preconditions.checkState(isSegmentOpen(),


### PR DESCRIPTION
## ISSUE
https://issues.apache.org/jira/browse/HDFS-15880

## OUTLINE

The SNN always send end logsegment rpc in cycle（dfs.ha.log-roll.period=120s）.
- 
- If no edit request occurs during this period, ANN will still send the RPC request to the journal node which is redundant.
- The `FSEditLog#endCurrentLogSegment` method is marked synchronized, it will affetc other rpc requests.


Editlogs only contains two operations :
```
LogSegmentOp [opCode=OP_START_LOG_SEGMENT, txid=-12345]
LogSegmentOp [opCode=OP_END_LOG_SEGMENT, txid=-12345]
```

```
[dcadmin@dw-work-006 ~]$ ll /work/data/hadoop/hdfs/journalnode/nn-work/current/
total 1100
-rw-r----- 1 dcadmin dcadmin       8 Mar  7 01:02 committed-txid
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:35 edits_0000000000000000001-0000000000000000002
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:37 edits_0000000000000000003-0000000000000000004
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:39 edits_0000000000000000005-0000000000000000006
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:41 edits_0000000000000000007-0000000000000000008
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:43 edits_0000000000000000009-0000000000000000010
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:45 edits_0000000000000000011-0000000000000000012
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:48 edits_0000000000000000013-0000000000000000014
-rw-r----- 1 dcadmin dcadmin      42 Mar  7 00:50 edits_0000000000000000015-0000000000000000016
```



