### PR TITLE
HDFS-15882. Fix incorrectly initializing RandomAccessFile based on configuration options

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/EditLogFileOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/EditLogFileOutputStream.java
@@ -84,9 +84,9 @@ public class EditLogFileOutputStream extends EditLogOutputStream {
     doubleBuf = new EditsDoubleBuffer(size);
     RandomAccessFile rp;
     if (shouldSyncWritesAndSkipFsync) {
-      rp = new RandomAccessFile(name, "rws");
-    } else {
       rp = new RandomAccessFile(name, "rw");
+    } else {
+      rp = new RandomAccessFile(name, "rws");
     }
     fp = new FileOutputStream(rp.getFD()); // open for append
     fc = rp.getChannel();


### PR DESCRIPTION
## ISSUE
https://issues.apache.org/jira/browse/HDFS-15882

## NOTICE

- `rw` Open for reading and writing.  If the file does not already exist then an attempt will be made to create it.
- `rws` Require that every update to the file's content or metadata be written synchronously to the underlying storage device. 

From the literal meaning of this variable `shouldSyncWritesAndSkipFsync`, we should use `rw` when shouldSyncWritesAndSkipFsync is true.

We use SATA disk to store the journal node's data. It's not effective for improving RPC performance whether the `shouldSyncWritesAndSkipFsync` variable is true or false. it's caused by initializing RandomAccessFile incorrectly.





