### PR TITLE
HDFS-15884. RBF: Remove unused method getCreateLocation in RouterRpcS…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -776,20 +776,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
         replication, blockSize, supportedVersions, ecPolicyName, storagePolicy);
   }
 
-
-  /**
-   * Get the location to create a file. It checks if the file already existed
-   * in one of the locations.
-   *
-   * @param src Path of the file to check.
-   * @return The remote location for this file.
-   * @throws IOException If the file has no creation location.
-   */
-  RemoteLocation getCreateLocation(final String src) throws IOException {
-    final List<RemoteLocation> locations = getLocationsForPath(src, true);
-    return getCreateLocation(src, locations);
-  }
-
   /**
    * Get the location to create a file. It checks if the file already existed
    * in one of the locations.


### PR DESCRIPTION
JIRA: [HDFS-15884](https://issues.apache.org/jira/browse/HDFS-15884)

Remove unused method `org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer#getCreateLocation`.
