### PR TITLE
HADOOP-17572. [branch-2.10] Docker image build fails due to the removal of openjdk-7-jdk package

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -156,6 +156,11 @@ pipeline {
                         # use emoji vote so it is easier to find the broken line
                         YETUS_ARGS+=("--github-use-emoji-vote")
 
+                        # Use both Java 7 and 8
+                        YETUS_ARGS+=("--java-home=/usr/lib/jvm/java-8-openjdk-amd64")
+                        YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/zulu-7-amd64")
+                        YETUS_ARGS+=("--multijdktests=compile")
+
                         "${TESTPATCHBIN}" "${YETUS_ARGS[@]}"
                         '''
                 }

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -94,12 +94,12 @@ RUN apt-get -q update \
 # OpenJDK 7
 #######
 # hadolint ignore=DL3008
-RUN add-apt-repository ppa:openjdk-r/ppa
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends openjdk-7-jdk \
+RUN curl -L -s -S https://cdn.azul.com/zulu/bin/zulu7.38.0.11-ca-jdk7.0.262-linux_amd64.deb \
+      -o /opt/jdk7.deb \
+    && apt-get -q install /opt/jdk7.deb \
+    && rm -rf /opt/jdk7.deb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-RUN update-java-alternatives --set java-1.7.0-openjdk-amd64
 
 ######
 # Install cmake 3.1.0 (3.5.1 ships with Xenial)

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -93,10 +93,9 @@ RUN apt-get -q update \
 #######
 # OpenJDK 7
 #######
-# hadolint ignore=DL3008
 RUN curl -L -s -S https://cdn.azul.com/zulu/bin/zulu7.38.0.11-ca-jdk7.0.262-linux_amd64.deb \
       -o /opt/jdk7.deb \
-    && apt-get -q install /opt/jdk7.deb \
+    && apt-get -q install -y --no-install-recommends /opt/jdk7.deb \
     && rm -rf /opt/jdk7.deb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/HadoopIllegalArgumentException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/HadoopIllegalArgumentException.java
@@ -1,3 +1,4 @@
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/HadoopIllegalArgumentException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/HadoopIllegalArgumentException.java
@@ -1,4 +1,3 @@
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
- Use Zulu OpenJDK 7.
- Enable multijdk option to compile with both Java 7 and 8 in GitHub PR.

JIRA: https://issues.apache.org/jira/browse/HADOOP-17572