### PR TITLE
HDFS-15886. Add a way to read the list of protected dirs from a special config file

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -153,17 +153,6 @@ public class CommonConfigurationKeysPublic {
   public static final String FS_PROTECTED_DIRECTORIES =
       "fs.protected.directories";
 
-  /**
-   *  Used to enable get protected directories from config file.
-   *  By default it is disabled
-   */
-  public static final String FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY=
-      "fs.protected.directories.config.file.enable";
-
-  /** Default value for FS_PROTECTED_DIRECTORIES_FILE_ENABLE_KEY */
-  public static final boolean FS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT=
-      false;
-
   // TBD: Code is still using hardcoded values (e.g. "fs.automatic.close")
   // instead of constant (e.g. FS_AUTOMATIC_CLOSE_KEY)
   //

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -153,6 +153,17 @@ public class CommonConfigurationKeysPublic {
   public static final String FS_PROTECTED_DIRECTORIES =
       "fs.protected.directories";
 
+  /**
+   *  Used to enable get protected directories from config file.
+   *  By default it is disabled
+   */
+  public static final String FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY=
+      "fs.protected.directories.config.file.enable";
+
+  /** Default value for FS_PROTECTED_DIRECTORIES_FILE_ENABLE_KEY */
+  public static final boolean FS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT=
+      false;
+
   // TBD: Code is still using hardcoded values (e.g. "fs.automatic.close")
   // instead of constant (e.g. FS_AUTOMATIC_CLOSE_KEY)
   //

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1546,6 +1546,18 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       false;
 
   /**
+   * Used to enable get protected directories from config file. By default it is disabled
+   */
+  public static final String DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY =
+      "dfs.protected.directories.config.file.enable";
+
+  /**
+   * Default value for DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY
+   */
+  public static final boolean DFS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT =
+      false;
+
+  /**
    *  HDFS-15548 to allow DISK/ARCHIVE configured on the same disk mount.
    *  The default ratio will be applied if DISK/ARCHIVE are configured
    *  on same disk mount.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1546,7 +1546,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       false;
 
   /**
-   * Used to enable get protected directories from config file. By default it is disabled
+   * whether to get the protected directories from a special configuration file
+   * which set on fs.protected.directories. By default it is disabled.
    */
   public static final String DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY =
       "dfs.protected.directories.config.file.enable";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -86,10 +86,10 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES;
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT;
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_ACCESSTIME_PRECISION_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_ACCESSTIME_PRECISION_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_QUOTA_BY_STORAGETYPE_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_QUOTA_BY_STORAGETYPE_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROTECTED_SUBDIRECTORIES_ENABLE;
@@ -392,8 +392,8 @@ public class FSDirectory implements Closeable {
         DFS_PROTECTED_SUBDIRECTORIES_ENABLE,
         DFS_PROTECTED_SUBDIRECTORIES_ENABLE_DEFAULT);
      this.isProtectedDirsConfigEnable = conf.getBoolean(
-        FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
-        FS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT);
+         DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
+         DFS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT);
 
     Preconditions.checkArgument(this.inodeXAttrsLimit >= 0,
         "Cannot set a negative limit on the number of xattrs per inode (%s).",
@@ -534,8 +534,8 @@ public class FSDirectory implements Closeable {
   static SortedSet<String> parseProtectedDirectories(Configuration conf) {
     return parseProtectedDirectories(
         conf.getBoolean(
-        FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
-        FS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT),
+            DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
+            DFS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT),
         conf.getTrimmed(FS_PROTECTED_DIRECTORIES));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -391,9 +391,9 @@ public class FSDirectory implements Closeable {
     this.isProtectedSubDirectoriesEnable = conf.getBoolean(
         DFS_PROTECTED_SUBDIRECTORIES_ENABLE,
         DFS_PROTECTED_SUBDIRECTORIES_ENABLE_DEFAULT);
-     this.isProtectedDirsConfigEnable = conf.getBoolean(
-         DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
-         DFS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT);
+    this.isProtectedDirsConfigEnable = conf.getBoolean(
+        DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
+        DFS_PROTECTED_DIRECTORIES_FILE_ENABLE_DEFAULT);
 
     Preconditions.checkArgument(this.inodeXAttrsLimit >= 0,
         "Cannot set a negative limit on the number of xattrs per inode (%s).",
@@ -556,7 +556,7 @@ public class FSDirectory implements Closeable {
     Collection<String> protectedDirs =
         configFileEnabled
             ? ProtectedDirsConfigReader.
-                parseProtectedProtectedDirsFromConfig(protectedDirsStringOrConfig)
+            parseProtectedProtectedDirsFromConfig(protectedDirsStringOrConfig)
             : StringUtils
                 .getTrimmedStringCollection(protectedDirsStringOrConfig);
     return parseProtectedDirectories(protectedDirs);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/ProtectedDirsConfigReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/ProtectedDirsConfigReader.java
@@ -1,17 +1,21 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements.  See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the License.  You may obtain
- * a copy of the License at
- *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.apache.hadoop.hdfs.util;
 
 import java.io.*;
@@ -29,7 +33,8 @@ import org.apache.hadoop.classification.InterfaceAudience;
 @InterfaceAudience.Private
 public class ProtectedDirsConfigReader {
 
-  private static final Log LOG = LogFactory.getLog(ProtectedDirsConfigReader.class);
+  private static final Log LOG = LogFactory
+      .getLog(ProtectedDirsConfigReader.class);
 
   private Set<String> currentDirectories;
 
@@ -97,7 +102,8 @@ public class ProtectedDirsConfigReader {
     return currentDirectories;
   }
 
-  public static Set<String> parseProtectedProtectedDirsFromConfig(String configFile) {
+  public static Set<String> parseProtectedProtectedDirsFromConfig(
+      String configFile) {
     try {
       ProtectedDirsConfigReader reader =
           new ProtectedDirsConfigReader(configFile);
@@ -107,7 +113,9 @@ public class ProtectedDirsConfigReader {
           configFile);
       return new HashSet<String>();
     } catch (IOException ex) {
-      LOG.error("Error in ProtectedDirsConfigReader.parseProtectedProtectedDirsFromConfig", ex);
+      LOG.error(
+          "Error in ProtectedDirsConfigReader.parseProtectedProtectedDirsFromConfig",
+          ex);
       return new HashSet<String>();
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/ProtectedDirsConfigReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/util/ProtectedDirsConfigReader.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdfs.util;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+import org.apache.hadoop.classification.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class ProtectedDirsConfigReader {
+
+  private static final Log LOG = LogFactory.getLog(ProtectedDirsConfigReader.class);
+
+  private Set<String> currentDirectories;
+
+  public ProtectedDirsConfigReader(String configFile) throws IOException {
+    currentDirectories = new HashSet<String>();
+    loadConfig(configFile);
+  }
+
+  private void readFileToSet(String filename,
+      Set<String> set) throws IOException {
+    File file = new File(filename);
+    InputStream fis = Files.newInputStream(file.toPath());
+    readFileToSetWithFileInputStream(filename, fis, set);
+  }
+
+  private void readFileToSetWithFileInputStream(String filename,
+      InputStream fileInputStream, Set<String> set)
+      throws IOException {
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(
+          new InputStreamReader(fileInputStream, StandardCharsets.UTF_8));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String[] paths = line.split("[ \t\n\f\r]+");
+        if (paths != null) {
+          for (int i = 0; i < paths.length; i++) {
+            paths[i] = paths[i].trim();
+            if (paths[i].startsWith("#")) {
+              // Everything from now on is a comment
+              break;
+            }
+            if (!paths[i].isEmpty()) {
+              LOG.info("Adding " + paths[i] + " to the list of " +
+                  " protected directories from " + filename);
+              set.add(paths[i]);
+            }
+          }
+        }
+      }
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+      fileInputStream.close();
+    }
+  }
+
+  private synchronized void loadConfig(String configFile) throws IOException {
+    LOG.info("Loading protected directories");
+    Set<String> newDirs = new HashSet<String>();
+
+    if (!configFile.isEmpty()) {
+      readFileToSet(configFile, newDirs);
+      currentDirectories = Collections.unmodifiableSet(newDirs);
+    }
+  }
+
+  /**
+   * Duplicate and empty values are removed
+   *
+   * @return currentDirectories
+   */
+  public synchronized Set<String> getProtectedProtectedDirs() {
+    return currentDirectories;
+  }
+
+  public static Set<String> parseProtectedProtectedDirsFromConfig(String configFile) {
+    try {
+      ProtectedDirsConfigReader reader =
+          new ProtectedDirsConfigReader(configFile);
+      return reader.getProtectedProtectedDirs();
+    } catch (NoSuchFileException ex) {
+      LOG.warn("The protected directories config flle is not found in " +
+          configFile);
+      return new HashSet<String>();
+    } catch (IOException ex) {
+      LOG.error("Error in ProtectedDirsConfigReader.parseProtectedProtectedDirsFromConfig", ex);
+      return new HashSet<String>();
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6069,6 +6069,14 @@
   </property>
 
   <property>
+    <name>dfs.protected.directories.config.file.enable</name>
+    <value>false</value>
+    <description>whether to get the protected directories from a special
+      configuration file which set on fs.protected.directories.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.storage.default.policy</name>
     <value>HOT</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestProtectedDirectories.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestProtectedDirectories.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.security.AccessControlException;
-import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,11 +61,11 @@ public class TestProtectedDirectories {
       TestProtectedDirectories.class);
 
   // Using /test/build/data/tmp directory to store temprory files
-  final String PATH_TEST_DIR = new File(System.getProperty(
+  private final String pathTestDir = new File(System.getProperty(
       "test.build.data", "/tmp")).getAbsolutePath();
 
-  String configFile = PATH_TEST_DIR + "/protected.dir.config";
-  String newConfigFile = PATH_TEST_DIR + "/protected.dir.config_new";
+  private String configFile = pathTestDir + "/protected.dir.config";
+  private String newConfigFile = pathTestDir + "/protected.dir.config_new";
 
 
   @Rule
@@ -124,7 +123,8 @@ public class TestProtectedDirectories {
         configFile);
 
     generateConfigFile(configFile,
-        protectedDirs.stream().map(Path::toString).collect(Collectors.toList()));
+        protectedDirs.stream().map(Path::toString)
+            .collect(Collectors.toList()));
 
     return setupTestCluster(conf, protectedDirs, unProtectedDirs);
   }
@@ -342,9 +342,10 @@ public class TestProtectedDirectories {
 
     FSDirectory fsDirectory = nn.getNamesystem().getFSDirectory();
 
-    TreeSet<String> protectedPathSet = new TreeSet<>(FSDirectory.normalizePaths(
-        protectedPaths.stream().map(Path::toString).collect(Collectors.toList()),
-        FS_PROTECTED_DIRECTORIES));
+    TreeSet<String> protectedPathSet = new TreeSet<>(
+        FSDirectory.normalizePaths(protectedPaths.stream().map(Path::toString)
+                .collect(Collectors.toList()),
+            FS_PROTECTED_DIRECTORIES));
 
     // verify
     assertEquals(conf.get(FS_PROTECTED_DIRECTORIES), configFile);
@@ -716,12 +717,13 @@ public class TestProtectedDirectories {
   }
 
   /**
-   * generate the configuration file with protectedPaths
+   * generate the configuration file with protectedPaths.
    * @param file
    * @param protectedPaths
    * @throws IOException
    */
-  private void generateConfigFile(String file, Collection<String> protectedPaths)
+  private void generateConfigFile(String file,
+      Collection<String> protectedPaths)
       throws IOException {
     try (FileWriter ifw = new FileWriter(file)) {
       for (String dir : protectedPaths) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestProtectedDirectories.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestProtectedDirectories.java
@@ -46,6 +46,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
 
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PROTECTED_SUBDIRECTORIES_ENABLE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -116,10 +117,10 @@ public class TestProtectedDirectories {
       throws Throwable {
     // Initialize the configuration.
     conf.setBoolean(
-        CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
+        DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
         true);
     conf.set(
-        CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES,
+        FS_PROTECTED_DIRECTORIES,
         configFile);
 
     generateConfigFile(configFile,
@@ -325,10 +326,10 @@ public class TestProtectedDirectories {
     Configuration conf = new HdfsConfiguration();
 
     conf.setBoolean(
-        CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
+        DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
         true);
     conf.set(
-        CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES,
+        FS_PROTECTED_DIRECTORIES,
         configFile);
 
     Collection<Path> protectedPaths = Arrays.asList(new Path("/a"), new Path(
@@ -359,10 +360,10 @@ public class TestProtectedDirectories {
     Configuration conf = new HdfsConfiguration();
 
     conf.setBoolean(
-        CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
+        DFS_PROTECTED_DIRECTORIES_CONFIG_FILE_ENABLE_KEY,
         true);
     conf.set(
-        CommonConfigurationKeys.FS_PROTECTED_DIRECTORIES,
+        FS_PROTECTED_DIRECTORIES,
         configFile);
 
     Collection<Path> protectedPaths = Arrays.asList(new Path("/a"), new Path(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestProtectedDirsConfigReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestProtectedDirsConfigReader.java
@@ -1,17 +1,21 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements.  See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the License.  You may obtain
- * a copy of the License at
- *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.apache.hadoop.hdfs.util;
 
 import static org.junit.Assert.assertEquals;
@@ -33,10 +37,10 @@ import org.junit.Test;
 public class TestProtectedDirsConfigReader {
 
   // Using /test/build/data/tmp directory to store temprory files
-  final String PATH_TEST_DIR = new File(System.getProperty(
+  private final String pathTestDir = new File(System.getProperty(
       "test.build.data", "/tmp")).getAbsolutePath();
 
-  String configFile = PATH_TEST_DIR + "/protected.dir.config";
+  private String configFile = pathTestDir + "/protected.dir.config";
 
   @Before
   public void setUp() throws Exception {
@@ -85,16 +89,16 @@ public class TestProtectedDirsConfigReader {
    * Test creating a new ProtectedDirConfigFileReader with nonexistent files
    */
   @Test
-  public void testCreateProtectedDirConfigFileReaderWithNonexistentFile() throws Exception {
+  public void testCreateReaderWithNonexistentFile() throws Exception {
     try {
       new ProtectedDirsConfigReader(
-          PATH_TEST_DIR + "/doesnt-exist");
+          pathTestDir + "/doesnt-exist");
       Assert.fail("Should throw FileNotFoundException");
     } catch (NoSuchFileException ex) {
       // Exception as expected
     }
     Set<String> dirs = ProtectedDirsConfigReader.
-        parseProtectedProtectedDirsFromConfig(PATH_TEST_DIR + "/doesnt-exist");
+        parseProtectedProtectedDirsFromConfig(pathTestDir + "/doesnt-exist");
     assertEquals(0, dirs.size());
   }
 
@@ -115,7 +119,8 @@ public class TestProtectedDirsConfigReader {
     // TestCase1: Check if lines beginning with # are ignored
     assertEquals(0, dirsLen);
 
-    // TestCase2: Check if given path names are reported by getProtectedProtectedDirs
+    // TestCase2: Check if given path names are reported
+    // by getProtectedProtectedDirs.
     assertFalse(hfp.getProtectedProtectedDirs().contains("/dire1/dire2"));
   }
 
@@ -123,7 +128,8 @@ public class TestProtectedDirsConfigReader {
    * Check if only comments can be written to paths file
    */
   @Test
-  public void testProtectedDirConfigFileReaderWithCommentsOnly() throws Exception {
+  public void testProtectedDirConfigFileReaderWithCommentsOnly()
+      throws Exception {
     FileWriter cfw = new FileWriter(configFile);
 
     cfw.write("#PROTECTED-DIRS-LIST\n");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestProtectedDirsConfigReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestProtectedDirsConfigReader.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdfs.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.NoSuchFileException;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test for ProtectedDirsConfigReader
+ */
+public class TestProtectedDirsConfigReader {
+
+  // Using /test/build/data/tmp directory to store temprory files
+  final String PATH_TEST_DIR = new File(System.getProperty(
+      "test.build.data", "/tmp")).getAbsolutePath();
+
+  String configFile = PATH_TEST_DIR + "/protected.dir.config";
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // Delete test files after running tests
+    new  File(configFile).delete();
+
+  }
+
+  /*
+   * 1.Create protected.dirs.config file
+   * 2.Write path names per line
+   * 3.Write comments starting with #
+   * 4.Close file
+   * 5.Compare if number of paths reported by ProtectedDirConfigFileReader
+   *   are equal to the number of paths written
+   */
+  @Test
+  public void testProtectedDirConfigFileReader() throws Exception {
+
+    FileWriter cfw = new FileWriter(configFile);
+
+    cfw.write("#PROTECTED-DIRS-LIST\n");
+    cfw.write("/dira1/dira2\n");
+    cfw.write("/dirb1/dirb2/dirb3\n");
+    cfw.write("/dirc1/dirc2/dirc3\n");
+    cfw.write("#This-is-comment\n");
+    cfw.write("/dird1/dird2 # /diri1/diri2\n");
+    cfw.write("/dird1/dird2 /dire1/dire2\n");
+    cfw.close();
+
+    ProtectedDirsConfigReader hfp = new ProtectedDirsConfigReader(configFile);
+
+    int dirsLen = hfp.getProtectedProtectedDirs().size();
+
+    assertEquals(5, dirsLen);
+    assertTrue(hfp.getProtectedProtectedDirs().contains("/dire1/dire2"));
+    assertFalse(hfp.getProtectedProtectedDirs().contains("/dirh1/dirh2"));
+
+  }
+
+  /*
+   * Test creating a new ProtectedDirConfigFileReader with nonexistent files
+   */
+  @Test
+  public void testCreateProtectedDirConfigFileReaderWithNonexistentFile() throws Exception {
+    try {
+      new ProtectedDirsConfigReader(
+          PATH_TEST_DIR + "/doesnt-exist");
+      Assert.fail("Should throw FileNotFoundException");
+    } catch (NoSuchFileException ex) {
+      // Exception as expected
+    }
+    Set<String> dirs = ProtectedDirsConfigReader.
+        parseProtectedProtectedDirsFromConfig(PATH_TEST_DIR + "/doesnt-exist");
+    assertEquals(0, dirs.size());
+  }
+
+
+  /*
+   * Test for null file
+   */
+  @Test
+  public void testProtectedDirConfigFileReaderWithNull() throws Exception {
+    FileWriter cfw = new FileWriter(configFile);
+
+    cfw.close();
+
+    ProtectedDirsConfigReader hfp = new ProtectedDirsConfigReader(configFile);
+
+    int dirsLen = hfp.getProtectedProtectedDirs().size();
+
+    // TestCase1: Check if lines beginning with # are ignored
+    assertEquals(0, dirsLen);
+
+    // TestCase2: Check if given path names are reported by getProtectedProtectedDirs
+    assertFalse(hfp.getProtectedProtectedDirs().contains("/dire1/dire2"));
+  }
+
+  /*
+   * Check if only comments can be written to paths file
+   */
+  @Test
+  public void testProtectedDirConfigFileReaderWithCommentsOnly() throws Exception {
+    FileWriter cfw = new FileWriter(configFile);
+
+    cfw.write("#PROTECTED-DIRS-LIST\n");
+    cfw.write("#This-is-comment\n");
+
+    cfw.close();
+
+    ProtectedDirsConfigReader hfp = new ProtectedDirsConfigReader(configFile);
+
+    int dirsLen = hfp.getProtectedProtectedDirs().size();
+
+    assertEquals(0, dirsLen);
+    assertFalse(hfp.getProtectedProtectedDirs().contains("/dire1/dire2"));
+
+  }
+
+  /*
+   * Test if spaces are allowed in path names
+   */
+  @Test
+  public void testProtectedDirConfigFileReaderWithSpaces() throws Exception {
+
+    FileWriter cfw = new FileWriter(configFile);
+
+    cfw.write("#PROTECTED-DIRS-LIST\n");
+    cfw.write("   somepath /dirb1/dirb2/dirb3");
+    cfw.write("   /dirc1/dirc2/dirc3 # /dird1/dird2");
+    cfw.close();
+
+    ProtectedDirsConfigReader hfp = new ProtectedDirsConfigReader(configFile);
+
+    int dirsLen = hfp.getProtectedProtectedDirs().size();
+
+    assertEquals(3, dirsLen);
+    assertTrue(hfp.getProtectedProtectedDirs().contains("/dirc1/dirc2/dirc3"));
+    assertFalse(hfp.getProtectedProtectedDirs().contains("/dire1/dire2"));
+    assertFalse(hfp.getProtectedProtectedDirs().contains("/dird1/dird2"));
+
+  }
+
+  /*
+   * Test if spaces , tabs and new lines are allowed
+   */
+  @Test
+  public void testProtectedDirConfigFileReaderWithTabs() throws Exception {
+    FileWriter cfw = new FileWriter(configFile);
+
+    cfw.write("#PROTECTED-DIRS-LIST\n");
+    cfw.write("     \n");
+    cfw.write("   somepath \t  /dirb1/dirb2/dirb3 \n /dird1/dird2");
+    cfw.write("   /dirc1/dirc2/dirc3 \t # /dire1/dire2");
+    cfw.close();
+
+    ProtectedDirsConfigReader hfp = new ProtectedDirsConfigReader(configFile);
+
+    int dirsLen = hfp.getProtectedProtectedDirs().size();
+
+    assertEquals(4, dirsLen);
+    assertTrue(hfp.getProtectedProtectedDirs().contains("/dirb1/dirb2/dirb3"));
+    assertFalse(hfp.getProtectedProtectedDirs().contains("/dire1/dire2"));
+
+  }
+}


### PR DESCRIPTION
# jira
https://issues.apache.org/jira/browse/HDFS-15886

We used protected dirs to ensure that important data directories cannot be deleted by mistake. But protected dirs can only be configured in hdfs-site.xml.

For ease of management,  we add a way to get the list of protected dirs from a special configuration file.

How to use.

1. set the config in hdfs-site.xml

```
<property>
<name>dfs.protected.directories.config.file.enable</name>
<value>true</value>
</property>
<property>
<name>fs.protected.directories</name>
<value>file:///path/to/protected.dirs.config</value>
</property>
```

2.  add some protected dirs to the config file (file:///path/to/protected.dirs.config)

```
/1
/2/3
```

3. done