### PR TITLE
HADOOP-17476. ITestAssumeRole.testAssumeRoleBadInnerAuth failure.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -255,8 +255,7 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     conf.set(SECRET_KEY, "not secret");
     expectFileSystemCreateFailure(conf,
         AWSBadRequestException.class,
-        "not a valid " +
-        "key=value pair (missing equal-sign) in Authorization header");
+        "IncompleteSignature");
   }
 
   @Test


### PR DESCRIPTION

Removes string match so change in AWS S3 error message doesn't  cause the test to fail