### PR TITLE
HDFS-15901.Solve the problem of DN repeated block reports occupying too many RPCs during Safemode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2603,6 +2603,24 @@ public class BlockManager implements BlockStatsMXBean {
       LOG.warn("Failed to find datanode {}", nodeReg);
       return 0;
     }
+
+    // During safemode, DataNodes are only allowed to report all data once.
+    if (namesystem.isInStartupSafeMode()) {
+      boolean allReported = true;
+      for (DatanodeStorageInfo storageInfo : node.getStorageInfos()) {
+        if (storageInfo.getBlockReportCount() < 1) {
+          allReported = false;
+          break;
+        }
+      }
+
+      if (allReported) {
+        LOG.info("The datanode {} has reported all blocks and does not need "
+            + "to be reported again during SafeMode.", nodeReg);
+        return 0;
+      }
+    }
+
     // Request a new block report lease.  The BlockReportLeaseManager has
     // its own internal locking.
     long leaseId = blockReportLeaseManager.requestLease(node);


### PR DESCRIPTION
…oo many RPCs during Safemode.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
