### PR TITLE
HDFS-15906. Close FSImage and FSNamesystem after formatting is complete

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1245,8 +1245,9 @@ public class NameNode extends ReconfigurableBase implements
     LOG.info("Formatting using clusterid: {}", clusterId);
     
     FSImage fsImage = new FSImage(conf, nameDirsToFormat, editDirsToFormat);
+    FSNamesystem fsn = null;
     try {
-      FSNamesystem fsn = new FSNamesystem(conf, fsImage);
+      fsn = new FSNamesystem(conf, fsImage);
       fsImage.getEditLog().initJournalsForWrite();
 
       // Abort NameNode format if reformat is disabled and if
@@ -1269,12 +1270,16 @@ public class NameNode extends ReconfigurableBase implements
       }
 
       fsImage.format(fsn, clusterId, force);
-      fsn.close();
     } catch (IOException ioe) {
       LOG.warn("Encountered exception during format", ioe);
       throw ioe;
     } finally {
-      fsImage.close();
+      if (fsImage != null) {
+        fsImage.close();
+      }
+      if (fsn != null) {
+        fsn.close();
+      }
     }
     return false;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1269,10 +1269,12 @@ public class NameNode extends ReconfigurableBase implements
       }
 
       fsImage.format(fsn, clusterId, force);
+      fsn.close();
     } catch (IOException ioe) {
       LOG.warn("Encountered exception during format", ioe);
-      fsImage.close();
       throw ioe;
+    } finally {
+      fsImage.close();
     }
     return false;
   }


### PR DESCRIPTION
JIRA: [HDFS-15906](https://issues.apache.org/jira/browse/HDFS-15906)

We should close FSImage and FSNamesystem after formatting is complete.