### PR TITLE
HDFS-15908. Possible Resource Leak in org.apache.hadoop.hdfs.qjournal.server.Journal

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
@@ -264,9 +264,9 @@ public class Journal implements Closeable {
    */
   @Override // Closeable
   public void close() throws IOException {
-    storage.close();
     IOUtils.closeStream(committedTxnId);
     IOUtils.closeStream(curSegment);
+    storage.close();
   }
   
   JNStorage getStorage() {


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://issues.apache.org/jira/browse/HDFS-15908).