### PR TITLE
HADOOP-17600. Replace Time.now() with Time.monotonicNow() for measuring time durations

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SocketIOWithTimeout.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SocketIOWithTimeout.java
@@ -194,7 +194,7 @@ abstract class SocketIOWithTimeout {
       }
 
       long timeoutLeft = timeout;
-      long endTime = (timeout > 0) ? (Time.now() + timeout): 0;
+      long endTime = (timeout > 0) ? (Time.monotonicNow() + timeout): 0;
       
       while (true) {
         // we might have to call finishConnect() more than once
@@ -209,7 +209,7 @@ abstract class SocketIOWithTimeout {
         
         if (ret == 0 ||
             (timeout > 0 &&  
-              (timeoutLeft = (endTime - Time.now())) <= 0)) {
+              (timeoutLeft = (endTime - Time.monotonicNow())) <= 0)) {
           throw new SocketTimeoutException(
                     timeoutExceptionString(channel, timeout, 
                                            SelectionKey.OP_CONNECT));
@@ -330,7 +330,7 @@ abstract class SocketIOWithTimeout {
       
       try {
         while (true) {
-          long start = (timeout == 0) ? 0 : Time.now();
+          long start = (timeout == 0) ? 0 : Time.monotonicNow();
 
           key = channel.register(info.selector, ops);
           ret = info.selector.select(timeoutLeft);
@@ -343,7 +343,7 @@ abstract class SocketIOWithTimeout {
            * unknown reasons. So select again if required.
            */
           if (timeout > 0) {
-            timeoutLeft -= Time.now() - start;
+            timeoutLeft -= Time.monotonicNow() - start;
             timeoutLeft = Math.max(0, timeoutLeft);
           }
           

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ThreadUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ThreadUtil.java
@@ -37,10 +37,10 @@ public class ThreadUtil {
    * @param millis the number of milliseconds for the current thread to sleep
    */
   public static void sleepAtLeastIgnoreInterrupts(long millis) {
-    long start = Time.now();
-    while (Time.now() - start < millis) {
+    long start = Time.monotonicNow();
+    while (Time.monotonicNow() - start < millis) {
       long timeToSleep = millis -
-          (Time.now() - start);
+          (Time.monotonicNow() - start);
       try {
         Thread.sleep(timeToSleep);
       } catch (InterruptedException ie) {

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HTestCase.java
@@ -144,18 +144,18 @@ public abstract class HTestCase {
    *         to <code>true</code>.
    */
   protected long waitFor(int timeout, boolean failIfTimeout, Predicate predicate) {
-    long started = Time.now();
-    long mustEnd = Time.now() + (long) (getWaitForRatio() * timeout);
+    long started = Time.monotonicNow();
+    long mustEnd = Time.monotonicNow() + (long) (getWaitForRatio() * timeout);
     long lastEcho = 0;
     try {
-      long waiting = mustEnd - Time.now();
+      long waiting = mustEnd - Time.monotonicNow();
       System.out.println(MessageFormat.format("Waiting up to [{0}] msec", waiting));
       boolean eval;
-      while (!(eval = predicate.evaluate()) && Time.now() < mustEnd) {
-        if ((Time.now() - lastEcho) > 5000) {
-          waiting = mustEnd - Time.now();
+      while (!(eval = predicate.evaluate()) && Time.monotonicNow() < mustEnd) {
+        if ((Time.monotonicNow() - lastEcho) > 5000) {
+          waiting = mustEnd - Time.monotonicNow();
           System.out.println(MessageFormat.format("Waiting up to [{0}] msec", waiting));
-          lastEcho = Time.now();
+          lastEcho = Time.monotonicNow();
         }
         Thread.sleep(100);
       }
@@ -166,7 +166,7 @@ public abstract class HTestCase {
           System.out.println(MessageFormat.format("Waiting timed out after [{0}] msec", timeout));
         }
       }
-      return (eval) ? Time.now() - started : -1;
+      return (eval) ? Time.monotonicNow() - started : -1;
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/ZKDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/security/token/ZKDelegationTokenSecretManagerImpl.java
@@ -115,9 +115,9 @@ public class ZKDelegationTokenSecretManagerImpl extends
         }
 
         LOG.info("Start loading token cache");
-        long start = Time.now();
+        long start = Time.monotonicNow();
         rebuildTokenCache(true);
-        LOG.info("Loaded token cache in {} milliseconds", Time.now() - start);
+        LOG.info("Loaded token cache in {} milliseconds", Time.monotonicNow() - start);
 
         int syncInterval = conf.getInt(ZK_DTSM_ROUTER_TOKEN_SYNC_INTERVAL,
             ZK_DTSM_ROUTER_TOKEN_SYNC_INTERVAL_DEFAULT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
@@ -1033,7 +1033,7 @@ public class DiskBalancer {
       }
 
       List<FsVolumeSpi.BlockIterator> poolIters = new LinkedList<>();
-      startTime = Time.now();
+      startTime = Time.monotonicNow();
       item.setStartTime(startTime);
       secondsElapsed = 0;
 
@@ -1120,7 +1120,7 @@ public class DiskBalancer {
             // throughput threshold.
             item.incCopiedSoFar(block.getNumBytes());
             item.incBlocksCopied();
-            secondsElapsed = TimeUnit.MILLISECONDS.toSeconds(Time.now() -
+            secondsElapsed = TimeUnit.MILLISECONDS.toSeconds(Time.monotonicNow() -
                 startTime);
             item.setSecondsElapsed(secondsElapsed);
           } catch (IOException ex) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/HATestUtil.java
@@ -88,8 +88,8 @@ public abstract class HATestUtil {
 
     active.getRpcServer().rollEditLog();
 
-    long start = Time.now();
-    while (Time.now() - start < TestEditLogTailer.NN_LAG_TIMEOUT) {
+    long start = Time.monotonicNow();
+    while (Time.monotonicNow() - start < TestEditLogTailer.NN_LAG_TIMEOUT) {
       long nn2HighestTxId = standby.getNamesystem().getFSImage()
         .getLastAppliedTxId();
       if (nn2HighestTxId >= activeTxId) {
@@ -341,13 +341,13 @@ public abstract class HATestUtil {
   
   public static void waitForCheckpoint(MiniDFSCluster cluster, int nnIdx,
       List<Integer> txids) throws InterruptedException {
-    long start = Time.now();
+    long start = Time.monotonicNow();
     while (true) {
       try {
         FSImageTestUtil.assertNNHasCheckpoints(cluster, nnIdx, txids);
         return;
       } catch (AssertionError err) {
-        if (Time.now() - start > 10000) {
+        if (Time.monotonicNow() - start > 10000) {
           throw err;
         } else {
           Thread.sleep(300);


### PR DESCRIPTION
JIRA ISSUE: [https://issues.apache.org/jira/browse/HADOOP-17600](https://issues.apache.org/jira/browse/HADOOP-17600)