### PR TITLE
HDFS-15918. Replace deprecated RAND_pseudo_bytes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/sasl_authenticator.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/sasl_authenticator.h
@@ -49,7 +49,7 @@ private:
 
   static size_t NextToken(const std::string &payload, size_t off,
                           std::string *tok);
-  void GenerateCNonce();
+  Status GenerateCNonce();
   std::string username_;
   std::string password_;
   std::string nonce_;


### PR DESCRIPTION
* RAND_pseudo_bytes is deprecated in OpenSSL
  1.1.1 and must be replaced by RAND_bytes.
