### PR TITLE
YARN-10712. Fix word errors in class comments

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
@@ -62,7 +62,7 @@ import com.google.common.base.Preconditions;
  * <p>
  * Rack localized {@link ResourceRequest}s are forwarded to the RMs that owns
  * the corresponding rack. Note that in some deployments each rack could be
- * striped across multiple RMs. Thsi policy respects that. If the
+ * striped across multiple RMs. This policy respects that. If the
  * {@link SubClusterResolver} cannot resolve this rack we default to forwarding
  * the {@link ResourceRequest} to the home sub-cluster.
  * </p>


### PR DESCRIPTION
Class of LocalityMulticastAMRMProxyPolicy’s class comment has error word “thsi”


Part of the comment：

Rack localized {@link ResourceRequest}s are forwarded to the RMs that owns
 the corresponding rack. Note that in some deployments each rack could be
striped across multiple RMs. Thsi policy respects that. If the
 {@link SubClusterResolver} cannot resolve this rack we default to forwarding
 the {@link ResourceRequest} to the home sub-cluster.
