### PR TITLE
HDFS-15922. Use memcpy for copying non-null terminated string in jni_helper.c

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
@@ -536,7 +536,7 @@ static ssize_t getClassPath_helper(const char *classpath, char* expandedClasspat
             // +1 for path separator or null terminator
             length += tokenlen + 1;
             if (expandedCP_curr != NULL) {
-                strncpy(expandedCP_curr, cp_token, tokenlen);
+                memcpy(expandedCP_curr, cp_token, tokenlen);
                 expandedCP_curr += tokenlen;
                 *expandedCP_curr = PATH_SEPARATOR;
                 expandedCP_curr++;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
@@ -422,9 +422,9 @@ static ssize_t wildcard_expandPath(const char* path, char* expanded)
 
                 if (expanded != NULL) {
                     // pathLength includes an extra '.'
-                    strncpy(dest, path, pathLength-1);
+                    memcpy(dest, path, pathLength - 1);
                     dest += pathLength - 1;
-                    strncpy(dest, filename, filenameLength);
+                    memcpy(dest, filename, filenameLength);
                     dest += filenameLength;
                     *dest = PATH_SEPARATOR;
                     dest++;


### PR DESCRIPTION
* strncpy reports a warning if the
  destination string isn't null
  terminated.
* The scenario here is that the string
  is deliberately not null terminated
  since we want to imperatively suffix
  a PATH_SEPARATOR at the end.
* Thus, the warning reported by strncpy
  even though valid, isn't applicable.
* Hence we replace strncpy with memcpy
  which doesn't worry if the string
  is null terminated or not.
