### PR TITLE
HDFS-15927. Catch polymorphic type by reference

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/hdfs_configuration.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/hdfs_configuration.cc
@@ -135,7 +135,7 @@ std::vector<NamenodeInfo> HdfsConfiguration::LookupNameService(const std::string
       URI uri;
       try {
         uri = URI::parse_from_string(PrependHdfsScheme(Get(dom_node_name)));
-      } catch (const uri_parse_error) {
+      } catch (const uri_parse_error&) {
         throw ha_parse_error("unable to find " + dom_node_name);
       }
 
@@ -148,7 +148,7 @@ std::vector<NamenodeInfo> HdfsConfiguration::LookupNameService(const std::string
       NamenodeInfo node(nameservice, *node_id, uri);
       namenodes.push_back(node);
     }
-  } catch (ha_parse_error e) {
+  } catch (const ha_parse_error& e) {
     LOG_ERROR(kRPC, << "HA cluster detected but failed because : " << e.what());
     namenodes.clear(); // Don't return inconsistent view
   }


### PR DESCRIPTION
* Need to catch polymorphic exception types by
  reference in order to realize the polymorphic
  usage. Otherwise, the functionality of the
  caught object is restricted to only that of
  the base class.
