### PR TITLE
HDFS-15928. Replace RAND_pseudo_bytes in rpc_engine.cc

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/request.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/request.cc
@@ -100,13 +100,19 @@ static void SetRequestHeader(std::weak_ptr<LockFreeRpcEngine> weak_engine, int c
     return;
   }
 
+  const auto& client_id = counted_engine->client_id();
+  if (client_id == nullptr) {
+    LOG_ERROR(kRPC, << "Failed to generate client ID");
+    return;
+  }
+
   rpc_header->set_rpckind(RPC_PROTOCOL_BUFFER);
   rpc_header->set_rpcop(RpcRequestHeaderProto::RPC_FINAL_PACKET);
   rpc_header->set_callid(call_id);
   if (retry_count != kNoRetry) {
     rpc_header->set_retrycount(retry_count);
   }
-  rpc_header->set_clientid(counted_engine->client_id());
+  rpc_header->set_clientid(*client_id);
   req_header->set_methodname(method_name);
   req_header->set_declaringclassprotocolname(counted_engine->protocol_name());
   req_header->set_clientprotocolversion(counted_engine->protocol_version());

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/rpc_engine.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/rpc_engine.cc
@@ -23,8 +23,11 @@
 #include "common/optional_wrapper.h"
 
 #include <algorithm>
+#include <memory>
 
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <openssl/rand.h>
+#include <openssl/err.h>
 
 namespace hdfs {
 
@@ -111,8 +114,7 @@ std::unique_ptr<const RetryPolicy> RpcEngine::MakeRetryPolicy(const Options &opt
   }
 }
 
-std::string RpcEngine::getRandomClientId()
-{
+std::unique_ptr<std::string> RpcEngine::getRandomClientId() {
   /**
    *  The server is requesting a 16-byte UUID:
    *  https://github.com/c9n/hadoop/blob/master/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ClientId.java
@@ -121,14 +123,19 @@ std::string RpcEngine::getRandomClientId()
    *  https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
    **/
   std::vector<unsigned char>buf(16);
-  RAND_pseudo_bytes(&buf[0], buf.size());
+  if (RAND_bytes(&buf[0], static_cast<int>(buf.size())) != 1) {
+    const auto *error = ERR_reason_error_string(ERR_get_error());
+    LOG_ERROR(kRPC, << "Unable to generate random client ID, err : " << error);
+    return nullptr;
+  }
 
   //clear the first four bits of byte 6 then set the second bit
   buf[6] = (buf[6] & 0x0f) | 0x40;
 
   //clear the second bit of byte 8 and set the first bit
   buf[8] = (buf[8] & 0xbf) | 0x80;
-  return std::string(reinterpret_cast<const char*>(&buf[0]), buf.size());
+  return std::unique_ptr<std::string>(
+      new std::string(reinterpret_cast<const char *>(&buf[0]), buf.size()));
 }
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/rpc_engine.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/rpc_engine.h
@@ -80,7 +80,7 @@ public:
   virtual int NextCallId() = 0;
 
   virtual const std::string &client_name() = 0;
-  virtual const std::string &client_id() = 0;
+  virtual const std::unique_ptr<std::string> &client_id() = 0;
   virtual const std::string &user_name() = 0;
   virtual const std::string &protocol_name() = 0;
   virtual int protocol_version() = 0;
@@ -142,7 +142,7 @@ class RpcEngine : public LockFreeRpcEngine, public std::enable_shared_from_this<
   std::unique_ptr<const RetryPolicy> TEST_GenerateRetryPolicyUsingOptions();
 
   const std::string &client_name() override { return client_name_; }
-  const std::string &client_id() override { return client_id_; }
+  const std::unique_ptr<std::string> &client_id() override { return client_id_; }
   const std::string &user_name() override { return auth_info_.getUser(); }
   const std::string &protocol_name() override { return protocol_name_; }
   int protocol_version() override { return protocol_version_; }
@@ -157,7 +157,7 @@ protected:
   virtual std::shared_ptr<RpcConnection> NewConnection();
   virtual std::unique_ptr<const RetryPolicy> MakeRetryPolicy(const Options &options);
 
-  static std::string getRandomClientId();
+  static std::unique_ptr<std::string> getRandomClientId();
 
   // Remember all of the last endpoints in case we need to reconnect and retry
   std::vector<boost::asio::ip::tcp::endpoint> last_endpoints_;
@@ -166,7 +166,7 @@ private:
   mutable std::shared_ptr<IoService> io_service_;
   const Options options_;
   const std::string client_name_;
-  const std::string client_id_;
+  const std::unique_ptr<std::string> client_id_;
   const std::string protocol_name_;
   const int protocol_version_;
   std::unique_ptr<const RetryPolicy> retry_policy_; //null --> no retry


### PR DESCRIPTION
* RAND_pseudo_bytes is deprecated in OpenSSL
  1.1.1 and must be replaced by RAND_bytes.
* Refactored RpcEngine where client_id is wrapped in
  a unique_ptr to provide the ability to do null check.
  We use a null check as a means to get the
  functionality similar to monads.
