### PR TITLE
HDFS-15935. Use memcpy for copying non-null terminated string.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_init.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/fuse-dfs/fuse_init.c
@@ -74,7 +74,7 @@ static void init_protectedpaths(dfs_context *dfs)
     }
     dfs->protectedpaths[j] = (char*)malloc(sizeof(char)*length+1);
     assert(dfs->protectedpaths[j]);
-    strncpy(dfs->protectedpaths[j], tmp, length);
+    memcpy(dfs->protectedpaths[j], tmp, length);
     dfs->protectedpaths[j][length] = '\0';
     if (eos) {
       tmp = eos + 1;

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-tests/test_libhdfs_ops.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs-tests/test_libhdfs_ops.c
@@ -58,7 +58,7 @@ void permission_disp(short permissions, char *rtr) {
       default:
         perm = "???";
       }
-      strncpy(rtr, perm, 3);
+      memcpy(rtr, perm, 3);
       rtr+=3;
     }
 }


### PR DESCRIPTION
* strncpy reports a warning if the
  destination string isn't null
  terminated. Since we append a
  custom character at the end ourselves,
  the warning reported by stnrcpy is
  valid, but not relevant.
* Thus, we use memcpy to avoid this
  warning.
