### PR TITLE
HADOOP-17608. Fix NPE in TestKMS

### DIFF
--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.crypto.key.kms.server;
 
 import java.util.function.Supplier;
+
+import org.apache.commons.lang3.ThreadUtils;
 import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
@@ -525,6 +527,7 @@ public class TestKMS {
     if (ssl) {
       sslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
       try {
+        // the first reloader thread is created here
         sslFactory.init();
       } catch (GeneralSecurityException ex) {
         throw new IOException(ex);
@@ -541,28 +544,23 @@ public class TestKMS {
         final URI uri = createKMSUri(getKMSUrl());
 
         if (ssl) {
+          // the second reloader thread is created here
           KeyProvider testKp = createProvider(uri, conf);
-          ThreadGroup threadGroup = Thread.currentThread().getThreadGroup();
-          while (threadGroup.getParent() != null) {
-            threadGroup = threadGroup.getParent();
-          }
-          Thread[] threads = new Thread[threadGroup.activeCount()];
-          threadGroup.enumerate(threads);
-          Thread reloaderThread = null;
-          for (Thread thread : threads) {
-            if (thread != null && thread.getName() != null
-                && (thread.getName().contains(SSL_RELOADER_THREAD_NAME))) {
-              reloaderThread = thread;
-            }
-          }
-          Assert.assertTrue("Reloader is not alive", reloaderThread.isAlive());
-          // Explicitly close the provider so we can verify the internal thread
-          // is shutdown
+          Collection<Thread> reloaderThreads =
+              ThreadUtils.findThreadsByName(SSL_RELOADER_THREAD_NAME);
+          // now there are two active reloader threads
+          assertEquals(2, reloaderThreads.size());
+          // Explicitly close the provider so we can verify
+          // the second reloader thread is shutdown
           testKp.close();
           boolean reloaderStillAlive = true;
           for (int i = 0; i < 10; i++) {
-            reloaderStillAlive = reloaderThread.isAlive();
-            if (!reloaderStillAlive) break;
+            for (Thread thread : reloaderThreads) {
+              if (!thread.isAlive()) {
+                reloaderStillAlive = false;
+                break;
+              }
+            }
             Thread.sleep(1000);
           }
           Assert.assertFalse("Reloader is still alive", reloaderStillAlive);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -564,6 +564,9 @@ public class TestKMS {
             Thread.sleep(1000);
           }
           Assert.assertFalse("Reloader is still alive", reloaderStillAlive);
+          reloaderThreads =
+              ThreadUtils.findThreadsByName(SSL_RELOADER_THREAD_NAME);
+          assertEquals(1, reloaderThreads.size());
         }
 
         if (kerberos) {

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -550,7 +550,7 @@ public class TestKMS {
           threadGroup.enumerate(threads);
           Thread reloaderThread = null;
           for (Thread thread : threads) {
-            if ((thread.getName() != null)
+            if (thread != null && thread.getName() != null
                 && (thread.getName().contains(SSL_RELOADER_THREAD_NAME))) {
               reloaderThread = thread;
             }


### PR DESCRIPTION
When running all the unit tests in TestKMS by `mvn test -Dtest=TestKMS` instead of specifying a test case (e.g., `mvn test -Dtest=TestKMS#testStartStopHttpsPseudo`) , NPE occurs because there may be some active null threads or some active threads are removed after allocating the active thread list.