### PR TITLE
HADOOP-17603. Upgrade tomcat-embed-core to 7.0.108

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -610,12 +610,12 @@
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
-        <version>7.0.55</version>
+        <version>7.0.108</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-logging-juli</artifactId>
-        <version>7.0.55</version>
+        <version>7.0.108</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17603

Upgrade tomcat-embed-core to 7.0.108 on branch-2.10

[CVE-2021-25329](https://nvd.nist.gov/vuln/detail/CVE-2021-25329) critical severity.
Impact: [CVE-2020-9494](https://nvd.nist.gov/vuln/detail/CVE-2020-9494)
7.0.0-7.0.107 are all affected by the vulnerability.

