### PR TITLE
HADOOP-17601. Upgrade Jackson databind in branch-2.10 to 2.9.10.7

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -75,7 +75,7 @@
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
     <jackson2.version>2.9.10</jackson2.version>
-    <jackson2.databind.version>2.9.10.6</jackson2.databind.version>
+    <jackson2.databind.version>2.9.10.7</jackson2.databind.version>
 
     <!-- SLF4J version -->
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Upgrade Jackson databind in branch-2.10 from 2.9.10.6 to 2.9.10.7: https://issues.apache.org/jira/browse/HADOOP-17601

Two known vulnerabilities found in Jackson-databind:

[CVE-2021-20190](https://nvd.nist.gov/vuln/detail/CVE-2021-20190) high severity
[CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) high severity
