### PR TITLE
HDFS-15939.Solve the problem that DataXceiverServer#run() does not record SocketTimeout exception.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiverServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiverServer.java
@@ -239,8 +239,9 @@ class DataXceiverServer implements Runnable {
         new Daemon(datanode.threadGroup,
             DataXceiver.create(peer, datanode, this))
             .start();
-      } catch (SocketTimeoutException ignored) {
-        // wake up to see if should continue to run
+      } catch (SocketTimeoutException ste) {
+        IOUtils.closeStream(peer);
+        LOG.warn("{}:DataXceiverServer", datanode.getDisplayName(), ste);
       } catch (AsynchronousCloseException ace) {
         // another thread closed our listener socket - that's expected during shutdown,
         // but not in other circumstances


### PR DESCRIPTION
…cord SocketTimeout exception.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
