### PR TITLE
HADOOP-17615. ADLS Gen1: Update adls SDK to 2.3.9

### DIFF
--- a/hadoop-tools/hadoop-azure-datalake/pom.xml
+++ b/hadoop-tools/hadoop-azure-datalake/pom.xml
@@ -33,7 +33,7 @@
     <minimalJsonVersion>0.9.1</minimalJsonVersion>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <azure.data.lake.store.sdk.version>2.3.6</azure.data.lake.store.sdk.version>
+    <azure.data.lake.store.sdk.version>2.3.9</azure.data.lake.store.sdk.version>
   </properties>
   <build>
     <plugins>
@@ -166,5 +166,12 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.openssl</groupId>
+      <artifactId>wildfly-openssl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
Test results are observed to be the same before and after the change.

[ERROR] Errors: 
[ERROR]   TestAdlContractGetFileStatusLive>AbstractContractGetFileStatusTest.testComplexDirActions:153->AbstractContractGetFileStatusTest.checkListStatusIteratorComplexDir:196 » NoClassDefFound
[ERROR]   TestAdlContractGetFileStatusLive>AbstractContractGetFileStatusTest.testListStatusIteratorFile:363->AbstractContractGetFileStatusTest.validateListingForFile:384 » NoClassDefFound
[ERROR]   TestAdlContractRootDirLive>AbstractContractRootDirectoryTest.testSimpleRootListing:251 » NoClassDefFound
[INFO] 
[ERROR] Tests run: 886, Failures: 0, Errors: 3, Skipped: 3