### PR TITLE
YARN-10493: RunC container repository v2

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2341,6 +2341,28 @@ public class YarnConfiguration extends Configuration {
    */
   public static final int DEFAULT_NUM_MANIFESTS_TO_CACHE = 10;
 
+  /**
+   * Optional cache to enable for the image tag to manifest plugin
+   */
+  public static final String NM_RUNC_MANIFEST_CACHE_ENABLED =
+    IMAGE_TAG_TO_MANIFEST_PLUGIN_PREFIX + "manifest-cache-enabled";
+
+  /**
+   * The manifest cache is enabled by default.
+   */
+  public static final boolean DEFAULT_NM_RUNC_MANIFEST_CACHE_ENABLED = true;
+
+  /**
+   * The HDFS image namespace that stores the image property files
+   */
+  public static final String NM_RUNC_IMAGE_META_NAMESPACE =
+    RUNC_CONTAINER_RUNTIME_PREFIX + "image-meta-namespace";
+
+  /**
+   * The default HDFS image namespace that stores the image property files
+   */
+  public static final String DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE = "library";
+
   /** Prefix for hdfs manifest hash to local resources plugin used with the
    * RuncContainerRuntime.
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2342,10 +2342,10 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_NUM_MANIFESTS_TO_CACHE = 10;
 
   /**
-   * Optional cache to enable for the image tag to manifest plugin
+   * Optional cache to enable for the image tag to manifest plugin.
    */
   public static final String NM_RUNC_MANIFEST_CACHE_ENABLED =
-    IMAGE_TAG_TO_MANIFEST_PLUGIN_PREFIX + "manifest-cache-enabled";
+      IMAGE_TAG_TO_MANIFEST_PLUGIN_PREFIX + "manifest-cache-enabled";
 
   /**
    * The manifest cache is enabled by default.
@@ -2353,13 +2353,14 @@ public class YarnConfiguration extends Configuration {
   public static final boolean DEFAULT_NM_RUNC_MANIFEST_CACHE_ENABLED = true;
 
   /**
-   * The HDFS image namespace that stores the image property files
+   * The HDFS image namespace location that stores the runc image property
+   * files.
    */
   public static final String NM_RUNC_IMAGE_META_NAMESPACE =
-    RUNC_CONTAINER_RUNTIME_PREFIX + "image-meta-namespace";
+      RUNC_CONTAINER_RUNTIME_PREFIX + "image-meta-namespace";
 
   /**
-   * The default HDFS image namespace that stores the image property files
+   * The default HDFS image namespace that stores the image property files.
    */
   public static final String DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE = "library";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2115,10 +2115,24 @@
   </property>
 
   <property>
+    <description>The HDFS image namespace location that stores the runc image
+      property files.</description>
+    <name>yarn.nodemanager.runtime.linux.runc.image-meta-namespace</name>
+    <value>library</value>
+  </property>
+
+  <property>
     <description>The runC image tag to manifest plugin
       class to be used.</description>
     <name>yarn.nodemanager.runtime.linux.runc.image-tag-to-manifest-plugin</name>
     <value>org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageTagToManifestPlugin</value>
+  </property>
+
+  <property>
+    <description>Optional cache to enable for the image tag to manifest
+      plugin.</description>
+    <name>yarn.nodemanager.runtime.linux.runc.image-tag-to-manifest-plugin.manifest-cache-enabled</name>
+    <value>true</value>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/HdfsManifestToResourcesV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/HdfsManifestToResourcesV2Plugin.java
@@ -1,0 +1,188 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc;
+
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.service.AbstractService;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheLoader;
+import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
+import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.apache.hadoop.yarn.api.records.URL;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NM_RUNC_STAT_CACHE_TIMEOUT;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_RUNC_STAT_CACHE_SIZE;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_STAT_CACHE_SIZE;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_STAT_CACHE_TIMEOUT;
+
+/**
+ * This class is a V2 plugin for the
+ * {@link org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.RuncContainerRuntime}
+ * that maps runC image manifests into their associated config and
+ * layers that are located in HDFS.
+ */
+@InterfaceStability.Unstable
+public class HdfsManifestToResourcesV2Plugin extends AbstractService implements
+    RuncManifestToResourcesPlugin {
+  private Configuration conf;
+  private String layerDir;
+  private String configDir;
+  private FileSystem fs;
+  private LoadingCache<Path, FileStatus> statCache;
+
+  private static final String CONFIG_MEDIA_TYPE =
+      "application/vnd.docker.container.image.v1+json";
+
+  private static final String LAYER_TAR_GZIP_MEDIA_TYPE =
+      "application/vnd.docker.image.rootfs.diff.tar.gzip";
+
+  private static final String SHA_256 = "sha256";
+
+  private static final String CONFIG_HASH_ALGORITHM =
+      SHA_256;
+
+  private static final String LAYER_HASH_ALGORITHM =
+      SHA_256;
+
+  private static final String ALPHA_NUMERIC = "[a-fA-F0-9]{64}";
+
+  private static final Log LOG = LogFactory.getLog(
+      HdfsManifestToResourcesV2Plugin.class);
+
+  public HdfsManifestToResourcesV2Plugin() {
+    super(HdfsManifestToResourcesV2Plugin.class.getName());
+  }
+
+  @Override
+  public void serviceInit(Configuration configuration) {
+    this.conf = configuration;
+    String toplevelDir = conf.get(NM_RUNC_IMAGE_TOPLEVEL_DIR,
+        DEFAULT_NM_RUNC_IMAGE_TOPLEVEL_DIR);
+    this.layerDir = toplevelDir + "/layer/";
+    this.configDir = toplevelDir + "/config/";
+    CacheLoader<Path, FileStatus> cacheLoader =
+        new CacheLoader<Path, FileStatus>() {
+        @Override
+        public FileStatus load(@Nonnull Path path) throws Exception {
+          return statBlob(path);
+        }
+    };
+    int statCacheSize = conf.getInt(NM_RUNC_STAT_CACHE_SIZE,
+        DEFAULT_RUNC_STAT_CACHE_SIZE);
+    int statCacheTimeout = conf.getInt(NM_RUNC_STAT_CACHE_TIMEOUT,
+        DEFAULT_NM_RUNC_STAT_CACHE_TIMEOUT);
+    this.statCache = CacheBuilder.newBuilder().maximumSize(statCacheSize)
+        .refreshAfterWrite(statCacheTimeout, TimeUnit.SECONDS)
+        .build(cacheLoader);
+  }
+
+  @Override
+  public void serviceStart() throws IOException {
+    Path path = new Path(layerDir);
+    this.fs = path.getFileSystem(conf);
+  }
+
+  @Override
+  public List<LocalResource> getLayerResources(ImageManifest manifest)
+      throws IOException  {
+    List<LocalResource> localRsrcs = new ArrayList<>();
+
+    for (ImageManifest.Blob blob : manifest.getLayers()) {
+      LocalResource rsrc = getResource(blob, layerDir,
+          LAYER_TAR_GZIP_MEDIA_TYPE, LAYER_HASH_ALGORITHM, ".sqsh");
+      localRsrcs.add(rsrc);
+    }
+
+    return localRsrcs;
+  }
+
+  public LocalResource getConfigResource(ImageManifest manifest)
+      throws IOException {
+    ImageManifest.Blob config = manifest.getConfig();
+    return getResource(config, configDir, CONFIG_MEDIA_TYPE,
+        CONFIG_HASH_ALGORITHM, "");
+  }
+
+  public LocalResource getResource(ImageManifest.Blob blob,
+      String dir, String expectedMediaType,
+      String expectedHashAlgorithm, String resourceSuffix) throws IOException {
+    String mediaType = blob.getMediaType();
+    if (!mediaType.equals(expectedMediaType)) {
+      throw new IOException("Invalid blob mediaType: " + mediaType);
+    }
+
+    if (blob.getDigest() == null) {
+      throw new IOException("Invalid blob digest");
+    }
+
+    String[] blobDigest = blob.getDigest().split(":", 2);
+
+    String algorithm = blobDigest[0];
+    if (!algorithm.equals(expectedHashAlgorithm)) {
+      throw new IOException("Invalid blob digest algorithm: " + algorithm);
+    }
+
+    String hash = blobDigest[1];
+    if (!hash.matches(ALPHA_NUMERIC)) {
+      throw new IOException("Malformed blob digest: " + hash);
+    }
+
+    long size = blob.getSize();
+    Path hashPath = new Path(dir, hash.substring(0, 2));
+    Path path = new Path(hashPath, hash + resourceSuffix);
+    LOG.debug("Getting resource: " + path);
+    LocalResource rsrc;
+
+    try {
+      FileStatus stat = statCache.get(path);
+      long timestamp = stat.getModificationTime();
+      URL url = URL.fromPath(path);
+
+      rsrc = LocalResource.newInstance(url,
+        LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
+        size, timestamp);
+    } catch (ExecutionException e) {
+      throw new IOException(e);
+    }
+
+    return rsrc;
+  }
+
+  protected FileStatus statBlob(Path path) throws IOException {
+    return fs.getFileStatus(path);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageMetadata.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageMetadata.java
@@ -50,7 +50,7 @@ public class ImageMetadata {
    */
   public String getNameTag() {
     parseImageCoordinates();
-    if (!tag.equals("")) {
+    if (!tag.isEmpty()) {
       return image + ":" + tag;
     } else {
       return image;
@@ -72,7 +72,7 @@ public class ImageMetadata {
    * image name and tag.
    */
   public void parseImageCoordinates() {
-    if (imageCoordinates == null || imageCoordinates.equals("")) {
+    if (imageCoordinates == null || imageCoordinates.isEmpty()) {
       throw new IllegalArgumentException("Invalid image coordinates, null" +
           " or empty.");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageMetadata.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageMetadata.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class stores and validates the runc image metadata.
+ */
+@InterfaceStability.Unstable
+public class ImageMetadata {
+  private String image;
+  private String tag;
+  private String metaNamespace;
+  private final String imageCoordinates;
+  private static final String DEFAULT_TAG = "latest";
+  private static final Pattern VALID_NS_PATTERN =
+      Pattern.compile("^[A-Za-z0-9]+$");
+  private static final Pattern VALID_NAME_PATTERN =
+      Pattern.compile("^[~^+-\\._A-Za-z0-9]+$");
+
+  public ImageMetadata(String imageCoordinates, String metaNamespace) {
+    this.imageCoordinates = imageCoordinates;
+    this.metaNamespace = metaNamespace;
+  }
+
+  /**
+   * Validates and returns the image name and tag.
+   *
+   * @return the image name and tag.
+   */
+  public String getNameTag() {
+    parseImageCoordinates();
+    if (!tag.equals("")) {
+      return image + ":" + tag;
+    } else {
+      return image;
+    }
+  }
+
+  /**
+   * Validates and returns the image namespace.
+   *
+   * @return the image namespace.
+   */
+  public String getMetaNamespace() {
+    parseImageCoordinates();
+    return metaNamespace;
+  }
+
+  /**
+   * Parses and validates image coordinates, containing the image namespace,
+   * image name and tag.
+   */
+  public void parseImageCoordinates() {
+    if (imageCoordinates == null || imageCoordinates.equals("")) {
+      throw new IllegalArgumentException("Invalid image coordinates, null" +
+          " or empty.");
+    }
+
+    String[] nameParts = imageCoordinates.split("/", -1);
+    String imageTag;
+    if (nameParts.length == 2) {
+      metaNamespace = nameParts[0];
+      imageTag = nameParts[1];
+    } else if (nameParts.length == 1) {
+      imageTag = nameParts[0];
+    } else {
+      throw new IllegalArgumentException("Invalid image coordinates: "
+          + imageCoordinates);
+    }
+
+    if (!VALID_NS_PATTERN.matcher(metaNamespace).matches()) {
+      throw new IllegalArgumentException("Invalid image namespace: "
+          + metaNamespace);
+    }
+
+    String[] tagParts = imageTag.split(":", -1);
+    if (tagParts.length == 2) {
+      image = tagParts[0];
+      tag = tagParts[1];
+    } else if (tagParts.length == 1) {
+      image = tagParts[0];
+      tag = DEFAULT_TAG;
+    } else {
+      throw new IllegalArgumentException("Invalid imageTag name: " + imageTag);
+    }
+
+    if (!VALID_NAME_PATTERN.matcher(image).matches()) {
+      throw new IllegalArgumentException("Invalid image name: " + image);
+    }
+
+    if (!VALID_NAME_PATTERN.matcher(tag).matches()) {
+      throw new IllegalArgumentException("Invalid tag name: " + tag);
+    }
+  }
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
@@ -86,7 +86,7 @@ public class ImageTagToManifestV2Plugin extends AbstractService
       throws IOException {
     LOG.debug("Getting manifest for imageTag: " + imageTag);
 
-    if (imageTag == null || imageTag.equals("")) {
+    if (imageTag == null || imageTag.isEmpty()) {
       throw new IOException("Unable to read the HDFS manifest file for a null "
           + "or empty imageTag");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
@@ -212,7 +212,7 @@ public class ImageTagToManifestV2Plugin extends AbstractService
         } else {
           return null;
         }
-        
+
         if (!hash.matches(HASH_REGEX)) {
           LOG.warn("Malformed image hash: " + hash);
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
@@ -1,0 +1,226 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.service.AbstractService;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NM_RUNC_MANIFEST_CACHE_ENABLED;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NUM_MANIFESTS_TO_CACHE;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_META_NAMESPACE;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_MANIFEST_CACHE_ENABLED;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_NUM_MANIFESTS_TO_CACHE;
+
+/**
+ * This class is a V2 plugin for the
+ * {@link org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.RuncContainerRuntime}
+ * to convert image tags into runC image manifests.
+ */
+@InterfaceStability.Unstable
+public class ImageTagToManifestV2Plugin extends AbstractService
+    implements RuncImageTagToManifestPlugin {
+
+  private Map<String, ImageManifest> manifestCache;
+  private ObjectMapper objMapper;
+  private Configuration conf;
+  private String manifestDir;
+  private String metaNamespaceDir;
+  private boolean manifestCacheEnabled;
+
+  private static final String MANIFEST_PREFIX = "runc.manifest";
+
+  private static final String ALPHA_NUMERIC = "[a-fA-F0-9]{64}";
+
+  private static final Log LOG = LogFactory.getLog(
+      ImageTagToManifestV2Plugin.class);
+
+  public ImageTagToManifestV2Plugin() {
+    super("ImageTagToManifestPluginService");
+  }
+
+  @Override
+  public ImageManifest getManifestFromImageTag(String imageTag)
+      throws IOException {
+
+    ImageManifest manifest;
+    if (manifestCacheEnabled) {
+      manifest = manifestCache.get(imageTag);
+      if (manifest != null) {
+        LOG.debug("Retrieving the manifest from the image manifest cache");
+        return manifest;
+      }
+    }
+
+    // 1. Read the hash from HDFS
+    // 2. Use tag as is and assume the tag is the hash
+    String hash = getHashFromImageTag(imageTag);
+    if (hash == null) {
+      hash = imageTag;
+    }
+
+    Path manifestHashPath = new Path(manifestDir, hash.substring(0, 2));
+    Path manifestPath = new Path(manifestHashPath, hash);
+    FileSystem fs = manifestPath.getFileSystem(conf);
+    FSDataInputStream input;
+    try {
+      input = fs.open(manifestPath);
+    } catch (IllegalArgumentException iae) {
+      throw new IOException("Failed to read the HDFS manifest file for "
+          + manifestPath.toString(), iae);
+    }
+
+    byte[] bytes = IOUtils.toByteArray(input);
+    manifest = objMapper.readValue(bytes, ImageManifest.class);
+
+    if (manifestCacheEnabled) {
+      manifestCache.put(imageTag, manifest);
+    }
+
+    return manifest;
+  }
+
+  @Override
+  public String getHashFromImageTag(String imageTag) {
+    String hash = null;
+
+    try {
+      BufferedReader br = getHdfsImageToHashReader(imageTag);
+      hash = readImageToHashFile(br);
+    } catch (IOException e) {
+      LOG.error("Failed to read the image hash from the image "
+          + "properties file");
+    }
+
+    return hash;
+  }
+
+  protected BufferedReader getHdfsImageToHashReader(String imageTag)
+      throws IOException {
+    // Default to latest if no tag is present
+    if (!imageTag.contains(":")) {
+      imageTag = imageTag + ":latest";
+    }
+
+    // Special image filename delimiter
+    String updatedImageTag = imageTag.replace(':', '@');
+    String imageFile = metaNamespaceDir + "/" + updatedImageTag
+        + ".properties";
+    LOG.debug("Checking HDFS for image file: " + imageFile);
+    Path propertiesFile = new Path(imageFile);
+    FileSystem fs = propertiesFile.getFileSystem(conf);
+    if (!fs.exists(propertiesFile)) {
+      LOG.warn("Did not load the hdfs image to hash properties file, "
+          + "file doesn't exist");
+      return null;
+    }
+
+    return new BufferedReader(new InputStreamReader(fs.open(propertiesFile),
+        StandardCharsets.UTF_8));
+  }
+
+  /** Read the image properties file to get the hash from the manifest
+   * prefix line.  Other image metadata lines are optional and ignored
+   * for now.
+   */
+  protected static String readImageToHashFile(BufferedReader br)
+      throws IOException {
+    if (br == null) {
+      return null;
+    }
+
+    String hash = null;
+    String line;
+    while ((line = br.readLine()) != null) {
+      if (line.startsWith(MANIFEST_PREFIX)) {
+        LOG.debug("Reading the hash from the manifest prefix line");
+
+        if (line.contains(":")) {
+          String[] parts = line.split(":");
+          hash = parts[1];
+        } else {
+          return null;
+        }
+
+        if (!hash.matches(ALPHA_NUMERIC)) {
+          LOG.warn("Malformed image hash: " + hash);
+        }
+      }
+    }
+
+    return hash;
+  }
+
+  @Override
+  protected void serviceInit(Configuration configuration) throws Exception {
+    super.serviceInit(configuration);
+    this.conf = configuration;
+    this.objMapper = new ObjectMapper();
+    manifestDir = conf.get(NM_RUNC_IMAGE_TOPLEVEL_DIR,
+        DEFAULT_NM_RUNC_IMAGE_TOPLEVEL_DIR) + "/manifest/";
+    String metaDir = conf.get(NM_RUNC_IMAGE_TOPLEVEL_DIR,
+        DEFAULT_NM_RUNC_IMAGE_TOPLEVEL_DIR) + "/meta/";
+    metaNamespaceDir = metaDir + conf.get(NM_RUNC_IMAGE_META_NAMESPACE,
+        DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE);
+    manifestCacheEnabled = conf.getBoolean(NM_RUNC_MANIFEST_CACHE_ENABLED,
+        DEFAULT_NM_RUNC_MANIFEST_CACHE_ENABLED);
+
+    if (manifestCacheEnabled) {
+      LOG.debug("The image manifest cache is enabled");
+      int numManifestsToCache = conf.getInt(NM_RUNC_NUM_MANIFESTS_TO_CACHE,
+          DEFAULT_NUM_MANIFESTS_TO_CACHE);
+      this.manifestCache = Collections.synchronizedMap(
+          new LRUCache(numManifestsToCache, 0.75f));
+    }
+  }
+
+  private static class LRUCache extends LinkedHashMap<String, ImageManifest> {
+    private final int cacheSize;
+
+    LRUCache(int initialCapacity, float loadFactor) {
+      super(initialCapacity, loadFactor, true);
+      this.cacheSize = initialCapacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(
+        Map.Entry<String, ImageManifest> eldest) {
+      return this.size() > cacheSize;
+    }
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/runc/ImageTagToManifestV2Plugin.java
@@ -154,9 +154,14 @@ public class ImageTagToManifestV2Plugin extends AbstractService
         StandardCharsets.UTF_8));
   }
 
-  /** Read the image properties file to get the hash from the manifest
-   * prefix line.  Other image metadata lines are optional and ignored
+  /**
+   * Read the image properties file to get the hash from the manifest
+   * prefix line.  Other image metadata lines are optional and are ignored
    * for now.
+   *
+   * @param br The HDFS image hash reader for the image property file.
+   * @return The manifest hash.
+   * @throws IOException when unable to read the hash.
    */
   protected static String readImageToHashFile(BufferedReader br)
       throws IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestHdfsManifestToResourcesV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestHdfsManifestToResourcesV2Plugin.java
@@ -1,0 +1,317 @@
+/*
+ * *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
+import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.apache.hadoop.yarn.api.records.URL;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.HdfsManifestToResourcesV2Plugin;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageManifest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class tests the hdfs manifest to resources V2 plugin used by the
+ * RuncContainerRuntime to map an image manifest into a list of local resources.
+ */
+public class TestHdfsManifestToResourcesV2Plugin {
+  private Configuration conf;
+  private final String tmpPath = System.getProperty("test.build.data") +
+      '/' + "hadoop.tmp.dir";
+  private static final String LAYER_MEDIA_TYPE =
+      "application/vnd.docker.image.rootfs.diff.tar.gzip";
+  private static final String CONFIG_MEDIA_TYPE =
+      "application/vnd.docker.container.image.v1+json";
+
+  @Before
+  public void setup() {
+    conf = new Configuration();
+    File tmpDir = new File(tmpPath);
+    tmpDir.mkdirs();
+  }
+
+  @After
+  public void cleanUp() throws IOException {
+    File tmpDir = new File(tmpPath);
+    FileUtils.deleteDirectory(tmpDir);
+  }
+
+  @Test
+  public void testGetLayerResources() throws IOException {
+    ImageManifest mockManifest = mock(ImageManifest.class);
+    ImageManifest.Blob mockLayer1 = mock(ImageManifest.Blob.class);
+    ImageManifest.Blob mockLayer2 = mock(ImageManifest.Blob.class);
+    String digest1Hash =
+        "e060f9dd9e8cd9ec0e2814b661a96d78f7298120d7654ba9f83ebfb11ff1fb1e";
+    String digest2Hash =
+        "5af5ff88469c8473487bfbc2fe81b4e7d84644bd91f1ab9305de47ef5673637e";
+    String digest1 =
+        "sha256:" + digest1Hash;
+    String digest2 =
+        "sha256:" + digest2Hash;
+    long size1 = 1234;
+    long size2 = 5678;
+
+    when(mockLayer1.getMediaType()).thenReturn(LAYER_MEDIA_TYPE);
+    when(mockLayer1.getDigest()).thenReturn(digest1);
+    when(mockLayer1.getSize()).thenReturn(size1);
+
+    when(mockLayer2.getMediaType()).thenReturn(LAYER_MEDIA_TYPE);
+    when(mockLayer2.getDigest()).thenReturn(digest2);
+    when(mockLayer2.getSize()).thenReturn(size2);
+
+    ArrayList<ImageManifest.Blob> mockLayers = new ArrayList<>();
+    mockLayers.add(mockLayer1);
+    mockLayers.add(mockLayer2);
+
+    when(mockManifest.getLayers()).thenReturn(mockLayers);
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    long modTime = 123456789;
+
+    HdfsManifestToResourcesV2Plugin hdfsManifestToResourcesV2Plugin =
+        new HdfsManifestToResourcesV2Plugin() {
+          @Override
+          protected FileStatus statBlob(Path path) throws IOException {
+            FileStatus mockFileStatus = mock(FileStatus.class);
+            when(mockFileStatus.getModificationTime()).thenReturn(modTime);
+            return mockFileStatus;
+          }
+        };
+    hdfsManifestToResourcesV2Plugin.init(conf);
+
+    List<LocalResource> returnedLayers =
+        hdfsManifestToResourcesV2Plugin.getLayerResources(mockManifest);
+
+    Path hashPath1 =
+        new Path(tmpPath + "/layer/", digest1Hash.substring(0, 2));
+    URL url1 = URL.fromPath(new Path(hashPath1, digest1Hash + ".sqsh"));
+
+    Path hashPath2 =
+        new Path(tmpPath + "/layer/", digest2Hash.substring(0, 2));
+    URL url2 = URL.fromPath(new Path(hashPath2, digest2Hash + ".sqsh"));
+
+    LocalResource rsrc1 = LocalResource.newInstance(url1,
+        LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
+        size1, modTime);
+    LocalResource rsrc2 = LocalResource.newInstance(url2,
+        LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
+        size2, modTime);
+
+    Assert.assertEquals(rsrc1, returnedLayers.get(0));
+    Assert.assertEquals(rsrc2, returnedLayers.get(1));
+  }
+
+  @Test
+  public void testGetConfigResources() throws IOException {
+    ImageManifest mockManifest = mock(ImageManifest.class);
+    ImageManifest.Blob mockConfig = mock(ImageManifest.Blob.class);
+    String digestHash =
+        "e23cac476d0238f0f859c1e07e5faad85262bca490ef5c3a9da32a5b39c6b204";
+    String digest =
+        "sha256:" + digestHash;
+    long size = 1234;
+
+    when(mockConfig.getMediaType()).thenReturn(CONFIG_MEDIA_TYPE);
+    when(mockConfig.getDigest()).thenReturn(digest);
+    when(mockConfig.getSize()).thenReturn(size);
+    when(mockManifest.getConfig()).thenReturn(mockConfig);
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    long modTime = 123456789;
+
+    HdfsManifestToResourcesV2Plugin hdfsManifestToResourcesPlugin =
+        new HdfsManifestToResourcesV2Plugin() {
+          @Override
+          protected FileStatus statBlob(Path path) {
+            FileStatus mockFileStatus = mock(FileStatus.class);
+            when(mockFileStatus.getModificationTime()).thenReturn(modTime);
+            return mockFileStatus;
+          }
+        };
+    hdfsManifestToResourcesPlugin.init(conf);
+
+    LocalResource returnedLayer =
+        hdfsManifestToResourcesPlugin.getConfigResource(mockManifest);
+
+    Path hashPath =
+        new Path(tmpPath + "/config/", digestHash.substring(0, 2));
+    URL url1 = URL.fromPath(new Path(hashPath, digestHash));
+
+    LocalResource rsrc = LocalResource.newInstance(url1,
+        LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
+        size, modTime);
+
+    Assert.assertEquals(rsrc, returnedLayer);
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetResourceFailsNullBlobDigest() throws IOException {
+    ImageManifest mockManifest = mock(ImageManifest.class);
+    ImageManifest.Blob mockConfig = mock(ImageManifest.Blob.class);
+    long size = 1234;
+
+    when(mockConfig.getMediaType()).thenReturn(CONFIG_MEDIA_TYPE);
+    when(mockConfig.getDigest()).thenReturn(null);
+    when(mockConfig.getSize()).thenReturn(size);
+    when(mockManifest.getConfig()).thenReturn(mockConfig);
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    long modTime = 123456789;
+
+    HdfsManifestToResourcesV2Plugin hdfsManifestToResourcesPlugin =
+        new HdfsManifestToResourcesV2Plugin() {
+        @Override
+        protected FileStatus statBlob(Path path) {
+          FileStatus mockFileStatus = mock(FileStatus.class);
+          when(mockFileStatus.getModificationTime()).thenReturn(modTime);
+          return mockFileStatus;
+        }
+      };
+    hdfsManifestToResourcesPlugin.init(conf);
+
+    LocalResource returnedLayer =
+        hdfsManifestToResourcesPlugin.getConfigResource(mockManifest);
+
+    Assert.assertNull(returnedLayer);
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetResourceFailsInvalidBlobMediaType() throws IOException {
+    ImageManifest mockManifest = mock(ImageManifest.class);
+    ImageManifest.Blob mockConfig = mock(ImageManifest.Blob.class);
+    String digestHash =
+        "e23cac476d0238f0f859c1e07e5faad85262bca490ef5c3a9da32a5b39c6b204";
+    String digest =
+        "sha256:" + digestHash;
+    long size = 1234;
+
+    String fakeMediaType = "application/fake.v1+json";
+
+    when(mockConfig.getMediaType()).thenReturn(fakeMediaType);
+    when(mockConfig.getDigest()).thenReturn(digest);
+    when(mockConfig.getSize()).thenReturn(size);
+    when(mockManifest.getConfig()).thenReturn(mockConfig);
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    long modTime = 123456789;
+
+    HdfsManifestToResourcesV2Plugin hdfsManifestToResourcesPlugin =
+        new HdfsManifestToResourcesV2Plugin() {
+        @Override
+        protected FileStatus statBlob(Path path) {
+          FileStatus mockFileStatus = mock(FileStatus.class);
+          when(mockFileStatus.getModificationTime()).thenReturn(modTime);
+          return mockFileStatus;
+        }
+      };
+    hdfsManifestToResourcesPlugin.init(conf);
+
+    LocalResource returnedLayer =
+        hdfsManifestToResourcesPlugin.getConfigResource(mockManifest);
+
+    Assert.assertNull(returnedLayer);
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetResourceFailsInvalidBlobAlgorithm() throws IOException {
+    ImageManifest mockManifest = mock(ImageManifest.class);
+    ImageManifest.Blob mockConfig = mock(ImageManifest.Blob.class);
+    String digestHash =
+        "e23cac476d0238f0f859c1e07e5faad85262bca490ef5c3a9da32a5b39c6b204";
+    long size = 1234;
+
+    when(mockConfig.getMediaType()).thenReturn(CONFIG_MEDIA_TYPE);
+    when(mockConfig.getDigest()).thenReturn(digestHash);
+    when(mockConfig.getSize()).thenReturn(size);
+    when(mockManifest.getConfig()).thenReturn(mockConfig);
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    long modTime = 123456789;
+
+    HdfsManifestToResourcesV2Plugin hdfsManifestToResourcesPlugin =
+        new HdfsManifestToResourcesV2Plugin() {
+        @Override
+        protected FileStatus statBlob(Path path) {
+          FileStatus mockFileStatus = mock(FileStatus.class);
+          when(mockFileStatus.getModificationTime()).thenReturn(modTime);
+          return mockFileStatus;
+        }
+      };
+    hdfsManifestToResourcesPlugin.init(conf);
+
+    LocalResource returnedLayer =
+        hdfsManifestToResourcesPlugin.getConfigResource(mockManifest);
+
+    Assert.assertNull(returnedLayer);
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetResourceFailsMalformedBlobDigest() throws IOException {
+    ImageManifest mockManifest = mock(ImageManifest.class);
+    ImageManifest.Blob mockConfig = mock(ImageManifest.Blob.class);
+    String digestHash =
+        "e23cac476d0238f0f859c1e07e5faa";
+    String digest =
+        "sha256:" + digestHash;
+    long size = 1234;
+
+    when(mockConfig.getMediaType()).thenReturn(CONFIG_MEDIA_TYPE);
+    when(mockConfig.getDigest()).thenReturn(digest);
+    when(mockConfig.getSize()).thenReturn(size);
+    when(mockManifest.getConfig()).thenReturn(mockConfig);
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    long modTime = 123456789;
+
+    HdfsManifestToResourcesV2Plugin hdfsManifestToResourcesPlugin =
+        new HdfsManifestToResourcesV2Plugin() {
+        @Override
+        protected FileStatus statBlob(Path path) {
+          FileStatus mockFileStatus = mock(FileStatus.class);
+          when(mockFileStatus.getModificationTime()).thenReturn(modTime);
+          return mockFileStatus;
+        }
+      };
+    hdfsManifestToResourcesPlugin.init(conf);
+
+    LocalResource returnedLayer =
+        hdfsManifestToResourcesPlugin.getConfigResource(mockManifest);
+
+    Assert.assertNull(returnedLayer);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageMetadata.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageMetadata.java
@@ -1,0 +1,215 @@
+/*
+ * *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageMetadata;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageTagToManifestV2Plugin;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_META_NAMESPACE;
+
+/**
+ * This class tests the ImageMetadata class for runc image metadata.
+ */
+public class TestImageMetadata {
+  private Configuration conf;
+  private ImageTagToManifestV2Plugin plugin;
+
+  @Before
+  public void setup() {
+    conf = new Configuration();
+    plugin = new ImageTagToManifestV2Plugin();
+  }
+
+  @Test
+  public void testGetImageMetadataDefaultMetaNamespace() {
+    String imageTag = "busybox:1.0.0";
+    plugin.init(conf);
+    String metaNamespace = conf.get(NM_RUNC_IMAGE_META_NAMESPACE,
+        DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE);
+    ImageMetadata imageMetadata = new ImageMetadata(imageTag, metaNamespace);
+
+    Assert.assertEquals("busybox:1.0.0", imageMetadata.getNameTag());
+    Assert.assertEquals("library", imageMetadata.getMetaNamespace());
+  }
+
+  @Test
+  public void testGetImageMetadataConfMetaNamespace() {
+    String imageTag = "busybox:1.0.0";
+    conf.set(NM_RUNC_IMAGE_META_NAMESPACE, "default");
+    plugin.init(conf);
+    String metaNamespace = conf.get(NM_RUNC_IMAGE_META_NAMESPACE,
+        DEFAULT_NM_RUNC_IMAGE_META_NAMESPACE);
+    ImageMetadata imageMetadata = new ImageMetadata(imageTag, metaNamespace);
+
+    Assert.assertEquals("busybox:1.0.0", imageMetadata.getNameTag());
+    Assert.assertEquals("default", imageMetadata.getMetaNamespace());
+  }
+
+  @Test
+  public void testGetImageMetadataProvidedMetaNamespace() {
+    String imageTag = "hadoop/busybox:1.0.0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "hadoop");
+
+    Assert.assertEquals("busybox:1.0.0", imageMetadata.getNameTag());
+    Assert.assertEquals("hadoop", imageMetadata.getMetaNamespace());
+  }
+
+  @Test
+  public void testGetImageMetadataDefaultsLatestTag() {
+    String imageTag = "busybox";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+
+    Assert.assertEquals("busybox:latest", imageMetadata.getNameTag());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidImageTagFails() {
+    String imageTag = "a/test/b";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidMetaNamespaceFails() {
+    String imageTag = "busybox:1.0.0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "f@kespace");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidMetaNamespace2Fails() {
+    String imageTag = "busybox:1.0.0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "$platform");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidMetaNamespace3Fails() {
+    String imageTag = "busybox:1.0.0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "default#1");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTagFails() {
+    String imageTag = "busybox:1.0.0:0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataNamespaceInvalidTagFails() {
+    String imageTag = "busybox:1.0.0:0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "hadoop");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTag2Fails() {
+    String imageTag = "busybox:#1.0.0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTag3Fails() {
+    String imageTag = "busybox:1.0$.0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTag4Fails() {
+    String imageTag = "//test:latest";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTag5Fails() {
+    String imageTag = "/:hadoop:latest";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTag6Fails() {
+    String imageTag = "a/b/:hadoop:latest";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataInvalidTag7Fails() {
+    String imageTag = "hadoop::1,0";
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(imageTag, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataNullImageTagFails() {
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata(null, "library");
+    imageMetadata.getNameTag();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testGetImageMetadataEmptyImageTagFails() {
+    plugin.init(conf);
+    ImageMetadata imageMetadata =
+        new ImageMetadata("", "library");
+    imageMetadata.getNameTag();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestV2Plugin.java
@@ -1,0 +1,321 @@
+/*
+ * *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageManifest;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageTagToManifestV2Plugin;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.mockito.Mockito.mock;
+
+/**
+ * This class tests the hdfs manifest to resources V2 plugin used by the
+ * RuncContainerRuntime to map an image manifest into a list of local resources.
+ */
+public class TestImageTagToManifestV2Plugin {
+  private MockImageTagToManifestV2Plugin mockImageTagToManifestV2Plugin;
+  private Configuration conf;
+  private final String tmpPath = System.getProperty("test.build.data") +
+      '/' + "hadoop.tmp.dir";
+  private ObjectMapper mapper;
+
+  private final String manifestJson =
+      "{\n" +
+        "   \"schemaVersion\": 2,\n" +
+        "   \"mediaType\": \"application/vnd.docker.distribution.manifest." +
+        "v2+json\",\n" +
+        "   \"config\": {\n" +
+        "      \"mediaType\": \"application/vnd.docker.container.image." +
+        "v1+json\",\n" +
+        "      \"size\": 2857,\n" +
+        "      \"digest\": \"sha256:e23cac476d0238f0f859c1e07e5faad85262bc" +
+        "a490ef5c3a9da32a5b39c6b204\"\n" +
+        "   },\n" +
+        "   \"layers\": [\n" +
+        "      {\n" +
+        "         \"mediaType\": \"application/vnd.docker.image.rootfs.diff." +
+        "tar.gzip\",\n" +
+        "         \"size\": 185784329,\n" +
+        "         \"digest\": \"sha256:e060f9dd9e8cd9ec0e2814b661a96d78f72" +
+        "98120d7654ba9f83ebfb11ff1fb1e\"\n" +
+        "      },\n" +
+        "      {\n" +
+        "         \"mediaType\": \"application/vnd.docker.image.rootfs.diff." +
+        "tar.gzip\",\n" +
+        "         \"size\": 10852,\n" +
+        "         \"digest\": \"sha256:5af5ff88469c8473487bfbc2fe81b4e7d8464" +
+        "4bd91f1ab9305de47ef5673637e\"\n" +
+        "      }\n" +
+        "   ]\n" +
+        "}";
+
+  @Before
+  public void setup() {
+    conf = new Configuration();
+    mapper = new ObjectMapper();
+    File tmpDir = new File(tmpPath);
+    tmpDir.mkdirs();
+  }
+
+  @After
+  public void cleanUp() throws IOException {
+    File tmpDir = new File(tmpPath);
+    FileUtils.deleteDirectory(tmpDir);
+  }
+
+  /**
+   * This class mocks the hdfs manifest to resources plugin used by the
+   * RuncContainerRuntime to enable testing.
+   */
+  public static class MockImageTagToManifestV2Plugin
+      extends ImageTagToManifestV2Plugin {
+    private final BufferedReader mockHdfsBufferedReader;
+
+    MockImageTagToManifestV2Plugin(BufferedReader mockHdfsBufferedReader) {
+      super();
+      this.mockHdfsBufferedReader = mockHdfsBufferedReader;
+    }
+
+    @Override
+    protected BufferedReader getHdfsImageToHashReader(String imageTag) {
+      return mockHdfsBufferedReader;
+    }
+  }
+
+  @Test
+  public void testHdfsGetHashFromImageTag() throws IOException {
+    String imageFile = "busybox@123.properties";
+    String imageTag = "busybox:123";
+    String imageHash =
+        "f650652f6914b7549cdf8b98866af75d26635ff7947f72c6fd239109dd1a50eb";
+
+    // Test image property file
+    FileWriter fw = new FileWriter(tmpPath + imageFile);
+    fw.append("#Mon Mar 08 15:15:15 CST 2021\n");
+    fw.append("runc.import.source=hub.docker.com/repo/busybox:123\n");
+    fw.append("runc.import.type=docker\n");
+    fw.append("runc.import.time=2021-03-08T21:15:14.652Z\n");
+    fw.append("runc.manifest=sha256:f650652f6914b7549cdf8b98866af75d26635" +
+        "ff7947f72c6fd239109dd1a50eb\n");
+    fw.close();
+
+    BufferedReader br =
+        new BufferedReader(new FileReader(tmpPath + imageFile));
+    mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    String returnedHash =
+        mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
+    br.close();
+
+    Assert.assertEquals(imageHash, returnedHash);
+  }
+
+  @Test
+  public void testHdfsGetHashFromImageTagFails() throws IOException {
+    String imageFile = "busybox@123.properties";
+    String imageTag = "busybox:123";
+    String imageHash =
+        "f650652f6914b7549cdf8b98866af75d26635ff7947f72c6fd239109dd1a50eb";
+
+    // Test image property file, non-matching hash
+    FileWriter fw = new FileWriter(tmpPath + imageFile);
+    fw.append("#Mon Mar 08 15:15:15 CST 2021\n");
+    fw.append("runc.import.source=hub.docker.com/repo/busybox:123\n");
+    fw.append("runc.import.type=docker\n");
+    fw.append("runc.import.time=2021-03-08T21:15:14.652Z\n");
+    fw.append("runc.manifest=sha256:aaaaaaa12344b7549cdf8b98866af75d266" +
+        "35ff7947f72c6fd239109dd1a50eb\n");
+    fw.close();
+
+    BufferedReader br =
+        new BufferedReader(new FileReader(tmpPath + imageFile));
+    mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    String returnedHash =
+        mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
+    br.close();
+
+    Assert.assertNotEquals(imageHash, returnedHash);
+  }
+
+  @Test
+  public void testHdfsGetHashFromImageTagFailsMissingNull() throws IOException {
+    String imageFile = "busybox@123.properties";
+    String imageTag = "busybox:123";
+
+    // Test image property file, missing manifest line
+    FileWriter fw = new FileWriter(tmpPath + imageFile);
+    fw.append("#Mon Mar 08 15:15:15 CST 2021\n");
+    fw.append("runc.import.source=hub.docker.com/repo/busybox:123\n");
+    fw.append("runc.import.type=docker\n");
+    fw.append("runc.import.time=2021-03-08T21:15:14.652Z\n");
+    fw.close();
+
+    BufferedReader br =
+        new BufferedReader(new FileReader(tmpPath + imageFile));
+    mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    String returnedHash =
+        mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
+    br.close();
+
+    Assert.assertNull(returnedHash);
+  }
+
+  @Test
+  public void testHdfsGetHashFromImageTagFailsParseNull() throws IOException {
+    String imageFile = "busybox@123.properties";
+    String imageTag = "busybox:123";
+
+    // Test image property file, missing : to parse
+    FileWriter fw = new FileWriter(tmpPath + imageFile);
+    fw.append("#Mon Mar 08 15:15:15 CST 2021\n");
+    fw.append("runc.import.source=hub.docker.com/repo/busybox:123\n");
+    fw.append("runc.import.type=docker\n");
+    fw.append("runc.import.time=2021-03-08T21:15:14.652Z\n");
+    fw.append("runc.manifest=sha256aaaaaaa12344b7549cdf8b98866af75d26635" +
+        "ff7947f72c6fd239109dd1a50eb\n");
+    fw.close();
+
+    BufferedReader br =
+        new BufferedReader(new FileReader(tmpPath + imageFile));
+    mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    String returnedHash =
+        mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
+    br.close();
+
+    Assert.assertNull(returnedHash);
+  }
+
+  @Test
+  public void testGetManifestFromImageTag() throws IOException {
+    String manifestHash =
+        "d0e8c542d28e8e868848aeb58beecb31079eb7ada1293c4bc2eded08daed605a";
+    String manifestPath = tmpPath + "/manifest/" + manifestHash.substring(0, 2);
+    File manifestDir = new File(manifestPath);
+    manifestDir.mkdirs();
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+
+    PrintWriter printWriter =
+        new PrintWriter(manifestPath + "/" + manifestHash);
+    printWriter.println(manifestJson);
+    printWriter.close();
+
+    BufferedReader mockHdfsBufferedReader = mock(BufferedReader.class);
+
+    mockImageTagToManifestV2Plugin =
+        new MockImageTagToManifestV2Plugin(mockHdfsBufferedReader) {
+      @Override
+      public String getHashFromImageTag(String imageTag) {
+        return manifestHash;
+      }
+    };
+    mockImageTagToManifestV2Plugin.init(conf);
+
+    ImageManifest manifest =
+        mockImageTagToManifestV2Plugin.getManifestFromImageTag("image");
+    ImageManifest expectedManifest =
+        mapper.readValue(manifestJson, ImageManifest.class);
+    Assert.assertEquals(expectedManifest.toString(), manifest.toString());
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetManifestFromImageTagNullHashFailsWithException()
+      throws IOException {
+    String manifestPath = tmpPath + "/manifests";
+    File manifestDir = new File(manifestPath);
+    manifestDir.mkdirs();
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+
+    // Null manifest hash test
+    PrintWriter printWriter = new PrintWriter(manifestPath + "/");
+    printWriter.println(manifestJson);
+    printWriter.close();
+
+    BufferedReader mockHdfsBufferedReader = mock(BufferedReader.class);
+
+    mockImageTagToManifestV2Plugin =
+      new TestImageTagToManifestV2Plugin.
+          MockImageTagToManifestV2Plugin(mockHdfsBufferedReader) {
+      @Override
+      public String getHashFromImageTag(String imageTag) {
+        return null;
+      }
+    };
+    mockImageTagToManifestV2Plugin.init(conf);
+
+    ImageManifest manifest =
+        mockImageTagToManifestV2Plugin.getManifestFromImageTag("image");
+    ImageManifest expectedManifest =
+        mapper.readValue(manifestJson, ImageManifest.class);
+    Assert.assertEquals(expectedManifest.toString(), manifest.toString());
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void testGetManifestFromImageTagV1FailsWithException()
+      throws IOException {
+    String manifestPath = tmpPath + "/manifests";
+    File manifestDir = new File(manifestPath);
+    manifestDir.mkdirs();
+
+    conf.set(NM_RUNC_IMAGE_TOPLEVEL_DIR, tmpPath);
+    String manifestHash =
+        "d0e8c542d28e8e868848aeb58beecb31079eb7ada1293c4bc2eded08daed605a";
+
+    // V1 repository layout test
+    PrintWriter printWriter =
+        new PrintWriter(manifestPath + "/" + manifestHash);
+    printWriter.println(manifestJson);
+    printWriter.close();
+
+    BufferedReader mockHdfsBufferedReader = mock(BufferedReader.class);
+
+    mockImageTagToManifestV2Plugin =
+      new TestImageTagToManifestV2Plugin.
+          MockImageTagToManifestV2Plugin(mockHdfsBufferedReader) {
+        @Override
+        public String getHashFromImageTag(String imageTag) {
+          return manifestHash;
+        }
+      };
+    mockImageTagToManifestV2Plugin.init(conf);
+
+    ImageManifest manifest =
+        mockImageTagToManifestV2Plugin.getManifestFromImageTag("image");
+    ImageManifest expectedManifest =
+        mapper.readValue(manifestJson, ImageManifest.class);
+    Assert.assertEquals(expectedManifest.toString(), manifest.toString());
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestV2Plugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestV2Plugin.java
@@ -110,7 +110,8 @@ public class TestImageTagToManifestV2Plugin {
     }
 
     @Override
-    protected BufferedReader getHdfsImageToHashReader(String imageTag) {
+    protected BufferedReader getHdfsImageToHashReader(String imageTag,
+        String imageNamespace) {
       return mockHdfsBufferedReader;
     }
   }
@@ -135,6 +136,7 @@ public class TestImageTagToManifestV2Plugin {
     BufferedReader br =
         new BufferedReader(new FileReader(tmpPath + imageFile));
     mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    mockImageTagToManifestV2Plugin.init(conf);
     String returnedHash =
         mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
     br.close();
@@ -143,7 +145,7 @@ public class TestImageTagToManifestV2Plugin {
   }
 
   @Test
-  public void testHdfsGetHashFromImageTagFails() throws IOException {
+  public void testHdfsGetHashFromImageTagWrongHashFails() throws IOException {
     String imageFile = "busybox@123.properties";
     String imageTag = "busybox:123";
     String imageHash =
@@ -162,6 +164,7 @@ public class TestImageTagToManifestV2Plugin {
     BufferedReader br =
         new BufferedReader(new FileReader(tmpPath + imageFile));
     mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    mockImageTagToManifestV2Plugin.init(conf);
     String returnedHash =
         mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
     br.close();
@@ -185,6 +188,7 @@ public class TestImageTagToManifestV2Plugin {
     BufferedReader br =
         new BufferedReader(new FileReader(tmpPath + imageFile));
     mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    mockImageTagToManifestV2Plugin.init(conf);
     String returnedHash =
         mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
     br.close();
@@ -210,11 +214,65 @@ public class TestImageTagToManifestV2Plugin {
     BufferedReader br =
         new BufferedReader(new FileReader(tmpPath + imageFile));
     mockImageTagToManifestV2Plugin = new MockImageTagToManifestV2Plugin(br);
+    mockImageTagToManifestV2Plugin.init(conf);
     String returnedHash =
         mockImageTagToManifestV2Plugin.getHashFromImageTag(imageTag);
     br.close();
 
     Assert.assertNull(returnedHash);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromNullImageTagFails() throws IOException {
+    String imageTag = null;
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromEmptyImageTagFails() throws IOException {
+    String imageTag = "";
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromInvalidImageTagFails() throws IOException {
+    String imageTag = "hadoop/busybox:1.0.0:0";
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromInvalidTagFails() throws IOException {
+    String imageTag = "busybox:1,0,0";
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    plugin.init(conf);
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromInvalidTag2Fails() throws IOException {
+    String imageTag = "busybox:,,111";
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    plugin.init(conf);
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromInvalidTag3Fails() throws IOException {
+    String imageTag = "//busybox:,,111";
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    plugin.init(conf);
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
+  }
+
+  @Test (expected = IOException.class)
+  public void testGetManifestFromInvalidTag4Fails() throws IOException {
+    String imageTag = "default@1/busybox:,,111";
+    ImageTagToManifestV2Plugin plugin = new ImageTagToManifestV2Plugin();
+    plugin.init(conf);
+    ImageManifest hash = plugin.getManifestFromImageTag(imageTag);
   }
 
   @Test


### PR DESCRIPTION
A new version of the image container repository. This aligns with the format that is used in the new Java CLI tool in YARN-10494.