### PR TITLE
HDFS-15945. DataNodes with zero capacity and zero blocks should be decommissioned immediately.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4584,8 +4584,8 @@ public class BlockManager implements BlockStatsMXBean {
    */
   boolean isNodeHealthyForDecommissionOrMaintenance(DatanodeDescriptor node) {
     if (!node.checkBlockReportReceived()) {
-      if (node.getCapacity() == 0 && node.getNumBlocks() == 0) {
-        LOG.info("The capacity and the number of blocks of {} are zero. "
+      if (node.getNumBlocks() == 0) {
+        LOG.info("The number of blocks of {} are zero. "
             + "Safe to decommission or put in maintenance.", node);
         return true;
       } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4584,8 +4584,8 @@ public class BlockManager implements BlockStatsMXBean {
    */
   boolean isNodeHealthyForDecommissionOrMaintenance(DatanodeDescriptor node) {
     if (!node.checkBlockReportReceived()) {
-      if (node.getNumBlocks() == 0) {
-        LOG.info("The number of blocks of {} are zero. "
+      if (node.getCapacity() == 0 && node.getNumBlocks() == 0) {
+        LOG.info("The capacity and the number of blocks of {} are zero. "
             + "Safe to decommission or put in maintenance.", node);
         return true;
       } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4585,6 +4585,8 @@ public class BlockManager implements BlockStatsMXBean {
   boolean isNodeHealthyForDecommissionOrMaintenance(DatanodeDescriptor node) {
     if (!node.checkBlockReportReceived()) {
       if (node.getCapacity() == 0 && node.getNumBlocks() == 0) {
+        // DataNode has a storage problem and doesn't send block reports.
+        // In this case, it is safe to decommission or put in maintenance.
         LOG.info("The capacity and the number of blocks of {} are zero. "
             + "Safe to decommission or put in maintenance.", node);
         return true;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4584,8 +4584,14 @@ public class BlockManager implements BlockStatsMXBean {
    */
   boolean isNodeHealthyForDecommissionOrMaintenance(DatanodeDescriptor node) {
     if (!node.checkBlockReportReceived()) {
-      LOG.info("Node {} hasn't sent its first block report.", node);
-      return false;
+      if (node.getCapacity() == 0 && node.getNumBlocks() == 0) {
+        LOG.info("The capacity and the number of blocks of {} are zero. "
+            + "Safe to decommission or put in maintenance.", node);
+        return true;
+      } else {
+        LOG.info("Node {} hasn't sent its first block report.", node);
+        return false;
+      }
     }
 
     if (node.isAlive()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
@@ -281,7 +281,13 @@ class HeartbeatManager implements DatanodeStatistics {
       node.setDecommissioned();
     } else {
       stats.subtract(node);
-      node.startDecommission();
+      if (node.getCapacity() == 0 && node.getNumBlocks() == 0) {
+        LOG.info("The capacity and the number of blocks are zero. " + node +
+            " is put decommissioned state immediately.");
+        node.setDecommissioned();
+      } else {
+        node.startDecommission();
+      }
       stats.add(node);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
@@ -281,13 +281,7 @@ class HeartbeatManager implements DatanodeStatistics {
       node.setDecommissioned();
     } else {
       stats.subtract(node);
-      if (node.getCapacity() == 0 && node.getNumBlocks() == 0) {
-        LOG.info("The capacity and the number of blocks are zero. " + node +
-            " is put decommissioned state immediately.");
-        node.setDecommissioned();
-      } else {
-        node.startDecommission();
-      }
+      node.startDecommission();
       stats.add(node);
     }
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDFS-15945