### PR TITLE
HDFS-15946. Fix java doc in FSPermissionChecker

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSPermissionChecker.java
@@ -549,7 +549,6 @@ public class FSPermissionChecker implements AccessControlEnforcer {
    * - Default entries may be present, but they are ignored during enforcement.
    *
    * @param inode INodeAttributes accessed inode
-   * @param snapshotId int snapshot ID
    * @param access FsAction requested permission
    * @param mode FsPermission mode from inode
    * @param aclFeature AclFeature of inode


### PR DESCRIPTION
JIRA: [HDFS-15946](https://issues.apache.org/jira/browse/HDFS-15946)

Fix java doc for org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker#hasAclPermission.