### PR TITLE
HDFS-15949. Fix integer overflow

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_ext_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_ext_test.cc
@@ -453,11 +453,11 @@ TEST_F(HdfsExtTest, TestHosts) {
   EXPECT_EQ(0, errno);
 
   //Test invalid arguments
-  EXPECT_EQ(nullptr, hdfsGetHosts(fs, filename.c_str(), 0, std::numeric_limits<int64_t>::max()+1));
+  EXPECT_EQ(nullptr, hdfsGetHosts(fs, filename.c_str(), 0, std::numeric_limits<int64_t>::min()));
   EXPECT_EQ((int) std::errc::invalid_argument, errno);
 
   //Test invalid arguments
-  EXPECT_EQ(nullptr, hdfsGetHosts(fs, filename.c_str(), std::numeric_limits<int64_t>::max()+1, std::numeric_limits<int64_t>::max()));
+  EXPECT_EQ(nullptr, hdfsGetHosts(fs, filename.c_str(), std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()));
   EXPECT_EQ((int) std::errc::invalid_argument, errno);
 }
 


### PR DESCRIPTION
* There are some instance where
  the overflow is deliberately
  done in order to get the lower
  bound. This results in an
  overflow warning.
* We fix this by using the min
  value directly.
