### PR TITLE
HDFS-15950. Remove unused hdfs.proto import

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/inotify.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/inotify.proto
@@ -32,7 +32,6 @@ package hadoop.hdfs;
 
 import "acl.proto";
 import "xattr.proto";
-import "hdfs.proto";
 
 enum EventType {
   EVENT_CREATE = 0x0;


### PR DESCRIPTION
* hdfs.proto is imported in inotify.proto
  and is unused. Thus, removing it.
