### PR TITLE
HDFS-15951. Remove unused parameters in NameNodeProxiesClient

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -78,11 +78,6 @@ public class NameNodeProxiesClient {
   private static final Logger LOG = LoggerFactory.getLogger(
       NameNodeProxiesClient.class);
 
-  /** Maximum # of retries for HAProxy with HAServiceProtocol. */
-  private static final int MAX_RETRIES = 3;
-  /** Initial retry delay for HAProxy with HAServiceProtocol. */
-  private static final int DELAY_MILLISECONDS = 200;
-
   /**
    * Wrapper for a client proxy as well as its associated service ID.
    * This is simply used as a tuple-like return type for created NN proxy.


### PR DESCRIPTION
JIRA: [HDFS-15951](https://issues.apache.org/jira/browse/HDFS-15951)

Remove unused parameters in org.apache.hadoop.hdfs.NameNodeProxiesClient.