### PR TITLE
HADOOP-17614. Bump netty to the latest 4.1.61.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -132,7 +132,7 @@
     <htrace4.version>4.1.0-incubating</htrace4.version>
     <metrics.version>3.2.4</metrics.version>
     <netty3.version>3.10.6.Final</netty3.version>
-    <netty4.version>4.1.48.Final</netty4.version>
+    <netty4.version>4.1.61.Final</netty4.version>
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
This is the branch-3.2 backport. There is a slight conflict so just in case here's the PR