### PR TITLE
HDFS-15953. fix DUMMY_CLIENT_ID verification

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
@@ -252,13 +252,13 @@ public abstract class FSEditLogOp {
   }
   
   public boolean hasRpcIds() {
-    return rpcClientId != RpcConstants.DUMMY_CLIENT_ID
+    return !Arrays.equals(rpcClientId, RpcConstants.DUMMY_CLIENT_ID)
         && rpcCallId != RpcConstants.INVALID_CALL_ID;
   }
   
   /** this has to be called after calling {@link #hasRpcIds()} */
   public byte[] getClientId() {
-    Preconditions.checkState(rpcClientId != RpcConstants.DUMMY_CLIENT_ID);
+    Preconditions.checkState(!Arrays.equals(rpcClientId, RpcConstants.DUMMY_CLIENT_ID));
     return rpcClientId;
   }
   


### PR DESCRIPTION
rpcClientId != RpcConstants.DUMMY_CLIENT_ID in FSEditLogOp#hasRpcIds()

// code placeholder
public boolean hasRpcIds() {
  return rpcClientId != RpcConstants.DUMMY_CLIENT_ID
      && rpcCallId != RpcConstants.INVALID_CALL_ID;
}
 
determine that two arrays are equal should use "Arrays.equals"
