### PR TITLE
MAPREDUCE-7334. TestJobEndNotifier fails.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobEndNotifier.java
@@ -80,7 +80,7 @@ public class TestJobEndNotifier {
       calledTimes++;
       try {
         // Sleep for a long time
-        Thread.sleep(1000000);
+        Thread.sleep(3000);
       } catch (InterruptedException e) {
         timedOut = true;
       }


### PR DESCRIPTION
Reduced the sleep time from 1000 to 3 seconds to shut down HttpServer2 gracefully.