### PR TITLE
HADOOP-17331. [JDK 16] TestDNS fails

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/DNS.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/DNS.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.net;
 
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.net.InetAddresses;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -58,7 +59,7 @@ public class DNS {
    * The cached hostname -initially null.
    */
 
-  private static final String cachedHostname = resolveLocalHostname();
+  private static String cachedHostname = resolveLocalHostname();
   private static final String cachedHostAddress = resolveLocalHostIPAddress();
   private static final String LOCALHOST = "localhost";
 
@@ -447,5 +448,15 @@ public class DNS {
       allAddrs.removeAll(getSubinterfaceInetAddrs(netIf));
     }
     return new Vector<InetAddress>(allAddrs);
+  }
+
+  @VisibleForTesting
+  static String getCachedHostname() {
+    return cachedHostname;
+  }
+
+  @VisibleForTesting
+  static void setCachedHostname(String hostname) {
+    cachedHostname = hostname;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestDNS.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestDNS.java
@@ -197,9 +197,9 @@ public class TestDNS {
   @Test (timeout=60000)
   public void testLookupWithHostsFallback() throws Exception {
     assumeNotWindows();
-    final String oldHostname = changeDnsCachedHostname(DUMMY_HOSTNAME);
-
+    final String oldHostname = DNS.getCachedHostname();
     try {
+      DNS.setCachedHostname(DUMMY_HOSTNAME);
       String hostname = DNS.getDefaultHost(
           getLoopbackInterface(), INVALID_DNS_SERVER, true);
 
@@ -207,7 +207,7 @@ public class TestDNS {
       assertThat(hostname, not(DUMMY_HOSTNAME));
     } finally {
       // Restore DNS#cachedHostname for subsequent tests.
-      changeDnsCachedHostname(oldHostname);
+      DNS.setCachedHostname(oldHostname);
     }
   }
 
@@ -219,9 +219,9 @@ public class TestDNS {
    */
   @Test(timeout=60000)
   public void testLookupWithoutHostsFallback() throws Exception {
-    final String oldHostname = changeDnsCachedHostname(DUMMY_HOSTNAME);
-
+    final String oldHostname = DNS.getCachedHostname();
     try {
+      DNS.setCachedHostname(DUMMY_HOSTNAME);
       String hostname = DNS.getDefaultHost(
           getLoopbackInterface(), INVALID_DNS_SERVER, false);
 
@@ -230,29 +230,13 @@ public class TestDNS {
       assertThat(hostname, is(DUMMY_HOSTNAME));
     } finally {
       // Restore DNS#cachedHostname for subsequent tests.
-      changeDnsCachedHostname(oldHostname);
+      DNS.setCachedHostname(oldHostname);
     }
   }
 
   private String getLoopbackInterface() throws SocketException {
     return NetworkInterface.getByInetAddress(
         InetAddress.getLoopbackAddress()).getName();
-  }
-
-  /**
-   * Change DNS#cachedHostName to something which cannot be a real
-   * host name. Uses reflection since it is a 'private final' field.
-   */
-  private String changeDnsCachedHostname(final String newHostname)
-      throws Exception {
-    final String oldCachedHostname = DNS.getDefaultHost(DEFAULT);
-    Field field = DNS.class.getDeclaredField("cachedHostname");
-    field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
-    modifiersField.setAccessible(true);
-    modifiersField.set(field, field.getModifiers() & ~Modifier.FINAL);
-    field.set(null, newHostname);
-    return oldCachedHostname;
   }
 
   /**


### PR DESCRIPTION
Using reflection to update a static final field is not allowed. Removed the final modifier and use a setter method to update the field.

This fix is similar to #2309 