### PR TITLE
HADOOP-17569. Building native code fails on Fedora 33.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/exception.c
@@ -111,8 +111,8 @@ jthrowable newIOException(JNIEnv* env, const char *fmt, ...)
 const char* terror(int errnum)
 {
 
-#if defined(__sun)
-// MT-Safe under Solaris which doesn't support sys_errlist/sys_nerr
+#if defined(__sun) || defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 32)
+// MT-Safe under Solaris or glibc >= 2.32 not supporting sys_errlist/sys_nerr
   return strerror(errnum); 
 #else
   if ((errnum < 0) || (errnum >= sys_nerr)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
@@ -69,6 +69,8 @@ if(WIN32)
     set(OUT_DIR bin)
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+    # using old default behavior on GCC >= 10.0
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
     set(OS_DIR ${CMAKE_SOURCE_DIR}/main/native/libhdfs/os/posix)
 
     # IMPORTANT: OUT_DIR MUST be relative to maven's


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17569

`strerror` of glibc >= 2.32 is thread safe. We can just use it. We still need existing code for supporting old glibc.
https://sourceware.org/pipermail/libc-announce/2020/000029.html
> * The deprecated symbols sys_errlist, _sys_errlist, sys_nerr, and _sys_nerr
>   are no longer available to newly linked binaries, and their declarations
>   have been removed from from <stdio.h>.  They are exported solely as
>   compatibility symbols to support old binaries.  All programs should use
>   strerror or strerror_r instead.
> 
> * Both strerror and strerror_l now share the same internal buffer in the
>   calling thread, meaning that the returned string pointer may be invalided
>   or contents might be overwritten on subsequent calls in the same thread or
>   if the thread is terminated.  It makes strerror MT-safe.

In addition, I added `-fcommon` to CFLAGS for building code of hadoop-hdfs-native-client since `-fno-common` (default from GCC 10.0) break the build.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678
