### PR TITLE
HDFS-15963. Unreleased volume references cause an infinite loop.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockSender.java
@@ -432,6 +432,7 @@ class BlockSender implements java.io.Closeable {
       ris = new ReplicaInputStreams(
           blockIn, checksumIn, volumeRef, fileIoProvider);
     } catch (IOException ioe) {
+      IOUtils.cleanupWithLogger(null, volumeRef);
       IOUtils.closeStream(this);
       org.apache.commons.io.IOUtils.closeQuietly(blockIn);
       org.apache.commons.io.IOUtils.closeQuietly(checksumIn);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -322,7 +322,7 @@ class FsDatasetAsyncDiskService {
 
     @Override
     public void run() {
-      try {
+      try (FsVolumeReference ref = this.volumeRef) {
         final long blockLength = replicaToDelete.getBlockDataLength();
         final long metaLength = replicaToDelete.getMetadataLength();
         boolean result;
@@ -344,8 +344,13 @@ class FsDatasetAsyncDiskService {
               block.getLocalBlock() + " URI " + replicaToDelete.getBlockURI());
         }
         updateDeletedBlockId(block);
-      } finally {
-        IOUtils.cleanupWithLogger(null, volumeRef);
+      } catch (Exception e) {
+        LOG.warn(
+            "ReplicaFileDeleteTask failed to " +
+                (trashDirectory == null ? "delete" : "move")
+                + " block " + block.getBlockPoolId() + " " +
+                block.getLocalBlock()
+                + " at file " + replicaToDelete.getBlockURI());
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -322,7 +322,7 @@ class FsDatasetAsyncDiskService {
 
     @Override
     public void run() {
-      try (FsVolumeReference ref = this.volumeRef) {
+      try {
         final long blockLength = replicaToDelete.getBlockDataLength();
         final long metaLength = replicaToDelete.getMetadataLength();
         boolean result;
@@ -344,13 +344,8 @@ class FsDatasetAsyncDiskService {
               block.getLocalBlock() + " URI " + replicaToDelete.getBlockURI());
         }
         updateDeletedBlockId(block);
-      } catch (Exception e) {
-        LOG.warn(
-            "ReplicaFileDeleteTask failed to " +
-                (trashDirectory == null ? "delete" : "move")
-                + " block " + block.getBlockPoolId() + " " +
-                block.getLocalBlock()
-                + " at file " + replicaToDelete.getBlockURI());
+      } finally {
+        IOUtils.cleanupWithLogger(null, this.volumeRef);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -167,18 +167,26 @@ class FsDatasetAsyncDiskService {
    * Execute the task sometime in the future, using ThreadPools.
    */
   synchronized void execute(FsVolumeImpl volume, Runnable task) {
-    if (executors == null) {
-      throw new RuntimeException("AsyncDiskService is already shutdown");
-    }
-    if (volume == null) {
-      throw new RuntimeException("A null volume does not have a executor");
-    }
-    ThreadPoolExecutor executor = executors.get(volume.getStorageID());
-    if (executor == null) {
-      throw new RuntimeException("Cannot find volume " + volume
-          + " for execution of task " + task);
-    } else {
-      executor.execute(task);
+    try {
+      if (executors == null) {
+        throw new RuntimeException("AsyncDiskService is already shutdown");
+      }
+      if (volume == null) {
+        throw new RuntimeException("A null volume does not have a executor");
+      }
+      ThreadPoolExecutor executor = executors.get(volume.getStorageID());
+      if (executor == null) {
+        throw new RuntimeException("Cannot find volume " + volume
+            + " for execution of task " + task);
+      } else {
+        executor.execute(task);
+      }
+    } catch (RuntimeException re) {
+      if (task instanceof ReplicaFileDeleteTask) {
+        IOUtils.cleanupWithLogger(null,
+            ((ReplicaFileDeleteTask) task).volumeRef);
+      }
+      throw re;
     }
   }
   
@@ -314,28 +322,31 @@ class FsDatasetAsyncDiskService {
 
     @Override
     public void run() {
-      final long blockLength = replicaToDelete.getBlockDataLength();
-      final long metaLength = replicaToDelete.getMetadataLength();
-      boolean result;
+      try {
+        final long blockLength = replicaToDelete.getBlockDataLength();
+        final long metaLength = replicaToDelete.getMetadataLength();
+        boolean result;
 
-      result = (trashDirectory == null) ? deleteFiles() : moveFiles();
+        result = (trashDirectory == null) ? deleteFiles() : moveFiles();
 
-      if (!result) {
-        LOG.warn("Unexpected error trying to "
-            + (trashDirectory == null ? "delete" : "move")
-            + " block " + block.getBlockPoolId() + " " + block.getLocalBlock()
-            + " at file " + replicaToDelete.getBlockURI() + ". Ignored.");
-      } else {
-        if(block.getLocalBlock().getNumBytes() != BlockCommand.NO_ACK){
-          datanode.notifyNamenodeDeletedBlock(block, volume.getStorageID());
+        if (!result) {
+          LOG.warn("Unexpected error trying to "
+              + (trashDirectory == null ? "delete" : "move")
+              + " block " + block.getBlockPoolId() + " " + block.getLocalBlock()
+              + " at file " + replicaToDelete.getBlockURI() + ". Ignored.");
+        } else {
+          if (block.getLocalBlock().getNumBytes() != BlockCommand.NO_ACK) {
+            datanode.notifyNamenodeDeletedBlock(block, volume.getStorageID());
+          }
+          volume.onBlockFileDeletion(block.getBlockPoolId(), blockLength);
+          volume.onMetaFileDeletion(block.getBlockPoolId(), metaLength);
+          LOG.info("Deleted " + block.getBlockPoolId() + " " +
+              block.getLocalBlock() + " URI " + replicaToDelete.getBlockURI());
         }
-        volume.onBlockFileDeletion(block.getBlockPoolId(), blockLength);
-        volume.onMetaFileDeletion(block.getBlockPoolId(), metaLength);
-        LOG.info("Deleted " + block.getBlockPoolId() + " "
-            + block.getLocalBlock() + " URI " + replicaToDelete.getBlockURI());
+        updateDeletedBlockId(block);
+      } finally {
+        IOUtils.cleanupWithLogger(null, volumeRef);
       }
-      updateDeletedBlockId(block);
-      IOUtils.cleanupWithLogger(null, volumeRef);
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -319,7 +319,7 @@ public class FsVolumeImpl implements FsVolumeSpi {
   }
 
   @VisibleForTesting
-  int getReferenceCount() {
+  public int getReferenceCount() {
     return this.reference.getReferenceCount();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
@@ -33,6 +33,9 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -561,5 +564,58 @@ public class TestDataTransferProtocol {
         0, block.getNumBytes(), block.getNumBytes(), newGS,
         checksum, CachingStrategy.newDefaultStrategy(), false, false,
         null, null, new String[0]);
+  }
+
+  @Test
+  public void testReleaseVolumeRefIfExceptionThrown() throws IOException {
+    Path file = new Path("dataprotocol.dat");
+    int numDataNodes = 1;
+
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_REPLICATION_KEY, numDataNodes);
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(
+        numDataNodes).build();
+    try {
+      cluster.waitActive();
+      datanode = cluster.getFileSystem().getDataNodeStats(
+          DatanodeReportType.LIVE)[0];
+      dnAddr = NetUtils.createSocketAddr(datanode.getXferAddr());
+      FileSystem fileSys = cluster.getFileSystem();
+
+      int fileLen = Math.min(
+          conf.getInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 4096), 4096);
+
+      DFSTestUtil.createFile(fileSys, file, fileLen, fileLen,
+          fileSys.getDefaultBlockSize(file),
+          fileSys.getDefaultReplication(file), 0L);
+
+      // get the first blockid for the file
+      final ExtendedBlock firstBlock = DFSTestUtil.getFirstBlock(fileSys, file);
+
+      String bpid = cluster.getNamesystem().getBlockPoolId();
+      ExtendedBlock blk = new ExtendedBlock(bpid, firstBlock.getLocalBlock());
+      sendBuf.reset();
+      recvBuf.reset();
+
+      // delete the meta file to create a exception in BlockSender constructor
+      DataNode dn = cluster.getDataNodes().get(0);
+      cluster.getMaterializedReplica(0, blk).deleteMeta();
+
+      FsVolumeImpl volume = (FsVolumeImpl) DataNodeTestUtils.getFSDataset(
+          dn).getVolume(blk);
+      int beforeCnt = volume.getReferenceCount();
+
+      sender.copyBlock(blk, BlockTokenSecretManager.DUMMY_TOKEN);
+      sendRecvData("Copy a block.", false);
+      Thread.sleep(1000);
+
+      int afterCnt = volume.getReferenceCount();
+      assertEquals(beforeCnt, afterCnt);
+
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } finally {
+      cluster.shutdown();
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
@@ -566,7 +566,7 @@ public class TestDataTransferProtocol {
         null, null, new String[0]);
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testReleaseVolumeRefIfExceptionThrown()
       throws IOException, InterruptedException {
     Path file = new Path("dataprotocol.dat");
@@ -590,7 +590,7 @@ public class TestDataTransferProtocol {
           fileSys.getDefaultBlockSize(file),
           fileSys.getDefaultReplication(file), 0L);
 
-      // get the first blockid for the file
+      // Get the first blockid for the file.
       final ExtendedBlock firstBlock = DFSTestUtil.getFirstBlock(fileSys, file);
 
       String bpid = cluster.getNamesystem().getBlockPoolId();
@@ -598,7 +598,7 @@ public class TestDataTransferProtocol {
       sendBuf.reset();
       recvBuf.reset();
 
-      // delete the meta file to create a exception in BlockSender constructor
+      // Delete the meta file to create a exception in BlockSender constructor.
       DataNode dn = cluster.getDataNodes().get(0);
       cluster.getMaterializedReplica(0, blk).deleteMeta();
 
@@ -608,7 +608,7 @@ public class TestDataTransferProtocol {
 
       sender.copyBlock(blk, BlockTokenSecretManager.DUMMY_TOKEN);
       sendRecvData("Copy a block.", false);
-      Thread.sleep(1000);
+      Thread.sleep(3000);
 
       int afterCnt = volume.getReferenceCount();
       assertEquals(beforeCnt, afterCnt);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
@@ -613,7 +613,6 @@ public class TestDataTransferProtocol {
       assertEquals(beforeCnt, afterCnt);
 
     } catch (InterruptedException e) {
-      e.printStackTrace();
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
@@ -567,7 +567,8 @@ public class TestDataTransferProtocol {
   }
 
   @Test
-  public void testReleaseVolumeRefIfExceptionThrown() throws IOException {
+  public void testReleaseVolumeRefIfExceptionThrown()
+      throws IOException, InterruptedException {
     Path file = new Path("dataprotocol.dat");
     int numDataNodes = 1;
 
@@ -612,7 +613,6 @@ public class TestDataTransferProtocol {
       int afterCnt = volume.getReferenceCount();
       assertEquals(beforeCnt, afterCnt);
 
-    } catch (InterruptedException e) {
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1826,7 +1826,7 @@ public class TestFsDatasetImpl {
       ((LocalReplica) info).getMetaFile().createNewFile();
       blockList.add(info);
 
-      // Create a runtime exception
+      // Create a runtime exception.
       dataset.asyncDiskService.shutdown();
 
       beforeCnt = vol.getReferenceCount();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1807,7 +1807,7 @@ public class TestFsDatasetImpl {
     }
   }
 
-  @Test
+  @Test(timeout = 20000)
   public void testReleaseVolumeRefIfExceptionThrown() throws IOException {
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(
         new HdfsConfiguration()).build();
@@ -1835,7 +1835,6 @@ public class TestFsDatasetImpl {
     } catch (RuntimeException re) {
       int afterCnt = vol.getReferenceCount();
       assertEquals(beforeCnt, afterCnt);
-      re.printStackTrace();
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.apache.hadoop.fs.DF;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.datanode.DirectoryScanner;
+import org.apache.hadoop.hdfs.server.datanode.LocalReplica;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Lists;
 
 import java.io.OutputStream;
@@ -1801,6 +1802,40 @@ public class TestFsDatasetImpl {
       fsdataset.checkAndUpdate(bpid, info);
       GenericTestUtils.waitFor(() ->
           blockManager.getLowRedundancyBlocksCount() == 0, 100, 5000);
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testReleaseVolumeRefIfExceptionThrown() throws IOException {
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(
+        new HdfsConfiguration()).build();
+    cluster.waitActive();
+    FsVolumeImpl vol = (FsVolumeImpl) dataset.getFsVolumeReferences().get(0);
+    ExtendedBlock eb;
+    ReplicaInfo info;
+    int beforeCnt = 0;
+    try {
+      List<Block> blockList = new ArrayList<Block>();
+      eb = new ExtendedBlock(BLOCKPOOL, 1, 1, 1001);
+      info = new FinalizedReplica(
+          eb.getLocalBlock(), vol, vol.getCurrentDir().getParentFile());
+      dataset.volumeMap.add(BLOCKPOOL, info);
+      ((LocalReplica) info).getBlockFile().createNewFile();
+      ((LocalReplica) info).getMetaFile().createNewFile();
+      blockList.add(info);
+
+      // Create a runtime exception
+      dataset.asyncDiskService.shutdown();
+
+      beforeCnt = vol.getReferenceCount();
+      dataset.invalidate(BLOCKPOOL, blockList.toArray(new Block[0]));
+
+    } catch (RuntimeException re) {
+      int afterCnt = vol.getReferenceCount();
+      assertEquals(beforeCnt, afterCnt);
+      re.printStackTrace();
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
@@ -298,7 +298,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
     int[] beforeCnts = new int[volumes.size()];
     FsDatasetImpl ds = (FsDatasetImpl) DataNodeTestUtils.getFSDataset(dn);
 
-    // Create a runtime exception
+    // Create a runtime exception.
     ds.asyncLazyPersistService.shutdown();
     for (int i = 0; i < volumes.size(); ++i) {
       beforeCnts[i] = ((FsVolumeImpl) volumes.get(i)).getReferenceCount();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
@@ -283,12 +283,13 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
       }
     }
   }
-  @Test
+
+  @Test(timeout = 20000)
   public void testReleaseVolumeRefIfExceptionThrown() throws IOException {
     getClusterBuilder().setRamDiskReplicaCapacity(2).build();
-    final String METHOD_NAME = GenericTestUtils.getMethodName();
-    final int SEED = 0xFADED;
-    Path path = new Path("/" + METHOD_NAME + ".Writer.File.dat");
+    final String methodName = GenericTestUtils.getMethodName();
+    final int seed = 0xFADED;
+    Path path = new Path("/" + methodName + ".Writer.File.dat");
 
     DataNode dn = cluster.getDataNodes().get(0);
     FsDatasetSpi.FsVolumeReferences volumes =
@@ -303,7 +304,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
         beforeCnts[i] = ((FsVolumeImpl) volumes.get(i)).getReferenceCount();
       }
 
-      makeRandomTestFile(path, BLOCK_SIZE, true, SEED);
+      makeRandomTestFile(path, BLOCK_SIZE, true, seed);
       Thread.sleep(3 * LAZY_WRITER_INTERVAL_SEC * 1000);
 
       for (int i = 0; i < volumes.size(); ++i) {
@@ -316,7 +317,6 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
             beforeCnts[i] == afterCnt || beforeCnts[i] == (afterCnt - 1));
       }
     } catch (InterruptedException e) {
-      e.printStackTrace();
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.junit.Assert;
@@ -278,6 +281,42 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
       } finally {
         latch.countDown();
       }
+    }
+  }
+  @Test
+  public void testReleaseVolumeRefIfExceptionThrown() throws IOException {
+    getClusterBuilder().setRamDiskReplicaCapacity(2).build();
+    final String METHOD_NAME = GenericTestUtils.getMethodName();
+    final int SEED = 0xFADED;
+    Path path = new Path("/" + METHOD_NAME + ".Writer.File.dat");
+
+    DataNode dn = cluster.getDataNodes().get(0);
+    FsDatasetSpi.FsVolumeReferences volumes =
+        DataNodeTestUtils.getFSDataset(dn).getFsVolumeReferences();
+    int[] beforeCnts = new int[volumes.size()];
+    try {
+      FsDatasetImpl ds = (FsDatasetImpl) DataNodeTestUtils.getFSDataset(dn);
+
+      // Create a runtime exception
+      ds.asyncLazyPersistService.shutdown();
+      for (int i = 0; i < volumes.size(); ++i) {
+        beforeCnts[i] = ((FsVolumeImpl) volumes.get(i)).getReferenceCount();
+      }
+
+      makeRandomTestFile(path, BLOCK_SIZE, true, SEED);
+      Thread.sleep(3 * LAZY_WRITER_INTERVAL_SEC * 1000);
+
+      for (int i = 0; i < volumes.size(); ++i) {
+        int afterCnt = ((FsVolumeImpl) volumes.get(i)).getReferenceCount();
+        // LazyWriter keeps trying to save copies even if
+        // asyncLazyPersistService is already shutdown.
+        // If we do not release references, the number of
+        // references will increase infinitely.
+        Assert.assertTrue(
+            beforeCnts[i] == afterCnt || beforeCnts[i] == (afterCnt - 1));
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
     }
   }
 }


### PR DESCRIPTION
This patch releases the three previously unreleased volume references.