### PR TITLE
HDFS-15966. Empty the statistical parameters when emptying the redundant queue

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/LowRedundancyBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/LowRedundancyBlocks.java
@@ -117,6 +117,8 @@ class LowRedundancyBlocks implements Iterable<BlockInfo> {
     corruptReplicationOneBlocks.reset();
     lowRedundancyECBlockGroups.reset();
     corruptECBlockGroups.reset();
+    highestPriorityLowRedundancyReplicatedBlocks.reset();
+    highestPriorityLowRedundancyECBlocks.reset();
   }
 
   /** Return the total number of insufficient redundancy blocks. */


### PR DESCRIPTION
Clear the two indicators highestPriorityLowRedundancyReplicatedBlocks and highestPriorityLowRedundancyReplicatedBlocks when emptying the redundant queue.