### PR TITLE
YARN-10733. TimelineService Hbase tests failing with timeouts

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -51,7 +51,7 @@
     <kafka.version>0.8.2.1</kafka.version>
 
     <hbase.version>1.4.13</hbase.version>
-    <hbase-compatible-hadoop.version>2.5.1</hbase-compatible-hadoop.version>
+    <hbase-compatible-hadoop.version>2.7.0</hbase-compatible-hadoop.version>
     <hbase-compatible-guava.version>12.0.1</hbase-compatible-guava.version>
 
     <hadoop.assemblies.version>${project.version}</hadoop.assemblies.version>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/flow/TestHBaseStorageFlowRunCompaction.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/flow/TestHBaseStorageFlowRunCompaction.java
@@ -382,7 +382,6 @@ public class TestHBaseStorageFlowRunCompaction {
     assertEquals(1, rowCount);
   }
 
-
   private FlowScanner getFlowScannerForTestingCompaction() {
     // create a FlowScanner object with the sole purpose of invoking a process
     // summation;


### PR DESCRIPTION
[YARN-10733:](https://issues.apache.org/jira/browse/YARN-10733) TimelineService Hbase tests are failing with timeout error on branch-2.10

Timeout running `hadoop-yarn-server-timelineservice-hbase-tests`. The failure of the tests is due to test unit `TestHBaseStorageFlowRunCompaction` getting stuck.
Upon checking the surefire reports, I found several Class no Found Exceptions.

```bash
Caused by: java.lang.NoClassDefFoundError: org/apache/hadoop/fs/CanUnbuffer
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.apache.hadoop.hbase.regionserver.StoreFileInfo.<clinit>(StoreFileInfo.java:66)
	at org.apache.hadoop.hbase.regionserver.HStore.createStoreFileAndReader(HStore.java:698)
	at org.apache.hadoop.hbase.regionserver.HStore.validateStoreFile(HStore.java:1895)
	at org.apache.hadoop.hbase.regionserver.HStore.flushCache(HStore.java:1009)
	at org.apache.hadoop.hbase.regionserver.HStore$StoreFlusherImpl.flushCache(HStore.java:2523)
	at org.apache.hadoop.hbase.regionserver.HRegion.internalFlushCacheAndCommit(HRegion.java:2638)
	... 33 more
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.fs.CanUnbuffer
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 51 more
```
