### PR TITLE
HDFS-15977. Call explicit_bzero only if it is available.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
@@ -51,6 +51,7 @@ find_package(GSasl)
 find_package(Threads)
 
 include(CheckCXXSourceCompiles)
+include(CheckSymbolExists)
 
 # Download and build gtest
 configure_file(CMakeLists-gtest.txt.in googletest-download/CMakeLists.txt)
@@ -167,6 +168,11 @@ if (NOT NO_SASL)
 else (NOT NO_SASL)
     message(STATUS "Compiling with NO SASL SUPPORT")
 endif (NOT NO_SASL)
+
+check_symbol_exists(explicit_bzero "string.h" HAVE_EXPLICIT_BZERO)
+if(HAVE_EXPLICIT_BZERO)
+    add_definitions(-DHAVE_EXPLICIT_BZERO)
+endif()
 
 add_definitions(-DASIO_STANDALONE -DASIO_CPP11_DATE_TIME)
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/syscall_linux.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/syscall_linux.cc
@@ -47,7 +47,12 @@ bool XPlatform::Syscall::WriteToStdoutImpl(const char* message) {
 void XPlatform::Syscall::ClearBufferSafely(void* buffer,
                                            const size_t sz_bytes) {
   if (buffer != nullptr) {
+#ifdef HAVE_EXPLICIT_BZERO
     explicit_bzero(buffer, sz_bytes);
+#else
+    // fallback to bzero
+    bzero(buffer, sz_bytes);
+#endif
   }
 }
 


### PR DESCRIPTION
Manually tested with CentOS 7.9.

JIRA: HDFS-15977