### PR TITLE
HDFS-15981. Removing redundant block queues will slow down block reporting

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -3578,10 +3578,7 @@ public class BlockManager implements BlockStatsMXBean {
 
     // handle low redundancy/extra redundancy
     short fileRedundancy = getExpectedRedundancyNum(storedBlock);
-    if (!isNeededReconstruction(storedBlock, num, pendingNum)) {
-      neededReconstruction.remove(storedBlock, numCurrentReplica,
-          num.readOnlyReplicas(), num.outOfServiceReplicas(), fileRedundancy);
-    } else {
+    if (isNeededReconstruction(storedBlock, num, pendingNum)) {
       updateNeededReconstructions(storedBlock, curReplicaDelta, 0);
     }
     if (shouldProcessExtraRedundancy(num, fileRedundancy)) {


### PR DESCRIPTION
When the block report satisfies the block distribution strategy, the block is removed from the lowredundancyBlocks. But removing the block from the lowredundancyBlocks is a redundant operation.

First, in the patch queue, the block removal operation will be performed in the method chooseSourceDatanodes and validateReconstructionWork.

second, the removal of the block report will only be at the QUEUE_REPLICAS_BADLY_DISTRIBUTED level, which is not an accurate operation.

Finally, when there is a large amount of data in the QUEUE_REPLICAS_BADLY_DISTRIBUTED queue, the processing efficiency of the block report will be reduced