### PR TITLE
HDFS-15985.Incorrect sorting will cause failure to load an FsImage file.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
@@ -385,7 +385,7 @@ public final class FSImageFormatProtobuf {
           if (n1 == null) {
             return n2 == null ? 0 : -1;
           } else if (n2 == null) {
-            return -1;
+            return 1;
           } else {
             return n1.ordinal() - n2.ordinal();
           }


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
