### PR TITLE
HDFS-15979. Move within EZ fails and cannot remove nested EZs. Contri…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testCryptoConf.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testCryptoConf.xml
@@ -247,7 +247,7 @@
     </test>
 
     <test>
-      <description>Test failure of renaming file cross EZ's</description>
+      <description>Test success of renaming file cross EZ's with the same key</description>
       <test-commands>
         <command>-fs NAMENODE -mkdir /src</command>
         <command>-fs NAMENODE -mkdir /dst</command>
@@ -258,7 +258,7 @@
         <command>-fs NAMENODE -mv /src/subdir /dst</command>-
       </test-commands>
       <cleanup-commands>
-        <command>-fs NAMENODE -rmdir /src/subdir</command>
+        <command>-fs NAMENODE -rmdir /dst/subdir</command>
         <command>-fs NAMENODE -rmdir /src/.Trash</command>
         <command>-fs NAMENODE -rmdir /src</command>
         <command>-fs NAMENODE -rmdir /dst/.Trash</command>
@@ -267,7 +267,7 @@
       <comparators>
         <comparator>
           <type>SubstringComparator</type>
-          <expected-output>/src/subdir can't be moved from encryption zone /src to encryption zone /dst.</expected-output>
+          <expected-output></expected-output>
         </comparator>
       </comparators>
     </test>


### PR DESCRIPTION
[HDFS-15979](https://issues.apache.org/jira/browse/HDFS-15979) Move within EZ fails and cannot remove nested EZs

The changes were contributed by @daryn-sharp and we have our internal clusters running on those changes with hadoop-2.8 and hadoop-2.10.
I made some modifications in order to handle the conflict since our internal branch has a feature that is not merged yet into the community (HDFS-13009).