### PR TITLE
HDFS-15980: Fix tests for HDFS-15754 Create packet metrics for DataNode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -166,10 +166,13 @@ public class TestDataNodeMetrics {
   @Test
   public void testReceivePacketSlowMetrics() throws Exception {
     Configuration conf = new HdfsConfiguration();
+    // This is required to trigger the PacketsSlowWriteToOsCache counter since we are only writing a 1-byte file.
+    BlockReceiver.CACHE_DROP_LAG_BYTES = 0;
     final int interval = 1;
     conf.setInt(DFSConfigKeys.DFS_METRICS_PERCENTILES_INTERVALS_KEY, interval);
+    final int NUM_DATANODES = 3;
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
-        .numDataNodes(3).build();
+        .numDataNodes(NUM_DATANODES).build();
     try {
       cluster.waitActive();
       DistributedFileSystem fs = cluster.getFileSystem();
@@ -195,14 +198,25 @@ public class TestDataNodeMetrics {
       fout.hsync();
       fout.close();
       List<DataNode> datanodes = cluster.getDataNodes();
-      DataNode datanode = datanodes.get(0);
-      MetricsRecordBuilder dnMetrics = getMetrics(datanode.getMetrics().name());
-      assertTrue("More than 1 packet received",
-          getLongCounter("TotalPacketsReceived", dnMetrics) > 1L);
-      assertTrue("More than 1 slow packet to mirror",
-          getLongCounter("TotalPacketsSlowWriteToMirror", dnMetrics) > 1L);
-      assertCounter("TotalPacketsSlowWriteToDisk", 1L, dnMetrics);
-      assertCounter("TotalPacketsSlowWriteToOsCache", 0L, dnMetrics);
+      long sumPacketsReceived = 0;
+      long sumPacketsSlowWriteToMirror = 0;
+      long sumPacketsSlowWriteToDisk = 0;
+      long sumPacketsSlowWriteToOsCache = 0;
+      for (DataNode datanode : datanodes) {
+        MetricsRecordBuilder dnMetrics = getMetrics(datanode.getMetrics().name());
+        sumPacketsReceived += getLongCounter("PacketsReceived", dnMetrics);
+        sumPacketsSlowWriteToMirror += getLongCounter("PacketsSlowWriteToMirror", dnMetrics);
+        sumPacketsSlowWriteToDisk += getLongCounter("PacketsSlowWriteToDisk", dnMetrics);
+        sumPacketsSlowWriteToOsCache += getLongCounter("PacketsSlowWriteToOsCache", dnMetrics);
+      }
+      assertTrue("At least 3 packets received",
+              sumPacketsReceived >= 3L);
+      assertTrue("At least 2 slow packets to mirror",
+              sumPacketsSlowWriteToMirror >= 2L);
+      assertEquals("Exactly 3 PacketsSlowWriteToDisk",
+              3L, sumPacketsSlowWriteToDisk);
+      assertEquals("Exactly 3 PacketsSlowWriteToOsCache",
+              3L, sumPacketsSlowWriteToOsCache);
     } finally {
       if (cluster != null) {
         cluster.shutdown();


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HDFS-15980


HDFS-15754 introduces 4 new metrics in DataNodeMetrics.  However the test associated with the patch has some bugs.  This issue is to fix those bugs in the tests.

Please note that the non-test code of HDFS-15754 worked fine without any bugs.

There are 3 issues:
1. The metric names in the tests were incorrect;
2. The tests only checked the metrics of DataNode 0, but one of the metrics, PacketsSlowWriteToMirror,  is only updated on 2 of the 3 DataNodes, so this created an indeterministic failure.
3. The metric PacketsSlowWriteToOsCache was not updated in the test due to the fact that the size of the file was smaller than BlockReceiver.CACHE_DROP_LAG_BYTES

All of them are fixed in this patch.
