### PR TITLE
HADOOP-17635. Update the ubuntu version in the build instruction.

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -51,14 +51,13 @@ Known issues:
   and run your IDE and Docker etc inside that VM.
 
 ----------------------------------------------------------------------------------
-Installing required packages for clean install of Ubuntu 14.04 LTS Desktop:
+Installing required packages for clean install of Ubuntu 18.04 LTS Desktop.
+(For Ubuntu 20.04, gcc/g++ and cmake bundled with Ubuntu can be used.
+Refer to  dev-support/docker/Dockerfile):
 
-* Oracle JDK 1.8 (preferred)
-  $ sudo apt-get purge openjdk*
-  $ sudo apt-get install software-properties-common
-  $ sudo add-apt-repository ppa:webupd8team/java
+* Open JDK 1.8
   $ sudo apt-get update
-  $ sudo apt-get install oracle-java8-installer
+  $ sudo apt-get -y install java-8-openjdk
 * Maven
   $ sudo apt-get -y install maven
 * Native libraries
@@ -86,12 +85,13 @@ Installing required packages for clean install of Ubuntu 14.04 LTS Desktop:
   $ curl -L https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download > boost_1_72_0.tar.bz2
   $ tar --bzip2 -xf boost_1_72_0.tar.bz2 && cd boost_1_72_0
   $ ./bootstrap.sh --prefix=/usr/
-  $ ./b2 --without-python install
+  $ ./b2 --without-python
+  $ sudo ./b2 --without-python install
 
 Optional packages:
 
 * Snappy compression (only used for hadoop-mapreduce-client-nativetask)
-  $ sudo apt-get install snappy libsnappy-dev
+  $ sudo apt-get install libsnappy-dev
 * Intel ISA-L library for erasure coding
   Please refer to https://01.org/intel%C2%AE-storage-acceleration-library-open-source-version
   (OR https://github.com/01org/isa-l)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17635

The setup procedure of Ubuntu 18.04 is defferent from 20.04. Uses of Ubuntu 18.04 need to install gcc-9 from supplemental repository and cmake >= 3.19 from source code. Leaving current instruction for Ubuntu 18.04 could be useful until majority of users move to 20.04.

Oracle Java(JDK) 8 is not available now. I replaced it with OpenJDK 8.
https://launchpad.net/~webupd8team/+archive/ubuntu/java

I tested the procedure on fresh Unbuntu 18.04 environment (on EC2 using ami-0ef85cf6e604e5650).
```
$ uname -a
Linux ip-172-31-18-242 5.4.0-1038-aws #40~18.04.1-Ubuntu SMP Sat Feb 6 01:56:56 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux

$ cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.5 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.5 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic

$ mvn clean install -DskipTests -DskipShade -Drequire.isal -Drequire.pmdk -Pnative -Pdist

$ ./hadoop-dist/target/hadoop-3.4.0-SNAPSHOT/bin/hadoop checknative
2021-04-19 04:23:17,621 INFO bzip2.Bzip2Factory: Successfully loaded & initialized native-bzip2 library system-native
2021-04-19 04:23:17,625 INFO zlib.ZlibFactory: Successfully loaded & initialized native-zlib library
2021-04-19 04:23:17,758 INFO nativeio.NativeIO: The native code was built with PMDK support, and PMDK libs were loaded successfully.
Native library checking:
hadoop:  true /home/ubuntu/hadoop/hadoop-dist/target/hadoop-3.4.0-SNAPSHOT/lib/native/libhadoop.so.1.0.0
zlib:    true /lib/x86_64-linux-gnu/libz.so.1
zstd  :  true /usr/lib/x86_64-linux-gnu/libzstd.so.1
bzip2:   true /lib/x86_64-linux-gnu/libbz2.so.1
openssl: true /usr/lib/x86_64-linux-gnu/libcrypto.so
ISA-L:   true /usr/lib/libisal.so.2
PMDK:    true /usr/local/lib/libpmem.so.1.0.0
```
