### PR TITLE
HADOOP-17641. ITestWasbUriAndConfiguration failing.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
@@ -65,7 +65,7 @@ public final class AzureBlobStorageTestAccount implements AutoCloseable,
   public static final String ACCOUNT_KEY_PROPERTY_NAME = "fs.azure.account.key.";
   public static final String TEST_ACCOUNT_NAME_PROPERTY_NAME = "fs.azure.account.name";
   public static final String WASB_TEST_ACCOUNT_NAME_WITH_DOMAIN = "fs.azure.wasb.account.name";
-  public static final String MOCK_ACCOUNT_NAME = "mockAccount.blob.core.windows.net";
+  public static final String MOCK_ACCOUNT_NAME = "mockAccount-c01112a3-2a23-433e-af2a-e808ea385136.blob.core.windows.net";
   public static final String WASB_ACCOUNT_NAME_DOMAIN_SUFFIX = ".blob.core.windows.net";
   public static final String WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX = "\\.blob(\\.preprod)?\\.core\\.windows\\.net";
   public static final String MOCK_CONTAINER_NAME = "mockContainer";


### PR DESCRIPTION

Moves the mock account name --which is required to never exist-- from mockAccount to an account with a UUID.

Dynamic UUID generation would seem overkill.

Contributed by Steve Loughran.

