### PR TITLE
HADOOP-17657: implement StreamCapabilities in SequenceFile.Writer and fall back to flush, if hflush is not supported

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -835,7 +835,7 @@ public class SequenceFile {
   }
   
   /** Write key/value pairs to a sequence-format file. */
-  public static class Writer implements java.io.Closeable, Syncable, StreamCapabilities {
+  public static class Writer implements java.io.Closeable, Syncable, Flushable, StreamCapabilities {
     private Configuration conf;
     FSDataOutputStream out;
     boolean ownOutputStream = true;
@@ -1364,18 +1364,21 @@ public class SequenceFile {
 
     @Override
     public void hflush() throws IOException {
-      if (out!=null) {
-        if (out.hasCapability(StreamCapabilities.HFLUSH)) {
-          out.hflush();
-        } else {
-          out.flush();
-        }
+      if (out != null) {
+        out.hflush();
+      }
+    }
+
+    @Override
+    public void flush() throws IOException {
+      if (out != null) {
+        out.flush();
       }
     }
 
     @Override
     public boolean hasCapability(String capability) {
-      if (capability!=null) {
+      if (capability != null) {
         return out.hasCapability(capability);
       }
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -1052,11 +1052,6 @@ public class SequenceFile {
       return new CompressionOption(value, codec);
     }
 
-    @org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting
-    public void setOutputStream(FSDataOutputStream out){
-      this.out = out;
-    }
-
     public static Option syncInterval(int value) {
       return new SyncIntervalOption(value);
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -1051,6 +1051,11 @@ public class SequenceFile {
       return new CompressionOption(value, codec);
     }
 
+    @org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting
+    public void setOutputStream(FSDataOutputStream out){
+      this.out = out;
+    }
+
     public static Option syncInterval(int value) {
       return new SyncIntervalOption(value);
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -1378,7 +1378,7 @@ public class SequenceFile {
 
     @Override
     public boolean hasCapability(String capability) {
-      if (capability != null) {
+      if (out !=null && capability != null) {
         return out.hasCapability(capability);
       }
       return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -835,7 +835,8 @@ public class SequenceFile {
   }
   
   /** Write key/value pairs to a sequence-format file. */
-  public static class Writer implements java.io.Closeable, Syncable, Flushable, StreamCapabilities {
+  public static class Writer implements java.io.Closeable, Syncable,
+                  Flushable, StreamCapabilities {
     private Configuration conf;
     FSDataOutputStream out;
     boolean ownOutputStream = true;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.conf.*;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -40,7 +39,6 @@ import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.times;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
@@ -747,7 +747,7 @@ public class TestSequenceFile {
       LongWritable key = new LongWritable();
       key.set(1);
       Text value = new Text();
-      value.set("value");
+      value.set("somevalue");
       writer.append(key, value);
       writer.flush();
       writer.hflush();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
@@ -734,15 +734,16 @@ public class TestSequenceFile {
   @Test
   public void testSequenceFileWriter() throws Exception {
     FileSystem fs = FileSystem.getLocal(conf);
-    Path p = new Path(GenericTestUtils.getTempPath("testSequenceFileWriter.seq"));
+    Path p = new Path(GenericTestUtils
+      .getTempPath("testSequenceFileWriter.seq"));
     try(SequenceFile.Writer writer = SequenceFile.createWriter(
-            fs, conf, p, NullWritable.class, NullWritable.class)) {
+            fs, conf, p, LongWritable.class, Text.class)) {
 
       LongWritable key = new LongWritable();
       key.set(1);
       Text value = new Text();
       value.set("value");
-      writer.append(key,value);
+      writer.append(key, value);
       writer.hflush();
       writer.hsync();
       Assertions.assertThat(fs.getFileStatus(p).getLen()).isGreaterThan(0);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestSequenceFile.java
@@ -733,17 +733,23 @@ public class TestSequenceFile {
 
   @Test
   public void testSequenceFileWriter() throws Exception {
-    FileSystem fs = FileSystem.getLocal(conf);
+    Configuration conf = new Configuration();
+    // This test only works with Raw File System and not Local File System
+    FileSystem fs = FileSystem.getLocal(conf).getRaw();
     Path p = new Path(GenericTestUtils
       .getTempPath("testSequenceFileWriter.seq"));
     try(SequenceFile.Writer writer = SequenceFile.createWriter(
             fs, conf, p, LongWritable.class, Text.class)) {
-
+      Assertions.assertThat(writer.hasCapability
+        (StreamCapabilities.HSYNC)).isEqualTo(true);
+      Assertions.assertThat(writer.hasCapability(
+        StreamCapabilities.HFLUSH)).isEqualTo(true);
       LongWritable key = new LongWritable();
       key.set(1);
       Text value = new Text();
       value.set("value");
       writer.append(key, value);
+      writer.flush();
       writer.hflush();
       writer.hsync();
       Assertions.assertThat(fs.getFileStatus(p).getLen()).isGreaterThan(0);


### PR DESCRIPTION
Following exception is thrown whenever we invoke ProtoMessageWriter.hflush on S3 from Tez, which internally calls org.apache.hadoop.io.SequenceFile$Writer.hflush ->  org.apache.hadoop.fs.FS DataOutputStream.hflush -> S3ABlockOutputStream.hflush which is not implemented and throws java.lang.UnsupportedOperationException. 


bdffe22d96ae [mdc@18060 class="yarn.YarnUncaughtExceptionHandler" level="ERROR" thread="HistoryEventHandlingThread"] Thread Thread[HistoryEventHandlingThread, 5,main] threw an Exception.^Mjava.lang.UnsupportedOperationException: S3A streams are not Syncable^M at org.apache.hadoop.fs.s3a.S3ABlockOutputStream.hflush(S3ABlockOutputStream.java:657)^M at org.apache.hadoop.fs.FS DataOutputStream.hflush(FSDataOutputStream.java:136)^M at org.apache.hadoop.io.SequenceFile$Writer.hflush(SequenceFile.java:1367)^M at org.apache.tez.dag.history.logging.proto.ProtoMessageWriter.hflush(ProtoMessageWr iter.java:64)^M at org.apache.tez.dag.history.logging.proto.ProtoHistoryLoggingService.finishCurrentDag(ProtoHistoryLoggingService.java:239)^M at org.apache.tez.dag.history.logging.proto.ProtoHistoryLoggingService.han dleEvent(ProtoHistoryLoggingService.java:198)^M at org.apache.tez.dag.history.logging.proto.ProtoHistoryLoggingService.loop(ProtoHistoryLoggingService.java:153)^M at java.lang.Thread.run(Thread.java:748)^M

In order to fix this issue we should implement StreamCapabilities in SequenceFile.Writer. Also, we should fall back to flush(), if hflush() is not supported. 