### PR TITLE
HADOOP-17471. ABFS to collect IOStatistics (#2731)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StoreStatisticNames.java
@@ -317,6 +317,30 @@ public final class StoreStatisticNames {
       = "action_http_get_request";
 
   /**
+   * An HTTP DELETE request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_DELETE_REQUEST
+      = "action_http_delete_request";
+
+  /**
+   * An HTTP PUT request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_PUT_REQUEST
+      = "action_http_put_request";
+
+  /**
+   * An HTTP PATCH request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_PATCH_REQUEST
+      = "action_http_patch_request";
+
+  /**
+   * An HTTP POST request was made: {@value}.
+   */
+  public static final String ACTION_HTTP_POST_REQUEST
+      = "action_http_post_request";
+
+  /**
    * An HTTP HEAD request was made: {@value}.
    */
   public static final String OBJECT_METADATA_REQUESTS

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsStatistic.java
@@ -18,7 +18,12 @@
 
 package org.apache.hadoop.fs.azurebfs;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.hadoop.fs.StorageStatistics.CommonStatisticNames;
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
 
 /**
  * Statistic which are collected in Abfs.
@@ -73,10 +78,44 @@ public enum AbfsStatistic {
   READ_THROTTLES("read_throttles",
       "Total number of times a read operation is throttled."),
   WRITE_THROTTLES("write_throttles",
-      "Total number of times a write operation is throttled.");
+      "Total number of times a write operation is throttled."),
+  SERVER_UNAVAILABLE("server_unavailable",
+      "Total number of times HTTP 503 status code is received in response."),
+
+  // HTTP Duration Trackers
+  HTTP_HEAD_REQUEST(StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST,
+      "Time taken to complete a HEAD request",
+      AbfsHttpConstants.HTTP_METHOD_HEAD),
+  HTTP_GET_REQUEST(StoreStatisticNames.ACTION_HTTP_GET_REQUEST,
+      "Time taken to complete a GET request",
+      AbfsHttpConstants.HTTP_METHOD_GET),
+  HTTP_DELETE_REQUEST(StoreStatisticNames.ACTION_HTTP_DELETE_REQUEST,
+      "Time taken to complete a DELETE request",
+      AbfsHttpConstants.HTTP_METHOD_DELETE),
+  HTTP_PUT_REQUEST(StoreStatisticNames.ACTION_HTTP_PUT_REQUEST,
+      "Time taken to complete a PUT request",
+      AbfsHttpConstants.HTTP_METHOD_PUT),
+  HTTP_PATCH_REQUEST(StoreStatisticNames.ACTION_HTTP_PATCH_REQUEST,
+      "Time taken to complete a PATCH request",
+      AbfsHttpConstants.HTTP_METHOD_PATCH),
+  HTTP_POST_REQUEST(StoreStatisticNames.ACTION_HTTP_POST_REQUEST,
+      "Time taken to complete a POST request",
+      AbfsHttpConstants.HTTP_METHOD_POST);
 
   private String statName;
   private String statDescription;
+
+  //For http call stats only.
+  private String httpCall;
+  private static final Map<String, String> HTTP_CALL_TO_NAME_MAP = new HashMap<>();
+
+  static {
+    for (AbfsStatistic statistic : values()) {
+      if (statistic.getHttpCall() != null) {
+        HTTP_CALL_TO_NAME_MAP.put(statistic.getHttpCall(), statistic.getStatName());
+      }
+    }
+  }
 
   /**
    * Constructor of AbfsStatistic to set statistic name and description.
@@ -87,6 +126,19 @@ public enum AbfsStatistic {
   AbfsStatistic(String statName, String statDescription) {
     this.statName = statName;
     this.statDescription = statDescription;
+  }
+
+  /**
+   * Constructor for AbfsStatistic for HTTP durationTrackers.
+   *
+   * @param statName        Name of the statistic.
+   * @param statDescription Description of the statistic.
+   * @param httpCall        HTTP call associated with the stat name.
+   */
+  AbfsStatistic(String statName, String statDescription, String httpCall) {
+    this.statName = statName;
+    this.statDescription = statDescription;
+    this.httpCall = httpCall;
   }
 
   /**
@@ -105,5 +157,24 @@ public enum AbfsStatistic {
    */
   public String getStatDescription() {
     return statDescription;
+  }
+
+  /**
+   * Getter for http call for HTTP duration trackers.
+   *
+   * @return http call of a statistic.
+   */
+  public String getHttpCall() {
+    return httpCall;
+  }
+
+  /**
+   * Get the statistic name using the http call name.
+   *
+   * @param httpCall The HTTP call used to get the statistic name.
+   * @return Statistic name.
+   */
+  public static String getStatNameFromHttpCall(String httpCall) {
+    return HTTP_CALL_TO_NAME_MAP.get(httpCall);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsCounters.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsCounters.java
@@ -25,13 +25,16 @@ import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTest
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.azurebfs.AbfsStatistic;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
+import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
 /**
  * An interface for Abfs counters.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-public interface AbfsCounters {
+public interface AbfsCounters extends IOStatisticsSource, DurationTrackerFactory {
 
   /**
    * Increment a AbfsStatistic by a long value.
@@ -63,4 +66,12 @@ public interface AbfsCounters {
   @VisibleForTesting
   Map<String, Long> toMap();
 
+  /**
+   * Start a DurationTracker for a request.
+   *
+   * @param key Name of the DurationTracker statistic.
+   * @return an instance of DurationTracker.
+   */
+  @Override
+  DurationTracker trackDuration(String key);
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -39,9 +39,6 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemExc
 import org.apache.hadoop.fs.azurebfs.utils.CachedSASToken;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
-import org.apache.hadoop.fs.statistics.StoreStatisticNames;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -485,10 +482,8 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     AbfsPerfTracker tracker = client.getAbfsPerfTracker();
     try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker, "readRemote", "read")) {
       LOG.trace("Trigger client.read for path={} position={} offset={} length={}", path, position, offset, length);
-      op = IOStatisticsBinding.trackDuration((IOStatisticsStore) ioStatistics,
-          StoreStatisticNames.ACTION_HTTP_GET_REQUEST,
-          () -> client.read(path, position, b, offset, length,
-              tolerateOobAppends ? "*" : eTag, cachedSasToken.get()));
+      op = client.read(path, position, b, offset, length,
+          tolerateOobAppends ? "*" : eTag, cachedSasToken.get());
       cachedSasToken.update(op.getSasToken());
       if (streamStatistics != null) {
         streamStatistics.remoteReadOperation();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -45,9 +45,6 @@ import org.apache.hadoop.fs.azurebfs.utils.CachedSASToken;
 import org.apache.hadoop.fs.statistics.DurationTracker;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
-import org.apache.hadoop.fs.statistics.StreamStatisticNames;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
-import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.FSExceptionMessages;
@@ -450,32 +447,29 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
       }
     }
     final Future<Void> job =
-        completionService.submit(IOStatisticsBinding
-            .trackDurationOfCallable((IOStatisticsStore) ioStatistics,
-                StreamStatisticNames.TIME_SPENT_ON_PUT_REQUEST,
-                () -> {
-                  AbfsPerfTracker tracker = client.getAbfsPerfTracker();
-                  try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
-                      "writeCurrentBufferToService", "append")) {
-                    AppendRequestParameters.Mode
-                        mode = APPEND_MODE;
-                    if (isFlush & isClose) {
-                      mode = FLUSH_CLOSE_MODE;
-                    } else if (isFlush) {
-                      mode = FLUSH_MODE;
-                    }
-                    AppendRequestParameters reqParams = new AppendRequestParameters(
-                        offset, 0, bytesLength, mode, false, leaseId);
-                    AbfsRestOperation op = client.append(path, bytes, reqParams,
-                        cachedSasToken.get());
-                    cachedSasToken.update(op.getSasToken());
-                    perfInfo.registerResult(op.getResult());
-                    byteBufferPool.putBuffer(ByteBuffer.wrap(bytes));
-                    perfInfo.registerSuccess(true);
-                    return null;
-                  }
-                })
-        );
+        completionService.submit(() -> {
+          AbfsPerfTracker tracker =
+              client.getAbfsPerfTracker();
+          try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
+              "writeCurrentBufferToService", "append")) {
+            AppendRequestParameters.Mode
+                mode = APPEND_MODE;
+            if (isFlush & isClose) {
+              mode = FLUSH_CLOSE_MODE;
+            } else if (isFlush) {
+              mode = FLUSH_MODE;
+            }
+            AppendRequestParameters reqParams = new AppendRequestParameters(
+                offset, 0, bytesLength, mode, false, leaseId);
+            AbfsRestOperation op = client.append(path, bytes, reqParams,
+                cachedSasToken.get());
+            cachedSasToken.update(op.getSasToken());
+            perfInfo.registerResult(op.getResult());
+            byteBufferPool.putBuffer(ByteBuffer.wrap(bytes));
+            perfInfo.registerSuccess(true);
+            return null;
+          }
+        });
 
     if (outputStreamStatistics != null) {
       if (job.isCancelled()) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -19,12 +19,12 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
 
-import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationExcep
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidAbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
+import org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding;
 
 /**
  * The AbfsRestOperation for Rest AbfsClient.
@@ -168,11 +169,29 @@ public class AbfsRestOperation {
   }
 
   /**
+   * Execute a AbfsRestOperation. Track the Duration of a request if
+   * abfsCounters isn't null.
+   *
+   */
+  public void execute() throws AzureBlobFileSystemException {
+
+    try {
+      IOStatisticsBinding.trackDurationOfInvocation(abfsCounters,
+          AbfsStatistic.getStatNameFromHttpCall(method),
+          () -> completeExecute());
+    } catch (AzureBlobFileSystemException aze) {
+      throw aze;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Error while tracking Duration of an "
+          + "AbfsRestOperation call", e);
+    }
+  }
+
+  /**
    * Executes the REST operation with retry, by issuing one or more
    * HTTP operations.
    */
-   @VisibleForTesting
-   public void execute() throws AzureBlobFileSystemException {
+  private void completeExecute() throws AzureBlobFileSystemException {
     // see if we have latency reports from the previous requests
     String latencyHeader = this.client.getAbfsPerfTracker().getClientLatency();
     if (latencyHeader != null && !latencyHeader.isEmpty()) {
@@ -259,6 +278,8 @@ public class AbfsRestOperation {
           && httpOperation.getStatusCode() <= HttpURLConnection.HTTP_PARTIAL) {
         incrementCounter(AbfsStatistic.BYTES_RECEIVED,
             httpOperation.getBytesReceived());
+      } else if (httpOperation.getStatusCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
+        incrementCounter(AbfsStatistic.SERVER_UNAVAILABLE, 1);
       }
     } catch (UnknownHostException ex) {
       String hostname = null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsDurationTrackers.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsDurationTrackers.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.services.AbfsInputStream;
+import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+import org.apache.hadoop.io.IOUtils;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_DELETE_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_GET_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_HEAD_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_PUT_REQUEST;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.extractStatistics;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupMeanStatistic;
+import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
+
+public class ITestAbfsDurationTrackers extends AbstractAbfsIntegrationTest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ITestAbfsDurationTrackers.class);
+  private static final AbfsStatistic[] HTTP_DURATION_TRACKER_LIST = {
+      HTTP_HEAD_REQUEST,
+      HTTP_GET_REQUEST,
+      HTTP_DELETE_REQUEST,
+      HTTP_PUT_REQUEST,
+  };
+
+  public ITestAbfsDurationTrackers() throws Exception {
+  }
+
+  /**
+   * Test to check if DurationTrackers for Abfs HTTP calls work correctly and
+   * track the duration of the http calls.
+   */
+  @Test
+  public void testAbfsHttpCallsDurations() throws IOException {
+    describe("test to verify if the DurationTrackers for abfs http calls "
+        + "work as expected.");
+
+    AzureBlobFileSystem fs = getFileSystem();
+    Path testFilePath = path(getMethodName());
+
+    // Declaring output and input stream.
+    AbfsOutputStream out = null;
+    AbfsInputStream in = null;
+    try {
+      // PUT the file.
+      out = createAbfsOutputStreamWithFlushEnabled(fs, testFilePath);
+      out.write('a');
+      out.hflush();
+
+      // GET the file.
+      in = fs.getAbfsStore().openFileForRead(testFilePath, fs.getFsStatistics());
+      int res = in.read();
+      LOG.info("Result of Read: {}", res);
+
+      // DELETE the file.
+      fs.delete(testFilePath, false);
+
+      // extract the IOStatistics from the filesystem.
+      IOStatistics ioStatistics = extractStatistics(fs);
+      LOG.info(ioStatisticsToPrettyString(ioStatistics));
+      assertDurationTracker(ioStatistics);
+    } finally {
+      IOUtils.cleanupWithLogger(LOG, out, in);
+    }
+  }
+
+  /**
+   * A method to assert that all the DurationTrackers for the http calls are
+   * working correctly.
+   *
+   * @param ioStatistics the IOStatisticsSource in use.
+   */
+  private void assertDurationTracker(IOStatistics ioStatistics) {
+    for (AbfsStatistic abfsStatistic : HTTP_DURATION_TRACKER_LIST) {
+      Assertions.assertThat(lookupMeanStatistic(ioStatistics,
+          abfsStatistic.getStatName() + StoreStatisticNames.SUFFIX_MEAN).mean())
+          .describedAs("The DurationTracker Named " + abfsStatistic.getStatName()
+                  + " Doesn't match the expected value.")
+          .isGreaterThan(0.0);
+    }
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
@@ -39,13 +39,12 @@ public class ITestAbfsStreamStatistics extends AbstractAbfsIntegrationTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestAbfsStreamStatistics.class);
 
-  private static final int LARGE_NUMBER_OF_OPS = 999999;
+  private static final int LARGE_NUMBER_OF_OPS = 99;
 
   /***
    * Testing {@code incrementReadOps()} in class {@code AbfsInputStream} and
    * {@code incrementWriteOps()} in class {@code AbfsOutputStream}.
    *
-   * @throws Exception
    */
   @Test
   public void testAbfsStreamOps() throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAbfsNetworkStatistics.java
@@ -21,13 +21,31 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.services.AbfsCounters;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.apache.hadoop.fs.statistics.IOStatistics;
+import org.apache.hadoop.fs.statistics.StoreStatisticNames;
+
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_PATCH_REQUEST;
+import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.HTTP_POST_REQUEST;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.extractStatistics;
+import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupMeanStatistic;
 
 public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestAbfsNetworkStatistics.class);
   private static final int LARGE_OPERATIONS = 1000;
+  private static final AbfsStatistic[] HTTP_DURATION_TRACKER_LIST = {
+      HTTP_POST_REQUEST,
+      HTTP_PATCH_REQUEST
+  };
 
   public TestAbfsNetworkStatistics() throws Exception {
   }
@@ -63,5 +81,59 @@ public class TestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
         metricMap);
     assertAbfsStatistics(AbfsStatistic.WRITE_THROTTLES, LARGE_OPERATIONS,
         metricMap);
+  }
+
+  /**
+   * Test to check if the DurationTrackers are tracking as expected whilst
+   * doing some work.
+   */
+  @Test
+  public void testAbfsNetworkDurationTrackers()
+      throws IOException, InterruptedException {
+    describe("Test to verify the actual values of DurationTrackers are "
+        + "greater than 0.0 while tracking some work.");
+
+    AbfsCounters abfsCounters = new AbfsCountersImpl(getFileSystem().getUri());
+    // Start dummy work for the DurationTrackers and start tracking.
+    try (DurationTracker ignoredPatch =
+        abfsCounters.trackDuration(AbfsStatistic.getStatNameFromHttpCall(AbfsHttpConstants.HTTP_METHOD_PATCH));
+        DurationTracker ignoredPost =
+            abfsCounters.trackDuration(AbfsStatistic.getStatNameFromHttpCall(AbfsHttpConstants.HTTP_METHOD_POST))
+    ) {
+      // Emulates doing some work.
+      Thread.sleep(10);
+      LOG.info("Execute some Http requests...");
+    }
+
+    // Extract the iostats from the abfsCounters instance.
+    IOStatistics ioStatistics = extractStatistics(abfsCounters);
+    // Asserting that the durationTrackers have mean > 0.0.
+    for (AbfsStatistic abfsStatistic : HTTP_DURATION_TRACKER_LIST) {
+      Assertions.assertThat(lookupMeanStatistic(ioStatistics,
+          abfsStatistic.getStatName() + StoreStatisticNames.SUFFIX_MEAN).mean())
+          .describedAs("The DurationTracker Named " + abfsStatistic.getStatName()
+                  + " Doesn't match the expected value")
+          .isGreaterThan(0.0);
+    }
+  }
+
+  /**
+   * Test to check if abfs counter for HTTP 503 statusCode works correctly
+   * when incremented.
+   */
+  @Test
+  public void testAbfsHTTP503ErrorCounter() throws IOException {
+    describe("tests to verify the expected value of the HTTP 503 error "
+        + "counter is equal to number of times incremented.");
+
+    AbfsCounters abfsCounters = new AbfsCountersImpl(getFileSystem().getUri());
+    // Incrementing the server_unavailable counter.
+    for (int i = 0; i < LARGE_OPERATIONS; i++) {
+      abfsCounters.incrementCounter(AbfsStatistic.SERVER_UNAVAILABLE, 1);
+    }
+    // Getting the IOStatistics counter map from abfsCounters.
+    Map<String, Long> metricsMap = abfsCounters.toMap();
+    assertAbfsStatistics(AbfsStatistic.SERVER_UNAVAILABLE, LARGE_OPERATIONS,
+        metricsMap);
   }
 }


### PR DESCRIPTION
The ABFS Filesystem and its input and output streams now implement
the IOStatisticSource interface and provide IOStatistics on
their interactions with Azure Storage.

This includes the min/max/mean durations of all REST API calls.

Contributed by Mehakmeet Singh <mehakmeet.singh@cloudera.com>