### PR TITLE
MAPREDUCE-7339. Making ALREADY_SPECULATING more priority

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DefaultSpeculator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DefaultSpeculator.java
@@ -379,6 +379,11 @@ public class DefaultSpeculator extends AbstractService implements
       }
     }
 
+    if(attempts.values().stream().filter(taskAttempt -> taskAttempt.getState() == TaskAttemptState.RUNNING
+            || taskAttempt.getState() == TaskAttemptState.STARTING).count() > 1){
+      return ALREADY_SPECULATING;
+    }
+
     TaskAttemptId runningTaskAttemptID = null;
 
     int numberRunningAttempts = 0;


### PR DESCRIPTION
ASF Jira: https://issues.apache.org/jira/browse/MAPREDUCE-7339

Change: DefaultSpeculator returns TOO_LATE_TO_SPECULATE or PROGRESS_IS_GOOD speculation value even if task is ALREADY SPECULATING. This PR targets to fix that