### PR TITLE
HADOOP-17674. Use spotbugs-maven-plugin in hadoop-huaweicloud.

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -60,10 +60,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
-          <findbugsXmlOutput>true</findbugsXmlOutput>
           <xmlOutput>true</xmlOutput>
           <excludeFilterFile>${basedir}/dev-support/findbugs-exclude.xml
           </excludeFilterFile>


### PR DESCRIPTION
JIRA: HADOOP-17674

Manually tested:
```
mvn spotbugs:spotbugs -pl hadoop-cloud-storage-project/hadoop-huaweicloud
(snip)
[INFO] --- spotbugs-maven-plugin:4.2.0:spotbugs (default-cli) @ hadoop-huaweicloud ---
[INFO] Fork Value is true
[INFO] Done SpotBugs Analysis....
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.349 s
[INFO] Finished at: 2021-04-27T19:45:10+09:00
[INFO] ------------------------------------------------------------------------
```