### PR TITLE
HDFS-16000. Rename performance optimization

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
@@ -223,7 +223,7 @@ class FSDirMkdirOp {
 
     INodesInPath iip =
         fsd.addLastINode(parent, dir,
-                permission.getPermission(), true, null, true);
+            permission.getPermission(), true, null, true);
     if (iip != null && aclEntries != null) {
       AclStorage.updateINodeAcl(dir, aclEntries, Snapshot.CURRENT_STATE_ID);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
@@ -221,8 +221,9 @@ class FSDirMkdirOp {
     final INodeDirectory dir = new INodeDirectory(inodeId, name, permission,
         timestamp);
 
-    INodesInPath iip = fsd.addLastINode(parent, dir,
-            permission.getPermission(), true, null, true);
+    INodesInPath iip =
+        fsd.addLastINode(parent, dir,
+                permission.getPermission(), true, null, true);
     if (iip != null && aclEntries != null) {
       AclStorage.updateINodeAcl(dir, aclEntries, Snapshot.CURRENT_STATE_ID);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
@@ -221,8 +221,8 @@ class FSDirMkdirOp {
     final INodeDirectory dir = new INodeDirectory(inodeId, name, permission,
         timestamp);
 
-    INodesInPath iip =
-        fsd.addLastINode(parent, dir, permission.getPermission(), true);
+    INodesInPath iip = fsd.addLastINode(parent, dir,
+            permission.getPermission(), true, null, true);
     if (iip != null && aclEntries != null) {
       AclStorage.updateINodeAcl(dir, aclEntries, Snapshot.CURRENT_STATE_ID);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.QuotaExceededException;
 import org.apache.hadoop.hdfs.protocol.SnapshotException;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockStoragePolicySuite;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory.DirOp;
 import org.apache.hadoop.hdfs.server.namenode.INode.BlocksMapUpdateInfo;
@@ -513,10 +514,14 @@ class FSDirRenameOp {
     if (srcStoragePolicyID != dstStoragePolicyID) {
       srcStoragePolicyCounts.add(srcIIP.getLastINode().
               computeQuotaUsage(bsps));
-      dstStoragePolicyCounts.add(srcIIP.getLastINode()
-              .computeQuotaUsage(bsps, dstParent.getStoragePolicyID(), false,
-                      Snapshot.CURRENT_STATE_ID));
-    } else if (srcParentNode != dstParentNode || tx.withCount != null) {
+      if (srcStoragePolicyID == HdfsConstants.BLOCK_STORAGE_POLICY_ID_UNSPECIFIED) {
+        dstStoragePolicyCounts.add(srcIIP.getLastINode()
+                .computeQuotaUsage(bsps, dstParent.getStoragePolicyID(), false,
+                        Snapshot.CURRENT_STATE_ID));
+      } else {
+        dstStoragePolicyCounts.add(srcStoragePolicyCounts);
+      }
+    } else if (srcParentNode != dstParentNode || tx.isSrcInSnapshot) {
       srcStoragePolicyCounts.add(srcIIP.getLastINode().computeQuotaUsage(bsps));
       dstStoragePolicyCounts.add(srcStoragePolicyCounts);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -70,7 +70,7 @@ class FSDirRenameOp {
    * dstInodes[dstInodes.length-1]
    */
   private static void verifyQuotaForRename(FSDirectory fsd, INodesInPath src,
-          INodesInPath dst, QuotaCounts counts) throws QuotaExceededException {
+      INodesInPath dst, QuotaCounts counts) throws QuotaExceededException {
     if (!fsd.getFSNamesystem().isImageLoaded() || fsd.shouldSkipQuotaChecks()) {
       // Do not check quota if edits log is still being processed
       return;
@@ -202,7 +202,7 @@ class FSDirRenameOp {
     BlockStoragePolicySuite bsps = fsd.getBlockStoragePolicySuite();
     RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP);
     computeQuotaCounts(srcStoragePolicyCounts, dstStoragePolicyCounts,
-            srcIIP, dstIIP, bsps, tx);
+        srcIIP, dstIIP, bsps, tx);
 
     verifyQuotaForRename(fsd, srcIIP, dstIIP, dstStoragePolicyCounts);
 
@@ -255,7 +255,7 @@ class FSDirRenameOp {
     BlocksMapUpdateInfo collectedBlocks = new BlocksMapUpdateInfo();
     // returns resolved path
     return renameTo(fsd, pc, src, dst, collectedBlocks,
-            logRetryCache, options);
+        logRetryCache, options);
   }
 
   /**
@@ -426,7 +426,7 @@ class FSDirRenameOp {
     QuotaCounts dstStoragePolicyCounts = new QuotaCounts.Builder().build();
     RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP);
     computeQuotaCounts(srcStoragePolicyCounts, dstStoragePolicyCounts,
-            srcIIP, dstIIP, bsps, tx);
+        srcIIP, dstIIP, bsps, tx);
 
     verifyQuotaForRename(fsd, srcIIP, dstIIP, dstStoragePolicyCounts);
 
@@ -445,7 +445,7 @@ class FSDirRenameOp {
 
       // add src as dst to complete rename
       INodesInPath renamedIIP = tx.
-              addSourceToDestination(dstStoragePolicyCounts);
+          addSourceToDestination(dstStoragePolicyCounts);
       if (renamedIIP != null) {
         undoRemoveSrc = false;
         if (NameNode.stateChangeLog.isDebugEnabled()) {
@@ -497,27 +497,27 @@ class FSDirRenameOp {
    *  the QuotaCount is calculated once using the storage policy of src.
    * */
   private static void computeQuotaCounts(
-          QuotaCounts srcStoragePolicyCounts,
-          QuotaCounts dstStoragePolicyCounts,
-          INodesInPath srcIIP,
-          INodesInPath dstIIP,
-          BlockStoragePolicySuite bsps,
-          RenameOperation tx) {
+      QuotaCounts srcStoragePolicyCounts,
+      QuotaCounts dstStoragePolicyCounts,
+      INodesInPath srcIIP,
+      INodesInPath dstIIP,
+      BlockStoragePolicySuite bsps,
+      RenameOperation tx) {
     INode dstParent = dstIIP.getINode(-2);
     INode srcParentNode = FSDirectory.
-            getFirstSetQuotaParentNode(srcIIP);
+        getFirstSetQuotaParentNode(srcIIP);
     INode srcInode = srcIIP.getLastINode();
     INode dstParentNode = FSDirectory.
-            getFirstSetQuotaParentNode(dstIIP);
+        getFirstSetQuotaParentNode(dstIIP);
     byte srcStoragePolicyID = FSDirectory.getStoragePolicyId(srcInode);
     byte dstStoragePolicyID = FSDirectory.getStoragePolicyId(dstParent);
     if (srcStoragePolicyID != dstStoragePolicyID) {
       srcStoragePolicyCounts.add(srcIIP.getLastINode().
-              computeQuotaUsage(bsps));
+          computeQuotaUsage(bsps));
       if (srcStoragePolicyID == HdfsConstants.BLOCK_STORAGE_POLICY_ID_UNSPECIFIED) {
         dstStoragePolicyCounts.add(srcIIP.getLastINode()
-                .computeQuotaUsage(bsps, dstParent.getStoragePolicyID(), false,
-                        Snapshot.CURRENT_STATE_ID));
+            .computeQuotaUsage(bsps, dstParent.getStoragePolicyID(), false,
+                Snapshot.CURRENT_STATE_ID));
       } else {
         dstStoragePolicyCounts.add(srcStoragePolicyCounts);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -69,7 +69,7 @@ class FSDirRenameOp {
    * dstInodes[dstInodes.length-1]
    */
   private static void verifyQuotaForRename(FSDirectory fsd, INodesInPath src,
-      INodesInPath dst) throws QuotaExceededException {
+          INodesInPath dst, QuotaCounts counts) throws QuotaExceededException {
     if (!fsd.getFSNamesystem().isImageLoaded() || fsd.shouldSkipQuotaChecks()) {
       // Do not check quota if edits log is still being processed
       return;
@@ -79,15 +79,8 @@ class FSDirRenameOp {
     // src[i - 1] is the last common ancestor.
     BlockStoragePolicySuite bsps = fsd.getBlockStoragePolicySuite();
     // Assume dstParent existence check done by callers.
-    INode dstParent = dst.getINode(-2);
-    // Use the destination parent's storage policy for quota delta verify.
-    final boolean isSrcSetSp = src.getLastINode().isSetStoragePolicy();
-    final byte storagePolicyID = isSrcSetSp ?
-        src.getLastINode().getLocalStoragePolicyID() :
-        dstParent.getStoragePolicyID();
-    final QuotaCounts delta = src.getLastINode()
-        .computeQuotaUsage(bsps, storagePolicyID, false,
-            Snapshot.CURRENT_STATE_ID);
+    QuotaCounts delta = new QuotaCounts.Builder().build();
+    delta = delta.add(counts);
 
     // Reduce the required quota by dst that is being removed
     final INode dstINode = dst.getLastINode();
@@ -202,7 +195,15 @@ class FSDirRenameOp {
     fsd.ezManager.checkMoveValidity(srcIIP, dstIIP);
     // Ensure dst has quota to accommodate rename
     verifyFsLimitsForRename(fsd, srcIIP, dstIIP);
-    verifyQuotaForRename(fsd, srcIIP, dstIIP);
+
+    QuotaCounts srcStoragePolicyCounts = new QuotaCounts.Builder().build();
+    QuotaCounts dstStoragePolicyCounts = new QuotaCounts.Builder().build();
+    BlockStoragePolicySuite bsps = fsd.getBlockStoragePolicySuite();
+
+    computeQuotaCounts(srcStoragePolicyCounts, dstStoragePolicyCounts,
+            srcIIP, dstIIP, bsps);
+
+    verifyQuotaForRename(fsd, srcIIP, dstIIP, dstStoragePolicyCounts);
 
     RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP);
 
@@ -211,11 +212,11 @@ class FSDirRenameOp {
     INodesInPath renamedIIP = null;
     try {
       // remove src
-      if (!tx.removeSrc4OldRename()) {
+      if (!tx.removeSrc4OldRename(srcStoragePolicyCounts)) {
         return null;
       }
 
-      renamedIIP = tx.addSourceToDestination();
+      renamedIIP = tx.addSourceToDestination(dstStoragePolicyCounts);
       added = (renamedIIP != null);
       if (added) {
         if (NameNode.stateChangeLog.isDebugEnabled()) {
@@ -230,7 +231,7 @@ class FSDirRenameOp {
       }
     } finally {
       if (!added) {
-        tx.restoreSource();
+        tx.restoreSource(srcStoragePolicyCounts);
       }
     }
     NameNode.stateChangeLog.warn("DIR* FSDirectory.unprotectedRenameTo: " +
@@ -254,7 +255,8 @@ class FSDirRenameOp {
 
     BlocksMapUpdateInfo collectedBlocks = new BlocksMapUpdateInfo();
     // returns resolved path
-    return renameTo(fsd, pc, src, dst, collectedBlocks, logRetryCache, options);
+    return renameTo(fsd, pc, src, dst, collectedBlocks,
+            logRetryCache, options);
   }
 
   /**
@@ -421,12 +423,17 @@ class FSDirRenameOp {
 
     // Ensure dst has quota to accommodate rename
     verifyFsLimitsForRename(fsd, srcIIP, dstIIP);
-    verifyQuotaForRename(fsd, srcIIP, dstIIP);
+    QuotaCounts srcStoragePolicyCounts = new QuotaCounts.Builder().build();
+    QuotaCounts dstStoragePolicyCounts = new QuotaCounts.Builder().build();
+    computeQuotaCounts(srcStoragePolicyCounts, dstStoragePolicyCounts,
+            srcIIP, dstIIP, bsps);
+
+    verifyQuotaForRename(fsd, srcIIP, dstIIP, dstStoragePolicyCounts);
 
     RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP);
 
     boolean undoRemoveSrc = true;
-    tx.removeSrc();
+    tx.removeSrc(srcStoragePolicyCounts);
 
     boolean undoRemoveDst = false;
     long removedNum = 0;
@@ -439,7 +446,8 @@ class FSDirRenameOp {
       }
 
       // add src as dst to complete rename
-      INodesInPath renamedIIP = tx.addSourceToDestination();
+      INodesInPath renamedIIP = tx.
+              addSourceToDestination(dstStoragePolicyCounts);
       if (renamedIIP != null) {
         undoRemoveSrc = false;
         if (NameNode.stateChangeLog.isDebugEnabled()) {
@@ -470,15 +478,50 @@ class FSDirRenameOp {
       }
     } finally {
       if (undoRemoveSrc) {
-        tx.restoreSource();
+        tx.restoreSource(srcStoragePolicyCounts);
       }
       if (undoRemoveDst) { // Rename failed - restore dst
-        tx.restoreDst(bsps);
+        tx.restoreDst(bsps, dstStoragePolicyCounts);
       }
     }
     NameNode.stateChangeLog.warn("DIR* FSDirectory.unprotectedRenameTo: " +
         "failed to rename " + src + " to " + dst);
     throw new IOException("rename from " + src + " to " + dst + " failed.");
+  }
+
+  /*
+   * Calculate QuotaCounts based on parent directory and storage policy
+   * 1. If the storage policy of src and dst are different,
+   *  calculate the QuotaCounts of src and dst respectively.
+   * 2. If all parent nodes of src and dst are not set with Quota,
+   *  there is no need to calculate QuotaCount.
+   * 3. if parent nodes of src and dst have Quota configured,
+   *  the QuotaCount is calculated once using the storage policy of src.
+   * */
+  private static void computeQuotaCounts(
+          QuotaCounts srcStoragePolicyCounts,
+          QuotaCounts dstStoragePolicyCounts,
+          INodesInPath srcIIP,
+          INodesInPath dstIIP,
+          BlockStoragePolicySuite bsps) {
+    INode dstParent = dstIIP.getINode(-2);
+    INode srcParentNode = FSDirectory.
+            getFirstSetQuotaParentNode(srcIIP);
+    INode srcInode = srcIIP.getLastINode();
+    INode dstParentNode = FSDirectory.
+            getFirstSetQuotaParentNode(dstIIP);
+    byte srcStoragePolicyID = FSDirectory.getStoragePolicyId(srcInode);
+    byte dstStoragePolicyID = FSDirectory.getStoragePolicyId(dstParent);
+    if (srcStoragePolicyID != dstStoragePolicyID) {
+      srcStoragePolicyCounts.add(srcIIP.getLastINode().
+              computeQuotaUsage(bsps));
+      dstStoragePolicyCounts.add(srcIIP.getLastINode()
+              .computeQuotaUsage(bsps, dstParent.getStoragePolicyID(), false,
+                      Snapshot.CURRENT_STATE_ID));
+    } else if (srcParentNode != dstParentNode) {
+      srcStoragePolicyCounts.add(srcIIP.getLastINode().computeQuotaUsage(bsps));
+      dstStoragePolicyCounts.add(srcStoragePolicyCounts);
+    }
   }
 
   /**
@@ -691,7 +734,7 @@ class FSDirRenameOp {
       }
     }
 
-    long removeSrc() throws IOException {
+    long removeSrc(QuotaCounts counts) throws IOException {
       long removedNum = fsd.removeLastINode(srcIIP);
       if (removedNum == -1) {
         String error = "Failed to rename " + srcIIP.getPath() + " to " +
@@ -701,13 +744,13 @@ class FSDirRenameOp {
         throw new IOException(error);
       } else {
         // update the quota count if necessary
-        fsd.updateCountForDelete(srcChild, srcIIP);
+        fsd.updateCountForDelete(srcChild, srcIIP, counts);
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
         return removedNum;
       }
     }
 
-    boolean removeSrc4OldRename() {
+    boolean removeSrc4OldRename(QuotaCounts counts) {
       final long removedSrc = fsd.removeLastINode(srcIIP);
       if (removedSrc == -1) {
         NameNode.stateChangeLog.warn("DIR* FSDirRenameOp.unprotectedRenameTo: "
@@ -716,7 +759,7 @@ class FSDirRenameOp {
         return false;
       } else {
         // update the quota count if necessary
-        fsd.updateCountForDelete(srcChild, srcIIP);
+        fsd.updateCountForDelete(srcChild, srcIIP, counts);
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
         return true;
       }
@@ -726,14 +769,17 @@ class FSDirRenameOp {
       long removedNum = fsd.removeLastINode(dstIIP);
       if (removedNum != -1) {
         oldDstChild = dstIIP.getLastINode();
+        // overwire needs to calculate QuotaCounts.
+        QuotaCounts counts = oldDstChild.computeQuotaUsage(
+            fsd.getBlockStoragePolicySuite());
         // update the quota count if necessary
-        fsd.updateCountForDelete(oldDstChild, dstIIP);
+        fsd.updateCountForDelete(oldDstChild, dstIIP, counts);
         dstIIP = INodesInPath.replace(dstIIP, dstIIP.length() - 1, null);
       }
       return removedNum;
     }
 
-    INodesInPath addSourceToDestination() {
+    INodesInPath addSourceToDestination(QuotaCounts counts) {
       final INode dstParent = dstParentIIP.getLastINode();
       final byte[] dstChildName = dstIIP.getLastLocalName();
       final INode toDst;
@@ -744,8 +790,11 @@ class FSDirRenameOp {
         withCount.getReferredINode().setLocalName(dstChildName);
         toDst = new INodeReference.DstReference(dstParent.asDirectory(),
             withCount, dstIIP.getLatestSnapshotId());
+        counts = toDst.computeQuotaUsage(fsd.getBlockStoragePolicySuite(),
+            dstParent.getStoragePolicyID(),
+            false, Snapshot.CURRENT_STATE_ID);
       }
-      return fsd.addLastINodeNoQuotaCheck(dstParentIIP, toDst);
+      return fsd.addLastINodeNoQuotaCheck(dstParentIIP, toDst, counts);
     }
 
     void updateMtimeAndLease(long timestamp) {
@@ -754,7 +803,7 @@ class FSDirRenameOp {
       dstParent.updateModificationTime(timestamp, dstIIP.getLatestSnapshotId());
     }
 
-    void restoreSource() {
+    void restoreSource(QuotaCounts counts) {
       // Rename failed - restore src
       final INode oldSrcChild = srcChild;
       // put it back
@@ -777,17 +826,19 @@ class FSDirRenameOp {
       } else {
         // srcParent is not an INodeDirectoryWithSnapshot, we only need to add
         // the srcChild back
-        fsd.addLastINodeNoQuotaCheck(srcParentIIP, srcChild);
+        fsd.addLastINodeNoQuotaCheck(srcParentIIP, srcChild, counts);
       }
     }
 
-    void restoreDst(BlockStoragePolicySuite bsps) {
+    void restoreDst(BlockStoragePolicySuite bsps, QuotaCounts counts) {
       Preconditions.checkState(oldDstChild != null);
-      final INodeDirectory dstParent = dstParentIIP.getLastINode().asDirectory();
+      final INodeDirectory dstParent = dstParentIIP.
+              getLastINode().asDirectory();
       if (dstParent.isWithSnapshot()) {
-        dstParent.undoRename4DstParent(bsps, oldDstChild, dstIIP.getLatestSnapshotId());
+        dstParent.undoRename4DstParent(bsps, oldDstChild,
+                dstIIP.getLatestSnapshotId());
       } else {
-        fsd.addLastINodeNoQuotaCheck(dstParentIIP, oldDstChild);
+        fsd.addLastINodeNoQuotaCheck(dstParentIIP, oldDstChild, counts);
       }
       if (oldDstChild != null && oldDstChild.isReference()) {
         final INodeReference removedDstRef = oldDstChild.asReference();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1199,7 +1199,7 @@ public class FSDirectory implements Closeable {
     writeLock();
     try {
       return addLastINode(existing, child, modes,
-              true, null, true);
+          true, null, true);
     } finally {
       writeUnlock();
     }
@@ -1495,8 +1495,8 @@ public class FSDirectory implements Closeable {
 
   static byte getStoragePolicyId(INode inode) {
     return inode.isSymlink() ?
-            HdfsConstants.BLOCK_STORAGE_POLICY_ID_UNSPECIFIED :
-            inode.getLocalStoragePolicyID();
+        HdfsConstants.BLOCK_STORAGE_POLICY_ID_UNSPECIFIED :
+        inode.getLocalStoragePolicyID();
   }
 
   static String normalizePath(String src) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1496,7 +1496,7 @@ public class FSDirectory implements Closeable {
   static byte getStoragePolicyId(INode inode) {
     return inode.isSymlink() ?
             HdfsConstants.BLOCK_STORAGE_POLICY_ID_UNSPECIFIED :
-            inode.getStoragePolicyID();
+            inode.getLocalStoragePolicyID();
   }
 
   static String normalizePath(String src) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1008,10 +1008,10 @@ public class FSDirectory implements Closeable {
    * when image/edits have been loaded and the file/dir to be deleted is not
    * contained in snapshots.
    */
-  void updateCountForDelete(final INode inode, final INodesInPath iip) {
+  void updateCountForDelete(final INode inode,
+      final INodesInPath iip, QuotaCounts counts) {
     if (getFSNamesystem().isImageLoaded() &&
         !inode.isInLatestSnapshot(iip.getLatestSnapshotId())) {
-      QuotaCounts counts = inode.computeQuotaUsage(getBlockStoragePolicySuite());
       unprotectedUpdateCount(iip, iip.length() - 1, counts.negation());
     }
   }
@@ -1198,7 +1198,8 @@ public class FSDirectory implements Closeable {
     cacheName(child);
     writeLock();
     try {
-      return addLastINode(existing, child, modes, true);
+      return addLastINode(existing, child, modes,
+              true, null, true);
     } finally {
       writeUnlock();
     }
@@ -1349,7 +1350,9 @@ public class FSDirectory implements Closeable {
    */
   @VisibleForTesting
   public INodesInPath addLastINode(INodesInPath existing, INode inode,
-      FsPermission modes, boolean checkQuota) throws QuotaExceededException {
+      FsPermission modes, boolean checkQuota,
+      QuotaCounts counts, boolean needComputeQuotaCounts)
+      throws QuotaExceededException {
     assert existing.getLastINode() != null &&
         existing.getLastINode().isDirectory();
 
@@ -1384,9 +1387,11 @@ public class FSDirectory implements Closeable {
     final byte storagePolicyID = isSrcSetSp ?
         inode.getLocalStoragePolicyID() :
         parent.getStoragePolicyID();
-    final QuotaCounts counts = inode
-        .computeQuotaUsage(getBlockStoragePolicySuite(),
-            storagePolicyID, false, Snapshot.CURRENT_STATE_ID);
+    if (needComputeQuotaCounts) {
+      counts = inode
+          .computeQuotaUsage(getBlockStoragePolicySuite(),
+              storagePolicyID, false, Snapshot.CURRENT_STATE_ID);
+    }
     updateCount(existing, pos, counts, checkQuota);
 
     boolean isRename = (inode.getParent() != null);
@@ -1404,10 +1409,12 @@ public class FSDirectory implements Closeable {
     return INodesInPath.append(existing, inode, inode.getLocalNameBytes());
   }
 
-  INodesInPath addLastINodeNoQuotaCheck(INodesInPath existing, INode i) {
+  INodesInPath addLastINodeNoQuotaCheck(INodesInPath existing,
+      INode i, QuotaCounts counts) {
     try {
       // All callers do not have create modes to pass.
-      return addLastINode(existing, i, null, false);
+      return addLastINode(existing, i, null, false,
+          counts, false);
     } catch (QuotaExceededException e) {
       NameNode.LOG.warn("FSDirectory.addChildNoQuotaCheck - unexpected", e);
     }
@@ -1466,6 +1473,30 @@ public class FSDirectory implements Closeable {
       }
     }
     return normalized;
+  }
+
+  /**
+   * Get the first Node that sets Quota.
+   */
+  static INode getFirstSetQuotaParentNode(INodesInPath iip) {
+    for (int i = iip.length() - 1; i > 0; i--) {
+      INode currNode = iip.getINode(i);
+      if (currNode == null) {
+        continue;
+      }
+      if (currNode.isDirectory()) {
+        if (currNode.isQuotaSet()) {
+          return currNode;
+        }
+      }
+    }
+    return null;
+  }
+
+  static byte getStoragePolicyId(INode inode) {
+    return inode.isSymlink() ?
+            HdfsConstants.BLOCK_STORAGE_POLICY_ID_UNSPECIFIED :
+            inode.getStoragePolicyID();
   }
 
   static String normalizePath(String src) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -1640,8 +1640,8 @@ public class TestRenameWithSnapshots {
     final Path foo2 = new Path(subdir2, foo.getName());
     FSDirectory fsdir2 = Mockito.spy(fsdir);
     Mockito.doThrow(new NSQuotaExceededException("fake exception")).when(fsdir2)
-            .addLastINode(any(), any(), any(), anyBoolean(),
-                    any(), anyBoolean());
+        .addLastINode(any(), any(), any(), anyBoolean(),
+            any(), anyBoolean());
     Whitebox.setInternalState(fsn, "dir", fsdir2);
     // rename /test/dir1/foo to /test/dir2/subdir2/foo. 
     // FSDirectory#verifyQuota4Rename will pass since the remaining quota is 2.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -1640,7 +1640,8 @@ public class TestRenameWithSnapshots {
     final Path foo2 = new Path(subdir2, foo.getName());
     FSDirectory fsdir2 = Mockito.spy(fsdir);
     Mockito.doThrow(new NSQuotaExceededException("fake exception")).when(fsdir2)
-        .addLastINode(any(), any(), any(), anyBoolean());
+            .addLastINode(any(), any(), any(), anyBoolean(),
+                    any(), anyBoolean());
     Whitebox.setInternalState(fsn, "dir", fsdir2);
     // rename /test/dir1/foo to /test/dir2/subdir2/foo. 
     // FSDirectory#verifyQuota4Rename will pass since the remaining quota is 2.


### PR DESCRIPTION
It takes a long time to move a large directory with rename. For example, it takes about 40 seconds to move a 1000W directory. When a large amount of data is deleted to the trash, the move large directory will occur when the recycle bin makes checkpoint. In addition, the user may also actively trigger the move large directory operation, which will cause the NameNode to lock too long and be killed by Zkfc. Through the flame graph, it is found that the main time consuming is to create the EnumCounters object.

Rename logic optimization:
Regardless of whether the rename operation is the source directory and the target directory, the quota count must be calculated three times. The first time, check whether the moved directory exceeds the target directory quota, the second time, calculate the mobile directory quota to update the source directory quota, and the third time, calculate the mobile directory configuration update to the target directory.
I think some of the above three quota quota calculations are unnecessary. For example, if all parent directories of the source directory and target directory are not configured with quota, there is no need to calculate quotaCount. Even if both the source directory and the target directory use quota, there is no need to calculate the quota three times. The calculation logic for the first and third times is the same, and it only needs to be calculated once.

For more information, please reference: [HDFS-16000](https://issues.apache.org/jira/browse/HDFS-16000)