### PR TITLE
MAPREDUCE-7342. Stop RMService in TestClientRedirect.testRedirect()

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClientRedirect.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClientRedirect.java
@@ -280,6 +280,14 @@ public class TestClientRedirect {
     }
 
     @Override
+    protected void serviceStop() throws Exception {
+      if (server != null) {
+        server.stop();
+      }
+      super.serviceStop();
+    }
+
+    @Override
     protected void serviceInit(Configuration conf) throws Exception {
       clientServiceBindAddress = RMADDRESS;
       /*


### PR DESCRIPTION
The test `org.apache.hadoop.mapred.TestClientRedirect.testRedirect` is not idempotent and fail if run twice in the same JVM, because it pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `TestClientRedirect.testRedirect` twice would result in the second run failing due to the following assertion error:
```
INFO  [main] service.AbstractService (AbstractService.java:noteFailure(267)) - Service test failed in state STARTED
org.apache.hadoop.yarn.exceptions.YarnRuntimeException: java.net.BindException: 

Problem binding to [0.0.0.0:8054] java.net.BindException: Address already in use
```
The root cause is that the RM server listening on port 8054 is started in the first run of this test, but hasn't been stopped when the test finishes. In the second run, when the test is trying to start the RMService, it fails because port 8054 is already in use, leading to the exception.

The suggested fix is to stop the RM server in the added overridden method `RMService.serviceStop()`.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

JIRA link: [MAPREDUCE-7342](https://issues.apache.org/jira/browse/MAPREDUCE-7342)
