### PR TITLE
HADOOP-17380 ITestS3AContractSeek.teardown closes FS before superclas…

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractSeek.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractSeek.java
@@ -141,11 +141,11 @@ public class ITestS3AContractSeek extends AbstractContractSeekTest {
 
   @Override
   public void teardown() throws Exception {
+    super.teardown();
     S3AFileSystem fs = getFileSystem();
     if (fs.getConf().getBoolean(FS_S3A_IMPL_DISABLE_CACHE, false)) {
       fs.close();
     }
-    super.teardown();
   }
 
   /**


### PR DESCRIPTION
Inside `ITestS3AContractSeek` the filesystem was getting closed before the
tests can execute their `teardown` method leading to the output log being
spammed with `IOException` messages.

Moving the order of operations around in `ITestS3AContractSeek.teardown`
so that `teardown` happens before closing the filesystem.

[HADOOP-17380](https://issues.apache.org/jira/browse/HADOOP-17380)