### PR TITLE
YARN-10776. Make ConfiguredRMFailoverProxyProvider select ResourceMan…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1035,6 +1035,10 @@ public class YarnConfiguration extends Configuration {
   public static final int
       DEFAULT_CLIENT_FAILOVER_RETRIES_ON_SOCKET_TIMEOUTS = 0;
 
+  public static final String CLIENT_FAILOVER_SHUFFLE_RM_KEY =
+      CLIENT_FAILOVER_PREFIX + "shuffle-rm";
+  public static final boolean CLIENT_FAILOVER_SHUFFLE_RM_DEFAULT = false;
+
   /** number of zookeeper operation retry times in ActiveStandbyElector */
   public static final String RM_HA_FC_ELECTOR_ZK_RETRIES_KEY = RM_HA_PREFIX
       + "failover-controller.active-standby-elector.zk.retries";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ConfiguredRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ConfiguredRMFailoverProxyProvider.java
@@ -21,7 +21,8 @@ package org.apache.hadoop.yarn.client;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,7 +58,8 @@ public class ConfiguredRMFailoverProxyProvider<T>
     this.protocol = protocol;
     this.rmProxy.checkAllowedProtocols(this.protocol);
     this.conf = new YarnConfiguration(configuration);
-    Collection<String> rmIds = HAUtil.getRMHAIds(conf);
+    ArrayList<String> rmIds = new ArrayList(HAUtil.getRMHAIds(conf));
+    Collections.shuffle(rmIds);
     this.rmServiceIds = rmIds.toArray(new String[rmIds.size()]);
     conf.set(YarnConfiguration.RM_HA_ID, rmServiceIds[currentProxyIndex]);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ConfiguredRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/ConfiguredRMFailoverProxyProvider.java
@@ -59,7 +59,10 @@ public class ConfiguredRMFailoverProxyProvider<T>
     this.rmProxy.checkAllowedProtocols(this.protocol);
     this.conf = new YarnConfiguration(configuration);
     ArrayList<String> rmIds = new ArrayList(HAUtil.getRMHAIds(conf));
-    Collections.shuffle(rmIds);
+    if (this.conf.getBoolean(YarnConfiguration.CLIENT_FAILOVER_SHUFFLE_RM_KEY,
+        YarnConfiguration.CLIENT_FAILOVER_SHUFFLE_RM_DEFAULT)) {
+      Collections.shuffle(rmIds);
+    }
     this.rmServiceIds = rmIds.toArray(new String[rmIds.size()]);
     conf.set(YarnConfiguration.RM_HA_ID, rmServiceIds[currentProxyIndex]);
 


### PR DESCRIPTION
I think we need to select resourcemanager or router randomly.

In federation mode, ConfiguredRMFailoverProxyProvider always connect first router in the configuration, it is better to shuffle the router list. 

We need random the router or rm list like hdfs since HDFS-6648.