### PR TITLE
HADOOP-17590 ABFS: Introduce Lease Operations with Append to provide single writer semantics

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -210,13 +210,13 @@ public class AbfsConfiguration{
   private String azureAppendBlobDirs;
 
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_WRITE_ENFORCE_LEASE,
-          DefaultValue = DEFAULT_FS_AZURE_WRITE_ENFORCE_LEASE)
+      DefaultValue = DEFAULT_FS_AZURE_WRITE_ENFORCE_LEASE)
   private boolean azureWriteEnforceLease;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_WRITE_LEASE_DURATION,
-          MinValue = MIN_LEASE_DURATION,
-          MaxValue = MAX_LEASE_DURATION,
-          DefaultValue = DEFAULT_FS_AZURE_WRITE_LEASE_DURATION)
+      MinValue = MIN_LEASE_DURATION,
+      MaxValue = MAX_LEASE_DURATION,
+      DefaultValue = DEFAULT_FS_AZURE_WRITE_LEASE_DURATION)
   private int azureWriteLeaseDuration;
 
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_INFINITE_LEASE_KEY,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -209,6 +209,16 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES)
   private String azureAppendBlobDirs;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_WRITE_ENFORCE_LEASE,
+          DefaultValue = DEFAULT_FS_AZURE_WRITE_ENFORCE_LEASE)
+  private boolean azureWriteEnforceLease;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_WRITE_LEASE_DURATION,
+          MinValue = MIN_LEASE_DURATION,
+          MaxValue = MAX_LEASE_DURATION,
+          DefaultValue = DEFAULT_FS_AZURE_WRITE_LEASE_DURATION)
+  private int azureWriteLeaseDuration;
+
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_INFINITE_LEASE_KEY,
       DefaultValue = DEFAULT_FS_AZURE_INFINITE_LEASE_DIRECTORIES)
   private String azureInfiniteLeaseDirs;
@@ -644,6 +654,14 @@ public class AbfsConfiguration{
 
   public String getAppendBlobDirs() {
     return this.azureAppendBlobDirs;
+  }
+
+  public boolean isLeaseEnforced() {
+    return this.azureWriteEnforceLease;
+  }
+
+  public int getWriteLeaseDuration() {
+    return this.azureWriteLeaseDuration;
   }
 
   public String getAzureInfiniteLeaseDirs() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -506,13 +506,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         triggerConditionalCreateOverwrite = true;
       }
 
+      AbfsLease lease = maybeCreateFiniteLease(relativePath, isNamespaceEnabled);
       AbfsRestOperation op;
       if (triggerConditionalCreateOverwrite) {
         op = conditionalCreateOverwriteFile(relativePath,
             statistics,
             isNamespaceEnabled ? getOctalNotation(permission) : null,
             isNamespaceEnabled ? getOctalNotation(umask) : null,
-            isAppendBlob
+            isAppendBlob,
+            lease
         );
 
       } else {
@@ -521,12 +523,14 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             isNamespaceEnabled ? getOctalNotation(permission) : null,
             isNamespaceEnabled ? getOctalNotation(umask) : null,
             isAppendBlob,
-            null);
+            null,
+            lease);
       }
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
 
-      AbfsLease lease = maybeCreateLease(relativePath);
-
+      if (lease == null) {
+        lease = maybeCreateLease(relativePath, isNamespaceEnabled);
+      }
       return new AbfsOutputStream(
           client,
           statistics,
@@ -551,7 +555,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       final FileSystem.Statistics statistics,
       final String permission,
       final String umask,
-      final boolean isAppendBlob) throws AzureBlobFileSystemException {
+      final boolean isAppendBlob,
+      AbfsLease lease) throws AzureBlobFileSystemException {
     AbfsRestOperation op;
 
     try {
@@ -559,7 +564,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       // avoided for cases when no pre-existing file is present (major portion
       // of create file traffic falls into the case of no pre-existing file).
       op = client.createPath(relativePath, true,
-          false, permission, umask, isAppendBlob, null);
+          false, permission, umask, isAppendBlob, null, lease);
     } catch (AbfsRestOperationException e) {
       if (e.getStatusCode() == HttpURLConnection.HTTP_CONFLICT) {
         // File pre-exists, fetch eTag
@@ -583,7 +588,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         try {
           // overwrite only if eTag matches with the file properties fetched befpre
           op = client.createPath(relativePath, true,
-              true, permission, umask, isAppendBlob, eTag);
+              true, permission, umask, isAppendBlob, eTag, lease);
         } catch (AbfsRestOperationException ex) {
           if (ex.getStatusCode() == HttpURLConnection.HTTP_PRECON_FAILED) {
             // Is a parallel access case, as file with eTag was just queried
@@ -639,7 +644,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       final AbfsRestOperation op = client.createPath(getRelativePath(path),
           false, overwrite,
               isNamespaceEnabled ? getOctalNotation(permission) : null,
-              isNamespaceEnabled ? getOctalNotation(umask) : null, false, null);
+              isNamespaceEnabled ? getOctalNotation(umask) : null, false, null, null);
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
     }
   }
@@ -738,7 +743,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         isAppendBlob = true;
       }
 
-      AbfsLease lease = maybeCreateLease(relativePath);
+      AbfsLease lease = maybeCreateLease(relativePath, getIsNamespaceEnabled());
 
       return new AbfsOutputStream(
           client,
@@ -1698,14 +1703,29 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     this.azureInfiniteLeaseDirSet.remove("");
   }
 
-  private AbfsLease maybeCreateLease(String relativePath)
+  private AbfsLease maybeCreateFiniteLease(String relativePath, boolean isNamespaceEnabled)
+          throws AzureBlobFileSystemException {
+      boolean enableInfiniteLease = isInfiniteLeaseKey(relativePath);
+      AbfsLease lease = null;
+      if (!enableInfiniteLease && abfsConfiguration.isLeaseEnforced() && isNamespaceEnabled) {
+          lease = new AbfsLease(client, relativePath, false);
+      }
+
+      return lease;
+  }
+
+  private AbfsLease maybeCreateLease(String relativePath, boolean isNamespaceEnabled)
       throws AzureBlobFileSystemException {
     boolean enableInfiniteLease = isInfiniteLeaseKey(relativePath);
-    if (!enableInfiniteLease) {
-      return null;
+    AbfsLease lease = null;
+    if (enableInfiniteLease) {
+      lease = new AbfsLease(client, relativePath, true);
+      leaseRefs.put(lease, null);
     }
-    AbfsLease lease = new AbfsLease(client, relativePath);
-    leaseRefs.put(lease, null);
+    else if (abfsConfiguration.isLeaseEnforced() && isNamespaceEnabled) {
+      lease = new AbfsLease(client, relativePath, false);
+    }
+
     return lease;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1704,14 +1704,14 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   private AbfsLease maybeCreateFiniteLease(String relativePath, boolean isNamespaceEnabled)
-          throws AzureBlobFileSystemException {
-      boolean enableInfiniteLease = isInfiniteLeaseKey(relativePath);
-      AbfsLease lease = null;
-      if (!enableInfiniteLease && abfsConfiguration.isLeaseEnforced() && isNamespaceEnabled) {
-          lease = new AbfsLease(client, relativePath, false);
-      }
+      throws AzureBlobFileSystemException {
+    boolean enableInfiniteLease = isInfiniteLeaseKey(relativePath);
+    AbfsLease lease = null;
+    if (!enableInfiniteLease && abfsConfiguration.isLeaseEnforced() && isNamespaceEnabled) {
+      lease = new AbfsLease(client, relativePath, false);
+    }
 
-      return lease;
+    return lease;
   }
 
   private AbfsLease maybeCreateLease(String relativePath, boolean isNamespaceEnabled)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -43,6 +43,8 @@ public final class AbfsHttpConstants {
   public static final String BREAK_LEASE_ACTION = "break";
   public static final String RELEASE_LEASE_ACTION = "release";
   public static final String RENEW_LEASE_ACTION = "renew";
+  public static final String ACQUIRE_RELEASE_LEASE_ACTION = "acquire-release";
+  public static final String AUTO_RENEW_LEASE_ACTION = "auto-renew";
   public static final String DEFAULT_LEASE_BREAK_PERIOD = "0";
   public static final String DEFAULT_TIMEOUT = "90";
   public static final String APPEND_BLOB_TYPE = "appendblob";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -87,6 +87,12 @@ public final class ConfigurationKeys {
   /** Provides a config to provide comma separated path prefixes on which Appendblob based files are created
    *  Default is empty. **/
   public static final String FS_AZURE_APPEND_BLOB_KEY = "fs.azure.appendblob.directories";
+  /** Provides a config control to disable or enable lease enforcement during write operations - appends and creates.
+   *  Default is false. **/
+  public static final String FS_AZURE_WRITE_ENFORCE_LEASE = "fs.azure.write.enforcelease";
+  /** Provides a config control to set lease duration in seconds if lease is to be enforced during write operations - appends and creates.
+   *  It is applicable for Hierarchical Namespace enabled accounts only. The lease duration must be between 15 and 60 seconds. Default is 60. **/
+  public static final String FS_AZURE_WRITE_LEASE_DURATION = "fs.azure.write.lease.duration";
   /** Provides a config to provide comma separated path prefixes which support infinite leases.
    *  Files under these paths will be leased when created or opened for writing and the lease will
    *  be released when the file is closed. The lease may be broken with the breakLease method on

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -81,6 +81,8 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_FS_AZURE_ENABLE_MKDIR_OVERWRITE = true;
   public static final String DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES = "";
   public static final String DEFAULT_FS_AZURE_INFINITE_LEASE_DIRECTORIES = "";
+  public static final boolean DEFAULT_FS_AZURE_WRITE_ENFORCE_LEASE = false;
+  public static final int DEFAULT_FS_AZURE_WRITE_LEASE_DURATION = 60;
   public static final int DEFAULT_LEASE_THREADS = 0;
   public static final int MIN_LEASE_THREADS = 0;
   public static final int DEFAULT_LEASE_DURATION = -1;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/AppendRequestParameters.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/AppendRequestParameters.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.azurebfs.contracts.services;
 
-import org.apache.hadoop.fs.azurebfs.services.AbfsLease;
-
 /**
  * Saves the different request parameters for append
  */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/AppendRequestParameters.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/AppendRequestParameters.java
@@ -35,20 +35,17 @@ public class AppendRequestParameters {
   private final int length;
   private final Mode mode;
   private final boolean isAppendBlob;
-  private AbfsLease lease;
 
   public AppendRequestParameters(final long position,
       final int offset,
       final int length,
       final Mode mode,
-      final boolean isAppendBlob,
-      AbfsLease lease) {
+      final boolean isAppendBlob) {
     this.position = position;
     this.offset = offset;
     this.length = length;
     this.mode = mode;
     this.isAppendBlob = isAppendBlob;
-    this.lease = lease;
   }
 
   public long getPosition() {
@@ -69,9 +66,5 @@ public class AppendRequestParameters {
 
   public boolean isAppendBlob() {
     return this.isAppendBlob;
-  }
-
-  public AbfsLease getLease() {
-    return this.lease;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/AppendRequestParameters.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/services/AppendRequestParameters.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.azurebfs.contracts.services;
 
+import org.apache.hadoop.fs.azurebfs.services.AbfsLease;
+
 /**
  * Saves the different request parameters for append
  */
@@ -33,20 +35,20 @@ public class AppendRequestParameters {
   private final int length;
   private final Mode mode;
   private final boolean isAppendBlob;
-  private final String leaseId;
+  private AbfsLease lease;
 
   public AppendRequestParameters(final long position,
       final int offset,
       final int length,
       final Mode mode,
       final boolean isAppendBlob,
-      final String leaseId) {
+      AbfsLease lease) {
     this.position = position;
     this.offset = offset;
     this.length = length;
     this.mode = mode;
     this.isAppendBlob = isAppendBlob;
-    this.leaseId = leaseId;
+    this.lease = lease;
   }
 
   public long getPosition() {
@@ -69,7 +71,7 @@ public class AppendRequestParameters {
     return this.isAppendBlob;
   }
 
-  public String getLeaseId() {
-    return this.leaseId;
+  public AbfsLease getLease() {
+    return this.lease;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -82,7 +82,7 @@ public class AbfsClient implements Closeable {
 
   private final URL baseUrl;
   private final SharedKeyCredentials sharedKeyCredentials;
-  private final String xMsVersion = "2019-12-12";
+  private final String xMsVersion = "2020-08-04";
   private final ExponentialRetryPolicy retryPolicy;
   private final String filesystem;
   private final AbfsConfiguration abfsConfiguration;
@@ -601,6 +601,7 @@ public class AbfsClient implements Closeable {
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_PROPOSED_LEASE_ID, lease.getLeaseID()));
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_DURATION, String.valueOf(abfsConfiguration.getWriteLeaseDuration())));
         } else if (reqParams.getMode() == AppendRequestParameters.Mode.FLUSH_CLOSE_MODE) {
+          lease.setLeaseAcquired(false);
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, RELEASE_LEASE_ACTION));
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ID, lease.getLeaseID()));
         } else {
@@ -691,6 +692,7 @@ public class AbfsClient implements Closeable {
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_PROPOSED_LEASE_ID, lease.getLeaseID()));
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_DURATION, String.valueOf(abfsConfiguration.getWriteLeaseDuration())));
         } else if (isClose) {
+          lease.setLeaseAcquired(false);
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, RELEASE_LEASE_ACTION));
           requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ID, lease.getLeaseID()));
         } else {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -396,7 +396,6 @@ public class AbfsClient implements Closeable {
       }
       throw ex;
     }
-
     return op;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.FutureCallback;
@@ -63,6 +64,8 @@ public final class AbfsLease {
 
   // Lease status variables
   private volatile boolean leaseFreed;
+  private volatile boolean leaseAcquired;
+  private volatile boolean isInfiniteLease = true;
   private volatile String leaseID = null;
   private volatile Throwable exception = null;
   private volatile int acquireRetryCount = 0;
@@ -78,16 +81,24 @@ public final class AbfsLease {
     }
   }
 
-  public AbfsLease(AbfsClient client, String path) throws AzureBlobFileSystemException {
-    this(client, path, DEFAULT_LEASE_ACQUIRE_MAX_RETRIES, DEFAULT_LEASE_ACQUIRE_RETRY_INTERVAL);
+  public AbfsLease(AbfsClient client, String path, boolean acquireLease) throws AzureBlobFileSystemException {
+    this(client, path, DEFAULT_LEASE_ACQUIRE_MAX_RETRIES, DEFAULT_LEASE_ACQUIRE_RETRY_INTERVAL, acquireLease);
   }
 
   @VisibleForTesting
   public AbfsLease(AbfsClient client, String path, int acquireMaxRetries,
-      int acquireRetryInterval) throws AzureBlobFileSystemException {
+      int acquireRetryInterval, boolean acquireLease) throws AzureBlobFileSystemException {
     this.leaseFreed = false;
     this.client = client;
     this.path = path;
+
+    if (!acquireLease) {
+        this.leaseID = UUID.randomUUID().toString();
+        this.leaseAcquired = false;
+        this.isInfiniteLease = false;
+        LOG.debug("Assigned lease without acquisition {} on {}.", leaseID, path);
+        return;
+    }
 
     if (client.getNumLeaseThreads() < 1) {
       throw new LeaseException(ERR_NO_LEASE_THREADS);
@@ -126,6 +137,7 @@ public final class AbfsLease {
       @Override
       public void onSuccess(@Nullable AbfsRestOperation op) {
         leaseID = op.getResult().getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID);
+        leaseAcquired = true;
         LOG.debug("Acquired lease {} on {}", leaseID, path);
       }
 
@@ -177,7 +189,19 @@ public final class AbfsLease {
     return leaseFreed;
   }
 
-  public String getLeaseID() {
+  public boolean isLeaseAcquired() {
+    return leaseAcquired;
+  }
+
+  public boolean isInfiniteLease() {
+    return isInfiniteLease;
+  }
+
+    public void setLeaseAcquired(boolean isLeaseAcquired) {
+      leaseAcquired = isLeaseAcquired;
+  }
+
+    public String getLeaseID() {
     return leaseID;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -198,6 +198,7 @@ public final class AbfsLease {
   }
 
     public void setLeaseAcquired(boolean isLeaseAcquired) {
+      leaseFreed = !isLeaseAcquired;
       leaseAcquired = isLeaseAcquired;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -386,7 +386,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
     try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
             "writeCurrentBufferToService", "append")) {
       AppendRequestParameters reqParams = new AppendRequestParameters(offset, 0,
-          bytesLength, APPEND_MODE, true, leaseId);
+          bytesLength, APPEND_MODE, true, lease);
       AbfsRestOperation op = client.append(path, bytes, reqParams, cachedSasToken.get());
       cachedSasToken.update(op.getSasToken());
       if (outputStreamStatistics != null) {
@@ -460,7 +460,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
               mode = FLUSH_MODE;
             }
             AppendRequestParameters reqParams = new AppendRequestParameters(
-                offset, 0, bytesLength, mode, false, leaseId);
+                offset, 0, bytesLength, mode, false, lease);
             AbfsRestOperation op = client.append(path, bytes, reqParams,
                 cachedSasToken.get());
             cachedSasToken.update(op.getSasToken());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -386,8 +386,8 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
     try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
             "writeCurrentBufferToService", "append")) {
       AppendRequestParameters reqParams = new AppendRequestParameters(offset, 0,
-          bytesLength, APPEND_MODE, true, lease);
-      AbfsRestOperation op = client.append(path, bytes, reqParams, cachedSasToken.get());
+          bytesLength, APPEND_MODE, true);
+      AbfsRestOperation op = client.append(path, bytes, reqParams, cachedSasToken.get(), lease);
       cachedSasToken.update(op.getSasToken());
       if (outputStreamStatistics != null) {
         outputStreamStatistics.uploadSuccessful(bytesLength);
@@ -460,9 +460,9 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
               mode = FLUSH_MODE;
             }
             AppendRequestParameters reqParams = new AppendRequestParameters(
-                offset, 0, bytesLength, mode, false, lease);
+                offset, 0, bytesLength, mode, false);
             AbfsRestOperation op = client.append(path, bytes, reqParams,
-                cachedSasToken.get());
+                cachedSasToken.get(), lease);
             cachedSasToken.update(op.getSasToken());
             perfInfo.registerResult(op.getResult());
             byteBufferPool.putBuffer(ByteBuffer.wrap(bytes));
@@ -529,7 +529,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
     try (AbfsPerfInfo perfInfo = new AbfsPerfInfo(tracker,
             "flushWrittenBytesToServiceInternal", "flush")) {
       AbfsRestOperation op = client.flush(path, offset, retainUncommitedData, isClose,
-          cachedSasToken.get(), leaseId);
+          cachedSasToken.get(), lease);
       cachedSasToken.update(op.getSasToken());
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
     } catch (AzureBlobFileSystemException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -235,7 +235,7 @@ public class AbfsRestOperation {
     try {
       // initialize the HTTP request and open the connection
       if (acquireLease && !requestHeaderUpdated) {
-        UpdateRequestHeaders();
+        updateRequestHeaders();
       }
 
       httpOperation = new AbfsHttpOperation(url, method, requestHeaders);
@@ -346,7 +346,7 @@ public class AbfsRestOperation {
     }
   }
 
-  private void UpdateRequestHeaders() {
+  private void updateRequestHeaders() {
     requestHeaderUpdated = true;
     boolean containsAutoRenew = requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION,
         AbfsHttpConstants.AUTO_RENEW_LEASE_ACTION));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -67,6 +67,10 @@ public class AbfsRestOperation {
   private int bufferLength;
   private int retryCount = 0;
 
+  private int leaseDuration = 0;
+  private boolean acquireLease = false;
+  private boolean requestHeaderUpdated = false;
+
   private AbfsHttpOperation result;
   private AbfsCounters abfsCounters;
 
@@ -230,6 +234,10 @@ public class AbfsRestOperation {
     AbfsHttpOperation httpOperation = null;
     try {
       // initialize the HTTP request and open the connection
+      if (acquireLease && !requestHeaderUpdated) {
+        UpdateRequestHeaders();
+      }
+
       httpOperation = new AbfsHttpOperation(url, method, requestHeaders);
       incrementCounter(AbfsStatistic.CONNECTIONS_MADE, 1);
 
@@ -310,6 +318,17 @@ public class AbfsRestOperation {
       return false;
     }
 
+    if (client.getRetryPolicy().isRetriableDueToLease(retryCount, httpOperation.getStatusCode(), operationType)
+          && isBundleLeaseOperation()) {
+      // first try simple retrial of the request
+      // if that doesn't work then acquire lease
+      if (retryCount >= 2) {
+        acquireLease = true;
+      }
+
+      return false;
+    }
+
     result = httpOperation;
 
     return true;
@@ -325,5 +344,38 @@ public class AbfsRestOperation {
     if (abfsCounters != null) {
       abfsCounters.incrementCounter(statistic, value);
     }
+  }
+
+  private void UpdateRequestHeaders() {
+    requestHeaderUpdated = true;
+    boolean containsAutoRenew = requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION,
+        AbfsHttpConstants.AUTO_RENEW_LEASE_ACTION));
+
+    if (!containsAutoRenew
+          && !requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, AbfsHttpConstants.RELEASE_LEASE_ACTION))) {
+      return;
+    }
+
+    String leaseId;
+    for (int i = 0; i < requestHeaders.size(); i++) {
+      if (requestHeaders.get(i).getName() == HttpHeaderConfigurations.X_MS_LEASE_ID) {
+        leaseId = requestHeaders.get(i).getValue();
+        requestHeaders.remove(i);
+        requestHeaders.remove(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION,
+            containsAutoRenew ? AbfsHttpConstants.AUTO_RENEW_LEASE_ACTION : AbfsHttpConstants.RELEASE_LEASE_ACTION));
+        requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION,
+            containsAutoRenew ? AbfsHttpConstants.ACQUIRE_LEASE_ACTION : AbfsHttpConstants.ACQUIRE_RELEASE_LEASE_ACTION));
+        requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_PROPOSED_LEASE_ID, leaseId));
+        requestHeaders.add(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_DURATION, String.valueOf(leaseDuration)));
+        break;
+      }
+    }
+  }
+
+  private boolean isBundleLeaseOperation() {
+    return (requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, AbfsHttpConstants.ACQUIRE_RELEASE_LEASE_ACTION))
+        || requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, AbfsHttpConstants.ACQUIRE_LEASE_ACTION))
+        || requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, AbfsHttpConstants.RELEASE_LEASE_ACTION))
+        || requestHeaders.contains(new AbfsHttpHeader(HttpHeaderConfigurations.X_MS_LEASE_ACTION, AbfsHttpConstants.AUTO_RENEW_LEASE_ACTION)));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -123,6 +123,24 @@ public class ExponentialRetryPolicy {
   }
 
   /**
+   * Returns if a request should be retried based on the retry count, current response,
+   * and the current strategy.
+   *
+   * @param retryCount The current retry attempt count.
+   * @param statusCode The status code of the response, or -1 for socket error.
+   * @param abfsRestOperationType The current operation type.
+   * @return true if the request should be retried; false otherwise.
+   */
+  public boolean isRetriableDueToLease(final int retryCount, final int statusCode,
+                                       final AbfsRestOperationType abfsRestOperationType) {
+    return ((abfsRestOperationType == AbfsRestOperationType.Append
+        || abfsRestOperationType == AbfsRestOperationType.Flush)
+        && (retryCount < this.retryCount
+            && (statusCode == HttpURLConnection.HTTP_CONFLICT
+            || statusCode == HttpURLConnection.HTTP_PRECON_FAILED)));
+  }
+
+  /**
    * Returns backoff interval between 80% and 120% of the desired backoff,
    * multiply by 2^n-1 for exponential.
    *

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBundleLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBundleLease.java
@@ -1,0 +1,314 @@
+package org.apache.hadoop.fs.azurebfs;
+
+import com.sun.jersey.api.ConflictException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Test lease operations.
+ */
+public class ITestAzureBlobFileSystemBundleLease extends
+    AbstractAbfsIntegrationTest {
+  private static final int BASE_SIZE = 1024;
+  private static final int ONE_THOUSAND = 1000;
+  private static final int ONE_MB = 1024 * 1024;
+  private static final int FLUSH_TIMES = 20;
+  private static final int TEST_BUFFER_SIZE = 3 * ONE_THOUSAND * BASE_SIZE;
+  private static final int THREAD_SLEEP_TIME = 1000;
+  private static final Path TEST_FILE_PATH = new Path("testfile");
+
+  public ITestAzureBlobFileSystemBundleLease() throws Exception {
+    super();
+    Configuration conf = getRawConfiguration();
+    conf.set(ConfigurationKeys.FS_AZURE_WRITE_ENFORCE_LEASE, "true");
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    assumeTrue(getFileSystem().getIsNamespaceEnabled());
+  }
+
+  @Test
+  public void testAppendWithLength0() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    try(FSDataOutputStream stream = fs.create(TEST_FILE_PATH)) {
+      final byte[] b = new byte[1024];
+      new Random().nextBytes(b);
+      stream.write(b, 1000, 0);
+    }
+
+    assertEquals(0, fs.getFileStatus(TEST_FILE_PATH).getLen());
+    //Try deletion. It should succeed as lease has been released.
+    fs.delete(TEST_FILE_PATH, false);
+  }
+
+  @Test
+  public void testAppendAfterCreate() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.create(TEST_FILE_PATH);
+    try(FSDataOutputStream stream = fs.append(TEST_FILE_PATH)) {
+      final byte[] b = new byte[1024];
+      new Random().nextBytes(b);
+      stream.write(b, 0, 1024);
+    }
+
+    assertEquals(1024, fs.getFileStatus(TEST_FILE_PATH).getLen());
+    //Try deletion. It should succeed as lease has been released.
+    fs.delete(TEST_FILE_PATH, false);
+  }
+
+  @Test
+  public void testMultipleWriter() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.create(TEST_FILE_PATH);
+    final byte[] b = new byte[1024];
+    new Random().nextBytes(b);
+    try(FSDataOutputStream stream = fs.append(TEST_FILE_PATH)) {
+      stream.write(b, 0, 1024);
+      intercept(ConflictException.class,
+          () -> fs.create(TEST_FILE_PATH, true));
+      FSDataOutputStream stream2 = fs.append(TEST_FILE_PATH);
+      intercept(ConflictException.class,
+          () -> stream2.write(b, 1000, 0));
+    }
+
+    //Retry Create and append after close
+    fs.create(TEST_FILE_PATH, true);
+    FSDataOutputStream stream2 = fs.append(TEST_FILE_PATH);
+    stream2.write(b, 0, 1024);
+
+    assertEquals(1024, fs.getFileStatus(TEST_FILE_PATH).getLen());
+    //Try deletion. It should succeed as lease has been released.
+    fs.delete(TEST_FILE_PATH, false);
+  }
+
+  @Test
+  public void testAbfsOutputStreamSyncFlush() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    final Path testFilePath = path(methodName.getMethodName());
+
+    final byte[] b;
+    try (FSDataOutputStream stream = fs.create(testFilePath)) {
+      b = new byte[TEST_BUFFER_SIZE];
+      new Random().nextBytes(b);
+      stream.write(b);
+
+      for (int i = 0; i < FLUSH_TIMES; i++) {
+        stream.hsync();
+        Thread.sleep(10);
+      }
+    }
+
+    final byte[] r = new byte[TEST_BUFFER_SIZE];
+    try (FSDataInputStream inputStream = fs.open(testFilePath, 4 * ONE_MB)) {
+      int result = inputStream.read(r);
+
+      assertNotEquals(-1, result);
+      assertArrayEquals(r, b);
+    }
+  }
+
+  @Test
+  public void testAbfsOutputStreamAsyncFlush() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    final Path testFilePath = path(methodName.getMethodName());
+    final byte[] b;
+    try (FSDataOutputStream stream = fs.create(testFilePath)) {
+      b = new byte[TEST_BUFFER_SIZE];
+      new Random().nextBytes(b);
+
+      for (int i = 0; i < 2; i++) {
+        stream.write(b);
+
+        for (int j = 0; j < FLUSH_TIMES; j++) {
+          stream.flush();
+          Thread.sleep(10);
+        }
+      }
+    }
+
+    final byte[] r = new byte[TEST_BUFFER_SIZE];
+    try (FSDataInputStream inputStream = fs.open(testFilePath, 4 * ONE_MB)) {
+      while (inputStream.available() != 0) {
+        int result = inputStream.read(r);
+
+        assertNotEquals("read returned -1", -1, result);
+        assertArrayEquals("buffer read from stream", r, b);
+      }
+    }
+  }
+
+  @Test
+  public void testHflush() throws Exception {
+    final AzureBlobFileSystem fs = this.getFileSystem();
+    byte[] buffer = new byte[TEST_BUFFER_SIZE];
+    new Random().nextBytes(buffer);
+    String fileName = UUID.randomUUID().toString();
+    final Path testFilePath = path(fileName);
+
+    try (FSDataOutputStream stream = fs.create(testFilePath))
+    {
+      stream.write(buffer);
+      stream.hflush();
+      byte[] readBuffer = new byte[buffer.length];
+      fs.open(testFilePath).read(readBuffer, 0, readBuffer.length);
+      assertArrayEquals(
+          "Bytes read do not match bytes written.",
+          buffer,
+          readBuffer);
+    }
+  }
+
+  @Test
+  public void testWriteHeavyBytesToFileSyncFlush() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    final Path testFilePath = path(methodName.getMethodName());
+    ExecutorService es;
+    try (FSDataOutputStream stream = fs.create(testFilePath)) {
+      es = Executors.newFixedThreadPool(10);
+
+      final byte[] b = new byte[TEST_BUFFER_SIZE];
+      new Random().nextBytes(b);
+
+      List<Future<Void>> tasks = new ArrayList<>();
+      for (int i = 0; i < FLUSH_TIMES; i++) {
+        Callable<Void> callable = new Callable<Void>() {
+          @Override
+          public Void call() throws Exception {
+            stream.write(b);
+            return null;
+          }
+        };
+
+        tasks.add(es.submit(callable));
+      }
+
+      boolean shouldStop = false;
+      while (!shouldStop) {
+        shouldStop = true;
+        for (Future<Void> task : tasks) {
+          if (!task.isDone()) {
+            stream.hsync();
+            shouldStop = false;
+            Thread.sleep(THREAD_SLEEP_TIME);
+          }
+        }
+      }
+
+      tasks.clear();
+    }
+
+    es.shutdownNow();
+    FileStatus fileStatus = fs.getFileStatus(testFilePath);
+    long expectedWrites = (long) TEST_BUFFER_SIZE * FLUSH_TIMES;
+    assertEquals("Wrong file length in " + testFilePath, expectedWrites, fileStatus.getLen());
+  }
+
+  @Test
+  public void testWriteHeavyBytesToFileAsyncFlush() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    ExecutorService es = Executors.newFixedThreadPool(10);
+
+    final Path testFilePath = path(methodName.getMethodName());
+    try (FSDataOutputStream stream = fs.create(testFilePath)) {
+
+      final byte[] b = new byte[TEST_BUFFER_SIZE];
+      new Random().nextBytes(b);
+
+      List<Future<Void>> tasks = new ArrayList<>();
+      for (int i = 0; i < FLUSH_TIMES; i++) {
+        Callable<Void> callable = new Callable<Void>() {
+          @Override
+          public Void call() throws Exception {
+            stream.write(b);
+            return null;
+          }
+        };
+
+        tasks.add(es.submit(callable));
+      }
+
+      boolean shouldStop = false;
+      while (!shouldStop) {
+        shouldStop = true;
+        for (Future<Void> task : tasks) {
+          if (!task.isDone()) {
+            stream.flush();
+            shouldStop = false;
+          }
+        }
+      }
+      Thread.sleep(THREAD_SLEEP_TIME);
+      tasks.clear();
+    }
+
+    es.shutdownNow();
+    FileStatus fileStatus = fs.getFileStatus(testFilePath);
+    assertEquals((long) TEST_BUFFER_SIZE * FLUSH_TIMES, fileStatus.getLen());
+  }
+
+  /**
+   * Tests
+   * 1. create overwrite=false of a file that doesnt pre-exist
+   * 2. create overwrite=false of a file that pre-exists
+   * 3. create overwrite=true of a file that doesnt pre-exist
+   * 4. create overwrite=true of a file that pre-exists
+   * matches the expectation when run against both combinations of
+   * fs.azure.enable.conditional.create.overwrite=true and
+   * fs.azure.enable.conditional.create.overwrite=false
+   * @throws Throwable
+   */
+  @Test
+  public void testDefaultCreateOverwriteFileTest() throws Throwable {
+    testCreateFileOverwrite(true);
+    testCreateFileOverwrite(false);
+  }
+
+  public void testCreateFileOverwrite(boolean enableConditionalCreateOverwrite)
+      throws Throwable {
+    final AzureBlobFileSystem currentFs = getFileSystem();
+    Configuration config = new Configuration(this.getRawConfiguration());
+    config.set("fs.azure.enable.conditional.create.overwrite",
+        Boolean.toString(enableConditionalCreateOverwrite));
+
+    final AzureBlobFileSystem fs =
+        (AzureBlobFileSystem) FileSystem.newInstance(currentFs.getUri(),
+            config);
+
+    final Path nonOverwriteFile = new Path("/NonOverwriteTest_FileName_"
+        + UUID.randomUUID().toString());
+
+    // Case 1: Not Overwrite - File does not pre-exist
+    // create should be successful
+    fs.create(nonOverwriteFile, false);
+
+    // Case 2: Not Overwrite - File pre-exists
+    intercept(FileAlreadyExistsException.class,
+        () -> fs.create(nonOverwriteFile, false));
+
+    final Path overwriteFilePath = new Path("/OverwriteTest_FileName_"
+        + UUID.randomUUID().toString());
+
+    // Case 3: Overwrite - File does not pre-exist
+    // create should be successful
+    fs.create(overwriteFilePath, true);
+
+    // Case 4: Overwrite - File pre-exists
+    fs.create(overwriteFilePath, true);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBundleLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBundleLease.java
@@ -19,7 +19,12 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.junit.Test;
 
@@ -103,7 +108,7 @@ public class ITestAzureBlobFileSystemBundleLease extends
       intercept(IOException.class,
           () -> {
         stream2.write(b, 1000, 0);
-        stream2.close();});
+        stream2.close(); });
     }
 
     //Retry Create and append after close
@@ -189,8 +194,7 @@ public class ITestAzureBlobFileSystemBundleLease extends
     String fileName = UUID.randomUUID().toString();
     final Path testFilePath = path(fileName);
 
-    try (FSDataOutputStream stream = fs.create(testFilePath))
-    {
+    try (FSDataOutputStream stream = fs.create(testFilePath)) {
       stream.write(buffer);
       stream.hflush();
       byte[] readBuffer = new byte[buffer.length];

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBundleLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBundleLease.java
@@ -1,6 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs;
 
-import com.sun.jersey.api.ConflictException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -254,7 +254,8 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.create(nonOverwriteFile, false).close();
 
     // One request to server to create path should be issued
-    createRequestCount++;
+    // One request to server to close should be issued
+    createRequestCount+=2;
 
     assertAbfsStatistics(
         CONNECTIONS_MADE,
@@ -281,7 +282,8 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.create(overwriteFilePath, true).close();
 
     // One request to server to create path should be issued
-    createRequestCount++;
+    // One request to server to close should be issued
+    createRequestCount+=2;
 
     assertAbfsStatistics(
         CONNECTIONS_MADE,
@@ -296,9 +298,10 @@ public class ITestAzureBlobFileSystemCreate extends
       // 1. create without overwrite
       // 2. GetFileStatus to get eTag
       // 3. create with overwrite
-      createRequestCount += 3;
+      // 4. close
+      createRequestCount += 4;
     } else {
-      createRequestCount++;
+      createRequestCount+=2;
     }
 
     assertAbfsStatistics(

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -377,7 +377,7 @@ public class ITestAzureBlobFileSystemCreate extends
         .createPath(any(String.class), eq(true), eq(false),
             isNamespaceEnabled ? any(String.class) : eq(null),
             isNamespaceEnabled ? any(String.class) : eq(null),
-            any(boolean.class), eq(null));
+            any(boolean.class), eq(null), eq(null));
 
     doThrow(fileNotFoundResponseEx) // Scn1: GFS fails with Http404
         .doThrow(serverErrorResponseEx) // Scn2: GFS fails with Http500
@@ -395,7 +395,7 @@ public class ITestAzureBlobFileSystemCreate extends
         .createPath(any(String.class), eq(true), eq(true),
             isNamespaceEnabled ? any(String.class) : eq(null),
             isNamespaceEnabled ? any(String.class) : eq(null),
-            any(boolean.class), eq(null));
+            any(boolean.class), eq(null), eq(null));
 
     // Scn1: GFS fails with Http404
     // Sequence of events expected:

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -251,7 +251,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
     // Case 1: Not Overwrite - File does not pre-exist
     // create should be successful
-    fs.create(nonOverwriteFile, false);
+    fs.create(nonOverwriteFile, false).close();
 
     // One request to server to create path should be issued
     createRequestCount++;
@@ -278,7 +278,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
     // Case 3: Overwrite - File does not pre-exist
     // create should be successful
-    fs.create(overwriteFilePath, true);
+    fs.create(overwriteFilePath, true).close();
 
     // One request to server to create path should be issued
     createRequestCount++;
@@ -289,7 +289,7 @@ public class ITestAzureBlobFileSystemCreate extends
         fs.getInstrumentationMap());
 
     // Case 4: Overwrite - File pre-exists
-    fs.create(overwriteFilePath, true);
+    fs.create(overwriteFilePath, true).close();
 
     if (enableConditionalCreateOverwrite) {
       // Three requests will be sent to server to create path,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSAS.java
@@ -396,7 +396,7 @@ public class ITestAzureBlobFileSystemDelegationSAS extends AbstractAbfsIntegrati
   public void testSignatureMask() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
     String src = "/testABC/test.xt";
-    fs.create(new Path(src));
+    fs.create(new Path(src)).close();
     AbfsRestOperation abfsHttpRestOperation = fs.getAbfsClient()
         .renamePath(src, "/testABC" + "/abc.txt", null);
     AbfsHttpOperation result = abfsHttpRestOperation.getResult();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInfiniteLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInfiniteLease.java
@@ -51,13 +51,13 @@ import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_PARALLEL_ACC
 /**
  * Test lease operations.
  */
-public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
+public class ITestAzureBlobFileSystemInfiniteLease extends AbstractAbfsIntegrationTest {
   private static final int TEST_EXECUTION_TIMEOUT = 30 * 1000;
   private static final int LONG_TEST_EXECUTION_TIMEOUT = 90 * 1000;
   private static final String TEST_FILE = "testfile";
   private final boolean isHNSEnabled;
 
-  public ITestAzureBlobFileSystemLease() throws Exception {
+  public ITestAzureBlobFileSystemInfiniteLease() throws Exception {
     super();
 
     this.isHNSEnabled = getConfiguration()
@@ -309,7 +309,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
     fs.mkdirs(testFilePath.getParent());
     fs.createNewFile(testFilePath);
 
-    AbfsLease lease = new AbfsLease(fs.getAbfsClient(), testFilePath.toUri().getPath());
+    AbfsLease lease = new AbfsLease(fs.getAbfsClient(), testFilePath.toUri().getPath(), false);
     Assert.assertNotNull("Did not successfully lease file", lease.getLeaseID());
     lease.free();
     Assert.assertEquals("Unexpected acquire retry count", 0, lease.getAcquireRetryCount());
@@ -321,7 +321,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .doCallRealMethod()
         .when(mockClient).acquireLease(anyString(), anyInt());
 
-    lease = new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1);
+    lease = new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, false);
     Assert.assertNotNull("Acquire lease should have retried", lease.getLeaseID());
     lease.free();
     Assert.assertEquals("Unexpected acquire retry count", 2, lease.getAcquireRetryCount());
@@ -330,7 +330,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .when(mockClient).acquireLease(anyString(), anyInt());
 
     LambdaTestUtils.intercept(AzureBlobFileSystemException.class, () -> {
-      new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1);
+      new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, false);
     });
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInfiniteLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInfiniteLease.java
@@ -309,7 +309,7 @@ public class ITestAzureBlobFileSystemInfiniteLease extends AbstractAbfsIntegrati
     fs.mkdirs(testFilePath.getParent());
     fs.createNewFile(testFilePath);
 
-    AbfsLease lease = new AbfsLease(fs.getAbfsClient(), testFilePath.toUri().getPath(), false);
+    AbfsLease lease = new AbfsLease(fs.getAbfsClient(), testFilePath.toUri().getPath(), true);
     Assert.assertNotNull("Did not successfully lease file", lease.getLeaseID());
     lease.free();
     Assert.assertEquals("Unexpected acquire retry count", 0, lease.getAcquireRetryCount());
@@ -321,7 +321,7 @@ public class ITestAzureBlobFileSystemInfiniteLease extends AbstractAbfsIntegrati
         .doCallRealMethod()
         .when(mockClient).acquireLease(anyString(), anyInt());
 
-    lease = new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, false);
+    lease = new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, true);
     Assert.assertNotNull("Acquire lease should have retried", lease.getLeaseID());
     lease.free();
     Assert.assertEquals("Unexpected acquire retry count", 2, lease.getAcquireRetryCount());
@@ -330,7 +330,7 @@ public class ITestAzureBlobFileSystemInfiniteLease extends AbstractAbfsIntegrati
         .when(mockClient).acquireLease(anyString(), anyInt());
 
     LambdaTestUtils.intercept(AzureBlobFileSystemException.class, () -> {
-      new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, false);
+      new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, true);
     });
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInfiniteLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInfiniteLease.java
@@ -148,7 +148,8 @@ public class ITestAzureBlobFileSystemInfiniteLease extends AbstractAbfsIntegrati
   private void twoWriters(AzureBlobFileSystem fs, Path testFilePath, boolean expectException) throws Exception {
     try (FSDataOutputStream out = fs.create(testFilePath)) {
       try (FSDataOutputStream out2 = fs.append(testFilePath)) {
-        out2.writeInt(2);
+        out2.writeInt(1);
+        out2.writeInt(1);
         out2.hsync();
       } catch (IOException e) {
         if (expectException) {
@@ -159,6 +160,12 @@ public class ITestAzureBlobFileSystemInfiniteLease extends AbstractAbfsIntegrati
       }
       out.writeInt(1);
       out.hsync();
+    } catch (IOException e) {
+      if (!expectException) {
+        GenericTestUtils.assertExceptionContains("400", e);
+      } else {
+        throw e;
+      }
     }
 
     Assert.assertTrue("Store leases were not freed", fs.getAbfsStore().areLeasesFreed());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
@@ -196,11 +196,11 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
     //  Trying to append with correct CPK headers
     AppendRequestParameters appendRequestParameters =
         new AppendRequestParameters(
-        0, 0, 5, Mode.APPEND_MODE, false, null);
+        0, 0, 5, Mode.APPEND_MODE, false);
     byte[] buffer = getRandomBytesArray(5);
     AbfsClient abfsClient = fs.getAbfsClient();
     AbfsRestOperation abfsRestOperation = abfsClient
-        .append(fileName, buffer, appendRequestParameters, null);
+        .append(fileName, buffer, appendRequestParameters, null, null);
     assertCPKHeaders(abfsRestOperation, true);
     assertResponseHeader(abfsRestOperation, true, X_MS_ENCRYPTION_KEY_SHA256,
         getCPKSha(fs));
@@ -216,7 +216,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
     try (AzureBlobFileSystem fs2 = (AzureBlobFileSystem) FileSystem.newInstance(conf);
          AbfsClient abfsClient2 = fs2.getAbfsClient()) {
       LambdaTestUtils.intercept(IOException.class, () -> {
-        abfsClient2.append(fileName, buffer, appendRequestParameters, null);
+        abfsClient2.append(fileName, buffer, appendRequestParameters, null, null);
       });
     }
 
@@ -225,7 +225,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
     try (AzureBlobFileSystem fs3 = (AzureBlobFileSystem) FileSystem
         .get(conf); AbfsClient abfsClient3 = fs3.getAbfsClient()) {
       LambdaTestUtils.intercept(IOException.class, () -> {
-        abfsClient3.append(fileName, buffer, appendRequestParameters, null);
+        abfsClient3.append(fileName, buffer, appendRequestParameters, null, null);
       });
     }
   }
@@ -239,11 +239,11 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
     //  Trying to append without CPK headers
     AppendRequestParameters appendRequestParameters =
         new AppendRequestParameters(
-        0, 0, 5, Mode.APPEND_MODE, false, null);
+        0, 0, 5, Mode.APPEND_MODE, false);
     byte[] buffer = getRandomBytesArray(5);
     AbfsClient abfsClient = fs.getAbfsClient();
     AbfsRestOperation abfsRestOperation = abfsClient
-        .append(fileName, buffer, appendRequestParameters, null);
+        .append(fileName, buffer, appendRequestParameters, null, null);
     assertCPKHeaders(abfsRestOperation, false);
     assertResponseHeader(abfsRestOperation, false, X_MS_ENCRYPTION_KEY_SHA256,
         "");
@@ -259,7 +259,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
     try (AzureBlobFileSystem fs2 = (AzureBlobFileSystem) FileSystem.newInstance(conf);
          AbfsClient abfsClient2 = fs2.getAbfsClient()) {
       LambdaTestUtils.intercept(IOException.class, () -> {
-        abfsClient2.append(fileName, buffer, appendRequestParameters, null);
+        abfsClient2.append(fileName, buffer, appendRequestParameters, null, null);
       });
     }
   }
@@ -467,7 +467,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
     AbfsRestOperation abfsRestOperation = abfsClient
         .createPath(testFileName, true, true,
             isNamespaceEnabled ? getOctalNotation(permission) : null,
-            isNamespaceEnabled ? getOctalNotation(umask) : null, false, null);
+            isNamespaceEnabled ? getOctalNotation(umask) : null, false, null, null);
     assertCPKHeaders(abfsRestOperation, isWithCPK);
     assertResponseHeader(abfsRestOperation, isWithCPK,
         X_MS_ENCRYPTION_KEY_SHA256, getCPKSha(fs));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
@@ -84,6 +84,7 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
     Assertions.assertThat(stream.getMaxRequestsThatCanBeQueued())
         .describedAs("maxRequestsToQueue should be " + maxRequestsToQueue)
         .isEqualTo(maxRequestsToQueue);
+    stream.close();
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -87,7 +87,7 @@ public final class TestAbfsOutputStream {
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -111,12 +111,12 @@ public final class TestAbfsOutputStream {
         WRITE_SIZE, 0, 2 * WRITE_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
   }
 
   /**
@@ -134,7 +134,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -153,12 +153,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, 5*WRITE_SIZE-BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -190,7 +190,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
     when(op.getSasToken()).thenReturn("testToken");
     when(op.getResult()).thenReturn(httpOp);
@@ -211,12 +211,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -248,7 +248,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
     when(op.getSasToken()).thenReturn("testToken");
     when(op.getResult()).thenReturn(httpOp);
@@ -269,12 +269,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
   }
 
   /**
@@ -292,7 +292,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -311,12 +311,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, true);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
   }
 
   /**
@@ -335,7 +335,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -354,12 +354,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -389,7 +389,7 @@ public final class TestAbfsOutputStream {
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), isNull())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -410,11 +410,11 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), isNull());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), isNull());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any(), null);
+        eq(PATH), any(byte[].class), any(), any(), isNull());
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
@@ -86,7 +87,7 @@ public final class TestAbfsOutputStream {
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -105,17 +106,17 @@ public final class TestAbfsOutputStream {
     out.hsync();
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, WRITE_SIZE, APPEND_MODE, false, null);
+        0, 0, WRITE_SIZE, APPEND_MODE, false);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        WRITE_SIZE, 0, 2 * WRITE_SIZE, APPEND_MODE, false, null);
+        WRITE_SIZE, 0, 2 * WRITE_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
   }
 
   /**
@@ -133,7 +134,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -147,17 +148,17 @@ public final class TestAbfsOutputStream {
     out.close();
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        0, 0, BUFFER_SIZE, APPEND_MODE, false);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        BUFFER_SIZE, 0, 5*WRITE_SIZE-BUFFER_SIZE, APPEND_MODE, false, null);
+        BUFFER_SIZE, 0, 5*WRITE_SIZE-BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -189,7 +190,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
     when(op.getSasToken()).thenReturn("testToken");
     when(op.getResult()).thenReturn(httpOp);
@@ -205,17 +206,17 @@ public final class TestAbfsOutputStream {
     out.close();
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        0, 0, BUFFER_SIZE, APPEND_MODE, false);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -247,7 +248,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
     when(op.getSasToken()).thenReturn("testToken");
     when(op.getResult()).thenReturn(httpOp);
@@ -263,17 +264,17 @@ public final class TestAbfsOutputStream {
     Thread.sleep(1000);
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        0, 0, BUFFER_SIZE, APPEND_MODE, false);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
   }
 
   /**
@@ -291,7 +292,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -305,17 +306,17 @@ public final class TestAbfsOutputStream {
     Thread.sleep(1000);
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, BUFFER_SIZE, APPEND_MODE, true, null);
+        0, 0, BUFFER_SIZE, APPEND_MODE, true);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, true, null);
+        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, true);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
   }
 
   /**
@@ -334,7 +335,7 @@ public final class TestAbfsOutputStream {
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
 
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -348,17 +349,17 @@ public final class TestAbfsOutputStream {
     out.hflush();
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        0, 0, BUFFER_SIZE, APPEND_MODE, false);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -388,7 +389,7 @@ public final class TestAbfsOutputStream {
     abfsConf = new AbfsConfiguration(conf, accountName1);
     AbfsPerfTracker tracker = new AbfsPerfTracker("test", accountName1, abfsConf);
     when(client.getAbfsPerfTracker()).thenReturn(tracker);
-    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
+    when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any(), null)).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
     AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
@@ -404,16 +405,16 @@ public final class TestAbfsOutputStream {
     Thread.sleep(1000);
 
     AppendRequestParameters firstReqParameters = new AppendRequestParameters(
-        0, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        0, 0, BUFFER_SIZE, APPEND_MODE, false);
     AppendRequestParameters secondReqParameters = new AppendRequestParameters(
-        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
+        BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(firstReqParameters), any(), null);
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(PATH), any(byte[].class), refEq(secondReqParameters), any(), null);
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(PATH), any(byte[].class), any(), any(), null);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 
-import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
The lease operations have been introduced as part of Create, Append, Flush to ensure the single writer semantics.

Testing Done:
1. Introduced new set of tests in the ITestAzureBlobFileSystemBundleLease.java 
2. Existing tests were run:
Region: Canary EastUs2euap
a. HNS account + OAuth config
b. HNS account + Shared Key config
c. Non-HNS account + SharedKey config
d. AppendBlob+HNS+Oauth config

Failures seen - testReadAndWriteWithDifferentBufferSizesAndSeek, ITestAbfsFileSystemContractDistCp, ITestAbfsFileSystemContractSecureDistCp, TestAbfsStreamOps with appendblob, testBlobBackCompatibility, testRandomRead & WasbAbfsCompatibility with non-HNS account
