### PR TITLE
HDFS-16031. Possible Resource Leak in org.apache.hadoop.hdfs.server.aliasmap#InMemoryAliasMap

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/aliasmap/InMemoryAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/aliasmap/InMemoryAliasMap.java
@@ -330,10 +330,13 @@ public class InMemoryAliasMap implements InMemoryAliasMapProtocol,
       tOut = new TarArchiveOutputStream(gzOut);
       addFileToTarGzRecursively(tOut, aliasMapDir, "", new Configuration());
     } finally {
-      if (tOut != null) {
-        tOut.finish();
+      try {
+        if (tOut != null) {
+          tOut.finish();
+        }
+      } finally {
+        IOUtils.cleanupWithLogger(null, tOut, gzOut, bOut);
       }
-      IOUtils.cleanupWithLogger(null, tOut, gzOut, bOut);
     }
     return outCompressedFile;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/aliasmap/InMemoryAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/aliasmap/InMemoryAliasMap.java
@@ -327,9 +327,6 @@ public class InMemoryAliasMap implements InMemoryAliasMapProtocol,
          TarArchiveOutputStream tOut = new TarArchiveOutputStream(gzOut)){
 
       addFileToTarGzRecursively(tOut, aliasMapDir, "", new Configuration());
-      if (tOut != null) {
-        tOut.finish();
-      }
     }
 
     return outCompressedFile;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/aliasmap/InMemoryAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/aliasmap/InMemoryAliasMap.java
@@ -320,24 +320,18 @@ public class InMemoryAliasMap implements InMemoryAliasMapProtocol,
   private static File getCompressedAliasMap(File aliasMapDir)
       throws IOException {
     File outCompressedFile = new File(aliasMapDir.getParent(), TAR_NAME);
-    BufferedOutputStream bOut = null;
-    GzipCompressorOutputStream gzOut = null;
-    TarArchiveOutputStream tOut = null;
-    try {
-      bOut = new BufferedOutputStream(
-          Files.newOutputStream(outCompressedFile.toPath()));
-      gzOut = new GzipCompressorOutputStream(bOut);
-      tOut = new TarArchiveOutputStream(gzOut);
+
+    try (BufferedOutputStream bOut = new BufferedOutputStream(
+            Files.newOutputStream(outCompressedFile.toPath()));
+         GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(bOut);
+         TarArchiveOutputStream tOut = new TarArchiveOutputStream(gzOut)){
+
       addFileToTarGzRecursively(tOut, aliasMapDir, "", new Configuration());
-    } finally {
-      try {
-        if (tOut != null) {
-          tOut.finish();
-        }
-      } finally {
-        IOUtils.cleanupWithLogger(null, tOut, gzOut, bOut);
+      if (tOut != null) {
+        tOut.finish();
       }
     }
+
     return outCompressedFile;
   }
 


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://issues.apache.org/jira/browse/HDFS-16031).