### PR TITLE
HADOOP-17719. DistCp with snapshot diff should support file systems other than DistributedFileSystem.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
@@ -97,12 +97,12 @@ class DistCpSync {
     final Path snapshotDiffDir = isRdiff() ? targetDir : sourceDir;
 
     if (!srcFs.hasPathCapability(
-            sourceDir,CommonPathCapabilities.FS_SNAPSHOTS)) {
+            sourceDir, CommonPathCapabilities.FS_SNAPSHOTS)) {
       throw new IllegalArgumentException(
           "The source file system does not support snapshot.");
     }
     if (!tgtFs.hasPathCapability(
-            targetDir,CommonPathCapabilities.FS_SNAPSHOTS)) {
+            targetDir, CommonPathCapabilities.FS_SNAPSHOTS)) {
       throw new IllegalArgumentException(
           "The target file system does not support snapshot.");
     }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
@@ -946,8 +946,10 @@ public class TestDistCpSync {
     options.appendToConf(conf);
     context = new DistCpContext(options);
 
-    conf.set(DistCpConstants.CONF_LABEL_TARGET_WORK_PATH, webhdfsTarget.toString());
-    conf.set(DistCpConstants.CONF_LABEL_TARGET_FINAL_PATH, webhdfsTarget.toString());
+    conf.set(DistCpConstants.CONF_LABEL_TARGET_WORK_PATH,
+        webhdfsTarget.toString());
+    conf.set(DistCpConstants.CONF_LABEL_TARGET_FINAL_PATH,
+        webhdfsTarget.toString());
 
     DistCpSync distCpSync = new DistCpSync(context, conf);
 
@@ -962,7 +964,8 @@ public class TestDistCpSync {
 
     // build copy listing
     final Path listingPath = new Path("/tmp/META/fileList.seq");
-    CopyListing listing = new SimpleCopyListing(conf, new Credentials(), distCpSync);
+    CopyListing listing =
+        new SimpleCopyListing(conf, new Credentials(), distCpSync);
     listing.buildListing(listingPath, context);
 
     Map<Text, CopyListingFileStatus> copyListing = getListing(listingPath);
@@ -976,8 +979,8 @@ public class TestDistCpSync {
     mapContext.getConfiguration().setBoolean(
         DistCpOptionSwitch.DIRECT_WRITE.getConfigLabel(), true);
     copyMapper.setup(mapContext);
-    for (Map.Entry<Text, CopyListingFileStatus> entry : copyListing.entrySet()) {
-      copyMapper.map(entry.getKey(), entry.getValue(), mapContext);
+    for (Map.Entry<Text, CopyListingFileStatus> e : copyListing.entrySet()) {
+      copyMapper.map(e.getKey(), e.getValue(), mapContext);
     }
 
     // verify that we only list modified and created files/directories


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17719

`distcp -diff` currently supports only DistributedFileSystem. Other file system could be used if getSnapshotDiffReport is supported.