### PR TITLE
HADOOP-17728. HDFS-16033. Fix issue of the StatisticsDataReferenceCleaner cleanUp

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,12 +4004,13 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
+      private int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove();
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove(REF_QUEUE_POLL_TIMEOUT);
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,13 +4004,14 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private int REF_QUEUE_POLL_TIMEOUT = 100;
+      private static int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove(REF_QUEUE_POLL_TIMEOUT);
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.
+                        remove(REF_QUEUE_POLL_TIMEOUT);
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,7 +4004,12 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private static int REF_QUEUE_POLL_TIMEOUT = 100;
+      /**
+       * Represents the timeout period expires for remove reference objects from
+       * the STATS_DATA_REF_QUEUE when the queue is empty.
+       */
+      private static final int REF_QUEUE_POLL_TIMEOUT = 10000;
+
       @Override
       public void run() {
         while (!Thread.interrupted()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `StatisticsDataReferenceCleaner`, Cleaner thread will be blocked if we remove reference from ReferenceQueue unless the queue.enqueue` called but no now.

As shown below, We call ReferenceQueue.remove() now while cleanUp, Call chain as follow：
`StatisticsDataReferenceCleaner#queue.remove()  ->  ReferenceQueue.remove(0)  -> lock.wait(0)`

lock.wait(0) will waitting perpetual unless lock.notify/notifyAll be called, But, lock.notifyAll is called when queue.enqueue only, so Cleaner thread will be blocked.

**ThreadDump:**
```
"Reference Handler" #2 daemon prio=10 os_prio=0 tid=0x00007f7afc088800 nid=0x2119 in Object.wait() [0x00007f7b00230000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x00000000c00c2f58> (a java.lang.ref.Reference$Lock)
        at java.lang.Object.wait(Object.java:502)
        at java.lang.ref.Reference.tryHandlePending(Reference.java:191)
        - locked <0x00000000c00c2f58> (a java.lang.ref.Reference$Lock)
        at java.lang.ref.Reference$ReferenceHandler.run(Reference.java:153)
```