### PR TITLE
HADOOP-16752. assertion failure in ITestAzureBlobFileSystemFileStatus

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -138,6 +138,6 @@ public class ITestAzureBlobFileSystemFileStatus extends
     assertTrue("lastModifiedTime should be after minCreateStartTime",
         minCreateStartTime < lastModifiedTime);
     assertTrue("lastModifiedTime should be before createEndTime",
-        createEndTime > lastModifiedTime);
+        createEndTime >= lastModifiedTime);
   }
 }


### PR DESCRIPTION
Reviewing the patch, the error message needs to print the expected/actual
values so if this isn't the fix, we have some idea of what is wrong

Change-Id: Iacdb90839136e77b2e2769f3b93049d4bfef0d0e


---

tested, Azure cardiff `-Dparallel-tests=abfs -DtestsThreadCount=5 -Dscale`