### PR TITLE
MAPREDUCE-7346. Fix divide by zero in AvgRecordFactory

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/AvgRecordFactory.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/AvgRecordFactory.java
@@ -61,10 +61,11 @@ class AvgRecordFactory extends RecordFactory {
   public AvgRecordFactory(long targetBytes, long targetRecords,
       Configuration conf, int minSpilledBytes) {
     this.targetBytes = targetBytes;
-    this.targetRecords = targetRecords <= 0 && this.targetBytes >= 0
-      ? Math.max(1,
+    this.targetRecords = targetRecords <= 0 ? (this.targetBytes >= 0 ?
+      Math.max(1,
           this.targetBytes / conf.getInt(GRIDMIX_MISSING_REC_SIZE, 64 * 1024))
-      : targetRecords;
+      : 1) : targetRecords;
+
     final long tmp = this.targetBytes / this.targetRecords;
     step = this.targetBytes - this.targetRecords * tmp;
     avgrec = (int) Math.min(Integer.MAX_VALUE, tmp + 1);


### PR DESCRIPTION
This commit fixes the issue [here](https://issues.apache.org/jira/browse/MAPREDUCE-7346).