### PR TITLE
HADOOP-17711. Fix divide by zero in LoadBalancingKMSClientProvider.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/LoadBalancingKMSClientProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/LoadBalancingKMSClientProvider.java
@@ -86,19 +86,24 @@ public class LoadBalancingKMSClientProvider extends KeyProvider implements
   private RetryPolicy retryPolicy = null;
 
   public LoadBalancingKMSClientProvider(URI providerUri,
-      KMSClientProvider[] providers, Configuration conf) {
+      KMSClientProvider[] providers, Configuration conf) throws IOException {
     this(providerUri, providers, Time.monotonicNow(), conf);
   }
 
   @VisibleForTesting
   LoadBalancingKMSClientProvider(KMSClientProvider[] providers, long seed,
-      Configuration conf) {
+      Configuration conf) throws IOException {
     this(URI.create("kms://testing"), providers, seed, conf);
   }
 
   private LoadBalancingKMSClientProvider(URI uri,
-      KMSClientProvider[] providers, long seed, Configuration conf) {
+      KMSClientProvider[] providers, long seed, Configuration conf) throws IOException {
     super(conf);
+
+    if (providers.length == 0) {
+      throw new IOException("No providers configured !");
+    }
+
     // uri is the token service so it can be instantiated for renew/cancel.
     dtService = KMSClientProvider.getDtService(uri);
     // if provider not in conf, new client will alias on uri else addr.
@@ -165,9 +170,6 @@ public class LoadBalancingKMSClientProvider extends KeyProvider implements
 
   private <T> T doOp(ProviderCallable<T> op, int currPos,
       boolean isIdempotent) throws IOException {
-    if (providers.length == 0) {
-      throw new IOException("No providers configured !");
-    }
     int numFailovers = 0;
     for (int i = 0;; i++, numFailovers++) {
       KMSClientProvider provider = providers[(currPos + i) % providers.length];
@@ -233,10 +235,6 @@ public class LoadBalancingKMSClientProvider extends KeyProvider implements
   }
 
   private int nextIdx() {
-    if (providers.length == 0) {
-      throw new IOException("No providers configured !");
-    }
-
     while (true) {
       int current = currentIdx.get();
       int next = (current + 1) % providers.length;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/LoadBalancingKMSClientProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/LoadBalancingKMSClientProvider.java
@@ -233,6 +233,10 @@ public class LoadBalancingKMSClientProvider extends KeyProvider implements
   }
 
   private int nextIdx() {
+    if (providers.length == 0) {
+      throw new IOException("No providers configured !");
+    }
+
     while (true) {
       int current = currentIdx.get();
       int next = (current + 1) % providers.length;


### PR DESCRIPTION
This pr fixes the issue [here](https://issues.apache.org/jira/browse/HADOOP-17711).
