### PR TITLE
HADOOP-17547 Magic committer to downgrade abort in cleanup if list uploads fails with access denied

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitter.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/commit/AbstractS3ACommitter.java
@@ -832,8 +832,8 @@ public abstract class AbstractS3ACommitter extends PathOutputCommitter
       try {
         pending = ops.listPendingUploadsUnderPath(dest);
       } catch (IOException e) {
-        // raised if the listPendingUploads call failed.
-        maybeIgnore(suppressExceptions, "aborting pending uploads", e);
+        // Swallow any errors given this is best effort
+        LOG.debug("Failed to list pending uploads under {}", dest, e);
         return;
       }
       if (!pending.isEmpty()) {


### PR DESCRIPTION
[HADOOP-17415](https://issues.apache.org/jira/browse/HADOOP-17547)

Caller without `s3:ListBucketMultipartUploads` permissions would have
any committers throw an `AccessDenied` exception whenever the committer
would try to cleanup any pending multipart uploads.

Changes:
- Swallowing exception and printing a log instead during cleanup;

Tested with `eu-west-1` and `mvn -Dparallel-tests -DtestsThreadCount=32 clean verify`
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 151, Failures: 0, Errors: 0, Skipped: 87
```