### PR TITLE
MAPREDUCE-7348. TestFrameworkUploader#testNativeIO fails.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/test/java/org/apache/hadoop/mapred/uploader/TestFrameworkUploader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/src/test/java/org/apache/hadoop/mapred/uploader/TestFrameworkUploader.java
@@ -477,7 +477,7 @@ public class TestFrameworkUploader {
       }
       Assert.assertFalse(uploader.checkSymlink(symlinkOutside));
     } finally {
-      FileUtils.deleteDirectory(parent);
+      FileUtils.forceDelete(parent);
     }
 
   }


### PR DESCRIPTION
JIRA: MAPREDUCE-7348.

The behavior of `FileUtils#deleteDirectory` is still changed even in commons-io 2.8. Use `FileUtils#forceDelete` instead of `FileUtils#deleteDirectory` to clean up the test dir.