### PR TITLE
HDFS-15916. Addendum. DistCp: Backward compatibility: Distcp fails from Hadoop 3 to Hadoop 2 for snapshotdiff.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -2395,7 +2395,8 @@ public class DistributedFileSystem extends FileSystem
       } catch (RpcNoSuchMethodException e) {
         // In case the server doesn't support getSnapshotDiffReportListing,
         // fallback to getSnapshotDiffReport.
-        LOG.warn("Falling back to getSnapshotDiffReport {}", e.getMessage());
+        DFSClient.LOG.warn(
+            "Falling back to getSnapshotDiffReport {}", e.getMessage());
         return dfs.getSnapshotDiffReport(snapshotDir, fromSnapshot, toSnapshot);
       }
       startPath = report.getLastPath();


### PR DESCRIPTION
Addendum, fixing log to DFSClient.LOG