### PR TITLE
HADOOP-17735. Upgrade AWS SDK to 1.11.1026

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -182,7 +182,7 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.11.901</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.1026</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
     <jasmine-maven-plugin.version>2.1</jasmine-maven-plugin.version>


### PR DESCRIPTION

Upgrade the AWS SDK to the latest version.

Tested: S3 london
```
-Dparallel-tests -DtestsThreadCount=8 -Dmarkers=keep -Ds3guard -Ddynamo
 -Dparallel-tests -DtestsThreadCount=8 -Dmarkers=delete -Dscale -Ds3guard -Ddynamo
```

some intermittent underful buffers on read(); the usual

Also 
* dependency review: no new spurious artifacts
* built: release; playing with that right now