### PR TITLE
HDFS-16048. RBF: Print network topology on the router web

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterHttpServer.java
@@ -125,6 +125,9 @@ public class RouterHttpServer extends AbstractService {
         RouterFsckServlet.PATH_SPEC,
         RouterFsckServlet.class,
         true);
+    httpServer.addInternalServlet(RouterNetworkTopologyServlet.SERVLET_NAME,
+        RouterNetworkTopologyServlet.PATH_SPEC,
+        RouterNetworkTopologyServlet.class);
   }
 
   public InetSocketAddress getHttpAddress() {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterNetworkTopologyServlet.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
+import org.apache.hadoop.hdfs.server.common.JspHelper;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.server.namenode.NameNodeHttpServer;
+import org.apache.hadoop.hdfs.server.namenode.NetworkTopologyServlet;
+import org.apache.hadoop.http.IsActiveServlet;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.net.Node;
+import org.apache.hadoop.net.NodeBase;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.StringUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * A servlet to print out the network topology from router.
+ */
+public class RouterNetworkTopologyServlet extends HttpServlet {
+
+  public static final String SERVLET_NAME = "topology";
+  public static final String PATH_SPEC = "/topology";
+
+  protected static final String FORMAT_JSON = "json";
+  protected static final String FORMAT_TEXT = "text";
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+          throws IOException {
+    final ServletContext context = getServletContext();
+
+    String format = parseAcceptHeader(request);
+    if (FORMAT_TEXT.equals(format)) {
+      response.setContentType("text/plain; charset=UTF-8");
+    } else if (FORMAT_JSON.equals(format)) {
+      response.setContentType("application/json; charset=UTF-8");
+    }
+
+    Router router = RouterHttpServer.getRouterFromContext(context);
+    DatanodeInfo[] datanodeReport =
+        router.getRpcServer().getDatanodeReport(HdfsConstants.DatanodeReportType.ALL);
+
+    try (PrintStream out = new PrintStream(
+            response.getOutputStream(), false, "UTF-8")) {
+      printTopology(out, datanodeReport, format);
+    } catch (Throwable t) {
+      String errMsg = "Print network topology failed. "
+              + StringUtils.stringifyException(t);
+      response.sendError(HttpServletResponse.SC_GONE, errMsg);
+      throw new IOException(errMsg);
+    } finally {
+      response.getOutputStream().close();
+    }
+  }
+
+  /**
+   * Display each rack and the nodes assigned to that rack, as determined
+   * by the NameNode, in a hierarchical manner.  The nodes and racks are
+   * sorted alphabetically.
+   *
+   * @param stream print stream
+   * @param datanodeInfos datanode Infos
+   * @param format the response format
+   */
+  public void printTopology(PrintStream stream, DatanodeInfo[] datanodeInfos,
+                            String format) throws NetworkTopologyServlet.BadFormatException, IOException {
+    if (datanodeInfos.length == 0) {
+      stream.print("No DataNodes");
+      return;
+    }
+
+    // Build a map of rack -> nodes
+    Map<String, TreeSet<String>> tree = new HashMap<>();
+    for(Node dni : datanodeInfos) {
+      String location = dni.getNetworkLocation();
+      String name = dni.getName();
+
+      tree.putIfAbsent(location, new TreeSet<>());
+      tree.get(location).add(name);
+    }
+
+    // Sort the racks (and nodes) alphabetically, display in order
+    ArrayList<String> racks = new ArrayList<>(tree.keySet());
+    Collections.sort(racks);
+
+    if (FORMAT_JSON.equals(format)) {
+      printJsonFormat(stream, tree, racks);
+    } else if (FORMAT_TEXT.equals(format)) {
+      printTextFormat(stream, tree, racks);
+    } else {
+      throw new NetworkTopologyServlet.BadFormatException("Bad format: " + format);
+    }
+  }
+
+  private void printJsonFormat(PrintStream stream, Map<String,
+          TreeSet<String>> tree, ArrayList<String> racks) throws IOException {
+    JsonFactory dumpFactory = new JsonFactory();
+    JsonGenerator dumpGenerator = dumpFactory.createGenerator(stream);
+    dumpGenerator.writeStartArray();
+
+    for(String r : racks) {
+      dumpGenerator.writeStartObject();
+      dumpGenerator.writeFieldName(r);
+      TreeSet<String> nodes = tree.get(r);
+      dumpGenerator.writeStartArray();
+
+      for(String n : nodes) {
+        dumpGenerator.writeStartObject();
+        dumpGenerator.writeStringField("ip", n);
+        String hostname = NetUtils.getHostNameOfIP(n);
+        if(hostname != null) {
+          dumpGenerator.writeStringField("hostname", hostname);
+        }
+        dumpGenerator.writeEndObject();
+      }
+      dumpGenerator.writeEndArray();
+      dumpGenerator.writeEndObject();
+    }
+    dumpGenerator.writeEndArray();
+    dumpGenerator.flush();
+
+    if (!dumpGenerator.isClosed()) {
+      dumpGenerator.close();
+    }
+  }
+
+  private void printTextFormat(PrintStream stream, Map<String,
+          TreeSet<String>> tree, ArrayList<String> racks) {
+    for(String r : racks) {
+      stream.println("Rack: " + r);
+      TreeSet<String> nodes = tree.get(r);
+
+      for(String n : nodes) {
+        stream.print("   " + n);
+        String hostname = NetUtils.getHostNameOfIP(n);
+        if(hostname != null) {
+          stream.print(" (" + hostname + ")");
+        }
+        stream.println();
+      }
+      stream.println();
+    }
+  }
+
+  @VisibleForTesting
+  static String parseAcceptHeader(HttpServletRequest request) {
+    String format = request.getHeader(HttpHeaders.ACCEPT);
+    return format != null && format.contains(FORMAT_JSON) ?
+            FORMAT_JSON : FORMAT_TEXT;
+  }
+
+  public static class BadFormatException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public BadFormatException(String msg) {
+      super(msg);
+    }
+  }
+
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterNetworkTopologyServlet.java
@@ -19,19 +19,10 @@ package org.apache.hadoop.hdfs.server.federation.router;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
-import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
-import org.apache.hadoop.hdfs.server.common.JspHelper;
-import org.apache.hadoop.hdfs.server.namenode.NameNode;
-import org.apache.hadoop.hdfs.server.namenode.NameNodeHttpServer;
-import org.apache.hadoop.hdfs.server.namenode.NetworkTopologyServlet;
-import org.apache.hadoop.http.IsActiveServlet;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.Node;
-import org.apache.hadoop.net.NodeBase;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.util.StringUtils;
 
@@ -42,14 +33,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.net.HttpURLConnection;
-import java.net.InetAddress;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
@@ -78,7 +64,8 @@ public class RouterNetworkTopologyServlet extends HttpServlet {
 
     Router router = RouterHttpServer.getRouterFromContext(context);
     DatanodeInfo[] datanodeReport =
-        router.getRpcServer().getDatanodeReport(HdfsConstants.DatanodeReportType.ALL);
+        router.getRpcServer().getDatanodeReport(
+            HdfsConstants.DatanodeReportType.ALL);
 
     try (PrintStream out = new PrintStream(
             response.getOutputStream(), false, "UTF-8")) {
@@ -103,7 +90,7 @@ public class RouterNetworkTopologyServlet extends HttpServlet {
    * @param format the response format
    */
   public void printTopology(PrintStream stream, DatanodeInfo[] datanodeInfos,
-                            String format) throws NetworkTopologyServlet.BadFormatException, IOException {
+      String format) throws IOException, BadFormatException {
     if (datanodeInfos.length == 0) {
       stream.print("No DataNodes");
       return;
@@ -128,7 +115,7 @@ public class RouterNetworkTopologyServlet extends HttpServlet {
     } else if (FORMAT_TEXT.equals(format)) {
       printTextFormat(stream, tree, racks);
     } else {
-      throw new NetworkTopologyServlet.BadFormatException("Bad format: " + format);
+      throw new BadFormatException("Bad format: " + format);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/explorer.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/explorer.html
@@ -48,6 +48,7 @@
             <li><a href="jmx">Metrics</a></li>
             <li><a href="conf">Configuration</a></li>
             <li><a href="stacks">Process Thread Dump</a></li>
+            <li><a href="topology">Network Topology</a></li>
           </ul>
         </li>
       </ul>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
@@ -52,6 +52,7 @@
         <li><a href="jmx">Metrics</a></li>
         <li><a href="conf">Configuration</a></li>
         <li><a href="stacks">Process Thread Dump</a></li>
+        <li><a href="topology">Network Topology</a></li>
       </ul>
     </li>
   </ul>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
+import org.apache.hadoop.hdfs.server.federation.StateStoreDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.resolver.MultipleDestinationMountTableResolver;
+import org.apache.hadoop.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HTTP_ENABLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestRouterNetworkTopologyServlet {
+
+  private static StateStoreDFSCluster clusterWithDatanodes;
+  private static StateStoreDFSCluster clusterNoDatanodes;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // Builder configuration
+    Configuration routerConf =
+        new RouterConfigBuilder().stateStore().admin().quota().rpc().build();
+    routerConf.set(DFS_ROUTER_HTTP_ENABLE, "true");
+    Configuration hdfsConf = new Configuration(false);
+
+    // Build and start a federated cluster
+    clusterWithDatanodes = new StateStoreDFSCluster(false, 2,
+        MultipleDestinationMountTableResolver.class);
+    clusterWithDatanodes.addNamenodeOverrides(hdfsConf);
+    clusterWithDatanodes.addRouterOverrides(routerConf);
+    clusterWithDatanodes.setNumDatanodesPerNameservice(9);
+    clusterWithDatanodes.setIndependentDNs();
+    clusterWithDatanodes.setRacks(
+        new String[] {"/rack1", "/rack1", "/rack1", "/rack2", "/rack2",
+            "/rack2", "/rack3", "/rack3", "/rack3", "/rack4", "/rack4",
+            "/rack4", "/rack5", "/rack5", "/rack5", "/rack6", "/rack6",
+            "/rack6"});
+    clusterWithDatanodes.startCluster();
+    clusterWithDatanodes.startRouters();
+    clusterWithDatanodes.waitClusterUp();
+    clusterWithDatanodes.waitActiveNamespaces();
+
+    // Build and start a federated cluster
+    clusterNoDatanodes = new StateStoreDFSCluster(false, 2,
+        MultipleDestinationMountTableResolver.class);
+    clusterNoDatanodes.addNamenodeOverrides(hdfsConf);
+    clusterNoDatanodes.addRouterOverrides(routerConf);
+    clusterNoDatanodes.shutdown();
+    clusterNoDatanodes.setNumDatanodesPerNameservice(0);
+    clusterNoDatanodes.setIndependentDNs();
+    clusterNoDatanodes.startCluster();
+    clusterNoDatanodes.startRouters();
+    clusterNoDatanodes.waitClusterUp();
+    clusterNoDatanodes.waitActiveNamespaces();
+  }
+
+  @Test
+  public void testPrintTopologyTextFormat() throws Exception {
+    // get http Address
+    String httpAddress = clusterWithDatanodes.getRandomRouter().getRouter()
+        .getHttpServerAddress().toString();
+
+    // send http request
+    URL url = new URL("http:/" + httpAddress + "/topology");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setReadTimeout(20000);
+    conn.setConnectTimeout(20000);
+    conn.connect();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
+    StringBuilder sb =
+        new StringBuilder("-- Network Topology -- \n");
+    sb.append(out);
+    sb.append("\n-- Network Topology -- ");
+    String topology = sb.toString();
+
+    // assert rack info
+    assertTrue(topology.contains("/ns0/rack1"));
+    assertTrue(topology.contains("/ns0/rack2"));
+    assertTrue(topology.contains("/ns0/rack3"));
+    assertTrue(topology.contains("/ns1/rack4"));
+    assertTrue(topology.contains("/ns1/rack5"));
+    assertTrue(topology.contains("/ns1/rack6"));
+
+    // assert node number
+    assertEquals(topology.split("127.0.0.1").length - 1,
+        18);
+
+    Thread.sleep(999999999L);
+  }
+
+  @Test
+  public void testPrintTopologyJsonFormat() throws Exception {
+    // get http Address
+    String httpAddress = clusterWithDatanodes.getRandomRouter().getRouter()
+            .getHttpServerAddress().toString();
+
+    // send http request
+    URL url = new URL("http:/" + httpAddress + "/topology");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setReadTimeout(20000);
+    conn.setConnectTimeout(20000);
+    conn.setRequestProperty("Accept", "application/json");
+    conn.connect();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
+    String topology = out.toString();
+
+    // parse json
+    JsonNode racks = new ObjectMapper().readTree(topology);
+
+    // assert rack number
+    assertEquals(racks.size(), 6);
+
+    // assert rack info
+    assertTrue(topology.contains("/ns0/rack1"));
+    assertTrue(topology.contains("/ns0/rack2"));
+    assertTrue(topology.contains("/ns0/rack3"));
+    assertTrue(topology.contains("/ns1/rack4"));
+    assertTrue(topology.contains("/ns1/rack5"));
+    assertTrue(topology.contains("/ns1/rack6"));
+
+    // assert node number
+    Iterator<JsonNode> elements = racks.elements();
+    int dataNodesCount = 0;
+    while(elements.hasNext()){
+        JsonNode rack = elements.next();
+        Iterator<Map.Entry<String, JsonNode>> fields = rack.fields();
+        while (fields.hasNext()) {
+            dataNodesCount += fields.next().getValue().size();
+        }
+    }
+    assertEquals(dataNodesCount, 18);
+  }
+
+  @Test
+  public void testPrintTopologyNoDatanodesTextFormat() throws Exception {
+    // get http Address
+    String httpAddress = clusterNoDatanodes.getRandomRouter().getRouter()
+        .getHttpServerAddress().toString();
+
+    // send http request
+    URL url = new URL("http:/" + httpAddress + "/topology");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setReadTimeout(20000);
+    conn.setConnectTimeout(20000);
+    conn.connect();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
+    StringBuilder sb =
+        new StringBuilder("-- Network Topology -- \n");
+    sb.append(out);
+    sb.append("\n-- Network Topology -- ");
+    String topology = sb.toString();
+
+    // assert node number
+    assertTrue(topology.contains("No DataNodes"));
+  }
+
+    @Test
+    public void testPrintTopologyNoDatanodesJsonFormat() throws Exception {
+      // get http Address
+      String httpAddress = clusterNoDatanodes.getRandomRouter().getRouter()
+              .getHttpServerAddress().toString();
+
+      // send http request
+      URL url = new URL("http:/" + httpAddress + "/topology");
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.setReadTimeout(20000);
+      conn.setConnectTimeout(20000);
+      conn.setRequestProperty("Accept", "application/json");
+      conn.connect();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
+      StringBuilder sb =
+          new StringBuilder("-- Network Topology -- \n");
+      sb.append(out);
+      sb.append("\n-- Network Topology -- ");
+      String topology = sb.toString();
+
+      // assert node number
+      assertTrue(topology.contains("No DataNodes"));
+    }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
@@ -151,11 +151,11 @@ public class TestRouterNetworkTopologyServlet {
     Iterator<JsonNode> elements = racks.elements();
     int dataNodesCount = 0;
     while(elements.hasNext()){
-        JsonNode rack = elements.next();
-        Iterator<Map.Entry<String, JsonNode>> fields = rack.fields();
-        while (fields.hasNext()) {
-            dataNodesCount += fields.next().getValue().size();
-        }
+      JsonNode rack = elements.next();
+      Iterator<Map.Entry<String, JsonNode>> fields = rack.fields();
+      while (fields.hasNext()) {
+        dataNodesCount += fields.next().getValue().size();
+      }
     }
     assertEquals(dataNodesCount, 18);
   }
@@ -184,28 +184,28 @@ public class TestRouterNetworkTopologyServlet {
     assertTrue(topology.contains("No DataNodes"));
   }
 
-    @Test
-    public void testPrintTopologyNoDatanodesJsonFormat() throws Exception {
-      // get http Address
-      String httpAddress = clusterNoDatanodes.getRandomRouter().getRouter()
-              .getHttpServerAddress().toString();
+   @Test
+   public void testPrintTopologyNoDatanodesJsonFormat() throws Exception {
+     // get http Address
+     String httpAddress = clusterNoDatanodes.getRandomRouter().getRouter()
+         .getHttpServerAddress().toString();
 
-      // send http request
-      URL url = new URL("http:/" + httpAddress + "/topology");
-      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      conn.setReadTimeout(20000);
-      conn.setConnectTimeout(20000);
-      conn.setRequestProperty("Accept", "application/json");
-      conn.connect();
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
-      StringBuilder sb =
-          new StringBuilder("-- Network Topology -- \n");
-      sb.append(out);
-      sb.append("\n-- Network Topology -- ");
-      String topology = sb.toString();
+     // send http request
+     URL url = new URL("http:/" + httpAddress + "/topology");
+     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+     conn.setReadTimeout(20000);
+     conn.setConnectTimeout(20000);
+     conn.setRequestProperty("Accept", "application/json");
+     conn.connect();
+     ByteArrayOutputStream out = new ByteArrayOutputStream();
+     IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
+     StringBuilder sb =
+         new StringBuilder("-- Network Topology -- \n");
+     sb.append(out);
+     sb.append("\n-- Network Topology -- ");
+     String topology = sb.toString();
 
-      // assert node number
-      assertTrue(topology.contains("No DataNodes"));
-    }
+     // assert node number
+     assertTrue(topology.contains("No DataNodes"));
+   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
@@ -72,7 +72,6 @@ public class TestRouterNetworkTopologyServlet {
         MultipleDestinationMountTableResolver.class);
     clusterNoDatanodes.addNamenodeOverrides(hdfsConf);
     clusterNoDatanodes.addRouterOverrides(routerConf);
-    clusterNoDatanodes.shutdown();
     clusterNoDatanodes.setNumDatanodesPerNameservice(0);
     clusterNoDatanodes.setIndependentDNs();
     clusterNoDatanodes.startCluster();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
@@ -113,8 +113,6 @@ public class TestRouterNetworkTopologyServlet {
     // assert node number
     assertEquals(topology.split("127.0.0.1").length - 1,
         18);
-
-    Thread.sleep(999999999L);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
@@ -110,8 +110,8 @@ public class TestRouterNetworkTopologyServlet {
     assertTrue(topology.contains("/ns1/rack6"));
 
     // assert node number
-    assertEquals(topology.split("127.0.0.1").length - 1,
-        18);
+    assertEquals(18,
+        topology.split("127.0.0.1").length - 1);
   }
 
   @Test
@@ -136,7 +136,7 @@ public class TestRouterNetworkTopologyServlet {
     JsonNode racks = new ObjectMapper().readTree(topology);
 
     // assert rack number
-    assertEquals(racks.size(), 6);
+    assertEquals(6, racks.size());
 
     // assert rack info
     assertTrue(topology.contains("/ns0/rack1"));
@@ -156,7 +156,7 @@ public class TestRouterNetworkTopologyServlet {
         dataNodesCount += fields.next().getValue().size();
       }
     }
-    assertEquals(dataNodesCount, 18);
+    assertEquals(18, dataNodesCount);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNetworkTopologyServlet.java
@@ -184,28 +184,28 @@ public class TestRouterNetworkTopologyServlet {
     assertTrue(topology.contains("No DataNodes"));
   }
 
-   @Test
-   public void testPrintTopologyNoDatanodesJsonFormat() throws Exception {
-     // get http Address
-     String httpAddress = clusterNoDatanodes.getRandomRouter().getRouter()
-         .getHttpServerAddress().toString();
+  @Test
+  public void testPrintTopologyNoDatanodesJsonFormat() throws Exception {
+    // get http Address
+    String httpAddress = clusterNoDatanodes.getRandomRouter().getRouter()
+        .getHttpServerAddress().toString();
 
-     // send http request
-     URL url = new URL("http:/" + httpAddress + "/topology");
-     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-     conn.setReadTimeout(20000);
-     conn.setConnectTimeout(20000);
-     conn.setRequestProperty("Accept", "application/json");
-     conn.connect();
-     ByteArrayOutputStream out = new ByteArrayOutputStream();
-     IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
-     StringBuilder sb =
-         new StringBuilder("-- Network Topology -- \n");
-     sb.append(out);
-     sb.append("\n-- Network Topology -- ");
-     String topology = sb.toString();
+    // send http request
+    URL url = new URL("http:/" + httpAddress + "/topology");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setReadTimeout(20000);
+    conn.setConnectTimeout(20000);
+    conn.setRequestProperty("Accept", "application/json");
+    conn.connect();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOUtils.copyBytes(conn.getInputStream(), out, 4096, true);
+    StringBuilder sb =
+        new StringBuilder("-- Network Topology -- \n");
+    sb.append(out);
+    sb.append("\n-- Network Topology -- ");
+    String topology = sb.toString();
 
-     // assert node number
-     assertTrue(topology.contains("No DataNodes"));
-   }
+    // assert node number
+    assertTrue(topology.contains("No DataNodes"));
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeHttpServer.java
@@ -253,7 +253,7 @@ public class NameNodeHttpServer {
     httpServer.addInternalServlet(IsNameNodeActiveServlet.SERVLET_NAME,
         IsNameNodeActiveServlet.PATH_SPEC,
         IsNameNodeActiveServlet.class);
-    httpServer.addInternalServlet("topology",
+    httpServer.addInternalServlet(NetworkTopologyServlet.SERVLET_NAME,
         NetworkTopologyServlet.PATH_SPEC, NetworkTopologyServlet.class);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NetworkTopologyServlet.java
@@ -46,6 +46,7 @@ import java.util.TreeSet;
 @InterfaceAudience.Private
 public class NetworkTopologyServlet extends DfsServlet {
 
+  public static final String SERVLET_NAME = "topology";
   public static final String PATH_SPEC = "/topology";
 
   protected static final String FORMAT_JSON = "json";
@@ -90,7 +91,7 @@ public class NetworkTopologyServlet extends DfsServlet {
    * @param leaves leaves nodes under base scope
    * @param format the response format
    */
-  private void printTopology(PrintStream stream, List<Node> leaves,
+  protected void printTopology(PrintStream stream, List<Node> leaves,
       String format) throws BadFormatException, IOException {
     if (leaves.isEmpty()) {
       stream.print("No DataNodes");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NetworkTopologyServlet.java
@@ -154,7 +154,7 @@ public class NetworkTopologyServlet extends DfsServlet {
   }
 
   protected void printTextFormat(PrintStream stream, Map<String,
-          TreeSet<String>> tree, ArrayList<String> racks) {
+      TreeSet<String>> tree, ArrayList<String> racks) {
     for(String r : racks) {
       stream.println("Rack: " + r);
       TreeSet<String> nodes = tree.get(r);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NetworkTopologyServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NetworkTopologyServlet.java
@@ -90,7 +90,7 @@ public class NetworkTopologyServlet extends DfsServlet {
    * @param leaves leaves nodes under base scope
    * @param format the response format
    */
-  public void printTopology(PrintStream stream, List<Node> leaves,
+  private void printTopology(PrintStream stream, List<Node> leaves,
       String format) throws BadFormatException, IOException {
     if (leaves.isEmpty()) {
       stream.print("No DataNodes");
@@ -120,7 +120,7 @@ public class NetworkTopologyServlet extends DfsServlet {
     }
   }
 
-  private void printJsonFormat(PrintStream stream, Map<String,
+  protected void printJsonFormat(PrintStream stream, Map<String,
       TreeSet<String>> tree, ArrayList<String> racks) throws IOException {
     JsonFactory dumpFactory = new JsonFactory();
     JsonGenerator dumpGenerator = dumpFactory.createGenerator(stream);
@@ -152,8 +152,8 @@ public class NetworkTopologyServlet extends DfsServlet {
     }
   }
 
-  private void printTextFormat(PrintStream stream, Map<String,
-      TreeSet<String>> tree, ArrayList<String> racks) {
+  protected void printTextFormat(PrintStream stream, Map<String,
+          TreeSet<String>> tree, ArrayList<String> racks) {
     for(String r : racks) {
       stream.println("Rack: " + r);
       TreeSet<String> nodes = tree.get(r);
@@ -171,7 +171,7 @@ public class NetworkTopologyServlet extends DfsServlet {
   }
 
   @VisibleForTesting
-  static String parseAcceptHeader(HttpServletRequest request) {
+  protected static String parseAcceptHeader(HttpServletRequest request) {
     String format = request.getHeader(HttpHeaders.ACCEPT);
     return format != null && format.contains(FORMAT_JSON) ?
             FORMAT_JSON : FORMAT_TEXT;


### PR DESCRIPTION
JIRA: [HDFS-16048](https://issues.apache.org/jira/browse/HDFS-16048)

In order to query the network topology information conveniently, we can print it on the router web. It's related to [HDFS-15970](https://issues.apache.org/jira/browse/HDFS-15970).