### PR TITLE
HADOOP-17745. Wrap IOException with InterruptedException cause properly

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/IOUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/IOUtils.java
@@ -482,8 +482,7 @@ public class IOUtils {
     if (exception instanceof InterruptedIOException
         || exception instanceof PathIOException) {
       return exception;
-    } else if (exception.getCause() != null
-            && exception.getCause() instanceof InterruptedException) {
+    } else if (exception.getCause() instanceof InterruptedException) {
       InterruptedIOException interruptedIOException =
               new InterruptedIOException(exception.getMessage());
       interruptedIOException.initCause(exception.getCause());

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/IOUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/IOUtils.java
@@ -482,6 +482,12 @@ public class IOUtils {
     if (exception instanceof InterruptedIOException
         || exception instanceof PathIOException) {
       return exception;
+    } else if (exception.getCause() != null
+            && exception.getCause() instanceof InterruptedException) {
+      InterruptedIOException interruptedIOException =
+              new InterruptedIOException(exception.getMessage());
+      interruptedIOException.initCause(exception.getCause());
+      return interruptedIOException;
     } else {
       String msg = String
           .format("Failed with %s while processing file/directory :[%s] in "

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestIOUtilsWrapExceptionSuite.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestIOUtilsWrapExceptionSuite.java
@@ -21,10 +21,14 @@ package org.apache.hadoop.io;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestIOUtilsWrapExceptionSuite extends Assert {
+public class TestIOUtilsWrapExceptionSuite extends AbstractHadoopTestBase {
     @Test
     public void testWrapExceptionWithInterruptedException() throws Exception {
         InterruptedIOException inputException = new InterruptedIOException("message");
@@ -33,8 +37,8 @@ public class TestIOUtilsWrapExceptionSuite extends Assert {
         Exception outputException = IOUtils.wrapException("path", "methodName", inputException);
 
         // The new exception should retain the input message, cause, and type
-        assertTrue(outputException instanceof InterruptedIOException);
-        assertTrue(outputException.getCause() instanceof NullPointerException);
+        Assertions.assertThat(outputException).isInstanceOf(InterruptedIOException.class);
+        Assertions.assertThat(outputException.getCause()).isInstanceOf(NullPointerException.class);
         assertEquals(outputException.getMessage(), inputException.getMessage());
         assertEquals(outputException.getCause(), inputException.getCause());
     }
@@ -48,8 +52,8 @@ public class TestIOUtilsWrapExceptionSuite extends Assert {
 
         // The new exception should retain the input message and cause
         // but be an InterruptedIOException because the cause was an InterruptedException
-        assertTrue(outputException instanceof InterruptedIOException);
-        assertTrue(outputException.getCause() instanceof InterruptedException);
+        Assertions.assertThat(outputException).isInstanceOf(InterruptedIOException.class);
+        Assertions.assertThat(outputException.getCause()).isInstanceOf(InterruptedException.class);
         assertEquals(outputException.getMessage(), inputException.getMessage());
         assertEquals(outputException.getCause(), inputException.getCause());
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestIOUtilsWrapExceptionSuite.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestIOUtilsWrapExceptionSuite.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIOUtilsWrapExceptionSuite extends Assert {
+    @Test
+    public void testWrapExceptionWithInterruptedException() throws Exception {
+        InterruptedIOException inputException = new InterruptedIOException("message");
+        NullPointerException causeException = new NullPointerException("cause");
+        inputException.initCause(causeException);
+        Exception outputException = IOUtils.wrapException("path", "methodName", inputException);
+
+        // The new exception should retain the input message, cause, and type
+        assertTrue(outputException instanceof InterruptedIOException);
+        assertTrue(outputException.getCause() instanceof NullPointerException);
+        assertEquals(outputException.getMessage(), inputException.getMessage());
+        assertEquals(outputException.getCause(), inputException.getCause());
+    }
+
+    @Test
+    public void testWrapExceptionWithInterruptedCauseException() throws Exception {
+        IOException inputException = new IOException("message");
+        InterruptedException causeException = new InterruptedException("cause");
+        inputException.initCause(causeException);
+        Exception outputException = IOUtils.wrapException("path", "methodName", inputException);
+
+        // The new exception should retain the input message and cause
+        // but be an InterruptedIOException because the cause was an InterruptedException
+        assertTrue(outputException instanceof InterruptedIOException);
+        assertTrue(outputException.getCause() instanceof InterruptedException);
+        assertEquals(outputException.getMessage(), inputException.getMessage());
+        assertEquals(outputException.getCause(), inputException.getCause());
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestIOUtilsWrapExceptionSuite.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestIOUtilsWrapExceptionSuite.java
@@ -21,12 +21,12 @@ package org.apache.hadoop.io;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import org.apache.hadoop.test.AbstractHadoopTestBase;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
+
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import static junit.framework.TestCase.assertEquals;
 
 public class TestIOUtilsWrapExceptionSuite extends AbstractHadoopTestBase {
     @Test
@@ -38,7 +38,8 @@ public class TestIOUtilsWrapExceptionSuite extends AbstractHadoopTestBase {
 
         // The new exception should retain the input message, cause, and type
         Assertions.assertThat(outputException).isInstanceOf(InterruptedIOException.class);
-        Assertions.assertThat(outputException.getCause()).isInstanceOf(NullPointerException.class);
+        Assertions.assertThat(outputException.getCause()).isInstanceOf(NullPointerException.class)
+                .describedAs("inner cause");
         assertEquals(outputException.getMessage(), inputException.getMessage());
         assertEquals(outputException.getCause(), inputException.getCause());
     }
@@ -54,7 +55,9 @@ public class TestIOUtilsWrapExceptionSuite extends AbstractHadoopTestBase {
         // but be an InterruptedIOException because the cause was an InterruptedException
         Assertions.assertThat(outputException).isInstanceOf(InterruptedIOException.class);
         Assertions.assertThat(outputException.getCause()).isInstanceOf(InterruptedException.class);
-        assertEquals(outputException.getMessage(), inputException.getMessage());
-        assertEquals(outputException.getCause(), inputException.getCause());
+        assertEquals("getMessage()",
+                outputException.getMessage(), inputException.getMessage());
+        assertEquals("getCause()",
+                outputException.getCause(), inputException.getCause());
     }
 }


### PR DESCRIPTION
The Azure client sometimes throws an IOException with an InterruptedException cause which can be converted to an InterruptedIOException. This is important for downstream consumers that rely on an InterruptedIOException to gracefully close.

