### PR TITLE
HDFS-16057. Make sure the order for location in ENTERING_MAINTENANCE …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -506,7 +506,7 @@ public class DatanodeManager {
   }
 
   private boolean isInactive(DatanodeInfo datanode) {
-    return datanode.isDecommissioned() ||
+    return datanode.isDecommissioned() || datanode.isEnteringMaintenance() ||
         (avoidStaleDataNodesForRead && datanode.isStale(staleInterval));
 
   }
@@ -572,8 +572,8 @@ public class DatanodeManager {
   }
 
   /**
-   * Move decommissioned/stale datanodes to the bottom. Also, sort nodes by
-   * network distance.
+   * Move decommissioned/entering_maintenance/stale datanodes to the bottom.
+   * Also, sort nodes by network distance.
    *
    * @param lb located block
    * @param targetHost target host
@@ -603,7 +603,7 @@ public class DatanodeManager {
     }
 
     DatanodeInfoWithStorage[] di = lb.getLocations();
-    // Move decommissioned/stale datanodes to the bottom
+    // Move decommissioned/entering_maintenance/stale datanodes to the bottom
     Arrays.sort(di, comparator);
 
     // Sort nodes by network distance only for located blocks

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -508,7 +508,6 @@ public class DatanodeManager {
   private boolean isInactive(DatanodeInfo datanode) {
     return datanode.isDecommissioned() || datanode.isEnteringMaintenance() ||
         (avoidStaleDataNodesForRead && datanode.isStale(staleInterval));
-
   }
   
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
-import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TestSortLocatedBlock {
 
-  Configuration conf = new HdfsConfiguration();
+  private Configuration conf = new HdfsConfiguration();
 
   @Before
   public void setup() throws Exception {
@@ -65,15 +65,16 @@ public class TestSortLocatedBlock {
    * @throws Exception
    */
   @Test
-  public void TestSortLocatedBlock() throws Exception {
+  public void testSortLocatedBlockAvoidStaleNodes() throws Exception {
     conf.setBoolean(DFSConfigKeys
         .DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_READ_KEY, true);
     MiniDFSCluster miniCluster =
         new MiniDFSCluster.Builder(conf).numDataNodes(5).build();
     FSNamesystem namesystem = miniCluster.getNamesystem();
-    DatanodeManager dnManager = namesystem.getBlockManager().getDatanodeManager();
+    DatanodeManager dnManager =
+        namesystem.getBlockManager().getDatanodeManager();
     List<DatanodeDescriptor> datanodes =
-        dnManager.getDatanodeListForReport(HdfsConstants.DatanodeReportType.ALL);
+        dnManager.getDatanodeListForReport(DatanodeReportType.ALL);
     DFSTestUtil.formatNameNode(conf);
     NamenodeProtocols rpcServer = miniCluster.getNameNodeRpc();
     DistributedFileSystem fileSystem = miniCluster.getFileSystem();
@@ -83,7 +84,8 @@ public class TestSortLocatedBlock {
     // create file with 5 replication
     String path = "/test";
     final long fileLen = 512;
-    DFSTestUtil.createFile(fileSystem, new Path(path), fileLen, (short)5, 0);
+    DFSTestUtil.createFile(fileSystem, new Path(path),
+        fileLen, (short)5, 0);
 
     DatanodeDescriptor dn0 = datanodes.get(0);
     DatanodeDescriptor dn1 = datanodes.get(1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
@@ -15,103 +15,129 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
-import org.apache.hadoop.hdfs.protocol.HdfsConstants.DatanodeReportType;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfoWithStorage;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
-import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
-import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
-import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.List;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * This class tests the sorting of located blocks based on
+ * multiple states.
+ */
 public class TestSortLocatedBlock {
+  static final Logger LOG = LoggerFactory
+      .getLogger(TestSortLocatedBlock.class);
 
-  private Configuration conf = new HdfsConfiguration();
+  static DatanodeManager dm;
+  static final long STALE_INTERVAL = 30 * 1000 * 60;
 
-  @Before
-  public void setup() throws Exception {
-    FileSystem.setDefaultUri(conf, "hdfs://localhost:0");
-    conf.set(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY, "0.0.0.0:0");
-    File baseDir = PathUtils.getTestDir(TestReplicationPolicy.class);
-    conf.set(DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY,
-        new File(baseDir, "name").getPath());
-    conf.setStrings(DFSConfigKeys
-        .FS_DEFAULT_NAME_KEY,
-        "hdfs://localhost:0");
-    conf.setLong(DFSConfigKeys
-        .DFS_NAMENODE_STALE_DATANODE_INTERVAL_KEY,
-        60000);
+  @BeforeClass
+  public static void setup() throws IOException {
+    dm = mockDatanodeManager();
   }
 
   /**
-   * Test sorting locations.
-   * @throws Exception
+   * Test to verify sorting with multiple state
+   * datanodes exists in storage lists.
+   *
+   * We have the following list of datanodes, and create LocatedBlock.
+   * d0 - decommissioned
+   * d1 - entering_maintenance
+   * d2 - decommissioned
+   * d3 - stale
+   * d4 - live(in-service)
+   *
+   * After sorting the expected datanodes list will be:
+   * live -> stale -> entering_maintenance -> decommissioned,
+   * (d4 -> d3 -> d1 -> d0 -> d2)
+   * or
+   * (d4 -> d3 -> d1 -> d2 -> d0).
    */
-  @Test
-  public void testSortLocatedBlockAvoidStaleNodes() throws Exception {
-    conf.setBoolean(DFSConfigKeys
-        .DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_READ_KEY, true);
-    MiniDFSCluster miniCluster =
-        new MiniDFSCluster.Builder(conf).numDataNodes(5).build();
-    FSNamesystem namesystem = miniCluster.getNamesystem();
-    DatanodeManager dnManager =
-        namesystem.getBlockManager().getDatanodeManager();
-    List<DatanodeDescriptor> datanodes =
-        dnManager.getDatanodeListForReport(DatanodeReportType.ALL);
-    DFSTestUtil.formatNameNode(conf);
-    NamenodeProtocols rpcServer = miniCluster.getNameNodeRpc();
-    DistributedFileSystem fileSystem = miniCluster.getFileSystem();
-    miniCluster.waitActive();
-    miniCluster.triggerHeartbeats();
+  @Test(timeout = 30000)
+  public void testWithMultipleStateDatanodes() {
+    LOG.info("Starting test testWithMultipleStateDatanodes");
+    long blockID = Long.MIN_VALUE;
+    int totalDns = 5;
+    DatanodeInfo[] locs = new DatanodeInfo[totalDns];
 
-    // create file with 5 replication
-    String path = "/test";
-    final long fileLen = 512;
-    DFSTestUtil.createFile(fileSystem, new Path(path),
-        fileLen, (short)5, 0);
+    // create datanodes
+    for (int i = 0; i < totalDns; i++) {
+      String ip = i + "." + i + "." + i + "." + i;
+      locs[i] = DFSTestUtil.getDatanodeInfo(ip);
+      locs[i].setLastUpdateMonotonic(Time.monotonicNow());
+    }
 
-    DatanodeDescriptor dn0 = datanodes.get(0);
-    DatanodeDescriptor dn1 = datanodes.get(1);
-    DatanodeDescriptor dn2 = datanodes.get(2);
+    // set decommissioned state
+    locs[0].setDecommissioned();
+    locs[2].setDecommissioned();
+    ArrayList<DatanodeInfo> decommissionedNodes = new ArrayList<>();
+    decommissionedNodes.add(locs[0]);
+    decommissionedNodes.add(locs[2]);
 
-    miniCluster.getNamesystem().writeLock();
-    // mock decommissioned node
-    dn0.setDecommissioned();
-    // mock maintained node
-    dn1.startMaintenance();
-    // mock stale
-    dn2.setLastUpdateMonotonic(Time.monotonicNow() -
+    // set entering_maintenance state
+    locs[1].startMaintenance();
+
+    // set stale state
+    locs[3].setLastUpdateMonotonic(Time.monotonicNow() -
         DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_DEFAULT * 1000 - 1);
-    miniCluster.getNamesystem().writeUnlock();
 
-    final LocatedBlocks lb = rpcServer.getBlockLocations(path, 0, fileLen);
-    LocatedBlock locatedBlock = lb.getLocatedBlocks().get(0);
-    DatanodeInfo[] locations = locatedBlock.getLocations();
+    ArrayList<LocatedBlock> locatedBlocks = new ArrayList<>();
+    locatedBlocks.add(new LocatedBlock(
+        new ExtendedBlock("pool", blockID,
+        1024L, new Date().getTime()), locs));
+
+    // sort located blocks
+    dm.sortLocatedBlocks(null, locatedBlocks);
+
+    // get locations after sorting
+    LocatedBlock locatedBlock = locatedBlocks.get(0);
+    DatanodeInfoWithStorage[] locations = locatedBlock.getLocations();
 
     // assert location order:
-    // live -> entering_maintenance -> decommissioned
-    // decommissioned
-    assertEquals(dn0.getDatanodeUuid(), locations[4].getDatanodeUuid());
-    // entering_maintenance
-    assertEquals(dn1.getDatanodeUuid(), locations[3].getDatanodeUuid());
+    // live -> stale -> entering_maintenance -> decommissioned
+    // live
+    assertEquals(locs[4].getIpAddr(), locations[0].getIpAddr());
     // stale
-    assertEquals(dn2.getDatanodeUuid(), locations[2].getDatanodeUuid());
+    assertEquals(locs[3].getIpAddr(), locations[1].getIpAddr());
+    // entering_maintenance
+    assertEquals(locs[1].getIpAddr(), locations[2].getIpAddr());
+    // decommissioned
+    assertEquals(true,
+        decommissionedNodes.contains(locations[3])
+        && decommissionedNodes.contains(locations[4]));
+  }
+
+  private static DatanodeManager mockDatanodeManager() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(
+        DFSConfigKeys.DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_READ_KEY,
+        true);
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_KEY,
+        STALE_INTERVAL);
+    FSNamesystem fsn = Mockito.mock(FSNamesystem.class);
+    BlockManager bm = Mockito.mock(BlockManager.class);
+    BlockReportLeaseManager blm = new BlockReportLeaseManager(conf);
+    Mockito.when(bm.getBlockReportLeaseManager()).thenReturn(blm);
+    DatanodeManager dm = new DatanodeManager(bm, fsn, conf);
+    return dm;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
@@ -47,8 +47,8 @@ public class TestSortLocatedBlock {
   static final Logger LOG = LoggerFactory
       .getLogger(TestSortLocatedBlock.class);
 
-  static DatanodeManager dm;
-  static final long STALE_INTERVAL = 30 * 1000 * 60;
+  private static DatanodeManager dm;
+  private static final long STALE_INTERVAL = 30 * 1000 * 60;
 
   @BeforeClass
   public static void setup() throws IOException {
@@ -137,7 +137,6 @@ public class TestSortLocatedBlock {
     BlockManager bm = Mockito.mock(BlockManager.class);
     BlockReportLeaseManager blm = new BlockReportLeaseManager(conf);
     Mockito.when(bm.getBlockReportLeaseManager()).thenReturn(blm);
-    DatanodeManager dm = new DatanodeManager(bm, fsn, conf);
-    return dm;
+    return new DatanodeManager(bm, fsn, conf);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
+import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
+import org.apache.hadoop.test.PathUtils;
+import org.apache.hadoop.util.Time;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestSortLocatedBlock {
+
+  Configuration conf = new HdfsConfiguration();
+
+  @Before
+  public void setup() throws Exception {
+    FileSystem.setDefaultUri(conf, "hdfs://localhost:0");
+    conf.set(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY, "0.0.0.0:0");
+    File baseDir = PathUtils.getTestDir(TestReplicationPolicy.class);
+    conf.set(DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY,
+        new File(baseDir, "name").getPath());
+    conf.setStrings(DFSConfigKeys
+        .FS_DEFAULT_NAME_KEY,
+        "hdfs://localhost:0");
+    conf.setLong(DFSConfigKeys
+        .DFS_NAMENODE_STALE_DATANODE_INTERVAL_KEY,
+        60000);
+  }
+
+  /**
+   * Test sorting locations.
+   * @throws Exception
+   */
+  @Test
+  public void TestSortLocatedBlock() throws Exception {
+    conf.setBoolean(DFSConfigKeys
+        .DFS_NAMENODE_AVOID_STALE_DATANODE_FOR_READ_KEY, true);
+    MiniDFSCluster miniCluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(5).build();
+    FSNamesystem namesystem = miniCluster.getNamesystem();
+    DatanodeManager dnManager = namesystem.getBlockManager().getDatanodeManager();
+    List<DatanodeDescriptor> datanodes =
+        dnManager.getDatanodeListForReport(HdfsConstants.DatanodeReportType.ALL);
+    DFSTestUtil.formatNameNode(conf);
+    NamenodeProtocols rpcServer = miniCluster.getNameNodeRpc();
+    DistributedFileSystem fileSystem = miniCluster.getFileSystem();
+    miniCluster.waitActive();
+    miniCluster.triggerHeartbeats();
+
+    // create file with 5 replication
+    String path = "/test";
+    final long fileLen = 512;
+    DFSTestUtil.createFile(fileSystem, new Path(path), fileLen, (short)5, 0);
+
+    DatanodeDescriptor dn0 = datanodes.get(0);
+    DatanodeDescriptor dn1 = datanodes.get(1);
+    DatanodeDescriptor dn2 = datanodes.get(2);
+
+    miniCluster.getNamesystem().writeLock();
+    // mock decommissioned node
+    dn0.setDecommissioned();
+    // mock maintained node
+    dn1.startMaintenance();
+    // mock stale
+    dn2.setLastUpdateMonotonic(Time.monotonicNow() -
+        DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_DEFAULT * 1000 - 1);
+    miniCluster.getNamesystem().writeUnlock();
+
+    final LocatedBlocks lb = rpcServer.getBlockLocations(path, 0, fileLen);
+    LocatedBlock locatedBlock = lb.getLocatedBlocks().get(0);
+    DatanodeInfo[] locations = locatedBlock.getLocations();
+
+    // assert location order:
+    // live -> entering_maintenance -> decommissioned
+    // decommissioned
+    assertEquals(dn0.getDatanodeUuid(), locations[4].getDatanodeUuid());
+    // entering_maintenance
+    assertEquals(dn1.getDatanodeUuid(), locations[3].getDatanodeUuid());
+    // stale
+    assertEquals(dn2.getDatanodeUuid(), locations[2].getDatanodeUuid());
+  }
+}


### PR DESCRIPTION
JIRA: [HDFS-16057](https://issues.apache.org/jira/browse/HDFS-16057).

We use compactor to sort locations in getBlockLocations(), and the expected result is: live -> stale -> entering_maintenance -> decommissioned.

But the networktopology.SortByDistance() will disrupt the order. We should also filtered out node in sate  AdminStates.ENTERING_MAINTENANCE before networktopology.SortByDistance().

org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager#sortLocatedBlock()
```
DatanodeInfoWithStorage[] di = lb.getLocations();
// Move decommissioned/stale datanodes to the bottom
Arrays.sort(di, comparator);

// Sort nodes by network distance only for located blocks
int lastActiveIndex = di.length - 1;
while (lastActiveIndex > 0 && isInactive(di[lastActiveIndex])) {
  --lastActiveIndex;
}
int activeLen = lastActiveIndex + 1;
if(nonDatanodeReader) {
  networktopology.sortByDistanceUsingNetworkLocation(client,
      lb.getLocations(), activeLen, createSecondaryNodeSorter());
} else {
  networktopology.sortByDistance(client, lb.getLocations(), activeLen,
      createSecondaryNodeSorter());
}
```

