### PR TITLE
[YARN-10817][Client] Avoid NPE when use yarn command like yarn queue -status

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,12 +4004,13 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
+      private int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove();
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove(REF_QUEUE_POLL_TIMEOUT);
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,14 +4004,12 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private static int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.
-                        remove(REF_QUEUE_POLL_TIMEOUT);
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove();
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,13 +4004,14 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private int REF_QUEUE_POLL_TIMEOUT = 100;
+      private static int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove(REF_QUEUE_POLL_TIMEOUT);
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.
+                        remove(REF_QUEUE_POLL_TIMEOUT);
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,7 +4004,12 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private static int REF_QUEUE_POLL_TIMEOUT = 100;
+      /**
+       * Represents the timeout period expires for remove reference objects from
+       * the STATS_DATA_REF_QUEUE when the queue is empty.
+       */
+      private static final int REF_QUEUE_POLL_TIMEOUT = 10000;
+
       @Override
       public void run() {
         while (!Thread.interrupted()) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,12 +4004,7 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      /**
-       * Represents the timeout period expires for remove reference objects from
-       * the STATS_DATA_REF_QUEUE when the queue is empty.
-       */
-      private static final int REF_QUEUE_POLL_TIMEOUT = 10000;
-
+      private static int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ClusterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/ClusterCLI.java
@@ -90,6 +90,8 @@ public class ClusterCLI extends YarnCLI {
             + " Also, this option is UNSTABLE, could be removed in future"
             + " releases.");
 
+    createAndStartYarnClient();
+
     int exitCode = -1;
     CommandLine parsedCli = null;
     try {
@@ -99,8 +101,6 @@ public class ClusterCLI extends YarnCLI {
       printUsage(opts);
       return exitCode;
     }
-
-    createAndStartYarnClient();
 
     if (parsedCli.hasOption(DIRECTLY_ACCESS_NODE_LABEL_STORE)) {
       accessLocal = true;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/NodeCLI.java
@@ -97,6 +97,8 @@ public class NodeCLI extends YarnCLI {
       }
     }
 
+    createAndStartYarnClient();
+
     int exitCode = -1;
     CommandLine cliParser = null;
     try {
@@ -106,8 +108,6 @@ public class NodeCLI extends YarnCLI {
       printUsage(opts);
       return exitCode;
     }
-
-    createAndStartYarnClient();
 
     if (cliParser.hasOption("status")) {
       if (args.length != 2) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/QueueCLI.java
@@ -61,6 +61,8 @@ public class QueueCLI extends YarnCLI {
     opts.addOption(HELP_CMD, false, "Displays help for all commands.");
     opts.getOption(STATUS_CMD).setArgName("Queue Name");
 
+    createAndStartYarnClient();
+
     CommandLine cliParser = null;
     try {
       cliParser = new GnuParser().parse(opts, args);
@@ -69,7 +71,7 @@ public class QueueCLI extends YarnCLI {
       printUsage(opts);
       return -1;
     }
-    createAndStartYarnClient();
+
     if (cliParser.hasOption(STATUS_CMD)) {
       if (args.length != 2) {
         printUsage(opts);


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Currently, We will encounter NullPointerException when we use some yarn shell commands, As follow:

yarn queue -status
```
Missing argument for options
usage: queue
 -help                  Displays help for all commands.
 -status <Queue Name>   List queue information about given queue.
Exception in thread "main" java.lang.NullPointerException
	at org.apache.hadoop.yarn.client.cli.YarnCLI.stop(YarnCLI.java:75)
	at org.apache.hadoop.yarn.client.cli.QueueCLI.main(QueueCLI.java:51)
```
Like this, and 
```
yarn cluster
yarn queue
yarn node
```

This is beacuse we dont init the `YarnClient` when missing argument for options, This PR will fix the issue.