### PR TITLE
[HADOOP-17758][HDFS][FOLLOWUP] NPE and excessive warnings after HADOOP-17728

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,12 +4004,13 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
+      private int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove();
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove(REF_QUEUE_POLL_TIMEOUT);
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,13 +4004,14 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private int REF_QUEUE_POLL_TIMEOUT = 100;
+      private static int REF_QUEUE_POLL_TIMEOUT = 100;
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove(REF_QUEUE_POLL_TIMEOUT);
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.
+                        remove(REF_QUEUE_POLL_TIMEOUT);
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4017,7 +4017,10 @@ public abstract class FileSystem extends Configured
             StatisticsDataReference ref =
                 (StatisticsDataReference)STATS_DATA_REF_QUEUE.
                         remove(REF_QUEUE_POLL_TIMEOUT);
-            ref.cleanUp();
+
+            if (null != ref) {
+              ref.cleanUp();
+            }
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);
             Thread.currentThread().interrupt();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,7 +4004,12 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      private static int REF_QUEUE_POLL_TIMEOUT = 100;
+      /**
+       * Represents the timeout period expires for remove reference objects from
+       * the STATS_DATA_REF_QUEUE when the queue is empty.
+       */
+      private static final int REF_QUEUE_POLL_TIMEOUT = 10000;
+
       @Override
       public void run() {
         while (!Thread.interrupted()) {


### PR DESCRIPTION
After HADOOP-17728, `StatisticsDataReferenceCleaner` may appear the following questions, That's beacuse `ReferenceQueue.remove` might return `null`.

2021-06-09 21:51:12,334 WARN  [org.apache.hadoop.fs.FileSystem$Statistics$StatisticsDataReferenceCleaner] fs.FileSystem (FileSystem.java:run(4025)) - Exception in the cleaner thread but it will continue to run
java.lang.NullPointerException
	at org.apache.hadoop.fs.FileSystem$Statistics$StatisticsDataReferenceCleaner.run(FileSystem.java:4020)
	at java.lang.Thread.run(Thread.java:748)
