### PR TITLE
HDFS-15671. testBalancerRPCDelayQpsDefault fails intermittently

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
@@ -655,9 +655,11 @@ public class TestBalancer {
     int numOfDatanodes = capacities.length;
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf)
-                                  .numDataNodes(0)
-                                  .build();
+      cluster = new MiniDFSCluster
+          .Builder(conf)
+          .numDataNodes(0)
+          .setNNRedundancyConsiderLoad(false)
+          .build();
       cluster.getConfiguration(0).setInt(DFSConfigKeys.DFS_REPLICATION_KEY,
           DFSConfigKeys.DFS_REPLICATION_DEFAULT);
       conf.setInt(DFSConfigKeys.DFS_REPLICATION_KEY,


### PR DESCRIPTION
HDFS-15671 TestBalancerRPCDelay#testBalancerRPCDelayQpsDefault fails on Trunk

Some blocks cannot be replicated on the existing nodes which causes the unit test to fail during the creation of the file and waiting for the replications.

Setting `dfs.namenode.redundancy.considerLoad` to false.

