### PR TITLE
[HADOOP-17758][HDFS][FOLLOWUP]NPE and excessive warnings after HADOOP-17728

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4004,19 +4004,13 @@ public abstract class FileSystem extends Configured
      * Background action to act on references being removed.
      */
     private static class StatisticsDataReferenceCleaner implements Runnable {
-      /**
-       * Represents the timeout period expires for remove reference objects from
-       * the STATS_DATA_REF_QUEUE when the queue is empty.
-       */
-      private static final int REF_QUEUE_POLL_TIMEOUT = 10000;
 
       @Override
       public void run() {
         while (!Thread.interrupted()) {
           try {
             StatisticsDataReference ref =
-                (StatisticsDataReference)STATS_DATA_REF_QUEUE.
-                        remove(REF_QUEUE_POLL_TIMEOUT);
+                (StatisticsDataReference)STATS_DATA_REF_QUEUE.remove();
             ref.cleanUp();
           } catch (InterruptedException ie) {
             LOGGER.warn("Cleaner thread interrupted, will stop", ie);


### PR DESCRIPTION
NPE after HADOOP-17728.

If something is added to the queue, ReferenceQueue.enqueue will be called, i.e. lock.notifyAll be called, That will not wait forerver.

more details: [HADOOP-17758](https://issues.apache.org/jira/browse/HADOOP-17758)
