### PR TITLE
HADOOP-17765. ABFS: Use Unique File Paths in Tests

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/UriUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/UriUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.azurebfs.utils;
 
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -70,7 +71,9 @@ public final class UriUtils {
    */
   public static String generateUniqueTestPath() {
     String testUniqueForkId = System.getProperty("test.unique.fork.id");
-    return testUniqueForkId == null ? "/test" : "/" + testUniqueForkId + "/test";
+//    return testUniqueForkId == null ? "/test" : "/" + testUniqueForkId + "/test";
+//    return testUniqueForkId == null ? UUID.randomUUID().toString() : "/" + testUniqueForkId + "/test";
+    return "/test" + UUID.randomUUID();
   }
 
   private UriUtils() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/UriUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/UriUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.azurebfs.utils;
 
-import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -71,9 +70,7 @@ public final class UriUtils {
    */
   public static String generateUniqueTestPath() {
     String testUniqueForkId = System.getProperty("test.unique.fork.id");
-//    return testUniqueForkId == null ? "/test" : "/" + testUniqueForkId + "/test";
-//    return testUniqueForkId == null ? UUID.randomUUID().toString() : "/" + testUniqueForkId + "/test";
-    return "/test" + UUID.randomUUID();
+    return testUniqueForkId == null ? "/test" : "/" + testUniqueForkId + "/test";
   }
 
   private UriUtils() {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -417,12 +418,12 @@ public abstract class AbstractAbfsIntegrationTest extends
   /**
    * Create a unique path by appending a GUID to given filepath
    * @param filepath path string
-   * @return a path qualified by the test filesystem
+   * @return unique filepath created using given filepath and GUID
    * @throws IOException IO errors
    */
-  protected Path path(String filepath) throws IOException {
-    return getFileSystem().makeQualified(
-        new Path(filepath + UUID.randomUUID()));
+  protected Path getUniquePath(String filepath) throws IOException {
+    return new Path(
+        filepath + StringUtils.right(UUID.randomUUID().toString(), 12));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -392,6 +392,7 @@ public abstract class AbstractAbfsIntegrationTest extends
   public Path getTestPath() {
     Path path = new Path(UriUtils.generateUniqueTestPath());
     return path;
+//    return new Path("/test" + UUID.randomUUID());
   }
 
   public AzureBlobFileSystemStore getAbfsStore(final AzureBlobFileSystem fs) {
@@ -411,7 +412,9 @@ public abstract class AbstractAbfsIntegrationTest extends
    */
   protected Path path(String filepath) throws IOException {
     return getFileSystem().makeQualified(
-        new Path(getTestPath(), filepath));
+        new Path(filepath + UUID.randomUUID()));
+//    return getFileSystem().makeQualified(
+//        new Path(getTestPath(), filepath));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -392,7 +392,6 @@ public abstract class AbstractAbfsIntegrationTest extends
   public Path getTestPath() {
     Path path = new Path(UriUtils.generateUniqueTestPath());
     return path;
-//    return new Path("/test" + UUID.randomUUID());
   }
 
   public AzureBlobFileSystemStore getAbfsStore(final AzureBlobFileSystem fs) {
@@ -410,11 +409,20 @@ public abstract class AbstractAbfsIntegrationTest extends
    * @return a path qualified by the test filesystem
    * @throws IOException IO problems
    */
+  protected Path pathUnderTestFolder(String filepath) throws IOException {
+    return getFileSystem().makeQualified(
+        new Path(getTestPath(), filepath));
+  }
+
+  /**
+   * Create a unique path by appending a GUID to given filepath
+   * @param filepath path string
+   * @return a path qualified by the test filesystem
+   * @throws IOException IO errors
+   */
   protected Path path(String filepath) throws IOException {
     return getFileSystem().makeQualified(
         new Path(filepath + UUID.randomUUID()));
-//    return getFileSystem().makeQualified(
-//        new Path(getTestPath(), filepath));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -91,7 +91,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   public void testListPathWithValidListMaxResultsValues()
       throws IOException, ExecutionException, InterruptedException {
     final int fileCount = 10;
-    final String directory = "testWithValidListMaxResultsValues";
+    final String directory = path("testWithValidListMaxResultsValues").toString();
     createDirectoryWithNFiles(directory, fileCount);
     final int[] testData = {fileCount + 100, fileCount + 1, fileCount,
         fileCount - 1, 1};
@@ -112,7 +112,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   public void testListPathWithValueGreaterThanServerMaximum()
       throws IOException, ExecutionException, InterruptedException {
     setListMaxResults(LIST_MAX_RESULTS_SERVER + 100);
-    final String directory = "testWithValueGreaterThanServerMaximum";
+    final String directory = path("testWithValueGreaterThanServerMaximum").toString();
     createDirectoryWithNFiles(directory, LIST_MAX_RESULTS_SERVER + 200);
     Assertions.assertThat(listPath(directory)).describedAs(
         "AbfsClient.listPath result will contain a maximum of %d items "

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -91,7 +91,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   public void testListPathWithValidListMaxResultsValues()
       throws IOException, ExecutionException, InterruptedException {
     final int fileCount = 10;
-    final String directory = path("testWithValidListMaxResultsValues").toString();
+    final String directory = getUniquePath("testWithValidListMaxResultsValues").toString();
     createDirectoryWithNFiles(directory, fileCount);
     final int[] testData = {fileCount + 100, fileCount + 1, fileCount,
         fileCount - 1, 1};
@@ -112,7 +112,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   public void testListPathWithValueGreaterThanServerMaximum()
       throws IOException, ExecutionException, InterruptedException {
     setListMaxResults(LIST_MAX_RESULTS_SERVER + 100);
-    final String directory = path("testWithValueGreaterThanServerMaximum").toString();
+    final String directory = getUniquePath("testWithValueGreaterThanServerMaximum").toString();
     createDirectoryWithNFiles(directory, LIST_MAX_RESULTS_SERVER + 200);
     Assertions.assertThat(listPath(directory)).describedAs(
         "AbfsClient.listPath result will contain a maximum of %d items "

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsDurationTrackers.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsDurationTrackers.java
@@ -64,7 +64,7 @@ public class ITestAbfsDurationTrackers extends AbstractAbfsIntegrationTest {
         + "work as expected.");
 
     AzureBlobFileSystem fs = getFileSystem();
-    Path testFilePath = path(getMethodName());
+    Path testFilePath = getUniquePath(getMethodName());
 
     // Declaring output and input stream.
     AbfsOutputStream out = null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsInputStreamStatistics.java
@@ -61,7 +61,7 @@ public class ITestAbfsInputStreamStatistics
 
     AzureBlobFileSystem fs = getFileSystem();
     AzureBlobFileSystemStore abfss = fs.getAbfsStore();
-    Path initValuesPath = path(getMethodName());
+    Path initValuesPath = getUniquePath(getMethodName());
     AbfsOutputStream outputStream = null;
     AbfsInputStream inputStream = null;
 
@@ -101,7 +101,7 @@ public class ITestAbfsInputStreamStatistics
 
     AzureBlobFileSystem fs = getFileSystem();
     AzureBlobFileSystemStore abfss = fs.getAbfsStore();
-    Path seekStatPath = path(getMethodName());
+    Path seekStatPath = getUniquePath(getMethodName());
 
     AbfsOutputStream out = null;
     AbfsInputStream in = null;
@@ -189,7 +189,7 @@ public class ITestAbfsInputStreamStatistics
 
     AzureBlobFileSystem fs = getFileSystem();
     AzureBlobFileSystemStore abfss = fs.getAbfsStore();
-    Path readStatPath = path(getMethodName());
+    Path readStatPath = getUniquePath(getMethodName());
 
     AbfsOutputStream out = null;
     AbfsInputStream in = null;
@@ -250,7 +250,7 @@ public class ITestAbfsInputStreamStatistics
     describe("Testing AbfsInputStream operations with statistics as null");
 
     AzureBlobFileSystem fs = getFileSystem();
-    Path nullStatFilePath = path(getMethodName());
+    Path nullStatFilePath = getUniquePath(getMethodName());
     byte[] oneKbBuff = new byte[ONE_KB];
 
     // Creating an AbfsInputStreamContext instance with null StreamStatistics.
@@ -304,7 +304,7 @@ public class ITestAbfsInputStreamStatistics
 
     AzureBlobFileSystem fs = getFileSystem();
     AzureBlobFileSystemStore abfss = fs.getAbfsStore();
-    Path readAheadCountersPath = path(getMethodName());
+    Path readAheadCountersPath = getUniquePath(getMethodName());
 
     /*
      * Setting the block size for readAhead as 4KB.
@@ -380,7 +380,7 @@ public class ITestAbfsInputStreamStatistics
         + "request in AbfsInputStream");
     AzureBlobFileSystem fs = getFileSystem();
     AzureBlobFileSystemStore abfss = fs.getAbfsStore();
-    Path actionHttpGetRequestPath = path(getMethodName());
+    Path actionHttpGetRequestPath = getUniquePath(getMethodName());
     AbfsInputStream abfsInputStream = null;
     AbfsOutputStream abfsOutputStream = null;
     try {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
@@ -231,7 +231,7 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
   @Test
   public void testHasNextForFile() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFile = path("testFile");
+    Path testFile = getUniquePath("testFile");
     String testFileName = testFile.toString();
     getFileSystem().create(testFile);
     setPageSize(10);
@@ -265,7 +265,7 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
 
   @Test
   public void testNonExistingPath() throws Throwable {
-    Path nonExistingDir = path("nonExistingPath");
+    Path nonExistingDir = getUniquePath("nonExistingPath");
     Assertions.assertThatThrownBy(
         () -> getFileSystem().listStatusIterator(nonExistingDir)).describedAs(
         "test the listStatusIterator call on a path which is not "

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
@@ -231,8 +231,8 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
   @Test
   public void testHasNextForFile() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    String testFileName = "testFile";
-    Path testFile = new Path(testFileName);
+    Path testFile = path("testFile");
+    String testFileName = testFile.toString();
     getFileSystem().create(testFile);
     setPageSize(10);
     RemoteIterator<FileStatus> fsItr = fs.listStatusIterator(testFile);
@@ -265,7 +265,7 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
 
   @Test
   public void testNonExistingPath() throws Throwable {
-    Path nonExistingDir = new Path("nonExistingPath");
+    Path nonExistingDir = path("nonExistingPath");
     Assertions.assertThatThrownBy(
         () -> getFileSystem().listStatusIterator(nonExistingDir)).describedAs(
         "test the listStatusIterator call on a path which is not "

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
@@ -58,7 +58,7 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
 
     AzureBlobFileSystem fs = getFileSystem();
     Map<String, Long> metricMap;
-    Path sendRequestPath = path(getMethodName());
+    Path sendRequestPath = getUniquePath(getMethodName());
     String testNetworkStatsString = "http_send";
 
     metricMap = fs.getInstrumentationMap();
@@ -193,7 +193,7 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
         + "Response is processed.");
 
     AzureBlobFileSystem fs = getFileSystem();
-    Path getResponsePath = path(getMethodName());
+    Path getResponsePath = getUniquePath(getMethodName());
     Map<String, Long> metricMap;
     String testResponseString = "some response";
 
@@ -304,7 +304,7 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
         + "response is failed");
 
     AzureBlobFileSystem fs = getFileSystem();
-    Path responseFailurePath = path(getMethodName());
+    Path responseFailurePath = getUniquePath(getMethodName());
     Map<String, Long> metricMap;
     FSDataOutputStream out = null;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsOutputStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsOutputStreamStatistics.java
@@ -55,7 +55,7 @@ public class ITestAbfsOutputStreamStatistics
   public void testAbfsOutputStreamUploadingBytes() throws IOException {
     describe("Testing bytes uploaded successfully by AbfsOutputSteam");
     final AzureBlobFileSystem fs = getFileSystem();
-    Path uploadBytesFilePath = path(getMethodName());
+    Path uploadBytesFilePath = getUniquePath(getMethodName());
     String testBytesToUpload = "bytes";
 
     try (
@@ -123,7 +123,7 @@ public class ITestAbfsOutputStreamStatistics
   public void testAbfsOutputStreamQueueShrink() throws IOException {
     describe("Testing queue shrink operations by AbfsOutputStream");
     final AzureBlobFileSystem fs = getFileSystem();
-    Path queueShrinkFilePath = path(getMethodName());
+    Path queueShrinkFilePath = getUniquePath(getMethodName());
     String testQueueShrink = "testQueue";
     if (fs.getAbfsStore().isAppendBlobKey(fs.makeQualified(queueShrinkFilePath).toString())) {
       // writeOperationsQueue is not used for appendBlob, hence queueShrink is 0
@@ -186,7 +186,7 @@ public class ITestAbfsOutputStreamStatistics
   public void testAbfsOutputStreamWriteBuffer() throws IOException {
     describe("Testing write current buffer operations by AbfsOutputStream");
     final AzureBlobFileSystem fs = getFileSystem();
-    Path writeBufferFilePath = path(getMethodName());
+    Path writeBufferFilePath = getUniquePath(getMethodName());
     String testWriteBuffer = "Buffer";
 
     try (AbfsOutputStream outForOneOp = createAbfsOutputStreamWithFlushEnabled(
@@ -240,7 +240,7 @@ public class ITestAbfsOutputStreamStatistics
     describe("Testing to check if DurationTracker for PUT request is working "
         + "correctly.");
     AzureBlobFileSystem fs = getFileSystem();
-    Path pathForPutRequest = path(getMethodName());
+    Path pathForPutRequest = getUniquePath(getMethodName());
 
     try(AbfsOutputStream outputStream =
         createAbfsOutputStreamWithFlushEnabled(fs, pathForPutRequest)) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +42,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.M
  */
 @RunWith(Parameterized.class)
 public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
-  private static final Path TEST_PATH = new Path("/testfile");
+  private static final String TEST_PATH = "/testfile";
 
   @Parameterized.Parameters(name = "Size={0}")
   public static Iterable<Object[]> sizes() {
@@ -73,13 +74,14 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
 
-    try (FSDataOutputStream stream = fs.create(TEST_PATH)) {
+    Path testPath = new Path(TEST_PATH + UUID.randomUUID());
+    try (FSDataOutputStream stream = fs.create(testPath)) {
       stream.write(b);
     }
 
     final byte[] readBuffer = new byte[2 * bufferSize];
     int result;
-    try (FSDataInputStream inputStream = fs.open(TEST_PATH)) {
+    try (FSDataInputStream inputStream = fs.open(testPath)) {
       inputStream.seek(bufferSize);
       result = inputStream.read(readBuffer, bufferSize, bufferSize);
       assertNotEquals(-1, result);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.util.Arrays;
 import java.util.Random;
-import java.util.UUID;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,7 +73,7 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
 
-    Path testPath = new Path(TEST_PATH + UUID.randomUUID());
+    Path testPath = path(TEST_PATH);
     try (FSDataOutputStream stream = fs.create(testPath)) {
       stream.write(b);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsReadWriteAndSeek.java
@@ -73,7 +73,7 @@ public class ITestAbfsReadWriteAndSeek extends AbstractAbfsScaleTest {
     final byte[] b = new byte[2 * bufferSize];
     new Random().nextBytes(b);
 
-    Path testPath = path(TEST_PATH);
+    Path testPath = getUniquePath(TEST_PATH);
     try (FSDataOutputStream stream = fs.create(testPath)) {
       stream.write(b);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -52,8 +52,8 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
   @Test
   public void testAbfsRestOperationExceptionFormat() throws IOException {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path nonExistedFilePath1 = path("nonExistedPath1");
-    Path nonExistedFilePath2 = path("nonExistedPath2");
+    Path nonExistedFilePath1 = new Path("nonExistedPath1");
+    Path nonExistedFilePath2 = new Path("nonExistedPath2");
     try {
       FileStatus fileStatus = fs.getFileStatus(nonExistedFilePath1);
     } catch (Exception ex) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -52,8 +52,8 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
   @Test
   public void testAbfsRestOperationExceptionFormat() throws IOException {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path nonExistedFilePath1 = new Path("nonExistedPath1");
-    Path nonExistedFilePath2 = new Path("nonExistedPath2");
+    Path nonExistedFilePath1 = path("nonExistedPath1");
+    Path nonExistedFilePath2 = path("nonExistedPath2");
     try {
       FileStatus fileStatus = fs.getFileStatus(nonExistedFilePath1);
     } catch (Exception ex) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStatistics.java
@@ -86,8 +86,8 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
         + " Abfs");
 
     AzureBlobFileSystem fs = getFileSystem();
-    Path createFilePath = path(getMethodName());
-    Path createDirectoryPath = path(getMethodName() + "Dir");
+    Path createFilePath = pathUnderTestFolder(getMethodName());
+    Path createDirectoryPath = pathUnderTestFolder(getMethodName() + "Dir");
 
     fs.mkdirs(createDirectoryPath);
     fs.createNonRecursive(createFilePath, FsPermission
@@ -114,8 +114,8 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
     with same name, hence <Name> + i to give unique names.
      */
     for (int i = 0; i < NUMBER_OF_OPS; i++) {
-      fs.mkdirs(path(getMethodName() + "Dir" + i));
-      fs.createNonRecursive(path(getMethodName() + i),
+      fs.mkdirs(getUniquePath(getMethodName() + "Dir" + i));
+      fs.createNonRecursive(getUniquePath(getMethodName() + i),
           FsPermission.getDefault(), false, 1024, (short) 1,
           1024, null);
     }
@@ -150,8 +150,8 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
     This directory path needs to be root for triggering the
     directories_deleted counter.
      */
-    Path createDirectoryPath = path("/");
-    Path createFilePath = path(getMethodName());
+    Path createDirectoryPath = pathUnderTestFolder("/");
+    Path createFilePath = pathUnderTestFolder(getMethodName());
 
     /*
     creating a directory and a file inside that directory.
@@ -160,7 +160,7 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
     files_deleted counters.
      */
     fs.mkdirs(createDirectoryPath);
-    fs.create(path(createDirectoryPath + getMethodName()));
+    fs.create(getUniquePath(createDirectoryPath + getMethodName()));
     fs.delete(createDirectoryPath, true);
 
     Map<String, Long> metricMap = fs.getInstrumentationMap();
@@ -196,8 +196,8 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
         + "exists methods on Abfs");
 
     AzureBlobFileSystem fs = getFileSystem();
-    Path createFilePath = path(getMethodName());
-    Path destCreateFilePath = path(getMethodName() + "New");
+    Path createFilePath = pathUnderTestFolder(getMethodName());
+    Path destCreateFilePath = pathUnderTestFolder(getMethodName() + "New");
 
     fs.create(createFilePath);
     fs.open(createFilePath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
@@ -52,8 +52,8 @@ public class ITestAbfsStreamStatistics extends AbstractAbfsIntegrationTest {
         + "Abfs");
 
     final AzureBlobFileSystem fs = getFileSystem();
-    Path smallOperationsFile = new Path("testOneReadWriteOps");
-    Path largeOperationsFile = new Path("testLargeReadWriteOps");
+    Path smallOperationsFile = path("testOneReadWriteOps");
+    Path largeOperationsFile = path("testLargeReadWriteOps");
     FileSystem.Statistics statistics = fs.getFsStatistics();
     String testReadWriteOps = "test this";
     statistics.reset();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStreamStatistics.java
@@ -52,8 +52,8 @@ public class ITestAbfsStreamStatistics extends AbstractAbfsIntegrationTest {
         + "Abfs");
 
     final AzureBlobFileSystem fs = getFileSystem();
-    Path smallOperationsFile = path("testOneReadWriteOps");
-    Path largeOperationsFile = path("testLargeReadWriteOps");
+    Path smallOperationsFile = getUniquePath("testOneReadWriteOps");
+    Path largeOperationsFile = getUniquePath("testLargeReadWriteOps");
     FileSystem.Statistics statistics = fs.getFsStatistics();
     String testReadWriteOps = "test this";
     statistics.reset();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
  */
 public class ITestAzureBlobFileSystemAppend extends
     AbstractAbfsIntegrationTest {
-  private static final Path TEST_FILE_PATH = new Path("testfile");
-  private static final Path TEST_FOLDER_PATH = new Path("testFolder");
+  private static final String TEST_FILE_PATH = "testfile";
+  private static final String TEST_FOLDER_PATH = "testFolder";
 
   public ITestAzureBlobFileSystemAppend() throws Exception {
     super();
@@ -42,7 +42,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test(expected = FileNotFoundException.class)
   public void testAppendDirShouldFail() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path filePath = TEST_FILE_PATH;
+    final Path filePath = path(TEST_FILE_PATH);
     fs.mkdirs(filePath);
     fs.append(filePath, 0);
   }
@@ -50,7 +50,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test
   public void testAppendWithLength0() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    try(FSDataOutputStream stream = fs.create(TEST_FILE_PATH)) {
+    try(FSDataOutputStream stream = fs.create(path(TEST_FILE_PATH))) {
       final byte[] b = new byte[1024];
       new Random().nextBytes(b);
       stream.write(b, 1000, 0);
@@ -62,7 +62,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test(expected = FileNotFoundException.class)
   public void testAppendFileAfterDelete() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path filePath = TEST_FILE_PATH;
+    final Path filePath = path(TEST_FILE_PATH);
     ContractTestUtils.touch(fs, filePath);
     fs.delete(filePath, false);
 
@@ -72,7 +72,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test(expected = FileNotFoundException.class)
   public void testAppendDirectory() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path folderPath = TEST_FOLDER_PATH;
+    final Path folderPath = path(TEST_FOLDER_PATH);
     fs.mkdirs(folderPath);
     fs.append(folderPath);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -42,7 +42,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test(expected = FileNotFoundException.class)
   public void testAppendDirShouldFail() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path filePath = path(TEST_FILE_PATH);
+    final Path filePath = getUniquePath(TEST_FILE_PATH);
     fs.mkdirs(filePath);
     fs.append(filePath, 0);
   }
@@ -50,7 +50,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test
   public void testAppendWithLength0() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    try(FSDataOutputStream stream = fs.create(path(TEST_FILE_PATH))) {
+    try(FSDataOutputStream stream = fs.create(getUniquePath(TEST_FILE_PATH))) {
       final byte[] b = new byte[1024];
       new Random().nextBytes(b);
       stream.write(b, 1000, 0);
@@ -62,7 +62,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test(expected = FileNotFoundException.class)
   public void testAppendFileAfterDelete() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path filePath = path(TEST_FILE_PATH);
+    final Path filePath = getUniquePath(TEST_FILE_PATH);
     ContractTestUtils.touch(fs, filePath);
     fs.delete(filePath, false);
 
@@ -72,7 +72,7 @@ public class ITestAzureBlobFileSystemAppend extends
   @Test(expected = FileNotFoundException.class)
   public void testAppendDirectory() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path folderPath = path(TEST_FOLDER_PATH);
+    final Path folderPath = getUniquePath(TEST_FOLDER_PATH);
     fs.mkdirs(folderPath);
     fs.append(folderPath);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -48,7 +48,7 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
     byte[] attributeValue2 = fs.getAbfsStore().encodeAttribute("你好");
     String attributeName1 = "user.asciiAttribute";
     String attributeName2 = "user.unicodeAttribute";
-    Path testFile = path("setGetXAttr");
+    Path testFile = getUniquePath("setGetXAttr");
 
     // after creating a file, the xAttr should not be present
     touch(testFile);
@@ -70,7 +70,7 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
     Assume.assumeTrue(fs.getIsNamespaceEnabled());
     byte[] attributeValue = fs.getAbfsStore().encodeAttribute("one");
     String attributeName = "user.someAttribute";
-    Path testFile = path("createReplaceXAttr");
+    Path testFile = getUniquePath("createReplaceXAttr");
 
     // after creating a file, it must be possible to create a new xAttr
     touch(testFile);
@@ -88,7 +88,7 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
     byte[] attributeValue1 = fs.getAbfsStore().encodeAttribute("one");
     byte[] attributeValue2 = fs.getAbfsStore().encodeAttribute("two");
     String attributeName = "user.someAttribute";
-    Path testFile = path("replaceXAttr");
+    Path testFile = getUniquePath("replaceXAttr");
 
     // after creating a file, it must not be possible to replace an xAttr
     intercept(IOException.class, () -> {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
+import java.util.UUID;
+
 /**
  * Test AzureBlobFileSystem back compatibility with WASB.
  */
@@ -50,13 +52,17 @@ public class ITestAzureBlobFileSystemBackCompat extends
     CloudBlobContainer container = blobClient.getContainerReference(this.getFileSystemName());
     container.createIfNotExists();
 
-    CloudBlockBlob blockBlob = container.getBlockBlobReference("test/10/10/10");
+    String testPath = "test" + UUID.randomUUID();
+    CloudBlockBlob blockBlob = container
+        .getBlockBlobReference(testPath + "/10/10/10");
     blockBlob.uploadText("");
 
-    blockBlob = container.getBlockBlobReference("test/10/123/3/2/1/3");
+    blockBlob = container.getBlockBlobReference(testPath + "/10/123/3/2/1/3");
     blockBlob.uploadText("");
 
-    FileStatus[] fileStatuses = fs.listStatus(new Path("/test/10/"));
+    System.out.println(new Path(String.format("%s/10/", testPath)));
+    FileStatus[] fileStatuses = fs
+        .listStatus(new Path(String.format("/%s/10/", testPath)));
     assertEquals(2, fileStatuses.length);
     assertEquals("10", fileStatuses[0].getPath().getName());
     assertTrue(fileStatuses[0].isDirectory());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
@@ -50,7 +50,7 @@ public class ITestAzureBlobFileSystemBackCompat extends
     CloudBlobContainer container = blobClient.getContainerReference(this.getFileSystemName());
     container.createIfNotExists();
 
-    Path testPath = path("test");
+    Path testPath = getUniquePath("test");
     CloudBlockBlob blockBlob = container
         .getBlockBlobReference(testPath + "/10/10/10");
     blockBlob.uploadText("");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
-import java.util.UUID;
-
 /**
  * Test AzureBlobFileSystem back compatibility with WASB.
  */
@@ -52,7 +50,7 @@ public class ITestAzureBlobFileSystemBackCompat extends
     CloudBlobContainer container = blobClient.getContainerReference(this.getFileSystemName());
     container.createIfNotExists();
 
-    String testPath = "test" + UUID.randomUUID();
+    Path testPath = path("test");
     CloudBlockBlob blockBlob = container
         .getBlockBlobReference(testPath + "/10/10/10");
     blockBlob.uploadText("");
@@ -60,7 +58,6 @@ public class ITestAzureBlobFileSystemBackCompat extends
     blockBlob = container.getBlockBlobReference(testPath + "/10/123/3/2/1/3");
     blockBlob.uploadText("");
 
-    System.out.println(new Path(String.format("%s/10/", testPath)));
     FileStatus[] fileStatuses = fs
         .listStatus(new Path(String.format("/%s/10/", testPath)));
     assertEquals(2, fileStatuses.length);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -350,7 +350,7 @@ public class ITestAzureBlobFileSystemCheckAccess
 
   private Path setupTestDirectoryAndUserAccess(String testFileName,
       FsAction fsAction) throws Exception {
-    Path file = new Path(TEST_FOLDER_PATH + testFileName);
+    Path file = path(TEST_FOLDER_PATH + testFileName);
     file = this.superUserFs.makeQualified(file);
     this.superUserFs.delete(file, true);
     this.superUserFs.create(file);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -350,7 +350,7 @@ public class ITestAzureBlobFileSystemCheckAccess
 
   private Path setupTestDirectoryAndUserAccess(String testFileName,
       FsAction fsAction) throws Exception {
-    Path file = path(TEST_FOLDER_PATH + testFileName);
+    Path file = getUniquePath(TEST_FOLDER_PATH + testFileName);
     file = this.superUserFs.makeQualified(file);
     this.superUserFs.delete(file, true);
     this.superUserFs.create(file);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCopy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCopy.java
@@ -53,7 +53,7 @@ public class ITestAzureBlobFileSystemCopy extends AbstractAbfsIntegrationTest {
     localFs.delete(localFilePath, true);
     try {
       writeString(localFs, localFilePath, "Testing");
-      Path dstPath = new Path("copiedFromLocal");
+      Path dstPath = path("copiedFromLocal");
       assertTrue(FileUtil.copy(localFs, localFilePath, fs, dstPath, false,
           fs.getConf()));
       assertIsFile(fs, dstPath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCopy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCopy.java
@@ -53,7 +53,7 @@ public class ITestAzureBlobFileSystemCopy extends AbstractAbfsIntegrationTest {
     localFs.delete(localFilePath, true);
     try {
       writeString(localFs, localFilePath, "Testing");
-      Path dstPath = path("copiedFromLocal");
+      Path dstPath = getUniquePath("copiedFromLocal");
       assertTrue(FileUtil.copy(localFs, localFilePath, fs, dstPath, false,
           fs.getConf()));
       assertIsFile(fs, dstPath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -65,8 +65,8 @@ import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.CONNECTIONS_MADE;
  */
 public class ITestAzureBlobFileSystemCreate extends
     AbstractAbfsIntegrationTest {
-  private static final Path TEST_FILE_PATH = new Path("testfile");
-  private static final Path TEST_FOLDER_PATH = new Path("testFolder");
+  private static final String TEST_FILE_PATH = "testfile";
+  private static final String TEST_FOLDER_PATH = "testFolder";
   private static final String TEST_CHILD_FILE = "childFile";
 
   public ITestAzureBlobFileSystemCreate() throws Exception {
@@ -76,7 +76,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testEnsureFileCreatedImmediately() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFilePath = new Path(TEST_FILE_PATH + UUID.randomUUID().toString());
+    Path testFilePath = path(TEST_FILE_PATH);
     FSDataOutputStream out = fs.create(testFilePath);
     try {
       assertIsFile(fs, testFilePath);
@@ -90,13 +90,14 @@ public class ITestAzureBlobFileSystemCreate extends
   @SuppressWarnings("deprecation")
   public void testCreateNonRecursive() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFile = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE + UUID.randomUUID());
+    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFile = new Path(testFolderPath, TEST_CHILD_FILE);
     try {
       fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null);
       fail("Should've thrown");
     } catch (FileNotFoundException expected) {
     }
-    fs.mkdirs(TEST_FOLDER_PATH);
+    fs.mkdirs(testFolderPath);
     fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null)
         .close();
     assertIsFile(fs, testFile);
@@ -106,14 +107,14 @@ public class ITestAzureBlobFileSystemCreate extends
   @SuppressWarnings("deprecation")
   public void testCreateNonRecursive1() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFile = new Path(TEST_FOLDER_PATH,
-        TEST_CHILD_FILE + UUID.randomUUID());
+    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFile = new Path(testFolderPath, TEST_CHILD_FILE);
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE), 1024, (short) 1, 1024, null);
       fail("Should've thrown");
     } catch (FileNotFoundException expected) {
     }
-    fs.mkdirs(TEST_FOLDER_PATH);
+    fs.mkdirs(testFolderPath);
     fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null)
         .close();
     assertIsFile(fs, testFile);
@@ -125,14 +126,14 @@ public class ITestAzureBlobFileSystemCreate extends
   public void testCreateNonRecursive2() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
 
-    Path testFile = new Path(TEST_FOLDER_PATH,
-        TEST_CHILD_FILE + UUID.randomUUID());
+    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFile = new Path(testFolderPath, TEST_CHILD_FILE);
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
       fail("Should've thrown");
     } catch (FileNotFoundException e) {
     }
-    fs.mkdirs(TEST_FOLDER_PATH);
+    fs.mkdirs(testFolderPath);
     fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null)
         .close();
     assertIsFile(fs, testFile);
@@ -144,8 +145,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testWriteAfterClose() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = new Path(TEST_FOLDER_PATH,
-        TEST_CHILD_FILE + UUID.randomUUID());
+    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testPath = new Path(testFolderPath, TEST_CHILD_FILE);
     FSDataOutputStream out = fs.create(testPath);
     out.close();
     intercept(IOException.class, () -> out.write('a'));
@@ -165,8 +166,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testTryWithResources() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = new Path(TEST_FOLDER_PATH,
-        TEST_CHILD_FILE + UUID.randomUUID());
+    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testPath = new Path(testFolderPath, TEST_CHILD_FILE);
     try (FSDataOutputStream out = fs.create(testPath)) {
       out.write('1');
       out.hsync();
@@ -199,8 +200,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testFilterFSWriteAfterClose() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = new Path(TEST_FOLDER_PATH,
-        TEST_CHILD_FILE + UUID.randomUUID());
+    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testPath = new Path(testFolderPath, TEST_CHILD_FILE);
     FSDataOutputStream out = fs.create(testPath);
     intercept(FileNotFoundException.class,
         () -> {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -76,20 +76,21 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testEnsureFileCreatedImmediately() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    FSDataOutputStream out = fs.create(TEST_FILE_PATH);
+    Path testFilePath = new Path(TEST_FILE_PATH + UUID.randomUUID().toString());
+    FSDataOutputStream out = fs.create(testFilePath);
     try {
-      assertIsFile(fs, TEST_FILE_PATH);
+      assertIsFile(fs, testFilePath);
     } finally {
       out.close();
     }
-    assertIsFile(fs, TEST_FILE_PATH);
+    assertIsFile(fs, testFilePath);
   }
 
   @Test
   @SuppressWarnings("deprecation")
   public void testCreateNonRecursive() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFile = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    Path testFile = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE + UUID.randomUUID());
     try {
       fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null);
       fail("Should've thrown");
@@ -105,7 +106,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @SuppressWarnings("deprecation")
   public void testCreateNonRecursive1() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFile = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    Path testFile = new Path(TEST_FOLDER_PATH,
+        TEST_CHILD_FILE + UUID.randomUUID());
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE), 1024, (short) 1, 1024, null);
       fail("Should've thrown");
@@ -123,7 +125,8 @@ public class ITestAzureBlobFileSystemCreate extends
   public void testCreateNonRecursive2() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
 
-    Path testFile = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    Path testFile = new Path(TEST_FOLDER_PATH,
+        TEST_CHILD_FILE + UUID.randomUUID());
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
       fail("Should've thrown");
@@ -141,7 +144,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testWriteAfterClose() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    Path testPath = new Path(TEST_FOLDER_PATH,
+        TEST_CHILD_FILE + UUID.randomUUID());
     FSDataOutputStream out = fs.create(testPath);
     out.close();
     intercept(IOException.class, () -> out.write('a'));
@@ -161,7 +165,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testTryWithResources() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    Path testPath = new Path(TEST_FOLDER_PATH,
+        TEST_CHILD_FILE + UUID.randomUUID());
     try (FSDataOutputStream out = fs.create(testPath)) {
       out.write('1');
       out.hsync();
@@ -194,7 +199,8 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testFilterFSWriteAfterClose() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = new Path(TEST_FOLDER_PATH, TEST_CHILD_FILE);
+    Path testPath = new Path(TEST_FOLDER_PATH,
+        TEST_CHILD_FILE + UUID.randomUUID());
     FSDataOutputStream out = fs.create(testPath);
     intercept(FileNotFoundException.class,
         () -> {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -76,7 +76,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testEnsureFileCreatedImmediately() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFilePath = path(TEST_FILE_PATH);
+    Path testFilePath = getUniquePath(TEST_FILE_PATH);
     FSDataOutputStream out = fs.create(testFilePath);
     try {
       assertIsFile(fs, testFilePath);
@@ -90,7 +90,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @SuppressWarnings("deprecation")
   public void testCreateNonRecursive() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFolderPath = getUniquePath(TEST_FOLDER_PATH);
     Path testFile = new Path(testFolderPath, TEST_CHILD_FILE);
     try {
       fs.createNonRecursive(testFile, true, 1024, (short) 1, 1024, null);
@@ -107,7 +107,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @SuppressWarnings("deprecation")
   public void testCreateNonRecursive1() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFolderPath = getUniquePath(TEST_FOLDER_PATH);
     Path testFile = new Path(testFolderPath, TEST_CHILD_FILE);
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE), 1024, (short) 1, 1024, null);
@@ -126,7 +126,7 @@ public class ITestAzureBlobFileSystemCreate extends
   public void testCreateNonRecursive2() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
 
-    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFolderPath = getUniquePath(TEST_FOLDER_PATH);
     Path testFile = new Path(testFolderPath, TEST_CHILD_FILE);
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
@@ -145,7 +145,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testWriteAfterClose() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFolderPath = getUniquePath(TEST_FOLDER_PATH);
     Path testPath = new Path(testFolderPath, TEST_CHILD_FILE);
     FSDataOutputStream out = fs.create(testPath);
     out.close();
@@ -166,7 +166,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testTryWithResources() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFolderPath = getUniquePath(TEST_FOLDER_PATH);
     Path testPath = new Path(testFolderPath, TEST_CHILD_FILE);
     try (FSDataOutputStream out = fs.create(testPath)) {
       out.write('1');
@@ -200,7 +200,7 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testFilterFSWriteAfterClose() throws Throwable {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testFolderPath = path(TEST_FOLDER_PATH);
+    Path testFolderPath = getUniquePath(TEST_FOLDER_PATH);
     Path testPath = new Path(testFolderPath, TEST_CHILD_FILE);
     FSDataOutputStream out = fs.create(testPath);
     intercept(FileNotFoundException.class,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemE2EScale.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemE2EScale.java
@@ -51,7 +51,7 @@ public class ITestAzureBlobFileSystemE2EScale extends
   @Test
   public void testWriteHeavyBytesToFileAcrossThreads() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path testFile = path(methodName.getMethodName());
+    final Path testFile = getUniquePath(methodName.getMethodName());
     final FSDataOutputStream stream = fs.create(testFile);
     ExecutorService es = Executors.newFixedThreadPool(TEN);
 
@@ -89,7 +89,7 @@ public class ITestAzureBlobFileSystemE2EScale extends
   public void testReadWriteHeavyBytesToFileWithStatistics() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
     final FileSystem.Statistics abfsStatistics;
-    final Path testFile = path(methodName.getMethodName());
+    final Path testFile = getUniquePath(methodName.getMethodName());
     int testBufferSize;
     final byte[] sourceData;
     try (FSDataOutputStream stream = fs.create(testFile)) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFlush.java
@@ -68,7 +68,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   @Test
   public void testAbfsOutputStreamAsyncFlushWithRetainUncommittedData() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     final byte[] b;
     try (FSDataOutputStream stream = fs.create(testFilePath)) {
       b = new byte[TEST_BUFFER_SIZE];
@@ -98,7 +98,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   @Test
   public void testAbfsOutputStreamSyncFlush() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
 
     final byte[] b;
     try (FSDataOutputStream stream = fs.create(testFilePath)) {
@@ -126,7 +126,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   @Test
   public void testWriteHeavyBytesToFileSyncFlush() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     ExecutorService es;
     try (FSDataOutputStream stream = fs.create(testFilePath)) {
       es = Executors.newFixedThreadPool(10);
@@ -173,7 +173,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
     final AzureBlobFileSystem fs = getFileSystem();
     ExecutorService es = Executors.newFixedThreadPool(10);
 
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(testFilePath)) {
 
       final byte[] b = new byte[TEST_BUFFER_SIZE];
@@ -228,7 +228,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
     fs.getAbfsStore().getAbfsConfiguration()
         .setDisableOutputStreamFlush(disableOutputStreamFlush);
 
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     byte[] buffer = getRandomBytesArray();
     // The test case must write "fs.azure.write.request.size" bytes
     // to the stream in order for the data to be uploaded to storage.
@@ -263,7 +263,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
     final AzureBlobFileSystem fs = this.getFileSystem();
     byte[] buffer = getRandomBytesArray();
     String fileName = UUID.randomUUID().toString();
-    final Path testFilePath = path(fileName);
+    final Path testFilePath = getUniquePath(fileName);
 
     try (FSDataOutputStream stream = getStreamAfterWrite(fs, testFilePath, buffer, true)) {
       stream.hflush();
@@ -275,7 +275,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   public void testHflushWithFlushDisabled() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     byte[] buffer = getRandomBytesArray();
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     boolean isAppendBlob = false;
     if (fs.getAbfsStore().isAppendBlobKey(fs.makeQualified(testFilePath).toString())) {
       isAppendBlob = true;
@@ -293,7 +293,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
     final AzureBlobFileSystem fs = this.getFileSystem();
     byte[] buffer = getRandomBytesArray();
 
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
 
     try (FSDataOutputStream stream = getStreamAfterWrite(fs, testFilePath, buffer, true)) {
       stream.hsync();
@@ -306,7 +306,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
     final AzureBlobFileSystem fs = this.getFileSystem();
     byte[] buffer = getRandomBytesArray();
 
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
 
     try (FSDataOutputStream stream = getStreamAfterWrite(fs, testFilePath, buffer, false)) {
       assertLacksStreamCapabilities(stream,
@@ -322,7 +322,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   public void testStreamCapabilitiesWithFlushEnabled() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     byte[] buffer = getRandomBytesArray();
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     try (FSDataOutputStream stream = getStreamAfterWrite(fs, testFilePath, buffer, true)) {
       assertHasStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -338,7 +338,7 @@ public class ITestAzureBlobFileSystemFlush extends AbstractAbfsScaleTest {
   public void testHsyncWithFlushDisabled() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     byte[] buffer = getRandomBytesArray();
-    final Path testFilePath = path(methodName.getMethodName());
+    final Path testFilePath = getUniquePath(methodName.getMethodName());
     boolean isAppendBlob = false;
     if (fs.getAbfsStore().isAppendBlobKey(fs.makeQualified(testFilePath).toString())) {
       isAppendBlob = true;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
@@ -74,7 +74,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testNoInfiniteLease() throws IOException {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getFileSystem();
     fs.mkdirs(testFilePath.getParent());
     try (FSDataOutputStream out = fs.create(testFilePath)) {
@@ -86,7 +86,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testNoLeaseThreads() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 0);
     fs.mkdirs(testFilePath.getParent());
     LambdaTestUtils.intercept(IOException.class, ERR_NO_LEASE_THREADS, () -> {
@@ -98,7 +98,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testOneWriter() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -113,7 +113,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testSubDir() throws Exception {
-    final Path testFilePath = new Path(new Path(path(methodName.getMethodName()), "subdir"),
+    final Path testFilePath = new Path(new Path(getUniquePath(methodName.getMethodName()), "subdir"),
         TEST_FILE);
     final AzureBlobFileSystem fs =
         getCustomFileSystem(testFilePath.getParent().getParent(), 1);
@@ -130,7 +130,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testTwoCreate() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -166,7 +166,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testTwoWritersCreateAppendNoInfiniteLease() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getFileSystem();
     fs.mkdirs(testFilePath.getParent());
 
@@ -175,7 +175,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = LONG_TEST_EXECUTION_TIMEOUT)
   public void testTwoWritersCreateAppendWithInfiniteLeaseEnabled() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -184,7 +184,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testLeaseFreedOnClose() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -201,7 +201,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testWriteAfterBreakLease() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -236,7 +236,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = LONG_TEST_EXECUTION_TIMEOUT)
   public void testLeaseFreedAfterBreak() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -258,7 +258,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testInfiniteLease() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -279,7 +279,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testFileSystemClose() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
 
@@ -304,7 +304,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
   @Test(timeout = TEST_EXECUTION_TIMEOUT)
   public void testAcquireRetry() throws Exception {
-    final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
+    final Path testFilePath = new Path(getUniquePath(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
     fs.mkdirs(testFilePath.getParent());
     fs.createNewFile(testFilePath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -187,8 +187,9 @@ public class ITestAzureBlobFileSystemListStatus extends
     boolean exceptionThrown = false;
     final AzureBlobFileSystem fs = getFileSystem();
 
-    Path nontrailingPeriodDir = path("testTrailingDir/dir");
-    Path trailingPeriodDir = path("testTrailingDir/dir.");
+    Path testPath = getUniquePath("testTrailingDir");
+    Path nontrailingPeriodDir = new Path(testPath + "/dir");
+    Path trailingPeriodDir = new Path(testPath + "/dir.");
 
     assertMkdirs(fs, nontrailingPeriodDir);
 
@@ -207,8 +208,9 @@ public class ITestAzureBlobFileSystemListStatus extends
     boolean exceptionThrown = false;
     final AzureBlobFileSystem fs = getFileSystem();
 
-    Path trailingPeriodFile = path("testTrailingDir/file.");
-    Path nontrailingPeriodFile = path("testTrailingDir/file");
+    Path testPath = getUniquePath("testTrailingDir");
+    Path trailingPeriodFile = new Path(testPath + "/file.");
+    Path nontrailingPeriodFile = new Path(testPath + "/file");
 
     createFile(fs, nontrailingPeriodFile, false, new byte[0]);
     assertPathExists(fs, "Trailing period file does not exist",
@@ -229,8 +231,9 @@ public class ITestAzureBlobFileSystemListStatus extends
     boolean exceptionThrown = false;
     final AzureBlobFileSystem fs = getFileSystem();
 
-    Path nonTrailingPeriodFile = path("testTrailingDir/file");
-    Path trailingPeriodFile = path("testTrailingDir/file.");
+    Path testPath = getUniquePath("testTrailingDir");
+    Path nonTrailingPeriodFile = new Path(testPath + "/file");
+    Path trailingPeriodFile = new Path(testPath + "/file.");
 
     createFile(fs, nonTrailingPeriodFile, false, new byte[0]);
     try {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -174,7 +174,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSeekToNewSource() throws Exception {
-    Path testPath = path(TEST_FILE_PREFIX + "_testSeekToNewSource");
+    Path testPath = getUniquePath(TEST_FILE_PREFIX + "_testSeekToNewSource");
     assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -189,7 +189,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSkipBounds() throws Exception {
-    Path testPath = path(TEST_FILE_PREFIX + "_testSkipBounds");
+    Path testPath = getUniquePath(TEST_FILE_PREFIX + "_testSkipBounds");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -230,7 +230,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testValidateSeekBounds() throws Exception {
-    Path testPath = path(TEST_FILE_PREFIX + "_testValidateSeekBounds");
+    Path testPath = getUniquePath(TEST_FILE_PREFIX + "_testValidateSeekBounds");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -281,7 +281,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSeekAndAvailableAndPosition() throws Exception {
-    Path testPath = path(TEST_FILE_PREFIX + "_testSeekAndAvailableAndPosition");
+    Path testPath = getUniquePath(TEST_FILE_PREFIX + "_testSeekAndAvailableAndPosition");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -347,7 +347,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSkipAndAvailableAndPosition() throws Exception {
-    Path testPath = path(TEST_FILE_PREFIX + "_testSkipAndAvailableAndPosition");
+    Path testPath = getUniquePath(TEST_FILE_PREFIX + "_testSkipAndAvailableAndPosition");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -413,7 +413,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
   @Test
   public void testSequentialReadAfterReverseSeekPerformance()
           throws Exception {
-    Path testPath = path(
+    Path testPath = getUniquePath(
         TEST_FILE_PREFIX + "_testSequentialReadAfterReverseSeekPerformance");
     assumeHugeFileExists(testPath);
     final int maxAttempts = 10;
@@ -447,7 +447,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
   public void testRandomReadPerformance() throws Exception {
     Assume.assumeFalse("This test does not support namespace enabled account",
             this.getFileSystem().getIsNamespaceEnabled());
-    Path testPath = path(TEST_FILE_PREFIX + "_testRandomReadPerformance");
+    Path testPath = getUniquePath(TEST_FILE_PREFIX + "_testRandomReadPerformance");
     assumeHugeFileExists(testPath);
 
     final AzureBlobFileSystem abFs = this.getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -174,7 +174,6 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSeekToNewSource() throws Exception {
-//    Path testPath = new Path(TEST_FILE_PREFIX + "_testSeekToNewSource");
     Path testPath = path(TEST_FILE_PREFIX + "_testSeekToNewSource");
     assumeHugeFileExists(testPath);
 
@@ -190,7 +189,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSkipBounds() throws Exception {
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testSkipBounds");
+    Path testPath = path(TEST_FILE_PREFIX + "_testSkipBounds");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -231,7 +230,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testValidateSeekBounds() throws Exception {
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testValidateSeekBounds");
+    Path testPath = path(TEST_FILE_PREFIX + "_testValidateSeekBounds");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -414,8 +413,8 @@ public class ITestAzureBlobFileSystemRandomRead extends
   @Test
   public void testSequentialReadAfterReverseSeekPerformance()
           throws Exception {
-    Path testPath = path(TEST_FILE_PREFIX +
-        "_testSequentialReadAfterReverseSeekPerformance");
+    Path testPath = path(
+        TEST_FILE_PREFIX + "_testSequentialReadAfterReverseSeekPerformance");
     assumeHugeFileExists(testPath);
     final int maxAttempts = 10;
     final double maxAcceptableRatio = 1.01;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -174,7 +174,8 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSeekToNewSource() throws Exception {
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testSeekToNewSource");
+//    Path testPath = new Path(TEST_FILE_PREFIX + "_testSeekToNewSource");
+    Path testPath = path(TEST_FILE_PREFIX + "_testSeekToNewSource");
     assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -281,7 +282,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSeekAndAvailableAndPosition() throws Exception {
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testSeekAndAvailableAndPosition");
+    Path testPath = path(TEST_FILE_PREFIX + "_testSeekAndAvailableAndPosition");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -347,7 +348,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testSkipAndAvailableAndPosition() throws Exception {
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testSkipAndAvailableAndPosition");
+    Path testPath = path(TEST_FILE_PREFIX + "_testSkipAndAvailableAndPosition");
     long testFileLength = assumeHugeFileExists(testPath);
 
     try (FSDataInputStream inputStream = this.getFileSystem().open(testPath)) {
@@ -413,7 +414,8 @@ public class ITestAzureBlobFileSystemRandomRead extends
   @Test
   public void testSequentialReadAfterReverseSeekPerformance()
           throws Exception {
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testSequentialReadAfterReverseSeekPerformance");
+    Path testPath = path(TEST_FILE_PREFIX +
+        "_testSequentialReadAfterReverseSeekPerformance");
     assumeHugeFileExists(testPath);
     final int maxAttempts = 10;
     final double maxAcceptableRatio = 1.01;
@@ -446,7 +448,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
   public void testRandomReadPerformance() throws Exception {
     Assume.assumeFalse("This test does not support namespace enabled account",
             this.getFileSystem().getIsNamespaceEnabled());
-    Path testPath = new Path(TEST_FILE_PREFIX + "_testRandomReadPerformance");
+    Path testPath = path(TEST_FILE_PREFIX + "_testRandomReadPerformance");
     assumeHugeFileExists(testPath);
 
     final AzureBlobFileSystem abFs = this.getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -177,15 +177,16 @@ public class ITestAzureBlobFileSystemRename extends
   public void testPosixRenameDirectory() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Path testPath = path("testPath");
-    fs.mkdirs(new Path(testPath + "testDir2/test1/test2/test3"));
-    fs.mkdirs(new Path(testPath + "testDir2/test4"));
-    Assert.assertTrue(fs.rename(new Path(testPath + "testDir2/test1/test2"
-        + "/test3"), new Path(testPath + "testDir2/test4")));
-    assertTrue(fs.exists(new Path(testPath + "testDir2")));
-    assertTrue(fs.exists(new Path(testPath + "testDir2/test1/test2")));
-    assertTrue(fs.exists(new Path(testPath + "testDir2/test4")));
-    assertTrue(fs.exists(new Path(testPath + "testDir2/test4/test3")));
-    assertFalse(fs.exists(new Path(testPath + "testDir2/test1/test2/test3")));
+    fs.mkdirs(new Path(testPath + "/testDir2/test1/test2/test3"));
+    fs.mkdirs(new Path(testPath + "/testDir2/test4"));
+    Assert.assertTrue(
+        fs.rename(new Path(testPath + "/testDir2/test1/test2/test3"),
+            new Path(testPath + "/testDir2/test4")));
+    assertTrue(fs.exists(new Path(testPath + "/testDir2")));
+    assertTrue(fs.exists(new Path(testPath + "/testDir2/test1/test2")));
+    assertTrue(fs.exists(new Path(testPath + "/testDir2/test4")));
+    assertTrue(fs.exists(new Path(testPath + "/testDir2/test4/test3")));
+    assertFalse(fs.exists(new Path(testPath + "/testDir2/test1/test2/test3")));
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -73,9 +73,9 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testEnsureFileIsRenamed() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path src = path("testEnsureFileIsRenamed-src");
+    Path src = getUniquePath("testEnsureFileIsRenamed-src");
     touch(src);
-    Path dest = path("testEnsureFileIsRenamed-dest");
+    Path dest = getUniquePath("testEnsureFileIsRenamed-dest");
     fs.delete(dest, true);
     assertRenameOutcome(fs, src, dest, true);
 
@@ -86,9 +86,9 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testRenameWithPreExistingDestination() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path src = path("renameSrc");
+    Path src = getUniquePath("renameSrc");
     touch(src);
-    Path dest = path("renameDest");
+    Path dest = getUniquePath("renameDest");
     touch(dest);
     assertRenameOutcome(fs, src, dest, false);
   }
@@ -96,13 +96,13 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testRenameFileUnderDir() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path sourceDir = path("/testSrc");
+    Path sourceDir = getUniquePath("/testSrc");
     assertMkdirs(fs, sourceDir);
     String filename = "file1";
     Path file1 = new Path(sourceDir, filename);
     touch(file1);
 
-    Path destDir = path("/testDst");
+    Path destDir = getUniquePath("/testDst");
     assertRenameOutcome(fs, sourceDir, destDir, true);
     FileStatus[] fileStatus = fs.listStatus(destDir);
     assertNotNull("Null file status", fileStatus);
@@ -114,7 +114,7 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testRenameDirectory() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    String testPath = path("testDir").toString();
+    String testPath = getUniquePath("testDir").toString();
     fs.mkdirs(new Path(testPath));
     Path test1 = new Path(testPath + "/test1");
     fs.mkdirs(test1);
@@ -176,7 +176,7 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testPosixRenameDirectory() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
-    Path testPath = path("testPath");
+    Path testPath = getUniquePath("testPath");
     fs.mkdirs(new Path(testPath + "/testDir2/test1/test2/test3"));
     fs.mkdirs(new Path(testPath + "/testDir2/test4"));
     Assert.assertTrue(

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRenameUnicode.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRenameUnicode.java
@@ -76,14 +76,14 @@ public class ITestAzureBlobFileSystemRenameUnicode extends
   @Test
   public void testRenameFileUsingUnicode() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path folderPath1 = path(srcDir);
+    Path folderPath1 = getUniquePath(srcDir);
     assertMkdirs(fs, folderPath1);
     assertIsDirectory(fs, folderPath1);
     Path filePath = new Path(folderPath1 + "/" + filename);
     touch(filePath);
     assertIsFile(fs, filePath);
 
-    Path folderPath2 = path(destDir);
+    Path folderPath2 = getUniquePath(destDir);
     assertRenameOutcome(fs, folderPath1, folderPath2, true);
     assertPathDoesNotExist(fs, "renamed", folderPath1);
     assertIsDirectory(fs, folderPath2);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRenameUnicode.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRenameUnicode.java
@@ -76,14 +76,14 @@ public class ITestAzureBlobFileSystemRenameUnicode extends
   @Test
   public void testRenameFileUsingUnicode() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path folderPath1 = new Path(srcDir);
+    Path folderPath1 = path(srcDir);
     assertMkdirs(fs, folderPath1);
     assertIsDirectory(fs, folderPath1);
     Path filePath = new Path(folderPath1 + "/" + filename);
     touch(filePath);
     assertIsFile(fs, filePath);
 
-    Path folderPath2 = new Path(destDir);
+    Path folderPath2 = path(destDir);
     assertRenameOutcome(fs, folderPath1, folderPath2, true);
     assertPathDoesNotExist(fs, "renamed", folderPath1);
     assertIsDirectory(fs, folderPath2);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFilesystemAcl.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFilesystemAcl.java
@@ -1274,7 +1274,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testSetOwnerForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
 
     assertTrue(fs.exists(filePath));
@@ -1291,7 +1291,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testSetPermissionForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
 
     assertTrue(fs.exists(filePath));
@@ -1310,7 +1310,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testModifyAclEntriesForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
@@ -1327,7 +1327,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testRemoveAclEntriesEntriesForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
@@ -1344,7 +1344,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testRemoveDefaultAclForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
     try {
       fs.removeDefaultAcl(filePath);
@@ -1358,7 +1358,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testRemoveAclForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
     try {
       fs.removeAcl(filePath);
@@ -1372,7 +1372,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testSetAclForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
@@ -1389,7 +1389,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testGetAclStatusForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = path(methodName.getMethodName());
+    final Path filePath = getUniquePath(methodName.getMethodName());
     fs.create(filePath);
     try {
       AclStatus aclSpec = fs.getAclStatus(filePath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFilesystemAcl.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFilesystemAcl.java
@@ -1274,7 +1274,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testSetOwnerForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
 
     assertTrue(fs.exists(filePath));
@@ -1291,7 +1291,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testSetPermissionForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
 
     assertTrue(fs.exists(filePath));
@@ -1310,7 +1310,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testModifyAclEntriesForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
@@ -1327,7 +1327,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testRemoveAclEntriesEntriesForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
@@ -1344,7 +1344,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testRemoveDefaultAclForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
     try {
       fs.removeDefaultAcl(filePath);
@@ -1358,7 +1358,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testRemoveAclForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
     try {
       fs.removeAcl(filePath);
@@ -1372,7 +1372,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testSetAclForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
@@ -1389,7 +1389,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   public void testGetAclStatusForNonNamespaceEnabledAccount() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     Assume.assumeTrue(!fs.getIsNamespaceEnabled());
-    final Path filePath = new Path(methodName.getMethodName());
+    final Path filePath = path(methodName.getMethodName());
     fs.create(filePath);
     try {
       AclStatus aclSpec = fs.getAclStatus(filePath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
@@ -106,7 +106,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
   @Test
   public void testReadWithCPK() throws Exception {
     final AzureBlobFileSystem fs = getAbfs(true);
-    String fileName = path("/" + methodName.getMethodName()).toString();
+    String fileName = "/" + methodName.getMethodName();
     createFileAndGetContent(fs, fileName, FILE_SIZE);
 
     AbfsClient abfsClient = fs.getAbfsClient();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
@@ -154,7 +154,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
   @Test
   public void testReadWithoutCPK() throws Exception {
     final AzureBlobFileSystem fs = getAbfs(false);
-    String fileName = path("/" + methodName.getMethodName()).toString();
+    String fileName = getUniquePath("/" + methodName.getMethodName()).toString();
     createFileAndGetContent(fs, fileName, FILE_SIZE);
 
     AbfsClient abfsClient = fs.getAbfsClient();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestCustomerProvidedKey.java
@@ -106,7 +106,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
   @Test
   public void testReadWithCPK() throws Exception {
     final AzureBlobFileSystem fs = getAbfs(true);
-    String fileName = "/" + methodName.getMethodName();
+    String fileName = path("/" + methodName.getMethodName()).toString();
     createFileAndGetContent(fs, fileName, FILE_SIZE);
 
     AbfsClient abfsClient = fs.getAbfsClient();
@@ -154,7 +154,7 @@ public class ITestCustomerProvidedKey extends AbstractAbfsIntegrationTest {
   @Test
   public void testReadWithoutCPK() throws Exception {
     final AzureBlobFileSystem fs = getAbfs(false);
-    String fileName = "/" + methodName.getMethodName();
+    String fileName = path("/" + methodName.getMethodName()).toString();
     createFileAndGetContent(fs, fileName, FILE_SIZE);
 
     AbfsClient abfsClient = fs.getAbfsClient();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemProperties.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemProperties.java
@@ -39,7 +39,7 @@ public class ITestFileSystemProperties extends AbstractAbfsIntegrationTest {
   @Test
   public void testReadWriteBytesToFileAndEnsureThreadPoolCleanup() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = path(TEST_PATH);
+    Path testPath = getUniquePath(TEST_PATH);
     try(FSDataOutputStream stream = fs.create(testPath)) {
       stream.write(TEST_DATA);
     }
@@ -55,7 +55,7 @@ public class ITestFileSystemProperties extends AbstractAbfsIntegrationTest {
   @Test
   public void testWriteOneByteToFileAndEnsureThreadPoolCleanup() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    Path testPath = path(TEST_PATH);
+    Path testPath = getUniquePath(TEST_PATH);
     try(FSDataOutputStream stream = fs.create(testPath)) {
       stream.write(TEST_DATA);
     }
@@ -81,7 +81,7 @@ public class ITestFileSystemProperties extends AbstractAbfsIntegrationTest {
     final AzureBlobFileSystem fs = getFileSystem();
     final Hashtable<String, String> properties = new Hashtable<>();
     properties.put("key", "{ value: valueTest }");
-    Path testPath = path(TEST_PATH);
+    Path testPath = getUniquePath(TEST_PATH);
     touch(testPath);
     fs.getAbfsStore().setPathProperties(testPath, properties);
     Hashtable<String, String> fetchedProperties =
@@ -106,7 +106,7 @@ public class ITestFileSystemProperties extends AbstractAbfsIntegrationTest {
     final AzureBlobFileSystem fs = getFileSystem();
     final Hashtable<String, String> properties = new Hashtable<>();
     properties.put("key", "{ value: valueTest兩 }");
-    Path testPath = path(TEST_PATH);
+    Path testPath = getUniquePath(TEST_PATH);
     touch(testPath);
     fs.getAbfsStore().setPathProperties(testPath, properties);
     Hashtable<String, String> fetchedProperties = fs.getAbfsStore().getPathStatus(testPath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemProperties.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemProperties.java
@@ -109,8 +109,7 @@ public class ITestFileSystemProperties extends AbstractAbfsIntegrationTest {
     Path testPath = path(TEST_PATH);
     touch(testPath);
     fs.getAbfsStore().setPathProperties(testPath, properties);
-    Hashtable<String, String> fetchedProperties =
-        fs.getAbfsStore().getPathStatus(testPath);
+    Hashtable<String, String> fetchedProperties = fs.getAbfsStore().getPathStatus(testPath);
 
     assertEquals(properties, fetchedProperties);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
@@ -172,11 +172,12 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
-    Path d1d4 = path("/d1/d2/d3/d4");
+    Path testPath = path("testpath");
+    Path d1d4 = new Path(testPath + "/d1/d2/d3/d4");
     assertMkdirs(abfs, d1d4);
 
     //set working directory to path1
-    Path path1 = path("/d1/d2");
+    Path path1 = new Path(testPath + "/d1/d2");
     wasb.setWorkingDirectory(path1);
     abfs.setWorkingDirectory(path1);
     assertEquals(path1, wasb.getWorkingDirectory());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
@@ -62,7 +62,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
-    Path path1 = new Path("/testfiles/~12/!008/3/abFsTestfile");
+    Path path1 = path("/testfiles/~12/!008/3/abFsTestfile");
     try(FSDataOutputStream abfsStream = fs.create(path1, true)) {
       abfsStream.write(ABFS_TEST_CONTEXT.getBytes());
       abfsStream.flush();
@@ -70,7 +70,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     }
 
     // create file using wasb
-    Path path2 = new Path("/testfiles/~12/!008/3/nativeFsTestfile");
+    Path path2 = path("/testfiles/~12/!008/3/nativeFsTestfile");
     LOG.info("{}", wasb.getUri());
     try(FSDataOutputStream nativeFsStream = wasb.create(path2, true)) {
       nativeFsStream.write(WASB_TEST_CONTEXT.getBytes());
@@ -98,7 +98,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
     for (int i = 0; i< 4; i++) {
-      Path path = new Path("/testReadFile/~12/!008/testfile" + i);
+      Path path = path("/testReadFile/~12/!008/testfile" + i);
       final FileSystem createFs = createFileWithAbfs[i] ? abfs : wasb;
 
       // Write
@@ -138,7 +138,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
     for (int i = 0; i < 4; i++) {
-      Path path = new Path("/testDir/t" + i);
+      Path path = path("/testDir/t" + i);
       //create
       final FileSystem createFs = createDirWithAbfs[i] ? abfs : wasb;
       assertTrue(createFs.mkdirs(path));
@@ -172,11 +172,11 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
-    Path d1d4 = new Path("/d1/d2/d3/d4");
+    Path d1d4 = path("/d1/d2/d3/d4");
     assertMkdirs(abfs, d1d4);
 
     //set working directory to path1
-    Path path1 = new Path("/d1/d2");
+    Path path1 = path("/d1/d2");
     wasb.setWorkingDirectory(path1);
     abfs.setWorkingDirectory(path1);
     assertEquals(path1, wasb.getWorkingDirectory());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
@@ -62,7 +62,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
-    Path path1 = path("/testfiles/~12/!008/3/abFsTestfile");
+    Path path1 = getUniquePath("/testfiles/~12/!008/3/abFsTestfile");
     try(FSDataOutputStream abfsStream = fs.create(path1, true)) {
       abfsStream.write(ABFS_TEST_CONTEXT.getBytes());
       abfsStream.flush();
@@ -70,7 +70,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     }
 
     // create file using wasb
-    Path path2 = path("/testfiles/~12/!008/3/nativeFsTestfile");
+    Path path2 = getUniquePath("/testfiles/~12/!008/3/nativeFsTestfile");
     LOG.info("{}", wasb.getUri());
     try(FSDataOutputStream nativeFsStream = wasb.create(path2, true)) {
       nativeFsStream.write(WASB_TEST_CONTEXT.getBytes());
@@ -98,7 +98,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
     for (int i = 0; i< 4; i++) {
-      Path path = path("/testReadFile/~12/!008/testfile" + i);
+      Path path = getUniquePath("/testReadFile/~12/!008/testfile" + i);
       final FileSystem createFs = createFileWithAbfs[i] ? abfs : wasb;
 
       // Write
@@ -138,7 +138,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
     for (int i = 0; i < 4; i++) {
-      Path path = path("/testDir/t" + i);
+      Path path = getUniquePath("/testDir/t" + i);
       //create
       final FileSystem createFs = createDirWithAbfs[i] ? abfs : wasb;
       assertTrue(createFs.mkdirs(path));
@@ -172,7 +172,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
 
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
-    Path testPath = path("testpath");
+    Path testPath = getUniquePath("testpath");
     Path d1d4 = new Path(testPath + "/d1/d2/d3/d4");
     assertMkdirs(abfs, d1d4);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
@@ -170,7 +170,7 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
 
   protected Path createFileWithContent(FileSystem fs, String fileName,
       byte[] fileContent) throws IOException {
-    Path testFilePath = path(fileName);
+    Path testFilePath = getUniquePath(fileName);
     try (FSDataOutputStream oStream = fs.create(testFilePath)) {
       oStream.write(fileContent);
       oStream.flush();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
@@ -41,7 +41,7 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
   public void testMaxRequestsAndQueueCapacityDefaults() throws Exception {
     Configuration conf = getRawConfiguration();
     final AzureBlobFileSystem fs = getFileSystem(conf);
-    try (FSDataOutputStream out = fs.create(path(TEST_FILE_PATH))) {
+    try (FSDataOutputStream out = fs.create(getUniquePath(TEST_FILE_PATH))) {
     AbfsOutputStream stream = (AbfsOutputStream) out.getWrappedStream();
 
       int maxConcurrentRequests
@@ -70,7 +70,7 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
     conf.set(ConfigurationKeys.AZURE_WRITE_MAX_REQUESTS_TO_QUEUE,
         "" + maxRequestsToQueue);
     final AzureBlobFileSystem fs = getFileSystem(conf);
-    FSDataOutputStream out = fs.create(path(TEST_FILE_PATH));
+    FSDataOutputStream out = fs.create(getUniquePath(TEST_FILE_PATH));
     AbfsOutputStream stream = (AbfsOutputStream) out.getWrappedStream();
 
     if (stream.isAppendBlobStream()) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsOutputStream.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
  * Test create operation.
  */
 public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
-  private static final Path TEST_FILE_PATH = new Path("testfile");
+  private static final String TEST_FILE_PATH = "testfile";
 
   public ITestAbfsOutputStream() throws Exception {
     super();
@@ -42,7 +42,7 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
   public void testMaxRequestsAndQueueCapacityDefaults() throws Exception {
     Configuration conf = getRawConfiguration();
     final AzureBlobFileSystem fs = getFileSystem(conf);
-    try (FSDataOutputStream out = fs.create(TEST_FILE_PATH)) {
+    try (FSDataOutputStream out = fs.create(path(TEST_FILE_PATH))) {
     AbfsOutputStream stream = (AbfsOutputStream) out.getWrappedStream();
 
       int maxConcurrentRequests
@@ -71,7 +71,7 @@ public class ITestAbfsOutputStream extends AbstractAbfsIntegrationTest {
     conf.set(ConfigurationKeys.AZURE_WRITE_MAX_REQUESTS_TO_QUEUE,
         "" + maxRequestsToQueue);
     final AzureBlobFileSystem fs = getFileSystem(conf);
-    FSDataOutputStream out = fs.create(TEST_FILE_PATH);
+    FSDataOutputStream out = fs.create(path(TEST_FILE_PATH));
     AbfsOutputStream stream = (AbfsOutputStream) out.getWrappedStream();
 
     if (stream.isAppendBlobStream()) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsPositionedRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsPositionedRead.java
@@ -48,7 +48,7 @@ public class ITestAbfsPositionedRead extends AbstractAbfsIntegrationTest {
   @Test
   public void testPositionedRead() throws IOException {
     describe("Testing positioned reads in AbfsInputStream");
-    Path dest = path(methodName.getMethodName());
+    Path dest = getUniquePath(methodName.getMethodName());
 
     byte[] data = ContractTestUtils.dataset(TEST_FILE_DATA_SIZE, 'a', 'z');
     ContractTestUtils.writeDataset(getFileSystem(), dest, data, data.length,
@@ -133,7 +133,7 @@ public class ITestAbfsPositionedRead extends AbstractAbfsIntegrationTest {
   @Test
   public void testPositionedReadWithBufferedReadDisabled() throws IOException {
     describe("Testing positioned reads in AbfsInputStream with BufferedReadDisabled");
-    Path dest = path(methodName.getMethodName());
+    Path dest = getUniquePath(methodName.getMethodName());
     byte[] data = ContractTestUtils.dataset(TEST_FILE_DATA_SIZE, 'a', 'z');
     ContractTestUtils.writeDataset(getFileSystem(), dest, data, data.length,
         TEST_FILE_DATA_SIZE, true);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsUnbuffer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsUnbuffer.java
@@ -42,7 +42,7 @@ public class ITestAbfsUnbuffer extends AbstractAbfsIntegrationTest {
   @Override
   public void setup() throws Exception {
     super.setup();
-    dest = path("ITestAbfsUnbuffer");
+    dest = getUniquePath("ITestAbfsUnbuffer");
 
     byte[] data = ContractTestUtils.dataset(16, 'a', 26);
     ContractTestUtils.writeDataset(getFileSystem(), dest, data, data.length,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -576,7 +576,7 @@ public class TestAbfsInputStream extends
     Configuration config = getRawConfiguration();
     config.unset(FS_AZURE_READ_AHEAD_QUEUE_DEPTH);
     AzureBlobFileSystem fs = getFileSystem(config);
-    Path testFile = path("/testFile");
+    Path testFile = getUniquePath("/testFile");
     fs.create(testFile);
     FSDataInputStream in = fs.open(testFile);
     Assertions.assertThat(
@@ -639,7 +639,7 @@ public class TestAbfsInputStream extends
       readAheadBlockSize = readRequestSize;
     }
 
-    Path testPath = path("/testReadAheadConfigs");
+    Path testPath = getUniquePath("/testReadAheadConfigs");
     final AzureBlobFileSystem fs = createTestFile(testPath,
         ALWAYS_READ_BUFFER_SIZE_TEST_FILE_SIZE, config);
     byte[] byteBuffer = new byte[ONE_MB];

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -576,7 +576,7 @@ public class TestAbfsInputStream extends
     Configuration config = getRawConfiguration();
     config.unset(FS_AZURE_READ_AHEAD_QUEUE_DEPTH);
     AzureBlobFileSystem fs = getFileSystem(config);
-    Path testFile = new Path("/testFile");
+    Path testFile = path("/testFile");
     fs.create(testFile);
     FSDataInputStream in = fs.open(testFile);
     Assertions.assertThat(
@@ -639,8 +639,7 @@ public class TestAbfsInputStream extends
       readAheadBlockSize = readRequestSize;
     }
 
-    Path testPath = new Path(
-        "/testReadAheadConfigs");
+    Path testPath = path("/testReadAheadConfigs");
     final AzureBlobFileSystem fs = createTestFile(testPath,
         ALWAYS_READ_BUFFER_SIZE_TEST_FILE_SIZE, config);
     byte[] byteBuffer = new byte[ONE_MB];

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStream.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -89,7 +90,8 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, false));
     final byte[] b = new byte[WRITE_SIZE];
     new Random().nextBytes(b);
@@ -110,12 +112,12 @@ public final class TestAbfsOutputStream {
         WRITE_SIZE, 0, 2 * WRITE_SIZE, APPEND_MODE, false, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
   }
 
   /**
@@ -136,7 +138,8 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, false));
     final byte[] b = new byte[WRITE_SIZE];
     new Random().nextBytes(b);
@@ -152,12 +155,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, 5*WRITE_SIZE-BUFFER_SIZE, APPEND_MODE, false, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -167,7 +170,7 @@ public final class TestAbfsOutputStream {
 
     verify(client, times(1)).flush(acFlushPath.capture(), acFlushPosition.capture(), acFlushRetainUnCommittedData.capture(), acFlushClose.capture(),
         acFlushSASToken.capture(), isNull());
-    assertThat(Arrays.asList(PATH)).describedAs("path").isEqualTo(acFlushPath.getAllValues());
+    assertThat(Arrays.asList(testPath)).describedAs("path").isEqualTo(acFlushPath.getAllValues());
     assertThat(Arrays.asList(Long.valueOf(5*WRITE_SIZE))).describedAs("position").isEqualTo(acFlushPosition.getAllValues());
     assertThat(Arrays.asList(false)).describedAs("RetainUnCommittedData flag").isEqualTo(acFlushRetainUnCommittedData.getAllValues());
     assertThat(Arrays.asList(true)).describedAs("Close flag").isEqualTo(acFlushClose.getAllValues());
@@ -194,7 +197,8 @@ public final class TestAbfsOutputStream {
     when(op.getSasToken()).thenReturn("testToken");
     when(op.getResult()).thenReturn(httpOp);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, false));
     final byte[] b = new byte[BUFFER_SIZE];
     new Random().nextBytes(b);
@@ -210,12 +214,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -225,7 +229,7 @@ public final class TestAbfsOutputStream {
 
     verify(client, times(1)).flush(acFlushPath.capture(), acFlushPosition.capture(), acFlushRetainUnCommittedData.capture(), acFlushClose.capture(),
         acFlushSASToken.capture(), isNull());
-    assertThat(Arrays.asList(PATH)).describedAs("path").isEqualTo(acFlushPath.getAllValues());
+    assertThat(Arrays.asList(testPath)).describedAs("path").isEqualTo(acFlushPath.getAllValues());
     assertThat(Arrays.asList(Long.valueOf(2*BUFFER_SIZE))).describedAs("position").isEqualTo(acFlushPosition.getAllValues());
     assertThat(Arrays.asList(false)).describedAs("RetainUnCommittedData flag").isEqualTo(acFlushRetainUnCommittedData.getAllValues());
     assertThat(Arrays.asList(true)).describedAs("Close flag").isEqualTo(acFlushClose.getAllValues());
@@ -252,7 +256,8 @@ public final class TestAbfsOutputStream {
     when(op.getSasToken()).thenReturn("testToken");
     when(op.getResult()).thenReturn(httpOp);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, false));
     final byte[] b = new byte[BUFFER_SIZE];
     new Random().nextBytes(b);
@@ -268,12 +273,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
   }
 
   /**
@@ -294,7 +299,8 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, true));
     final byte[] b = new byte[BUFFER_SIZE];
     new Random().nextBytes(b);
@@ -310,12 +316,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, true, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
   }
 
   /**
@@ -337,7 +343,8 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, false));
     final byte[] b = new byte[BUFFER_SIZE];
     new Random().nextBytes(b);
@@ -353,12 +360,12 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
 
     ArgumentCaptor<String> acFlushPath = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> acFlushPosition = ArgumentCaptor.forClass(Long.class);
@@ -368,7 +375,7 @@ public final class TestAbfsOutputStream {
 
     verify(client, times(1)).flush(acFlushPath.capture(), acFlushPosition.capture(), acFlushRetainUnCommittedData.capture(), acFlushClose.capture(),
         acFlushSASToken.capture(), isNull());
-    assertThat(Arrays.asList(PATH)).describedAs("path").isEqualTo(acFlushPath.getAllValues());
+    assertThat(Arrays.asList(testPath)).describedAs("path").isEqualTo(acFlushPath.getAllValues());
     assertThat(Arrays.asList(Long.valueOf(2*BUFFER_SIZE))).describedAs("position").isEqualTo(acFlushPosition.getAllValues());
     assertThat(Arrays.asList(false)).describedAs("RetainUnCommittedData flag").isEqualTo(acFlushRetainUnCommittedData.getAllValues());
     assertThat(Arrays.asList(false)).describedAs("Close flag").isEqualTo(acFlushClose.getAllValues());
@@ -391,7 +398,8 @@ public final class TestAbfsOutputStream {
     when(client.append(anyString(), any(byte[].class), any(AppendRequestParameters.class), any())).thenReturn(op);
     when(client.flush(anyString(), anyLong(), anyBoolean(), anyBoolean(), any(), isNull())).thenReturn(op);
 
-    AbfsOutputStream out = new AbfsOutputStream(client, null, PATH, 0,
+    String testPath = PATH + UUID.randomUUID();
+    AbfsOutputStream out = new AbfsOutputStream(client, null, testPath, 0,
         populateAbfsOutputStreamContext(BUFFER_SIZE, true, false, false));
     final byte[] b = new byte[BUFFER_SIZE];
     new Random().nextBytes(b);
@@ -409,11 +417,11 @@ public final class TestAbfsOutputStream {
         BUFFER_SIZE, 0, BUFFER_SIZE, APPEND_MODE, false, null);
 
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(firstReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(firstReqParameters), any());
     verify(client, times(1)).append(
-        eq(PATH), any(byte[].class), refEq(secondReqParameters), any());
+        eq(testPath), any(byte[].class), refEq(secondReqParameters), any());
     // confirm there were only 2 invocations in all
     verify(client, times(2)).append(
-        eq(PATH), any(byte[].class), any(), any());
+        eq(testPath), any(byte[].class), any(), any());
   }
 }


### PR DESCRIPTION
Many of ABFS driver tests use common names for file paths (e.g., "/testfile"). This poses a risk of errors during parallel test runs when static variables (such as those for monitoring stats) affected by file paths are introduced.

Using unique test file names will avoid possible errors arising from shared resources during parallel runs.