### PR TITLE
HADOOP-17715 ABFS: Append blob tests with non HNS accounts fail (#3028)

### DIFF
--- a/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
+++ b/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
@@ -26,12 +26,19 @@ set -eo pipefail
 begin
 
 ### ADD THE TEST COMBINATIONS BELOW. DO NOT EDIT THE ABOVE LINES.
+### THE SCRIPT REQUIRES THE FOLLOWING UTILITIES xmlstarlet AND pcregrep.
 
 
 combination=HNS-OAuth
 properties=("fs.azure.abfs.account.name" "fs.azure.test.namespace.enabled"
 "fs.azure.account.auth.type")
 values=("{account name}.dfs.core.windows.net" "true" "OAuth")
+generateconfigs
+
+combination=AppendBlob-HNS-OAuth
+properties=("fs.azure.abfs.account.name" "fs.azure.test.namespace.enabled"
+"fs.azure.account.auth.type" "fs.azure.test.appendblob.enabled")
+values=("{account name}.dfs.core.windows.net" "true" "OAuth" "true")
 generateconfigs
 
 combination=HNS-SharedKey

--- a/hadoop-tools/hadoop-azure/src/test/resources/azure-auth-keys.xml.template
+++ b/hadoop-tools/hadoop-azure/src/test/resources/azure-auth-keys.xml.template
@@ -167,7 +167,8 @@ create the test FS instance.
     <value>false</value>
     <description>If made true, tests will be running under the assumption that
       append blob is enabled and the root directory and contract test root
-      directory will be part of the append blob directories.
+      directory will be part of the append blob directories. Should be false for
+      non-HNS accounts.
     </description>
   </property>
 


### PR DESCRIPTION
(cherry picked from commit 4c039fafebfe7b4d68b60c5ec6075d889ab1c40b)
