### PR TITLE
HADOOP-17769. Upgrade JUnit to 4.13.2. fixes TestBlockRecovery

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -502,7 +502,7 @@ javax.xml.bind:jaxb-api:2.2.11
 Eclipse Public License 1.0
 --------------------------
 
-junit:junit:4.12
+junit:junit:4.13.2
 
 
 HSQL License

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -198,7 +198,7 @@
     <snakeyaml.version>1.26</snakeyaml.version>
     <hbase.one.version>1.4.8</hbase.one.version>
     <hbase.two.version>2.0.2</hbase.two.version>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.5.1</junit.jupiter.version>
     <junit.vintage.version>5.5.1</junit.vintage.version>
     <junit.platform.version>1.5.1</junit.platform.version>


### PR DESCRIPTION
HADOOP-17769 Upgrade JUnit to 4.13.2
JUnit 4.13.1 has a bug that is reported in Junit issue-1652 _Timeout ThreadGroups should not be destroyed._

The bug has been fixed in Junit-4.13.2