### PR TITLE
HADOOP-17769. Upgrade JUnit to 4.13.2. fixes TestBlockRecovery

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -824,7 +824,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -369,7 +369,7 @@
             <additionnalDependency>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
-              <version>4.11</version>
+              <version>4.13.2</version>
             </additionnalDependency>
           </additionnalDependencies>
         </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
@@ -191,7 +191,7 @@
             <additionalDependency>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
-              <version>4.11</version>
+              <version>4.13.2</version>
             </additionalDependency>
           </additionalDependencies>
         </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/pom.xml
@@ -170,7 +170,7 @@
             <additionnalDependency>
               <groupId>junit</groupId>
               <artifactId>junit</artifactId>
-              <version>4.11</version>
+              <version>4.13.2</version>
             </additionnalDependency>
           </additionnalDependencies>
         </configuration>


### PR DESCRIPTION
HADOOP-17769 Upgrade JUnit to 4.13.2
JUnit 4.13.1 has a bug that is reported in Junit issue-1652 Timeout ThreadGroups should not be destroyed.

The bug has been fixed in Junit-4.13.2

Backporting PR-3130 to branch-2.10
