### PR TITLE
HADOOP-17764. S3AInputStream read does not re-open the input stream on the second read retry attempt

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1439,10 +1439,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * using FS state as well as the status.
    * @param fileStatus file status.
    * @param seekPolicy input policy for this operation
+   * @param changePolicy change policy for this operation.
    * @param readAheadRange readahead value.
+   * @param auditSpan audit span.
    * @return a context for read and select operations.
    */
-  private S3AReadOpContext createReadContext(
+  @VisibleForTesting
+  protected S3AReadOpContext createReadContext(
       final FileStatus fileStatus,
       final S3AInputPolicy seekPolicy,
       final ChangeDetectionPolicy changePolicy,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -396,41 +396,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     }
   }
 
-  @FunctionalInterface
-  interface CheckedIntSupplier {
-    int get() throws IOException;
-  }
-
-  /**
-   * Helper function that allows to retry an IntSupplier in case of `IOException`.
-   * This function is used by `read()` and `read(buf, off, len)` functions. It tries to run
-   * `readFn` and in case of `IOException`:
-   *   1. If it gets an EOFException, return -1
-   *   2. Else, run `onReadFailure` and retry running `readFn`. If it fails again,
-   *   we run `onReadFailure` and re-throw the error.
-   * @param readFn the function to read, it must return an integer
-   * @param length length of data being attempted to read
-   * @return -1 if `readFn` throws EOFException, else returns int value from the result of `readFn`
-   * @throws IOException if retry of `readFn` also fails with `IOException`
-   */
-  private int retryReadOnce(CheckedIntSupplier readFn, int length) throws IOException {
-    try {
-      return readFn.get();
-    } catch (EOFException e) {
-      return -1;
-    } catch (IOException e) {
-      onReadFailure(e, length, e instanceof SocketTimeoutException);
-      try {
-        return readFn.get();
-      } catch (EOFException eof) {
-        return -1;
-      } catch (IOException ioe) {
-        onReadFailure(e, length, e instanceof SocketTimeoutException);
-        throw ioe;
-      }
-    }
-  }
-
   @Override
   @Retries.RetryTranslated  // Some retries only happen w/ S3Guard, as intended.
   public synchronized int read() throws IOException {
@@ -451,8 +416,21 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     // certainly could.
     Invoker invoker = context.getReadInvoker();
     int byteRead = invoker.retry("read", pathStr, true,
-      () -> retryReadOnce(() -> wrappedStream.read(), 1)
-    );
+        () -> {
+          int b;
+          try {
+            b = wrappedStream.read();
+          } catch (EOFException e) {
+            return -1;
+          } catch (SocketTimeoutException e) {
+            onReadFailure(e, 1, true);
+            throw e;
+          } catch (IOException e) {
+            onReadFailure(e, 1, false);
+            throw e;
+          }
+          return b;
+        });
 
     if (byteRead >= 0) {
       pos++;
@@ -526,8 +504,22 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
 
     streamStatistics.readOperationStarted(nextReadPos, len);
     int bytesRead = invoker.retry("read", pathStr, true,
-      () -> retryReadOnce(() -> wrappedStream.read(buf, off, len), len)
-    );
+        () -> {
+          int bytes;
+          try {
+            bytes = wrappedStream.read(buf, off, len);
+          } catch (EOFException e) {
+            // the base implementation swallows EOFs.
+            return -1;
+          } catch (SocketTimeoutException e) {
+            onReadFailure(e, len, true);
+            throw e;
+          } catch (IOException e) {
+            onReadFailure(e, len, false);
+            throw e;
+          }
+          return bytes;
+        });
 
     if (bytesRead > 0) {
       pos += bytesRead;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -102,7 +102,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
 
       @Override
       public GetObjectRequest newGetRequest(String key) {
-        return fs.getRequestFactory().newGetObjectRequest(key);
+        return new GetObjectRequest(fs.getBucket(), key);
       }
 
       @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -41,9 +41,10 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests S3AInputStream retry behavior on read failure.
- * These tests are for validating expected behavior of retrying the S3AInputStream
- * read() and read(b, off, len), it tests that the read should reopen the input stream and retry
- * the read when IOException is thrown during the read process.
+ * These tests are for validating expected behavior of retrying the
+ * S3AInputStream read() and read(b, off, len), it tests that the read should
+ * reopen the input stream and retry the read when IOException is thrown
+ * during the read process.
  */
 public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
 
@@ -65,7 +66,8 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
     S3AInputStream s3AInputStream = getMockedS3AInputStream();
     s3AInputStream.read(result, 0, INPUT.length());
 
-    assertArrayEquals("The read result should equals to the test input stream content",
+    assertArrayEquals(
+        "The read result should equals to the test input stream content",
         INPUT.getBytes(), result);
   }
 
@@ -75,7 +77,8 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
     S3AInputStream s3AInputStream = getMockedS3AInputStream();
     s3AInputStream.readFully(0, result);
 
-    assertArrayEquals("The read result should equals to the test input stream content",
+    assertArrayEquals(
+        "The read result should equals to the test input stream content",
         INPUT.getBytes(), result);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -140,7 +140,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
     };
   }
 
-  // Get mocked S3ObjectInputStream where we can trigger IOException to sumulate the read failure
+  // Get mocked S3ObjectInputStream where we can trigger IOException to simulate the read failure
   private S3ObjectInputStream getMockedInputStream(boolean triggerFailure) {
     return new S3ObjectInputStream(IOUtils.toInputStream(input, Charset.defaultCharset()), null) {
       final IOException exception = new SSLException(new SocketException("Connection reset"));

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.net.SocketException;
+import java.nio.charset.Charset;
+
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.junit.Test;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.audit.impl.NoopSpan;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
+import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
+
+import static java.lang.Math.min;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests S3AInputStream retry behavior on read failure.
+ * These tests are for validating expected behavior of retrying the S3AInputStream
+ * read() and read(b, off, len), it tests that the read should reopen the input stream and retry
+ * the read when IOException is thrown during the read process.
+ */
+public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
+
+  String input = "ab";
+
+  @Test
+  public void testInputStreamReadRetryForException() throws IOException {
+    S3AInputStream s3AInputStream = getMockedS3AInputStream();
+
+    assertEquals("'a' from the test input stream 'ab' should be the first character being read",
+        input.charAt(0), s3AInputStream.read());
+    assertEquals("'b' from the test input stream 'ab' should be the second character being read",
+        input.charAt(1), s3AInputStream.read());
+  }
+
+  @Test
+  public void testInputStreamReadRetryLengthForException() throws IOException {
+    byte[] result = new byte[input.length()];
+    S3AInputStream s3AInputStream = getMockedS3AInputStream();
+    s3AInputStream.read(result, 0, input.length());
+
+    assertArrayEquals("The read result should equals to the test input stream content",
+        input.getBytes(), result);
+  }
+
+  private S3AInputStream getMockedS3AInputStream() {
+    Path path = new Path("test-path");
+    String eTag = "test-etag";
+    String versionId = "test-version-id";
+    String owner = "test-owner";
+
+    S3AFileStatus s3AFileStatus = new S3AFileStatus(
+        input.length(), 0, path, input.length(), owner, eTag, versionId);
+
+    S3ObjectAttributes s3ObjectAttributes = new S3ObjectAttributes(
+        fs.getBucket(), path, fs.pathToKey(path), fs.getServerSideEncryptionAlgorithm(),
+        new EncryptionSecrets().getEncryptionKey(), eTag, versionId, input.length());
+
+    S3AReadOpContext s3AReadOpContext = fs.createReadContext(s3AFileStatus, S3AInputPolicy.Normal,
+        ChangeDetectionPolicy.getPolicy(fs.getConf()), 100, NoopSpan.INSTANCE);
+
+    return new S3AInputStream(s3AReadOpContext, s3ObjectAttributes, getMockedInputStreamCallback());
+  }
+
+  // Get mocked InputStreamCallbacks where we return mocked S3Object
+  private S3AInputStream.InputStreamCallbacks getMockedInputStreamCallback() {
+    return new S3AInputStream.InputStreamCallbacks() {
+
+      final S3Object mockedS3Object = getMockedS3Object();
+
+      @Override
+      public S3Object getObject(GetObjectRequest request) {
+        // Set s3 client to return mocked s3object with already defined read behavior
+        return mockedS3Object;
+      }
+
+      @Override
+      public GetObjectRequest newGetRequest(String key) {
+        return fs.getRequestFactory().newGetObjectRequest(key);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  // Get mocked S3Object where return bad input stream on the first couple of getObjectContent calls
+  private S3Object getMockedS3Object() {
+    S3ObjectInputStream objectInputStreamBad1 = getMockedInputStream(true);
+    S3ObjectInputStream objectInputStreamBad2 = getMockedInputStream(true);
+    S3ObjectInputStream objectInputStreamGood = getMockedInputStream(false);
+
+    return new S3Object() {
+      final S3ObjectInputStream[] inputStreams =
+          {objectInputStreamBad1, objectInputStreamBad2, objectInputStreamGood};
+
+      Integer inputStreamIndex = 0;
+
+      @Override
+      public S3ObjectInputStream getObjectContent() {
+        // Set getObjectContent behavior: returns bad stream twice, and good stream afterwards
+        inputStreamIndex++;
+        return inputStreams[min(inputStreamIndex, inputStreams.length) - 1];
+      }
+
+      @Override
+      public ObjectMetadata getObjectMetadata() {
+        // Set getObjectMetadata behavior: returns dummy metadata
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setHeader("ETag", "test-etag");
+        return metadata;
+      }
+    };
+  }
+
+  // Get mocked S3ObjectInputStream where we can trigger IOException to sumulate the read failure
+  private S3ObjectInputStream getMockedInputStream(boolean triggerFailure) {
+    return new S3ObjectInputStream(IOUtils.toInputStream(input, Charset.defaultCharset()), null) {
+      final IOException exception = new SSLException(new SocketException("Connection reset"));
+
+      @Override
+      public int read() throws IOException {
+        int result = super.read();
+        if (triggerFailure) {
+          throw exception;
+        }
+        return result;
+      }
+
+      @Override
+      public int read(byte[] b, int off, int len) throws IOException {
+        int result = super.read(b, off, len);
+        if (triggerFailure) {
+          throw exception;
+        }
+        return result;
+      }
+    };
+  }
+}


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
