### PR TITLE
YARN-10829. Support getApplications API in FederationClientInterceptor

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/GetApplicationsResponse.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/GetApplicationsResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.yarn.api.protocolrecords;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -49,6 +51,16 @@ public abstract class GetApplicationsResponse {
     GetApplicationsResponse response =
         Records.newRecord(GetApplicationsResponse.class);
     response.setApplicationList(applications);
+    return response;
+  }
+
+  @Private
+  @Unstable
+  public static GetApplicationsResponse newInstance(
+      Collection<ApplicationReport> applications) {
+    GetApplicationsResponse response =
+        Records.newRecord(GetApplicationsResponse.class);
+    response.setApplicationList(new ArrayList<>(applications));
     return response;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3991,6 +3991,15 @@ public class YarnConfiguration extends Configuration {
       ROUTER_PREFIX + "submit.retry";
   public static final int DEFAULT_ROUTER_CLIENTRM_SUBMIT_RETRY = 3;
 
+  /**
+   * The interceptor class used in FederationClientInterceptor should return
+   * partial ApplicationReports.
+   */
+  public static final String ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED =
+          ROUTER_PREFIX + "partial-result.enabled";
+  public static final boolean DEFAULT_ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED =
+          false;
+
   public static final String ROUTER_WEBAPP_PREFIX = ROUTER_PREFIX + "webapp.";
 
   public static final String ROUTER_USER_CLIENT_THREADS_SIZE =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
@@ -185,6 +185,8 @@ public class TestYarnConfigurationFields extends TestConfigurationFieldsBase {
     configurationPrefixToSkipCompare
         .add(YarnConfiguration.ROUTER_CLIENTRM_SUBMIT_RETRY);
     configurationPrefixToSkipCompare
+            .add(YarnConfiguration.ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
+    configurationPrefixToSkipCompare
         .add(YarnConfiguration.ROUTER_WEBAPP_PARTIAL_RESULTS_ENABLED);
     configurationPrefixToSkipCompare
         .add(YarnConfiguration.ROUTER_WEBAPP_CONNECT_TIMEOUT);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
@@ -185,7 +185,7 @@ public class TestYarnConfigurationFields extends TestConfigurationFieldsBase {
     configurationPrefixToSkipCompare
         .add(YarnConfiguration.ROUTER_CLIENTRM_SUBMIT_RETRY);
     configurationPrefixToSkipCompare
-            .add(YarnConfiguration.ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
+        .add(YarnConfiguration.ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
     configurationPrefixToSkipCompare
         .add(YarnConfiguration.ROUTER_WEBAPP_PARTIAL_RESULTS_ENABLED);
     configurationPrefixToSkipCompare

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -199,7 +199,7 @@ public class FederationClientInterceptor
         new ConcurrentHashMap<SubClusterId, ApplicationClientProtocol>();
     routerMetrics = RouterMetrics.getMetrics();
 
-    returnPartialReport  = conf.getBoolean(
+    returnPartialReport = conf.getBoolean(
         YarnConfiguration.ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED,
         YarnConfiguration.DEFAULT_ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
   }
@@ -715,6 +715,7 @@ public class FederationClientInterceptor
     }
     return results;
   }
+
   <R> Map<SubClusterId, R> invokeConcurrent(Collection<SubClusterId> clusterIds,
       ClientMethod request, Class<R> clazz) throws YarnException, IOException {
     ArrayList<SubClusterId> clusterIdList = new ArrayList<>(clusterIds);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFact
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -635,9 +636,8 @@ public class FederationClientInterceptor
         federationFacade.getSubClusters(true);
     ClientMethod remoteMethod = new ClientMethod("getApplications",
         new Class[] {GetApplicationsRequest.class}, new Object[] {request});
-    ArrayList<SubClusterId> clusterIds = new ArrayList<>(subclusters.keySet());
     Map<SubClusterId, GetApplicationsResponse> applications =
-        invokeConcurrent(clusterIds, remoteMethod,
+        invokeConcurrent(subclusters.keySet(), remoteMethod,
             GetApplicationsResponse.class);
 
     // Merge the Application Reports
@@ -714,6 +714,11 @@ public class FederationClientInterceptor
       throw new YarnException(e);
     }
     return results;
+  }
+  <R> Map<SubClusterId, R> invokeConcurrent(Collection<SubClusterId> clusterIds,
+      ClientMethod request, Class<R> clazz) throws YarnException, IOException {
+    ArrayList<SubClusterId> clusterIdList = new ArrayList<>(clusterIds);
+    return invokeConcurrent(clusterIdList, request, clazz);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -198,12 +198,9 @@ public class FederationClientInterceptor
         new ConcurrentHashMap<SubClusterId, ApplicationClientProtocol>();
     routerMetrics = RouterMetrics.getMetrics();
 
-    returnPartialReport =
-            conf.getBoolean(
-                    YarnConfiguration
-                            .ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED,
-                    YarnConfiguration
-                            .DEFAULT_ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
+    returnPartialReport  = conf.getBoolean(
+        YarnConfiguration.ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED,
+        YarnConfiguration.DEFAULT_ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
   }
 
   @Override
@@ -631,21 +628,21 @@ public class FederationClientInterceptor
       throws YarnException, IOException {
     if (request == null) {
       RouterServerUtil.logAndThrowException(
-              "Missing getApplications request.",
-              null);
+          "Missing getApplications request.",
+          null);
     }
     Map<SubClusterId, SubClusterInfo> subclusters =
-            federationFacade.getSubClusters(true);
+        federationFacade.getSubClusters(true);
     ClientMethod remoteMethod = new ClientMethod("getApplications",
-            new Class[] {GetApplicationsRequest.class}, new Object[] {request});
+        new Class[] {GetApplicationsRequest.class}, new Object[] {request});
     ArrayList<SubClusterId> clusterIds = new ArrayList<>(subclusters.keySet());
     Map<SubClusterId, GetApplicationsResponse> applications =
-            invokeConcurrent(clusterIds, remoteMethod,
-                    GetApplicationsResponse.class);
+        invokeConcurrent(clusterIds, remoteMethod,
+            GetApplicationsResponse.class);
 
-    //Merge the Application Reports
+    // Merge the Application Reports
     return RouterYarnClientUtils.mergeApplications(applications.values(),
-            returnPartialReport);
+        returnPartialReport);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -199,8 +199,11 @@ public class FederationClientInterceptor
     routerMetrics = RouterMetrics.getMetrics();
 
     returnPartialReport =
-            conf.getBoolean(YarnConfiguration.ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED,
-                    YarnConfiguration.DEFAULT_ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
+            conf.getBoolean(
+                    YarnConfiguration
+                            .ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED,
+                    YarnConfiguration
+                            .DEFAULT_ROUTER_CLIENTRM_PARTIAL_RESULTS_ENABLED);
   }
 
   @Override
@@ -641,7 +644,8 @@ public class FederationClientInterceptor
                     GetApplicationsResponse.class);
 
     //Merge the Application Reports
-    return RouterYarnClientUtils.mergeApplications(applications.values(), returnPartialReport);
+    return RouterYarnClientUtils.mergeApplications(applications.values(),
+            returnPartialReport);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -109,7 +109,6 @@ public final class RouterYarnClientUtils {
         }
       }
     }
-    
     // Check the remaining UAMs are depending or not from federation
     for (ApplicationReport appReport : federationUAMSum.values()) {
       if (returnPartialResult || appReport.getName() != null

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -67,15 +67,17 @@ public final class RouterYarnClientUtils {
   }
 
   /**
-   * Merges a list of ApplicationReports grouping by ApplicationId. Our current policy is
-   * to merge the application reports from the reachable SubClusters.
+   * Merges a list of ApplicationReports grouping by ApplicationId.
+   * Our current policy is to merge the application reports from the reachable
+   * SubClusters.
    * @param responses a list of ApplicationResponse to merge
-   * @param returnPartialResult if the merge ApplicationReports should contain partial
-   * result or not
+   * @param returnPartialResult if the merge ApplicationReports should contain
+   * partial result or not
    * @return the merged ApplicationsResponse
    */
   public static GetApplicationsResponse mergeApplications(
-          Collection<GetApplicationsResponse> responses, boolean returnPartialResult){
+          Collection<GetApplicationsResponse> responses,
+          boolean returnPartialResult){
     Map<ApplicationId, ApplicationReport> federationAM = new HashMap<>();
     Map<ApplicationId, ApplicationReport> federationUAMSum = new HashMap<>();
 
@@ -112,8 +114,10 @@ public final class RouterYarnClientUtils {
     // Check the remaining UAMs are depending or not from federation
     for (ApplicationReport appReport : federationUAMSum.values()) {
       if (returnPartialResult || appReport.getName() != null
-              && !(appReport.getName().startsWith(UnmanagedApplicationManager.APP_NAME)
-              || appReport.getName().startsWith(PARTIAL_REPORT))) {
+              && !(appReport.getName()
+              .startsWith(UnmanagedApplicationManager.APP_NAME)
+              || appReport.getName()
+              .startsWith(PARTIAL_REPORT))) {
         federationAM.put(appReport.getApplicationId(), appReport);
       }
     }
@@ -122,33 +126,49 @@ public final class RouterYarnClientUtils {
     return GetApplicationsResponse.newInstance(appList);
   }
 
-  private static ApplicationReport mergeUAMWithUAM(ApplicationReport uam1, ApplicationReport uam2){
+  private static ApplicationReport mergeUAMWithUAM(ApplicationReport uam1,
+                                                   ApplicationReport uam2){
     uam1.setName(PARTIAL_REPORT + uam1.getApplicationId());
     mergeAMWithUAM(uam1, uam1);
     mergeAMWithUAM(uam1, uam2);
     return uam1;
   }
 
-  private static void mergeAMWithUAM(ApplicationReport am, ApplicationReport uam){
-    ApplicationResourceUsageReport resourceUsageReport = am.getApplicationResourceUsageReport();
+  private static void mergeAMWithUAM(ApplicationReport am,
+                                     ApplicationReport uam){
+    ApplicationResourceUsageReport resourceUsageReport =
+            am.getApplicationResourceUsageReport();
     resourceUsageReport.setNumUsedContainers(
-            resourceUsageReport.getNumUsedContainers() + uam.getApplicationResourceUsageReport().getNumUsedContainers());
+            resourceUsageReport.getNumUsedContainers() +
+                    uam.getApplicationResourceUsageReport()
+                            .getNumUsedContainers());
     resourceUsageReport.setNumReservedContainers(
-            resourceUsageReport.getNumReservedContainers() + uam.getApplicationResourceUsageReport().getNumReservedContainers());
-    resourceUsageReport.setUsedResources(Resources.add(resourceUsageReport.getUsedResources(),
+            resourceUsageReport.getNumReservedContainers() +
+                    uam.getApplicationResourceUsageReport()
+                            .getNumReservedContainers());
+    resourceUsageReport.setUsedResources(Resources.add(
+            resourceUsageReport.getUsedResources(),
             uam.getApplicationResourceUsageReport().getUsedResources()));
-    resourceUsageReport.setReservedResources(Resources.add(resourceUsageReport.getReservedResources(),
+    resourceUsageReport.setReservedResources(Resources.add(
+            resourceUsageReport.getReservedResources(),
             uam.getApplicationResourceUsageReport().getReservedResources()));
-    resourceUsageReport.setNeededResources(Resources.add(resourceUsageReport.getNeededResources(),
+    resourceUsageReport.setNeededResources(Resources.add(
+            resourceUsageReport.getNeededResources(),
             uam.getApplicationResourceUsageReport().getNeededResources()));
     resourceUsageReport.setMemorySeconds(
-            resourceUsageReport.getMemorySeconds() + uam.getApplicationResourceUsageReport().getMemorySeconds());
+            resourceUsageReport.getMemorySeconds() +
+                    uam.getApplicationResourceUsageReport().getMemorySeconds());
     resourceUsageReport.setVcoreSeconds(
-            resourceUsageReport.getVcoreSeconds() + uam.getApplicationResourceUsageReport().getVcoreSeconds());
+            resourceUsageReport.getVcoreSeconds() +
+                    uam.getApplicationResourceUsageReport().getVcoreSeconds());
     resourceUsageReport.setQueueUsagePercentage(
-            resourceUsageReport.getQueueUsagePercentage() + uam.getApplicationResourceUsageReport().getQueueUsagePercentage());
+            resourceUsageReport.getQueueUsagePercentage() +
+                    uam.getApplicationResourceUsageReport()
+                            .getQueueUsagePercentage());
     resourceUsageReport.setClusterUsagePercentage(
-            resourceUsageReport.getClusterUsagePercentage() + uam.getApplicationResourceUsageReport().getClusterUsagePercentage());
+            resourceUsageReport.getClusterUsagePercentage() +
+                    uam.getApplicationResourceUsageReport()
+                            .getClusterUsagePercentage());
     am.getApplicationTags().addAll(uam.getApplicationTags());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -170,7 +170,6 @@ public final class RouterYarnClientUtils {
             uamResourceReport.getClusterUsagePercentage());
 
     am.setApplicationResourceUsageReport(amResourceReport);
-    am.getApplicationTags().addAll(uam.getApplicationTags());
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -99,8 +99,9 @@ public final class RouterYarnClientUtils {
           mergeAMWithUAM(federationAM.get(appId), appReport);
         } else if (federationUAMSum.containsKey(appId)) {
           // Merge the current UAM with its own UAM and update the list of UAM
-          federationUAMSum.put(appId,
-              mergeUAMWithUAM(federationUAMSum.get(appId), appReport));
+          ApplicationReport mergedUAMReport =
+              mergeUAMWithUAM(federationUAMSum.get(appId), appReport);
+          federationUAMSum.put(appId, mergedUAMReport);
         } else {
           // Insert in the list of UAM
           federationUAMSum.put(appId, appReport);
@@ -180,9 +181,13 @@ public final class RouterYarnClientUtils {
    */
   private static boolean mergeUamToReport(String appName,
       boolean returnPartialResult){
-
-    return returnPartialResult || (appName != null &&
-        !(appName.startsWith(UnmanagedApplicationManager.APP_NAME) ||
-            appName.startsWith(PARTIAL_REPORT)));
+    if (returnPartialResult) {
+      return true;
+    }
+    if (appName == null) {
+      return false;
+    }
+    return !(appName.startsWith(UnmanagedApplicationManager.APP_NAME) ||
+        appName.startsWith(PARTIAL_REPORT));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -83,7 +83,7 @@ public final class RouterYarnClientUtils {
       for (ApplicationReport appReport : appResponse.getApplicationList()){
         ApplicationId appId = appReport.getApplicationId();
         // Check if this ApplicationReport is an AM
-        if (appReport.getHost() != null) {
+        if (!appReport.isUnmanagedApp()) {
           // Insert in the list of AM
           federationAM.put(appId, appReport);
           // Check if there are any UAM found before

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -121,7 +121,6 @@ public final class RouterYarnClientUtils {
   private static ApplicationReport mergeUAMWithUAM(ApplicationReport uam1,
       ApplicationReport uam2){
     uam1.setName(PARTIAL_REPORT + uam1.getApplicationId());
-    mergeAMWithUAM(uam1, uam1);
     mergeAMWithUAM(uam1, uam2);
     return uam1;
   }
@@ -170,6 +169,7 @@ public final class RouterYarnClientUtils {
         amResourceReport.getClusterUsagePercentage() +
             uamResourceReport.getClusterUsagePercentage());
 
+    am.setApplicationResourceUsageReport(amResourceReport);
     am.getApplicationTags().addAll(uam.getApplicationTags());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -17,14 +17,27 @@
  */
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport;
 import org.apache.hadoop.yarn.api.records.YarnClusterMetrics;
+import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
+import org.apache.hadoop.yarn.util.resource.Resources;
 
 /**
  * Util class for Router Yarn client API calls.
  */
 public final class RouterYarnClientUtils {
+
+  private final static String PARTIAL_REPORT = "Partial Report ";
 
   private RouterYarnClientUtils() {
 
@@ -51,5 +64,92 @@ public final class RouterYarnClientUtils {
               .getNumUnhealthyNodeManagers());
     }
     return GetClusterMetricsResponse.newInstance(tmp);
+  }
+
+  /**
+   * Merges a list of ApplicationReports grouping by ApplicationId. Our current policy is
+   * to merge the application reports from the reachable SubClusters.
+   * @param responses a list of ApplicationResponse to merge
+   * @param returnPartialResult if the merge ApplicationReports should contain partial
+   * result or not
+   * @return the merged ApplicationsResponse
+   */
+  public static GetApplicationsResponse mergeApplications(
+          Collection<GetApplicationsResponse> responses, boolean returnPartialResult){
+    Map<ApplicationId, ApplicationReport> federationAM = new HashMap<>();
+    Map<ApplicationId, ApplicationReport> federationUAMSum = new HashMap<>();
+
+    for(GetApplicationsResponse appResponse : responses){
+      for(ApplicationReport appReport : appResponse.getApplicationList()){
+        ApplicationId appId = appReport.getApplicationId();
+        // Check if this ApplicationReport is an AM
+        if (appReport.getHost() != null) {
+          // Insert in the list of AM
+          federationAM.put(appId, appReport);
+          // Check if there are any UAM found before
+          if (federationUAMSum.containsKey(appId)) {
+            // Merge the current AM with the found UAM
+            mergeAMWithUAM(appReport, federationUAMSum.get(appId));
+            // Remove the sum of the UAMs
+            federationUAMSum.remove(appId);
+          }
+          // This ApplicationReport is an UAM
+        } else {
+          if (federationAM.containsKey(appId)) {
+            // Merge the current UAM with its own AM
+            mergeAMWithUAM(federationAM.get(appId), appReport);
+          } else if (federationUAMSum.containsKey(appId)) {
+            // Merge the current UAM with its own UAM and update the list of UAM
+            federationUAMSum.put(appId,
+                    mergeUAMWithUAM(federationUAMSum.get(appId), appReport));
+          } else {
+            // Insert in the list of UAM
+            federationUAMSum.put(appId, appReport);
+          }
+        }
+      }
+    }
+    
+    // Check the remaining UAMs are depending or not from federation
+    for (ApplicationReport appReport : federationUAMSum.values()) {
+      if (returnPartialResult || appReport.getName() != null
+              && !(appReport.getName().startsWith(UnmanagedApplicationManager.APP_NAME)
+              || appReport.getName().startsWith(PARTIAL_REPORT))) {
+        federationAM.put(appReport.getApplicationId(), appReport);
+      }
+    }
+
+    List<ApplicationReport> appList = new ArrayList<>(federationAM.values());
+    return GetApplicationsResponse.newInstance(appList);
+  }
+
+  private static ApplicationReport mergeUAMWithUAM(ApplicationReport uam1, ApplicationReport uam2){
+    uam1.setName(PARTIAL_REPORT + uam1.getApplicationId());
+    mergeAMWithUAM(uam1, uam1);
+    mergeAMWithUAM(uam1, uam2);
+    return uam1;
+  }
+
+  private static void mergeAMWithUAM(ApplicationReport am, ApplicationReport uam){
+    ApplicationResourceUsageReport resourceUsageReport = am.getApplicationResourceUsageReport();
+    resourceUsageReport.setNumUsedContainers(
+            resourceUsageReport.getNumUsedContainers() + uam.getApplicationResourceUsageReport().getNumUsedContainers());
+    resourceUsageReport.setNumReservedContainers(
+            resourceUsageReport.getNumReservedContainers() + uam.getApplicationResourceUsageReport().getNumReservedContainers());
+    resourceUsageReport.setUsedResources(Resources.add(resourceUsageReport.getUsedResources(),
+            uam.getApplicationResourceUsageReport().getUsedResources()));
+    resourceUsageReport.setReservedResources(Resources.add(resourceUsageReport.getReservedResources(),
+            uam.getApplicationResourceUsageReport().getReservedResources()));
+    resourceUsageReport.setNeededResources(Resources.add(resourceUsageReport.getNeededResources(),
+            uam.getApplicationResourceUsageReport().getNeededResources()));
+    resourceUsageReport.setMemorySeconds(
+            resourceUsageReport.getMemorySeconds() + uam.getApplicationResourceUsageReport().getMemorySeconds());
+    resourceUsageReport.setVcoreSeconds(
+            resourceUsageReport.getVcoreSeconds() + uam.getApplicationResourceUsageReport().getVcoreSeconds());
+    resourceUsageReport.setQueueUsagePercentage(
+            resourceUsageReport.getQueueUsagePercentage() + uam.getApplicationResourceUsageReport().getQueueUsagePercentage());
+    resourceUsageReport.setClusterUsagePercentage(
+            resourceUsageReport.getClusterUsagePercentage() + uam.getApplicationResourceUsageReport().getClusterUsagePercentage());
+    am.getApplicationTags().addAll(uam.getApplicationTags());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -22,16 +22,20 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
-
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.MockApps;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationRequest;
@@ -40,11 +44,12 @@ import org.apache.hadoop.yarn.api.protocolrecords.KillApplicationRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.KillApplicationResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationResponse;
-import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.manager.UniformBroadcastPolicyManager;
@@ -530,5 +535,106 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         invokeConcurrent(new ArrayList<>(), remoteMethod,
             GetClusterMetricsResponse.class);
     Assert.assertEquals(true, clusterMetrics.isEmpty());
+  }
+
+  /**
+   * This test validates the correctness of
+   * GetApplicationsResponse in case the
+   * application exists in the cluster.
+   */
+  @Test
+  public void testGetApplicationsResponse()
+          throws YarnException, IOException, InterruptedException {
+    LOG.info("Test FederationClientInterceptor: " +
+            "Get Applications Response");
+    ApplicationId appId =
+            ApplicationId.newInstance(System.currentTimeMillis(), 1);
+
+    SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
+    SubmitApplicationResponse response = interceptor.submitApplication(request);
+
+    Assert.assertNotNull(response);
+    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+
+    Set<String> appTypes = Collections.singleton("MockApp");
+    GetApplicationsRequest requestGet =
+            GetApplicationsRequest.newInstance(appTypes);
+
+    GetApplicationsResponse responseGet =
+            interceptor.getApplications(requestGet);
+
+    Assert.assertNotNull(responseGet);
+  }
+
+  /**
+   * This test validates
+   * the correctness of GetApplicationsResponse in case of
+   * empty request.
+   */
+  @Test
+  public void testGetApplicationsNullRequest() throws Exception {
+    LOG.info("Test FederationClientInterceptor : Get Applications request");
+    LambdaTestUtils.intercept(YarnException.class,
+            "Missing getApplications request.",
+            () -> interceptor.getApplications(null));
+  }
+
+  /**
+   * This test validates
+   * the correctness of GetApplicationsResponse in case applications
+   * with given type does not exist.
+   */
+  @Test
+  public void testGetApplicationsApplicationTypeNotExists() throws Exception{
+    LOG.info("Test FederationClientInterceptor : Application with type does not exist");
+
+    ApplicationId appId =
+            ApplicationId.newInstance(System.currentTimeMillis(), 1);
+
+    SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
+    SubmitApplicationResponse response = interceptor.submitApplication(request);
+
+    Assert.assertNotNull(response);
+    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+
+    Set<String> appTypes = Collections.singleton("SPARK");
+
+    GetApplicationsResponse responseGet =
+            interceptor.getApplications(
+                    GetApplicationsRequest.
+                            newInstance(appTypes));
+
+    Assert.assertNotNull(responseGet);
+    Assert.assertEquals(0, responseGet.getApplicationList().size());
+  }
+
+  /**
+   * This test validates
+   * the correctness of GetApplicationsResponse in case applications
+   * with given YarnApplicationState does not exist.
+   */
+  @Test
+  public void testGetApplicationsApplicationStateNotExists() throws Exception{
+    LOG.info("Test FederationClientInterceptor : Application with state does not exist");
+
+    ApplicationId appId =
+            ApplicationId.newInstance(System.currentTimeMillis(), 1);
+
+    SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
+    SubmitApplicationResponse response = interceptor.submitApplication(request);
+
+    Assert.assertNotNull(response);
+    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+
+    EnumSet<YarnApplicationState> applicationStates = EnumSet.noneOf(YarnApplicationState.class);
+    applicationStates.add(YarnApplicationState.KILLED);
+
+    GetApplicationsResponse responseGet =
+            interceptor.getApplications(
+                    GetApplicationsRequest.
+                            newInstance(applicationStates));
+    
+    Assert.assertNotNull(responseGet);
+    Assert.assertEquals(0, responseGet.getApplicationList().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -633,7 +633,6 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
             interceptor.getApplications(
                     GetApplicationsRequest.
                             newInstance(applicationStates));
-    
     Assert.assertNotNull(responseGet);
     Assert.assertEquals(0, responseGet.getApplicationList().size());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -544,11 +544,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
    */
   @Test
   public void testGetApplicationsResponse()
-          throws YarnException, IOException, InterruptedException {
+      throws YarnException, IOException, InterruptedException {
     LOG.info("Test FederationClientInterceptor: " +
-            "Get Applications Response");
+        "Get Applications Response");
     ApplicationId appId =
-            ApplicationId.newInstance(System.currentTimeMillis(), 1);
+        ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
@@ -558,10 +558,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     Set<String> appTypes = Collections.singleton("MockApp");
     GetApplicationsRequest requestGet =
-            GetApplicationsRequest.newInstance(appTypes);
+        GetApplicationsRequest.newInstance(appTypes);
 
     GetApplicationsResponse responseGet =
-            interceptor.getApplications(requestGet);
+        interceptor.getApplications(requestGet);
 
     Assert.assertNotNull(responseGet);
   }
@@ -575,7 +575,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
   public void testGetApplicationsNullRequest() throws Exception {
     LOG.info("Test FederationClientInterceptor : Get Applications request");
     LambdaTestUtils.intercept(YarnException.class,
-            "Missing getApplications request.",
+        "Missing getApplications request.",
         () -> interceptor.getApplications(null));
   }
 
@@ -600,13 +600,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     Set<String> appTypes = Collections.singleton("SPARK");
 
+    GetApplicationsRequest requestGet =
+        GetApplicationsRequest.newInstance(appTypes);
+
     GetApplicationsResponse responseGet =
-            interceptor.getApplications(
-                    GetApplicationsRequest.
-                            newInstance(appTypes));
+            interceptor.getApplications(requestGet);
 
     Assert.assertNotNull(responseGet);
-    Assert.assertEquals(0, responseGet.getApplicationList().size());
+    Assert.assertTrue(responseGet.getApplicationList().isEmpty());
   }
 
   /**
@@ -632,10 +633,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
             YarnApplicationState.class);
     applicationStates.add(YarnApplicationState.KILLED);
 
+    GetApplicationsRequest requestGet =
+        GetApplicationsRequest.newInstance(applicationStates);
+
     GetApplicationsResponse responseGet =
-            interceptor.getApplications(
-                    GetApplicationsRequest.
-                            newInstance(applicationStates));
+            interceptor.getApplications(requestGet);
+
     Assert.assertNotNull(responseGet);
     Assert.assertEquals(0, responseGet.getApplicationList().size());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -545,8 +545,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
   @Test
   public void testGetApplicationsResponse()
       throws YarnException, IOException, InterruptedException {
-    LOG.info("Test FederationClientInterceptor: " +
-        "Get Applications Response");
+    LOG.info("Test FederationClientInterceptor: Get Applications Response");
     ApplicationId appId =
         ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
@@ -573,7 +572,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
    */
   @Test
   public void testGetApplicationsNullRequest() throws Exception {
-    LOG.info("Test FederationClientInterceptor : Get Applications request");
+    LOG.info("Test FederationClientInterceptor: Get Applications request");
     LambdaTestUtils.intercept(YarnException.class,
         "Missing getApplications request.",
         () -> interceptor.getApplications(null));
@@ -586,11 +585,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
    */
   @Test
   public void testGetApplicationsApplicationTypeNotExists() throws Exception{
-    LOG.info("Test FederationClientInterceptor :" +
-            " Application with type does not exist");
+    LOG.info("Test FederationClientInterceptor: Application with type does "
+        + "not exist");
 
     ApplicationId appId =
-            ApplicationId.newInstance(System.currentTimeMillis(), 1);
+        ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
@@ -604,7 +603,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationsRequest.newInstance(appTypes);
 
     GetApplicationsResponse responseGet =
-            interceptor.getApplications(requestGet);
+        interceptor.getApplications(requestGet);
 
     Assert.assertNotNull(responseGet);
     Assert.assertTrue(responseGet.getApplicationList().isEmpty());
@@ -617,11 +616,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
    */
   @Test
   public void testGetApplicationsApplicationStateNotExists() throws Exception{
-    LOG.info("Test FederationClientInterceptor :" +
-            " Application with state does not exist");
+    LOG.info("Test FederationClientInterceptor:" +
+        " Application with state does not exist");
 
     ApplicationId appId =
-            ApplicationId.newInstance(System.currentTimeMillis(), 1);
+        ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
@@ -630,16 +629,16 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     EnumSet<YarnApplicationState> applicationStates = EnumSet.noneOf(
-            YarnApplicationState.class);
+        YarnApplicationState.class);
     applicationStates.add(YarnApplicationState.KILLED);
 
     GetApplicationsRequest requestGet =
         GetApplicationsRequest.newInstance(applicationStates);
 
     GetApplicationsResponse responseGet =
-            interceptor.getApplications(requestGet);
+        interceptor.getApplications(requestGet);
 
     Assert.assertNotNull(responseGet);
-    Assert.assertEquals(0, responseGet.getApplicationList().size());
+    Assert.assertTrue(responseGet.getApplicationList().isEmpty());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -576,7 +576,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     LOG.info("Test FederationClientInterceptor : Get Applications request");
     LambdaTestUtils.intercept(YarnException.class,
             "Missing getApplications request.",
-            () -> interceptor.getApplications(null));
+        () -> interceptor.getApplications(null));
   }
 
   /**
@@ -586,7 +586,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
    */
   @Test
   public void testGetApplicationsApplicationTypeNotExists() throws Exception{
-    LOG.info("Test FederationClientInterceptor : Application with type does not exist");
+    LOG.info("Test FederationClientInterceptor :" +
+            " Application with type does not exist");
 
     ApplicationId appId =
             ApplicationId.newInstance(System.currentTimeMillis(), 1);
@@ -615,7 +616,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
    */
   @Test
   public void testGetApplicationsApplicationStateNotExists() throws Exception{
-    LOG.info("Test FederationClientInterceptor : Application with state does not exist");
+    LOG.info("Test FederationClientInterceptor :" +
+            " Application with state does not exist");
 
     ApplicationId appId =
             ApplicationId.newInstance(System.currentTimeMillis(), 1);
@@ -626,7 +628,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     Assert.assertNotNull(response);
     Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
-    EnumSet<YarnApplicationState> applicationStates = EnumSet.noneOf(YarnApplicationState.class);
+    EnumSet<YarnApplicationState> applicationStates = EnumSet.noneOf(
+            YarnApplicationState.class);
     applicationStates.add(YarnApplicationState.KILLED);
 
     GetApplicationsResponse responseGet =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -77,7 +77,6 @@ public class TestRouterYarnClientUtils {
     ArrayList<GetApplicationsResponse> responses = new ArrayList<>();
     responses.add(getApplicationsResponse(1, false));
     responses.add(getApplicationsResponse(2, false));
-
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
     Assert.assertNotNull(result);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -75,50 +75,57 @@ public class TestRouterYarnClientUtils {
     responses.add(getApplicationsResponse(1));
     responses.add(getApplicationsResponse(2));
     GetApplicationsResponse result = RouterYarnClientUtils.
-            mergeApplications(responses, false);
+        mergeApplications(responses, false);
     Assert.assertNotNull(result);
     Assert.assertEquals(2, result.getApplicationList().size());
   }
 
+  /**
+   * This generates a GetApplicationsResponse with 2 applications with
+   * same ApplicationId. One of them is added with host value equal to
+   * null to validate unmanaged application merge with managed application.
+   * @param value Used as Id in ApplicationId
+   * @return GetApplicationsResponse
+   */
   private GetApplicationsResponse getApplicationsResponse(int value) {
     List<ApplicationReport> applications = new ArrayList<>();
 
     //Add managed application to list
-    ApplicationId applicationId = ApplicationId.newInstance(1234,
-            value);
+    ApplicationId appId = ApplicationId.newInstance(1234,
+        value);
     Resource resource = Resource.newInstance(1024, 1);
     ApplicationResourceUsageReport appResourceUsageReport =
-            ApplicationResourceUsageReport.newInstance(
-                    1, 2, resource, resource,
-                    resource, null, 0.1f,
-                    0.1f, null);
+        ApplicationResourceUsageReport.newInstance(
+            1, 2, resource, resource,
+            resource, null, 0.1f,
+            0.1f, null);
 
-    ApplicationReport newApplicationReport = ApplicationReport.newInstance(
-            applicationId, ApplicationAttemptId.newInstance(applicationId,
-                    1),
-            "user", "queue", "appname", "host",
-            124, null, YarnApplicationState.RUNNING,
-            "diagnostics", "url", 0, 0,
-            0, FinalApplicationStatus.SUCCEEDED,
-            appResourceUsageReport,
-            "N/A", 0.53789f, "YARN",
-            null);
+    ApplicationReport appReport = ApplicationReport.newInstance(
+        appId, ApplicationAttemptId.newInstance(appId,
+            1),
+        "user", "queue", "appname", "host",
+        124, null, YarnApplicationState.RUNNING,
+        "diagnostics", "url", 0, 0,
+        0, FinalApplicationStatus.SUCCEEDED,
+        appResourceUsageReport,
+        "N/A", 0.53789f, "YARN",
+        null);
 
     //Add unmanaged application to list
-    ApplicationId applicationId2 = ApplicationId.newInstance(1234,
-            value);
-    ApplicationReport newApplicationReport2 = ApplicationReport.newInstance(
-            applicationId2, ApplicationAttemptId.newInstance(applicationId,
-                    1),
-            "user", "queue", "appname", null, 124,
-            null, YarnApplicationState.RUNNING,
-            "diagnostics", "url", 0, 0,
-            0, FinalApplicationStatus.SUCCEEDED,
-            appResourceUsageReport, "N/A", 0.53789f,
-            "YARN", null);
+    ApplicationId appId2 = ApplicationId.newInstance(1234,
+        value);
+    ApplicationReport appReport2 = ApplicationReport.newInstance(
+        appId2, ApplicationAttemptId.newInstance(appId2,
+            1),
+        "user", "queue", "appname", null, 124,
+        null, YarnApplicationState.RUNNING,
+        "diagnostics", "url", 0, 0,
+        0, FinalApplicationStatus.SUCCEEDED,
+        appResourceUsageReport, "N/A", 0.53789f,
+        "YARN", null);
 
-    applications.add(newApplicationReport);
-    applications.add(newApplicationReport2);
+    applications.add(appReport);
+    applications.add(appReport2);
 
     return GetApplicationsResponse.newInstance(applications);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -74,38 +74,48 @@ public class TestRouterYarnClientUtils {
     ArrayList<GetApplicationsResponse> responses = new ArrayList<>();
     responses.add(getApplicationsResponse(1));
     responses.add(getApplicationsResponse(2));
-    GetApplicationsResponse result = RouterYarnClientUtils.mergeApplications(responses, false);
+    GetApplicationsResponse result = RouterYarnClientUtils.
+            mergeApplications(responses, false);
     Assert.assertNotNull(result);
-    Assert.assertEquals(2,result.getApplicationList().size() );
+    Assert.assertEquals(2, result.getApplicationList().size());
   }
 
   private GetApplicationsResponse getApplicationsResponse(int value) {
     List<ApplicationReport> applications = new ArrayList<>();
 
     //Add managed application to list
-    ApplicationId applicationId = ApplicationId.newInstance(1234, value);
+    ApplicationId applicationId = ApplicationId.newInstance(1234,
+            value);
     Resource resource = Resource.newInstance(1024, 1);
     ApplicationResourceUsageReport appResourceUsageReport =
             ApplicationResourceUsageReport.newInstance(
-                    1,2,resource, resource,
-                    resource, null, 0.1f,0.1f,
-                    null);
+                    1, 2, resource, resource,
+                    resource, null, 0.1f,
+                    0.1f, null);
 
     ApplicationReport newApplicationReport = ApplicationReport.newInstance(
-            applicationId, ApplicationAttemptId.newInstance(applicationId, 1),
-            "user", "queue", "appname", "host", 124, null,
-            YarnApplicationState.RUNNING, "diagnostics", "url", 0, 0,0,
-            FinalApplicationStatus.SUCCEEDED, appResourceUsageReport, "N/A", 0.53789f, "YARN",
+            applicationId, ApplicationAttemptId.newInstance(applicationId,
+                    1),
+            "user", "queue", "appname", "host",
+            124, null, YarnApplicationState.RUNNING,
+            "diagnostics", "url", 0, 0,
+            0, FinalApplicationStatus.SUCCEEDED,
+            appResourceUsageReport,
+            "N/A", 0.53789f, "YARN",
             null);
 
     //Add unmanaged application to list
-    ApplicationId applicationId2 = ApplicationId.newInstance(1234, value);
+    ApplicationId applicationId2 = ApplicationId.newInstance(1234,
+            value);
     ApplicationReport newApplicationReport2 = ApplicationReport.newInstance(
-            applicationId2, ApplicationAttemptId.newInstance(applicationId, 1),
-            "user", "queue", "appname", null, 124, null,
-            YarnApplicationState.RUNNING, "diagnostics", "url", 0,0, 0,
-            FinalApplicationStatus.SUCCEEDED, appResourceUsageReport, "N/A", 0.53789f, "YARN",
-            null);
+            applicationId2, ApplicationAttemptId.newInstance(applicationId,
+                    1),
+            "user", "queue", "appname", null, 124,
+            null, YarnApplicationState.RUNNING,
+            "diagnostics", "url", 0, 0,
+            0, FinalApplicationStatus.SUCCEEDED,
+            appResourceUsageReport, "N/A", 0.53789f,
+            "YARN", null);
 
     applications.add(newApplicationReport);
     applications.add(newApplicationReport2);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -91,19 +91,27 @@ public class TestRouterYarnClientUtils {
     ArrayList<GetApplicationsResponse> responses = new ArrayList<>();
     responses.add(getApplicationsResponse(1, true));
 
-    // Check response if partial results are disabled
-    GetApplicationsResponse result = RouterYarnClientUtils.
-        mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertTrue(result.getApplicationList().isEmpty());
-
     // Check response if partial results are enabled
-    result = RouterYarnClientUtils.
+    GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, true);
     Assert.assertNotNull(result);
     Assert.assertEquals(1, result.getApplicationList().size());
-    String appName = result.getApplicationList().iterator().next().getName();
+    ApplicationReport appReport = result.getApplicationList().iterator().next();
+    String appName = appReport.getName();
     Assert.assertTrue(appName.startsWith(PARTIAL_REPORT));
+
+    // Check ApplicationResourceUsageReport merge
+    ApplicationResourceUsageReport resourceUsageReport =
+        appReport.getApplicationResourceUsageReport();
+
+    Assert.assertEquals(2, resourceUsageReport.getNumUsedContainers());
+    Assert.assertEquals(4, resourceUsageReport.getNumReservedContainers());
+
+    // Check response if partial results are disabled
+    result = RouterYarnClientUtils.
+        mergeApplications(responses, false);
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result.getApplicationList().isEmpty());
   }
 
   /**


### PR DESCRIPTION
Implementing getApplications API in FederationClientInterceptors.
Unit tests are running successfully on dev machine.
