### PR TITLE
HADOOP-17769. Upgrade JUnit to 4.13.2. branch-3.3 

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -464,7 +464,7 @@ javax.xml.bind:jaxb-api:2.2.11
 Eclipse Public License 1.0
 --------------------------
 
-junit:junit:4.13.1
+junit:junit:4.13.2
 
 Eclipse Distribution License 1.0
 --------------------------

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -200,7 +200,7 @@
     <snakeyaml.version>1.26</snakeyaml.version>
     <hbase.one.version>1.4.8</hbase.one.version>
     <hbase.two.version>2.0.2</hbase.two.version>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.5.1</junit.jupiter.version>
     <junit.vintage.version>5.5.1</junit.vintage.version>
     <junit.platform.version>1.5.1</junit.platform.version>


### PR DESCRIPTION
(#3130). Contributed by Ahmed Hussein.

Signed-off-by: Ayush Saxena <ayushsaxena@apache.org>
(cherry picked from commit 581f43dce15d5753deb33f72ec275d0ea67b1403)

backport upgrading Junit-4.13.2 to branch-3.3

@ayushtkn 
