### PR TITLE
HADOOP-17769. Upgrade JUnit to 4.13.2. branch-3.2

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1635,7 +1635,7 @@ derived.)
 
 The binary distribution of this product bundles these dependencies under the
 following license:
-JUnit 4.11
+JUnit 4.13.2
 Eclipse JDT Core 3.1.1
 --------------------------------------------------------------------------------
 (EPL v1.0)

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -183,7 +183,7 @@
     <snakeyaml.version>1.16</snakeyaml.version>
     <hbase.one.version>1.2.6</hbase.one.version>
     <hbase.two.version>2.0.0-beta-1</hbase.two.version>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>4.13.2</junit.version>
     <woodstox.version>5.3.0</woodstox.version>
     <json-smart.version>2.4.2</json-smart.version>
     <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>


### PR DESCRIPTION
(#3130). Contributed by Ahmed Hussein.

Signed-off-by: Ayush Saxena <ayushsaxena@apache.org>
(cherry picked from commit 581f43dce15d5753deb33f72ec275d0ea67b1403)

backport upgrading Junit-4.13.2 to branch-3.2

@ayushtkn 
