### PR TITLE
HDFS-16088. Standby NameNode process getLiveDatanodeStorageReport req…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/NameNodeConnector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/NameNodeConnector.java
@@ -462,7 +462,7 @@ public class NameNodeConnector implements Closeable {
         + ", bpid=" + blockpoolID + "]";
   }
 
-  private class ProxyPair {
+  private static class ProxyPair {
     private final ClientProtocol clientProtocol;
     private final boolean isRequestStandby;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -174,6 +174,8 @@ public class TestBalancerWithHANameNodes {
       // Check getBlocks request to Standby NameNode.
       assertTrue(log.getOutput().contains(
           "Request #getBlocks to Standby NameNode success."));
+      assertTrue(log.getOutput().contains(
+          "Request #getLiveDatanodeStorageReport to Standby NameNode success"));
     } finally {
       cluster.shutdown();
     }
@@ -292,7 +294,6 @@ public class TestBalancerWithHANameNodes {
           null, conf, NameNodeConnector.DEFAULT_MAX_IDLE_ITERATIONS);
       DatanodeStorageReport[] ldspFromSnn =
           nncStandby.getLiveDatanodeStorageReport();
-      //
       assertTrue(log.getOutput().contains(
           "Request #getLiveDatanodeStorageReport to Standby NameNode success"));
       nncStandby.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -259,7 +259,7 @@ public class TestBalancerWithHANameNodes {
     LogCapturer log =LogCapturer.captureLogs(
         LoggerFactory.getLogger(NameNodeConnector.class));
     // We needs to assert datanode info from ANN and SNN, so the
-    // heartbeat should disabled for the duration of method execution
+    // heartbeat should disabled for the duration of method execution.
     copiedConf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 60000);
     cluster = new MiniDFSCluster.Builder(copiedConf)
         .nnTopology(MiniDFSNNTopology.simpleHATopology())
@@ -276,55 +276,84 @@ public class TestBalancerWithHANameNodes {
       String nsId = DFSUtilClient.getNameServiceIds(conf)
           .toArray()[0].toString();
 
-      // request to active namenode
+      // Request to active namenode.
       NameNodeConnector nncActive = new NameNodeConnector(
           "nncActive", namenode,
           nsId, new Path("/test"),
           null, conf, NameNodeConnector.DEFAULT_MAX_IDLE_ITERATIONS);
-      DatanodeStorageReport[] ldspFromAnn =
+      DatanodeStorageReport[] datanodeStorageReportFromAnn =
           nncActive.getLiveDatanodeStorageReport();
       assertTrue(!log.getOutput().contains(
           "Request #getLiveDatanodeStorageReport to Standby NameNode success"));
       nncActive.close();
 
-      // request to standby namenode
+      // Request to standby namenode.
       conf.setBoolean(DFSConfigKeys.DFS_HA_ALLOW_STALE_READ_KEY,
           true);
       NameNodeConnector nncStandby = new NameNodeConnector(
           "nncStandby", namenode,
           nsId, new Path("/test"),
           null, conf, NameNodeConnector.DEFAULT_MAX_IDLE_ITERATIONS);
-      DatanodeStorageReport[] ldspFromSnn =
+      DatanodeStorageReport[] datanodeStorageReportFromSnn =
           nncStandby.getLiveDatanodeStorageReport();
       assertTrue(log.getOutput().contains(
           "Request #getLiveDatanodeStorageReport to Standby NameNode success"));
       nncStandby.close();
 
-      // assert datanode info
-      assertEquals(ldspFromAnn[0].getDatanodeInfo().getDatanodeReport(),
-          ldspFromSnn[0].getDatanodeInfo().getDatanodeReport());
-      assertEquals(ldspFromAnn[1].getDatanodeInfo().getDatanodeReport(),
-          ldspFromSnn[1].getDatanodeInfo().getDatanodeReport());
+      // Assert datanode info.
+      assertEquals(
+          datanodeStorageReportFromAnn[0].getDatanodeInfo()
+              .getDatanodeReport(),
+          datanodeStorageReportFromSnn[0].getDatanodeInfo()
+              .getDatanodeReport());
+      assertEquals(
+          datanodeStorageReportFromAnn[1].getDatanodeInfo()
+              .getDatanodeReport(),
+          datanodeStorageReportFromSnn[1].getDatanodeInfo()
+              .getDatanodeReport());
 
-      // assert all fields datanode storage info
+      // Assert all fields datanode storage info.
       for (int i = 0; i < TEST_CAPACITIES.length; i++) {
         assertEquals(
-            ldspFromAnn[i].getStorageReports()[0].getStorage().toString(),
-            ldspFromSnn[i].getStorageReports()[0].getStorage().toString());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].getCapacity(),
-            ldspFromSnn[i].getStorageReports()[0].getCapacity());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].getBlockPoolUsed(),
-            ldspFromSnn[i].getStorageReports()[0].getBlockPoolUsed());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].getDfsUsed(),
-            ldspFromSnn[i].getStorageReports()[0].getDfsUsed());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].getRemaining(),
-            ldspFromSnn[i].getStorageReports()[0].getRemaining());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].getMount(),
-            ldspFromSnn[i].getStorageReports()[0].getMount());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].getNonDfsUsed(),
-            ldspFromSnn[i].getStorageReports()[0].getNonDfsUsed());
-        assertEquals(ldspFromAnn[i].getStorageReports()[0].isFailed(),
-            ldspFromSnn[i].getStorageReports()[0].isFailed());
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getStorage().toString(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getStorage().toString());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getCapacity(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getCapacity());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getBlockPoolUsed(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getBlockPoolUsed());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getDfsUsed(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getDfsUsed());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getRemaining(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getRemaining());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getMount(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getMount());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .getNonDfsUsed(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .getNonDfsUsed());
+        assertEquals(
+            datanodeStorageReportFromAnn[i].getStorageReports()[0]
+                .isFailed(),
+            datanodeStorageReportFromSnn[i].getStorageReports()[0]
+                .isFailed());
       }
     } finally {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -258,7 +258,9 @@ public class TestBalancerWithHANameNodes {
     // Try capture NameNodeConnector log.
     LogCapturer log =LogCapturer.captureLogs(
         LoggerFactory.getLogger(NameNodeConnector.class));
-
+    // We needs to assert datanode info from ANN and SNN, so the
+    // heartbeat should disabled for the duration of method execution
+    copiedConf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 60000);
     cluster = new MiniDFSCluster.Builder(copiedConf)
         .nnTopology(MiniDFSNNTopology.simpleHATopology())
         .numDataNodes(TEST_CAPACITIES.length)


### PR DESCRIPTION
JIRA: [HDFS-16088](https://issues.apache.org/jira/browse/HDFS-16088)

As with [HDFS-13183](https://issues.apache.org/jira/browse/HDFS-13183) , NameNodeConnector#getLiveDatanodeStorageReport() can also request to SNN to reduce the ANN load.

There are two points that need to be mentioned:
1. FSNamesystem#getDatanodeStorageReport() is OperationCategory.UNCHECKED, so we can access SNN directly.
2. We can share the same UT(testBalancerRequestSBNWithHA) with NameNodeConnector#getBlocks().

