### PR TITLE
HADOOP-17774. bytesRead FS statistic showing twice the correct value in S3A

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -713,6 +713,16 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   }
 
   /**
+   * Get FS Statistic for this S3AFS instance.
+   *
+   * @return FS statistic instance.
+   */
+  @VisibleForTesting
+  public FileSystem.Statistics getFsStatistics() {
+    return statistics;
+  }
+
+  /**
    * Get current listing instance.
    * @return this instance's listing.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -988,6 +988,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
         closed.incrementAndGet();
         bytesDiscardedInClose.addAndGet(remainingInCurrentRequest);
         totalBytesRead.addAndGet(remainingInCurrentRequest);
+        filesystemStatistics.incrementBytesRead(remainingInCurrentRequest);
       }
     }
 
@@ -1144,7 +1145,6 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
         // increment the filesystem statistics for this thread.
         if (filesystemStatistics != null) {
           long t = getTotalBytesRead();
-          filesystemStatistics.incrementBytesRead(t);
           filesystemStatistics.incrementBytesReadByDistance(DISTANCE, t);
         }
       }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
@@ -44,11 +44,11 @@ public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
   public void testBytesReadWithStream() throws IOException {
     S3AFileSystem fs = getFileSystem();
     Path filePath = path(getMethodName());
-    byte[] oneMbBuf = new byte[ONE_KB];
+    byte[] oneKbBuf = new byte[ONE_KB];
 
-    // Writing 1MB in a file.
+    // Writing 1KB in a file.
     try (FSDataOutputStream out = fs.create(filePath)) {
-      out.write(oneMbBuf);
+      out.write(oneKbBuf);
       // Verify if correct number of bytes were written.
       IOStatisticAssertions.assertThatStatisticCounter(out.getIOStatistics(),
           StreamStatisticNames.STREAM_WRITE_BYTES)
@@ -59,12 +59,12 @@ public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
 
     // Reading 1KB from first InputStream.
     try (FSDataInputStream in = fs.open(filePath, ONE_KB)) {
-      in.readFully(0, oneMbBuf);
+      in.readFully(0, oneKbBuf);
     }
 
     // Reading 1KB from second InputStream.
     try (FSDataInputStream in2 = fs.open(filePath, ONE_KB)) {
-      in2.readFully(0, oneMbBuf);
+      in2.readFully(0, oneKbBuf);
     }
 
     FileSystem.Statistics fsStats = fs.getFsStatistics();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.statistics;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.AbstractS3ATestBase;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+
+public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
+
+  private static final int ONE_MB = 1024 * 1024;
+  private static final int TWO_MB = 2 * 1024 * 1024;
+
+  /**
+   * Verify the fs statistic bytesRead after reading from 2 different
+   * InputStreams for the same filesystem instance.
+   */
+  @Test
+  public void testBytesReadWithStream() throws IOException {
+    S3AFileSystem fs = getFileSystem();
+    Path filePath = path(getMethodName());
+    byte[] oneMbBuf = new byte[ONE_MB];
+
+    // Writing 1MB in a file.
+    FSDataOutputStream out = fs.create(filePath);
+    out.write(oneMbBuf);
+    out.close();
+
+    // Reading 1MB from first InputStream.
+    FSDataInputStream in = fs.open(filePath, ONE_MB);
+    in.readFully(0, oneMbBuf);
+    in.close();
+
+    // Reading 1MB from second InputStream.
+    FSDataInputStream in2 = fs.open(filePath, ONE_MB);
+    in2.readFully(0, oneMbBuf);
+    in2.close();
+
+    FileSystem.Statistics fsStats = fs.getFsStatistics();
+    // Verifying that total bytes read by FS is equal to 2MB.
+    assertEquals(TWO_MB, fsStats.getBytesRead());
+  }
+}


### PR DESCRIPTION
Test command: ```mvn clean verify -Dparallel-tests -DtestsThreadCount=4 -Dscale```
Region: ap-south-1

```
INFO] Results:
[INFO] 
[WARNING] Tests run: 568, Failures: 0, Errors: 0, Skipped: 5
```
```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ITestS3AMiscOperationCost.testGetContentSummaryRoot:96->AbstractS3ACostTest.verifyMetrics:376->lambda$testGetContentSummaryRoot$1:96->getContentSummary:140 » TestTimedOut
[ERROR]   ITestS3AMiscOperationCost.testGetContentSummaryRoot:96->AbstractS3ACostTest.verifyMetrics:376->lambda$testGetContentSummaryRoot$1:96->getContentSummary:140 » TestTimedOut
[INFO] 
[ERROR] Tests run: 1460, Failures: 0, Errors: 2, Skipped: 462
```
```
[ERROR] Errors: 
[ERROR]   ITestS3AContractRootDir>AbstractContractRootDirectoryTest.testRecursiveRootListing:267 » TestTimedOut
[INFO] 
[ERROR] Tests run: 151, Failures: 2, Errors: 1, Skipped: 28
```

Seeing these errors: 
```
[ERROR] Failures: 
[ERROR]   ITestS3AContractRootDir.testListEmptyRootDirectory:82->AbstractContractRootDirectoryTest.testListEmptyRootDirectory:196->Assert.fail:89 Deleted file: unexpectedly found s3a://mehakmeet-singh-data/user as  S3AFileStatus{path=s3a://mehakmeet-singh-data/user; isDirectory=true; modification_time=0; access_time=0; owner=mehakmeet.singh; group=mehakmeet.singh; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=true; isErasureCoded=false} isEmptyDirectory=FALSE eTag=null versionId=null
[ERROR]   ITestS3AContractRootDir>AbstractContractRootDirectoryTest.testRmEmptyRootDirNonRecursive:101->Assert.fail:89 After 20 attempts: listing after rm /* not empty
final [00] S3AFileStatus{path=s3a://mehakmeet-singh-data/user; isDirectory=true; modification_time=0; access_time=0; owner=mehakmeet.singh; group=mehakmeet.singh; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=true; isErasureCoded=false} isEmptyDirectory=FALSE eTag=null versionId=null

```
have seen these errors intermittently, due to some issue with DynamoDB table. 
@steveloughran suggested ```hadoop org.apache.hadoop.fs.s3a.s3guard.PurgeS3GuardDynamoTable  -force s3a://example-bucket/```
But that fails with an error: 
```
2021-06-25 16:18:43,464 INFO service.AbstractService: Service PurgeS3GuardDynamoTable failed in state STARTED
-1: Filesystem has no metadata store: s3a://mehakmeet-singh-data
	at org.apache.hadoop.fs.s3a.s3guard.AbstractS3GuardDynamoDBDiagnostic.failure(AbstractS3GuardDynamoDBDiagnostic.java:115)
	at org.apache.hadoop.fs.s3a.s3guard.AbstractS3GuardDynamoDBDiagnostic.require(AbstractS3GuardDynamoDBDiagnostic.java:94)
	at org.apache.hadoop.fs.s3a.s3guard.AbstractS3GuardDynamoDBDiagnostic.bindStore(AbstractS3GuardDynamoDBDiagnostic.java:157)
	at org.apache.hadoop.fs.s3a.s3guard.AbstractS3GuardDynamoDBDiagnostic.bindFromCLI(AbstractS3GuardDynamoDBDiagnostic.java:147)
	at org.apache.hadoop.fs.s3a.s3guard.PurgeS3GuardDynamoTable.serviceStart(PurgeS3GuardDynamoTable.java:123)
	at org.apache.hadoop.service.AbstractService.start(AbstractService.java:194)
	at org.apache.hadoop.service.launcher.ServiceLauncher.coreServiceLaunch(ServiceLauncher.java:619)
	at org.apache.hadoop.service.launcher.ServiceLauncher.launchService(ServiceLauncher.java:494)
	at org.apache.hadoop.fs.s3a.s3guard.DumpS3GuardDynamoTable.serviceMain(DumpS3GuardDynamoTable.java:517)
	at org.apache.hadoop.fs.s3a.s3guard.PurgeS3GuardDynamoTable.main(PurgeS3GuardDynamoTable.java:205)
2021-06-25 16:18:43,467 INFO util.ExitUtil: Exiting with status -1: Filesystem has no metadata store: s3a://mehakmeet-singh-data
```
Would like the reviewers to run the aws test suite once in their setup while reviewing as well. 
CC: @steveloughran @mukund-thakur @bogthe 