### PR TITLE
HDFS-16089. EC: Add metric EcReconstructionValidateTimeMillis for Striped…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedBlockReconstructor.java
@@ -135,9 +135,16 @@ class StripedBlockReconstructor extends StripedReconstructor
       resetBuffers(inputs);
 
       DataNodeFaultInjector.get().badDecoding(outputs);
+      long start = Time.monotonicNow();
       try {
         getValidator().validate(inputs, erasedIndices, outputs);
+        long validateEnd = Time.monotonicNow();
+        getDatanode().getMetrics().incrECReconstructionValidateTime(
+            validateEnd - start);
       } catch (InvalidDecodingException e) {
+        long validateFailedEnd = Time.monotonicNow();
+        getDatanode().getMetrics().incrECReconstructionValidateTime(
+            validateFailedEnd - start);
         getDatanode().getMetrics().incrECInvalidReconstructionTasks();
         throw e;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -168,6 +168,8 @@ public class DataNodeMetrics {
   private MutableCounterLong ecReconstructionDecodingTimeMillis;
   @Metric("Milliseconds spent on write by erasure coding worker")
   private MutableCounterLong ecReconstructionWriteTimeMillis;
+  @Metric("Milliseconds spent on validating by erasure coding worker")
+  private MutableCounterLong ecReconstructionValidateTimeMillis;
   @Metric("Sum of all BPServiceActors command queue length")
   private MutableCounterLong sumOfActorCommandQueueLength;
   @Metric("Num of processed commands of all BPServiceActors")
@@ -627,6 +629,10 @@ public class DataNodeMetrics {
 
   public void incrECReconstructionDecodingTime(long millis) {
     ecReconstructionDecodingTimeMillis.incr(millis);
+  }
+
+  public void incrECReconstructionValidateTime(long millis) {
+    ecReconstructionValidateTimeMillis.incr(millis);
   }
 
   public DataNodeUsageReport getDNUsageReport(long timeSinceLastReport) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestReconstructStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestReconstructStripedBlocks.java
@@ -364,7 +364,7 @@ public class TestReconstructStripedBlocks {
     }
   }
 
-  @Test(timeout=120000) // 1 min timeout
+  @Test(timeout=120000) // 2 min timeout
   public void testReconstructionWork() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setLong(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 0);


### PR DESCRIPTION
JIRA: [HDFS-16089](https://issues.apache.org/jira/browse/HDFS-16089)

Add metric EcReconstructionValidateTimeMillis for StripedBlockReconstructor, so that we can count the elapsed time for striped block reconstructing.