### PR TITLE
YARN-10835. Pass user defined variables of yarn.nodemanager.env-whitelist along jobs

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -1137,6 +1137,17 @@ public abstract class TaskAttemptImpl implements
     }
     MapReduceChildJVM.setVMEnv(myEnv, remoteTask);
 
+    if (conf.getBoolean(YarnConfiguration.NM_ENV_WHITELIST_EXPORT_ENABLED,
+        YarnConfiguration.DEFAULT_NM_ENV_WHITELIST_EXPORT_ENABLED)) {
+      String[] whitelistVars = conf.get(YarnConfiguration.NM_ENV_WHITELIST,
+          YarnConfiguration.DEFAULT_NM_ENV_WHITELIST).split(",");
+      for (String var : whitelistVars) {
+        if (System.getenv(var) != null && !System.getenv(var).isEmpty()) {
+          myEnv.put(var, System.getenv(var));
+        }
+      }
+    }
+
     // Set up the launch command
     List<String> commands = MapReduceChildJVM.getVMCommand(
         taskAttemptListener.getAddress(), remoteTask, jvmID);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1265,7 +1265,10 @@ public class YarnConfiguration extends Configuration {
       ApplicationConstants.Environment.HADOOP_CONF_DIR.key(),
       ApplicationConstants.Environment.CLASSPATH_PREPEND_DISTCACHE.key(),
       ApplicationConstants.Environment.HADOOP_YARN_HOME.key()));
-  
+  public static final String NM_ENV_WHITELIST_EXPORT_ENABLED = NM_ENV_WHITELIST
+      + "export.enabled";
+  public static final boolean DEFAULT_NM_ENV_WHITELIST_EXPORT_ENABLED = false;
+
   /** address of node manager IPC.*/
   public static final String NM_ADDRESS = NM_PREFIX + "address";
   public static final int DEFAULT_NM_PORT = 0;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/YarnClientImpl.java
@@ -310,6 +310,20 @@ public class YarnClientImpl extends YarnClient {
       throw new ApplicationIdNotProvidedException(
           "ApplicationId is not provided in ApplicationSubmissionContext");
     }
+
+    if (isNMEnvWhitelistExportEnabled()) {
+      String[] whitelistVars = getConfig().get(
+          YarnConfiguration.NM_ENV_WHITELIST,
+          YarnConfiguration.DEFAULT_NM_ENV_WHITELIST).split(",");
+      for(String var : whitelistVars) {
+        String value = getNMEnvWhitelistValue(var);
+        if (value != null) {
+          appContext.getAMContainerSpec().getEnvironment()
+              .put(var, value);
+        }
+      }
+    }
+
     SubmitApplicationRequest request =
         Records.newRecord(SubmitApplicationRequest.class);
     request.setApplicationSubmissionContext(appContext);
@@ -522,6 +536,12 @@ public class YarnClientImpl extends YarnClient {
   @VisibleForTesting
   protected boolean isSecurityEnabled() {
     return UserGroupInformation.isSecurityEnabled();
+  }
+
+  protected boolean isNMEnvWhitelistExportEnabled() {
+    return getConfig().getBoolean(
+        YarnConfiguration.NM_ENV_WHITELIST_EXPORT_ENABLED,
+        YarnConfiguration.DEFAULT_NM_ENV_WHITELIST_EXPORT_ENABLED);
   }
 
   @Override
@@ -1190,5 +1210,15 @@ public class YarnClientImpl extends YarnClient {
     } catch (Throwable t) {
       LOG.error("Fail to shell to container: " + t.getMessage());
     }
+  }
+
+  private String getNMEnvWhitelistValue(String key) {
+    if (System.getenv(key) != null && !System.getenv(key).isEmpty()) {
+      return System.getenv(key);
+    }
+    if (System.getProperty(key) != null && !System.getProperty(key).isEmpty()) {
+      return System.getProperty(key);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
The configuration of "yarn.nodemanager.env-whitelist" has been helpful in running multi version Hadoop on Yarn. But the pain point is that users need to use different configurations to run jobs of different versions of Hadoop.

The first idea is to have SRE prepared different versions of configurations and let users specify different environment variables of "HADOOP_CONF_DIR", this shifts the burden from users to SRE that they have to maintain different versions of configurations with only one or two configurations changed.

This ticket proposes to export the value of the environment variable in "yarn.nodemanager.env-whitelist" via the environment variable or Java properties of the client submitting jobs. So that SRE only has to maintain one version of configuration and users can easily define Hadoop version with one export in an environment variable or Java property.

# What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/YARN-10835

# How was this patch tested?
Add unit test to pass Java properties to `ContainerLaunchContext`.