### PR TITLE
HADOOP-17719. DistCp with snapshot diff should support file systems supporting getSnapshotDiffReport.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSUtilClient;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.tools.CopyListing.InvalidInputException;

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.tools.mapred.CopyMapper;
 import org.junit.After;
 import org.junit.Assert;
@@ -982,6 +983,16 @@ public class TestDistCpSync {
     Path webHdfsTarget = new Path(webfs.getUri().toString(), target);
 
     snapshotDiffWithPaths(webHdfsSource, webHdfsTarget);
+  }
+
+  @Test
+  public void testSyncSnapshotDiffWithLocalFileSystem() throws Exception {
+    String[] args = new String[]{"-update","-diff", "s1", "s2",
+        "file:///source", "file:///target"};
+    LambdaTestUtils.intercept(
+        IllegalArgumentException.class,
+        "The source file system does not support snapshot",
+        () -> new DistCp(conf, OptionsParser.parse(args)).execute());
   }
 
   private void snapshotDiffWithPaths(Path sourceFSPath,

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
@@ -987,7 +987,7 @@ public class TestDistCpSync {
 
   @Test
   public void testSyncSnapshotDiffWithLocalFileSystem() throws Exception {
-    String[] args = new String[]{"-update","-diff", "s1", "s2",
+    String[] args = new String[]{"-update", "-diff", "s1", "s2",
         "file:///source", "file:///target"};
     LambdaTestUtils.intercept(
         IllegalArgumentException.class,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17719

This PR allows (third party) file systems other than DistributedFileSystem or WebHdfsFileSystem to used for `distcp -update -diff`.

The is intended to be intermediate fix before moving snapshot related classes to hadoop-common as part of FileSystem specification.
