### PR TITLE
HDFS-16104. Remove unused parameter and fix java doc for DiskBalancerCLI

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DiskBalancerCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DiskBalancerCLI.java
@@ -199,7 +199,7 @@ public class DiskBalancerCLI extends Configured implements Tool {
           "Invalid or extra Arguments: " + Arrays
               .toString(Arrays.copyOfRange(cmdArgs, 2, cmdArgs.length)));
     }
-    return dispatch(cmd, opts);
+    return dispatch(cmd);
   }
 
   /**
@@ -469,10 +469,8 @@ public class DiskBalancerCLI extends Configured implements Tool {
    * Dispatches calls to the right command Handler classes.
    *
    * @param cmd  - CommandLine
-   * @param opts options of command line
-   * @param out  the output stream used for printing
    */
-  private int dispatch(CommandLine cmd, Options opts)
+  private int dispatch(CommandLine cmd)
       throws Exception {
     Command dbCmd = null;
     try {


### PR DESCRIPTION
JIRA: [HDFS-16104](https://issues.apache.org/jira/browse/HDFS-16104)

Remove unused parameter and fix java doc for DiskBalancerCLI.