### PR TITLE
HDFS-16105. Edit log corruption due to mismatch between fileId and path

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -765,7 +765,8 @@ public class FSDirectory implements Closeable {
 
   INodesInPath resolvePath(FSPermissionChecker pc, String src, long fileId)
       throws UnresolvedLinkException, FileNotFoundException,
-      AccessControlException, ParentNotDirectoryException {
+      AccessControlException, ParentNotDirectoryException,
+      IllegalResolvePathException {
     // Older clients may not have given us an inode ID to work with.
     // In this case, we have to try to resolve the path and hope it
     // hasn't changed or been deleted since the file was opened for write.
@@ -778,9 +779,23 @@ public class FSDirectory implements Closeable {
         iip = INodesInPath.fromComponents(INode.getPathComponents(src));
       } else {
         iip = INodesInPath.fromINode(inode);
+        checkResolvePath(iip, src);
       }
     }
     return iip;
+  }
+
+  /**
+   * Check whether src path and fileId match.
+   */
+  void checkResolvePath(INodesInPath iip, String src)
+      throws IllegalResolvePathException {
+    if (!iip.getPath().equals(src)) {
+      throw new IllegalResolvePathException(
+          "Arguments don't match, fileId = " + iip.getLastINode().getId()
+          + " and its iip = " + iip.getPath()
+          + ", src = " + src);
+    }
   }
 
   // this method can be removed after IIP is used more extensively

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/IllegalResolvePathException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/IllegalResolvePathException.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.namenode;
+
+import java.io.IOException;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+
+/**
+ * Thrown when src path and iip from fileId don't match.
+ */
+@InterfaceAudience.Private
+public class IllegalResolvePathException extends IOException {
+  private static final long serialVersionUID = 1L;
+
+  public IllegalResolvePathException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
