### PR TITLE
fix state in applicationhistory web page

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/WebPageUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/webapp/WebPageUtils.java
@@ -59,7 +59,7 @@ public class WebPageUtils {
     sb.append("[\n")
       .append("{'sType':'natural', 'aTargets': [0], ")
       .append("'mRender': parseHadoopID },\n")
-      .append("{'sType':'num-ignore-str', 'aTargets': [7, 8, 9], ")
+      .append("{'sType':'num-ignore-str', 'aTargets': [6, 7, 8], ")
       .append("'mRender': renderHadoopDate },\n");
     if (isResourceManager) {
       // Update following line if any column added in RM page before column 11


### PR DESCRIPTION

Recently, when i deploy  hadoop 3.3 , after submit a task and finished running ,then from application history web page(8188), 
I see the state column is valid.  

![image](https://user-images.githubusercontent.com/7209497/124079444-b6f0d080-da7b-11eb-966d-f6f096b505fb.png)


after debug from source code 

found 
7,8,9 should be 6, 7, 8
`<script type="text/javascript">
    $(function() {
      $('#nav').accordion({autoHeight:false, active:0});
    appsDataTable =  $('#apps').dataTable({bStateSave : true, "fnStateSave": function (oSettings, oData) {  data = oData.aoSearchCols;for(i =0 ; i < data.length; i ++) {data[i].sSearch = ""} sessionStorage.setItem( oSettings.sTableId, JSON.stringify(oData) ); }, "fnStateLoad": function (oSettings) { return JSON.parse( sessionStorage.getItem(oSettings.sTableId) );}, bJQueryUI:true, sPaginationType: 'full_numbers', iDisplayLength:20, aLengthMenu:[20, 40, 60, 80, 100], 'aaData': appsTableData, bDeferRender: true, bProcessing: true
, aoColumnDefs: [
{'sType':'natural', 'aTargets': [0], 'mRender': parseHadoopID },
{'sType':'num-ignore-str', 'aTargets': [7, 8, 9], 'mRender': renderHadoopDate },
{'sType':'numeric', bSearchable:false, 'aTargets':[11], 'mRender': parseHadoopProgress }
], aaSorting: [[0, 'desc']]}).fnSetFilteringDelay(188);
    });
  </script>
`
 
From below you can see appsTableData is 13 column, and 6, 7, 8 is relate timestamp(Date)

`appsTableData
[Array(13)]
0: Array(13)
0: "<a href='/applicationhistory/app/application_1625053883552_0001'>application_1625053883552_0001</a>"
1: “XXXXXXXXXX"
2: “XXXXXXXXXXXXX"
3: "YARN"
4: "rtt"
5: "0"
6: "1625053927116"
7: "1625064679564"
8: "1625064933490"
9: "FINISHED"
10: "SUCCEEDED"
11: "<br title='100.0'> <div class='ui-progressbar ui-widget ui-widget-content ui-corner-all' title='100.0%'> <div class='ui-progressbar-value ui-widget-header ui-corner-left' style='width:100.0%'> </div> </div>"
12: "<a href='http://node1:8088/proxy/application_1625053883552_0001/'>History</a>"
length: 13
__proto__: Array(0)
length: 1
__proto__: Array(0)`

after fix
![image](https://user-images.githubusercontent.com/7209497/124079459-beb07500-da7b-11eb-996b-4417e6404890.png)



