### PR TITLE
Fix NPE in Find.java

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java
@@ -114,7 +114,9 @@ public class Find extends FsCommand {
       if (expr.isOperator()) {
         operators.add(expr);
       } else {
-        primaries.add(expr);
+        if (expr != null) {
+          primaries.add(expr);
+        }
       }
     }
     Collections.sort(operators, new Comparator<Expression>() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/DancingLinks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/DancingLinks.java
@@ -420,7 +420,10 @@ public class DancingLinks<ColumnName> {
     }
     int result = search(choices, output);
     for(int i=prefix.length-1; i >=0; --i) {
-      rollback(choices.get(i));
+      Node<ColumnName> choice = choices.get(i);
+      if (choice != null) {
+        rollback(choice);
+      }
     }
     return result;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DumpS3GuardDynamoTable.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/s3guard/DumpS3GuardDynamoTable.java
@@ -415,8 +415,11 @@ public class DumpS3GuardDynamoTable extends AbstractS3GuardDynamoDBDiagnostic {
       }
       List<DirListingMetadata> childMD = new ArrayList<>(childDirs.size());
       for (DDBPathMetadata childDir : childDirs) {
-        childMD.add(getStore().listChildren(
-            childDir.getFileStatus().getPath()));
+        DirListingMetadata data = getStore().listChildren(
+            childDir.getFileStatus().getPath());
+        if (data != null) {
+            childMD.add(data);
+        }
       }
       pushAll(queue, childMD);
     }


### PR DESCRIPTION
Hello,
Our static analyzer found a following potential NPE. We have checked the feasibility of this execution trace. It is necessary to defend this vulnerability to improve the code quality. We have provided the patch for you. Please check and confirm it.

Here is the bug trace.

1. Select the false branch at this point (expressionClass==null is true), and null assigned to instance
https://github.com/apache/hadoop/blob/986d0a4f1d5543fa0b4f5916729728f78b4acec9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/ExpressionFactory.java#L129-L133

2. Return instance to caller, which can be null (The return value can be null)
https://github.com/apache/hadoop/blob/986d0a4f1d5543fa0b4f5916729728f78b4acec9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/ExpressionFactory.java#L133

3. Function createExpression executes and stores the return value to expr (expr can be null)
https://github.com/apache/hadoop/blob/986d0a4f1d5543fa0b4f5916729728f78b4acec9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java#L113

4. Function add executes and primaries contains null value
https://github.com/apache/hadoop/blob/986d0a4f1d5543fa0b4f5916729728f78b4acec9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java#L117

5. Function next executes and stores the return value to expr (expr can be null)
https://github.com/apache/hadoop/blob/986d0a4f1d5543fa0b4f5916729728f78b4acec9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java#L139

6. expr is passed as the this pointer to function getUsage (expr can be null), which will leak to null pointer dereference
https://github.com/apache/hadoop/blob/986d0a4f1d5543fa0b4f5916729728f78b4acec9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/find/Find.java#L140


Commit: 986d0a4f1d5543fa0b4f5916729728f78b4acec9




ContainerAnalyzer