### PR TITLE
MAPREDUCE-7351 - CleanupJob during handle of SIGTERM signal

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -1714,6 +1714,16 @@ public class MRAppMaster extends CompositeService {
       }
       appMaster.notifyIsLastAMRetry(appMaster.isLastAMRetry);
       appMaster.stop();
+      try {
+        JobContext jobContext = appMaster.getJobContextFromConf(appMaster.getConfig());
+        appMaster.committer.abortJob(jobContext, State.KILLED);
+      } catch (FileNotFoundException e) {
+        System.out.println("Previous job temporary files do not exist, no clean up was necessary.");
+      } catch (Exception e) {
+        // the clean up of a previous attempt is not critical to the success
+        // of this job - only logging the error
+        System.err.println("Error while trying to clean up previous job's temporary files" + e);
+      }
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -1715,14 +1715,17 @@ public class MRAppMaster extends CompositeService {
       appMaster.notifyIsLastAMRetry(appMaster.isLastAMRetry);
       appMaster.stop();
       try {
-        JobContext jobContext = appMaster.getJobContextFromConf(appMaster.getConfig());
+        JobContext jobContext = appMaster
+                .getJobContextFromConf(appMaster.getConfig());
         appMaster.committer.abortJob(jobContext, State.KILLED);
       } catch (FileNotFoundException e) {
-        System.out.println("Previous job temporary files do not exist, no clean up was necessary.");
+          System.out.println("Previous job temporary " +
+                "files do not exist, no clean up was necessary.");
       } catch (Exception e) {
         // the clean up of a previous attempt is not critical to the success
         // of this job - only logging the error
-        System.err.println("Error while trying to clean up previous job's temporary files" + e);
+        System.err.println("Error while trying to " +
+                "clean up previous job's temporary files" + e);
       }
     }
   }


### PR DESCRIPTION
Currently MR CleanupJob happens when the job is either successful or fail. But during kill, it is not handled. This leaves all the temporary folders under the output path.

JIRA: https://issues.apache.org/jira/browse/MAPREDUCE-7351

During JobKill or Jvm shutdown, this patch deletes the temporary files in hdfs.

Testing done:
1. Killed the running job in map0%reduce0% , map0%reduce100%, it deleted the temporary files with this change. 
