### PR TITLE
HADOOP-17775. Remove JavaScript package from Docker environment.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -144,25 +144,6 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 RUN pip3 install pylint==2.6.0 python-dateutil==2.8.1
 
 ###
-# Install node.js 10.21.0 for web UI framework (4.2.6 ships with Xenial)
-###
-RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=10.21.0-1nodesource1 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g bower@1.8.8
-
-###
-## Install Yarn 1.22.5 for web UI framework
-####
-RUN curl -s -S https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
-    && apt-get -q update \
-    && apt-get install -y --no-install-recommends yarn=1.22.5-1 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-###
 # Install hadolint
 ####
 RUN curl -L -s -S \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17775

for branch-3.2.
