### PR TITLE
HADOOP-17801. No error message reported when bucket doesn't exist in S3AFS

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -681,7 +681,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         trackDurationOfOperation(getDurationTrackerFactory(),
             STORE_EXISTS_PROBE.getSymbol(),
             () -> s3.doesBucketExist(bucket)))) {
-      throw new UnknownStoreException("Bucket " + bucket + " does not exist");
+      throw new UnknownStoreException("Bucket " + bucket + " does not exist",
+          "/");
     }
   }
 
@@ -699,7 +700,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         trackDurationOfOperation(getDurationTrackerFactory(),
             STORE_EXISTS_PROBE.getSymbol(),
             () -> s3.doesBucketExistV2(bucket)))) {
-      throw new UnknownStoreException("Bucket " + bucket + " does not exist");
+      throw new UnknownStoreException("Bucket " + bucket + " does not exist",
+          "/");
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -681,8 +681,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         trackDurationOfOperation(getDurationTrackerFactory(),
             STORE_EXISTS_PROBE.getSymbol(),
             () -> s3.doesBucketExist(bucket)))) {
-      throw new UnknownStoreException("/", "Bucket " + bucket + " does not "
-          + "exist");
+      throw new UnknownStoreException("s3a://" + bucket + "/", " Bucket does "
+          + "not exist");
     }
   }
 
@@ -700,8 +700,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         trackDurationOfOperation(getDurationTrackerFactory(),
             STORE_EXISTS_PROBE.getSymbol(),
             () -> s3.doesBucketExistV2(bucket)))) {
-      throw new UnknownStoreException("/", "Bucket " + bucket + " does not "
-          + "exist");
+      throw new UnknownStoreException("s3a://" + bucket + "/", " Bucket does "
+          + "not exist");
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -681,8 +681,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         trackDurationOfOperation(getDurationTrackerFactory(),
             STORE_EXISTS_PROBE.getSymbol(),
             () -> s3.doesBucketExist(bucket)))) {
-      throw new UnknownStoreException("Bucket " + bucket + " does not exist",
-          "/");
+      throw new UnknownStoreException("/", "Bucket " + bucket + " does not "
+          + "exist");
     }
   }
 
@@ -700,8 +700,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         trackDurationOfOperation(getDurationTrackerFactory(),
             STORE_EXISTS_PROBE.getSymbol(),
             () -> s3.doesBucketExistV2(bucket)))) {
-      throw new UnknownStoreException("Bucket " + bucket + " does not exist",
-          "/");
+      throw new UnknownStoreException("/", "Bucket " + bucket + " does not "
+          + "exist");
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -254,7 +254,7 @@ public final class S3AUtils {
       case 404:
         if (isUnknownBucket(ase)) {
           // this is a missing bucket
-          ioe = new UnknownStoreException(message, ase, path);
+          ioe = new UnknownStoreException(path, message, ase);
         } else {
           // a normal unknown object
           ioe = new FileNotFoundException(message);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -254,7 +254,7 @@ public final class S3AUtils {
       case 404:
         if (isUnknownBucket(ase)) {
           // this is a missing bucket
-          ioe = new UnknownStoreException(message, ase);
+          ioe = new UnknownStoreException(message, ase, path);
         } else {
           // a normal unknown object
           ioe = new FileNotFoundException(message);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -254,7 +254,7 @@ public final class S3AUtils {
       case 404:
         if (isUnknownBucket(ase)) {
           // this is a missing bucket
-          ioe = new UnknownStoreException(path, ase);
+          ioe = new UnknownStoreException(message, ase);
         } else {
           // a normal unknown object
           ioe = new FileNotFoundException(message);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/UnknownStoreException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/UnknownStoreException.java
@@ -18,10 +18,9 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import java.io.IOException;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.PathIOException;
 
 /**
  * The bucket or other AWS resource is unknown.
@@ -33,23 +32,28 @@ import org.apache.hadoop.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
-public class UnknownStoreException extends IOException {
+public class UnknownStoreException extends PathIOException {
 
   /**
    * Constructor.
-   * @param message message
+   *
+   * @param message message.
+   * @param path    path trying to access.
    */
-  public UnknownStoreException(final String message) {
-    this(message, null);
+  public UnknownStoreException(final String message, final String path) {
+    this(message, null, path);
   }
 
   /**
    * Constructor.
-   * @param message message
-   * @param cause cause (may be null)
+   *
+   * @param message message.
+   * @param cause   cause (may be null).
+   * @param path    path trying to access.
    */
-  public UnknownStoreException(final String message, Throwable cause) {
-    super(message);
+  public UnknownStoreException(final String message, Throwable cause,
+      String path) {
+    super(path, message);
     if (cause != null) {
       initCause(cause);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/UnknownStoreException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/UnknownStoreException.java
@@ -37,22 +37,22 @@ public class UnknownStoreException extends PathIOException {
   /**
    * Constructor.
    *
-   * @param message message.
    * @param path    path trying to access.
+   * @param message message.
    */
-  public UnknownStoreException(final String message, final String path) {
-    this(message, null, path);
+  public UnknownStoreException(final String path, final String message) {
+    this(path, message, null);
   }
 
   /**
    * Constructor.
    *
+   * @param path    path trying to access.
    * @param message message.
    * @param cause   cause (may be null).
-   * @param path    path trying to access.
    */
-  public UnknownStoreException(final String message, Throwable cause,
-      String path) {
+  public UnknownStoreException(String path, final String message,
+      Throwable cause) {
     super(path, message);
     if (cause != null) {
       initCause(cause);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AExceptionTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AExceptionTranslation.java
@@ -38,6 +38,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.s3a.impl.ErrorTranslation;
@@ -181,8 +182,12 @@ public class TestS3AExceptionTranslation {
 
   private static <E extends Throwable> E verifyTranslated(Class<E> clazz,
       AmazonClientException exception) throws Exception {
-    return verifyExceptionClass(clazz,
-        translateException("test", "/", exception));
+    // Verifying that the translated exception have the correct error message.
+    IOException ioe = translateException("test", "/", exception);
+    Assertions.assertThat(ioe.getMessage()).describedAs("Translated "
+        + "Exception should contain the error message of the actual exception")
+        .contains(exception.getMessage());
+    return verifyExceptionClass(clazz, ioe);
   }
 
   private void assertContainsInterrupted(boolean expected, Throwable thrown)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AExceptionTranslation.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AExceptionTranslation.java
@@ -38,7 +38,6 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.s3a.impl.ErrorTranslation;
@@ -184,9 +183,9 @@ public class TestS3AExceptionTranslation {
       AmazonClientException exception) throws Exception {
     // Verifying that the translated exception have the correct error message.
     IOException ioe = translateException("test", "/", exception);
-    Assertions.assertThat(ioe.getMessage()).describedAs("Translated "
-        + "Exception should contain the error message of the actual exception")
-        .contains(exception.getMessage());
+    assertExceptionContains(exception.getMessage(), ioe,
+        "Translated Exception should contain the error message of the "
+            + "actual exception");
     return verifyExceptionClass(clazz, ioe);
   }
 


### PR DESCRIPTION
`mvn clean verify -Dparallel-tests -DtestsThreadCount=4 -Dscale`
Region: ap-south-1
All tests ran successfully. 
Changed test: 
```
[INFO] Running org.apache.hadoop.fs.s3a.TestS3AExceptionTranslation
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.367 s - in org.apache.hadoop.fs.s3a.TestS3AExceptionTranslation
```
