### PR TITLE
YARN-10814. Fallback to RandomSecretProvider if the secret file is empty

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationFilter.java
@@ -237,6 +237,8 @@ public class AuthenticationFilter implements Filter {
         provider.init(config, ctx, validity);
       } catch (Exception e) {
         if (!disallowFallbackToRandomSecretProvider) {
+          LOG.error("Unable to initialize FileSignerSecretProvider, reason: "
+                       + e.getMessage());
           LOG.info("Unable to initialize FileSignerSecretProvider, " +
                        "falling back to use random secrets.");
           provider = new RandomSignerSecretProvider();

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/server/AuthenticationFilter.java
@@ -237,10 +237,8 @@ public class AuthenticationFilter implements Filter {
         provider.init(config, ctx, validity);
       } catch (Exception e) {
         if (!disallowFallbackToRandomSecretProvider) {
-          LOG.error("Unable to initialize FileSignerSecretProvider, reason: "
-                       + e.getMessage());
-          LOG.info("Unable to initialize FileSignerSecretProvider, " +
-                       "falling back to use random secrets.");
+          LOG.warn("Unable to initialize FileSignerSecretProvider, " +
+              "falling back to use random secrets. Reason: " + e.getMessage());
           provider = new RandomSignerSecretProvider();
           provider.init(config, ctx, validity);
         } else {

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestAuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestAuthenticationFilter.java
@@ -305,6 +305,33 @@ public class TestAuthenticationFilter {
       filter.destroy();
     }
   }
+
+  @Test
+  public void testEmptySecretFileFallbacksToRandomSecret() throws Exception {
+    AuthenticationFilter filter = new AuthenticationFilter();
+    try {
+      FilterConfig config = Mockito.mock(FilterConfig.class);
+      Mockito.when(config.getInitParameter(
+              AuthenticationFilter.AUTH_TYPE)).thenReturn("simple");
+      File secretFile = File.createTempFile("test_empty_secret", ".txt");
+      Assert.assertTrue(secretFile.exists());
+      Mockito.when(config.getInitParameter(
+              AuthenticationFilter.SIGNATURE_SECRET_FILE))
+              .thenReturn(secretFile.getAbsolutePath());
+      Mockito.when(config.getInitParameterNames()).thenReturn(
+              new Vector<>(Arrays.asList(AuthenticationFilter.AUTH_TYPE,
+                      AuthenticationFilter.SIGNATURE_SECRET_FILE)).elements());
+      ServletContext context = Mockito.mock(ServletContext.class);
+      Mockito.when(context.getAttribute(
+              AuthenticationFilter.SIGNER_SECRET_PROVIDER_ATTRIBUTE))
+              .thenReturn(null);
+      Mockito.when(config.getServletContext()).thenReturn(context);
+      filter.init(config);
+      Assert.assertTrue(filter.isRandomSecret());
+    } finally {
+      filter.destroy();
+    }
+  }
   
   @Test
   public void testInitCaseSensitivity() throws Exception {

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestAuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestAuthenticationFilter.java
@@ -314,6 +314,7 @@ public class TestAuthenticationFilter {
       Mockito.when(config.getInitParameter(
               AuthenticationFilter.AUTH_TYPE)).thenReturn("simple");
       File secretFile = File.createTempFile("test_empty_secret", ".txt");
+      secretFile.deleteOnExit();
       Assert.assertTrue(secretFile.exists());
       Mockito.when(config.getInitParameter(
               AuthenticationFilter.SIGNATURE_SECRET_FILE))

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
@@ -64,8 +64,9 @@ public class TestFileSignerSecretProvider {
             AuthenticationFilter.SIGNATURE_SECRET_FILE,
             secretFile.getAbsolutePath());
 
-    Exception exception = assertThrows(RuntimeException.class,
-            () -> secretProvider.init(secretProviderProps, null, -1));
-    assertTrue(exception.getMessage().startsWith("No secret in signature secret file:"));
+    Exception exception = assertThrows(RuntimeException.class, () ->
+        secretProvider.init(secretProviderProps, null, -1));
+    assertTrue(exception.getMessage().startsWith(
+        "No secret in signature secret file:"));
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
@@ -16,6 +16,7 @@ package org.apache.hadoop.security.authentication.util;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -64,8 +65,13 @@ public class TestFileSignerSecretProvider {
             AuthenticationFilter.SIGNATURE_SECRET_FILE,
             secretFile.getAbsolutePath());
 
-    Exception exception = assertThrows(RuntimeException.class, () ->
-        secretProvider.init(secretProviderProps, null, -1));
+    Exception exception =
+        assertThrows(RuntimeException.class, new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            secretProvider.init(secretProviderProps, null, -1);
+          }
+        });
     assertTrue(exception.getMessage().startsWith(
         "No secret in signature secret file:"));
   }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
@@ -22,6 +22,9 @@ import java.io.FileWriter;
 import java.io.Writer;
 import java.util.Properties;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 public class TestFileSignerSecretProvider {
 
   @Test
@@ -47,5 +50,22 @@ public class TestFileSignerSecretProvider {
     byte[][] allSecrets = secretProvider.getAllSecrets();
     Assert.assertEquals(1, allSecrets.length);
     Assert.assertArrayEquals(secretValue.getBytes(), allSecrets[0]);
+  }
+
+  @Test
+  public void testEmptySecretFileThrows() throws Exception {
+    File secretFile = File.createTempFile("test_empty_secret", ".txt");
+    assertTrue(secretFile.exists());
+
+    FileSignerSecretProvider secretProvider
+            = new FileSignerSecretProvider();
+    Properties secretProviderProps = new Properties();
+    secretProviderProps.setProperty(
+            AuthenticationFilter.SIGNATURE_SECRET_FILE,
+            secretFile.getAbsolutePath());
+
+    Exception exception = assertThrows(RuntimeException.class,
+            () -> secretProvider.init(secretProviderProps, null, -1));
+    assertTrue(exception.getMessage().startsWith("No secret in signature secret file:"));
   }
 }


### PR DESCRIPTION
…pty.

The rest endpoint would be unusable with an empty secret file
(throwing IllegalArgumentExceptions).

Any IO error would have resulted in the same fallback path.

Change-Id: Ieb147a0f6f8f628cdafb3c987d0c9a440fa8c6d0

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
