### PR TITLE
HADOOP-17803. Remove WARN logging from LoggingAuditor when executing a request outside an audit span

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
@@ -411,11 +411,8 @@ public class LoggingAuditor
     public <T extends AmazonWebServiceRequest> T beforeExecution(
         final T request) {
 
-
       String error = "executing a request outside an audit span "
           + analyzer.analyze(request);
-      LOG.warn("{} {}",
-          getSpanId(), error);
       final String unaudited = getSpanId() + " "
           + UNAUDITED_OPERATION + " " + error;
       if (isRequestNotAlwaysInSpan(request)) {


### PR DESCRIPTION
Built successfully with `mvn -T 4 clean install -DskipTests`. 