### PR TITLE
YARN-10861. Make NodeHealthCheckerService pluggable in NodeManager

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1999,6 +1999,10 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_NM_CONTAINER_METRICS_UNREGISTER_DELAY_MS =
       10000;
 
+  /** The Service to check the health of the node. */
+  public static final String NM_HEALTH_CHECKER_SERVICE =
+      NM_PREFIX + "health-checker-service.class";
+
   /** Prefix for all node manager disk health checker configs. */
   private static final String NM_DISK_HEALTH_CHECK_PREFIX =
       "yarn.nodemanager.disk-health-checker.";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerService.java
@@ -18,102 +18,17 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.health;
 
-import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
-import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.CompositeService;
-import org.apache.hadoop.service.Service;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
- * This class provides functionality of checking the health of a node and
- * reporting back to the service for which the health checker has been asked to
- * report.
- *
- * It is a {@link CompositeService}: every {@link Service} must be registered
- * first in serviceInit, and should also implement the {@link HealthReporter}
- * interface - otherwise an exception is thrown.
- *
- * Calling functions of HealthReporter merge its dependent
- * services' reports.
- *
- * @see HealthReporter
- * @see LocalDirsHandlerService
- * @see TimedHealthReporterService
+ * This is the base class for NodeHealthCheckerService.
+ * The default implementation is {@link NodeHealthCheckerServiceImpl}
  */
-public class NodeHealthCheckerService extends CompositeService
-    implements HealthReporter {
+public abstract class NodeHealthCheckerService extends CompositeService {
 
-  public static final Logger LOG =
-      LoggerFactory.getLogger(NodeHealthCheckerService.class);
-  private static final int MAX_SCRIPTS = 4;
-
-  private List<HealthReporter> reporters;
-  private LocalDirsHandlerService dirsHandler;
-  private ExceptionReporter exceptionReporter;
-
-  public static final String SEPARATOR = ";";
-
-  public NodeHealthCheckerService(
-      LocalDirsHandlerService dirHandlerService) {
-    super(NodeHealthCheckerService.class.getName());
-
-    this.reporters = new ArrayList<>();
-    this.dirsHandler = dirHandlerService;
-    this.exceptionReporter = new ExceptionReporter();
-  }
-
-  @Override
-  protected void serviceInit(Configuration conf) throws Exception {
-    reporters.add(exceptionReporter);
-    addHealthReporter(dirsHandler);
-    String[] configuredScripts = conf.getTrimmedStrings(
-        YarnConfiguration.NM_HEALTH_CHECK_SCRIPTS,
-        YarnConfiguration.DEFAULT_NM_HEALTH_CHECK_SCRIPTS);
-    if (configuredScripts.length > MAX_SCRIPTS) {
-      throw new IllegalArgumentException("Due to performance reasons " +
-          "running more than " + MAX_SCRIPTS + "scripts is not allowed.");
-    }
-    for (String configuredScript : configuredScripts) {
-      addHealthReporter(NodeHealthScriptRunner.newInstance(
-          configuredScript, conf));
-    }
-    super.serviceInit(conf);
-  }
-
-  /**
-   * Adds a {@link Service} implementing the {@link HealthReporter} interface,
-   * if that service has not been added to this {@link CompositeService} yet.
-   *
-   * @param service to add
-   * @throws Exception if not a {@link HealthReporter}
-   *         implementation is provided to this function
-   */
-  @VisibleForTesting
-  void addHealthReporter(Service service) throws Exception {
-    if (service != null) {
-      if (getServices().stream()
-          .noneMatch(x -> x.getName().equals(service.getName()))) {
-        if (!(service instanceof HealthReporter)) {
-          throw new Exception("Attempted to add service to " +
-              "NodeHealthCheckerService that does not implement " +
-              "HealthReporter.");
-        }
-        reporters.add((HealthReporter) service);
-        addService(service);
-      } else {
-        LOG.debug("Omitting duplicate service: {}.", service.getName());
-      }
-    }
+  public NodeHealthCheckerService(String name) {
+    super(name);
   }
 
   /**
@@ -121,44 +36,26 @@ public class NodeHealthCheckerService extends CompositeService
    *
    * @return the report string about the health of the node
    */
-  @Override
-  public String getHealthReport() {
-    ArrayList<String> reports = reporters.stream()
-        .map(reporter -> Strings.emptyToNull(reporter.getHealthReport()))
-        .collect(Collectors.toCollection(ArrayList::new));
-    return Joiner.on(SEPARATOR).skipNulls().join(reports);
-  }
+  public abstract String getHealthReport();
 
   /**
    * @return <em>true</em> if the node is healthy
    */
-  @Override
-  public boolean isHealthy() {
-    return reporters.stream().allMatch(HealthReporter::isHealthy);
-  }
+  public abstract boolean isHealthy();
 
   /**
    * @return when the last time the node health status is reported
    */
-  @Override
-  public long getLastHealthReportTime() {
-    Optional<Long> max = reporters.stream()
-        .map(HealthReporter::getLastHealthReportTime).max(Long::compareTo);
-    return max.orElse(0L);
-  }
+  public abstract long getLastHealthReportTime();
 
   /**
    * @return the disk handler
    */
-  public LocalDirsHandlerService getDiskHandler() {
-    return dirsHandler;
-  }
+  public abstract LocalDirsHandlerService getDiskHandler();
 
   /**
    * Propagating an exception to {@link ExceptionReporter}.
    * @param exception the exception to propagate
    */
-  public void reportException(Exception exception) {
-    exceptionReporter.reportException(exception);
-  }
+  public abstract void reportException(Exception exception);
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerServiceImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/health/NodeHealthCheckerServiceImpl.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.health;
+
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.service.Service;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides functionality of checking the health of a node and
+ * reporting back to the service for which the health checker has been asked to
+ * report.
+ *
+ * It is a {@link CompositeService}: every {@link Service} must be registered
+ * first in serviceInit, and should also implement the {@link HealthReporter}
+ * interface - otherwise an exception is thrown.
+ *
+ * Calling functions of HealthReporter merge its dependent
+ * services' reports.
+ *
+ * @see HealthReporter
+ * @see LocalDirsHandlerService
+ * @see TimedHealthReporterService
+ */
+public class NodeHealthCheckerServiceImpl extends NodeHealthCheckerService
+    implements HealthReporter {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(NodeHealthCheckerService.class);
+  private static final int MAX_SCRIPTS = 4;
+
+  private List<HealthReporter> reporters;
+  private LocalDirsHandlerService dirsHandler;
+  private ExceptionReporter exceptionReporter;
+
+  public static final String SEPARATOR = ";";
+
+  public NodeHealthCheckerServiceImpl(
+      LocalDirsHandlerService dirHandlerService) {
+    super(NodeHealthCheckerServiceImpl.class.getName());
+
+    this.reporters = new ArrayList<>();
+    this.dirsHandler = dirHandlerService;
+    this.exceptionReporter = new ExceptionReporter();
+  }
+
+  @Override
+  protected void serviceInit(Configuration conf) throws Exception {
+    reporters.add(exceptionReporter);
+    addHealthReporter(dirsHandler);
+    String[] configuredScripts = conf.getTrimmedStrings(
+        YarnConfiguration.NM_HEALTH_CHECK_SCRIPTS,
+        YarnConfiguration.DEFAULT_NM_HEALTH_CHECK_SCRIPTS);
+    if (configuredScripts.length > MAX_SCRIPTS) {
+      throw new IllegalArgumentException("Due to performance reasons " +
+          "running more than " + MAX_SCRIPTS + "scripts is not allowed.");
+    }
+    for (String configuredScript : configuredScripts) {
+      addHealthReporter(NodeHealthScriptRunner.newInstance(
+          configuredScript, conf));
+    }
+    super.serviceInit(conf);
+  }
+
+  /**
+   * Adds a {@link Service} implementing the {@link HealthReporter} interface,
+   * if that service has not been added to this {@link CompositeService} yet.
+   *
+   * @param service to add
+   * @throws Exception if not a {@link HealthReporter}
+   *         implementation is provided to this function
+   */
+  @VisibleForTesting
+  void addHealthReporter(Service service) throws Exception {
+    if (service != null) {
+      if (getServices().stream()
+          .noneMatch(x -> x.getName().equals(service.getName()))) {
+        if (!(service instanceof HealthReporter)) {
+          throw new Exception("Attempted to add service to " +
+              "NodeHealthCheckerService that does not implement " +
+              "HealthReporter.");
+        }
+        reporters.add((HealthReporter) service);
+        addService(service);
+      } else {
+        LOG.debug("Omitting duplicate service: {}.", service.getName());
+      }
+    }
+  }
+
+  /**
+   * Joining the health reports of the dependent services.
+   *
+   * @return the report string about the health of the node
+   */
+  @Override
+  public String getHealthReport() {
+    ArrayList<String> reports = reporters.stream()
+        .map(reporter -> Strings.emptyToNull(reporter.getHealthReport()))
+        .collect(Collectors.toCollection(ArrayList::new));
+    return Joiner.on(SEPARATOR).skipNulls().join(reports);
+  }
+
+  /**
+   * @return <em>true</em> if the node is healthy
+   */
+  @Override
+  public boolean isHealthy() {
+    return reporters.stream().allMatch(HealthReporter::isHealthy);
+  }
+
+  /**
+   * @return when the last time the node health status is reported
+   */
+  @Override
+  public long getLastHealthReportTime() {
+    Optional<Long> max = reporters.stream()
+        .map(HealthReporter::getLastHealthReportTime).max(Long::compareTo);
+    return max.orElse(0L);
+  }
+
+  /**
+   * @return the disk handler
+   */
+  public LocalDirsHandlerService getDiskHandler() {
+    return dirsHandler;
+  }
+
+  /**
+   * Propagating an exception to {@link ExceptionReporter}.
+   * @param exception the exception to propagate
+   */
+  public void reportException(Exception exception) {
+    exceptionReporter.reportException(exception);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestEventFlow.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestEventFlow.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.yarn.server.nodemanager.NodeManager.NMContext;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.BaseContainerManagerTest;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.TestContainerManager;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.security.NMContainerTokenSecretManager;
@@ -106,7 +107,7 @@ public class TestEventFlow {
     Dispatcher dispatcher = new AsyncDispatcher();
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
     NodeHealthCheckerService healthChecker =
-        new NodeHealthCheckerService(dirsHandler);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
     healthChecker.init(conf);
     NodeManagerMetrics metrics = NodeManagerMetrics.create();
     NodeStatusUpdater nodeStatusUpdater =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.doNothing;
 
 import org.apache.hadoop.yarn.server.nodemanager.NodeResourceMonitorImpl;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +173,12 @@ public abstract class BaseContainerManagerTest {
     this.nodeStatusUpdater = nodeStatusUpdater;
   }
 
+  public void setNodeHealthCheckerService(NodeHealthCheckerService nhcs,
+      Configuration yarnConfiguration) {
+    this.nodeHealthCheckerService = nhcs;
+    this.nodeHealthCheckerService.init(yarnConfiguration);
+  }
+
   protected ContainerExecutor createContainerExecutor() {
     DefaultContainerExecutor exec = new DefaultContainerExecutor();
     exec.setConf(conf);
@@ -208,7 +215,7 @@ public abstract class BaseContainerManagerTest {
 
     dirsHandler = new LocalDirsHandlerService();
     dirsHandler.init(conf);
-    nodeHealthCheckerService = new NodeHealthCheckerService(dirsHandler);
+    nodeHealthCheckerService = new NodeHealthCheckerServiceImpl(dirsHandler);
     nodeStatusUpdater = new NodeStatusUpdaterImpl(
         context, new AsyncDispatcher(), nodeHealthCheckerService, metrics) {
       @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
@@ -85,7 +85,6 @@ import org.apache.hadoop.yarn.server.nodemanager.ContainerExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
 import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
-import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
 import org.apache.hadoop.yarn.server.nodemanager.NodeManager.NMContext;
 import org.apache.hadoop.yarn.server.nodemanager.NodeStatusUpdater;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Application;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
@@ -106,6 +106,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.Contai
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.ContainersMonitorImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.scheduler.ContainerScheduler;
 
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.TestNodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreService;
@@ -156,8 +157,8 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
     delSrvc.init(conf);
     exec = createContainerExecutor();
     dirsHandler = new LocalDirsHandlerService();
-    nodeHealthChecker = new NodeHealthCheckerService(dirsHandler);
-    nodeHealthChecker.init(conf);
+    setNodeHealthCheckerService(
+        new NodeHealthCheckerServiceImpl(dirsHandler), conf);
 
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/health/TestNodeHealthCheckerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/health/TestNodeHealthCheckerService.java
@@ -140,8 +140,9 @@ public class TestNodeHealthCheckerService {
     }
     nodeHealthScriptRunner = spy(nodeHealthScriptRunner);
     NodeHealthCheckerService nodeHealthChecker =
-        new NodeHealthCheckerService(dirsHandler);
-    nodeHealthChecker.addHealthReporter(nodeHealthScriptRunner);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
+    ((NodeHealthCheckerServiceImpl) nodeHealthChecker)
+        .addHealthReporter(nodeHealthScriptRunner);
     nodeHealthChecker.init(conf);
 
     doReturn(true).when(nodeHealthScriptRunner).isHealthy();
@@ -190,7 +191,7 @@ public class TestNodeHealthCheckerService {
         healthStatus.getIsNodeHealthy());
     Assert.assertTrue("Node script time out message not propagated",
         healthStatus.getHealthReport().equals(
-            Joiner.on(NodeHealthCheckerService.SEPARATOR).skipNulls().join(
+            Joiner.on(NodeHealthCheckerServiceImpl.SEPARATOR).skipNulls().join(
                 NodeHealthScriptRunner.NODE_HEALTH_SCRIPT_TIMED_OUT_MSG,
                 Strings.emptyToNull(
                     nodeHealthChecker.getDiskHandler()
@@ -230,8 +231,9 @@ public class TestNodeHealthCheckerService {
     Configuration conf = new Configuration();
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
     NodeHealthCheckerService nodeHealthChecker =
-        new NodeHealthCheckerService(dirsHandler);
-    nodeHealthChecker.addHealthReporter(customHealthReporter);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
+    ((NodeHealthCheckerServiceImpl) nodeHealthChecker)
+        .addHealthReporter(customHealthReporter);
     nodeHealthChecker.init(conf);
 
     assertThat(nodeHealthChecker.isHealthy()).isTrue();
@@ -246,7 +248,7 @@ public class TestNodeHealthCheckerService {
     Configuration conf = new Configuration();
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
     NodeHealthCheckerService nodeHealthChecker =
-        new NodeHealthCheckerService(dirsHandler);
+        new NodeHealthCheckerServiceImpl(dirsHandler);
     nodeHealthChecker.init(conf);
     assertThat(nodeHealthChecker.isHealthy()).isTrue();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestContainerLogsPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestContainerLogsPage.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.launcher.ContainerLaunch;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.ContainerLogsPage.ContainersLogsBlock;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
@@ -80,7 +81,7 @@ public class TestContainerLogsPage {
 
   private NodeHealthCheckerService createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   @Test(timeout=30000)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMContainerWebSocket.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMContainerWebSocket.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.yarn.server.nodemanager.NodeManager;
 import org.apache.hadoop.yarn.server.nodemanager.ResourceView;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
@@ -120,7 +121,7 @@ public class TestNMContainerWebSocket {
 
   private NodeHealthCheckerService createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServer.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
@@ -80,7 +81,7 @@ public class TestNMWebServer {
 
   private NodeHealthCheckerService createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   private int startNMWebAppServer(String webAddr) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServices.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.gpu.AssignedGpuDevice;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.gpu.GpuDevice;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMResourceInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.GpuDeviceInformation;
@@ -143,7 +144,7 @@ public class TestNMWebServices extends JerseyTestBase {
           LOGSERVICEWSADDR);
       dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       aclsManager = new ApplicationACLsManager(conf);
       nmContext = new NodeManager.NMContext(null, null, dirsHandler,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesApps.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Ap
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.ApplicationState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.AppsInfo;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
@@ -105,7 +106,7 @@ public class TestNMWebServicesApps extends JerseyTestBase {
       conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
       LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       dirsHandler = healthChecker.getDiskHandler();
       aclsManager = new ApplicationACLsManager(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesAuxServices.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.yarn.server.nodemanager.ResourceView;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.AuxServices;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceRecord;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
@@ -125,7 +126,7 @@ public class TestNMWebServicesAuxServices extends JerseyTestBase {
       conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
       LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       dirsHandler = healthChecker.getDiskHandler();
       ApplicationACLsManager aclsManager = new ApplicationACLsManager(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebServicesContainers.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Ap
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.WebServer.NMWebApp;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
@@ -130,7 +131,7 @@ public class TestNMWebServicesContainers extends JerseyTestBase {
       conf.set(YarnConfiguration.NM_LOG_DIRS, testLogDir.getAbsolutePath());
       LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
       NodeHealthCheckerService healthChecker =
-          new NodeHealthCheckerService(dirsHandler);
+          new NodeHealthCheckerServiceImpl(dirsHandler);
       healthChecker.init(conf);
       dirsHandler = healthChecker.getDiskHandler();
       aclsManager = new ApplicationACLsManager(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebTerminal.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/webapp/TestNMWebTerminal.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
 import org.apache.hadoop.yarn.server.nodemanager.NodeManager;
 import org.apache.hadoop.yarn.server.nodemanager.ResourceView;
 import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService;
+import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerServiceImpl;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.junit.After;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class TestNMWebTerminal {
 
   private NodeHealthCheckerService createNodeHealthCheckerService() {
     LocalDirsHandlerService dirsHandler = new LocalDirsHandlerService();
-    return new NodeHealthCheckerService(dirsHandler);
+    return new NodeHealthCheckerServiceImpl(dirsHandler);
   }
 
   private int startNMWebAppServer(String webAddr) {


### PR DESCRIPTION
This PR aims to support NodeHealthCheckerService as pluggable interface, 
The custom NodeHealthCheckerService can be used by setting `yarn.nodemanager.health-checker-service.class` in the configuration. If no class is set it falls back to the default class i.e `NodeHealthCheckerServiceImpl`

Linked Jira: [YARN-10861](https://issues.apache.org/jira/browse/YARN-10861)
