### PR TITLE
HADOOP-17812. NPE in S3AInputStream read() after failure to reconnect to store

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -419,6 +419,12 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
         () -> {
           int b;
           try {
+            // When exception happens before re-setting wrappedStream in "reopen" called
+            // by onReadFailure, then wrappedStream will be null. But the **retry** may
+            // re-execute this block and cause NPE if we don't check wrappedStream
+            if (wrappedStream == null) {
+              throw new IOException("Null IO stream for reading "  + uri);
+            }
             b = wrappedStream.read();
           } catch (EOFException e) {
             return -1;
@@ -507,6 +513,12 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
         () -> {
           int bytes;
           try {
+            // When exception happens before re-setting wrappedStream in "reopen" called
+            // by onReadFailure, then wrappedStream will be null. But the **retry** may
+            // re-execute this block and cause NPE if we don't check wrappedStream
+            if (wrappedStream == null) {
+              throw new IOException("Null IO stream for reading "  + uri);
+            }
             bytes = wrappedStream.read(buf, off, len);
           } catch (EOFException e) {
             // the base implementation swallows EOFs.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -418,21 +418,21 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     int byteRead = invoker.retry("read", pathStr, true,
         () -> {
           int b;
+          // When exception happens before re-setting wrappedStream in "reopen" called
+          // by onReadFailure, then wrappedStream will be null. But the **retry** may
+          // re-execute this block and cause NPE if we don't check wrappedStream
+          if (wrappedStream == null) {
+            reopen("failure recovery", getPos(), 1, false);
+          }
           try {
-            // When exception happens before re-setting wrappedStream in "reopen" called
-            // by onReadFailure, then wrappedStream will be null. But the **retry** may
-            // re-execute this block and cause NPE if we don't check wrappedStream
-            if (wrappedStream == null) {
-              throw new IOException("Null IO stream for reading "  + uri);
-            }
             b = wrappedStream.read();
           } catch (EOFException e) {
             return -1;
           } catch (SocketTimeoutException e) {
-            onReadFailure(e, 1, true);
+            onReadFailure(e, true);
             throw e;
           } catch (IOException e) {
-            onReadFailure(e, 1, false);
+            onReadFailure(e, false);
             throw e;
           }
           return b;
@@ -450,15 +450,12 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   }
 
   /**
-   * Handle an IOE on a read by attempting to re-open the stream.
+   * Close the stream on read failure.
    * The filesystem's readException count will be incremented.
    * @param ioe exception caught.
-   * @param length length of data being attempted to read
-   * @throws IOException any exception thrown on the re-open attempt.
    */
   @Retries.OnceTranslated
-  private void onReadFailure(IOException ioe, int length, boolean forceAbort)
-          throws IOException {
+  private void onReadFailure(IOException ioe, boolean forceAbort) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Got exception while trying to read from stream {}, " +
           "client: {} object: {}, trying to recover: ",
@@ -469,7 +466,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
           uri, client, object);
     }
     streamStatistics.readException();
-    reopen("failure recovery", pos, length, forceAbort);
+    closeStream("failure recovery", contentRangeFinish, forceAbort);
   }
 
   /**
@@ -512,22 +509,22 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     int bytesRead = invoker.retry("read", pathStr, true,
         () -> {
           int bytes;
+          // When exception happens before re-setting wrappedStream in "reopen" called
+          // by onReadFailure, then wrappedStream will be null. But the **retry** may
+          // re-execute this block and cause NPE if we don't check wrappedStream
+          if (wrappedStream == null) {
+            reopen("failure recovery", getPos(), 1, false);
+          }
           try {
-            // When exception happens before re-setting wrappedStream in "reopen" called
-            // by onReadFailure, then wrappedStream will be null. But the **retry** may
-            // re-execute this block and cause NPE if we don't check wrappedStream
-            if (wrappedStream == null) {
-              throw new IOException("Null IO stream for reading "  + uri);
-            }
             bytes = wrappedStream.read(buf, off, len);
           } catch (EOFException e) {
             // the base implementation swallows EOFs.
             return -1;
           } catch (SocketTimeoutException e) {
-            onReadFailure(e, len, true);
+            onReadFailure(e, true);
             throw e;
           } catch (IOException e) {
-            onReadFailure(e, len, false);
+            onReadFailure(e, false);
             throw e;
           }
           return bytes;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -129,12 +129,17 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
         mockedS3ObjectIndex++;
         // open() -> lazySeek() -> reopen()
         //        -> getObject (mockedS3ObjectIndex=1) -> getObjectContent(objectInputStreamBad1)
-        // read() -> objectInputStreamBad1 throws exception -> onReadFailure -> reopen
-        //        -> getObject (mockedS3ObjectIndex=2) -> getObjectContent(objectInputStreamBad2)
-        //  -> retry -> wrappedStream.read -> objectInputStreamBad2 throws exception
-        //        -> onReadFailure -> reopen -> getObject (mockedS3ObjectIndex=3) throws exception
-        //        -> reopen throws exception
-        //  -> retry -> re-execute wrappedStream.read (we need to check if wrappedStream == null)
+        // read() -> objectInputStreamBad1 throws exception
+        //        -> onReadFailure -> close wrappedStream
+        //  -> retry(1) -> wrappedStream==null -> reopen -> getObject (mockedS3ObjectIndex=2)
+        //        -> getObjectContent(objectInputStreamBad2)-> objectInputStreamBad2
+        //        -> wrappedStream.read -> objectInputStreamBad2 throws exception
+        //        -> onReadFailure -> close wrappedStream
+        //  -> retry(2) -> wrappedStream==null -> reopen
+        //        -> getObject (mockedS3ObjectIndex=3) throws exception
+        //  -> retry(3) -> wrappedStream==null -> reopen -> getObject (mockedS3ObjectIndex=4)
+        //        -> getObjectContent(objectInputStreamGood)-> objectInputStreamGood
+        //        -> wrappedStream.read
         if (mockedS3ObjectIndex == 3) {
           throw new SdkClientException("Failed to get S3Object");
         }


### PR DESCRIPTION
When IOException happens during "wrappedStream.read", onReadFailure->reopen
will be called and reopen will try to re-open "wrappedStream", but what if
exception happens during getting S3Object, then "wrappedStream" will be null,
finally, the "retry" may re-execute the read block and cause the NPE.

See the issue https://issues.apache.org/jira/browse/HADOOP-17812

