### PR TITLE
HDFS-16140. TestBootstrapAliasmap fails by BindException.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapAliasmap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapAliasmap.java
@@ -51,6 +51,9 @@ public class TestBootstrapAliasmap {
   public void setup() throws Exception {
     Configuration conf = new Configuration();
     MiniDFSCluster.setupNamenodeProvidedConfiguration(conf);
+    // use free port instead of default 50200 port
+    conf.set(DFSConfigKeys.DFS_PROVIDED_ALIASMAP_INMEMORY_RPC_ADDRESS,
+            "127.0.0.1:" + NetUtils.getFreeSocketPort());
     cluster = new MiniDFSCluster.Builder(conf)
         .numDataNodes(1)
         .build();


### PR DESCRIPTION
Use an available port instead of the default 50200 port in the test.

JIRA: HDFS-16140