### PR TITLE
HADOOP-16128 Fix FileSystem.newInstance resource leaks in unit tests

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
@@ -162,12 +162,12 @@ public class ITestS3AAWSCredentialsProvider {
     conf.set(AWS_CREDENTIALS_PROVIDER,
         AnonymousAWSCredentialsProvider.class.getName());
     Path testFile = getCSVTestPath(conf);
-    FileSystem fs = FileSystem.newInstance(testFile.toUri(), conf);
-    assertNotNull(fs);
-    assertTrue(fs instanceof S3AFileSystem);
-    FileStatus stat = fs.getFileStatus(testFile);
-    assertNotNull(stat);
-    assertEquals(testFile, stat.getPath());
+    try (FileSystem fs = FileSystem.newInstance(testFile.toUri(), conf);) {
+        assertNotNull(fs);
+        assertTrue(fs instanceof S3AFileSystem);
+        FileStatus stat = fs.getFileStatus(testFile);
+        assertNotNull(stat);
+        assertEquals(testFile, stat.getPath());
+    }
   }
-
 }


### PR DESCRIPTION
Motivation - 
Fix resource leak created in unit tests that instantiate FileSystem resource. 

Result - 
Fixed the resource leaks in the unit test for the S3A module. Run all unit tests locally successfully. 
