### PR TITLE
HADOOP-17834. Bump aliyun-sdk-oss to 3.13.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -214,7 +214,7 @@ com.aliyun:aliyun-java-sdk-core:3.4.0
 com.aliyun:aliyun-java-sdk-ecs:4.2.0
 com.aliyun:aliyun-java-sdk-ram:3.0.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
-com.aliyun.oss:aliyun-sdk-oss:3.4.1
+com.aliyun.oss:aliyun-sdk-oss:3.13.0
 com.amazonaws:aws-java-sdk-bundle:1.11.901
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1468,7 +1468,7 @@
       <dependency>
         <groupId>com.aliyun.oss</groupId>
         <artifactId>aliyun-sdk-oss</artifactId>
-        <version>3.4.1</version>
+        <version>3.13.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
See description of https://issues.apache.org/jira/browse/HADOOP-17834.

Confirmed that with this change, jdom 1.1 is gone from the dependency tree:

```
$ mvn dependency:tree | grep jdom                                  
[INFO] |  +- org.jdom:jdom2:jar:2.0.6:provided
[INFO] |  +- org.jdom:jdom2:jar:2.0.6:compile
[INFO] |     +- org.jdom:jdom2:jar:2.0.6:compile
[INFO] |     +- org.jdom:jdom2:jar:2.0.6:compile
```