### PR TITLE
YARN-10878. move TestNMSimulator off com.google

### DIFF
--- a/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/nodemanager/TestNMSimulator.java
+++ b/hadoop-tools/hadoop-sls/src/test/java/org/apache/hadoop/yarn/sls/nodemanager/TestNMSimulator.java
@@ -157,13 +157,10 @@ public class TestNMSimulator {
       numClusterNodes = rm.getResourceScheduler().getNumClusterNodes();
     }
 
-    GenericTestUtils.waitFor(new com.google.common.base.Supplier<Boolean>() {
-      @Override
-      public Boolean get() {
-        return rm.getResourceScheduler().getRootQueueMetrics()
-            .getAvailableMB() > 0;
-      }
-    }, 500, 10000);
+    GenericTestUtils.waitFor(() ->
+            rm.getResourceScheduler().getRootQueueMetrics()
+                .getAvailableMB() > 0,
+        500, 10000);
 
     Assert.assertEquals("Node should have no runningApps.",
         node.getNode().getRunningApps().size(), 0);
@@ -207,13 +204,10 @@ public class TestNMSimulator {
       numClusterNodes = rm.getResourceScheduler().getNumClusterNodes();
     }
 
-    GenericTestUtils.waitFor(new com.google.common.base.Supplier<Boolean>() {
-      @Override
-      public Boolean get() {
-        return rm.getResourceScheduler().getRootQueueMetrics()
-            .getAvailableMB() > 0;
-      }
-    }, 500, 10000);
+    GenericTestUtils.waitFor(() ->
+            rm.getResourceScheduler().getRootQueueMetrics()
+                .getAvailableMB() > 0,
+        500, 10000);
 
     Assert.assertEquals("Node should have no runningApps.",
         node.getNode().getRunningApps().size(), 0);


### PR DESCRIPTION

Converting from a class to a lambda expression removes all need to reference the google stuff
