### PR TITLE
HADOOP-17837: Add unresolved endpoint value to UnknownHostException

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -589,7 +589,7 @@ public class NetUtils {
     } catch (SocketTimeoutException ste) {
       throw new ConnectTimeoutException(ste.getMessage());
     }  catch (UnresolvedAddressException uae) {
-      throw new UnknownHostException(uae.getMessage());
+      throw new UnknownHostException(endpoint.toString());
     }
 
     // There is a very rare case allowed by the TCP specification, such that

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -111,6 +111,7 @@ public class TestNetUtils {
       fail("Should not have connected");
     } catch (UnknownHostException uhe) {
       LOG.info("Got exception: ", uhe);
+      assertEquals("invalid-test-host:0", uhe.getMessage());
     }
   }
 


### PR DESCRIPTION
Per https://issues.apache.org/jira/browse/HADOOP-17837, adds `endpoint.toString() to the UnknownHostException. UnresolvedAddressException cannot have a message, so the current behavior is a UHE with no message as well. Adding the endpoint to the exception will make it easier to debug when these arise.