### PR TITLE
HADOOP-17837: Add unresolved endpoint value to UnknownHostException (ADDENDUM)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.security.KerberosAuthException;
 import org.apache.hadoop.security.NetUtilsTestResolver;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -111,7 +112,7 @@ public class TestNetUtils {
       fail("Should not have connected");
     } catch (UnknownHostException uhe) {
       LOG.info("Got exception: ", uhe);
-      assertEquals("invalid-test-host:0", uhe.getMessage());
+      GenericTestUtils.assertExceptionContains("invalid-test-host:0", uhe);
     }
   }
 


### PR DESCRIPTION
Addresses a comment made in https://github.com/apache/hadoop/pull/3272.

The other comment about concatenating the UnresolvedAddressException message is unnecessary. In all versions of java it's impossible to add a message to an UnresolvedAddressException.  See [java11](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/channels/UnresolvedAddressException.html), there is only a no-args constructor and no `setMessage()` method.