### PR TITLE
YARN-10873: Account for scheduled AM containers before deactivating node

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -38,7 +38,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 import org.apache.commons.collections.keyvalue.DefaultMapEntry;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -1424,11 +1424,6 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
      * @return true if node has any AM scheduled on it.
      */
     private boolean hasScheduledAMContainers(RMNodeImpl rmNode) {
-      ResourceScheduler resourceScheduler = rmNode.context.getScheduler();
-      // Some UTs have scheduler set to null.
-      if (resourceScheduler == null) {
-        return false;
-      }
       return rmNode.context.getScheduler()
           .getSchedulerNode(rmNode.getNodeID())
           .getCopiedListOfRunningContainers()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -38,6 +38,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 import org.apache.commons.collections.keyvalue.DefaultMapEntry;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -1423,6 +1424,11 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
      * @return true if node has any AM scheduled on it.
      */
     private boolean hasScheduledAMContainers(RMNodeImpl rmNode) {
+      ResourceScheduler resourceScheduler = rmNode.context.getScheduler();
+      // Some UTs have scheduler set to null.
+      if (resourceScheduler == null) {
+        return false;
+      }
       return rmNode.context.getScheduler()
           .getSchedulerNode(rmNode.getNodeID())
           .getCopiedListOfRunningContainers()

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -1354,27 +1354,22 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       boolean isNodeDecommissioning =
           initialState.equals(NodeState.DECOMMISSIONING);
       if (isNodeDecommissioning) {
-        // This check solves the following race condition -
+        List<ApplicationId> keepAliveApps = statusEvent.getKeepAliveAppIds();
+        // hasScheduledAMContainers solves the following race condition -
         // 1. launch AM container on a node with 0 containers.
         // 2. gracefully decommission this node.
-        // 3. At the same time the node heartbeats to RM.
-        //    rmNode.runningApplications will be empty as this data structure is
-        //    updated later in this method. This will cause the node to be
+        // 3. Node heartbeats to RM. In StatusUpdateWhenHealthyTransition,
+        //    rmNode.runningApplications will be empty as it is updated after
+        //    call to RMNodeImpl.deactivateNode. This will cause the node to be
         //    deactivated even though container is running on it and hence kill
         //    all containers running on it.
         // In order to avoid such race conditions the ground truth is retrieved
         // from the scheduler before deactivating a DECOMMISSIONING node.
         // Only AM containers are considered as AM container reattempts can
         // cause application failures if max attempts is set to 1.
-        boolean hasLaunchedRMMasterContainers = rmNode.context.getScheduler()
-            .getSchedulerNode(rmNode.getNodeID())
-            .getCopiedListOfRunningContainers()
-            .stream().anyMatch(RMContainer::isAMContainer);
-
-        List<ApplicationId> keepAliveApps = statusEvent.getKeepAliveAppIds();
         if (rmNode.runningApplications.isEmpty() &&
             (keepAliveApps == null || keepAliveApps.isEmpty()) &&
-            !hasLaunchedRMMasterContainers) {
+            !hasScheduledAMContainers(rmNode)) {
           LOG.info("No containers running on " + rmNode.nodeId + ". "
               + "Attempting to deactivate decommissioning node.");
           RMNodeImpl.deactivateNode(rmNode, NodeState.DECOMMISSIONED);
@@ -1421,6 +1416,17 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       }
 
       return initialState;
+    }
+
+    /**
+     * Checks if the scheduler has scheduled any AMs on the given node.
+     * @return true if node has any AM scheduled on it.
+     */
+    private boolean hasScheduledAMContainers(RMNodeImpl rmNode) {
+      return rmNode.context.getScheduler()
+          .getSchedulerNode(rmNode.getNodeID())
+          .getCopiedListOfRunningContainers()
+          .stream().anyMatch(RMContainer::isAMContainer);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.apache.commons.collections.keyvalue.DefaultMapEntry;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -1353,9 +1354,29 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       boolean isNodeDecommissioning =
           initialState.equals(NodeState.DECOMMISSIONING);
       if (isNodeDecommissioning) {
+        // This check solves the following race condition -
+        // 1. launch AM container on a node with 0 containers.
+        // 2. gracefully decommission this node.
+        // 3. At the same time the node heartbeats to RM.
+        //    rmNode.runningApplications will be empty as this data structure is
+        //    updated later in this method. This will cause the node to be
+        //    deactivated even though container is running on it and hence kill
+        //    all containers running on it.
+        // In order to avoid such race conditions the ground truth is retrieved
+        // from the scheduler before deactivating a DECOMMISSIONING node.
+        // Only AM containers are considered as AM container reattempts can
+        // cause application failures if max attempts is set to 1.
+        boolean hasLaunchedRMMasterContainers = rmNode.context.getScheduler()
+            .getSchedulerNode(rmNode.getNodeID())
+            .getCopiedListOfRunningContainers()
+            .stream().anyMatch(RMContainer::isAMContainer);
+
         List<ApplicationId> keepAliveApps = statusEvent.getKeepAliveAppIds();
         if (rmNode.runningApplications.isEmpty() &&
-            (keepAliveApps == null || keepAliveApps.isEmpty())) {
+            (keepAliveApps == null || keepAliveApps.isEmpty()) &&
+            !hasLaunchedRMMasterContainers) {
+          LOG.info("No containers running on " + rmNode.nodeId + ". "
+              + "Attempting to deactivate decommissioning node.");
           RMNodeImpl.deactivateNode(rmNode, NodeState.DECOMMISSIONED);
           return NodeState.DECOMMISSIONED;
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMNodeTransitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMNodeTransitions.java
@@ -68,6 +68,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeResourceUpdate
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeStartedEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeStatusEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.YarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeAddedSchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeRemovedSchedulerEvent;
@@ -81,6 +83,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -125,7 +128,7 @@ public class TestRMNodeTransitions {
     rmContext =
         new RMContextImpl(rmDispatcher, mock(ContainerAllocationExpirer.class),
           null, null, mock(DelegationTokenRenewer.class), null, null, null,
-          null, null);
+          null, getMockResourceScheduler());
     NodesListManager nodesListManager = mock(NodesListManager.class);
     HostsFileReader reader = mock(HostsFileReader.class);
     when(nodesListManager.getHostsReader()).thenReturn(reader);
@@ -191,6 +194,16 @@ public class TestRMNodeTransitions {
     doReturn(RMNodeEventType.STATUS_UPDATE).when(event).getType();
     doReturn(getAppIdList()).when(event).getKeepAliveAppIds();
     return event;
+  }
+
+  private ResourceScheduler getMockResourceScheduler() {
+    ResourceScheduler resourceScheduler = mock(ResourceScheduler.class);
+    SchedulerNode schedulerNode = mock(SchedulerNode.class);
+    when(schedulerNode.getCopiedListOfRunningContainers())
+        .thenReturn(Collections.emptyList());
+    when(resourceScheduler.getSchedulerNode(ArgumentMatchers.any()))
+        .thenReturn(schedulerNode);
+    return resourceScheduler;
   }
 
   private List<ApplicationId> getAppIdList() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
@@ -464,7 +464,7 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
    * Test graceful decommission of node when an AM container is scheduled on a
    * node just before it is gracefully decommissioned.
    */
-  @Test
+  @Test (timeout = 60000)
   public void testGracefulDecommissionAfterAMContainerAlloc() throws Exception {
     Configuration conf = new Configuration();
     conf.set(YarnConfiguration.RM_NODES_EXCLUDE_FILE_PATH, hostFile


### PR DESCRIPTION
When a node heartbeats to the RM, the StatusUpdateWhenHealthyTransition checks if rmNode.runningApplications is empty before deactivating the node (killing all containers on the node).

The data structure rmNode.runningApplications is updated in the same transition but after the call to RMNodeImpl.deactivateNode.

This can lead a race condition when a node is gracefully decommissioned immediately after launching a container on a node with 0 containers. 

The heartbeat received from the node just after the container gets launched will update rmNode.runningApplications after RMNodeImpl.deactivateNode is called, causing the node to be deactivated and all scheduled containers to be killed. 

If the container was an AM container, a retry is attempted without counting towards application failure. But for cases where max attempts is set to 1, the application is never retried (YARN-5617) and hence fails.

This PR checks the scheduler if any application's AM are scheduled on the node before deactivating it.