### PR TITLE
HDFS-16158. Discover datanodes with unbalanced volume usage by the st…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeLifelineProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeLifelineProtocolClientSideTranslatorPB.java
@@ -80,11 +80,13 @@ public class DatanodeLifelineProtocolClientSideTranslatorPB implements
   public void sendLifeline(DatanodeRegistration registration,
       StorageReport[] reports, long cacheCapacity, long cacheUsed,
       int xmitsInProgress, int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) throws IOException {
+      VolumeFailureSummary volumeFailureSummary,
+      float volumeUsageStdDev) throws IOException {
     HeartbeatRequestProto.Builder builder = HeartbeatRequestProto.newBuilder()
         .setRegistration(PBHelper.convert(registration))
         .setXmitsInProgress(xmitsInProgress).setXceiverCount(xceiverCount)
-        .setFailedVolumes(failedVolumes);
+        .setFailedVolumes(failedVolumes)
+        .setVolumeUsageStdDev(volumeUsageStdDev);
     builder.addAllReports(PBHelperClient.convertStorageReports(reports));
     if (cacheCapacity != 0) {
       builder.setCacheCapacity(cacheCapacity);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeLifelineProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeLifelineProtocolServerSideTranslatorPB.java
@@ -62,7 +62,8 @@ public class DatanodeLifelineProtocolServerSideTranslatorPB implements
       impl.sendLifeline(PBHelper.convert(request.getRegistration()), report,
           request.getCacheCapacity(), request.getCacheUsed(),
           request.getXmitsInProgress(), request.getXceiverCount(),
-          request.getFailedVolumes(), volumeFailureSummary);
+          request.getFailedVolumes(), volumeFailureSummary,
+          request.getVolumeUsageStdDev());
       return VOID_LIFELINE_RESPONSE_PROTO;
     } catch (IOException e) {
       throw new ServiceException(e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolClientSideTranslatorPB.java
@@ -138,13 +138,15 @@ public class DatanodeProtocolClientSideTranslatorPB implements
       VolumeFailureSummary volumeFailureSummary,
       boolean requestFullBlockReportLease,
       @Nonnull SlowPeerReports slowPeers,
-      @Nonnull SlowDiskReports slowDisks)
+      @Nonnull SlowDiskReports slowDisks,
+      float volumeUsageStdDev)
           throws IOException {
     HeartbeatRequestProto.Builder builder = HeartbeatRequestProto.newBuilder()
         .setRegistration(PBHelper.convert(registration))
         .setXmitsInProgress(xmitsInProgress).setXceiverCount(xceiverCount)
         .setFailedVolumes(failedVolumes)
-        .setRequestFullBlockReportLease(requestFullBlockReportLease);
+        .setRequestFullBlockReportLease(requestFullBlockReportLease)
+        .setVolumeUsageStdDev(volumeUsageStdDev);
     builder.addAllReports(PBHelperClient.convertStorageReports(reports));
     if (cacheCapacity != 0) {
       builder.setCacheCapacity(cacheCapacity);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
@@ -122,7 +122,8 @@ public class DatanodeProtocolServerSideTranslatorPB implements
           request.getXceiverCount(), request.getFailedVolumes(),
           volumeFailureSummary, request.getRequestFullBlockReportLease(),
           PBHelper.convertSlowPeerInfo(request.getSlowPeersList()),
-          PBHelper.convertSlowDiskInfo(request.getSlowDisksList()));
+          PBHelper.convertSlowDiskInfo(request.getSlowDisksList()),
+          request.getVolumeUsageStdDev());
     } catch (IOException e) {
       throw new ServiceException(e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -2657,24 +2657,24 @@ public class BlockManager implements BlockStatsMXBean {
 
   void updateHeartbeat(DatanodeDescriptor node, StorageReport[] reports,
       long cacheCapacity, long cacheUsed, int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
 
     for (StorageReport report: reports) {
       providedStorageMap.updateStorage(node, report.getStorage());
     }
     node.updateHeartbeat(reports, cacheCapacity, cacheUsed, xceiverCount,
-        failedVolumes, volumeFailureSummary);
+        failedVolumes, volumeFailureSummary, volumeUsageStdDev);
   }
 
   void updateHeartbeatState(DatanodeDescriptor node,
       StorageReport[] reports, long cacheCapacity, long cacheUsed,
       int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
     for (StorageReport report: reports) {
       providedStorageMap.updateStorage(node, report.getStorage());
     }
     node.updateHeartbeatState(reports, cacheCapacity, cacheUsed, xceiverCount,
-        failedVolumes, volumeFailureSummary);
+        failedVolumes, volumeFailureSummary, volumeUsageStdDev);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -380,9 +380,9 @@ public class DatanodeDescriptor extends DatanodeInfo {
    */
   void updateHeartbeat(StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int volFailures,
-      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageSD) {
     updateHeartbeatState(reports, cacheCapacity, cacheUsed, xceiverCount,
-        volFailures, volumeFailureSummary, volumeUsageStdDev);
+        volFailures, volumeFailureSummary, volumeUsageSD);
     heartbeatedSinceRegistration = true;
   }
 
@@ -391,9 +391,9 @@ public class DatanodeDescriptor extends DatanodeInfo {
    */
   void updateHeartbeatState(StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int volFailures,
-      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageSD) {
     updateStorageStats(reports, cacheCapacity, cacheUsed, xceiverCount,
-        volFailures, volumeFailureSummary, volumeUsageStdDev);
+        volFailures, volumeFailureSummary, volumeUsageSD);
     setLastUpdate(Time.now());
     setLastUpdateMonotonic(Time.monotonicNow());
     rollBlocksScheduled(getLastUpdateMonotonic());
@@ -401,7 +401,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
 
   private void updateStorageStats(StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int volFailures,
-      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageSD) {
     long totalCapacity = 0;
     long totalRemaining = 0;
     long totalBlockPoolUsed = 0;
@@ -455,7 +455,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
     setXceiverCount(xceiverCount);
     this.volumeFailures = volFailures;
     this.volumeFailureSummary = volumeFailureSummary;
-    this.volumeUsageStdDev = volumeUsageStdDev;
+    this.volumeUsageStdDev = volumeUsageSD;
     for (StorageReport report : reports) {
 
       DatanodeStorageInfo storage = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -218,6 +218,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
   private long lastBlocksScheduledRollTime = 0;
   private int volumeFailures = 0;
   private VolumeFailureSummary volumeFailureSummary = null;
+  private float volumeUsageStdDev;
   
   /** 
    * When set to true, the node is not in include list and is not allowed
@@ -340,7 +341,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
   }
 
   public void resetBlocks() {
-    updateStorageStats(this.getStorageReports(), 0L, 0L, 0, 0, null);
+    updateStorageStats(this.getStorageReports(), 0L, 0L, 0, 0, null, 0.0f);
     synchronized (invalidateBlocks) {
       this.invalidateBlocks.clear();
     }
@@ -379,9 +380,9 @@ public class DatanodeDescriptor extends DatanodeInfo {
    */
   void updateHeartbeat(StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int volFailures,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
     updateHeartbeatState(reports, cacheCapacity, cacheUsed, xceiverCount,
-        volFailures, volumeFailureSummary);
+        volFailures, volumeFailureSummary, volumeUsageStdDev);
     heartbeatedSinceRegistration = true;
   }
 
@@ -390,9 +391,9 @@ public class DatanodeDescriptor extends DatanodeInfo {
    */
   void updateHeartbeatState(StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int volFailures,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
     updateStorageStats(reports, cacheCapacity, cacheUsed, xceiverCount,
-        volFailures, volumeFailureSummary);
+        volFailures, volumeFailureSummary, volumeUsageStdDev);
     setLastUpdate(Time.now());
     setLastUpdateMonotonic(Time.monotonicNow());
     rollBlocksScheduled(getLastUpdateMonotonic());
@@ -400,7 +401,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
 
   private void updateStorageStats(StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int volFailures,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
     long totalCapacity = 0;
     long totalRemaining = 0;
     long totalBlockPoolUsed = 0;
@@ -454,6 +455,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
     setXceiverCount(xceiverCount);
     this.volumeFailures = volFailures;
     this.volumeFailureSummary = volumeFailureSummary;
+    this.volumeUsageStdDev = volumeUsageStdDev;
     for (StorageReport report : reports) {
 
       DatanodeStorageInfo storage = null;
@@ -943,6 +945,13 @@ public class DatanodeDescriptor extends DatanodeInfo {
    */
   public VolumeFailureSummary getVolumeFailureSummary() {
     return volumeFailureSummary;
+  }
+
+  /**
+   * @return the standard deviation of volume usage
+   */
+  public float getVolumeUsageStdDev() {
+    return volumeUsageStdDev;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1751,7 +1751,8 @@ public class DatanodeManager {
       int maxTransfers, int failedVolumes,
       VolumeFailureSummary volumeFailureSummary,
       @Nonnull SlowPeerReports slowPeers,
-      @Nonnull SlowDiskReports slowDisks) throws IOException {
+      @Nonnull SlowDiskReports slowDisks,
+      float volumeUsageStdDev) throws IOException {
     final DatanodeDescriptor nodeinfo;
     try {
       nodeinfo = getDatanode(nodeReg);
@@ -1769,7 +1770,8 @@ public class DatanodeManager {
       return new DatanodeCommand[]{RegisterCommand.REGISTER};
     }
     heartbeatManager.updateHeartbeat(nodeinfo, reports, cacheCapacity,
-        cacheUsed, xceiverCount, failedVolumes, volumeFailureSummary);
+        cacheUsed, xceiverCount, failedVolumes, volumeFailureSummary,
+        volumeUsageStdDev);
 
     // If we are in safemode, do not send back any recovery / replication
     // requests. Don't even drain the existing queue of work.
@@ -1891,12 +1893,15 @@ public class DatanodeManager {
    * @param xceiverCount estimated count of transfer threads running at DataNode
    * @param failedVolumes count of failed volumes at DataNode
    * @param volumeFailureSummary info on failed volumes at DataNode
+   * @param volumeUsageStdDev the standard deviation of volume usage
+   x
    * @throws IOException if there is an error
    */
   public void handleLifeline(DatanodeRegistration nodeReg,
       StorageReport[] reports, long cacheCapacity,
       long cacheUsed, int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) throws IOException {
+      VolumeFailureSummary volumeFailureSummary,
+      float volumeUsageStdDev) throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Received handleLifeline from nodeReg = " + nodeReg);
     }
@@ -1917,7 +1922,7 @@ public class DatanodeManager {
       return;
     }
     heartbeatManager.updateLifeline(nodeinfo, reports, cacheCapacity, cacheUsed,
-        xceiverCount, failedVolumes, volumeFailureSummary);
+        xceiverCount, failedVolumes, volumeFailureSummary, volumeUsageStdDev);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1894,7 +1894,7 @@ public class DatanodeManager {
    * @param failedVolumes count of failed volumes at DataNode
    * @param volumeFailureSummary info on failed volumes at DataNode
    * @param volumeUsageStdDev the standard deviation of volume usage
-   x
+   *
    * @throws IOException if there is an error
    */
   public void handleLifeline(DatanodeRegistration nodeReg,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
@@ -223,7 +223,8 @@ class HeartbeatManager implements DatanodeStatistics {
       addDatanode(d);
 
       //update its timestamp
-      d.updateHeartbeatState(StorageReport.EMPTY_ARRAY, 0L, 0L, 0, 0, null);
+      d.updateHeartbeatState(StorageReport.EMPTY_ARRAY,
+          0L, 0L, 0, 0, null, 0.0f);
       stats.add(d);
     }
   }
@@ -254,24 +255,24 @@ class HeartbeatManager implements DatanodeStatistics {
   synchronized void updateHeartbeat(final DatanodeDescriptor node,
       StorageReport[] reports, long cacheCapacity, long cacheUsed,
       int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
     stats.subtract(node);
     blockManager.updateHeartbeat(node, reports, cacheCapacity, cacheUsed,
-        xceiverCount, failedVolumes, volumeFailureSummary);
+        xceiverCount, failedVolumes, volumeFailureSummary, volumeUsageStdDev);
     stats.add(node);
   }
 
   synchronized void updateLifeline(final DatanodeDescriptor node,
       StorageReport[] reports, long cacheCapacity, long cacheUsed,
       int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) {
+      VolumeFailureSummary volumeFailureSummary, float volumeUsageStdDev) {
     stats.subtract(node);
     // This intentionally calls updateHeartbeatState instead of
     // updateHeartbeat, because we don't want to modify the
     // heartbeatedSinceRegistration flag.  Arrival of a lifeline message does
     // not count as arrival of the first heartbeat.
     blockManager.updateHeartbeatState(node, reports, cacheCapacity, cacheUsed,
-        xceiverCount, failedVolumes, volumeFailureSummary);
+        xceiverCount, failedVolumes, volumeFailureSummary, volumeUsageStdDev);
     stats.add(node);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -536,6 +536,7 @@ class BPServiceActor implements Runnable {
     scheduler.scheduleNextHeartbeat();
     StorageReport[] reports =
         dn.getFSDataset().getStorageReports(bpos.getBlockPoolId());
+    float volumeUsageStdDev = dn.getFSDataset().getVolumeUsageStdDev();
     if (LOG.isDebugEnabled()) {
       LOG.debug("Sending heartbeat with " + reports.length +
                 " storage reports from service actor: " + this);
@@ -567,7 +568,8 @@ class BPServiceActor implements Runnable {
         volumeFailureSummary,
         requestBlockReportLease,
         slowPeers,
-        slowDisks);
+        slowDisks,
+        volumeUsageStdDev);
 
     if (outliersReportDue) {
       // If the report was due and successfully sent, schedule the next one.
@@ -1117,6 +1119,7 @@ class BPServiceActor implements Runnable {
           .getVolumeFailureSummary();
       int numFailedVolumes = volumeFailureSummary != null ?
           volumeFailureSummary.getFailedStorageLocations().length : 0;
+      float volumeUsageStdDev = dn.getFSDataset().getVolumeUsageStdDev();
       lifelineNamenode.sendLifeline(bpRegistration,
                                     reports,
                                     dn.getFSDataset().getCacheCapacity(),
@@ -1124,7 +1127,8 @@ class BPServiceActor implements Runnable {
                                     dn.getXmitsInProgress(),
                                     dn.getXceiverCount(),
                                     numFailedVolumes,
-                                    volumeFailureSummary);
+                                    volumeFailureSummary,
+                                    volumeUsageStdDev);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
@@ -230,6 +230,9 @@ public interface FsDatasetSpi<V extends FsVolumeSpi> extends FSDatasetMBean {
   /** @return a volume information map (name {@literal =>} info). */
   Map<String, Object> getVolumeInfoMap();
 
+  /** @return the standard deviation of a volume usage. */
+  float getVolumeUsageStdDev();
+
   /**
    * Returns info about volume failures.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3193,16 +3193,16 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
   @Override
   public float getVolumeUsageStdDev() {
-    Collection<VolumeInfo> volumes = getVolumeInfo();
+    Collection<VolumeInfo> volumeInfos = getVolumeInfo();
     ArrayList<Float> usages = new ArrayList<Float>();
     float totalDfsUsed = 0;
     float dev = 0;
-    for (VolumeInfo v : volumes) {
+    for (VolumeInfo v : volumeInfos) {
       usages.add(v.volumeUsagePercent);
       totalDfsUsed += v.volumeUsagePercent;
     }
 
-    totalDfsUsed /= volumes.size();
+    totalDfsUsed /= volumeInfos.size();
     Collections.sort(usages);
     for (Float usage : usages) {
       dev += (usage - totalDfsUsed) * (usage - totalDfsUsed);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1593,14 +1593,15 @@ public class NameNodeRpcServer implements NamenodeProtocols {
       int failedVolumes, VolumeFailureSummary volumeFailureSummary,
       boolean requestFullBlockReportLease,
       @Nonnull SlowPeerReports slowPeers,
-      @Nonnull SlowDiskReports slowDisks)
+      @Nonnull SlowDiskReports slowDisks,
+      float volumeUsageStdDev)
           throws IOException {
     checkNNStartup();
     verifyRequest(nodeReg);
     return namesystem.handleHeartbeat(nodeReg, report,
         dnCacheCapacity, dnCacheUsed, xceiverCount, xmitsInProgress,
         failedVolumes, volumeFailureSummary, requestFullBlockReportLease,
-        slowPeers, slowDisks);
+        slowPeers, slowDisks, volumeUsageStdDev);
   }
 
   @Override // DatanodeProtocol
@@ -1727,11 +1728,13 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   public void sendLifeline(DatanodeRegistration nodeReg, StorageReport[] report,
       long dnCacheCapacity, long dnCacheUsed, int xmitsInProgress,
       int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) throws IOException {
+      VolumeFailureSummary volumeFailureSummary,
+      float volumeUsageStdDev) throws IOException {
     checkNNStartup();
     verifyRequest(nodeReg);
     namesystem.handleLifeline(nodeReg, report, dnCacheCapacity, dnCacheUsed,
-        xceiverCount, xmitsInProgress, failedVolumes, volumeFailureSummary);
+        xceiverCount, xmitsInProgress, failedVolumes, volumeFailureSummary,
+        volumeUsageStdDev);
   }
 
   /** 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeLifelineProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeLifelineProtocol.java
@@ -38,5 +38,6 @@ public interface DatanodeLifelineProtocol {
   void sendLifeline(DatanodeRegistration registration, StorageReport[] reports,
       long dnCacheCapacity, long dnCacheUsed, int xmitsInProgress,
       int xceiverCount, int failedVolumes,
-      VolumeFailureSummary volumeFailureSummary) throws IOException;
+      VolumeFailureSummary volumeFailureSummary,
+      float volumeUsageStdDev) throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
@@ -112,6 +112,7 @@ public interface DatanodeProtocol {
    * @param slowPeers Details of peer DataNodes that were detected as being
    *                  slow to respond to packet writes. Empty report if no
    *                  slow peers were detected by the DataNode.
+   * @param volumeUsageStdDev the standard deviation of volume usage
    * @throws IOException on error
    */
   @Idempotent
@@ -125,7 +126,8 @@ public interface DatanodeProtocol {
                                        VolumeFailureSummary volumeFailureSummary,
                                        boolean requestFullBlockReportLease,
                                        @Nonnull SlowPeerReports slowPeers,
-                                       @Nonnull SlowDiskReports slowDisks)
+                                       @Nonnull SlowDiskReports slowDisks,
+                                       float volumeUsageStdDev)
       throws IOException;
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
@@ -211,6 +211,7 @@ message HeartbeatRequestProto {
   optional bool requestFullBlockReportLease = 9 [ default = false ];
   repeated SlowPeerReportProto slowPeers = 10;
   repeated SlowDiskReportProto slowDisks = 11;
+  optional float volumeUsageStdDev = 12;
 }
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/datanode/datanode.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/datanode/datanode.html
@@ -106,6 +106,7 @@
       <th>Directory</th>
       <th>StorageType</th>
       <th>Capacity Used</th>
+      <th>Capacity Used Percent</th>
       <th>Capacity Left</th>
       <th>Capacity Reserved</th>
       <th>Reserved Space for Replicas</th>
@@ -117,6 +118,7 @@
       <td>{name}</td>
       <td>{storageType}</td>
       <td>{usedSpace|fmt_bytes}</td>
+      <td>{volumeUsagePercent|fmt_percentage}</td>
       <td>{freeSpace|fmt_bytes}</td>
       <td>{reservedSpace|fmt_bytes}</td>
       <td>{reservedSpaceForReplicas|fmt_bytes}</td>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -320,6 +320,7 @@
       <th style="width:180px; text-align:center">Capacity</th>
       <th>Blocks</th>
       <th>Block pool used</th>
+      <th>Volume Usage StdDev</th>
       <th>Version</th>
     </tr>
   </thead>
@@ -343,6 +344,7 @@
     </td>
     <td title="Blocks Scheduled : {blockScheduled}">{numBlocks}</td>
     <td ng-value="{blockPoolUsedPercent}">{blockPoolUsed|fmt_bytes} ({blockPoolUsedPercent|fmt_percentage})</td>
+    <td ng-value="{volumeUsageStdDev}">{volumeUsageStdDev|fmt_percentage}</td>
     <td>{version}</td>
   </tr>
   {/LiveNodes}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.js
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.js
@@ -360,6 +360,7 @@
               { 'orderDataType': 'ng-value', 'type': 'num' , "defaultContent": 0},
               { 'type': 'num' , "defaultContent": 0},
               { 'orderDataType': 'ng-value', 'type': 'num' , "defaultContent": 0},
+              { 'orderDataType': 'ng-value', 'type': 'num' , "defaultContent": 0},
               { 'type': 'string' , "defaultContent": ""}
               ],
               initComplete: function () {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BaseReplicationPolicyTest.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BaseReplicationPolicyTest.java
@@ -58,7 +58,7 @@ abstract public class BaseReplicationPolicyTest {
   static void updateHeartbeatWithUsage(DatanodeDescriptor dn,
     long capacity, long dfsUsed, long remaining, long blockPoolUsed,
     long dnCacheCapacity, long dnCacheUsed, int xceiverCount,
-    int volFailures, float volumeUsageStdDev) {
+      int volFailures, float volumeUsageStdDev) {
     dn.getStorageInfos()[0].setUtilizationForTesting(
         capacity, dfsUsed, remaining, blockPoolUsed);
     dn.updateHeartbeat(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BaseReplicationPolicyTest.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BaseReplicationPolicyTest.java
@@ -58,12 +58,13 @@ abstract public class BaseReplicationPolicyTest {
   static void updateHeartbeatWithUsage(DatanodeDescriptor dn,
     long capacity, long dfsUsed, long remaining, long blockPoolUsed,
     long dnCacheCapacity, long dnCacheUsed, int xceiverCount,
-    int volFailures) {
+    int volFailures, float volumeUsageStdDev) {
     dn.getStorageInfos()[0].setUtilizationForTesting(
         capacity, dfsUsed, remaining, blockPoolUsed);
     dn.updateHeartbeat(
         BlockManagerTestUtil.getStorageReportsForDatanode(dn),
-        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null);
+        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null,
+        volumeUsageStdDev);
   }
 
   abstract DatanodeDescriptor[] getDatanodeDescriptors(Configuration conf);
@@ -107,7 +108,8 @@ abstract public class BaseReplicationPolicyTest {
     for (int i=0; i < dataNodes.length; i++) {
       updateHeartbeatWithUsage(dataNodes[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
+          0L, 0L, 0, 0, 0.0f);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBPPBalanceLocal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBPPBalanceLocal.java
@@ -101,11 +101,12 @@ public class TestAvailableSpaceBPPBalanceLocal {
   protected static void updateHeartbeatWithUsage(DatanodeDescriptor dn,
       long capacity, long dfsUsed, long remaining, long blockPoolUsed,
       long dnCacheCapacity, long dnCacheUsed, int xceiverCount,
-      int volFailures) {
+      int volFailures, float volumeUsageStdDev) {
     dn.getStorageInfos()[0]
         .setUtilizationForTesting(capacity, dfsUsed, remaining, blockPoolUsed);
     dn.updateHeartbeat(BlockManagerTestUtil.getStorageReportsForDatanode(dn),
-        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null);
+        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null,
+        volumeUsageStdDev);
   }
 
   protected static void setupDataNodeCapacity() {
@@ -115,14 +116,14 @@ public class TestAvailableSpaceBPPBalanceLocal {
         updateHeartbeatWithUsage(dataNodes[i],
             4 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L,
             4 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L, 0L,
-            0L, 0, 0);
+            0L, 0, 0, 0.0f);
       } else {
         // remaining 25%
         updateHeartbeatWithUsage(dataNodes[i],
             4 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE,
             3 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L, 0L, 0L,
-            0, 0);
+            0, 0, 0.0f);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -99,12 +99,13 @@ public class TestAvailableSpaceBlockPlacementPolicy {
   private static void updateHeartbeatWithUsage(DatanodeDescriptor dn,
       long capacity, long dfsUsed, long remaining, long blockPoolUsed,
       long dnCacheCapacity, long dnCacheUsed, int xceiverCount,
-      int volFailures) {
+      int volFailures, float volumeUsageStdDev) {
     dn.getStorageInfos()[0].setUtilizationForTesting(
         capacity, dfsUsed, remaining, blockPoolUsed);
     dn.updateHeartbeat(
         BlockManagerTestUtil.getStorageReportsForDatanode(dn),
-        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null);
+        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null,
+        volumeUsageStdDev);
   }
 
   private static void setupDataNodeCapacity() {
@@ -112,12 +113,13 @@ public class TestAvailableSpaceBlockPlacementPolicy {
       if ((i % 2) == 0) {
         // remaining 100%
         updateHeartbeatWithUsage(dataNodes[i], 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-          0L, 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize, 0L, 0L, 0L, 0, 0);
+          0L, 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+          0L, 0L, 0L, 0, 0, 0.0f);
       } else {
         // remaining 50%
         updateHeartbeatWithUsage(dataNodes[i], 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
           HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize, HdfsServerConstants.MIN_BLOCKS_FOR_WRITE
-              * blockSize, 0L, 0L, 0L, 0, 0);
+              * blockSize, 0L, 0L, 0L, 0, 0, 0.0f);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -113,8 +113,8 @@ public class TestAvailableSpaceBlockPlacementPolicy {
       if ((i % 2) == 0) {
         // remaining 100%
         updateHeartbeatWithUsage(dataNodes[i], 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-          0L, 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
-          0L, 0L, 0L, 0, 0, 0.0f);
+            0L, 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,
+            0L, 0L, 0L, 0, 0, 0.0f);
       } else {
         // remaining 50%
         updateHeartbeatWithUsage(dataNodes[i], 2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * blockSize,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceRackFaultTolerantBPP.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceRackFaultTolerantBPP.java
@@ -106,11 +106,12 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
   private static void updateHeartbeatWithUsage(DatanodeDescriptor dn,
       long capacity, long dfsUsed, long remaining, long blockPoolUsed,
       long dnCacheCapacity, long dnCacheUsed, int xceiverCount,
-      int volFailures) {
+      int volFailures, float volumeUsageStdDev) {
     dn.getStorageInfos()[0]
         .setUtilizationForTesting(capacity, dfsUsed, remaining, blockPoolUsed);
     dn.updateHeartbeat(BlockManagerTestUtil.getStorageReportsForDatanode(dn),
-        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null);
+        dnCacheCapacity, dnCacheUsed, xceiverCount, volFailures, null,
+        volumeUsageStdDev);
   }
 
   private static void setupDataNodeCapacity() {
@@ -120,14 +121,14 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
         updateHeartbeatWithUsage(dataNodes[i],
             2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L,
             2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L, 0L,
-            0L, 0, 0);
+            0L, 0, 0, 0.0f);
       } else {
         // remaining 50%
         updateHeartbeatWithUsage(dataNodes[i],
             2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE,
             HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L, 0L, 0L,
-            0, 0);
+            0, 0, 0.0f);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -198,7 +198,7 @@ public class TestBlockManager {
           2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L);
       dn.updateHeartbeat(
           BlockManagerTestUtil.getStorageReportsForDatanode(dn), 0L, 0L, 0, 0,
-          null);
+          null, 0.0f);
       bm.getDatanodeManager().checkIfClusterIsNowMultiRack(dn);
     }
   }
@@ -1453,7 +1453,7 @@ public class TestBlockManager {
         }
       }
       failedStorageDataNode.updateHeartbeat(reports.toArray(StorageReport
-          .EMPTY_ARRAY), 0L, 0L, 0, 0, null);
+          .EMPTY_ARRAY), 0L, 0L, 0, 0, null, 0.0f);
       ns.writeLock();
       DatanodeStorageInfo corruptStorageInfo= null;
       for(int i=0; i<corruptStorageDataNode.getStorageInfos().length; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
@@ -92,7 +92,7 @@ public class TestBlockReportLease {
       // Send heartbeat and request full block report lease
       HeartbeatResponse hbResponse = rpcServer.sendHeartbeat(
           dnRegistration, storages, 0, 0, 0, 0, 0, null, true,
-              SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
+              SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT, 0.0f);
 
       DelayAnswer delayer = new DelayAnswer(BlockManager.LOG);
       doAnswer(delayer).when(spyBlockManager).processReport(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -982,7 +982,7 @@ public class TestDatanodeManager {
     Mockito.when(dm.getDatanode(dnReg)).thenReturn(nodeInfo);
     DatanodeCommand[] cmds = dm.handleHeartbeat(
         dnReg, new StorageReport[1], "bp-123", 0, 0, 10, maxTransfers, 0, null,
-        SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
+        SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT, 0.0f);
 
     long expectedNumCmds = Arrays.stream(
         new int[]{numReplicationTasks, numECTasks})

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNameNodePrunesMissingStorages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNameNodePrunesMissingStorages.java
@@ -117,7 +117,7 @@ public class TestNameNodePrunesMissingStorages {
       cluster.stopDataNode(0);
       cluster.getNameNodeRpc().sendHeartbeat(dnReg, prunedReports, 0L, 0L, 0, 0,
           0, null, true, SlowPeerReports.EMPTY_REPORT,
-          SlowDiskReports.EMPTY_REPORT);
+          SlowDiskReports.EMPTY_REPORT, 0.0f);
 
       // Check that the missing storage was pruned.
       assertThat(dnDescriptor.getStorageInfos().length, is(expectedStoragesAfterTest));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestOverReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestOverReplicatedBlocks.java
@@ -105,7 +105,7 @@ public class TestOverReplicatedBlocks {
               datanode.getStorageInfos()[0].setUtilizationForTesting(100L, 100L, 0, 100L);
               datanode.updateHeartbeat(
                   BlockManagerTestUtil.getStorageReportsForDatanode(datanode),
-                  0L, 0L, 0, 0, null);
+                  0L, 0L, 0, 0, null, 0.0f);
             }
           }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicy.java
@@ -107,7 +107,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
         capacity, dfsUsed, remaining, blockPoolUsed);
     dn.updateHeartbeat(
         BlockManagerTestUtil.getStorageReportsForDatanode(dn),
-        0L, 0L, 0, 0, null);
+        0L, 0L, 0, 0, null, 0.0f);
   }
 
   private void resetHeartbeatForStorages() {
@@ -115,7 +115,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
       updateHeartbeatWithUsage(dataNodes[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L,
-          0, 0);
+          0, 0, 0.0f);
     }
     // No available space in the extra storage of dn0
     updateHeartbeatForExtraStorage(0L, 0L, 0L, 0L);
@@ -149,7 +149,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     updateHeartbeatWithUsage(dataNodes[5],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         (2*HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE)/3, 0L,
-        0L, 0L, 0, 0);
+        0L, 0L, 0, 0, 0.0f);
 
     updateHeartbeatForExtraStorage(
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
@@ -173,7 +173,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     updateHeartbeatWithUsage(dataNodes[5],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         (2*HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE)/3, 0L,
-        0L, 0L, 0, 0);
+        0L, 0L, 0, 0, 0.0f);
 
     updateHeartbeatForExtraStorage(
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
@@ -202,7 +202,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        0L, 0L, 4, 0); // overloaded
+        0L, 0L, 4, 0, 0.0f); // overloaded
 
     DatanodeStorageInfo[] targets;
     targets = chooseTarget(0);
@@ -321,7 +321,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L,
-        0L, 0L, 0, 0); // no space
+        0L, 0L, 0, 0, 0.0f); // no space
         
     DatanodeStorageInfo[] targets;
     targets = chooseTarget(0);
@@ -369,7 +369,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     for(int i=0; i<2; i++) {
       updateHeartbeatWithUsage(dataNodes[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
       
     DatanodeStorageInfo[] targets;
@@ -457,7 +458,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     bm.getDatanodeManager().getHeartbeatManager().addDatanode(newDn);
     updateHeartbeatWithUsage(newDn,
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+        2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+        0L, 0L, 0L, 0, 0, 0.0f);
 
     // Try picking three nodes. Only two should return.
     excludedNodes.clear();
@@ -505,7 +507,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     for(int i=0; i<2; i++) {
       updateHeartbeatWithUsage(dataNodes[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
     
     final LogVerificationAppender appender = new LogVerificationAppender();
@@ -1044,7 +1047,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     updateHeartbeatWithUsage(excessSSD.getDatanodeDescriptor(),
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0,
-        0);
+        0, 0.0f);
 
     // use delete hint case.
 
@@ -1671,7 +1674,7 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
       updateHeartbeatWithUsage(dataNodes[i],
           2 * HdfsServerConstants.MIN_BLOCKS_FOR_WRITE * BLOCK_SIZE, 0L,
           (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE - 1) * BLOCK_SIZE,
-          0L, 0L, 0L, 0, 0);
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
     assertFalse(dnManager.shouldAvoidStaleDataNodesForWrite());
     resetHeartbeatForStorages();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyConsiderLoad.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyConsiderLoad.java
@@ -78,17 +78,20 @@ public class TestReplicationPolicyConsiderLoad
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[3]),
           dataNodes[3].getCacheCapacity(),
           dataNodes[3].getCacheUsed(),
-          2, 0, null);
+          2, 0, null,
+          dataNodes[3].getVolumeUsageStdDev());
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[4],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[4]),
           dataNodes[4].getCacheCapacity(),
           dataNodes[4].getCacheUsed(),
-          4, 0, null);
+          4, 0, null,
+          dataNodes[4].getVolumeUsageStdDev());
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[5],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[5]),
           dataNodes[5].getCacheCapacity(),
           dataNodes[5].getCacheUsed(),
-          4, 0, null);
+          4, 0, null,
+          dataNodes[5].getVolumeUsageStdDev());
 
       // value in the above heartbeats
       final int load = 2 + 4 + 4;
@@ -137,33 +140,39 @@ public class TestReplicationPolicyConsiderLoad
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[0]),
           dataNodes[0].getCacheCapacity(),
           dataNodes[0].getCacheUsed(),
-          5, 0, null);
+          5, 0, null,
+          dataNodes[0].getVolumeUsageStdDev());
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[1],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[1]),
           dataNodes[1].getCacheCapacity(),
           dataNodes[1].getCacheUsed(),
-          10, 0, null);
+          10, 0, null,
+          dataNodes[1].getVolumeUsageStdDev());
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[2],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[2]),
           dataNodes[2].getCacheCapacity(),
           dataNodes[2].getCacheUsed(),
-          5, 0, null);
+          5, 0, null,
+          dataNodes[2].getVolumeUsageStdDev());
 
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[3],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[3]),
           dataNodes[3].getCacheCapacity(),
           dataNodes[3].getCacheUsed(),
-          10, 0, null);
+          10, 0, null,
+          dataNodes[3].getVolumeUsageStdDev());
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[4],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[4]),
           dataNodes[4].getCacheCapacity(),
           dataNodes[4].getCacheUsed(),
-          15, 0, null);
+          15, 0, null,
+          dataNodes[4].getVolumeUsageStdDev());
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[5],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[5]),
           dataNodes[5].getCacheCapacity(),
           dataNodes[5].getCacheUsed(),
-          15, 0, null);
+          15, 0, null,
+          dataNodes[5].getVolumeUsageStdDev());
       //Add values in above heartbeats
       double load = 5 + 10 + 15 + 10 + 15 + 5;
       // Call chooseTarget()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithNodeGroup.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithNodeGroup.java
@@ -290,7 +290,7 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        0L, 0L, 4, 0); // overloaded
+        0L, 0L, 4, 0, 0.0f); // overloaded
 
     DatanodeStorageInfo[] targets;
     targets = chooseTarget(0);
@@ -327,7 +327,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
 
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+        0L, 0L, 0L, 0, 0, 0.0f);
   }
 
   private void verifyNoTwoTargetsOnSameNodeGroup(DatanodeStorageInfo[] targets) {
@@ -398,7 +399,7 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L,
-        0L, 0L, 0, 0); // no space
+        0L, 0L, 0, 0, 0.0f); // no space
 
     DatanodeStorageInfo[] targets;
     targets = chooseTarget(0);
@@ -429,7 +430,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
 
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
+        0L, 0L, 0, 0, 0.0f);
   }
 
   /**
@@ -447,7 +449,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     for(int i=0; i<3; i++) {
       updateHeartbeatWithUsage(dataNodes[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
 
     DatanodeStorageInfo[] targets;
@@ -513,7 +516,7 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     updateHeartbeatWithUsage(dataNodes[7],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L,
-        0L, 0L, 0, 0); // no space
+        0L, 0L, 0, 0, 0.0f); // no space
 
     DatanodeStorageInfo[] targets;
     targets = chooseTarget(1, dataNodes[7]);
@@ -709,7 +712,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     for(int i=0; i<dataNodesInBoundaryCase.length; i++) {
       updateHeartbeatWithUsage(dataNodesInBoundaryCase[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
 
     DatanodeStorageInfo[] targets;
@@ -740,7 +744,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     for(int i=0; i<dataNodesInBoundaryCase.length; i++) {
       updateHeartbeatWithUsage(dataNodesInBoundaryCase[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
     List<DatanodeStorageInfo> chosenNodes = new ArrayList<>();
     chosenNodes.add(storagesInBoundaryCase[0]);
@@ -778,7 +783,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     for(int i=0; i<dataNodesInMoreTargetsCase.length; i++) {
       updateHeartbeatWithUsage(dataNodesInMoreTargetsCase[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
 
     DatanodeStorageInfo[] targets;
@@ -829,7 +835,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     for(int i=0; i<dataNodesForDependencies.length; i++) {
       updateHeartbeatWithUsage(dataNodesForDependencies[i],
           2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+          2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+          0L, 0L, 0L, 0, 0, 0.0f);
     }
 
     List<DatanodeStorageInfo> chosenNodes = new ArrayList<>();
@@ -883,7 +890,7 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     updateHeartbeatWithUsage(dataNodes[3],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         (HdfsServerConstants.MIN_BLOCKS_FOR_WRITE-1)*BLOCK_SIZE, 0L,
-        0L, 0L, 0, 0); // no space
+        0L, 0L, 0, 0, 0.0f); // no space
 
     DatanodeStorageInfo[] targets;
     List<DatanodeDescriptor> expectedTargets =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithUpgradeDomain.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithUpgradeDomain.java
@@ -85,7 +85,7 @@ public class TestReplicationPolicyWithUpgradeDomain
     updateHeartbeatWithUsage(dataNodes[0],
         2* HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
         HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        0L, 0L, 4, 0);
+        0L, 0L, 4, 0, 0.0f);
 
     DatanodeStorageInfo[] targets;
     targets = chooseTarget(0);
@@ -118,7 +118,8 @@ public class TestReplicationPolicyWithUpgradeDomain
 
     updateHeartbeatWithUsage(dataNodes[0],
         2*HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L,
-        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE, 0L, 0L, 0L, 0, 0);
+        HdfsServerConstants.MIN_BLOCKS_FOR_WRITE*BLOCK_SIZE,
+        0L, 0L, 0L, 0, 0, 0.0f);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestVolumeUsageStdDev.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestVolumeUsageStdDev.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.eclipse.jetty.util.ajax.JSON;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Map;
+
+public class TestVolumeUsageStdDev {
+  private final static int numDataNodes = 5;
+  private final static int storagesPerDatanode = 3;
+  private final static int defaultBlockSize = 102400;
+  private final static int bufferLen = 1024;
+  private static Configuration conf;
+  private MiniDFSCluster cluster;
+  private FileSystem fs;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = new HdfsConfiguration();
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, defaultBlockSize);
+
+    long capacity = 8 * defaultBlockSize;
+    long[][] capacities = new long[numDataNodes][storagesPerDatanode];
+    String[] hostnames = new String[5];
+    for (int i = 0; i < numDataNodes; i++) {
+      hostnames[i] = i + "." + i + "." + i + "." + i;
+      for(int j=0;j<storagesPerDatanode;j++){
+        capacities[i][j]=capacity;
+      }
+    }
+
+    cluster = new MiniDFSCluster.Builder(conf)
+        .hosts(hostnames)
+        .numDataNodes(numDataNodes)
+        .storagesPerDatanode(storagesPerDatanode)
+        .storageCapacities(capacities).build();
+    cluster.waitActive();
+    fs = cluster.getFileSystem();
+  }
+
+  /**
+   * Create files of different sizes for each datanode.
+   * Ensure that the file size is smaller than the blocksize
+   * and only one block is generated. In this way, data will
+   * be written to only one volume.
+   *
+   * Using favoredNodes, we can write files of a specified size
+   * to specified datanodes to create a batch of datanodes with
+   * different volumeUsageStdDev.
+   *
+   * Then, we assert the value of volumeUsageStdDev on namenode
+   * and datanode is the same.
+   */
+  @Test
+  public void testVolumeUsageStdDev() throws IOException {
+    // Create file for each datanode.
+    ArrayList<DataNode> dataNodes = cluster.getDataNodes();
+    DFSTestUtil.createFile(fs, new Path("/file0"), false, bufferLen, 1000,
+        defaultBlockSize, (short) 1, 0, false,
+        new InetSocketAddress[]{dataNodes.get(0).getXferAddress()});
+    DFSTestUtil.createFile(fs, new Path("/file1"), false, bufferLen, 2000,
+        defaultBlockSize, (short) 1, 0, false,
+        new InetSocketAddress[]{dataNodes.get(1).getXferAddress()});
+    DFSTestUtil.createFile(fs, new Path("/file2"), false, bufferLen, 4000,
+        defaultBlockSize, (short) 1, 0, false,
+        new InetSocketAddress[]{dataNodes.get(2).getXferAddress()});
+    DFSTestUtil.createFile(fs, new Path("/file3"), false, bufferLen, 8000,
+        defaultBlockSize, (short) 1, 0, false,
+        new InetSocketAddress[]{dataNodes.get(3).getXferAddress()});
+    DFSTestUtil.createFile(fs, new Path("/file4"), false, bufferLen, 16000,
+        defaultBlockSize, (short) 1, 0, false,
+        new InetSocketAddress[]{dataNodes.get(4).getXferAddress()});
+
+    // Trigger Heartbeats.
+    cluster.triggerHeartbeats();
+
+    // Assert that the volumeUsageStdDev on namenode and Datanode are the same.
+    String liveNodes = cluster.getNameNode().getNamesystem().getLiveNodes();
+    Map<String, Map<String, Object>> info =
+        (Map<String, Map<String, Object>>) JSON.parse(liveNodes);
+    for (DataNode dataNode : dataNodes) {
+      String dnAddress = dataNode.getDisplayName();
+      float volumeUsageStdDev = dataNode.getFSDataset().getVolumeUsageStdDev();
+      Assert.assertEquals(
+          String.valueOf(volumeUsageStdDev),
+          String.valueOf(info.get(dnAddress).get("volumeUsageStdDev")));
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestVolumeUsageStdDev.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestVolumeUsageStdDev.java
@@ -37,10 +37,10 @@ import java.util.ArrayList;
 import java.util.Map;
 
 public class TestVolumeUsageStdDev {
-  private final static int numDataNodes = 5;
-  private final static int storagesPerDatanode = 3;
-  private final static int defaultBlockSize = 102400;
-  private final static int bufferLen = 1024;
+  private final static int NUM_DATANODES = 5;
+  private final static int STORAGES_PER_DATANODE = 3;
+  private final static int DEFAULT_BLOCK_SIZE = 102400;
+  private final static int BUFFER_LENGTH = 1024;
   private static Configuration conf;
   private MiniDFSCluster cluster;
   private FileSystem fs;
@@ -48,22 +48,22 @@ public class TestVolumeUsageStdDev {
   @Before
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
-    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, defaultBlockSize);
-
-    long capacity = 8 * defaultBlockSize;
-    long[][] capacities = new long[numDataNodes][storagesPerDatanode];
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, DEFAULT_BLOCK_SIZE);
+    // Ensure that each volume capacity is larger than the DEFAULT_BLOCK_SIZE.
+    long capacity = 8 * DEFAULT_BLOCK_SIZE;
+    long[][] capacities = new long[NUM_DATANODES][STORAGES_PER_DATANODE];
     String[] hostnames = new String[5];
-    for (int i = 0; i < numDataNodes; i++) {
+    for (int i = 0; i < NUM_DATANODES; i++) {
       hostnames[i] = i + "." + i + "." + i + "." + i;
-      for(int j=0;j<storagesPerDatanode;j++){
+      for(int j = 0; j < STORAGES_PER_DATANODE; j++){
         capacities[i][j]=capacity;
       }
     }
 
     cluster = new MiniDFSCluster.Builder(conf)
         .hosts(hostnames)
-        .numDataNodes(numDataNodes)
-        .storagesPerDatanode(storagesPerDatanode)
+        .numDataNodes(NUM_DATANODES)
+        .storagesPerDatanode(STORAGES_PER_DATANODE)
         .storageCapacities(capacities).build();
     cluster.waitActive();
     fs = cluster.getFileSystem();
@@ -82,24 +82,25 @@ public class TestVolumeUsageStdDev {
    * Then, we assert the value of volumeUsageStdDev on namenode
    * and datanode is the same.
    */
+  @SuppressWarnings("unchecked")
   @Test
   public void testVolumeUsageStdDev() throws IOException {
     // Create file for each datanode.
     ArrayList<DataNode> dataNodes = cluster.getDataNodes();
-    DFSTestUtil.createFile(fs, new Path("/file0"), false, bufferLen, 1000,
-        defaultBlockSize, (short) 1, 0, false,
+    DFSTestUtil.createFile(fs, new Path("/file0"), false, BUFFER_LENGTH, 1000,
+        DEFAULT_BLOCK_SIZE, (short) 1, 0, false,
         new InetSocketAddress[]{dataNodes.get(0).getXferAddress()});
-    DFSTestUtil.createFile(fs, new Path("/file1"), false, bufferLen, 2000,
-        defaultBlockSize, (short) 1, 0, false,
+    DFSTestUtil.createFile(fs, new Path("/file1"), false, BUFFER_LENGTH, 2000,
+        DEFAULT_BLOCK_SIZE, (short) 1, 0, false,
         new InetSocketAddress[]{dataNodes.get(1).getXferAddress()});
-    DFSTestUtil.createFile(fs, new Path("/file2"), false, bufferLen, 4000,
-        defaultBlockSize, (short) 1, 0, false,
+    DFSTestUtil.createFile(fs, new Path("/file2"), false, BUFFER_LENGTH, 4000,
+        DEFAULT_BLOCK_SIZE, (short) 1, 0, false,
         new InetSocketAddress[]{dataNodes.get(2).getXferAddress()});
-    DFSTestUtil.createFile(fs, new Path("/file3"), false, bufferLen, 8000,
-        defaultBlockSize, (short) 1, 0, false,
+    DFSTestUtil.createFile(fs, new Path("/file3"), false, BUFFER_LENGTH, 8000,
+        DEFAULT_BLOCK_SIZE, (short) 1, 0, false,
         new InetSocketAddress[]{dataNodes.get(3).getXferAddress()});
-    DFSTestUtil.createFile(fs, new Path("/file4"), false, bufferLen, 16000,
-        defaultBlockSize, (short) 1, 0, false,
+    DFSTestUtil.createFile(fs, new Path("/file4"), false, BUFFER_LENGTH, 16000,
+        DEFAULT_BLOCK_SIZE, (short) 1, 0, false,
         new InetSocketAddress[]{dataNodes.get(4).getXferAddress()});
 
     // Trigger Heartbeats.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/InternalDataNodeTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/InternalDataNodeTestUtils.java
@@ -163,7 +163,8 @@ public class InternalDataNodeTestUtils {
             Mockito.anyInt(), Mockito.any(),
             Mockito.anyBoolean(),
             Mockito.any(),
-            Mockito.any())).thenReturn(
+            Mockito.any(),
+            Mockito.anyFloat())).thenReturn(
         new HeartbeatResponse(new DatanodeCommand[0], new NNHAStatusHeartbeat(
             HAServiceState.ACTIVE, 1), null, ThreadLocalRandom.current()
             .nextLong() | 1L));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -1531,6 +1531,11 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   }
 
   @Override
+  public float getVolumeUsageStdDev() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public FsVolumeSpi getVolume(ExtendedBlock b) {
     return getStorage(b.getLocalBlock()).getVolume();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -1532,7 +1532,7 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
 
   @Override
   public float getVolumeUsageStdDev() {
-    throw new UnsupportedOperationException();
+    return  0.0f;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
@@ -178,7 +178,8 @@ public class TestBPOfferService {
           Mockito.any(VolumeFailureSummary.class),
           Mockito.anyBoolean(),
           Mockito.any(SlowPeerReports.class),
-          Mockito.any(SlowDiskReports.class));
+          Mockito.any(SlowDiskReports.class),
+          Mockito.anyFloat());
     mockHaStatuses[nnIdx] = new NNHAStatusHeartbeat(HAServiceState.STANDBY, 0);
     datanodeCommands[nnIdx] = new DatanodeCommand[0];
     return mock;
@@ -1131,7 +1132,8 @@ public class TestBPOfferService {
         Mockito.any(VolumeFailureSummary.class),
         Mockito.anyBoolean(),
         Mockito.any(SlowPeerReports.class),
-        Mockito.any(SlowDiskReports.class)))
+        Mockito.any(SlowDiskReports.class),
+        Mockito.anyFloat()))
         //heartbeat to old NN instance
         .thenAnswer(new HeartbeatAnswer(0))
         //heartbeat to new NN instance with Register Command

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery.java
@@ -218,7 +218,8 @@ public class TestBlockRecovery {
             Mockito.any(),
             Mockito.anyBoolean(),
             Mockito.any(),
-            Mockito.any()))
+            Mockito.any(),
+            Mockito.anyFloat()))
         .thenReturn(new HeartbeatResponse(
             new DatanodeCommand[0],
             new NNHAStatusHeartbeat(HAServiceState.ACTIVE, 1),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery2.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery2.java
@@ -157,7 +157,8 @@ public class TestBlockRecovery2 {
         Mockito.any(),
         Mockito.anyBoolean(),
         Mockito.any(),
-        Mockito.any()))
+        Mockito.any(),
+        Mockito.anyFloat()))
         .thenReturn(new HeartbeatResponse(
             new DatanodeCommand[0],
             new NNHAStatusHeartbeat(HAServiceProtocol.HAServiceState.ACTIVE, 1),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeLifeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeLifeline.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyFloat;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -171,7 +172,8 @@ public class TestDataNodeLifeline {
             any(),
             anyBoolean(),
             any(SlowPeerReports.class),
-            any(SlowDiskReports.class));
+            any(SlowDiskReports.class),
+            anyFloat());
 
     // Intercept lifeline to trigger latch count-down on each call.
     doAnswer(new LatchCountingAnswer<Void>(lifelinesSent))
@@ -183,7 +185,8 @@ public class TestDataNodeLifeline {
             anyInt(),
             anyInt(),
             anyInt(),
-            any());
+            any(),
+            anyFloat());
 
     // While waiting on the latch for the expected number of lifeline messages,
     // poll DataNode tracking information.  Thanks to the lifeline, we expect
@@ -210,7 +213,8 @@ public class TestDataNodeLifeline {
         anyInt(),
         anyInt(),
         anyInt(),
-        any());
+        any(),
+        anyFloat());
 
     // Also verify lifeline call through metrics.  We expect at least
     // numLifelines, guaranteed by waiting on the latch.  There is a small
@@ -240,7 +244,8 @@ public class TestDataNodeLifeline {
             any(),
             anyBoolean(),
             any(SlowPeerReports.class),
-            any(SlowDiskReports.class));
+            any(SlowDiskReports.class),
+            anyFloat());
 
     // While waiting on the latch for the expected number of heartbeat messages,
     // poll DataNode tracking information.  We expect that the DataNode always
@@ -263,7 +268,8 @@ public class TestDataNodeLifeline {
         anyInt(),
         anyInt(),
         anyInt(),
-        any());
+        any(),
+        anyFloat());
 
     // Also verify no lifeline calls through metrics.
     assertEquals("Expect metrics to count no lifeline calls.", 0,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
@@ -216,7 +216,8 @@ public class TestDatanodeProtocolRetryPolicy {
            Mockito.any(),
            Mockito.anyBoolean(),
            Mockito.any(),
-           Mockito.any());
+           Mockito.any(),
+           Mockito.anyFloat());
 
     dn = new DataNode(conf, locations, null, null) {
       @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestStorageReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestStorageReport.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyLong;
 
 public class TestStorageReport {
@@ -110,7 +111,8 @@ public class TestStorageReport {
         anyLong(), anyLong(), anyInt(), anyInt(), anyInt(),
         any(), Mockito.anyBoolean(),
         Mockito.any(SlowPeerReports.class),
-        Mockito.any(SlowDiskReports.class));
+        Mockito.any(SlowDiskReports.class),
+        anyFloat());
 
     StorageReport[] reports = captor.getValue();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -91,6 +91,11 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   }
 
   @Override
+  public float getVolumeUsageStdDev() {
+    return 0.0f;
+  }
+
+  @Override
   public List<ReplicaInfo> getFinalizedBlocks(String bpid) {
     return null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetCache.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
@@ -210,7 +211,7 @@ public class TestFsDatasetCache {
           (StorageReport[]) any(), anyLong(), anyLong(),
           anyInt(), anyInt(), anyInt(), (VolumeFailureSummary) any(),
           anyBoolean(), any(SlowPeerReports.class),
-          any(SlowDiskReports.class));
+          any(SlowDiskReports.class), anyFloat());
     } finally {
       lock.writeLock().unlock();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -1019,7 +1019,7 @@ public class NNThroughputBenchmark implements Tool {
           DF_CAPACITY, DF_USED, DF_CAPACITY - DF_USED, DF_USED, 0L) };
       DatanodeCommand[] cmds = dataNodeProto.sendHeartbeat(dnRegistration, rep,
           0L, 0L, 0, 0, 0, null, true,
-          SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT)
+          SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT, 0.0f)
           .getCommands();
       if(cmds != null) {
         for (DatanodeCommand cmd : cmds ) {
@@ -1070,7 +1070,7 @@ public class NNThroughputBenchmark implements Tool {
           false, DF_CAPACITY, DF_USED, DF_CAPACITY - DF_USED, DF_USED, 0) };
       DatanodeCommand[] cmds = dataNodeProto.sendHeartbeat(dnRegistration,
           rep, 0L, 0L, 0, 0, 0, null, true,
-          SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT)
+          SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT, 0.0f)
           .getCommands();
       if (cmds != null) {
         for (DatanodeCommand cmd : cmds) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NameNodeAdapter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NameNodeAdapter.java
@@ -158,7 +158,7 @@ public class NameNodeAdapter {
     return namesystem.handleHeartbeat(nodeReg,
         BlockManagerTestUtil.getStorageReportsForDatanode(dd),
         dd.getCacheCapacity(), dd.getCacheRemaining(), 0, 0, 0, null, true,
-        SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
+        SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT, 0.0f);
   }
 
   public static boolean setReplication(final FSNamesystem ns,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeadDatanode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeadDatanode.java
@@ -140,7 +140,7 @@ public class TestDeadDatanode {
         false, 0, 0, 0, 0, 0) };
     DatanodeCommand[] cmd =
         dnp.sendHeartbeat(reg, rep, 0L, 0L, 0, 0, 0, null, true,
-            SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT)
+            SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT, 0.0f)
         .getCommands();
     assertEquals(1, cmd.length);
     assertEquals(cmd[0].getAction(), RegisterCommand.REGISTER


### PR DESCRIPTION
JIRA: [HDFS-16158](https://issues.apache.org/jira/browse/HDFS-16158)

Discover datanodes with unbalanced volume usage by the standard deviation

In some scenarios, we may cause unbalanced datanode disk usage:
1. Repair the damaged disk and make it online again.
2. Add disks to some Datanodes.
3. Some disks are damaged, resulting in slow data writing.
4. Use some custom volume choosing policies.

In the case of unbalanced disk usage, a sudden increase in datanode write traffic may result in busy disk I/O with low volume usage, resulting in decreased throughput across datanodes.

In this case, we need to find these nodes in time to do diskBalance, or other processing. Based on the volume usage of each datanode, we can calculate the standard deviation of the volume usage. The more unbalanced the volume, the higher the standard deviation.

To prevent the namenode from being too busy, we can calculate the standard variance on the datanode side, transmit it to the namenode through heartbeat, and display the result on the Web of namenode. We can then sort directly to find the nodes on the Web where the volumes usages are unbalanced.

![namenode-web](https://user-images.githubusercontent.com/55134131/128893408-14685fac-25bf-4661-9f28-6978052baaba.jpg)

