### PR TITLE
YARN-10882. Fix branch-3.1 build: zstd library is missing from the Dockerfile

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get -q update \
         libssl-dev \
         libsnappy-dev \
         libtool \
+        libzstd1-dev \
         locales \
         make \
         pinentry-curses \


### PR DESCRIPTION
zstd dependency was not installed in the docker environment and caused
a build issue in hadoop-common

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
