### PR TITLE
MAPREDUCE-7361. Clean shared state pollution to avoid flaky tests in class TestTaskProgressReporter

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
@@ -253,6 +253,7 @@ public class TestTaskProgressReporter {
 
   @Test (timeout=10000)
   public void testTaskProgress() throws Exception {
+    statusUpdateTimes = 0;
     JobConf job = new JobConf();
     job.setLong(MRJobConfig.TASK_PROGRESS_REPORT_INTERVAL, 1000);
     Task task = new DummyTask();


### PR DESCRIPTION
Link to issue: [https://issues.apache.org/jira/browse/MAPREDUCE-7361](https://issues.apache.org/jira/browse/MAPREDUCE-7361)
## What is the purpose of this change
This PR is to clean the polluted shared status among the 3 tests: 
```
Test1: org.apache.hadoop.mapred.TestTaskProgressReporter.testBytesWrittenRespectingLimit
Test2: org.apache.hadoop.mapred.TestTaskProgressReporter.testScratchDirSize
Test3: org.apache.hadoop.mapred.TestTaskProgressReporter.testTaskProgress
```
- Test1 and Test2 pollute the shared status with Test3, which can make test3 fail. 
- It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by this test.
## Reproduce the test failures
Run the tests in the same JVM in the following orders:
- Test1 and Test3
- Test2 and Test3
## Expected result
The tests should run successfully when multiple tests that use this shared state are run in the same JVM.
## Actual result
- Run Test1 and Test3, Test3 fails:
```
[ERROR]   TestTaskProgressReporter.testTaskProgress:267 expected:<[2]> but was:<[3]>
```
- Run Test2 and Test3, Test3 fails:
```
[ERROR]   TestTaskProgressReporter.testTaskProgress:267 expected:<[2]> but was:<[11]>
```

## Fix
Clean the value of `statusUpdateTimes` to 0 at the start of Test3 to clean the pollution from Test1 and Test2.