### PR TITLE
HADOOP-17849. Exclude spotbugs-annotations from transitive dependencies on branch-3.2.

### DIFF
--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -322,6 +322,10 @@
           <groupId>dnsjava</groupId>
           <artifactId>dnsjava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Add optional runtime dependency on the in-development timeline server module


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17849

Building Hadoop in dist profile with ZooKeeper 3.4.14 fails on hadoop-client-check-test-invariants. Excluding com.github.spotbugs:spotbugs-annotation from transitive dependencies should fix this for users needing zookeeer-3.4.14. Since the dependency is provided/optional on ZooKeeper 3.5.x, branch-3.3 and above are not affected.