### PR TITLE
HDFS-16176. fix Client EC -unsetPolicy not success

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirErasureCodingOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirErasureCodingOp.java
@@ -186,7 +186,7 @@ final class FSDirErasureCodingOp {
     // check whether the directory already has an erasure coding policy
     // directly on itself.
     final Boolean hasEcXAttr =
-        getErasureCodingPolicyXAttrForINode(fsn, inode) == null ? false : true;
+        getErasureCodingPolicyXAttrForINode(fsn, inode, srcIIP.getPathSnapshotId()) == null ? false : true;
     final List<XAttr> xattrs = Lists.newArrayListWithCapacity(1);
     xattrs.add(ecXAttr);
     final EnumSet<XAttrSetFlag> flag = hasEcXAttr ?
@@ -329,7 +329,7 @@ final class FSDirErasureCodingOp {
 
     // Check whether the directory has a specific erasure coding policy
     // directly on itself.
-    final XAttr ecXAttr = getErasureCodingPolicyXAttrForINode(fsn, inode);
+    final XAttr ecXAttr = getErasureCodingPolicyXAttrForINode(fsn, inode, srcIIP.getPathSnapshotId());
     if (ecXAttr == null) {
       return null;
     }
@@ -486,7 +486,7 @@ final class FSDirErasureCodingOp {
   }
 
   private static XAttr getErasureCodingPolicyXAttrForINode(
-      FSNamesystem fsn, INode inode) throws IOException {
+      FSNamesystem fsn, INode inode, int snapshotId) throws IOException {
     // INode can be null
     if (inode == null) {
       return null;
@@ -500,7 +500,7 @@ final class FSDirErasureCodingOp {
       if (inode.isSymlink()) {
         return null;
       }
-      final XAttrFeature xaf = inode.getXAttrFeature();
+      final XAttrFeature xaf = inode.getXAttrFeature(snapshotId);
       if (xaf != null) {
         XAttr xattr = xaf.getXAttr(XATTR_ERASURECODING_POLICY);
         if (xattr != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestUnsetAndChangeDirectoryEcPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestUnsetAndChangeDirectoryEcPolicy.java
@@ -94,6 +94,7 @@ public class TestUnsetAndChangeDirectoryEcPolicy {
     final int numBlocks = 1;
     final int fileLen = blockGroupSize * numBlocks;
     final Path dirPath = new Path("/striped");
+    final Path subDirPath = new Path(dirPath, "sub_dir");
     final Path ecFilePath = new Path(dirPath, "ec_file");
     final Path replicateFilePath = new Path(dirPath, "3x_file");
 
@@ -107,6 +108,7 @@ public class TestUnsetAndChangeDirectoryEcPolicy {
     // Set EC policy on directory
     fs.setErasureCodingPolicy(dirPath, ecPolicy.getName());
 
+    fs.mkdirs(subDirPath);
     DFSTestUtil.createFile(fs, ecFilePath, fileLen, (short) 1, 0L);
     fs.unsetErasureCodingPolicy(dirPath);
     DFSTestUtil.createFile(fs, replicateFilePath, fileLen, (short) 1, 0L);
@@ -121,6 +123,11 @@ public class TestUnsetAndChangeDirectoryEcPolicy {
     tempEcPolicy = fs.getErasureCodingPolicy(replicateFilePath);
     Assert.assertNull("Replicate file should not have erasure coding policy!",
         tempEcPolicy);
+
+    // Subdirectory should not return erasure coding policy
+    tempEcPolicy = fs.getErasureCodingPolicy(subDirPath);
+    Assert.assertNull("Subdirectory should no have erasure coding policy set!",
+            tempEcPolicy);
 
     // Directory should not return erasure coding policy
     tempEcPolicy = fs.getErasureCodingPolicy(dirPath);


### PR DESCRIPTION
A directory explicitly set ecpolicy, when use -unsetPolicy to remove the setting, it has been unsuccessful. Expect to delete the setting successfully