### PR TITLE
HDFS-16177. Bug fix for Util#receiveFile

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Util.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Util.java
@@ -287,7 +287,7 @@ public final class Util {
         fos.getChannel().force(true);
         fos.close();
         double writeSec = Math.max(((float)
-            (flushStartTime - Time.monotonicNow())) / 1000.0, 0.001);
+            (Time.monotonicNow() - flushStartTime)) / 1000.0, 0.001);
         xferCombined += writeSec;
         xferStats.append(String
             .format(" Synchronous (fsync) write to disk of " +


### PR DESCRIPTION
JIRA: [HDFS-16177](https://issues.apache.org/jira/browse/HDFS-16177)

The time to write file was miscalculated in Util#receiveFile.

![image](https://user-images.githubusercontent.com/55134131/129893185-50226ae5-a9de-4066-adfa-53812c8d967b.png)

