### PR TITLE
HDFS-16178. Make recursive rmdir in libhdfs++ cross platform

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/utils/temp-dir.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/utils/temp-dir.cc
@@ -16,23 +16,18 @@
  * limitations under the License.
  */
 
+#include <filesystem>
+#include <iostream>
 #include <string>
+#include <system_error>
 #include <vector>
 
-#include <ftw.h>
 #include <gtest/gtest.h>
-#include <sys/stat.h>
 
 #include "utils/temp-dir.h"
 #include "x-platform/syscall.h"
 
 namespace TestUtils {
-/*
- * Callback to remove a directory in the nftw visitor.
- */
-int nftw_remove(const char *fpath, const struct stat *sb, int typeflag,
-                struct FTW *ftwbuf);
-
 TempDir::TempDir() {
   std::vector path_pattern(path_.begin(), path_.end());
   is_path_init_ = XPlatform::Syscall::CreateTempDir(path_pattern);
@@ -57,19 +52,17 @@ TempDir &TempDir::operator=(TempDir &&other) noexcept {
 }
 
 TempDir::~TempDir() {
-  if (is_path_init_) {
-    nftw(path_.c_str(), nftw_remove, 64, FTW_DEPTH | FTW_PHYS);
+  if (!is_path_init_) {
+    return;
   }
-}
 
-int nftw_remove(const char *fpath, const struct stat *sb, int typeflag,
-                FTW *ftwbuf) {
-  (void)sb;
-  (void)typeflag;
-  (void)ftwbuf;
+  const std::filesystem::path tmp_dir_path(path_);
+  std::error_code tmp_dir_rm_err;
 
-  int rv = remove(fpath);
-  EXPECT_EQ(0, rv);
-  return rv;
+  const auto tmp_dir_rm_result = remove_all(tmp_dir_path, tmp_dir_rm_err);
+  if (!tmp_dir_rm_result) {
+    std::cerr << "Error in deleting directory " << path_ << ": "
+              << tmp_dir_rm_err.message() << std::endl;
+  }
 }
 } // namespace TestUtils

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/utils/temp-dir.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/utils/temp-dir.cc
@@ -60,6 +60,7 @@ TempDir::~TempDir() {
   std::error_code tmp_dir_rm_err;
 
   const auto tmp_dir_rm_result = remove_all(tmp_dir_path, tmp_dir_rm_err);
+  EXPECT_TRUE(tmp_dir_rm_result);
   if (!tmp_dir_rm_result) {
     std::cerr << "Error in deleting directory " << path_ << ": "
               << tmp_dir_rm_err.message() << std::endl;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
* The TempDir class in libhdfs++ is currently
  using nftw API provided by ftw.h, which is
  only present in Linux and not on Windows.
* This PR uses the remove_all API from C++17
  std::filesystem to make this cross platform
  in an equivalent manner.


### How was this patch tested?
The API used here was tested with standalone
program -
https://github.com/GauthamBanasandra/x-platform/commit/87e68a626548aac87c4e0bdcff8a33d2d769dc69

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

