### PR TITLE
HADOOP-17851 Support user specified content encoding for S3A

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -411,7 +411,7 @@ public final class Constants {
   public static final String DEFAULT_CANNED_ACL = "";
 
   // gzip, deflate, compress, br, etc.
-  public static final String CONTENT_ENCODING = "fs.s3a.contentEncoding";
+  public static final String CONTENT_ENCODING = "fs.s3a.content.encoding";
   public static final String DEFAULT_CONTENT_ENCODING = null;
 
   // should we try to purge old multipart uploads when starting up

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -410,6 +410,10 @@ public final class Constants {
   public static final String CANNED_ACL = "fs.s3a.acl.default";
   public static final String DEFAULT_CANNED_ACL = "";
 
+  // gzip, deflate, compress, br, etc.
+  public static final String CONTENT_ENCODING = "fs.s3a.contentEncoding";
+  public static final String DEFAULT_CONTENT_ENCODING = null;
+
   // should we try to purge old multipart uploads when starting up
   public static final String PURGE_EXISTING_MULTIPART =
       "fs.s3a.multipart.purge";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -412,7 +412,6 @@ public final class Constants {
 
   // gzip, deflate, compress, br, etc.
   public static final String CONTENT_ENCODING = "fs.s3a.content.encoding";
-  public static final String DEFAULT_CONTENT_ENCODING = null;
 
   // should we try to purge old multipart uploads when starting up
   public static final String PURGE_EXISTING_MULTIPART =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -925,12 +925,16 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // request factory.
     initCannedAcls(getConf());
 
+    // Any encoding type
+    String contentEncoding = getConf().get(CONTENT_ENCODING, DEFAULT_CONTENT_ENCODING);
+
     return RequestFactoryImpl.builder()
         .withBucket(requireNonNull(bucket))
         .withCannedACL(getCannedACL())
         .withEncryptionSecrets(requireNonNull(encryptionSecrets))
         .withMultipartPartCountLimit(partCountLimit)
         .withRequestPreparer(getAuditManager()::requestCreated)
+        .withContentEncoding(contentEncoding)
         .build();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -926,7 +926,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     initCannedAcls(getConf());
 
     // Any encoding type
-    String contentEncoding = getConf().get(CONTENT_ENCODING, DEFAULT_CONTENT_ENCODING);
+    String contentEncoding = getConf().getTrimmed(CONTENT_ENCODING, null);
 
     return RequestFactoryImpl.builder()
         .withBucket(requireNonNull(bucket))

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -104,7 +104,7 @@ public interface RequestFactory {
    * Get the content encoding (e.g. gzip) or return null if none.
    * @return content encoding
    */
-  public String getContentEncoding();
+  String getContentEncoding();
 
   /**
    * Create a new object metadata instance.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -101,6 +101,12 @@ public interface RequestFactory {
   S3AEncryptionMethods getServerSideEncryptionAlgorithm();
 
   /**
+   * Get the content encoding (e.g. gzip) or return null if none.
+   * @return content encoding
+   */
+  public String getContentEncoding();
+
+  /**
    * Create a new object metadata instance.
    * Any standard metadata headers are added here, for example:
    * encryption.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -253,8 +253,6 @@ public class RequestFactoryImpl implements RequestFactory {
    * @param metadata to update.
    */
   protected void setOptionalObjectMetadata(ObjectMetadata metadata) {
-    final String contentEncoding =
-      getContentEncoding();
     final S3AEncryptionMethods algorithm
         = getServerSideEncryptionAlgorithm();
     if (S3AEncryptionMethods.SSE_S3 == algorithm) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -119,6 +119,11 @@ public class RequestFactoryImpl implements RequestFactory {
   private final PrepareRequest requestPreparer;
 
   /**
+   * Content encoding (null for none).
+   */
+  private final String contentEncoding;
+
+  /**
    * Constructor.
    * @param builder builder with all the configuration.
    */
@@ -130,6 +135,7 @@ public class RequestFactoryImpl implements RequestFactory {
     this.multipartPartCountLimit = builder.multipartPartCountLimit;
     this.requesterPays = builder.requesterPays;
     this.requestPreparer = builder.requestPreparer;
+    this.contentEncoding = builder.contentEncoding;
   }
 
   /**
@@ -194,6 +200,15 @@ public class RequestFactoryImpl implements RequestFactory {
   }
 
   /**
+   * Get the content encoding (e.g. gzip) or return null if none.
+   * @return content encoding
+   */
+  @Override
+  public String getContentEncoding() {
+    return contentEncoding;
+  }
+
+  /**
    * Sets server side encryption parameters to the part upload
    * request when encryption is enabled.
    * @param request upload part request
@@ -238,6 +253,8 @@ public class RequestFactoryImpl implements RequestFactory {
    * @param metadata to update.
    */
   protected void setOptionalObjectMetadata(ObjectMetadata metadata) {
+    final String contentEncoding =
+      getContentEncoding();
     final S3AEncryptionMethods algorithm
         = getServerSideEncryptionAlgorithm();
     if (S3AEncryptionMethods.SSE_S3 == algorithm) {
@@ -586,6 +603,9 @@ public class RequestFactoryImpl implements RequestFactory {
     /** Requester Pays flag. */
     private boolean requesterPays = false;
 
+    /** Content Encoding. */
+    private String contentEncoding = null;
+
     /**
      * Multipart limit.
      */
@@ -605,6 +625,16 @@ public class RequestFactoryImpl implements RequestFactory {
      */
     public RequestFactory build() {
       return new RequestFactoryImpl(this);
+    }
+
+    /**
+     * Content encoding.
+     * @param value new value
+     * @return the builder
+     */
+    public RequestFactoryBuilder withContentEncoding(final String value) {
+      contentEncoding = value;
+      return this;
     }
 
     /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -260,6 +260,9 @@ public class RequestFactoryImpl implements RequestFactory {
     if (S3AEncryptionMethods.SSE_S3 == algorithm) {
       metadata.setSSEAlgorithm(algorithm.getMethod());
     }
+    if (contentEncoding != null) {
+      metadata.setContentEncoding(contentEncoding);
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -605,7 +605,7 @@ public class RequestFactoryImpl implements RequestFactory {
     private boolean requesterPays = false;
 
     /** Content Encoding. */
-    private String contentEncoding = null;
+    private String contentEncoding;
 
     /**
      * Multipart limit.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import java.util.Map;
+
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.assertj.core.api.Assertions;
@@ -28,7 +30,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_CONTENT_ENCODING;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_CONTENT_ENCODING;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.decodeBytes;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 import static org.apache.hadoop.fs.s3a.Constants.CONTENT_ENCODING;
@@ -66,12 +69,12 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
    * Assert that a given object has gzip encoding specified.
    * @param path path
    */
-  private void assertObjectHasEncoding(Path path) {
+  private void assertObjectHasEncoding(Path path) throws Throwable {
     S3AFileSystem fs = getFileSystem();
 
     StoreContext storeContext = fs.createStoreContext();
-    String key = storeContext.pathToKey(path);
-    String encoding = fs.getXAttrs(XA_CONTENT_ENCODING);
+    Map<String, byte[]> xAttrs = fs.getXAttrs(path);
+    String encoding = decodeBytes(xAttrs.get(XA_CONTENT_ENCODING));
     Assertions.assertThat(encoding)
         .describedAs("Encoding of object %s is gzip", path)
         .isEqualTo("gzip");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.util.List;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.audit.S3AAuditConstants;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+
+import static org.apache.hadoop.fs.s3a.Constants.CONTENT_ENCODING;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+
+/**
+ * Tests of content encoding object meta data.
+ */
+public class ITestS3AContentEncoding extends AbstractS3ATestBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ITestS3ACannedACLs.class);
+
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    conf.set(CONTENT_ENCODING, "gzip");
+
+    return conf;
+  }
+
+  @Test
+  public void testCreatedObjectsHaveEncoding() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    Path dir = methodPath();
+    fs.mkdirs(dir);
+    Path path = new Path(dir, "1");
+    ContractTestUtils.touch(fs, path);
+    assertObjectHasEncoding(path);
+  }
+
+  /**
+   * Assert that a given object has gzip encoding specified
+   * @param path path
+   */
+  private void assertObjectHasEncoding(Path path) {
+    S3AFileSystem fs = getFileSystem();
+
+    StoreContext storeContext = fs.createStoreContext();
+    AmazonS3 s3 = fs.getAmazonS3ClientForTesting("encoding");
+    String key = storeContext.pathToKey(path);
+    ObjectMetadata meta = s3.getObjectMetadata(storeContext.getBucket(),
+        key);
+    String encoding = meta.getContentEncoding();
+    Assertions.assertThat(encoding)
+        .describedAs("Encoding of object %s is gzip", path)
+        .equals("gzip!");
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -77,6 +77,6 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
     String encoding = meta.getContentEncoding();
     Assertions.assertThat(encoding)
         .describedAs("Encoding of object %s is gzip", path)
-        .isEqualTo("gzip!");
+        .isEqualTo("gzip");
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -41,9 +41,6 @@ import static org.apache.hadoop.fs.s3a.Constants.CONTENT_ENCODING;
  */
 public class ITestS3AContentEncoding extends AbstractS3ATestBase {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ITestS3ACannedACLs.class);
-
   @Override
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
@@ -62,7 +59,7 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
     assertObjectHasEncoding(path);
     Path path2 = new Path(dir, "2");
     fs.rename(path, path2);
-    assertObjectHasEncoding(path);
+    assertObjectHasEncoding(path2);
   }
 
   /**
@@ -76,7 +73,7 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
     Map<String, byte[]> xAttrs = fs.getXAttrs(path);
     String encoding = decodeBytes(xAttrs.get(XA_CONTENT_ENCODING));
     Assertions.assertThat(encoding)
-        .describedAs("Encoding of object %s is gzip", path)
+        .describedAs("Encoding of object %s should be gzip, is %s", path, encoding)
         .isEqualTo("gzip");
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -77,6 +77,6 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
     String encoding = meta.getContentEncoding();
     Assertions.assertThat(encoding)
         .describedAs("Encoding of object %s is gzip", path)
-        .equals("gzip!");
+        .isEqualTo("gzip!");
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_CONTENT_ENCODING;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 import static org.apache.hadoop.fs.s3a.Constants.CONTENT_ENCODING;
@@ -69,11 +70,8 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
     S3AFileSystem fs = getFileSystem();
 
     StoreContext storeContext = fs.createStoreContext();
-    AmazonS3 s3 = fs.getAmazonS3ClientForTesting("encoding");
     String key = storeContext.pathToKey(path);
-    ObjectMetadata meta = s3.getObjectMetadata(storeContext.getBucket(),
-        key);
-    String encoding = meta.getContentEncoding();
+    String encoding = fs.getXAttrs(XA_CONTENT_ENCODING);
     Assertions.assertThat(encoding)
         .describedAs("Encoding of object %s is gzip", path)
         .isEqualTo("gzip");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import java.util.List;
-
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.assertj.core.api.Assertions;
@@ -30,11 +28,9 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.fs.s3a.audit.S3AAuditConstants;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
 
 import static org.apache.hadoop.fs.s3a.Constants.CONTENT_ENCODING;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 
 /**
  * Tests of content encoding object meta data.
@@ -60,10 +56,13 @@ public class ITestS3AContentEncoding extends AbstractS3ATestBase {
     Path path = new Path(dir, "1");
     ContractTestUtils.touch(fs, path);
     assertObjectHasEncoding(path);
+    Path path2 = new Path(dir, "2");
+    fs.rename(path, path2);
+    assertObjectHasEncoding(path);
   }
 
   /**
-   * Assert that a given object has gzip encoding specified
+   * Assert that a given object has gzip encoding specified.
    * @param path path
    */
   private void assertObjectHasEncoding(Path path) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContentEncoding.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.fs.s3a;
 
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSUserDefinedKey.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSUserDefinedKey.java
@@ -39,8 +39,9 @@ public class ITestS3AEncryptionSSEKMSUserDefinedKey
     // get the KMS key for this test.
     Configuration c = new Configuration();
     String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
-    if (StringUtils.isBlank(kmsKey) || !c.get(SERVER_SIDE_ENCRYPTION_ALGORITHM)
-        .equals(S3AEncryptionMethods.CSE_KMS.name())) {
+    String encryptionAlgorithm = c.get(SERVER_SIDE_ENCRYPTION_ALGORITHM);
+    if (kmsKey == null || StringUtils.isBlank(kmsKey) || encryptionAlgorithm == null ||
+        !encryptionAlgorithm.equals(S3AEncryptionMethods.CSE_KMS.name())) {
       skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
           SSE_KMS.getMethod() + " or CSE-KMS algorithm is used instead of "
           + "SSE-KMS");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSUserDefinedKey.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEKMSUserDefinedKey.java
@@ -39,9 +39,8 @@ public class ITestS3AEncryptionSSEKMSUserDefinedKey
     // get the KMS key for this test.
     Configuration c = new Configuration();
     String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
-    String encryptionAlgorithm = c.get(SERVER_SIDE_ENCRYPTION_ALGORITHM);
-    if (kmsKey == null || StringUtils.isBlank(kmsKey) || encryptionAlgorithm == null ||
-        !encryptionAlgorithm.equals(S3AEncryptionMethods.CSE_KMS.name())) {
+    String encryptionAlgorithm = c.get(SERVER_SIDE_ENCRYPTION_ALGORITHM, "");
+    if (StringUtils.isBlank(kmsKey) || !encryptionAlgorithm.equals(S3AEncryptionMethods.CSE_KMS.name())) {
       skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
           SSE_KMS.getMethod() + " or CSE-KMS algorithm is used instead of "
           + "SSE-KMS");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
@@ -45,8 +45,9 @@ public class ITestS3AHugeFilesEncryption extends AbstractSTestS3AHugeFiles {
   public void setup() throws Exception {
     Configuration c = new Configuration();
     String kmsKey = c.get(SERVER_SIDE_ENCRYPTION_KEY);
-    if (StringUtils.isBlank(kmsKey) || !c.get(SERVER_SIDE_ENCRYPTION_ALGORITHM)
-        .equals(S3AEncryptionMethods.CSE_KMS.name())) {
+    String encryptionAlgorithm = c.get(SERVER_SIDE_ENCRYPTION_ALGORITHM);
+    if (kmsKey == null || StringUtils.isBlank(kmsKey) || encryptionAlgorithm == null ||
+        !encryptionAlgorithm.equals(S3AEncryptionMethods.CSE_KMS.name())) {
       skip(SERVER_SIDE_ENCRYPTION_KEY + " is not set for " +
           SSE_KMS.getMethod() + " or CSE-KMS algorithm is used instead of "
           + "SSE-KMS");


### PR DESCRIPTION

Adds support for user specified content encoding for S3A in the option `fs.s3a.content.encoding`
