### PR TITLE
HDFS-16181. [SBN Read] Fix metric of RpcRequestCacheMissAmount can't display when tailEditLog form JN

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
@@ -773,7 +773,7 @@ public class Journal implements Closeable {
           .setEditLog(output.toByteString())
           .build();
     } catch (JournaledEditsCache.CacheMissException cme) {
-      metrics.rpcRequestCacheMissAmount.add(cme.getCacheMissAmount());
+      metrics.addRpcRequestCacheMissAmount(cme.getCacheMissAmount());
       throw cme;
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
@@ -51,7 +51,6 @@ class JournalMetrics {
   @Metric("Number of bytes served via RPC")
   MutableCounterLong bytesServedViaRpc;
 
-  @Metric
   MutableStat rpcRequestCacheMissAmount;
 
   @Metric("Number of RPC requests with zero edits returned")

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
@@ -52,11 +52,7 @@ class JournalMetrics {
   MutableCounterLong bytesServedViaRpc;
 
   @Metric
-  MutableStat rpcRequestCacheMissAmount = new MutableStat(
-      "RpcRequestCacheMissAmount", "Number of RPC requests unable to be " +
-      "served due to lack of availability in cache, and how many " +
-      "transactions away the request was from being in the cache.",
-      "Misses", "Txns");
+  MutableStat rpcRequestCacheMissAmount;
 
   @Metric("Number of RPC requests with zero edits returned")
   MutableCounterLong rpcEmptyResponses;
@@ -87,6 +83,11 @@ class JournalMetrics {
           "syncs" + interval + "s",
           "Journal sync time", "ops", "latencyMicros", interval);
     }
+    rpcRequestCacheMissAmount = registry
+        .newStat("RpcRequestCacheMissAmount", "Number of RPC requests unable to be " +
+                "served due to lack of availability in cache, and how many " +
+                "transactions away the request was from being in the cache.",
+            "Misses", "Txns");
   }
   
   public static JournalMetrics create(Journal j) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
@@ -51,7 +51,7 @@ class JournalMetrics {
   @Metric("Number of bytes served via RPC")
   MutableCounterLong bytesServedViaRpc;
 
-  MutableStat rpcRequestCacheMissAmount;
+  private MutableStat rpcRequestCacheMissAmount;
 
   @Metric("Number of RPC requests with zero edits returned")
   MutableCounterLong rpcEmptyResponses;
@@ -148,5 +148,9 @@ class JournalMetrics {
 
   public void incrNumEditLogsSynced() {
     numEditLogsSynced.incr();
+  }
+
+  public void addRpcRequestCacheMissAmount(long cacheMissAmount) {
+    rpcRequestCacheMissAmount.add(cacheMissAmount);
   }
 }


### PR DESCRIPTION
### Description of PR
I found the JN turn on edit cache, but the metric of rpcRequestCacheMissAmount can not display.

JIRA: https://issues.apache.org/jira/browse/HDFS-16181
 

