### PR TITLE
YARN-10884: Handle empty owners to parse log files

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
@@ -134,6 +134,7 @@ public class EntityGroupFSTimelineStore extends CompositeService
   private int appCacheMaxSize = 0;
   private List<TimelineEntityGroupPlugin> cacheIdPlugins;
   private Map<TimelineEntityGroupId, EntityCacheItem> cachedLogs;
+  private boolean aclsEnabled;
 
   @VisibleForTesting
   @InterfaceAudience.Private
@@ -204,6 +205,8 @@ public class EntityGroupFSTimelineStore extends CompositeService
         YarnConfiguration
             .TIMELINE_SERVICE_ENTITYGROUP_FS_STORE_DONE_DIR_DEFAULT));
     fs = activeRootPath.getFileSystem(conf);
+    aclsEnabled = conf.getBoolean(YarnConfiguration.YARN_ACL_ENABLE,
+    YarnConfiguration.DEFAULT_YARN_ACL_ENABLE);
     CallerContext.setCurrent(
         new CallerContext.Builder(ATS_V15_SERVER_DFS_CALLER_CTXT).build());
     super.serviceInit(conf);
@@ -766,16 +769,24 @@ public class EntityGroupFSTimelineStore extends CompositeService
             continue;
           }
           String filename = statCache.getPath().getName();
+          String owner = statCache.getOwner();
+          /* YARN-10884: Owner of File is set to Null on WASB Append Operation. ATS fails to read such
+          files as UGI cannot be constructed using Null User. To Fix this, anonymous user is set when 
+          ACL us Disabled as the UGI is not needed there */
+          if ((owner == null || owner.isEmpty()) && !aclsEnabled) {
+             LOG.debug("The owner was null when acl disabled, hence making the owner anonymous");
+             owner = "anonymous";
+          }
           // We should only update time for log files.
           boolean shouldSetTime = true;
           LOG.debug("scan for log file: {}", filename);
           if (filename.startsWith(DOMAIN_LOG_PREFIX)) {
-            addSummaryLog(attemptDirName, filename, statCache.getOwner(), true);
+            addSummaryLog(attemptDirName, filename, owner, true);
           } else if (filename.startsWith(SUMMARY_LOG_PREFIX)) {
-            addSummaryLog(attemptDirName, filename, statCache.getOwner(),
+            addSummaryLog(attemptDirName, filename, owner,
                 false);
           } else if (filename.startsWith(ENTITY_LOG_PREFIX)) {
-            addDetailLog(attemptDirName, filename, statCache.getOwner());
+            addDetailLog(attemptDirName, filename, owner);
           } else {
             shouldSetTime = false;
           }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
@@ -770,12 +770,12 @@ public class EntityGroupFSTimelineStore extends CompositeService
           }
           String filename = statCache.getPath().getName();
           String owner = statCache.getOwner();
-          //YARN-10884: Owner of File is set to Null on WASB Append Operation. ATS fails to read such
-          //files as UGI cannot be constructed using Null User.To Fix this,anonymous user is set when
-          //ACL us Disabled as the UGI is not needed there
+          //YARN-10884:Owner of File is set to Null on WASB Append Operation.ATS fails to read such
+          //files as UGI cannot be constructed using Null User.To Fix this,anonymous user is set
+          //when ACL us Disabled as the UGI is not needed there
           if ((owner == null || owner.isEmpty()) && !aclsEnabled) {
-             LOG.debug("The owner was null when acl disabled, hence making the owner anonymous");
-             owner = "anonymous";
+            LOG.debug("The owner was null when acl disabled, hence making the owner anonymous");
+            owner = "anonymous";
           }
           // We should only update time for log files.
           boolean shouldSetTime = true;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
@@ -770,9 +770,9 @@ public class EntityGroupFSTimelineStore extends CompositeService
           }
           String filename = statCache.getPath().getName();
           String owner = statCache.getOwner();
-          /* YARN-10884: Owner of File is set to Null on WASB Append Operation. ATS fails to read such
-          files as UGI cannot be constructed using Null User. To Fix this, anonymous user is set when 
-          ACL us Disabled as the UGI is not needed there */
+          //YARN-10884: Owner of File is set to Null on WASB Append Operation. ATS fails to read such
+          //files as UGI cannot be constructed using Null User. To Fix this, anonymous user is set when 
+          //ACL us Disabled as the UGI is not needed there
           if ((owner == null || owner.isEmpty()) && !aclsEnabled) {
              LOG.debug("The owner was null when acl disabled, hence making the owner anonymous");
              owner = "anonymous";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/main/java/org/apache/hadoop/yarn/server/timeline/EntityGroupFSTimelineStore.java
@@ -771,7 +771,7 @@ public class EntityGroupFSTimelineStore extends CompositeService
           String filename = statCache.getPath().getName();
           String owner = statCache.getOwner();
           //YARN-10884: Owner of File is set to Null on WASB Append Operation. ATS fails to read such
-          //files as UGI cannot be constructed using Null User. To Fix this, anonymous user is set when 
+          //files as UGI cannot be constructed using Null User.To Fix this,anonymous user is set when
           //ACL us Disabled as the UGI is not needed there
           if ((owner == null || owner.isEmpty()) && !aclsEnabled) {
              LOG.debug("The owner was null when acl disabled, hence making the owner anonymous");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
@@ -270,7 +270,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
       appLogs.parseSummaryLogs(tdm);
       PluginStoreTestUtils.verifyTestEntities(tdm);
     } catch (IllegalArgumentException ie) {
-      Assert.fail("Should not have thrown any exception as there should be a anonymous user configured");
+      Assert.fail("No exception needs to be thrown as anonymous user is configured");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileContextTestHelper;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
@@ -67,6 +68,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
 
@@ -252,6 +255,23 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     appLogs.parseSummaryLogs(tdm);
     PluginStoreTestUtils.verifyTestEntities(tdm);
     assertEquals(beforeScan + 2L, scanned.value());
+  }
+
+  @Test
+  public void testWithAnonymousUser() throws Exception {
+    try {
+      TimelineDataManager tdm = PluginStoreTestUtils.getTdmWithMemStore(config);
+      EntityGroupFSTimelineStore.AppLogs appLogs =
+              store.new AppLogs(mainTestAppId, mainTestAppDirPath,
+                      AppState.COMPLETED);
+      FileStatus fileStatus = mock(FileStatus.class);
+      when(fileStatus.getOwner()).thenReturn(null);
+      appLogs.scanForLogs();
+      appLogs.parseSummaryLogs(tdm);
+      PluginStoreTestUtils.verifyTestEntities(tdm);
+    } catch (IllegalArgumentException ie) {
+      Assert.fail("Should not have thrown any exception as there should be a anonymous user configured");
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Wasb FileSystem sets owner as empty during append operation. 
ATS1.5 fails to read such files with below error 
```
 java.lang.IllegalArgumentException: Null user
        at org.apache.hadoop.security.UserGroupInformation.createRemoteUser(UserGroupInformation.java:1271)
        at org.apache.hadoop.security.UserGroupInformation.createRemoteUser(UserGroupInformation.java:1258)
        at org.apache.hadoop.yarn.server.timeline.LogInfo.parsePath(LogInfo.java:141)
        at org.apache.hadoop.yarn.server.timeline.LogInfo.parseForStore(LogInfo.java:114)
        at org.apache.hadoop.yarn.server.timeline.EntityGroupFSTimelineStore$AppLogs.parseSummaryLogs(EntityGroupFSTimelineStore.java:701)
        at org.apache.hadoop.yarn.server.timeline.EntityGroupFSTimelineStore$AppLogs.parseSummaryLogs(EntityGroupFSTimelineStore.java:675)
        at org.apache.hadoop.yarn.server.timeline.EntityGroupFSTimelineStore$ActiveLogParser.run(EntityGroupFSTimelineStore.java:888)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
The owner information is used only when the ACL is enabled and not used when ACL is disabled. 
Hence, making the owner ```anonymous``` , only when the ACL is disabled so that the append operation is successful.


### How was this patch tested?
The patch was tested in a device which uses wasb storage and made sure that the exception is not seen post patching. 

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

