### PR TITLE
HADOOP-17858. Avoid possible class loading deadlock with VerifierNone initialization

### DIFF
--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/RpcProgram.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/RpcProgram.java
@@ -28,7 +28,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.oncrpc.RpcAcceptedReply.AcceptState;
-import org.apache.hadoop.oncrpc.security.Verifier;
 import org.apache.hadoop.oncrpc.security.VerifierNone;
 import org.apache.hadoop.portmap.PortmapMapping;
 import org.apache.hadoop.portmap.PortmapRequest;
@@ -213,7 +212,7 @@ public abstract class RpcProgram extends ChannelInboundHandlerAdapter {
   private void sendAcceptedReply(RpcCall call, SocketAddress remoteAddress,
       AcceptState acceptState, ChannelHandlerContext ctx) {
     RpcAcceptedReply reply = RpcAcceptedReply.getInstance(call.getXid(),
-        acceptState, Verifier.VERIFIER_NONE);
+        acceptState, VerifierNone.INSTANCE);
 
     XDR out = new XDR();
     reply.write(out);

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Verifier.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/Verifier.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.oncrpc.XDR;
  */
 public abstract class Verifier extends RpcAuthInfo {
 
-  public static final Verifier VERIFIER_NONE = new VerifierNone();
-
   protected Verifier(AuthFlavor flavor) {
     super(flavor);
   }

--- a/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/VerifierNone.java
+++ b/hadoop-common-project/hadoop-nfs/src/main/java/org/apache/hadoop/oncrpc/security/VerifierNone.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
 /** Verifier used by AUTH_NONE. */
 public class VerifierNone extends Verifier {
 
+  public static final Verifier INSTANCE = new VerifierNone();
+
   public VerifierNone() {
     super(AuthFlavor.AUTH_NONE);
   }


### PR DESCRIPTION
### Description of PR
Superclass Verifier has a static initializer VERIFIER_NONE that initializes sub-class VerifierNone. This reference can result in deadlock during class loading as per https://docs.oracle.com/javase/specs/jls/se8/html/jls-12.html#jls-12.4.2.

As of today, only RpcProgram use this instance and hence it is safe but if more clients start using this (specifically static ones), it has potential to bring deadlock. We should break this referencing before it is late.

### How was this patch tested?
TestRPC* unit tests

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

