### PR TITLE
HDFS-6874. Add GETFILEBLOCKLOCATIONS operation to HttpFS.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -3892,10 +3892,19 @@ public class DistributedFileSystem extends FileSystem
     return new FileSystemMultipartUploaderBuilder(this, basePath);
   }
 
+  /**
+   * Returns LocatedBlocks of the corresponding HDFS file p from offset start
+   * for length len.
+   * This is similar to {@link #getFileBlockLocations(Path, long, long)} except
+   * that it returns LocatedBlocks rather than BlockLocation array.
+   * @param p path representing the file of interest.
+   * @param start offset
+   * @param len length
+   * @return a LocatedBlocks object
+   * @throws IOException
+   */
   public LocatedBlocks getLocatedBlocks(Path p, long start, long len)
       throws IOException {
-    statistics.incrementReadOps(1);
-    storageStatistics.incrementOpCounter(OpType.GET_FILE_BLOCK_LOCATIONS);
     final Path absF = fixRelativePart(p);
     return new FileSystemLinkResolver<LocatedBlocks>() {
       @Override
@@ -3909,8 +3918,9 @@ public class DistributedFileSystem extends FileSystem
           DistributedFileSystem myDfs = (DistributedFileSystem)fs;
           return myDfs.getLocatedBlocks(p, start, len);
         }
-        throw new UnsupportedOperationException("Cannot recoverLease through" +
-            " a symlink to a non-DistributedFileSystem: " + fs + " -> " + p);
+        throw new UnsupportedOperationException("Cannot getLocatedBlocks " +
+            "through a symlink to a non-DistributedFileSystem: " + fs + " -> "+
+            p);
       }
     }.resolve(this, absF);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
@@ -912,7 +913,8 @@ public class JsonUtilClient {
     return snapshotStatus;
   }
 
-  static BlockLocation[] toBlockLocationArray(Map<?, ?> json)
+  @VisibleForTesting
+  public static BlockLocation[] toBlockLocationArray(Map<?, ?> json)
       throws IOException {
     final Map<?, ?> rootmap =
         (Map<?, ?>) json.get(BlockLocation.class.getSimpleName() + "s");
@@ -929,7 +931,7 @@ public class JsonUtilClient {
   }
 
   /** Convert a Json map to BlockLocation. **/
-  static BlockLocation toBlockLocation(Map<?, ?> m) throws IOException {
+  private static BlockLocation toBlockLocation(Map<?, ?> m) throws IOException {
     if (m == null) {
       return null;
     }
@@ -946,6 +948,7 @@ public class JsonUtilClient {
         storageIds, storageTypes, offset, length, corrupt);
   }
 
+  @VisibleForTesting
   static String[] toStringArray(List<?> list) {
     if (list == null) {
       return null;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.hdfs.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
+
+import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
@@ -907,5 +910,52 @@ public class JsonUtilClient {
             isDeleted, DFSUtilClient.string2Bytes(
                 SnapshotStatus.getParentPath(fullPath)));
     return snapshotStatus;
+  }
+
+  static BlockLocation[] toBlockLocationArray(Map<?, ?> json)
+      throws IOException {
+    final Map<?, ?> rootmap =
+        (Map<?, ?>) json.get(BlockLocation.class.getSimpleName() + "s");
+    final List<?> array =
+        JsonUtilClient.getList(rootmap, BlockLocation.class.getSimpleName());
+    Preconditions.checkNotNull(array);
+    final BlockLocation[] locations = new BlockLocation[array.size()];
+    int i = 0;
+    for (Object object : array) {
+      final Map<?, ?> m = (Map<?, ?>) object;
+      locations[i++] = JsonUtilClient.toBlockLocation(m);
+    }
+    return locations;
+  }
+
+  /** Convert a Json map to BlockLocation. **/
+  static BlockLocation toBlockLocation(Map<?, ?> m) throws IOException {
+    if (m == null) {
+      return null;
+    }
+    long length = ((Number) m.get("length")).longValue();
+    long offset = ((Number) m.get("offset")).longValue();
+    boolean corrupt = Boolean.getBoolean(m.get("corrupt").toString());
+    String[] storageIds = toStringArray(getList(m, "storageIds"));
+    String[] cachedHosts = toStringArray(getList(m, "cachedHosts"));
+    String[] hosts = toStringArray(getList(m, "hosts"));
+    String[] names = toStringArray(getList(m, "names"));
+    String[] topologyPaths = toStringArray(getList(m, "topologyPaths"));
+    StorageType[] storageTypes = toStorageTypeArray(getList(m, "storageTypes"));
+    return new BlockLocation(names, hosts, cachedHosts, topologyPaths,
+        storageIds, storageTypes, offset, length, corrupt);
+  }
+
+  static String[] toStringArray(List<?> list) {
+    if (list == null) {
+      return null;
+    } else {
+      final String[] array = new String[list.size()];
+      int i = 0;
+      for (Object object : list) {
+        array[i++] = object.toString();
+      }
+      return array;
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -1873,7 +1873,9 @@ public class WebHdfsFileSystem extends FileSystem
             offset, length);
       }
     } catch (RemoteException e) {
-      if (isGetFileBlockLocationsException(e)) {
+      // parsing the exception is needed only if the client thinks the service
+      // is compatible
+      if (isServerHCFSCompatible && isGetFileBlockLocationsException(e)) {
         LOG.warn("Server does not appear to support GETFILEBLOCKLOCATIONS." +
                 "Fallback to the old GET_BLOCK_LOCATIONS. Exception: " +
             e.getMessage());

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
@@ -199,6 +199,22 @@
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okio</groupId>
+          <artifactId>okio</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
@@ -1722,7 +1723,8 @@ public class HttpFSFileSystem extends FileSystem
     return getFileBlockLocations(status.getPath(), offset, length);
   }
 
-  private BlockLocation[] toBlockLocations(JSONObject json) throws IOException {
+  @VisibleForTesting
+  static BlockLocation[] toBlockLocations(JSONObject json) throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     MapType subType = mapper.getTypeFactory().constructMapType(Map.class,
         String.class, BlockLocation[].class);

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -24,8 +24,11 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CommonPathCapabilities;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.DelegationTokenRenewer;
@@ -138,6 +141,8 @@ public class HttpFSFileSystem extends FileSystem
   public static final String OLD_SNAPSHOT_NAME_PARAM = "oldsnapshotname";
   public static final String FSACTION_MODE_PARAM = "fsaction";
   public static final String EC_POLICY_NAME_PARAM = "ecpolicy";
+  public static final String OFFSET_PARAM = "offset";
+  public static final String LENGTH_PARAM = "length";
 
   public static final Short DEFAULT_PERMISSION = 0755;
   public static final String ACLSPEC_DEFAULT = "";
@@ -237,6 +242,7 @@ public class HttpFSFileSystem extends FileSystem
 
   public static final String STORAGE_POLICIES_JSON = "BlockStoragePolicies";
   public static final String STORAGE_POLICY_JSON = "BlockStoragePolicy";
+  public static final String BLOCK_LOCATIONS_JSON = "BlockLocations";
 
   public static final int HTTP_TEMPORARY_REDIRECT = 307;
 
@@ -267,7 +273,8 @@ public class HttpFSFileSystem extends FileSystem
     GETSNAPSHOTTABLEDIRECTORYLIST(HTTP_GET), GETSNAPSHOTLIST(HTTP_GET),
     GETSERVERDEFAULTS(HTTP_GET),
     CHECKACCESS(HTTP_GET), SETECPOLICY(HTTP_PUT), GETECPOLICY(
-        HTTP_GET), UNSETECPOLICY(HTTP_POST), SATISFYSTORAGEPOLICY(HTTP_PUT);
+        HTTP_GET), UNSETECPOLICY(HTTP_POST), SATISFYSTORAGEPOLICY(HTTP_PUT),
+    GET_BLOCK_LOCATIONS(HTTP_GET);
 
     private String httpMethod;
 
@@ -1691,5 +1698,43 @@ public class HttpFSFileSystem extends FileSystem
     HttpURLConnection conn = getConnection(
         Operation.SATISFYSTORAGEPOLICY.getMethod(), params, path, true);
     HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_OK);
+  }
+
+  @Override
+  public BlockLocation[] getFileBlockLocations(Path path, long start, long len)
+      throws IOException {
+    Map<String, String> params = new HashMap<>();
+    params.put(OP_PARAM, Operation.GETFILEBLOCKLOCATIONS.toString());
+    params.put(OFFSET_PARAM, Long.toString(start));
+    params.put(LENGTH_PARAM, Long.toString(len));
+    HttpURLConnection conn = getConnection(
+        Operation.GETFILEBLOCKLOCATIONS.getMethod(), params, path, true);
+    HttpExceptionUtils.validateResponse(conn, HttpURLConnection.HTTP_OK);
+    JSONObject json = (JSONObject) HttpFSUtils.jsonParse(conn);
+    return toBlockLocations(json);
+  }
+
+  public BlockLocation[] getFileBlockLocations(final FileStatus status,
+      final long offset, final long length) throws IOException {
+    if (status == null) {
+      return null;
+    }
+    return getFileBlockLocations(status.getPath(), offset, length);
+  }
+
+  private BlockLocation[] toBlockLocations(JSONObject json) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    MapType subType = mapper.getTypeFactory().constructMapType(Map.class,
+        String.class, BlockLocation[].class);
+    MapType rootType = mapper.getTypeFactory().constructMapType(Map.class,
+        mapper.constructType(String.class), mapper.constructType(subType));
+
+    Map<String, Map<String, BlockLocation[]>> jsonMap =
+        mapper.readValue(json.toJSONString(), rootType);
+    Map<String, BlockLocation[]> locationMap =
+        jsonMap.get(BLOCK_LOCATIONS_JSON);
+    BlockLocation[] locationArray =
+        locationMap.get(BlockLocation.class.getSimpleName());
+    return locationArray;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/client/HttpFSFileSystem.java
@@ -1715,6 +1715,7 @@ public class HttpFSFileSystem extends FileSystem
     return toBlockLocations(json);
   }
 
+  @Override
   public BlockLocation[] getFileBlockLocations(final FileStatus status,
       final long offset, final long length) throws IOException {
     if (status == null) {
@@ -1735,8 +1736,6 @@ public class HttpFSFileSystem extends FileSystem
         mapper.readValue(json.toJSONString(), rootType);
     Map<String, BlockLocation[]> locationMap =
         jsonMap.get(BLOCK_LOCATIONS_JSON);
-    BlockLocation[] locationArray =
-        locationMap.get(BlockLocation.class.getSimpleName());
-    return locationArray;
+    return locationMap.get(BlockLocation.class.getSimpleName());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/FSOperations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/FSOperations.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.fs.http.server;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.BlockStoragePolicySpi;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileChecksum;
@@ -2130,6 +2131,40 @@ public final class FSOperations {
             + ". Please check your fs.defaultFS configuration");
       }
       return null;
+    }
+  }
+
+  /**
+   * Executor that performs a getFileBlockLocations operation.
+   */
+
+  @InterfaceAudience.Private
+  @SuppressWarnings("rawtypes")
+  public static class FSFileBlockLocations
+      implements FileSystemAccess.FileSystemExecutor<Map> {
+    private Path path;
+    private long offsetValue;
+    private long lengthValue;
+
+    /**
+     * Creates a file-block-locations executor.
+     *
+     * @param path the path to retrieve the location
+     * @param offsetValue offset into the given file
+     * @param lengthValue length for which to get locations for
+     */
+    public FSFileBlockLocations(String path, long offsetValue,
+        long lengthValue) {
+      this.path = new Path(path);
+      this.offsetValue = offsetValue;
+      this.lengthValue = lengthValue;
+    }
+
+    @Override
+    public Map execute(FileSystem fs) throws IOException {
+      BlockLocation[] locations = fs.getFileBlockLocations(this.path,
+          this.offsetValue, this.lengthValue);
+      return JsonUtil.toJsonMap(locations);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/FSOperations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/FSOperations.java
@@ -2171,7 +2171,7 @@ public final class FSOperations {
 
   /**
    * Executor that performs a getFileBlockLocations operation for legacy
-   * clients.
+   * clients that supports only GET_BLOCK_LOCATIONS.
    */
 
   @InterfaceAudience.Private
@@ -2200,13 +2200,12 @@ public final class FSOperations {
     public Map execute(FileSystem fs) throws IOException {
       if (fs instanceof DistributedFileSystem) {
         DistributedFileSystem dfs = (DistributedFileSystem)fs;
-        LocatedBlocks
-            locations = dfs.getLocatedBlocks(this.path, this.offsetValue, this.lengthValue);
+        LocatedBlocks locations = dfs.getLocatedBlocks(
+            this.path, this.offsetValue,this.lengthValue);
         return JsonUtil.toJsonMap(locations);
-      } else {
-        throw new IOException("Unable to support FSFileBlockLocationsLegacy " +
-            "because the file system is not DistributedFileSystem.");
       }
+      throw new IOException("Unable to support FSFileBlockLocationsLegacy " +
+          "because the file system is not DistributedFileSystem.");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSParametersProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSParametersProvider.java
@@ -123,6 +123,10 @@ public class HttpFSParametersProvider extends ParametersProvider {
     PARAMS_DEF.put(Operation.GETECPOLICY, new Class[] {});
     PARAMS_DEF.put(Operation.UNSETECPOLICY, new Class[] {});
     PARAMS_DEF.put(Operation.SATISFYSTORAGEPOLICY, new Class[] {});
+    PARAMS_DEF.put(Operation.GETFILEBLOCKLOCATIONS,
+        new Class[] {OffsetParam.class, LenParam.class});
+    PARAMS_DEF.put(Operation.GET_BLOCK_LOCATIONS,
+        new Class[] {OffsetParam.class, LenParam.class});
   }
 
   public HttpFSParametersProvider() {

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -522,8 +522,8 @@ public class HttpFSServer {
       if (lenParam != null && lenParam.longValue() > 0) {
         len = lenParam.longValue();
       }
-      FSOperations.FSFileBlockLocations command =
-          new FSOperations.FSFileBlockLocations(path, offset, len);
+      FSOperations.FSFileBlockLocationsLegacy command =
+          new FSOperations.FSFileBlockLocationsLegacy(path, offset, len);
       @SuppressWarnings("rawtypes")
       Map locations = fsExecute(user, command);
       final String json = JsonUtil.toJsonString("LocatedBlocks", locations);

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -514,13 +514,12 @@ public class HttpFSServer {
       long len = Long.MAX_VALUE;
       Long offsetParam = params.get(OffsetParam.NAME, OffsetParam.class);
       Long lenParam = params.get(LenParam.NAME, LenParam.class);
-      AUDIT_LOG.info("[{}] offset [{}] len [{}]",
-          new Object[] { path, offsetParam, lenParam });
-      if (offsetParam != null && offsetParam.longValue() > 0) {
-        offset = offsetParam.longValue();
+      AUDIT_LOG.info("[{}] offset [{}] len [{}]", path, offsetParam, lenParam);
+      if (offsetParam != null && offsetParam > 0) {
+        offset = offsetParam;
       }
-      if (lenParam != null && lenParam.longValue() > 0) {
-        len = lenParam.longValue();
+      if (lenParam != null && lenParam > 0) {
+        len = lenParam;
       }
       FSOperations.FSFileBlockLocationsLegacy command =
           new FSOperations.FSFileBlockLocationsLegacy(path, offset, len);

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServer.java
@@ -370,7 +370,24 @@ public class HttpFSServer {
       break;
     }
     case GETFILEBLOCKLOCATIONS: {
-      response = Response.status(Response.Status.BAD_REQUEST).build();
+      long offset = 0;
+      long len = Long.MAX_VALUE;
+      Long offsetParam = params.get(OffsetParam.NAME, OffsetParam.class);
+      Long lenParam = params.get(LenParam.NAME, LenParam.class);
+      AUDIT_LOG.info("[{}] offset [{}] len [{}]",
+          new Object[] { path, offsetParam, lenParam });
+      if (offsetParam != null && offsetParam.longValue() > 0) {
+        offset = offsetParam.longValue();
+      }
+      if (lenParam != null && lenParam.longValue() > 0) {
+        len = lenParam.longValue();
+      }
+      FSOperations.FSFileBlockLocations command =
+          new FSOperations.FSFileBlockLocations(path, offset, len);
+      @SuppressWarnings("rawtypes")
+      Map locations = fsExecute(user, command);
+      final String json = JsonUtil.toJsonString("BlockLocations", locations);
+      response = Response.ok(json).type(MediaType.APPLICATION_JSON).build();
       break;
     }
     case GETACLSTATUS: {
@@ -490,6 +507,27 @@ public class HttpFSServer {
       String js = fsExecute(user, command);
       AUDIT_LOG.info("[{}]", path);
       response = Response.ok(js).type(MediaType.APPLICATION_JSON).build();
+      break;
+    }
+    case GET_BLOCK_LOCATIONS: {
+      long offset = 0;
+      long len = Long.MAX_VALUE;
+      Long offsetParam = params.get(OffsetParam.NAME, OffsetParam.class);
+      Long lenParam = params.get(LenParam.NAME, LenParam.class);
+      AUDIT_LOG.info("[{}] offset [{}] len [{}]",
+          new Object[] { path, offsetParam, lenParam });
+      if (offsetParam != null && offsetParam.longValue() > 0) {
+        offset = offsetParam.longValue();
+      }
+      if (lenParam != null && lenParam.longValue() > 0) {
+        len = lenParam.longValue();
+      }
+      FSOperations.FSFileBlockLocations command =
+          new FSOperations.FSFileBlockLocations(path, offset, len);
+      @SuppressWarnings("rawtypes")
+      Map locations = fsExecute(user, command);
+      final String json = JsonUtil.toJsonString("LocatedBlocks", locations);
+      response = Response.ok(json).type(MediaType.APPLICATION_JSON).build();
       break;
     }
     default: {

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -1956,26 +1956,26 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
   private void testGetFileBlockLocations() throws Exception {
     BlockLocation[] locations1, locations2 = null;
     Path testFile = null;
-    try {
-      if (!this.isLocalFS()) {
-        FileSystem fs = this.getHttpFSFileSystem();
-        testFile = new Path(getProxiedFSTestDir(), "singleBlock.txt");
-        DFSTestUtil.createFile(fs, testFile, (long) 1, (short) 1, 0L);
-        if (fs instanceof HttpFSFileSystem) {
-          HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
-          locations1 = httpFS.getFileBlockLocations(testFile, 0, 1);
-          Assert.assertNotNull(locations1);
-        } else if (fs instanceof WebHdfsFileSystem) {
-          WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
-          locations2 = webHdfsFileSystem.getFileBlockLocations(testFile, 0, 1);
-          Assert.assertNotNull(locations2);
-        } else {
-          Assert
-              .fail(fs.getClass().getSimpleName() + " doesn't support access");
-        }
+    if (!this.isLocalFS()) {
+      FileSystem fs = this.getHttpFSFileSystem();
+      testFile = new Path(getProxiedFSTestDir(), "singleBlock.txt");
+      DFSTestUtil.createFile(fs, testFile, (long) 1, (short) 1, 0L);
+      if (fs instanceof HttpFSFileSystem) {
+        HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
+        locations1 = httpFS.getFileBlockLocations(testFile, 0, 1);
+        Assert.assertNotNull(locations1);
+
+        // TODO: add test for HttpFSFileSystem.toBlockLocations()
+        Json
+        httpFS.toBlockLocations()
+      } else if (fs instanceof WebHdfsFileSystem) {
+        WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
+        locations2 = webHdfsFileSystem.getFileBlockLocations(testFile, 0, 1);
+        Assert.assertNotNull(locations2);
+      } else {
+        Assert
+            .fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
-    } catch (Exception e) {
-      e.printStackTrace();
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.fs.http.client;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.BlockStoragePolicySpi;
@@ -40,8 +43,10 @@ import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.AppendTestUtil;
+import org.apache.hadoop.hdfs.DFSClientAdapter;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DFSUtilClient;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
@@ -49,6 +54,7 @@ import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.hdfs.protocol.SnapshotException;
 import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
@@ -69,6 +75,9 @@ import org.apache.hadoop.test.TestHdfsHelper;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
 import org.apache.hadoop.util.Lists;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ContainerFactory;
+import org.json.simple.parser.JSONParser;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -76,6 +85,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -97,11 +108,13 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(value = Parameterized.class)
 public abstract class BaseTestHttpFSWith extends HFSTestCase {
-
+  public static final Logger LOG = LoggerFactory
+      .getLogger(BaseTestHttpFSWith.class);
   protected abstract Path getProxiedFSTestDir();
 
   protected abstract String getProxiedFSURI();
@@ -186,7 +199,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
 
   protected void testGet() throws Exception {
     FileSystem fs = getHttpFSFileSystem();
-    Assert.assertNotNull(fs);
+    assertNotNull(fs);
     URI uri = new URI(getScheme() + "://" +
                       TestJettyHelper.getJettyURL().toURI().getAuthority());
     assertEquals(fs.getUri(), uri);
@@ -1335,6 +1348,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       break;
     case GETFILEBLOCKLOCATIONS:
       testGetFileBlockLocations();
+      testGetFileBlockLocationsFallback();
       break;
     }
 
@@ -1963,19 +1977,84 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       if (fs instanceof HttpFSFileSystem) {
         HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
         locations1 = httpFS.getFileBlockLocations(testFile, 0, 1);
-        Assert.assertNotNull(locations1);
+        assertNotNull(locations1);
 
         // TODO: add test for HttpFSFileSystem.toBlockLocations()
-        Json
-        httpFS.toBlockLocations()
+        String jsonString = JsonUtil.toJsonString(locations1);
+        JSONParser parser = new JSONParser();
+        JSONObject jsonObject = (JSONObject)parser.parse(
+            jsonString, (ContainerFactory)null);
+        BlockLocation[] deserializedLocation =
+            httpFS.toBlockLocations(jsonObject);
+        assertEquals(locations1.length, deserializedLocation.length);
+        for (int i = 0; i < locations1.length; i++) {
+          assertEquals(locations1[i].toString(),
+              deserializedLocation[i].toString());
+        }
       } else if (fs instanceof WebHdfsFileSystem) {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         locations2 = webHdfsFileSystem.getFileBlockLocations(testFile, 0, 1);
-        Assert.assertNotNull(locations2);
+        assertNotNull(locations2);
       } else {
         Assert
             .fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
+    }
+  }
+
+  private void testGetFileBlockLocationsFallback() throws IOException,
+      InterruptedException {
+    Configuration conf = new Configuration(false);
+
+    // create a HDFS file. Get its HdfsFileStatus.
+    // convert that to json string, return back to client
+    // verify the client gets the expected string.
+    Path testFile = new Path(getProxiedFSTestDir(), "singleBlock.txt");
+    DistributedFileSystem distributedFs = (DistributedFileSystem) FileSystem
+        .get(testFile.toUri(), this.getProxiedFSConf());
+    DFSTestUtil.createFile(distributedFs, testFile, (long) 1, (short) 1, 0L);
+
+    MiniDFSCluster cluster = ((TestHdfsHelper) hdfsTestHelper)
+        .getMiniDFSCluster();
+    LocatedBlocks locatedBlocks = DFSClientAdapter.callGetBlockLocations(
+        cluster.getNameNodeRpc(0), testFile.toString(), 0L, 1);
+    String json = JsonUtil.toJsonString(locatedBlocks);
+    LOG.info("json = {}", json);
+
+    try (MockWebServer server = new MockWebServer()) {
+      server.enqueue(new MockResponse().setBody("{\n"
+          + "  \"RemoteException\":\n" + "  {\n"
+          + "    \"exception\"    : \"IllegalArgumentException\",\n"
+          + "    \"javaClassName\": \"java.lang.IllegalArgumentException\",\n"
+          + "    \"message\"      : \"Invalid value for webhdfs parameter \\\"GETFILEBLOCKLOCATIONS\\\": ...\"\n"
+          + "  }\n" + "}").setResponseCode(400)); // BAD_REQUEST
+      server.enqueue(new MockResponse().setBody(json));
+      server.start();
+      URI uri = URI.create(String.format("%s://%s:%d", getScheme(),
+          server.getHostName(), server.getPort()));
+
+      FileSystem fs = FileSystem.get(uri, conf);
+
+      // verify client FileSystem handles fallback from GETFILEBLOCKLOCATIONS to
+      // GET_BLOCK_LOCATIONS correctly.
+      BlockLocation[] locations = DFSUtilClient.locatedBlocks2Locations(locatedBlocks);
+      BlockLocation[] locations1 = fs.getFileBlockLocations(testFile, 0, 1);
+      // assert locations1 == locations
+      assertEquals(locations.length, locations1.length);
+      for (int i = 0; i< locations.length; i++) {
+        assertEquals(locations[i].toString(), locations1[i].toString());
+      }
+
+      // verify server did receive both requests.
+      RecordedRequest req = server.takeRequest();
+      LOG.info("req received = {}. check against: {}", req.getPath(),
+          "/webhdfs/v1" + testFile.toString() + "?op=GETFILEBLOCKLOCATIONS");
+      assertTrue(req.getPath().startsWith("/webhdfs/v1" + testFile.toString() + "?op=GETFILEBLOCKLOCATIONS"));
+
+      RecordedRequest req2 = server.takeRequest();
+      LOG.info("req received = {}. check against: {}", req2.getPath(),
+          "/webhdfs/v1" + testFile.toString() + "?op=GET_BLOCK_LOCATIONS");
+      assertTrue(req2.getPath().startsWith("/webhdfs/v1" + testFile.toString() + "?op=GET_BLOCK_LOCATIONS"));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdfs.protocol.*;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.StringUtils;
 
@@ -635,7 +636,8 @@ public class JsonUtil {
     return m;
   }
 
-  private static Map<String, Object> toJsonMap(
+  @VisibleForTesting
+  static Map<String, Object> toJsonMap(
       final BlockLocation blockLocation) throws IOException {
     if (blockLocation == null) {
       return null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
@@ -655,4 +655,18 @@ public class JsonUtil {
     m.put(BlockLocation.class.getSimpleName(), blockLocations);
     return toJsonString("BlockLocations", m);
   }
+
+  public static Map<String, Object> toJsonMap(BlockLocation[] locations)
+      throws IOException {
+    if (locations == null) {
+      return null;
+    }
+    final Map<String, Object> m = new TreeMap<>();
+    Object[] blockLocations = new Object[locations.length];
+    for (int i = 0; i < locations.length; i++) {
+      blockLocations[i] = toJsonMap(locations[i]);
+    }
+    m.put(BlockLocation.class.getSimpleName(), blockLocations);
+    return m;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
@@ -335,6 +335,17 @@ public class JsonUtil {
       return null;
     }
 
+    final Map<String, Object> m = toJsonMap(locatedblocks);
+    return toJsonString(LocatedBlocks.class, m);
+  }
+
+  /** Convert LocatedBlocks to a Map. */
+  public static Map<String, Object> toJsonMap(final LocatedBlocks locatedblocks)
+      throws IOException {
+    if (locatedblocks == null) {
+      return null;
+    }
+
     final Map<String, Object> m = new TreeMap<String, Object>();
     m.put("fileLength", locatedblocks.getFileLength());
     m.put("isUnderConstruction", locatedblocks.isUnderConstruction());
@@ -342,7 +353,7 @@ public class JsonUtil {
     m.put("locatedBlocks", toJsonArray(locatedblocks.getLocatedBlocks()));
     m.put("lastLocatedBlock", toJsonMap(locatedblocks.getLastLocatedBlock()));
     m.put("isLastBlockComplete", locatedblocks.isLastBlockComplete());
-    return toJsonString(LocatedBlocks.class, m);
+    return m;
   }
 
   /** Convert a ContentSummary to a Json string. */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtilClient.java
@@ -17,12 +17,18 @@
  */
 package org.apache.hadoop.hdfs.web;
 
-import org.junit.Assert;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.util.JsonSerialization;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class TestJsonUtilClient {
   @Test
@@ -31,9 +37,33 @@ public class TestJsonUtilClient {
         Arrays.asList("aaa", "bbb", "ccc"));
 
     String[] strArr = JsonUtilClient.toStringArray(strList);
-    Assert.assertEquals("Expected 3 items in the array", 3, strArr.length);
-    Assert.assertEquals("aaa", strArr[0]);
-    Assert.assertEquals("bbb", strArr[1]);
-    Assert.assertEquals("ccc", strArr[2]);
+    assertEquals("Expected 3 items in the array", 3, strArr.length);
+    assertEquals("aaa", strArr[0]);
+    assertEquals("bbb", strArr[1]);
+    assertEquals("ccc", strArr[2]);
+  }
+
+  @Test
+  public void testToBlockLocationArray() throws Exception {
+    BlockLocation blockLocation = new BlockLocation(
+        new String[] {"127.0.0.1:62870"},
+        new String[] {"127.0.0.1"},
+        null,
+        new String[] {"/default-rack/127.0.0.1:62870"},
+        null,
+        new StorageType[] {StorageType.DISK},
+        0, 1, false);
+
+    Map<String, Object> BlockLocationsMap =
+        JsonUtil.toJsonMap(new BlockLocation[] {blockLocation});
+    String json = JsonUtil.toJsonString("BlockLocations", BlockLocationsMap);
+    assertNotNull(json);
+    Map<?,?> jsonMap = JsonSerialization.mapReader().readValue(json);
+
+    BlockLocation[] deserializedBlockLocations =
+        JsonUtilClient.toBlockLocationArray(jsonMap);
+    assertEquals(1, deserializedBlockLocations.length);
+    assertEquals(blockLocation.toString(),
+        deserializedBlockLocations[0].toString());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestJsonUtilClient.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.web;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestJsonUtilClient {
+  @Test
+  public void testToStringArray() throws Exception {
+    List<String> strList = new ArrayList<String>(
+        Arrays.asList("aaa", "bbb", "ccc"));
+
+    String[] strArr = JsonUtilClient.toStringArray(strList);
+    Assert.assertEquals("Expected 3 items in the array", 3, strArr.length);
+    Assert.assertEquals("aaa", strArr[0]);
+    Assert.assertEquals("bbb", strArr[1]);
+    Assert.assertEquals("ccc", strArr[2]);
+  }
+}

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -132,6 +132,7 @@
     <hikari.version>4.0.3</hikari.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp.version>2.7.5</okhttp.version>
+    <okhttp3.version>3.7.0</okhttp3.version>
     <jdom.version>1.1</jdom.version>
     <jna.version>5.2.0</jna.version>
     <grizzly.version>2.2.21</grizzly.version>
@@ -223,7 +224,13 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>3.7.0</version>
+        <version>${okhttp3.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp3.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### Description of PR
This is a rebase of the patch file 11 attached to HDFS-6874.

The GETFILEBLOCKLOCATIONS is HCFS compatible. Add support of it to httpfs to makes it possible for more applications to run directly against HttpFS server.

Add GETFILEBLOCKLOCATIONS op support for httpfs server (HttpFSServer). Add the same for httpfs client (HttpFSFileSystem)
Let webhdfs client (WebHdfsFileSystem ) tries the new GETFILEBLOCKLOCATIONS op if the server supports it. Otherwise, fall back to the old GET_FILE_BLOCK_LOCATIONS op. The selection is cached so the second invocation doesn't need to trial and error again.

### How was this patch tested?
Unit tests.


