### PR TITLE
HADOOP-17859. Fix to avoid connection timed out when UDP DNS Query on DNS Registry

### DIFF
--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
@@ -963,6 +963,12 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
           LOG.info("{}: received UDP query {}", remoteAddress,
               query.getQuestion());
           response = generateReply(query, null);
+          if (response.length > output.capacity()) {
+            LOG.warn("{}: Response of UDP query {} exceeds capacity {}",
+                remoteAddress, query.getQuestion(), output.capacity());
+            query.getHeader().setFlag(Flags.TC);
+            response = query.toWire();
+          }
           if (response == null) {
             continue;
           }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

UDP DNS query on YARN Registry DNS got connection timed out at times.

After checking logs on registry dns, we found the cause that size of UDP Response is greater than Preallocated Byte buffer(4096)

We added failsafe case by returning input query with TC flag so that client can know they should retried using TCP protocol.

Apache Jira URL: https://issues.apache.org/jira/browse/HADOOP-17859

### How was this patch tested?

We tested this case after patching and operating our cluster.
Connection timeout occured 10+ cases every week. After patching, 0 case reported

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

