### PR TITLE
YARN-10892. YARN Preemption Monitor got java.util.ConcurrentModificationException when three or more partitions exists

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/FifoCandidatesSelector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/FifoCandidatesSelector.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.util.resource.Resources;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class FifoCandidatesSelector
         // sure such containers will be preemptionCandidates first
         Map<String, TreeSet<RMContainer>> ignorePartitionExclusivityContainers =
             leafQueue.getIgnoreExclusivityRMContainers();
-        for (String partition : resToObtainByPartition.keySet()) {
+        for (String partition : new HashSet<String>(resToObtainByPartition.keySet())) {
           if (ignorePartitionExclusivityContainers.containsKey(partition)) {
             TreeSet<RMContainer> rmContainers =
                 ignorePartitionExclusivityContainers.get(partition);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicyInterQueueWithDRF.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicyInterQueueWithDRF.java
@@ -246,4 +246,58 @@ public class TestProportionalCapacityPreemptionPolicyInterQueueWithDRF
         new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
             getAppAttemptId(1))));
   }
+
+  @Test
+  public void testResourceTypesInterQueuePreemptionWithThreePartitions() throws IOException {
+    /*
+     *            root
+     *           /  \  \
+     *        batch  a  b
+     *
+     *  Each of batch, a, b have 100:100 resources
+     *  All partitions are non-exclusive.
+     *  Total cluster resource have 300:300
+     *  app1 on batch uses mem=100, cpu=100 from batch, mem=50, cpu=50 from a, mem=50, cpu=50 from b
+     *  app2 on a uses mem=50, cpu=50 from a and requests mem=50, cpu=50 more from a
+     *  app3 on a uses mem=50, cpu=50 from b and requests mem=50, cpu=50 more from b
+     *
+     *  We expect it can preempt from app1 successfully
+     */
+    String labelsConfig = "=100:100,false;" + // default partition (100, non-exclusive)
+        "x=100:100,false;" + // x partition (100, non-exclusive)
+        "y=100:100,false;"; // y partition (100, non-exclusive)
+    String nodesConfig = "n1= res=50:50;n2= res=50:50;" + // n1~n2 are default partition
+        "x1=x res=50:50;x2=x res=50:50;" + // x1~x2 are x partition
+        "y1=y res=50:50;y2=y res=50:50;"; // y1~y2 are y partition
+    String queuesConfig =
+        // guaranteed,max,used,pending
+        "root(=[100:100 100:100 100:100 0:0],x=[100:100 100:100 100:100 50:50]," +
+            "y=[100:100 100:100 100:100 50:50]);" + //root
+            "-batch(=[100:100 100:100 100:100 0:0],x=[0:0 0:0 50:50 0:0],y=[0:0 0:0 50:50 0:0]);" + // batch queue
+            "-a(=[0:0 0:0 0:0 0:0],x=[100:100 100:100 50:50 50:50],y=[0:0 0:0 0:0 0:0]);" + // x queue
+            "-b(=[0:0 0:0 0:0 0:0],x=[0:0 0:0 0:0 0:0],y=[100:100 100:100 50:50 50:50]);";  // y queue
+    String appsConfig =
+        //queueName\t(priority,resource,host,expression,#repeat,reserved)
+        "batch\t" + // app1 in batch
+            "(1,50:50,n1,,1,false)(1,50:50,n2,,1,false)" + // 100 * default in n1~n2
+            "(1,50:50,x1,,1,false)" + // 50 * x in x1
+            "(1,50:50,y1,,1,false);" + // 50 * y in y1
+            "a\t" + // app2 in x
+            "(1,50:50,x2,x,1,false);" + // 50 * x in x2
+            "b\t" + // app3 in y
+            "(1,50:50,y2,y,1,false);";  // 50 * y in y2
+
+    buildEnv(labelsConfig, nodesConfig, queuesConfig, appsConfig);
+    policy.editSchedule();
+
+    verify(eventHandler, times(2)).handle(argThat(
+        new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
+            getAppAttemptId(1))));
+    verify(eventHandler, times(0)).handle(argThat(
+        new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
+            getAppAttemptId(2))));
+    verify(eventHandler, times(0)).handle(argThat(
+        new TestProportionalCapacityPreemptionPolicy.IsPreemptionRequestFor(
+            getAppAttemptId(3))));
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/mockframework/MockQueueHierarchy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/mockframework/MockQueueHierarchy.java
@@ -211,6 +211,15 @@ class MockQueueHierarchy {
     LOG.debug("Parent=" + (parentQueue == null ? "null" : parentQueue
         .getQueuePath()));
 
+    Boolean isLeafQueue = !isParent(queueExprArray, idx);
+    if (isLeafQueue) {
+      LeafQueue lq = (LeafQueue) queue;
+      when(lq.getTotalPendingResourcesConsideringUserLimit(isA(Resource.class),
+          isA(String.class), eq(false))).thenReturn(Resources.none());
+      when(lq.getTotalPendingResourcesConsideringUserLimit(isA(Resource.class),
+          isA(String.class), eq(true))).thenReturn(Resources.none());
+    }
+
     // Setup other fields like used resource, guaranteed resource, etc.
     String capacitySettingStr = q.substring(q.indexOf("(") + 1, q.indexOf(")"));
     for (String s : capacitySettingStr.split(",")) {
@@ -237,8 +246,6 @@ class MockQueueHierarchy {
       qc.setAbsoluteMaximumCapacity(partitionName, absMax);
       qc.setAbsoluteUsedCapacity(partitionName, absUsed);
       qc.setUsedCapacity(partitionName, used);
-      qr.setEffectiveMaxResource(parseResourceFromString(values[1].trim()));
-      qr.setEffectiveMinResource(parseResourceFromString(values[0].trim()));
       qr.setEffectiveMaxResource(partitionName,
           parseResourceFromString(values[1].trim()));
       qr.setEffectiveMinResource(partitionName,
@@ -255,12 +262,12 @@ class MockQueueHierarchy {
         reserved = parseResourceFromString(values[4].trim());
         ru.setReserved(partitionName, reserved);
       }
-      if (!isParent(queueExprArray, idx)) {
+      if (isLeafQueue) {
         LeafQueue lq = (LeafQueue) queue;
         when(lq.getTotalPendingResourcesConsideringUserLimit(isA(Resource.class),
-            isA(String.class), eq(false))).thenReturn(pending);
+            eq(partitionName), eq(false))).thenReturn(pending);
         when(lq.getTotalPendingResourcesConsideringUserLimit(isA(Resource.class),
-            isA(String.class), eq(true))).thenReturn(
+            eq(partitionName), eq(true))).thenReturn(
             Resources.subtract(pending, reserved));
       }
       ru.setUsed(partitionName, parseResourceFromString(values[2].trim()));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

On our cluster with a large number of NMs, preemption monitor thread consistently got java.util.ConcurrentModificationException when specific conditions met. (And preemption doesn't work, of course)

What We found as conditions are as follow. (All 4 conditions should be met)

1. There are at least two non-exclusive partitions except default partition (let me call the partitions as X and Y partition)
2. app1 in the queue belonging to default partition (let me call the queue as 'dev' queue) borrowed resources from both X, Y partitions 
3. app2, app3 submitted to queues belonging to each X, Y partition is 'PENDING' because resources are consumed by app1
4. Preemption monitor can clear borrowed resources from X or Y when the container of app1 is preempted.  

Main problem is that FifoCandiatesSelector.selectCandidates tried to remove HashMap key(partition name) while iterating HashMap.

Logically, it is correct because we didn't traverse the same partition again on this 'selectCandidates'. However HashMap structure does not allow modification while iterating.

I made test case to reproduce the error case(testResourceTypesInterQueuePreemptionWithThreePartitions).

We found and patched our cluster on 3.1.2 but it seems trunk still has the same problem.

I attached patch based on the trunk.

Apache jira URL: https://issues.apache.org/jira/browse/YARN-10892

Thanks!

>> {{2020-09-07 12:20:37,105 ERROR monitor.SchedulingMonitor (SchedulingMonitor.java:run(116)) - Exception raised while executing preemption checker, skip this run..., exception=
java.util.ConcurrentModificationException
at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437)
at java.util.HashMap$KeyIterator.next(HashMap.java:1461)
at org.apache.hadoop.yarn.server.resourcemanager.monitor.capacity.FifoCandidatesSelector.selectCandidates(FifoCandidatesSelector.java:105)
at org.apache.hadoop.yarn.server.resourcemanager.monitor.capacity.ProportionalCapacityPreemptionPolicy.containerBasedPreemptOrKill(ProportionalCapacityPreemptionPolicy.java:489)
at org.apache.hadoop.yarn.server.resourcemanager.monitor.capacity.ProportionalCapacityPreemptionPolicy.editSchedule(ProportionalCapacityPreemptionPolicy.java:320)
at org.apache.hadoop.yarn.server.resourcemanager.monitor.SchedulingMonitor.invokePolicy(SchedulingMonitor.java:99)
at org.apache.hadoop.yarn.server.resourcemanager.monitor.SchedulingMonitor$PolicyInvoker.run(SchedulingMonitor.java:111)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)}}

### How was this patch tested?

I added new testcase to reproduce the problem.
new testcase will be failed without this patch.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
