### PR TITLE
HDFS-16184. De-flake TestBlockScanner#testSkipRecentAccessFile

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
@@ -1004,6 +1004,8 @@ public class TestBlockScanner {
         TestScanResultHandler.getInfo(ctx.volumes.get(0));
     synchronized (info) {
       info.shouldRun = true;
+      info.sem = new Semaphore(1);
+      info.sem.acquire();
       info.notify();
     }
     try {
@@ -1017,6 +1019,7 @@ public class TestBlockScanner {
       LOG.debug("Timeout for all files are accessed in last period.");
     }
     synchronized (info) {
+      info.sem.release();
       info.shouldRun = false;
       info.notify();
     }


### PR DESCRIPTION
### Description of PR
Test TestBlockScanner#testSkipRecentAccessFile is flaky:
```
[ERROR] testSkipRecentAccessFile(org.apache.hadoop.hdfs.server.datanode.TestBlockScanner)  Time elapsed: 3.936 s  <<< FAILURE!
java.lang.AssertionError: Scan nothing for all files are accessed in last period.
	at org.junit.Assert.fail(Assert.java:89)
	at org.apache.hadoop.hdfs.server.datanode.TestBlockScanner.testSkipRecentAccessFile(TestBlockScanner.java:1015)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```

## Reason for failure:
Thread in VolumnScanner keeps scanning blocks. Before block scan, it executes `TestScanResultHandler#setup` and it keeps waiting on `info` object until main thread in `testSkipRecentAccessFile()` notifies `info` object and sets it's `shouldRun` to true for VolumnScanner thread to successfully return from `TestScanResultHandler#setup`. Now in main test, we try to assert that `info.blocksScanned` stays 0 which is only possible if VolumnScanner's block scanner thread does not reach `info.blocksScanned++` point, which cannot be guaranteed always and hence this test is flaky.

## Fix:
In order to fix this, the main thread in `testSkipRecentAccessFile()` should initialize `info.sem` as Semaphore (permitting only single thread to take a lock, Mutex) and take a lock by main thread so that until released, block scan thread cannot reach point `info.blocksScanned++` and hence the test never fails. Before the block scanner thread reach the point of incrementing blocksScanned count, it has to acquire Semaphore and it gets blocked here until main thread releases the lock.

### How was this patch tested?
Unit tests