### PR TITLE
HADOOP-17869. `fs.s3a.connection.maximum` should be bigger than `fs.s3a.threads.max`

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1381,7 +1381,7 @@
 
 <property>
   <name>fs.s3a.connection.maximum</name>
-  <value>65</value>
+  <value>96</value>
   <description>Controls the maximum number of simultaneous connections to S3.
     This must be bigger than the value of fs.s3a.threads.max so as to stop
     threads being blocked waiting for new HTTPS connections.

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1381,7 +1381,7 @@
 
 <property>
   <name>fs.s3a.connection.maximum</name>
-  <value>48</value>
+  <value>65</value>
   <description>Controls the maximum number of simultaneous connections to S3.
     This must be bigger than the value of fs.s3a.threads.max so as to stop
     threads being blocked waiting for new HTTPS connections.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -147,7 +147,7 @@ public final class Constants {
 
   // number of simultaneous connections to s3
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
-  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 65;
+  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 96;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -147,7 +147,7 @@ public final class Constants {
 
   // number of simultaneous connections to s3
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
-  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 48;
+  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 65;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =


### PR DESCRIPTION
### Description of PR

This PR aims to increase `fs.s3a.connection.maximum` to be bigger than `fs.s3a.threads.max`.

### How was this patch tested?

HADOOP-15183 defined this variable like the following.
- https://github.com/apache/hadoop/commit/e02eb24e0a9139418120027b694492e0738df20a#diff-268b9968a4db21ac6eeb7bcaef10e4db744d00ba53989fc7251bb3e8d9eac7dfR1216-R1221
> Controls the maximum number of simultaneous connections to S3. This must be bigger than the value of fs.s3a.threads.max so as to stop threads being blocked waiting for new HTTPS connections.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

