### PR TITLE
HADOOP-17873. ABFS: Fix transient failures in ITestAbfsStreamStatistics and ITestAbfsRestOperationException

### DIFF
--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -506,6 +506,9 @@
                     <include>**/azurebfs/Test*.java</include>
                     <include>**/azurebfs/**/Test*.java</include>
                   </includes>
+                  <excludes>
+                    <exclude>**/azurebfs/ITestAbfsStreamStatistics*.java</exclude>
+                  </excludes>
                 </configuration>
               </execution>
             </executions>
@@ -555,6 +558,7 @@
                     <exclude>**/azurebfs/ITestAzureBlobFileSystemListStatus.java</exclude>
                     <exclude>**/azurebfs/extensions/ITestAbfsDelegationTokens.java</exclude>
                     <exclude>**/azurebfs/ITestSmallWriteOptimization.java</exclude>
+                    <exclude>**/azurebfs/ITestAbfsStreamStatistics*.java</exclude>
                   </excludes>
 
                 </configuration>
@@ -595,6 +599,9 @@
                     <include>**/azurebfs/ITestAzureBlobFileSystemListStatus.java</include>
                     <include>**/azurebfs/extensions/ITestAbfsDelegationTokens.java</include>
                     <include>**/azurebfs/ITestSmallWriteOptimization.java</include>
+                    <excludes>
+                      <exclude>**/azurebfs/ITestAbfsStreamStatistics*.java</exclude>
+                    </excludes>
                   </includes>
                 </configuration>
               </execution>

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -506,9 +506,6 @@
                     <include>**/azurebfs/Test*.java</include>
                     <include>**/azurebfs/**/Test*.java</include>
                   </includes>
-                  <excludes>
-                    <exclude>**/azurebfs/ITestAbfsStreamStatistics*.java</exclude>
-                  </excludes>
                 </configuration>
               </execution>
             </executions>
@@ -601,9 +598,7 @@
                     <include>**/azurebfs/extensions/ITestAbfsDelegationTokens.java</include>
                     <include>**/azurebfs/ITestSmallWriteOptimization.java</include>
                     <include>**/azurebfs/services/ITestReadBufferManager.java</include>
-                    <excludes>
-                      <exclude>**/azurebfs/ITestAbfsStreamStatistics*.java</exclude>
-                    </excludes>
+                    <include>**/azurebfs/ITestAbfsStreamStatistics*.java</include>
                   </includes>
                 </configuration>
               </execution>

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/CustomTokenProviderAdapter.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/CustomTokenProviderAdapter.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.fs.azurebfs.oauth2;
 import java.io.IOException;
 import java.net.URI;
 
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,5 +138,10 @@ public final class CustomTokenProviderAdapter extends AccessTokenProvider
   public String getUserAgentSuffix() {
     String suffix = ExtensionHelper.getUserAgentSuffix(adaptee, "");
     return suffix != null ? suffix : "";
+  }
+
+  @VisibleForTesting
+  protected CustomTokenProviderAdaptee getCustomTokenProviderAdaptee() {
+    return adaptee;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1204,4 +1204,9 @@ public class AbfsClient implements Closeable {
   public <V> void addCallback(ListenableFuture<V> future, FutureCallback<V> callback) {
     Futures.addCallback(future, callback, executorService);
   }
+
+  @VisibleForTesting
+  protected AccessTokenProvider getTokenProvider() {
+    return tokenProvider;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -37,10 +37,12 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.fs.azurebfs.security.AbfsDelegationTokenManager;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
+import org.apache.hadoop.fs.azurebfs.services.TestAbfsClient;
 import org.apache.hadoop.fs.azure.AzureNativeFileSystemStore;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
 import org.apache.hadoop.fs.azure.metrics.AzureFileSystemInstrumentation;
@@ -241,6 +243,9 @@ public abstract class AbstractAbfsIntegrationTest extends
     }
   }
 
+  public AccessTokenProvider getAccessTokenProvider(final AzureBlobFileSystem fs) {
+    return TestAbfsClient.getAccessTokenProvider(fs.getAbfsStore().getClient());
+  }
 
   public void loadConfiguredFileSystem() throws Exception {
       // disable auto-creation of filesystem

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -122,10 +122,10 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
         });
 
     // Number of retries done should be as configured
-    Assert.assertTrue(
-        "Number of token fetch retries (" + retryTestTokenProvider.getReTryCount()
-            + ") done, does not match with fs.azure.custom.token.fetch.retry.count configured (" + numOfRetries
-            + ")", retryTestTokenProvider.getReTryCount() == numOfRetries);
+    Assert.assertEquals(
+        "Number of token fetch retries done does not match with fs.azure"
+            + ".custom.token.fetch.retry.count configured", numOfRetries,
+        retryTestTokenProvider.getRetryCount());
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -111,7 +111,10 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
     final AzureBlobFileSystem fs1 =
         (AzureBlobFileSystem) FileSystem.newInstance(fs.getUri(),
         config);
-    RetryTestTokenProvider.ResetStatusToFirstTokenFetch();
+    RetryTestTokenProvider retryTestTokenProvider
+        = RetryTestTokenProvider.getCurrentRetryTestProviderInstance(
+        getAccessTokenProvider(fs1));
+    retryTestTokenProvider.resetStatusToFirstTokenFetch();
 
     intercept(Exception.class,
         ()-> {
@@ -120,9 +123,9 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
 
     // Number of retries done should be as configured
     Assert.assertTrue(
-        "Number of token fetch retries (" + RetryTestTokenProvider.reTryCount
+        "Number of token fetch retries (" + retryTestTokenProvider.getReTryCount()
             + ") done, does not match with fs.azure.custom.token.fetch.retry.count configured (" + numOfRetries
-            + ")", RetryTestTokenProvider.reTryCount == numOfRetries);
+            + ")", retryTestTokenProvider.getReTryCount() == numOfRetries);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
@@ -45,7 +45,7 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
 
   /**
    * Clear earlier retry details and reset RetryTestTokenProvider instance to
-   * state of first access token fetch call
+   * state of first access token fetch call.
    */
   public void resetStatusToFirstTokenFetch() {
     isThisFirstTokenFetch = true;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
@@ -30,12 +30,12 @@ import org.slf4j.LoggerFactory;
  */
 public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
 
-  // Need to track first token fetch otherwise will get counted as a retry too.
-  private static boolean isThisFirstTokenFetch = true;
-  public static int reTryCount = 0;
+  private static final Logger LOG = LoggerFactory.getLogger(
+      RetryTestTokenProvider.class);
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(RetryTestTokenProvider.class);
+  // Need to track first token fetch otherwise will get counted as a retry too.
+  private boolean isThisFirstTokenFetch = true;
+  public int reTryCount = 0;
 
   @Override
   public void initialize(Configuration configuration, String accountName)
@@ -43,7 +43,7 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
 
   }
 
-  public static void ResetStatusToFirstTokenFetch() {
+  public void resetStatusToFirstTokenFetch() {
     isThisFirstTokenFetch = true;
     reTryCount = 0;
   }
@@ -63,5 +63,14 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
   @Override
   public Date getExpiryTime() {
     return new Date();
+  }
+
+  public static RetryTestTokenProvider getCurrentRetryTestProviderInstance(
+      AccessTokenProvider customTokenProvider) {
+    return (RetryTestTokenProvider) ((CustomTokenProviderAdapter) customTokenProvider).getCustomTokenProviderAdaptee();
+  }
+
+  public int getReTryCount() {
+    return reTryCount;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
@@ -35,7 +35,7 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
 
   // Need to track first token fetch otherwise will get counted as a retry too.
   private boolean isThisFirstTokenFetch = true;
-  private int reTryCount = 0;
+  private int retryCount = 0;
 
   @Override
   public void initialize(Configuration configuration, String accountName)
@@ -43,9 +43,13 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
 
   }
 
+  /**
+   * Clear earlier retry details and reset RetryTestTokenProvider instance to
+   * state of first access token fetch call
+   */
   public void resetStatusToFirstTokenFetch() {
     isThisFirstTokenFetch = true;
-    reTryCount = 0;
+    retryCount = 0;
   }
 
   @Override
@@ -53,7 +57,7 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
     if (isThisFirstTokenFetch) {
       isThisFirstTokenFetch = false;
     } else {
-      reTryCount++;
+      retryCount++;
     }
 
     LOG.debug("RetryTestTokenProvider: Throw an exception in fetching tokens");
@@ -70,7 +74,7 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
     return (RetryTestTokenProvider) ((CustomTokenProviderAdapter) customTokenProvider).getCustomTokenProviderAdaptee();
   }
 
-  public int getReTryCount() {
-    return reTryCount;
+  public int getRetryCount() {
+    return retryCount;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/RetryTestTokenProvider.java
@@ -35,7 +35,7 @@ public class RetryTestTokenProvider implements CustomTokenProviderAdaptee {
 
   // Need to track first token fetch otherwise will get counted as a retry too.
   private boolean isThisFirstTokenFetch = true;
-  public int reTryCount = 0;
+  private int reTryCount = 0;
 
   @Override
   public void initialize(Configuration configuration, String accountName)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsClient.java
@@ -395,4 +395,8 @@ public final class TestAbfsClient {
         url,
         requestHeaders);
   }
+
+  public static AccessTokenProvider getAccessTokenProvider(AbfsClient client) {
+    return client.getTokenProvider();
+  }
 }


### PR DESCRIPTION
PR addresses transient failures in the following test classes:

- ITestAbfsStreamStatistics: Uses a filesystem level static instance to record read/write statistics, which also tracks these operations in other tests running parallelly. To be marked for sequential-only run to avoid transient failure
- ITestAbfsRestOperationException: The use of a static member to track retry count causes transient failures when two tests of this class happen to run together. Switch to non-static variable for assertions on retry count