### PR TITLE
HADOOP-17874. ExceptionsHandler to add terse/suppressed Exceptions in thread-safe manner

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -68,6 +68,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
@@ -184,17 +185,22 @@ public abstract class Server {
    * e.g., terse exception group for concise logging messages
    */
   static class ExceptionsHandler {
-    private volatile Set<String> terseExceptions = new HashSet<>();
-    private volatile Set<String> suppressedExceptions = new HashSet<>();
+
+    private final Set<String> terseExceptions =
+        ConcurrentHashMap.newKeySet();
+    private final Set<String> suppressedExceptions =
+        ConcurrentHashMap.newKeySet();
 
     /**
      * Add exception classes for which server won't log stack traces.
      * Optimized for infrequent invocation.
      * @param exceptionClass exception classes 
      */
-    synchronized void addTerseLoggingExceptions(Class<?>... exceptionClass) {
-      // Thread-safe replacement of terseExceptions.
-      terseExceptions = addExceptions(terseExceptions, exceptionClass);
+    void addTerseLoggingExceptions(Class<?>... exceptionClass) {
+      terseExceptions.addAll(Arrays
+          .stream(exceptionClass)
+          .map(Class::toString)
+          .collect(Collectors.toSet()));
     }
 
     /**
@@ -202,11 +208,11 @@ public abstract class Server {
      * Optimized for infrequent invocation.
      * @param exceptionClass exception classes
      */
-    synchronized void addSuppressedLoggingExceptions(
-        Class<?>... exceptionClass) {
-      // Thread-safe replacement of suppressedExceptions.
-      suppressedExceptions = addExceptions(
-          suppressedExceptions, exceptionClass);
+    void addSuppressedLoggingExceptions(Class<?>... exceptionClass) {
+      suppressedExceptions.addAll(Arrays
+          .stream(exceptionClass)
+          .map(Class::toString)
+          .collect(Collectors.toSet()));
     }
 
     boolean isTerseLog(Class<?> t) {
@@ -217,23 +223,6 @@ public abstract class Server {
       return suppressedExceptions.contains(t.toString());
     }
 
-    /**
-     * Return a new set containing all the exceptions in exceptionsSet
-     * and exceptionClass.
-     * @return
-     */
-    private static Set<String> addExceptions(
-        final Set<String> exceptionsSet, Class<?>[] exceptionClass) {
-      // Make a copy of the exceptionSet for performing modification
-      final HashSet<String> newSet = new HashSet<>(exceptionsSet);
-
-      // Add all class names into the HashSet
-      for (Class<?> name : exceptionClass) {
-        newSet.add(name.toString());
-      }
-
-      return Collections.unmodifiableSet(newSet);
-    }
   }
 
   

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -192,7 +192,7 @@ public abstract class Server {
      * Optimized for infrequent invocation.
      * @param exceptionClass exception classes 
      */
-    void addTerseLoggingExceptions(Class<?>... exceptionClass) {
+    synchronized void addTerseLoggingExceptions(Class<?>... exceptionClass) {
       // Thread-safe replacement of terseExceptions.
       terseExceptions = addExceptions(terseExceptions, exceptionClass);
     }
@@ -202,7 +202,8 @@ public abstract class Server {
      * Optimized for infrequent invocation.
      * @param exceptionClass exception classes
      */
-    void addSuppressedLoggingExceptions(Class<?>... exceptionClass) {
+    synchronized void addSuppressedLoggingExceptions(
+        Class<?>... exceptionClass) {
       // Thread-safe replacement of suppressedExceptions.
       suppressedExceptions = addExceptions(
           suppressedExceptions, exceptionClass);


### PR DESCRIPTION
### Description of PR
Even though we have explicit comments stating that we have thread-safe replacement of terseExceptions and suppressedExceptions, in reality we don't have it. As we can't guarantee only non-concurrent addition of Exceptions at a time from any Server implementation, we should make this thread-safe.

### How was this patch tested?
Local dev testing with running unit test to add Exceptions concurrently. Verified read-after-write consistency.