### PR TITLE
HADOOP-17878: add config for aliyun oss cname support

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
@@ -110,6 +110,7 @@ public class AliyunOSSFileSystemStore {
     clientConf.setUserAgent(
         conf.get(USER_AGENT_PREFIX, USER_AGENT_PREFIX_DEFAULT) + ", Hadoop/"
             + VersionInfo.getVersion());
+    clientConf.setSupportCname(conf.getBoolean(CNAME_SUPPORT_KEY, DEFAULT_CNAME_SUPPORT));
 
     String proxyHost = conf.getTrimmed(PROXY_HOST_KEY, "");
     int proxyPort = conf.getInt(PROXY_PORT_KEY, -1);

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
@@ -110,7 +110,7 @@ public class AliyunOSSFileSystemStore {
     clientConf.setUserAgent(
         conf.get(USER_AGENT_PREFIX, USER_AGENT_PREFIX_DEFAULT) + ", Hadoop/"
             + VersionInfo.getVersion());
-    clientConf.setSupportCname(conf.getBoolean(CNAME_SUPPORT_KEY, DEFAULT_CNAME_SUPPORT));
+    clientConf.setSupportCname(conf.getBoolean(CNAME_SUPPORT_KEY, CNAME_SUPPORT_DEFAULT));
 
     String proxyHost = conf.getTrimmed(PROXY_HOST_KEY, "");
     int proxyPort = conf.getInt(PROXY_PORT_KEY, -1);

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
@@ -75,6 +75,10 @@ public final class Constants {
       "fs.oss.connection.establish.timeout";
   public static final int ESTABLISH_TIMEOUT_DEFAULT = 50000;
 
+  // cname support
+  public static final String CNAME_SUPPORT_KEY = "fs.oss.cname.support.enabled";
+  public static final boolean DEFAULT_CNAME_SUPPORT = true;
+
   // Time until we give up on a connection to oss
   public static final String SOCKET_TIMEOUT_KEY = "fs.oss.connection.timeout";
   public static final int SOCKET_TIMEOUT_DEFAULT = 200000;

--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/Constants.java
@@ -77,7 +77,7 @@ public final class Constants {
 
   // cname support
   public static final String CNAME_SUPPORT_KEY = "fs.oss.cname.support.enabled";
-  public static final boolean DEFAULT_CNAME_SUPPORT = true;
+  public static final boolean CNAME_SUPPORT_DEFAULT = true;
 
   // Time until we give up on a connection to oss
   public static final String SOCKET_TIMEOUT_KEY = "fs.oss.connection.timeout";


### PR DESCRIPTION
### Description of PR
As described in jira [HDFS-16189](https://issues.apache.org/jira/browse/HDFS-16189), cname support need to be closed if we don't use cname 