### PR TITLE
YARN-10902. Release reserved container on blacklist node for an application

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacityScheduler.java
@@ -6068,4 +6068,58 @@ public class TestCapacityScheduler extends CapacitySchedulerTestBase {
     Assert.assertEquals(0, desQueue.getUsedResources().getMemorySize());
     rm1.close();
   }
+
+  @Test(timeout = 30000)
+  public void testReleaseReservedContainerOnBlacklistedNode() throws Exception {
+    MockRM rm = new MockRM();
+    rm.start();
+    MockNM nm1 = rm.registerNode("h1:1234", 8 * GB);
+    MockNM nm2 = rm.registerNode("h2:1234", 8 * GB);
+    rm.drainEvents();
+
+    CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
+    RMNode rmNode1 = rm.getRMContext().getRMNodes().get(nm1.getNodeId());
+    RMNode rmNode2 = rm.getRMContext().getRMNodes().get(nm2.getNodeId());
+    LeafQueue defaultQueue = (LeafQueue) cs.getQueue("default");
+
+    // launch an app to queue, AM container should be launched in nm1
+    MockRMAppSubmissionData data =
+        MockRMAppSubmissionData.Builder.createWithMemory(4 * GB, rm)
+            .withAppName("app")
+            .withUser("user")
+            .withAcls(null)
+            .withQueue("default")
+            .withUnmanagedAM(false)
+            .build();
+    RMApp app1 = MockRMAppSubmitter.submit(rm, data);
+    MockAM am1 = MockRM.launchAndRegisterAM(app1, rm, nm1);
+    Resource allocateResource = Resources.createResource(5 * GB);
+    am1.allocate("*", (int) allocateResource.getMemorySize(), 1, 0,
+        new ArrayList<>(), "");
+    FiCaSchedulerApp schedulerApp1 =
+        cs.getApplicationAttempt(am1.getApplicationAttemptId());
+
+    cs.handle(new NodeUpdateSchedulerEvent(rmNode1));
+    // one reserved container on nm1
+    Assert.assertEquals(1, schedulerApp1.getReservedContainers().size());
+    Assert.assertEquals(9 * GB,
+        defaultQueue.getQueueResourceUsage().getUsed().getMemorySize());
+
+    // add the NM1 to app1's blacklist
+    cs.allocate(schedulerApp1.getApplicationAttemptId(), Collections.emptyList(), null,
+        Collections.emptyList(),
+        Collections.singletonList("h1"), null, NULL_UPDATE_REQUESTS);
+
+    // the reserved container on blacklist node(nm1) should be released
+    cs.handle(new NodeUpdateSchedulerEvent(rmNode1));
+    Assert.assertEquals(0, schedulerApp1.getReservedContainers().size());
+
+    // the requested container will be allocated on nm2
+    cs.handle(new NodeUpdateSchedulerEvent(rmNode2));
+    Assert.assertEquals(0, schedulerApp1.getReservedContainers().size());
+    Assert.assertEquals(9 * GB,
+        defaultQueue.getQueueResourceUsage().getUsed().getMemorySize());
+
+    rm.close();
+  }
 }


### PR DESCRIPTION
### Description of PR
Resources on application blacklisted node with reserved container can not allocate to other applications. In this case, the reserved container should be cancelled. 

### How was this patch tested?
A unit test `testReleaseReservedContainerOnBlacklistedNode()` is added into `TestCapacityScheduler`.

### For code changes:

- [Yes] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [No] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [No] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [No] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

