### PR TITLE
HADOOP-17877. BuiltInGzipCompressor header and trailer should not be static variables

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
@@ -39,15 +39,15 @@ public class BuiltInGzipCompressor implements Compressor {
    * Fixed ten-byte gzip header. See {@link GZIPOutputStream}'s source for
    * details.
    */
-  private final byte[] GZIP_HEADER = new byte[]{
+  private final byte[] gzipHeader = new byte[]{
       0x1f, (byte) 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
   // The trailer will be overwritten based on crc and output size.
-  private final byte[] GZIP_TRAILER = new byte[]{
+  private final byte[] gzipTrailer = new byte[]{
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-  private final int GZIP_HEADER_LEN = GZIP_HEADER.length;
-  private final int GZIP_TRAILER_LEN = GZIP_TRAILER.length;
+  private final int gzipHeaderLen = gzipHeader.length;
+  private final int gzipTrailerLen = gzipTrailer.length;
 
   private Deflater deflater;
 
@@ -210,12 +210,12 @@ public class BuiltInGzipCompressor implements Compressor {
       return 0;
     }
 
-    int n = Math.min(len, GZIP_HEADER_LEN - headerOff);
-    System.arraycopy(GZIP_HEADER, headerOff, b, off, n);
+    int n = Math.min(len, gzipHeaderLen - headerOff);
+    System.arraycopy(gzipHeader, headerOff, b, off, n);
     headerOff += n;
 
     // Completes header output.
-    if (headerOff == GZIP_HEADER_LEN) {
+    if (headerOff == gzipHeaderLen) {
       state = BuiltInGzipDecompressor.GzipStateLabel.INFLATE_STREAM;
     }
 
@@ -225,15 +225,15 @@ public class BuiltInGzipCompressor implements Compressor {
   private void fillTrailer() {
     if (state == BuiltInGzipDecompressor.GzipStateLabel.TRAILER_CRC) {
       int streamCrc = (int) crc.getValue();
-      GZIP_TRAILER[0] = (byte) (streamCrc & 0x000000ff);
-      GZIP_TRAILER[1] = (byte) ((streamCrc & 0x0000ff00) >> 8);
-      GZIP_TRAILER[2] = (byte) ((streamCrc & 0x00ff0000) >> 16);
-      GZIP_TRAILER[3] = (byte) ((streamCrc & 0xff000000) >> 24);
+      gzipTrailer[0] = (byte) (streamCrc & 0x000000ff);
+      gzipTrailer[1] = (byte) ((streamCrc & 0x0000ff00) >> 8);
+      gzipTrailer[2] = (byte) ((streamCrc & 0x00ff0000) >> 16);
+      gzipTrailer[3] = (byte) ((streamCrc & 0xff000000) >> 24);
 
-      GZIP_TRAILER[4] = (byte) (accuBufLen & 0x000000ff);
-      GZIP_TRAILER[5] = (byte) ((accuBufLen & 0x0000ff00) >> 8);
-      GZIP_TRAILER[6] = (byte) ((accuBufLen & 0x00ff0000) >> 16);
-      GZIP_TRAILER[7] = (byte) ((accuBufLen & 0xff000000) >> 24);
+      gzipTrailer[4] = (byte) (accuBufLen & 0x000000ff);
+      gzipTrailer[5] = (byte) ((accuBufLen & 0x0000ff00) >> 8);
+      gzipTrailer[6] = (byte) ((accuBufLen & 0x00ff0000) >> 16);
+      gzipTrailer[7] = (byte) ((accuBufLen & 0xff000000) >> 24);
 
       crc.reset();
       accuBufLen = 0;
@@ -245,11 +245,11 @@ public class BuiltInGzipCompressor implements Compressor {
       return 0;
     }
 
-    int n = Math.min(len, GZIP_TRAILER_LEN - trailerOff);
-    System.arraycopy(GZIP_TRAILER, trailerOff, b, off, n);
+    int n = Math.min(len, gzipTrailerLen - trailerOff);
+    System.arraycopy(gzipTrailer, trailerOff, b, off, n);
     trailerOff += n;
 
-    if (trailerOff == GZIP_TRAILER_LEN) {
+    if (trailerOff == gzipTrailerLen) {
       state = BuiltInGzipDecompressor.GzipStateLabel.FINISHED;
       currentBufLen = 0;
       headerOff = 0;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
@@ -39,15 +39,15 @@ public class BuiltInGzipCompressor implements Compressor {
    * Fixed ten-byte gzip header. See {@link GZIPOutputStream}'s source for
    * details.
    */
-  private static final byte[] GZIP_HEADER = new byte[]{
+  private final byte[] GZIP_HEADER = new byte[]{
       0x1f, (byte) 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
   // The trailer will be overwritten based on crc and output size.
-  private static final byte[] GZIP_TRAILER = new byte[]{
+  private final byte[] GZIP_TRAILER = new byte[]{
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-  private static final int GZIP_HEADER_LEN = GZIP_HEADER.length;
-  private static final int GZIP_TRAILER_LEN = GZIP_TRAILER.length;
+  private final int GZIP_HEADER_LEN = GZIP_HEADER.length;
+  private final int GZIP_TRAILER_LEN = GZIP_TRAILER.length;
 
   private Deflater deflater;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodec.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodec.java
@@ -109,7 +109,7 @@ public class TestCodec {
     }
     // without hadoop-native installed.
     ZlibFactory.setNativeZlibLoaded(false);
-    assumeTrue(ZlibFactory.isNativeZlibLoaded(conf));
+    assertFalse(ZlibFactory.isNativeZlibLoaded(conf));
     codecTest(conf, seed, 0, "org.apache.hadoop.io.compress.GzipCodec");
     codecTest(conf, seed, count, "org.apache.hadoop.io.compress.GzipCodec");
   }
@@ -570,7 +570,7 @@ public class TestCodec {
     }
     // without hadoop-native installed.
     ZlibFactory.setNativeZlibLoaded(false);
-    assumeTrue(ZlibFactory.isNativeZlibLoaded(conf));
+    assertFalse(ZlibFactory.isNativeZlibLoaded(conf));
     sequenceFileCodecTest(conf, 100, "org.apache.hadoop.io.compress.GzipCodec", 5);
     sequenceFileCodecTest(conf, 100, "org.apache.hadoop.io.compress.GzipCodec", 100);
     sequenceFileCodecTest(conf, 200000, "org.apache.hadoop.io.compress.GzipCodec", 1000000);


### PR DESCRIPTION
In the newly added BuiltInGzipCompressor, we should not let header and trailer as static variables as they are modifiable from different instances at the same time.

I prepared a test. But as this is like race-condition, so it is not definitely causing the issue. Just post the test here for reference.

```java
@Test
  public void testGzipCompressorsInSameJVM() throws InterruptedException {
    // This test makes sure multiple BuiltInGzipCompressor can work in same JVM.

    // don't use native libs
    ZlibFactory.setNativeZlibLoaded(false);
    Configuration conf = new Configuration();
    CompressionCodec codec = ReflectionUtils.newInstance(GzipCodec.class, conf);

    class CompressionThread extends Thread {
      Compressor compressor;
      byte[] b;
      int inputSize;

      boolean failed = false;
      Exception exception;

      CompressionThread(CompressionCodec codec, int inputSize, byte[] b) {
        compressor = codec.createCompressor();
        assertEquals("Compressor is not a BuiltInGzipCompressor", BuiltInGzipCompressor.class, compressor.getClass());

        this.b = b;
        this.inputSize = inputSize;
      }

      public void run() {
        compressor.setInput(b,0,  b.length);
        compressor.finish();

        byte[] output = new byte[inputSize + 1024];
        int outputOff = 0;

        try {
          while (!compressor.finished()) {
            byte[] buf = new byte[2];
            int compressed = compressor.compress(buf, 0, buf.length);
            System.arraycopy(buf, 0, output, outputOff, compressed);
            outputOff += compressed;
          }
        } catch (IOException e) {
          failed = true;
          exception = e;
        }

        DataInputBuffer gzbuf = new DataInputBuffer();
        gzbuf.reset(output, outputOff);

        try {
          Decompressor decom = codec.createDecompressor();
          assertNotNull("Got a null decompressor", decom);
          assertEquals("Decompressor is not a BuiltInGzipDecompressor", BuiltInGzipDecompressor.class, decom.getClass());
          InputStream gzin = codec.createInputStream(gzbuf, decom);

          DataOutputBuffer dflbuf = new DataOutputBuffer();
          dflbuf.reset();
          IOUtils.copyBytes(gzin, dflbuf, 4096);
          byte[] dflchk = Arrays.copyOf(dflbuf.getData(), dflbuf.getLength());
          assertArrayEquals("decompressed data must be the same as original input", b, dflchk);
        } catch (IOException e) {
          failed = true;
          exception = e;
        }
      }
    }

    Random r = new Random();
    while (true) {
      long seed = r.nextLong();
      r.setSeed(seed);

      int inputSize = r.nextInt(128 * 1024) + 1;

      byte[] b1 = new byte[inputSize];
      r.nextBytes(b1);

      CompressionThread p1 = new CompressionThread(codec, inputSize, b1);

      // Tweak the input bytes a bit. So their crc values will be different.
      byte[] b2 = new byte[inputSize];
      System.arraycopy(b1, 0, b2, 0, inputSize);
      b2[0] = (byte) r.nextInt();
      CompressionThread p2 = new CompressionThread(codec, inputSize, b2);
      p1.start();
      p2.start();
      p1.join();
      p2.join();
      if (p1.failed) {
        fail("Failure happens during two compression threads running: " + p1.exception.getMessage());
      }
      if (p2.failed) {
        fail("Failure happens during two compression threads running: " + p2.exception.getMessage());
      }
    }
  }
```


