### PR TITLE
YARN-10929. Refrain from creating new Configuration object in AbstractManagedParentQueue#initializeLeafQueueConfigs

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractManagedParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractManagedParentQueue.java
@@ -173,8 +173,7 @@ public abstract class AbstractManagedParentQueue extends ParentQueue {
 
   protected CapacitySchedulerConfiguration initializeLeafQueueConfigs(String configPrefix) {
 
-    CapacitySchedulerConfiguration leafQueueConfigs = new
-        CapacitySchedulerConfiguration(csContext.getConf(), false);
+    CapacitySchedulerConfiguration leafQueueConfigs = csContext.getConfiguration();
 
     Map<String, String> templateConfigs = getCSConfigurationsWithPrefix(configPrefix);
     for (Map.Entry<String, String> confKeyValuePair : templateConfigs.entrySet()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractManagedParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractManagedParentQueue.java
@@ -18,14 +18,12 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerDynamicEditException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.QueueEntitlement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -169,26 +167,14 @@ public abstract class AbstractManagedParentQueue extends ParentQueue {
   }
 
   protected Map<String, String> getCSConfigurationsWithPrefix(String prefix) {
-    Map<String, String> configsWithPrefix = new HashMap<>();
-
-    for (Map.Entry<String, String> confKeyValuePair :
-        csContext.getConfiguration().getPropsWithPrefix(prefix).entrySet()) {
-      configsWithPrefix.put(prefix + confKeyValuePair.getKey(), confKeyValuePair.getValue());
-    }
-
-    return configsWithPrefix;
+    ConfigurationProperties properties = csContext.getConfiguration().getConfigurationProperties();
+    return properties.getPropertiesWithPrefix(prefix, true);
   }
 
   protected CapacitySchedulerConfiguration initializeLeafQueueConfigs(String configPrefix) {
 
     CapacitySchedulerConfiguration leafQueueConfigs = new
         CapacitySchedulerConfiguration(csContext.getConf(), false);
-
-    String resourceTypePrefix = YarnConfiguration.RESOURCE_TYPES + ".";
-    Map<String, String> rtConfigs = getCSConfigurationsWithPrefix(resourceTypePrefix);
-    for (Map.Entry<String, String> confKeyValuePair: rtConfigs.entrySet()) {
-      leafQueueConfigs.set(confKeyValuePair.getKey(), confKeyValuePair.getValue());
-    }
 
     Map<String, String> templateConfigs = getCSConfigurationsWithPrefix(configPrefix);
     for (Map.Entry<String, String> confKeyValuePair : templateConfigs.entrySet()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ManagedParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ManagedParentQueue.java
@@ -463,17 +463,13 @@ public class ManagedParentQueue extends AbstractManagedParentQueue {
 
   public CapacitySchedulerConfiguration getLeafQueueConfigs(
       CapacitySchedulerConfiguration templateConfig, String leafQueueName) {
-    CapacitySchedulerConfiguration leafQueueConfigTemplate = new
-        CapacitySchedulerConfiguration(new Configuration(false), false);
-    for (final Iterator<Map.Entry<String, String>> iterator =
-         templateConfig.iterator(); iterator.hasNext(); ) {
-      Map.Entry<String, String> confKeyValuePair = iterator.next();
+    for (Map.Entry<String, String> confKeyValuePair : templateConfig) {
       final String name = confKeyValuePair.getKey().replaceFirst(
           CapacitySchedulerConfiguration
               .AUTO_CREATED_LEAF_QUEUE_TEMPLATE_PREFIX,
           leafQueueName);
-      leafQueueConfigTemplate.set(name, confKeyValuePair.getValue());
+      templateConfig.set(name, confKeyValuePair.getValue());
     }
-    return leafQueueConfigTemplate;
+    return templateConfig;
   }
 }


### PR DESCRIPTION
### Description of PR
Refrain from creating new Configuration object and remove the unneccessary configuration sorting in AbstractManagedParentQueue#initializeLeafQueueConfigs. 

### How was this patch tested?
This patch just refactor code and should be covered by exists test.

### For code changes:

- [Yes] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [No] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [No] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [No] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

