### PR TITLE
HADOOP-17223. backport to branch-2.10 bumping httpclient and httpcore

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -77,6 +77,10 @@
     <jackson2.version>2.9.10</jackson2.version>
     <jackson2.databind.version>2.9.10.7</jackson2.databind.version>
 
+    <!-- httpcomponents versions -->
+    <httpclient.version>4.5.2</httpclient.version>
+    <httpcore.version>4.4.4</httpcore.version>
+
     <!-- SLF4J version -->
     <slf4j.version>1.7.25</slf4j.version>
 
@@ -564,12 +568,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.2</version>
+        <version>${httpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.4</version>
+        <version>${httpcore.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -78,8 +78,8 @@
     <jackson2.databind.version>2.9.10.7</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
-    <httpclient.version>4.5.2</httpclient.version>
-    <httpcore.version>4.4.4</httpcore.version>
+    <httpclient.version>4.5.13</httpclient.version>
+    <httpcore.version>4.4.13</httpcore.version>
 
     <!-- SLF4J version -->
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
[HADOOP-17223](https://issues.apache.org/jira/browse/HADOOP-17223) update org.apache.httpcomponents:httpclient to 4.5.13 and httpcore to 4.4.13

There is CVE-2020-13956
moderate severity

Apache HttpClient versions prior to version 4.5.13 and 5.0.3 can misinterpret malformed authority component in reques...
pom.xml update suggested:
org.apache.httpcomponents:httpclient ~> 4.5.13 

this PR is to backport the changes into branch-2.10 bumping httpcomponents:httpclient to 4.5.13

