### PR TITLE
HDFS-16200: Improve NameNode failover

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -882,6 +882,11 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.datanode.ec.reconstruction.validation";
   public static final boolean DFS_DN_EC_RECONSTRUCTION_VALIDATION_VALUE = false;
 
+  public static final String DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY =
+          "dfs.disable.datanode.topology.sort";
+  public static final boolean DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY_DEFAULT = false;
+
+
   public static final String
       DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_KEY =
       "dfs.datanode.directoryscan.throttle.limit.ms.per.sec";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -294,6 +294,10 @@ public class BlockManager implements BlockStatsMXBean {
     return blocksMap.getECBlockGroups();
   }
 
+  public boolean isTopologySortDisabled() {
+    return this.topologySortDisabled;
+  }
+
   /**
    * redundancyRecheckInterval is how often namenode checks for new
    * reconstruction work.
@@ -458,12 +462,24 @@ public class BlockManager implements BlockStatsMXBean {
   /** Storages accessible from multiple DNs. */
   private final ProvidedStorageMap providedStorageMap;
 
+  /**
+   * Enable/disable topology sorting for datanodes. Enable for colocated clusters
+   * while disable for compute/storage separate clusters since they won't be in
+   * the same host or rack.
+   */
+   private final boolean topologySortDisabled;
+
   public BlockManager(final Namesystem namesystem, boolean haEnabled,
       final Configuration conf) throws IOException {
     this.namesystem = namesystem;
     datanodeManager = new DatanodeManager(this, namesystem, conf);
     heartbeatManager = datanodeManager.getHeartbeatManager();
     this.blockIdManager = new BlockIdManager(this);
+
+    this.topologySortDisabled = conf.getBoolean(
+            DFSConfigKeys.DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY,
+            DFSConfigKeys.DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY_DEFAULT);
+
     blocksPerPostpondedRescan = (int)Math.min(Integer.MAX_VALUE,
         datanodeManager.getBlocksPerPostponedMisreplicatedBlocksRescan());
     rescannedMisreplicatedBlocks =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -169,6 +169,12 @@ public class DatanodeManager {
   /** The number of stale storages */
   private volatile int numStaleStorages;
 
+  /** Enable/disable topology sorting for datanodes. Enable for colocated clusters
+   * while disable for compute/storage separate clusters since they won't be in
+   * the same host or rack.
+   */
+  private final boolean topologySortDisabled;
+
   /**
    * Number of blocks to check for each postponedMisreplicatedBlocks iteration
    */
@@ -236,6 +242,10 @@ public class DatanodeManager {
       final Configuration conf) throws IOException {
     this.namesystem = namesystem;
     this.blockManager = blockManager;
+
+    this.topologySortDisabled = conf.getBoolean(
+        DFSConfigKeys.DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY,
+        DFSConfigKeys.DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY_DEFAULT);
 
     this.useDfsNetworkTopology = conf.getBoolean(
         DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_KEY,
@@ -587,11 +597,14 @@ public class DatanodeManager {
    */
   private void sortLocatedBlock(final LocatedBlock lb, String targetHost,
       Comparator<DatanodeInfo> comparator) {
-    // As it is possible for the separation of node manager and datanode, 
-    // here we should get node but not datanode only .
+    // Resolving topology is expensive especially by calling external script.
+    // If datanode and nodemanager are not colocated, we can disable resolving topology
+    // since they will not locate on the same host and rack.
+    // Otherwise, it resolves nodemanager topology and compares/sorts the datanodes
+    // by comparing the distances between nodemanager and the datanodes.
     boolean nonDatanodeReader = false;
     Node client = getDatanodeByHost(targetHost);
-    if (client == null) {
+    if (client == null && !this.topologySortDisabled) {
       nonDatanodeReader = true;
       List<String> hosts = new ArrayList<>(1);
       hosts.add(targetHost);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -169,12 +169,6 @@ public class DatanodeManager {
   /** The number of stale storages */
   private volatile int numStaleStorages;
 
-  /** Enable/disable topology sorting for datanodes. Enable for colocated clusters
-   * while disable for compute/storage separate clusters since they won't be in
-   * the same host or rack.
-   */
-  private final boolean topologySortDisabled;
-
   /**
    * Number of blocks to check for each postponedMisreplicatedBlocks iteration
    */
@@ -242,11 +236,6 @@ public class DatanodeManager {
       final Configuration conf) throws IOException {
     this.namesystem = namesystem;
     this.blockManager = blockManager;
-
-    this.topologySortDisabled = conf.getBoolean(
-        DFSConfigKeys.DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY,
-        DFSConfigKeys.DFS_DISABLE_DATANODE_TOPOLOGY_SORT_KEY_DEFAULT);
-
     this.useDfsNetworkTopology = conf.getBoolean(
         DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_KEY,
         DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_DEFAULT);
@@ -604,7 +593,7 @@ public class DatanodeManager {
     // by comparing the distances between nodemanager and the datanodes.
     boolean nonDatanodeReader = false;
     Node client = getDatanodeByHost(targetHost);
-    if (client == null && !this.topologySortDisabled) {
+    if (client == null && !blockManager.isTopologySortDisabled()) {
       nonDatanodeReader = true;
       List<String> hosts = new ArrayList<>(1);
       hosts.add(targetHost);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirWriteFileOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirWriteFileOp.java
@@ -277,7 +277,7 @@ class FSDirWriteFileOp {
     // If client locality is ignored, clientNode remains 'null' to indicate
     if (!ignoreClientLocality) {
       clientNode = bm.getDatanodeManager().getDatanodeByHost(r.clientMachine);
-      if (clientNode == null) {
+      if (clientNode == null && !bm.isTopologySortDisabled()) {
         clientNode = getClientNode(bm, r.clientMachine);
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3081,7 +3081,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       readUnlock("getAdditionalDatanode");
     }
 
-    if (clientnode == null) {
+    if (clientnode == null && !blockManager.isTopologySortDisabled()) {
       clientnode = FSDirWriteFileOp.getClientNode(blockManager, clientMachine);
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -36,6 +36,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -84,8 +85,14 @@ public class TestDatanodeManager {
   final int NUM_ITERATIONS = 500;
 
   private static DatanodeManager mockDatanodeManager(
-      FSNamesystem fsn, Configuration conf) throws IOException {
+          FSNamesystem fsn, Configuration conf) throws IOException {
+    return mockDatanodeManager(fsn, conf, false);
+  }
+
+  private static DatanodeManager mockDatanodeManager(
+          FSNamesystem fsn, Configuration conf, boolean topologySortDisabled) throws IOException {
     BlockManager bm = Mockito.mock(BlockManager.class);
+    Mockito.when(bm.isTopologySortDisabled()).thenReturn(topologySortDisabled);
     BlockReportLeaseManager blm = new BlockReportLeaseManager(conf);
     Mockito.when(bm.getBlockReportLeaseManager()).thenReturn(blm);
     DatanodeManager dm = new DatanodeManager(bm, fsn, conf);
@@ -325,8 +332,7 @@ public class TestDatanodeManager {
 
     FSNamesystem fsn = Mockito.mock(FSNamesystem.class);
     Mockito.when(fsn.hasWriteLock()).thenReturn(true);
-    DatanodeManager dm = mockDatanodeManager(fsn, conf);
-
+    DatanodeManager dm = mockDatanodeManager(fsn, conf, true);
     // register 5 datanodes, each with different storage ID and type
     DatanodeInfo[] locs = new DatanodeInfo[5];
     String[] storageIDs = new String[5];


### PR DESCRIPTION
This patch adds a configuration to skip resolving the topology for the client hosts, e.g., YARN hosts. Such topology info is useful in colocated environment but not in non-colocated env. 


### How was this patch tested?
unit test
