### PR TITLE
HADOOP-17885. Upgrade JSON smart to 1.3.3 on branch-2.10

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -147,6 +147,7 @@
     <!-- the version of Hadoop declared in the version resources; can be overridden
     so that Hadoop 3.x can declare itself a 2.x artifact. -->
     <declared.hadoop.version>${project.version}</declared.hadoop.version>
+    <json-smart.version>1.3.3</json-smart.version>
     <woodstox.version>5.3.0</woodstox.version>
   </properties>
 
@@ -1217,7 +1218,7 @@
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
-        <version>1.3.1</version>
+        <version>${json-smart.version}</version>
       </dependency>
 
         <dependency>


### PR DESCRIPTION
[HADOOP-17885](https://issues.apache.org/jira/browse/HADOOP-17885) Upgrade JSON smart to 1.3.3 on branch-2.10

Currently branch-2.10 is using JSON Smart 1.3.1 version which is vulnerable to CVE-2021-27568.

We can upgrade the version to 1.3.1.

