### PR TITLE
HADOOP-17887. Remove the wrapper class GzipOutputStream

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
@@ -56,7 +56,6 @@ public class BuiltInGzipCompressor implements Compressor {
 
   private int numExtraBytesWritten = 0;
 
-  private int currentBufLen = 0;
   private int accuBufLen = 0;
 
   private final Checksum crc = DataChecksum.newCrc32();
@@ -162,7 +161,6 @@ public class BuiltInGzipCompressor implements Compressor {
   public void reinit(Configuration conf) {
     init(conf);
     numExtraBytesWritten = 0;
-    currentBufLen = 0;
     headerOff = 0;
     trailerOff = 0;
     crc.reset();
@@ -174,7 +172,6 @@ public class BuiltInGzipCompressor implements Compressor {
     deflater.reset();
     state = BuiltInGzipDecompressor.GzipStateLabel.HEADER_BASIC;
     numExtraBytesWritten = 0;
-    currentBufLen = 0;
     headerOff = 0;
     trailerOff = 0;
     crc.reset();
@@ -197,8 +194,7 @@ public class BuiltInGzipCompressor implements Compressor {
 
     deflater.setInput(b, off, len);
     crc.update(b, off, len);  // CRC-32 is on uncompressed data
-    currentBufLen = len;
-    accuBufLen += currentBufLen;
+    accuBufLen += len;
   }
 
   private int writeHeader(byte[] b, int off, int len) {
@@ -247,7 +243,6 @@ public class BuiltInGzipCompressor implements Compressor {
 
     if (trailerOff == gzipTrailerLen) {
       state = BuiltInGzipDecompressor.GzipStateLabel.FINISHED;
-      currentBufLen = 0;
       headerOff = 0;
       trailerOff = 0;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipCompressor.java
@@ -86,10 +86,6 @@ public class BuiltInGzipCompressor implements Compressor {
 
     int compressedBytesWritten = 0;
 
-    if (currentBufLen <= 0) {
-      return compressedBytesWritten;
-    }
-
     // If we are not within uncompressed data yet, output the header.
     if (state == BuiltInGzipDecompressor.GzipStateLabel.HEADER_BASIC) {
       int outputHeaderSize = writeHeader(b, off, len);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodec.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/compress/TestCodec.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.io.compress;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1049,6 +1050,47 @@ public class TestCodec {
       if (poolDecompressor != poolDecompressor2) {
         fail("Did not reuse native gzip decompressor in pool");
       }
+    }
+  }
+
+  @Test(timeout=20000)
+  public void testGzipCompressorWithEmptyInput() throws IOException {
+    // don't use native libs
+    ZlibFactory.setNativeZlibLoaded(false);
+    Configuration conf = new Configuration();
+    CompressionCodec codec = ReflectionUtils.newInstance(GzipCodec.class, conf);
+
+    Compressor compressor = codec.createCompressor();
+    assertThat(compressor).withFailMessage("should be BuiltInGzipCompressor")
+            .isInstanceOf(BuiltInGzipCompressor.class);
+
+    byte[] b = new byte[0];
+    compressor.setInput(b, 0, b.length);
+    compressor.finish();
+
+    byte[] output = new byte[100];
+    int outputOff = 0;
+
+    while (!compressor.finished()) {
+      byte[] buf = new byte[100];
+      int compressed = compressor.compress(buf, 0, buf.length);
+      System.arraycopy(buf, 0, output, outputOff, compressed);
+      outputOff += compressed;
+    }
+
+    DataInputBuffer gzbuf = new DataInputBuffer();
+    gzbuf.reset(output, outputOff);
+
+    Decompressor decom = codec.createDecompressor();
+    assertThat(decom).as("decompressor should not be null").isNotNull();
+    assertThat(decom).withFailMessage("should be BuiltInGzipDecompressor")
+            .isInstanceOf(BuiltInGzipDecompressor.class);
+    try (InputStream gzin = codec.createInputStream(gzbuf, decom);
+         DataOutputBuffer dflbuf = new DataOutputBuffer()) {
+      dflbuf.reset();
+      IOUtils.copyBytes(gzin, dflbuf, 4096);
+      final byte[] dflchk = Arrays.copyOf(dflbuf.getData(), dflbuf.getLength());
+      assertThat(b).as("check decompressed output").isEqualTo(dflchk);
     }
   }
 }


### PR DESCRIPTION
As we provide built-in gzip compressor, we can use it in compressor stream. The wrapper `GzipOutputStream` can be removed now.

BTW, I did a microbenchmark by running 10 times of compressing/decompresing random data.

The average time:

After: 12.93s
Before: 13.52s

It is pretty close.


