### PR TITLE
HDFS-16210. RBF: Add the option of refreshCallQueue to RouterAdmin

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
@@ -81,11 +81,15 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.ipc.ProtobufRpcEngine2;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.RPC.Server;
+import org.apache.hadoop.ipc.RefreshCallQueueProtocol;
 import org.apache.hadoop.ipc.RefreshRegistry;
 import org.apache.hadoop.ipc.RefreshResponse;
 import org.apache.hadoop.ipc.proto.GenericRefreshProtocolProtos;
+import org.apache.hadoop.ipc.proto.RefreshCallQueueProtocolProtos;
 import org.apache.hadoop.ipc.protocolPB.GenericRefreshProtocolPB;
 import org.apache.hadoop.ipc.protocolPB.GenericRefreshProtocolServerSideTranslatorPB;
+import org.apache.hadoop.ipc.protocolPB.RefreshCallQueueProtocolPB;
+import org.apache.hadoop.ipc.protocolPB.RefreshCallQueueProtocolServerSideTranslatorPB;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.ProxyUsers;
@@ -102,7 +106,7 @@ import org.apache.hadoop.thirdparty.protobuf.BlockingService;
  * router. It is created, started, and stopped by {@link Router}.
  */
 public class RouterAdminServer extends AbstractService
-    implements RouterAdminProtocol {
+    implements RouterAdminProtocol, RefreshCallQueueProtocol {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(RouterAdminServer.class);
@@ -197,8 +201,16 @@ public class RouterAdminServer extends AbstractService
         GenericRefreshProtocolProtos.GenericRefreshProtocolService.
         newReflectiveBlockingService(genericRefreshXlator);
 
+    RefreshCallQueueProtocolServerSideTranslatorPB refreshCallQueueXlator =
+        new RefreshCallQueueProtocolServerSideTranslatorPB(this);
+    BlockingService refreshCallQueueService =
+        RefreshCallQueueProtocolProtos.RefreshCallQueueProtocolService.
+        newReflectiveBlockingService(refreshCallQueueXlator);
+
     DFSUtil.addPBProtocol(conf, GenericRefreshProtocolPB.class,
         genericRefreshService, adminServer);
+    DFSUtil.addPBProtocol(conf, RefreshCallQueueProtocolPB.class,
+        refreshCallQueueService, adminServer);
   }
 
   /**
@@ -763,5 +775,13 @@ public class RouterAdminServer extends AbstractService
   public boolean refreshSuperUserGroupsConfiguration() throws IOException {
     ProxyUsers.refreshSuperUserGroupsConfiguration();
     return true;
+  }
+
+  @Override // RefreshCallQueueProtocol
+  public void refreshCallQueue() throws IOException {
+    LOG.info("Refreshing call queue.");
+
+    Configuration conf = new Configuration();
+    router.getRpcServer().getServer().refreshCallQueue(conf);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
@@ -781,7 +781,7 @@ public class RouterAdminServer extends AbstractService
   public void refreshCallQueue() throws IOException {
     LOG.info("Refreshing call queue.");
 
-    Configuration conf = new Configuration();
-    router.getRpcServer().getServer().refreshCallQueue(conf);
+    Configuration configuration = new Configuration();
+    router.getRpcServer().getServer().refreshCallQueue(configuration);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -1263,15 +1263,15 @@ public class RouterAdmin extends Configured implements Tool {
   }
 
   /**
-   * Refresh Router's call Queue
+   * Refresh Router's call Queue.
    *
    * @throws IOException if the operation was not successful.
    */
   private int refreshCallQueue() throws IOException {
     Configuration conf = getConf();
     String hostport =  getConf().getTrimmed(
-            RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_KEY,
-            RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_DEFAULT);
+        RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_KEY,
+        RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_DEFAULT);
 
     // Create the client
     Class<?> xface = RefreshCallQueueProtocolPB.class;
@@ -1279,13 +1279,13 @@ public class RouterAdmin extends Configured implements Tool {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
 
     RPC.setProtocolEngine(conf, xface, ProtobufRpcEngine2.class);
-      RefreshCallQueueProtocolPB proxy = (RefreshCallQueueProtocolPB) RPC.getProxy(
-            xface, RPC.getProtocolVersion(xface), address, ugi, conf,
-            NetUtils.getDefaultSocketFactory(conf), 0);
+    RefreshCallQueueProtocolPB proxy = (RefreshCallQueueProtocolPB)RPC.getProxy(
+        xface, RPC.getProtocolVersion(xface), address, ugi, conf,
+        NetUtils.getDefaultSocketFactory(conf), 0);
 
     int returnCode = -1;
     try (RefreshCallQueueProtocolClientSideTranslatorPB xlator =
-      new RefreshCallQueueProtocolClientSideTranslatorPB(proxy)) {
+        new RefreshCallQueueProtocolClientSideTranslatorPB(proxy)) {
       xlator.refreshCallQueue();
       System.out.println("Refresh call queue successful for " + hostport);
       returnCode = 0;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -77,6 +77,8 @@ import org.apache.hadoop.ipc.RefreshResponse;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.protocolPB.GenericRefreshProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ipc.protocolPB.GenericRefreshProtocolPB;
+import org.apache.hadoop.ipc.protocolPB.RefreshCallQueueProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ipc.protocolPB.RefreshCallQueueProtocolPB;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
@@ -388,6 +390,8 @@ public class RouterAdmin extends Configured implements Tool {
         exitCode = genericRefresh(argv, i);
       } else if ("-refreshSuperUserGroupsConfiguration".equals(cmd)) {
         exitCode = refreshSuperUserGroupsConfiguration();
+      } else if ("-refreshCallQueue".equals(cmd)) {
+        exitCode = refreshCallQueue();
       } else {
         throw new IllegalArgumentException("Unknown Command: " + cmd);
       }
@@ -1256,6 +1260,39 @@ public class RouterAdmin extends Configured implements Tool {
         return -1;
       }
     }
+  }
+
+  /**
+   * Refresh Router's call Queue
+   *
+   * @throws IOException if the operation was not successful.
+   */
+  private int refreshCallQueue() throws IOException {
+    Configuration conf = getConf();
+    String hostport =  getConf().getTrimmed(
+            RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_KEY,
+            RBFConfigKeys.DFS_ROUTER_ADMIN_ADDRESS_DEFAULT);
+
+    // Create the client
+    Class<?> xface = RefreshCallQueueProtocolPB.class;
+    InetSocketAddress address = NetUtils.createSocketAddr(hostport);
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+
+    RPC.setProtocolEngine(conf, xface, ProtobufRpcEngine2.class);
+      RefreshCallQueueProtocolPB proxy = (RefreshCallQueueProtocolPB) RPC.getProxy(
+            xface, RPC.getProtocolVersion(xface), address, ugi, conf,
+            NetUtils.getDefaultSocketFactory(conf), 0);
+
+    int returnCode = -1;
+    try (RefreshCallQueueProtocolClientSideTranslatorPB xlator =
+      new RefreshCallQueueProtocolClientSideTranslatorPB(proxy)) {
+      xlator.refreshCallQueue();
+      System.out.println("Refresh call queue successful for " + hostport);
+      returnCode = 0;
+    } catch (IOException ioe){
+      System.out.println("Refresh call queue failed for " + hostport);
+    }
+    return returnCode;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/RouterAdmin.java
@@ -1287,10 +1287,10 @@ public class RouterAdmin extends Configured implements Tool {
     try (RefreshCallQueueProtocolClientSideTranslatorPB xlator =
         new RefreshCallQueueProtocolClientSideTranslatorPB(proxy)) {
       xlator.refreshCallQueue();
-      System.out.println("Refresh call queue successful for " + hostport);
+      System.out.println("Refresh call queue successfully for " + hostport);
       returnCode = 0;
     } catch (IOException ioe){
-      System.out.println("Refresh call queue failed for " + hostport);
+      System.out.println("Refresh call queue unsuccessfully for " + hostport);
     }
     return returnCode;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
@@ -1746,7 +1746,7 @@ public class TestRouterAdminCLI {
     System.setOut(new PrintStream(out));
     String[] argv = new String[]{"-refreshCallQueue"};
     assertEquals(0, ToolRunner.run(admin, argv));
-    assertTrue(out.toString().contains("Refresh call queue successful"));
+    assertTrue(out.toString().contains("Refresh call queue successfully"));
   }
 
   private void addMountTable(String src, String nsId, String dst)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterAdminCLI.java
@@ -1740,6 +1740,15 @@ public class TestRouterAdminCLI {
     assertEquals(0, ToolRunner.run(admin, argv));
   }
 
+  @Test
+  public void testRefreshCallQueue() throws Exception {
+
+    System.setOut(new PrintStream(out));
+    String[] argv = new String[]{"-refreshCallQueue"};
+    assertEquals(0, ToolRunner.run(admin, argv));
+    assertTrue(out.toString().contains("Refresh call queue successful"));
+  }
+
   private void addMountTable(String src, String nsId, String dst)
       throws Exception {
     String[] argv = new String[] {"-add", src, nsId, dst};


### PR DESCRIPTION
### Description of PR

We enabled FairCallQueue to RouterRpcServer, but Router can not refreshCallQueue as NameNode does.

This ticket is to enable the refreshCallQueue for Router so that we don't have to restart the Routers when updating FairCallQueue configurations.

 
The option is not to refreshCallQueue to NameNodes, just trying to refresh the callQueue of Router itself.

Jira ticket: https://issues.apache.org/jira/browse/HDFS-16210

### How was this patch tested?

Unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

