### PR TITLE
HDFS-16213. Flaky test TestFsDatasetImpl#testDnRestartWithHardLink

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/FileIoProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/FileIoProvider.java
@@ -513,6 +513,7 @@ public class FileIoProvider {
     try {
       faultInjectorEventHook.beforeMetadataOp(volume, DELETE);
       boolean deleted = FileUtil.fullyDelete(dir);
+      LOG.trace("Deletion of dir {} {}", dir, deleted ? "succeeded" : "failed");
       profilingEventHook.afterMetadataOp(volume, DELETE, begin);
       return deleted;
     } catch(Exception e) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -131,7 +131,7 @@ class BlockPoolSlice {
    * Only tests can use true value to bypass processing RBW and Finalized
    * replicas.
    */
-  private static boolean disableAddingFinalizedReplicaForTest = false;
+  private static boolean disableProcessingReplicaForTest = false;
 
   /**
    * Only to be used by "tests" and not by "source code". The intention of this
@@ -148,7 +148,7 @@ class BlockPoolSlice {
    */
   @VisibleForTesting
   public static void disableFinalizedReplicaAdditionForTest(boolean newVal) {
-    disableAddingFinalizedReplicaForTest = newVal;
+    disableProcessingReplicaForTest = newVal;
   }
 
   /**
@@ -466,7 +466,7 @@ class BlockPoolSlice {
     }
 
     boolean success = readReplicasFromCache(volumeMap, lazyWriteReplicaMap);
-    if (!success && !disableAddingFinalizedReplicaForTest) {
+    if (!success && !disableProcessingReplicaForTest) {
       List<IOException> exceptions = Collections
           .synchronizedList(new ArrayList<IOException>());
       Queue<RecursiveAction> subTaskQueue =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -131,14 +131,14 @@ class BlockPoolSlice {
    * Only tests can use true value to bypass processing RBW and Finalized
    * replicas.
    */
-  private static boolean disableProcessingReplicaForTest = false;
+  private static boolean isReplicaProcessingDisabledForTest = false;
 
   /**
    * Only to be used by "tests" and not by "source code". The intention of this
    * is to enable/disable adding AddReplicaProcessor to the addReplicaThreadPool
    * fork-join pool when reading replicas from cache is not successful
    * (typically when Datanode is just started).
-   * By disabling flag 'disableAddingFinalizedReplicaForTest' (i.e. true value),
+   * By disabling flag 'isReplicaProcessingDisabledForTest' (i.e. true value),
    * we will never let AddReplicaProcessor take care of deleting duplicate
    * Finalized or RBW replica if one exists, and this is often useful for
    * some tests.
@@ -147,8 +147,8 @@ class BlockPoolSlice {
    *     or RBW replicas.
    */
   @VisibleForTesting
-  public static void disableFinalizedReplicaAdditionForTest(boolean newVal) {
-    disableProcessingReplicaForTest = newVal;
+  public static void disableReplicaProcessingForTest(boolean newVal) {
+    isReplicaProcessingDisabledForTest = newVal;
   }
 
   /**
@@ -466,7 +466,7 @@ class BlockPoolSlice {
     }
 
     boolean success = readReplicasFromCache(volumeMap, lazyWriteReplicaMap);
-    if (!success && !disableProcessingReplicaForTest) {
+    if (!success && !isReplicaProcessingDisabledForTest) {
       List<IOException> exceptions = Collections
           .synchronizedList(new ArrayList<IOException>());
       Queue<RecursiveAction> subTaskQueue =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -1088,7 +1088,7 @@ class BlockPoolSlice {
   }
 
   @VisibleForTesting
-  public void setDeleteDuplicateReplicasForTests(
+  void setDeleteDuplicateReplicasForTests(
       boolean deleteDuplicateReplicasForTests) {
     this.deleteDuplicateReplicas = deleteDuplicateReplicasForTests;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1070,7 +1070,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
           + srcReplica + " metadata to "
           + dstMeta, e);
     }
-    LOG.info("Linked {} to {} . Dest meta file: {}",
+    LOG.debug("Linked {} to {} . Dest meta file: {}",
         srcReplica.getBlockURI(), dstFile, dstMeta);
     return new File[]{dstMeta, dstFile};
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -26,6 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -1049,14 +1050,17 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   static File[] hardLinkBlockFiles(ReplicaInfo srcReplica, File dstMeta,
       File dstFile)
       throws IOException {
+    FsVolumeSpi srcReplicaVolume = srcReplica.getVolume();
+    File destParentFile = dstFile.getParentFile();
     // Create parent folder if not exists.
     boolean isDirCreated = srcReplica.getFileIoProvider()
-        .mkdirs(srcReplica.getVolume(), dstFile.getParentFile());
-    LOG.trace("Dir creation of {} on volume {} {}", dstFile.getParentFile(),
-        srcReplica.getVolume(), isDirCreated ? "succeeded" : "failed");
+        .mkdirs(srcReplicaVolume, destParentFile);
+    LOG.trace("Dir creation of {} on volume {} {}", destParentFile,
+        srcReplicaVolume, isDirCreated ? "succeeded" : "failed");
+    URI srcReplicaUri = srcReplica.getBlockURI();
     try {
       HardLink.createHardLink(
-          new File(srcReplica.getBlockURI()), dstFile);
+          new File(srcReplicaUri), dstFile);
     } catch (IOException e) {
       throw new IOException("Failed to hardLink "
           + srcReplica + " block file to "
@@ -1070,8 +1074,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
           + srcReplica + " metadata to "
           + dstMeta, e);
     }
-    LOG.debug("Linked {} to {} . Dest meta file: {}",
-        srcReplica.getBlockURI(), dstFile, dstMeta);
+    LOG.debug("Linked {} to {} . Dest meta file: {}", srcReplicaUri, dstFile,
+        dstMeta);
     return new File[]{dstMeta, dstFile};
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -1050,8 +1050,10 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       File dstFile)
       throws IOException {
     // Create parent folder if not exists.
-    srcReplica.getFileIoProvider()
+    boolean isDirCreated = srcReplica.getFileIoProvider()
         .mkdirs(srcReplica.getVolume(), dstFile.getParentFile());
+    LOG.trace("Dir creation of {} on volume {} {}", dstFile.getParentFile(),
+        srcReplica.getVolume(), isDirCreated ? "succeeded" : "failed");
     try {
       HardLink.createHardLink(
           new File(srcReplica.getBlockURI()), dstFile);
@@ -1068,9 +1070,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
           + srcReplica + " metadata to "
           + dstMeta, e);
     }
-    if (LOG.isDebugEnabled()) {
-      LOG.info("Linked " + srcReplica.getBlockURI() + " to " + dstFile);
-    }
+    LOG.info("Linked {} to {} . Dest meta file: {}",
+        srcReplica.getBlockURI(), dstFile, dstMeta);
     return new File[]{dstMeta, dstFile};
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -2483,12 +2483,8 @@ public class MiniDFSCluster implements AutoCloseable {
 
   public void waitDatanodeFullyStarted(DataNode dn, int timeout)
       throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(new Supplier<Boolean>() {
-      @Override
-      public Boolean get() {
-        return dn.isDatanodeFullyStarted();
-      }
-    }, 100, timeout);
+    GenericTestUtils.waitFor(dn::isDatanodeFullyStarted, 100, timeout,
+        "Datanode is not started even after " + timeout + " ms of waiting");
   }
 
   private void waitDataNodeFullyStarted(final DataNode dn)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -50,10 +50,8 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManagerTestUtil;
-import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.common.Storage;
 import org.apache.hadoop.hdfs.server.common.Storage.StorageDirectory;
-import org.apache.hadoop.hdfs.server.common.StorageInfo;
 import org.apache.hadoop.hdfs.server.datanode.BlockScanner;
 import org.apache.hadoop.hdfs.server.datanode.DNConf;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
@@ -78,7 +76,9 @@ import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -124,7 +124,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TestFsDatasetImpl {
-  Logger LOG = LoggerFactory.getLogger(TestFsDatasetImpl.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TestFsDatasetImpl.class);
+
   private static final String BASE_DIR =
       new FileSystemTestHelper().getTestRootDir();
   private String replicaCacheRootDir = BASE_DIR + Path.SEPARATOR + "cache";
@@ -132,16 +135,15 @@ public class TestFsDatasetImpl {
   private static final String CLUSTER_ID = "cluser-id";
   private static final String[] BLOCK_POOL_IDS = {"bpid-0", "bpid-1"};
 
-  // Use to generate storageUuid
-  private static final DataStorage dsForStorageUuid = new DataStorage(
-      new StorageInfo(HdfsServerConstants.NodeType.DATA_NODE));
-
   private Configuration conf;
   private DataNode datanode;
   private DataStorage storage;
   private FsDatasetImpl dataset;
   
   private final static String BLOCKPOOL = "BP-TEST";
+
+  @Rule
+  public TestName name = new TestName();
 
   private static Storage.StorageDirectory createStorageDirectory(File root,
       Configuration conf)
@@ -228,6 +230,7 @@ public class TestFsDatasetImpl {
     assertEquals(NUM_INIT_VOLUMES, getNumVolumes());
     assertEquals(0, dataset.getNumFailedVolumes());
   }
+
   @Test(timeout=10000)
   public void testReadLockEnabledByDefault()
       throws Exception {
@@ -1132,7 +1135,7 @@ public class TestFsDatasetImpl {
       Assert.assertEquals(0, cluster.getNamesystem().getCorruptReplicaBlocks());
 
       FileSystem fs = cluster.getFileSystem();
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       DFSTestUtil.createFile(fs, filePath, 1, (short) 1, 0);
 
       block = DFSTestUtil.getFirstBlock(fs, filePath);
@@ -1179,7 +1182,7 @@ public class TestFsDatasetImpl {
       FileSystem fs = cluster.getFileSystem();
       DataNode dataNode = cluster.getDataNodes().get(0);
 
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       long fileLen = 100;
       ExtendedBlock block = createTestFile(fs, fileLen, filePath);
 
@@ -1227,7 +1230,7 @@ public class TestFsDatasetImpl {
       FileSystem fs = cluster.getFileSystem();
       DataNode dataNode = cluster.getDataNodes().get(0);
 
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       DFSTestUtil.createFile(fs, filePath, 100, (short) 1, 0);
       ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, filePath);
 
@@ -1266,7 +1269,7 @@ public class TestFsDatasetImpl {
       FileSystem fs = cluster.getFileSystem();
       DataNode dataNode = cluster.getDataNodes().get(0);
 
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       long fileLen = 100;
 
       ExtendedBlock block = createTestFile(fs, fileLen, filePath);
@@ -1307,7 +1310,7 @@ public class TestFsDatasetImpl {
    * DiskScanner should clean up the hardlink correctly.
    */
   @Test(timeout = 30000)
-  public void testDnRestartWithHardLink() {
+  public void testDnRestartWithHardLink() throws Exception {
     MiniDFSCluster cluster = null;
     try {
       conf.setBoolean(DFSConfigKeys
@@ -1320,10 +1323,11 @@ public class TestFsDatasetImpl {
               new StorageType[]{StorageType.DISK, StorageType.ARCHIVE})
           .storagesPerDatanode(2)
           .build();
+      cluster.waitActive();
       FileSystem fs = cluster.getFileSystem();
       DataNode dataNode = cluster.getDataNodes().get(0);
 
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       long fileLen = 100;
 
       ExtendedBlock block = createTestFile(fs, fileLen, filePath);
@@ -1331,11 +1335,34 @@ public class TestFsDatasetImpl {
       FsDatasetImpl fsDataSetImpl = (FsDatasetImpl) dataNode.getFSDataset();
 
       final ReplicaInfo oldReplicaInfo = fsDataSetImpl.getReplicaInfo(block);
+      StorageType oldStorageType = oldReplicaInfo.getVolume().getStorageType();
 
       fsDataSetImpl.finalizeNewReplica(
           createNewReplicaObjWithLink(block, fsDataSetImpl), block);
 
       ReplicaInfo newReplicaInfo = fsDataSetImpl.getReplicaInfo(block);
+      StorageType newStorageType = newReplicaInfo.getVolume().getStorageType();
+      assertEquals(StorageType.DISK, oldStorageType);
+      assertEquals(StorageType.ARCHIVE, newStorageType);
+
+      // Why do we need to do this?
+      // When Datanode comes up, BPServiceActors handshakes to Namenode and
+      // tries to initialize Block pool and in the process, it tries to get
+      // VolumeMap using BlockPoolSlice instance. While doing so, reading
+      // replicas from cache fails and hence, the thread tries to add
+      // Finalized and RBW replicas to addReplicaThreadPool fork-join pool
+      // in order to build the map. This process also tries to identify if
+      // there exists any duplicate replica. For this particular test, sometimes
+      // this process can detect duplicate replica on /data2 while processing
+      // finalized replica of /data1. Hence, before we can confirm
+      // newReplicaInfo.getBlockURI() exists, finalized replica on /data2
+      // might get deleted (rare and flaky case). Although the probability for
+      // the thread processing the identification and deletion of duplicate
+      // finalized replica to be faster than main thread is less, it cannot be
+      // avoided. Hence, we disable adding Finalized and RBW replicas to
+      // addReplicaThreadPool in BlockPoolSlice here and re-enable it only after
+      // we confirm the existence of newReplicaInfo on "/data2" ARCHIVE storage.
+      BlockPoolSlice.disableFinalizedReplicaAdditionForTest(true);
 
       cluster.restartDataNode(0);
       cluster.waitDatanodeFullyStarted(cluster.getDataNodes().get(0), 60000);
@@ -1344,26 +1371,30 @@ public class TestFsDatasetImpl {
       assertTrue(Files.exists(Paths.get(newReplicaInfo.getBlockURI())));
       assertTrue(Files.exists(Paths.get(oldReplicaInfo.getBlockURI())));
 
+      BlockPoolSlice.disableFinalizedReplicaAdditionForTest(false);
+
       DirectoryScanner scanner = new DirectoryScanner(
           cluster.getDataNodes().get(0).getFSDataset(), conf);
       scanner.start();
       scanner.run();
 
-      GenericTestUtils.waitFor(new Supplier<Boolean>() {
-        @Override public Boolean get() {
-          return !Files.exists(Paths.get(oldReplicaInfo.getBlockURI()));
-        }
-      }, 100, 10000);
+      GenericTestUtils.waitFor(
+          () -> !Files.exists(Paths.get(oldReplicaInfo.getBlockURI())),
+          100, 10000, "Old replica is not deleted by DirScanner even after "
+              + "10s of waiting has elapsed");
       assertTrue(Files.exists(Paths.get(newReplicaInfo.getBlockURI())));
 
       validateFileLen(fs, fileLen, filePath);
 
-    } catch (Exception ex) {
-      LOG.info("Exception in testDnRestartWithHardLink ", ex);
-      fail("Exception while testing testDnRestartWithHardLink ");
+      // Additional tests to ensure latest replica gets deleted after file
+      // deletion.
+      fs.delete(filePath, false);
+      GenericTestUtils.waitFor(
+          () -> !Files.exists(Paths.get(newReplicaInfo.getBlockURI())),
+          100, 10000);
     } finally {
-      if (cluster.isClusterUp()) {
-        cluster.shutdown();
+      if (cluster != null && cluster.isClusterUp()) {
+        cluster.shutdown(true, true);
       }
     }
   }
@@ -1384,7 +1415,7 @@ public class TestFsDatasetImpl {
           .build();
       FileSystem fs = cluster.getFileSystem();
       DataNode dataNode = cluster.getDataNodes().get(0);
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       long fileLen = 100;
 
       ExtendedBlock block = createTestFile(fs, fileLen, filePath);
@@ -1432,7 +1463,7 @@ public class TestFsDatasetImpl {
           .build();
       FileSystem fs = cluster.getFileSystem();
       DataNode dataNode = cluster.getDataNodes().get(0);
-      Path filePath = new Path("testData");
+      Path filePath = new Path(name.getMethodName());
       long fileLen = 100;
 
       ExtendedBlock block = createTestFile(fs, fileLen, filePath);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1317,6 +1317,11 @@ public class TestFsDatasetImpl {
           .DFS_DATANODE_ALLOW_SAME_DISK_TIERING, true);
       conf.setDouble(DFSConfigKeys
           .DFS_DATANODE_RESERVE_FOR_ARCHIVE_DEFAULT_PERCENTAGE, 0.5);
+      // Since Datanode restart in the middle of block movement may leave
+      // uncleaned hardlink, disabling this config (i.e. deletion of duplicate
+      // replica) will prevent this edge-case from happening.
+      // We also re-enable deletion of duplicate replica just before starting
+      // Dir Scanner using setDeleteDuplicateReplicasForTests (HDFS-16213).
       conf.setBoolean(DFSConfigKeys.DFS_DATANODE_DUPLICATE_REPLICA_DELETION,
           false);
       cluster = new MiniDFSCluster.Builder(conf)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1362,7 +1362,7 @@ public class TestFsDatasetImpl {
       // avoided. Hence, we disable adding Finalized and RBW replicas to
       // addReplicaThreadPool in BlockPoolSlice here and re-enable it only after
       // we confirm the existence of newReplicaInfo on "/data2" ARCHIVE storage.
-      BlockPoolSlice.disableFinalizedReplicaAdditionForTest(true);
+      BlockPoolSlice.disableReplicaProcessingForTest(true);
 
       cluster.restartDataNode(0);
       cluster.waitDatanodeFullyStarted(cluster.getDataNodes().get(0), 60000);
@@ -1371,7 +1371,7 @@ public class TestFsDatasetImpl {
       assertTrue(Files.exists(Paths.get(newReplicaInfo.getBlockURI())));
       assertTrue(Files.exists(Paths.get(oldReplicaInfo.getBlockURI())));
 
-      BlockPoolSlice.disableFinalizedReplicaAdditionForTest(false);
+      BlockPoolSlice.disableReplicaProcessingForTest(false);
 
       DirectoryScanner scanner = new DirectoryScanner(
           cluster.getDataNodes().get(0).getFSDataset(), conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1312,6 +1312,9 @@ public class TestFsDatasetImpl {
   @Test(timeout = 30000)
   public void testDnRestartWithHardLink() throws Exception {
     MiniDFSCluster cluster = null;
+    boolean isReplicaDeletionEnabled =
+        conf.getBoolean(DFSConfigKeys.DFS_DATANODE_DUPLICATE_REPLICA_DELETION,
+            DFSConfigKeys.DFS_DATANODE_DUPLICATE_REPLICA_DELETION_DEFAULT);
     try {
       conf.setBoolean(DFSConfigKeys
           .DFS_DATANODE_ALLOW_SAME_DISK_TIERING, true);
@@ -1384,7 +1387,8 @@ public class TestFsDatasetImpl {
           () -> !Files.exists(Paths.get(newReplicaInfo.getBlockURI())),
           100, 10000);
     } finally {
-      conf.unset(DFSConfigKeys.DFS_DATANODE_DUPLICATE_REPLICA_DELETION);
+      conf.setBoolean(DFSConfigKeys.DFS_DATANODE_DUPLICATE_REPLICA_DELETION,
+          isReplicaDeletionEnabled);
       if (cluster != null && cluster.isClusterUp()) {
         cluster.shutdown(true, true);
       }


### PR DESCRIPTION
### Description of PR
TestFsDatasetImpl#testDnRestartWithHardLink is flapper:
```
[ERROR] testDnRestartWithHardLink(org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.TestFsDatasetImpl)  Time elapsed: 7.768 s  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.TestFsDatasetImpl.testDnRestartWithHardLink(TestFsDatasetImpl.java:1344)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

### How was this patch tested?
Unit testing. The current flaky behaviour is easy to reproduce by running the test code twice as part of same test.
The resolution is to disable the detection as well as deletion of duplicate finalized replica by BlockPoolSlice instance.

When Datanode comes up, BPServiceActors handshakes to Namenode and tries to initialize Block pool and in the process, it tries to get VolumeMap using BlockPoolSlice instance. While doing so, reading replicas from cache fails and hence, the thread tries to add Finalized and RBW replicas to addReplicaThreadPool fork-join pool in order to build the map. This process also tries to identify if there exists any duplicate replica. For this particular test, sometimes this process can detect duplicate replica on /data2 while processing finalized replica of /data1. Hence, before we can confirm newReplicaInfo.getBlockURI() exists, finalized replica on /data2 might get deleted (rare and flaky case). Although the probability for the thread processing the identification and deletion of duplicate finalized replica to be faster than main thread is less, it cannot be avoided. Hence, we disable adding Finalized and RBW replicas to addReplicaThreadPool in BlockPoolSlice here and re-enable it only after we confirm the existence of newReplicaInfo on "/data2" ARCHIVE storage.