### PR TITLE
HADOOP-17895. Add the test to reproduce the failure of `RawLocalFileSystem.mkdir` with unicode filename

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractMkdir.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractMkdir.java
@@ -19,8 +19,11 @@
 package org.apache.hadoop.fs.contract.rawlocal;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractMkdirTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Test;
 
 /**
  * Test dir operations on a the local FS.
@@ -30,5 +33,12 @@ public class TestRawlocalContractMkdir extends AbstractContractMkdirTest {
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
     return new RawlocalFSContract(conf);
+  }
+
+  @Test
+  public void testMkDirRmDirUnicode() throws Throwable {
+    FileSystem fs = getFileSystem();
+    Path dir = path("testMkDirRmDirUnicode/dir-\\U0001f63b");
+    fs.mkdirs(dir); // this should not fail.
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractMkdir.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractMkdir.java
@@ -38,7 +38,9 @@ public class TestRawlocalContractMkdir extends AbstractContractMkdirTest {
   @Test
   public void testMkDirRmDirUnicode() throws Throwable {
     FileSystem fs = getFileSystem();
-    Path dir = path("/tmp/TestRawlocalContractMkdir-\uD83D\uDE3B");
+    // Only failed once (the second run will work due to folder already created)
+    String prefix = "/tmp/testMkDirRmDirUnicode-" + System.currentTimeMillis();
+    Path dir = path(prefix + "-\uD83D\uDE3B");
     fs.mkdirs(dir); // this should not fail.
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractMkdir.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractMkdir.java
@@ -38,7 +38,7 @@ public class TestRawlocalContractMkdir extends AbstractContractMkdirTest {
   @Test
   public void testMkDirRmDirUnicode() throws Throwable {
     FileSystem fs = getFileSystem();
-    Path dir = path("testMkDirRmDirUnicode/dir-\\U0001f63b");
+    Path dir = path("/tmp/TestRawlocalContractMkdir-\uD83D\uDE3B");
     fs.mkdirs(dir); // this should not fail.
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
A sample PR to reproduce the failure for https://issues.apache.org/jira/projects/HADOOP/issues/HADOOP-17895?filter=allopenissues

### How was this patch tested?
Run the test with NativeIO enabled (it's failing)

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

