### PR TITLE
HADOOP-17897. Allow nested blocks in switch case in checkstyle settings.

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -160,7 +160,9 @@
 
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
-        <module name="AvoidNestedBlocks"/>
+        <module name="AvoidNestedBlocks">
+          <property name="allowInSwitchCase" value="true"/>
+        </module>
         <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
         <module name="NeedBraces"/>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17897

Nested blocks in switch case are used in existing code and checkstyle warning are just ignored. It should be allowed in project checkstyle settings.

