### PR TITLE
HADOOP-17898. Upgrade BouncyCastle to 1.69

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -468,8 +468,8 @@ com.microsoft.azure:azure-cosmosdb-gateway:2.4.5
 com.microsoft.azure:azure-data-lake-store-sdk:2.3.3
 com.microsoft.azure:azure-keyvault-core:1.0.0
 com.microsoft.sqlserver:mssql-jdbc:6.2.1.jre7
-org.bouncycastle:bcpkix-jdk15on:1.60
-org.bouncycastle:bcprov-jdk15on:1.60
+org.bouncycastle:bcpkix-jdk15on:1.69
+org.bouncycastle:bcprov-jdk15on:1.69
 org.checkerframework:checker-qual:2.5.2
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jruby.jcodings:jcodings:1.0.13

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -105,7 +105,7 @@
     <guava.version>27.0-jre</guava.version>
     <guice.version>4.2.3</guice.version>
 
-    <bouncycastle.version>1.60</bouncycastle.version>
+    <bouncycastle.version>1.69</bouncycastle.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>


### PR DESCRIPTION
### Description of PR

HADOOP-17898 . BouncyCastle to 1.69

- CVEs are reported for releases lower than 1.66 
[CVE-2020-26939](https://nvd.nist.gov/vuln/detail/CVE-2020-26939) moderate severity
[CVE-2020-15522](https://nvd.nist.gov/vuln/detail/CVE-2020-15522) moderate severity 

### How was this patch tested?

- build locally succeeded
- `mvn dependency:tree`
- Looked into linked Jiras of HADOOP-15832 and reviewed the dependencies affected by the upgrade
-  I verified that they have no class errors as reported in YARN-8919 and YARN-8899
```bash
mvn test -Dtest=TestFileArgs,TestMultipleCachefiles,TestStreamingBadRecords,\
TestSymLink,TestMultipleArchiveFiles,TestGridmixSubmission,TestDistCacheEmulation,\
TestLoadJob,TestSleepJob,TestDistCh,TestCleanupAfterKIll

### For code changes:

- [X] the title or this PR starts with the corresponding JIRA issue id
- [X] updated `LICENSE-binary`

