### PR TITLE
HADOOP-17899. Avoid using implicit dependency on junit-jupiter-api.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/http/TestHttpFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/http/TestHttpFileSystem.java
@@ -25,8 +25,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
+
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 public class TestHttpFileSystem {
   private final Configuration conf = new Configuration(false);
 
-  @BeforeEach
+  @Before
   public void setUp() {
     conf.set("fs.http.impl", HttpFileSystem.class.getCanonicalName());
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17899

Compilation of branch-3.3 fails due to lack of transitive dependency existing in trunk.

```
[ERROR] /home/centos/srcs/hadoop/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/http/TestHttpFileSystem.java:[29,29] package org.junit.jupiter.api does not exist
[ERROR] /home/centos/srcs/hadoop/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/http/TestHttpFileSystem.java:[47,4] cannot find symbol
  symbol:   class BeforeEach
  location: class org.apache.hadoop.fs.http.TestHttpFileSystem
[INFO] 2 errors
```

junit-jupiter-api is transitive dependency of curator-test-5.2.0 in trunk. branch-3.3 using curator-test-4.2.0 does not have it. Existing tests of Hadoop are using JUnit 4. hadoop-common should avoid using implicit dependency on junit-jupiter-api until migration to JUnit 5 is done.