### PR TITLE
YARN-10917. Investigate and simplify CapacitySchedulerConfigValidator…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfigValidator.java
@@ -163,7 +163,8 @@ public final class CapacitySchedulerConfigValidator {
     }
   }
 
-  private static void validateParentQueueConversion(CSQueue oldQueue, CSQueue newQueue) throws IOException {
+  private static void validateParentQueueConversion(CSQueue oldQueue,
+                                                    CSQueue newQueue) throws IOException {
     if (oldQueue instanceof ParentQueue) {
       if (!(oldQueue instanceof ManagedParentQueue) && newQueue instanceof ManagedParentQueue) {
         throw new IOException(
@@ -189,7 +190,8 @@ public final class CapacitySchedulerConfigValidator {
     }
   }
 
-  private static void validateLeafQueueConversion(CSQueue oldQueue, CSQueue newQueue) throws IOException {
+  private static void validateLeafQueueConversion(CSQueue oldQueue,
+                                                  CSQueue newQueue) throws IOException {
     if (oldQueue instanceof LeafQueue && newQueue instanceof ParentQueue) {
       if (isEitherQueueStopped(oldQueue.getState(), newQueue.getState())) {
         LOG.info("Converting the leaf queue: {} to parent queue.", oldQueue.getQueuePath());


### PR DESCRIPTION
…#validateQueueHierarchy.

Change-Id: I721799bd66df45303e324153d8d042fd6b1edc8e

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


This was just a refactor, existing tests should cover this method.

I checked the if - elif statements, fortunately they did not utilise the previous if branch, proof:

```
  // if (oldQueue instanceof ParentQueue && !(oldQueue instanceof ManagedParentQueue) && newQueue instanceof ManagedParentQueue)
  // a: oldQueue instanceof ParentQueue
  // b: oldQueue instanceof ManagedParentQueue
  // c: newQueue instanceof ManagedParentQueue
  // a && !b && c                  --> a && !b && c

  // else if (oldQueue instanceof ManagedParentQueue && !(newQueue instanceof ManagedParentQueue))
  // !(a && !b && c) && (b && !c)  --> b && !c
  //                               --> (oldQueue instanceof ManagedParentQueue && !(newQueue instanceof ManagedParentQueue))

  // else if (oldQueue instanceof LeafQueue && newQueue instanceof ParentQueue)
  // d: oldQueue instanceof LeafQueue
  // !(!(a && !b && c) && (b && !c)) && (d && c)  --> c && d
  //                                              --> newQueue instanceof ManagedParentQueue && oldQueue instanceof LeafQueue


  // else if (oldQueue instanceof ParentQueue && newQueue instanceof LeafQueue)
  // e: newQueue instanceof LeafQueue
  // !(!(!(a && !b && c) && (b && !c)) && (d && c)) && (a && e)  --> (a && !c && e) || (a && !d && e)
  //                                                             --> (oldQueue instanceof ParentQueue && !(newQueue instanceof ManagedParentQueue) && newQueue instanceof LeafQueue) || (oldQueue instanceof ParentQueue && !(oldQueue instanceof LeafQueue) && newQueue instanceof LeafQueue)
  //                                                             --> (oldQueue instanceof ParentQueue && !(newQueue instanceof ManagedParentQueue) && newQueue instanceof LeafQueue) || (oldQueue instanceof ParentQueue && newQueue instanceof LeafQueue)
  //                                                             --> oldQueue instanceof ParentQueue && newQueue instanceof LeafQueue
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

