### PR TITLE
HADOOP-17900. Move ClusterStorageCapacityExceededException to Public from LimitedPrivate.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ClusterStorageCapacityExceededException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ClusterStorageCapacityExceededException.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.classification.InterfaceStability;
  * cluster filesystem is exceeded. See also
  * https://issues.apache.org/jira/browse/MAPREDUCE-7148.
  */
-@InterfaceAudience.LimitedPrivate({ "HDFS", "MapReduce", "Tez" })
+@InterfaceAudience.Public
 @InterfaceStability.Evolving
 public class ClusterStorageCapacityExceededException extends IOException {
   private static final long serialVersionUID = 1L;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DSQuotaExceededException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/DSQuotaExceededException.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import static org.apache.hadoop.util.StringUtils.TraditionalBinaryPrefix.long2String;
 
-@InterfaceAudience.Private
+@InterfaceAudience.Public
 @InterfaceStability.Evolving
 public class DSQuotaExceededException extends QuotaExceededException {
   protected static final long serialVersionUID = 1L;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/NSQuotaExceededException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/NSQuotaExceededException.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hdfs.protocol;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
-@InterfaceAudience.Private
+@InterfaceAudience.Public
 @InterfaceStability.Evolving
 public final class NSQuotaExceededException extends QuotaExceededException {
   protected static final long serialVersionUID = 1L;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/QuotaByStorageTypeExceededException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/QuotaByStorageTypeExceededException.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.StorageType;
 
 import static org.apache.hadoop.util.StringUtils.TraditionalBinaryPrefix.long2String;
 
-@InterfaceAudience.Private
+@InterfaceAudience.Public
 @InterfaceStability.Evolving
 public class QuotaByStorageTypeExceededException extends QuotaExceededException {
   protected static final long serialVersionUID = 1L;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/QuotaExceededException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/QuotaExceededException.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.ClusterStorageCapacityExceededException;
  *  DSQuotaExceededException or
  *  NSQuotaExceededException
  */
-@InterfaceAudience.Private
+@InterfaceAudience.Public
 @InterfaceStability.Evolving
 public class QuotaExceededException extends ClusterStorageCapacityExceededException {
   protected static final long serialVersionUID = 1L;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/FSLimitException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/FSLimitException.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hdfs.protocol;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
-@InterfaceAudience.Private
+@InterfaceAudience.Public
 @InterfaceStability.Evolving
 
 /**


### PR DESCRIPTION
### Description of PR
Makes ClusterStorageCapacityExceededException Public, Wanted to get this used for a retry logic to fail fast in Hive, But the LimitedPrivate Annotation doesn't let anyone else use it. I don't feel it is something which can harm if made Public, So, atleast in Future it can be used.

### How was this patch tested?
👀

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?