### PR TITLE
HADOOP-17563. Upgrade BouncyCastle to 1.69

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -468,8 +468,8 @@ com.microsoft.azure:azure-cosmosdb-gateway:2.4.5
 com.microsoft.azure:azure-data-lake-store-sdk:2.3.3
 com.microsoft.azure:azure-keyvault-core:1.0.0
 com.microsoft.sqlserver:mssql-jdbc:6.2.1.jre7
-org.bouncycastle:bcpkix-jdk15on:1.60
-org.bouncycastle:bcprov-jdk15on:1.60
+org.bouncycastle:bcpkix-jdk15on:1.69
+org.bouncycastle:bcprov-jdk15on:1.69
 org.checkerframework:checker-qual:2.5.2
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jruby.jcodings:jcodings:1.0.13

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -105,7 +105,7 @@
     <guava.version>27.0-jre</guava.version>
     <guice.version>4.2.3</guice.version>
 
-    <bouncycastle.version>1.60</bouncycastle.version>
+    <bouncycastle.version>1.69</bouncycastle.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-17563 . BouncyCastle to 1.69

- CVEs are reported for releases lower than 1.66 

### How was this patch tested?

- build locally succeeded `mvn clean install -Pdist -Dtar -DskipTests -Dmaven.javadoc`
- `mvn dependency:tree`
- Looked into linked Jiras of HADOOP-15832 and reviewed the dependencies affected by the upgrade
- Some of the the tests below are already timing out on the default branch. However, I verified that they have no class errors as reported in YARN-8919 and YARN-8899
```bash
mvn test -Dtest=TestFileArgs,TestMultipleCachefiles,TestStreamingBadRecords,\
TestSymLink,TestMultipleArchiveFiles,TestGridmixSubmission,TestDistCacheEmulation,\
TestLoadJob,TestSleepJob,TestDistCh,TestCleanupAfterKIll
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id
- [X] Updated README.txt

