### PR TITLE
HADOOP-17902. Fix Hadoop build on Debian 10

### DIFF
--- a/dev-support/docker/Dockerfile_debian_10
+++ b/dev-support/docker/Dockerfile_debian_10
@@ -29,11 +29,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 
-#####
-# For installing the latest packages
-#####
-RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list
-
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_TERSE true
 
@@ -41,16 +36,18 @@ ENV DEBCONF_TERSE true
 # Platform package dependency resolver
 ######
 COPY pkg-resolver pkg-resolver
-RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
-    && chmod a+r pkg-resolver/*.json
+RUN chmod a+x pkg-resolver/install-pkg-resolver.sh
+RUN pkg-resolver/install-pkg-resolver.sh debian:10
 
 ######
 # Install packages from apt
 ######
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends python3 \
     && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py debian:10) \
+    && echo 'deb http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list \
+    && apt-get -q update \
+    && apt-get -q install -y --no-install-recommends -t bullseye $(pkg-resolver/resolve.py --release=bullseye debian:10) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -85,7 +82,6 @@ ENV HADOOP_SKIP_YETUS_VERIFICATION true
 ####
 # Install packages
 ####
-RUN pkg-resolver/install-common-pkgs.sh
 RUN pkg-resolver/install-spotbugs.sh debian:10
 RUN pkg-resolver/install-boost.sh debian:10
 RUN pkg-resolver/install-protobuf.sh debian:10

--- a/dev-support/docker/pkg-resolver/install-pkg-resolver.sh
+++ b/dev-support/docker/pkg-resolver/install-pkg-resolver.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ $# -lt 1 ]; then
+  echo "ERROR: No platform specified, please specify one"
+  exit 1
+fi
+
+chmod a+x pkg-resolver/*.sh pkg-resolver/*.py
+chmod a+r pkg-resolver/*.json
+
+if [ "$1" == "debian:10" ]; then
+  apt-get -q update
+  apt-get -q install -y --no-install-recommends python3 \
+    python3-pip \
+    python3-pkg-resources \
+    python3-setuptools \
+    python3-wheel
+  pip3 install pylint==2.6.0 python-dateutil==2.8.1
+else
+  # Need to add the code for the rest of the platforms - HADOOP-17920
+  echo "ERROR: The given platform $1 is not yet supported or is invalid"
+  exit 1
+fi

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -122,10 +122,12 @@
     ]
   },
   "gcc": {
-    "debian:10": [
-      "gcc",
-      "g++"
-    ],
+    "debian:10": {
+      "bullseye": [
+        "gcc",
+        "g++"
+      ]
+    },
     "ubuntu:focal": [
       "gcc",
       "g++"

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
@@ -45,7 +45,6 @@ using ::testing::Return;
 
 using namespace hdfs;
 
-
 class MockReader : public BlockReader {
 public:
   MOCK_METHOD2(

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
@@ -45,6 +45,7 @@ using ::testing::Return;
 
 using namespace hdfs;
 
+
 class MockReader : public BlockReader {
 public:
   MOCK_METHOD2(


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
* Debian testing has unstable list of
  packages. Hence, switching to bullseye
  which is a standard Debian release.

### How was this patch tested?
The Hadoop CI has been able to build
and run the tests, confirming that there
aren't any issues with this change.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

