### PR TITLE
HADOOP-17901. Performance degradation in Text.append() after HADOOP-1…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -34,6 +34,7 @@ import java.text.StringCharacterIterator;
 import java.util.Arrays;
 
 import org.apache.avro.reflect.Stringable;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -300,7 +301,7 @@ public class Text extends BinaryComparable
    */
   private boolean ensureCapacity(final int capacity) {
     if (bytes.length < capacity) {
-      // Try to expand  the backing array by the factor of 1.5x  
+      // Try to expand the backing array by the factor of 1.5x
       // (by taking the current size + diving it by half)
       int targetSize = Math.max(capacity, bytes.length + (bytes.length >> 1));
       bytes = new byte[targetSize];

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -34,7 +34,6 @@ import java.text.StringCharacterIterator;
 import java.util.Arrays;
 
 import org.apache.avro.reflect.Stringable;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -268,8 +267,7 @@ public class Text extends BinaryComparable
    */
   public void append(byte[] utf8, int start, int len) {
     byte[] original = bytes;
-    int capacity = Math.max(length + len, length + (length >> 1));
-    if (ensureCapacity(capacity)) {
+    if (ensureCapacity(length + len)) {
       System.arraycopy(original, 0, bytes, 0, length);
     }
     System.arraycopy(utf8, start, bytes, length, len);
@@ -302,7 +300,8 @@ public class Text extends BinaryComparable
    */
   private boolean ensureCapacity(final int capacity) {
     if (bytes.length < capacity) {
-      bytes = new byte[capacity];
+      int targetSize = Math.max(capacity, bytes.length + (bytes.length >> 1));
+      bytes = new byte[targetSize];
       return true;
     }
     return false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -300,6 +300,8 @@ public class Text extends BinaryComparable
    */
   private boolean ensureCapacity(final int capacity) {
     if (bytes.length < capacity) {
+      // Try to expand  the backing array by the factor of 1.5x  
+      // (by taking the current size + diving it by half)
       int targetSize = Math.max(capacity, bytes.length + (bytes.length >> 1));
       bytes = new byte[targetSize];
       return true;


### PR DESCRIPTION
…6951.

Change-Id: I628380b6d29a2796d9d67bd38b423cdb1830bf04

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-16951 introduced a performance regression to Text.append(). The backing array is not increased as intended, which resulted in a lot of unnecessary new arrays.

### How was this patch tested?

Tried the change on a cluster, where a mapper successfully read a large text file (1.1GB) without slowing down.
Executed unit tests, which all passed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

