### PR TITLE
YARN-10938. Support reservation scheduling enabled switch for capacity scheduler

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/ResourceLimits.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/ResourceLimits.java
@@ -42,6 +42,7 @@ public class ResourceLimits {
   private Resource blockedHeadroom;
 
   private boolean allowPreempt = false;
+  private boolean allowReserve = true;
 
   public ResourceLimits(Resource limit) {
     this(limit, Resources.none());
@@ -83,6 +84,14 @@ public class ResourceLimits {
 
   public void setIsAllowPreemption(boolean allowPreempt) {
    this.allowPreempt = allowPreempt;
+  }
+
+  public boolean isAllowReservation() {
+    return allowReserve;
+  }
+
+  public void setAllowReservation(boolean allowReserve) {
+    this.allowReserve = allowReserve;
   }
 
   public void addBlockedHeadroom(Resource resource) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacityScheduler.java
@@ -234,6 +234,7 @@ public class CapacityScheduler extends
   private boolean multiNodePlacementEnabled;
 
   private boolean printedVerboseLoggingForAsyncScheduling;
+  private boolean reservationEnabled;
 
   /**
    * EXPERT
@@ -387,6 +388,8 @@ public class CapacityScheduler extends
             this.conf.getMultiNodePlacementPolicies());
       }
 
+      reservationEnabled = this.conf.isReservationEnabled();
+
       LOG.info("Initialized CapacityScheduler with " + "calculator="
           + getResourceCalculator().getClass() + ", " + "minimumAllocation="
           + getMinimumResourceCapability() + ", " + "maximumAllocation="
@@ -396,7 +399,8 @@ public class CapacityScheduler extends
           + multiNodePlacementEnabled + ", " + "assignMultipleEnabled="
           + assignMultipleEnabled + ", " + "maxAssignPerHeartbeat="
           + maxAssignPerHeartbeat + ", " + "offswitchPerHeartbeatLimit="
-          + offswitchPerHeartbeatLimit);
+          + offswitchPerHeartbeatLimit + ", " + "reservationEnabled="
+          + reservationEnabled);
     } finally {
       writeLock.unlock();
     }
@@ -3446,5 +3450,9 @@ public class CapacityScheduler extends
   @VisibleForTesting
   public void setQueueManager(CapacitySchedulerQueueManager qm) {
     this.queueManager = qm;
+  }
+
+  public boolean isReservationEnabled() {
+    return reservationEnabled;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -140,6 +140,12 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public static final String DEFAULT_NODE_LABEL_EXPRESSION =
       "default-node-label-expression";
 
+  @Private
+  public static final String RESERVATION_ENABLED = PREFIX + "reservation.enabled";
+
+  @Private
+  public static final boolean DEFAULT_RESERVATION_ENABLED = true;
+
   public static final String RESERVE_CONT_LOOK_ALL_NODES = PREFIX
       + "reservations-continue-look-all-nodes";
 
@@ -855,6 +861,10 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
       String label, float percent) {
     setFloat(getNodeLabelPrefix(queue, label)
         + MAXIMUM_AM_RESOURCE_SUFFIX, percent);
+  }
+
+  public boolean isReservationEnabled() {
+    return getBoolean(RESERVATION_ENABLED, DEFAULT_RESERVATION_ENABLED);
   }
 
   /*

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerContext.java
@@ -97,6 +97,12 @@ public interface CapacitySchedulerContext {
   boolean isConfigurationMutable();
 
   /**
+   * Returns if reservation scheduling is enabled.
+   * @return if reservation scheduling is enabled
+   */
+  boolean isReservationEnabled();
+
+  /**
    * Get clock from scheduler
    * @return Clock
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -1160,6 +1160,7 @@ public class LeafQueue extends AbstractCSQueue {
     }
 
     setPreemptionAllowed(currentResourceLimits, candidates.getPartition());
+    currentResourceLimits.setAllowReservation(csContext.isReservationEnabled());
 
     // Check for reserved resources, try to allocate reserved container first.
     CSAssignment assignment = allocateFromReservedContainer(clusterResource,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
@@ -622,7 +622,8 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
     } else {
       // if we are allowed to allocate but this node doesn't have space, reserve
       // it or if this was an already a reserved container, reserve it again
-      if (shouldAllocOrReserveNewContainer || rmContainer != null) {
+      if (currentResoureLimits.isAllowReservation() &&
+              (shouldAllocOrReserveNewContainer || rmContainer != null)) {
         if (reservationsContinueLooking && rmContainer == null) {
           // we could possibly ignoring queue capacity or user limits when
           // reservationsContinueLooking is set. Make sure we didn't need to

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -218,6 +218,7 @@ public class TestLeafQueue {
     containerTokenSecretManager.rollMasterKey();
     when(csContext.getContainerTokenSecretManager()).thenReturn(
         containerTokenSecretManager);
+    when(csContext.isReservationEnabled()).thenReturn(true);
 
     root = 
         CapacitySchedulerQueueManager.parseQueue(csContext, csConf, null,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservations.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestReservations.java
@@ -1585,9 +1585,8 @@ public class TestReservations {
   }
 
   @Test
-  public void testDynamicReservationSwitch() throws Exception {
-    CapacitySchedulerConfiguration csConf =
-            new CapacitySchedulerConfiguration();
+  public void testReservationSwitch() throws Exception {
+    CapacitySchedulerConfiguration csConf = new CapacitySchedulerConfiguration();
     csConf.setBoolean(CapacitySchedulerConfiguration.RESERVATION_ENABLED, false);
     setup(csConf);
 
@@ -1595,156 +1594,140 @@ public class TestReservations {
     LeafQueue a = stubLeafQueue((LeafQueue) queues.get(A));
 
     // Users
-    final String user_0 = "user_0";
+    final String user0 = "user_0";
 
     // Submit applications
-    final ApplicationAttemptId appAttemptId_0 = TestUtils
+    final ApplicationAttemptId appAttemptId0 = TestUtils
             .getMockApplicationAttemptId(0, 0);
-    FiCaSchedulerApp app_0 = new FiCaSchedulerApp(appAttemptId_0, user_0, a,
+    FiCaSchedulerApp app0 = new FiCaSchedulerApp(appAttemptId0, user0, a,
             mock(ActiveUsersManager.class), spyRMContext);
-    app_0 = spy(app_0);
-    Mockito.doNothing().when(app_0).updateAMContainerDiagnostics(any(AMState.class),
+    app0 = spy(app0);
+    Mockito.doNothing().when(app0).updateAMContainerDiagnostics(any(AMState.class),
             any(String.class));
-    rmContext.getRMApps().put(app_0.getApplicationId(), mock(RMApp.class));
+    rmContext.getRMApps().put(app0.getApplicationId(), mock(RMApp.class));
+    a.submitApplicationAttempt(app0, user0);
 
-    a.submitApplicationAttempt(app_0, user_0);
-
-    final ApplicationAttemptId appAttemptId_1 = TestUtils
+    final ApplicationAttemptId appAttemptId1 = TestUtils
             .getMockApplicationAttemptId(1, 0);
-    FiCaSchedulerApp app_1 = new FiCaSchedulerApp(appAttemptId_1, user_0, a,
+    FiCaSchedulerApp app1 = new FiCaSchedulerApp(appAttemptId1, user0, a,
             mock(ActiveUsersManager.class), spyRMContext);
-    app_1 = spy(app_1);
-    Mockito.doNothing().when(app_1).updateAMContainerDiagnostics(any(AMState.class),
+    app1 = spy(app1);
+    Mockito.doNothing().when(app1).updateAMContainerDiagnostics(any(AMState.class),
             any(String.class));
-    a.submitApplicationAttempt(app_1, user_0);
+    a.submitApplicationAttempt(app1, user0);
 
     // Setup some nodes
-    String host_0 = "host_0";
-    FiCaSchedulerNode node_0 = TestUtils.getMockNode(host_0, DEFAULT_RACK, 0,
-            8 * GB);
-    String host_1 = "host_1";
-    FiCaSchedulerNode node_1 = TestUtils.getMockNode(host_1, DEFAULT_RACK, 0,
-            8 * GB);
-    String host_2 = "host_2";
-    FiCaSchedulerNode node_2 = TestUtils.getMockNode(host_2, DEFAULT_RACK, 0,
-            8 * GB);
+    String host0 = "host_0";
+    FiCaSchedulerNode node0 = TestUtils.getMockNode(host0, DEFAULT_RACK, 0, 8 * GB);
+    String host1 = "host_1";
+    FiCaSchedulerNode node1 = TestUtils.getMockNode(host1, DEFAULT_RACK, 0, 8 * GB);
+    String host2 = "host_2";
+    FiCaSchedulerNode node2 = TestUtils.getMockNode(host2, DEFAULT_RACK, 0, 8 * GB);
 
     Map<ApplicationAttemptId, FiCaSchedulerApp> apps = ImmutableMap.of(
-            app_0.getApplicationAttemptId(), app_0, app_1.getApplicationAttemptId(),
-            app_1);
-    Map<NodeId, FiCaSchedulerNode> nodes = ImmutableMap.of(node_0.getNodeID(),
-            node_0, node_1.getNodeID(), node_1, node_2.getNodeID(), node_2);
+            app0.getApplicationAttemptId(), app0, app1.getApplicationAttemptId(), app1);
+    Map<NodeId, FiCaSchedulerNode> nodes = ImmutableMap.of(node0.getNodeID(),
+            node0, node1.getNodeID(), node1, node2.getNodeID(), node2);
 
-    when(csContext.getNode(node_0.getNodeID())).thenReturn(node_0);
-    when(csContext.getNode(node_1.getNodeID())).thenReturn(node_1);
-    when(csContext.getNode(node_2.getNodeID())).thenReturn(node_2);
-
-    cs.getNodeTracker().addNode(node_0);
-    cs.getNodeTracker().addNode(node_1);
-    cs.getNodeTracker().addNode(node_2);
+    when(csContext.getNode(node0.getNodeID())).thenReturn(node0);
+    when(csContext.getNode(node1.getNodeID())).thenReturn(node1);
+    when(csContext.getNode(node2.getNodeID())).thenReturn(node2);
+    cs.getNodeTracker().addNode(node0);
+    cs.getNodeTracker().addNode(node1);
+    cs.getNodeTracker().addNode(node2);
 
     final int numNodes = 3;
     Resource clusterResource = Resources.createResource(numNodes * (8 * GB));
     when(csContext.getNumClusterNodes()).thenReturn(numNodes);
-    root.updateClusterResource(clusterResource,
-            new ResourceLimits(clusterResource));
+    root.updateClusterResource(clusterResource, new ResourceLimits(clusterResource));
 
     // Setup resource-requests
     Priority priorityAM = TestUtils.createMockPriority(1);
     Priority priorityMap = TestUtils.createMockPriority(5);
     Priority priorityReduce = TestUtils.createMockPriority(10);
 
-    app_0.updateResourceRequests(Collections.singletonList(TestUtils
+    app0.updateResourceRequests(Collections.singletonList(TestUtils
             .createResourceRequest(ResourceRequest.ANY, 2 * GB, 1, true,
                     priorityAM, recordFactory)));
-    app_0.updateResourceRequests(Collections.singletonList(TestUtils
+    app0.updateResourceRequests(Collections.singletonList(TestUtils
             .createResourceRequest(ResourceRequest.ANY, 5 * GB, 2, true,
                     priorityReduce, recordFactory)));
-    app_0.updateResourceRequests(Collections.singletonList(TestUtils
+    app0.updateResourceRequests(Collections.singletonList(TestUtils
             .createResourceRequest(ResourceRequest.ANY, 3 * GB, 2, true,
                     priorityMap, recordFactory)));
 
     // Start testing...
     // Only AM
     TestUtils.applyResourceCommitRequest(clusterResource,
-            a.assignContainers(clusterResource, node_0,
+            a.assignContainers(clusterResource, node0,
                     new ResourceLimits(clusterResource),
                     SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY), nodes, apps);
     assertEquals(2 * GB, a.getUsedResources().getMemorySize());
-    assertEquals(2 * GB, app_0.getCurrentConsumption().getMemorySize());
-    assertEquals(0 * GB, a.getMetrics().getReservedMB());
+    assertEquals(2 * GB, app0.getCurrentConsumption().getMemorySize());
     assertEquals(2 * GB, a.getMetrics().getAllocatedMB());
     assertEquals(22 * GB, a.getMetrics().getAvailableMB());
-    assertEquals(2 * GB, node_0.getAllocatedResource().getMemorySize());
-    assertEquals(0 * GB, node_1.getAllocatedResource().getMemorySize());
-    assertEquals(0 * GB, node_2.getAllocatedResource().getMemorySize());
+    assertEquals(2 * GB, node0.getAllocatedResource().getMemorySize());
 
     // Only 1 map - simulating reduce
     TestUtils.applyResourceCommitRequest(clusterResource,
-            a.assignContainers(clusterResource, node_0,
+            a.assignContainers(clusterResource, node0,
                     new ResourceLimits(clusterResource),
                     SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY), nodes, apps);
     assertEquals(5 * GB, a.getUsedResources().getMemorySize());
-    assertEquals(5 * GB, app_0.getCurrentConsumption().getMemorySize());
-    assertEquals(0 * GB, a.getMetrics().getReservedMB());
+    assertEquals(5 * GB, app0.getCurrentConsumption().getMemorySize());
     assertEquals(5 * GB, a.getMetrics().getAllocatedMB());
     assertEquals(19 * GB, a.getMetrics().getAvailableMB());
-    assertEquals(5 * GB, node_0.getAllocatedResource().getMemorySize());
-    assertEquals(0 * GB, node_1.getAllocatedResource().getMemorySize());
-    assertEquals(0 * GB, node_2.getAllocatedResource().getMemorySize());
+    assertEquals(5 * GB, node0.getAllocatedResource().getMemorySize());
 
     // Only 1 map to other node - simulating reduce
     TestUtils.applyResourceCommitRequest(clusterResource,
-            a.assignContainers(clusterResource, node_1,
+            a.assignContainers(clusterResource, node1,
                     new ResourceLimits(clusterResource),
                     SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY), nodes, apps);
     assertEquals(8 * GB, a.getUsedResources().getMemorySize());
-    assertEquals(8 * GB, app_0.getCurrentConsumption().getMemorySize());
+    assertEquals(8 * GB, app0.getCurrentConsumption().getMemorySize());
     assertEquals(0 * GB, a.getMetrics().getReservedMB());
     assertEquals(8 * GB, a.getMetrics().getAllocatedMB());
     assertEquals(16 * GB, a.getMetrics().getAvailableMB());
-    assertEquals(16 * GB, app_0.getHeadroom().getMemorySize());
-    assertEquals(null, node_0.getReservedContainer());
-    assertEquals(5 * GB, node_0.getAllocatedResource().getMemorySize());
-    assertEquals(3 * GB, node_1.getAllocatedResource().getMemorySize());
-    assertEquals(0 * GB, node_2.getAllocatedResource().getMemorySize());
-    assertEquals(2, app_0.getOutstandingAsksCount(
-            toSchedulerKey(priorityReduce)));
+    assertEquals(16 * GB, app0.getHeadroom().getMemorySize());
+    assertEquals(null, node0.getReservedContainer());
+    assertEquals(5 * GB, node0.getAllocatedResource().getMemorySize());
+    assertEquals(3 * GB, node1.getAllocatedResource().getMemorySize());
+    assertEquals(0 * GB, node2.getAllocatedResource().getMemorySize());
+    assertEquals(2, app0.getOutstandingAsksCount(toSchedulerKey(priorityReduce)));
 
     // try to assign reducer (5G on node 0 and should not reserve)
     TestUtils.applyResourceCommitRequest(clusterResource,
-            a.assignContainers(clusterResource, node_0,
+            a.assignContainers(clusterResource, node0,
                     new ResourceLimits(clusterResource),
                     SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY), nodes, apps);
     assertEquals(8 * GB, a.getUsedResources().getMemorySize());
-    assertEquals(8 * GB, app_0.getCurrentConsumption().getMemorySize());
+    assertEquals(8 * GB, app0.getCurrentConsumption().getMemorySize());
     assertEquals(0 * GB, a.getMetrics().getReservedMB());
     assertEquals(8 * GB, a.getMetrics().getAllocatedMB());
     assertEquals(16 * GB, a.getMetrics().getAvailableMB());
-    assertEquals(16 * GB, app_0.getHeadroom().getMemorySize());
-    assertEquals(null, node_0.getReservedContainer());
-    assertEquals(5 * GB, node_0.getAllocatedResource().getMemorySize());
-    assertEquals(3 * GB, node_1.getAllocatedResource().getMemorySize());
-    assertEquals(0 * GB, node_2.getAllocatedResource().getMemorySize());
-    assertEquals(2, app_0.getOutstandingAsksCount(
-            toSchedulerKey(priorityReduce)));
+    assertEquals(16 * GB, app0.getHeadroom().getMemorySize());
+    assertEquals(null, node0.getReservedContainer());
+    assertEquals(5 * GB, node0.getAllocatedResource().getMemorySize());
+    assertEquals(3 * GB, node1.getAllocatedResource().getMemorySize());
+    assertEquals(0 * GB, node2.getAllocatedResource().getMemorySize());
+    assertEquals(2, app0.getOutstandingAsksCount(toSchedulerKey(priorityReduce)));
 
     // assign reducer to node 2
     TestUtils.applyResourceCommitRequest(clusterResource,
-            a.assignContainers(clusterResource, node_2,
+            a.assignContainers(clusterResource, node2,
                     new ResourceLimits(clusterResource),
                     SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY), nodes, apps);
     assertEquals(13 * GB, a.getUsedResources().getMemorySize());
-    assertEquals(13 * GB, app_0.getCurrentConsumption().getMemorySize());
+    assertEquals(13 * GB, app0.getCurrentConsumption().getMemorySize());
     assertEquals(0 * GB, a.getMetrics().getReservedMB());
     assertEquals(13 * GB, a.getMetrics().getAllocatedMB());
     assertEquals(11 * GB, a.getMetrics().getAvailableMB());
-    assertEquals(11 * GB, app_0.getHeadroom().getMemorySize());
-    assertEquals(null, node_0.getReservedContainer());
-    assertEquals(5 * GB, node_0.getAllocatedResource().getMemorySize());
-    assertEquals(3 * GB, node_1.getAllocatedResource().getMemorySize());
-    assertEquals(5 * GB, node_2.getAllocatedResource().getMemorySize());
-    assertEquals(1, app_0.getOutstandingAsksCount(
-            toSchedulerKey(priorityReduce)));
+    assertEquals(11 * GB, app0.getHeadroom().getMemorySize());
+    assertEquals(null, node0.getReservedContainer());
+    assertEquals(5 * GB, node0.getAllocatedResource().getMemorySize());
+    assertEquals(3 * GB, node1.getAllocatedResource().getMemorySize());
+    assertEquals(5 * GB, node2.getAllocatedResource().getMemorySize());
+    assertEquals(1, app0.getOutstandingAsksCount(toSchedulerKey(priorityReduce)));
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently the CapacityScheduler uses reservations in order to handle requests for large containers and the fact there might not currently be enough space available on a single host. But this algorithm is not suitable for small cluster which only have very limited resources. So we can add a switch property in capacity scheduler's configuration to avoid reservation scheduling in these use cases.

CHANGES:

Add "yarn.scheduler.capacity.reservation.enabled" in capacity scheduler's configuration.

### How was this patch tested?
Add a unit test for switch in resourcemanager.scheduler.capacity.TestReservations

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

