### PR TITLE
HDFS-16216. RBF: Wrong path when get mount point status

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -846,7 +846,7 @@ public class RouterClientProtocol implements ClientProtocol {
         }
         Path childPath = new Path(src, child);
         HdfsFileStatus dirStatus =
-            getMountPointStatus(childPath.toString(), 0, date);
+            getMountPointStatus(childPath.toString(), 0, date, true);
 
         // if there is no subcluster path, always add mount point
         if (lastName == null) {
@@ -919,10 +919,10 @@ public class RouterClientProtocol implements ClientProtocol {
         if (dates != null && dates.containsKey(src)) {
           date = dates.get(src);
         }
-        ret = getMountPointStatus(src, children.size(), date);
+        ret = getMountPointStatus(src, children.size(), date, false);
       } else if (children != null) {
         // The src is a mount point, but there are no files or directories
-        ret = getMountPointStatus(src, 0, 0);
+        ret = getMountPointStatus(src, 0, 0, false);
       }
     }
 
@@ -1983,11 +1983,12 @@ public class RouterClientProtocol implements ClientProtocol {
    * @param name Name of the mount point.
    * @param childrenNum Number of children.
    * @param date Map with the dates.
+   * @param appendName If append name.
    * @return New HDFS file status representing a mount point.
    */
   @VisibleForTesting
   HdfsFileStatus getMountPointStatus(
-      String name, int childrenNum, long date) {
+      String name, int childrenNum, long date, boolean appendName) {
     long modTime = date;
     long accessTime = date;
     FsPermission permission = FsPermission.getDirDefault();
@@ -2038,7 +2039,7 @@ public class RouterClientProtocol implements ClientProtocol {
     }
     long inodeId = 0;
     Path path = new Path(name);
-    String nameStr = path.getName();
+    String nameStr = appendName ? path.getName() : "";
     return new HdfsFileStatus.Builder()
         .isdir(true)
         .mtime(modTime)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
@@ -356,22 +356,29 @@ public class TestRouterMountTable {
     String child = "testA";
     Path childPath = new Path(src, child);
     HdfsFileStatus dirStatus =
-        clientProtocol.getMountPointStatus(childPath.toString(), 0, 0);
+        clientProtocol.getMountPointStatus(childPath.toString(), 0, 0, true);
     assertEquals(child, dirStatus.getLocalName());
 
     String src1 = "/testA";
     String child1 = "testB";
     Path childPath1 = new Path(src1, child1);
     HdfsFileStatus dirStatus1 =
-        clientProtocol.getMountPointStatus(childPath1.toString(), 0, 0);
+        clientProtocol.getMountPointStatus(childPath1.toString(), 0, 0, true);
     assertEquals(child1, dirStatus1.getLocalName());
 
     String src2 = "/testA/testB";
     String child2 = "testC";
     Path childPath2 = new Path(src2, child2);
     HdfsFileStatus dirStatus2 =
-        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0);
+        clientProtocol.getMountPointStatus(childPath2.toString(), 0, 0, true);
     assertEquals(child2, dirStatus2.getLocalName());
+
+    String src3 = "/testA/testB/testC";
+    String child3 = "testD";
+    Path childPath3 = new Path(src3, child3);
+    HdfsFileStatus dirStatus3 =
+        clientProtocol.getMountPointStatus(childPath3.toString(), 0, 0, false);
+    assertTrue(dirStatus3.getLocalName().length() == 0);
   }
   /**
    * GetListing of testPath through router.
@@ -762,5 +769,32 @@ public class TestRouterMountTable {
     } finally {
       nnFs0.delete(new Path("/testLsMountEntryDest"), true);
     }
+  }
+
+
+  @Test
+  public void testGetMountPointFileStatus() throws Exception {
+
+    // Add a read only entry
+    MountTable test = MountTable.newInstance(
+        "/test", Collections.singletonMap("ns0", "/empty"));
+    assertTrue(addMountTable(test));
+    MountTable testFull= MountTable.newInstance(
+        "/test/test1/test2/test3", Collections.singletonMap("ns0", "/empty"));
+    assertTrue(addMountTable(testFull));
+
+
+    FileStatus status =
+        routerFs.getFileStatus(new Path("/test"));
+    assertEquals("/test", status.getPath().toUri().getPath());
+
+    status = routerFs.getFileStatus(new Path("/test/test1"));
+    assertEquals("/test/test1", status.getPath().toUri().getPath());
+
+    status = routerFs.getFileStatus(new Path("/test/test1/test2"));
+    assertEquals("/test/test1/test2", status.getPath().toUri().getPath());
+
+    status = routerFs.getFileStatus(new Path("/test/test1/test2/test3"));
+    assertEquals("/test/test1/test2/test3", status.getPath().toUri().getPath());
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/HDFS-16216

### How was this patch tested?
UT.  TestRouterMountTable.testGetMountPointFileStatus

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

