### PR TITLE
HDFS-16220.[FGL]Configurable INodeMap#NAMESPACE_KEY_DEPTH&NUM_RANGES_STATIC.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PartitionedGSet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PartitionedGSet.java
@@ -275,6 +275,10 @@ public class PartitionedGSet<K, E extends K> implements GSet<K, E> {
     return new EntryIterator();
   }
 
+  public Set<K> entryKeySet() {
+    return partitions.keySet();
+  }
+
   /**
    * Iterator over the elements in the set.
    * Iterates first by keys, then inside the partition

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -979,6 +979,13 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String  DFS_NAMENODE_INODE_ATTRIBUTES_PROVIDER_BYPASS_USERS_KEY = "dfs.namenode.inode.attributes.provider.bypass.users";
   public static final String  DFS_NAMENODE_INODE_ATTRIBUTES_PROVIDER_BYPASS_USERS_DEFAULT = "";
 
+  public static final String  DFS_NAMENODE_INOD_NAMESPACE_KEY_DEPTH =
+      "dfs.namenode.inode.namespace.key.depth";
+  public static final int     DFS_NAMENODE_INOD_NAMESPACE_KEY_DEPTH_DEFAULT = 2;
+  public static final String  DFS_NAMENODE_INOD_NUM_RANGES =
+      "dfs.namenode.inode.num.ranges";
+  public static final long    DFS_NAMENODE_INOD_NUM_RANGES_DEFAULT = 256;
+
   public static final String  DFS_DATANODE_BP_READY_TIMEOUT_KEY = "dfs.datanode.bp-ready.timeout";
   public static final long    DFS_DATANODE_BP_READY_TIMEOUT_DEFAULT = 20;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -324,7 +324,7 @@ public class FSDirectory implements Closeable {
   FSDirectory(FSNamesystem ns, Configuration conf) throws IOException {
     this.inodeId = new INodeId();
     rootDir = createRoot(ns);
-    inodeMap = INodeMap.newInstance(rootDir, ns);
+    inodeMap = INodeMap.newInstance(rootDir, ns, conf);
     tempInodeMap = new HashMap<>(1000);
 
     // add rootDir to inodeMapTemp.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
@@ -608,7 +608,7 @@ public abstract class INode implements INodeAttributes, Diff.Element<byte[]> {
       return key[0];
     }
     long idx = LARGE_PRIME * key[0];
-    idx = (idx ^ (idx >> 32)) & (INodeMap.NUM_RANGES_STATIC -1);
+    idx = (idx ^ (idx >> 32)) & (INodeMap.getNumRanges() -1);
     return idx;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -5153,6 +5153,25 @@
 </property>
 
 <property>
+  <name>dfs.namenode.inode.namespace.key.depth</name>
+  <value>2</value>
+  <description>
+    Defines a finite number of parent keys for INodeIdKey.
+    For example, if the value is 2, INodeIdKey can be represented as :
+    '{RootINodeId, parentINodeId, selfINodeId}'.
+  </description>
+</property>
+
+<property>
+  <name>dfs.namenode.inode.num.ranges</name>
+  <value>256</value>
+  <description>
+    Defines the initial number of PartitionedEntries that a PartitionedGSet
+    contains, usually a power of 2.
+  </description>
+</property>
+
+<property>
   <name>dfs.namenode.max-num-blocks-to-log</name>
   <value>1000</value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeMap.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.namenode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test {@link INodeMap}.
+ */
+public class TestINodeMap {
+  public static final Logger LOG =
+    LoggerFactory.getLogger(TestINodeMap.class);
+
+  @Test
+  public void testSpaceKeyDepthAndNumRanges() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_INOD_NAMESPACE_KEY_DEPTH, 3);
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_INOD_NUM_RANGES, 128);
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+      cluster.waitActive();
+      FSNamesystem fsn = cluster.getNamesystem();
+      FSDirectory fsDirectory = new FSDirectory(fsn, conf);
+      assertTrue(fsDirectory.getINodeMap() != null);
+      assertEquals(INodeMap.getNumRanges(), 128);
+      assertEquals(INodeMap.getNumSpaceKeyDepth(), 3);
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testRangeKeys() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_INOD_NAMESPACE_KEY_DEPTH, 4);
+    conf.setLong(DFSConfigKeys.DFS_NAMENODE_INOD_NUM_RANGES, 8);
+    MiniDFSCluster cluster = null;
+    try {
+      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+      cluster.waitActive();
+      FSNamesystem fsn = cluster.getNamesystem();
+      FSDirectory fsDirectory = new FSDirectory(fsn, conf);
+      INodeMap iNodeMap = fsDirectory.getINodeMap();
+      int level = 0;
+      for (Iterator<INode> it = iNodeMap.rangeKeys().iterator(); it.hasNext();) {
+        INode inode = it.next();
+        long[] namespaceKey = inode.getNamespaceKey(4);
+        assertEquals(level, namespaceKey[0]);
+        assertEquals(0, namespaceKey[1]);
+        assertEquals(0, namespaceKey[2]);
+        assertEquals(INodeId.ROOT_INODE_ID, namespaceKey[3]);
+        level++;
+      }
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+}


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
INodeMap#NAMESPACE_KEY_DEPTH&NUM_RANGES_STATIC is configurable.


### How was this patch tested?
INodeMap#NAMESPACE_KEY_DEPTH and NUM_RANGES_STATIC can be successfully obtained after changing the values of INodeMap#NAMESPACE_KEY_DEPTH and NUM_RANGES_STATIC in the Configuration.

jira:HDFS-16220
