### PR TITLE
HADOOP-17905. Modify Text.ensureCapacity() to efficiently max out the…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -34,7 +34,6 @@ import java.text.StringCharacterIterator;
 import java.util.Arrays;
 
 import org.apache.avro.reflect.Stringable;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -73,7 +72,7 @@ public class Text extends BinaryComparable
     }
   };
 
-  // max size of the byte array, seems to be a safe choice for multiple VMs
+  // max size of the byte array, seems to be a safe choice for multiple JVMs
   // (see ArrayList.MAX_ARRAY_SIZE)
   private static final int ARRAY_MAX_SIZE = Integer.MAX_VALUE - 8;
 
@@ -305,17 +304,15 @@ public class Text extends BinaryComparable
    */
   private boolean ensureCapacity(final int capacity) {
     if (bytes.length < capacity) {
-      // use long to allow overflow
-      long tmpLength = bytes.length;
-      long tmpCapacity = capacity;
-
       // Try to expand the backing array by the factor of 1.5x
       // (by taking the current size + diving it by half).
       //
       // If the calculated value is beyond the size
       // limit, we cap it to ARRAY_MAX_SIZE
+
       int targetSize = (int)Math.min(ARRAY_MAX_SIZE,
-          Math.max(tmpCapacity, tmpLength + (tmpLength >> 1)));
+          Math.max((long)capacity,
+              (long) bytes.length + (bytes.length >> 1)));
 
       bytes = new byte[targetSize];
       return true;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -310,9 +310,9 @@ public class Text extends BinaryComparable
       // If the calculated value is beyond the size
       // limit, we cap it to ARRAY_MAX_SIZE
 
-      int targetSize = (int)Math.min(ARRAY_MAX_SIZE,
-          Math.max((long)capacity,
-              (long) bytes.length + (bytes.length >> 1)));
+      long targetSizeLong = bytes.length + (bytes.length >> 1);
+      int targetSize = (int)Math.min(targetSizeLong, ARRAY_MAX_SIZE);
+      targetSize = Math.max(capacity, targetSize);
 
       bytes = new byte[targetSize];
       return true;


### PR DESCRIPTION
… backing array size

Change-Id: I3cfae85000c5fa7aa86c40c2d7efa282958178bf

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Allow org.apache.hadoop.io.Text to expand the underlying byte array to a safe maximum. 

### How was this patch tested?

1. Ran unit tests
2. Ran a MapReduce job where a single mapper processed a text file with a size of 1.8G with no line feeds. Array expansion was verified with extra printouts.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

