### PR TITLE
HDFS-16227. De-flake TestMover#testMoverWithStripedFile

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
@@ -970,7 +970,8 @@ public class TestMover {
         for (LocatedBlock lb : blocks.getLocatedBlocks()) {
           for (StorageType type : lb.getStorageTypes()) {
             if (!StorageType.ARCHIVE.equals(type)) {
-              LOG.info("Block {} has unexpected StorageType: {}",
+              LOG.info("Block {} has StorageType: {}. It might not have been "
+                      + "updated yet, awaiting the latest update.",
                   lb.getBlock().toString(), type);
               return false;
             }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
@@ -872,7 +872,6 @@ public class TestMover {
   public void testMoverWithStripedFile() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConfWithStripe(conf);
-
     // start 10 datanodes
     int numOfDatanodes =10;
     int storagesPerDatanode=2;
@@ -1000,7 +999,6 @@ public class TestMover {
               { StorageType.SSD, StorageType.DISK } },
           true, null, null, null, capacities, null, false, false, false, null);
       cluster.triggerHeartbeats();
-
       // move file blocks to ONE_SSD policy
       client.setStoragePolicy(barDir, "ONE_SSD");
 


### PR DESCRIPTION
### Description of PR
TestMover#testMoverWithStripedFile fails intermittently with stacktrace:
```
[ERROR] testMoverWithStripedFile(org.apache.hadoop.hdfs.server.mover.TestMover)  Time elapsed: 48.439 s  <<< FAILURE!
java.lang.AssertionError: expected:<ARCHIVE> but was:<DISK>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.hadoop.hdfs.server.mover.TestMover.testMoverWithStripedFile(TestMover.java:965)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```
Example of this flaky behaviour: https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-3386/6/artifact/out/patch-unit-hadoop-hdfs-project_hadoop-hdfs.txt

### How was this patch tested?
Introduced wait until Namenode reports correct storage type for all blocks of given file as there might be some delay in the reporting.