### PR TITLE
HDFS-16217. RBF: Set default value of hdfs.fedbalance.procedure.scheduler.journal.uri by adding appropriate config resources

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/DFSRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/DFSRouter.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.service.CompositeService.CompositeServiceShutdownHook;
+import org.apache.hadoop.tools.fedbalance.FedBalance;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
@@ -66,6 +67,8 @@ public final class DFSRouter {
           new CompositeServiceShutdownHook(router), SHUTDOWN_HOOK_PRIORITY);
 
       Configuration conf = new HdfsConfiguration();
+      conf.addResource(FedBalance.FED_BALANCE_DEFAULT_XML);
+      conf.addResource(FedBalance.FED_BALANCE_SITE_XML);
       router.init(conf);
       router.start();
     } catch (Throwable e) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/DFSRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/DFSRouter.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+
 import static org.apache.hadoop.util.ExitUtil.terminate;
 
 import org.apache.hadoop.conf.Configuration;
@@ -66,9 +68,7 @@ public final class DFSRouter {
       ShutdownHookManager.get().addShutdownHook(
           new CompositeServiceShutdownHook(router), SHUTDOWN_HOOK_PRIORITY);
 
-      Configuration conf = new HdfsConfiguration();
-      conf.addResource(FedBalance.FED_BALANCE_DEFAULT_XML);
-      conf.addResource(FedBalance.FED_BALANCE_SITE_XML);
+      Configuration conf = getConfiguration();
       router.init(conf);
       router.start();
     } catch (Throwable e) {
@@ -76,4 +76,13 @@ public final class DFSRouter {
       terminate(1, e);
     }
   }
+
+  @VisibleForTesting
+  static Configuration getConfiguration() {
+    Configuration conf = new HdfsConfiguration();
+    conf.addResource(FedBalance.FED_BALANCE_DEFAULT_XML);
+    conf.addResource(FedBalance.FED_BALANCE_SITE_XML);
+    return conf;
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -436,7 +436,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       URI journalUri;
       try {
         journalUri = new URI(sConf.get(SCHEDULER_JOURNAL_URI));
-      } catch (URISyntaxException e) {
+      } catch (URISyntaxException | NullPointerException e) {
         throw new IOException("Bad journal uri. Please check configuration for "
             + SCHEDULER_JOURNAL_URI);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DN_R
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_OPTION;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_OPTION_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RouterFederationRename.RouterRenameOption;
+import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.DEFAULT_SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 
 import java.io.FileNotFoundException;
@@ -435,7 +436,8 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       Configuration sConf = new Configuration(conf);
       URI journalUri;
       try {
-        journalUri = new URI(sConf.get(SCHEDULER_JOURNAL_URI));
+        journalUri = new URI(
+            sConf.get(SCHEDULER_JOURNAL_URI, DEFAULT_SCHEDULER_JOURNAL_URI));
       } catch (URISyntaxException e) {
         throw new IOException("Bad journal uri. Please check configuration for "
             + SCHEDULER_JOURNAL_URI);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -31,7 +31,6 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DN_R
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_OPTION;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FEDERATION_RENAME_OPTION_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RouterFederationRename.RouterRenameOption;
-import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.DEFAULT_SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 
 import java.io.FileNotFoundException;
@@ -436,8 +435,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
       Configuration sConf = new Configuration(conf);
       URI journalUri;
       try {
-        journalUri = new URI(
-            sConf.get(SCHEDULER_JOURNAL_URI, DEFAULT_SCHEDULER_JOURNAL_URI));
+        journalUri = new URI(sConf.get(SCHEDULER_JOURNAL_URI));
       } catch (URISyntaxException e) {
         throw new IOException("Bad journal uri. Please check configuration for "
             + SCHEDULER_JOURNAL_URI);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestDFSRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestDFSRouter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.tools.fedbalance.FedBalanceConfigs;
+
+public class TestDFSRouter {
+
+  @Test
+  public void testDefaultConfigs() {
+    Configuration configuration = DFSRouter.getConfiguration();
+    String journalUri =
+        configuration.get(FedBalanceConfigs.SCHEDULER_JOURNAL_URI);
+    int workerThreads =
+        configuration.getInt(FedBalanceConfigs.WORK_THREAD_NUM, -1);
+    Assert.assertEquals("hdfs://localhost:8020/tmp/procedure", journalUri);
+    Assert.assertEquals(10, workerThreads);
+  }
+
+}

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
@@ -42,9 +42,6 @@ public final class FedBalanceConfigs {
    persistence and recover. */
   public static final String SCHEDULER_JOURNAL_URI =
       "hdfs.fedbalance.procedure.scheduler.journal.uri";
-  public static final String DEFAULT_SCHEDULER_JOURNAL_URI =
-      "hdfs://localhost:8020/tmp/procedure";
-
   public static final String JOB_PREFIX = "JOB-";
   public static final String TMP_TAIL = ".tmp";
 

--- a/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
+++ b/hadoop-tools/hadoop-federation-balance/src/main/java/org/apache/hadoop/tools/fedbalance/FedBalanceConfigs.java
@@ -42,6 +42,9 @@ public final class FedBalanceConfigs {
    persistence and recover. */
   public static final String SCHEDULER_JOURNAL_URI =
       "hdfs.fedbalance.procedure.scheduler.journal.uri";
+  public static final String DEFAULT_SCHEDULER_JOURNAL_URI =
+      "hdfs://localhost:8020/tmp/procedure";
+
   public static final String JOB_PREFIX = "JOB-";
   public static final String TMP_TAIL = ".tmp";
 


### PR DESCRIPTION
### Description of PR
When dfs.federation.router.federation.rename.option is set to DISTCP and hdfs.fedbalance.procedure.scheduler.journal.uri is not set, DFSRouter fails to launch.
```
2021-09-08 15:39:11,818 ERROR org.apache.hadoop.hdfs.server.federation.router.DFSRouter: Failed to start router
    java.lang.NullPointerException
    at java.base/java.net.URI$Parser.parse(URI.java:3104)
    at java.base/java.net.URI.<init>(URI.java:600)
    at org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.initRouterFedRename(RouterRpcServer.java:444)
    at org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.<init>(RouterRpcServer.java:419)
    at org.apache.hadoop.hdfs.server.federation.router.Router.createRpcServer(Router.java:391)
    at org.apache.hadoop.hdfs.server.federation.router.Router.serviceInit(Router.java:188)
    at org.apache.hadoop.service.AbstractService.init(AbstractService.java:164)
    at org.apache.hadoop.hdfs.server.federation.router.DFSRouter.main(DFSRouter.java:69)
```
hdfs.fedbalance.procedure.scheduler.journal.uri is hdfs://localhost:8020/tmp/procedure by default, however, the default value is not used in DFSRouter.

### How was this patch tested?
Local dev testing. After applying fix for HDFS-16219, we can reproduce above error. And the fix provides default value to hdfs.fedbalance.procedure.scheduler.journal.uri.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

