### PR TITLE
HADOOP-17913. Filter deps with release labels

### DIFF
--- a/dev-support/docker/README.md
+++ b/dev-support/docker/README.md
@@ -26,9 +26,11 @@ the other. Different platforms have different toolchains. Some packages tend to 
 across platforms and most commonly, a package that's readily available in one platform's toolchain
 isn't available on another. We thus, resort to building and installing the package from source,
 causing duplication of code since this needs to be done for all the Dockerfiles pertaining to all
-the platforms. We need a system to track a dependency - for a package - for a platform. Thus,
-there's a lot of diversity that needs to be handled for managing package dependencies and
-`pkg-resolver` caters to that.
+the platforms. We need a system to track a dependency - for a package - for a platform
+
+- (and optionally) for a release. Thus, there's a lot of diversity that needs to be handled for
+  managing package dependencies and
+  `pkg-resolver` caters to that.
 
 ## Supported platforms
 
@@ -53,6 +55,21 @@ there's a lot of diversity that needs to be handled for managing package depende
       "package_2",
       "package_3"
     ]
+  },
+  "dependency_3": {
+    "platform_1": {
+      "release_1": "package_1_1_1",
+      "release_2": [
+        "package_1_2_1",
+        "package_1_2_2"
+      ]
+    },
+    "platform_2": [
+      "package_2_1",
+      {
+        "release_1": "package_2_1_1"
+      }
+    ]
   }
 }
 ```
@@ -65,6 +82,29 @@ how to interpret the above JSON -
 2. For `dependency_2`, `package_1` and `package_2` needs to be installed for `platform_2`.
 3. For `dependency_2`, `package_1`, `package_3` and `package_3` needs to be installed for
    `platform_1`.
+4. For `dependency_3`, `package_1_1_1` gets installed only if `release_1` has been specified
+   for `platform_1`.
+5. For `dependency_3`, the packages `package_1_2_1` and `package_1_2_2` gets installed only
+   if `release_2` has been specified for `platform_1`.
+6. For `dependency_3`, for `platform_2`, `package_2_1` is always installed, but `package_2_1_1` gets
+   installed only if `release_1` has been specified.
+
+### Tool help
+
+```shell
+$ pkg-resolver/resolve.py -h
+usage: resolve.py [-h] [-r RELEASE] platform
+
+Platform package dependency resolver for building Apache Hadoop
+
+positional arguments:
+  platform              The name of the platform to resolve the dependencies for
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -r RELEASE, --release RELEASE
+                        The release label to filter the packages for the given platform
+```
 
 ## Standalone packages
 

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -122,10 +122,12 @@
     ]
   },
   "gcc": {
-    "debian:10": [
-      "gcc",
-      "g++"
-    ],
+    "debian:10": {
+      "bullseye": [
+        "gcc",
+        "g++"
+      ]
+    },
     "ubuntu:focal": [
       "gcc",
       "g++"

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -122,12 +122,10 @@
     ]
   },
   "gcc": {
-    "debian:10": {
-      "bullseye": [
-        "gcc",
-        "g++"
-      ]
-    },
+    "debian:10": [
+      "gcc",
+      "g++"
+    ],
     "ubuntu:focal": [
       "gcc",
       "g++"

--- a/dev-support/docker/pkg-resolver/resolve.py
+++ b/dev-support/docker/pkg-resolver/resolve.py
@@ -81,9 +81,9 @@ if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser(
         description='Platform package dependency resolver for building Apache Hadoop')
     arg_parser.add_argument('-r', '--release', nargs=1, type=str,
-                            help='The release label to filter the packages for the given platform.')
+                            help='The release label to filter the packages for the given platform')
     arg_parser.add_argument('platform', nargs=1, type=str,
-                            help='The name of the platform to resolve the dependencies for.')
+                            help='The name of the platform to resolve the dependencies for')
     args = arg_parser.parse_args()
 
     if not is_supported_platform(args.platform[0]):

--- a/dev-support/docker/pkg-resolver/resolve.py
+++ b/dev-support/docker/pkg-resolver/resolve.py
@@ -20,6 +20,7 @@
 Platform package dependency resolver for building Apache Hadoop.
 """
 
+import argparse
 import json
 import sys
 from check_platform import is_supported_platform
@@ -65,13 +66,21 @@ if __name__ == '__main__':
               file=sys.stderr)
         sys.exit(1)
 
-    platform_arg = sys.argv[1]
-    if not is_supported_platform(platform_arg):
+    arg_parser = argparse.ArgumentParser(
+        description='Platform package dependency resolver for building Apache Hadoop')
+    arg_parser.add_argument('-r', '--release', nargs=1, type=str,
+                            help='The release label to filter the packages for the given platform.')
+    arg_parser.add_argument('platform', nargs=1, type=str,
+                            help='The name of the platform to resolve the dependencies for.')
+    args = arg_parser.parse_args()
+
+    if not is_supported_platform(args.platform[0]):
         print(
             'ERROR: The given platform {} is not supported. '
             'Please refer to platforms.json for a list of supported platforms'.format(
-                platform_arg), file=sys.stderr)
+                args.platform), file=sys.stderr)
         sys.exit(1)
 
-    packages_to_install = get_packages(platform_arg)
+    packages_to_install = get_packages(args.platform[0],
+                                       args.release[0] if args.release is not None else None)
     print(' '.join(packages_to_install))

--- a/dev-support/docker/pkg-resolver/resolve.py
+++ b/dev-support/docker/pkg-resolver/resolve.py
@@ -40,6 +40,16 @@ def get_packages(platform, release=None):
     packages = []
 
     def process_package(package, in_release=False):
+        """
+        Processes the given package object that belongs to a platform and adds it to the packages
+        list variable in the parent scope.
+        In essence, this method recursively traverses the JSON structure defined in packages.json
+        and performs the core filtering.
+
+        :param package: The package object to process.
+        :param in_release: A boolean that indicates whether the current travels belongs to a package
+        that needs to be filtered for the given release label.
+        """
         if isinstance(package, list):
             for entry in package:
                 process_package(entry, in_release)
@@ -49,6 +59,8 @@ def get_packages(platform, release=None):
             for entry in package.get(release):
                 process_package(entry, in_release=True)
         elif isinstance(package, str):
+            # Filter out the package that doesn't belong to this release,
+            # if a release label has been specified.
             if release is not None and not in_release:
                 return
             packages.append(package)

--- a/dev-support/docker/pkg-resolver/resolve.py
+++ b/dev-support/docker/pkg-resolver/resolve.py
@@ -56,7 +56,7 @@ def get_packages(platform, release=None):
         elif isinstance(package, dict):
             if release is None:
                 return
-            for entry in package.get(release):
+            for entry in package.get(release, []):
                 process_package(entry, in_release=True)
         elif isinstance(package, str):
             # Filter out the package that doesn't belong to this release,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
* This PR adds an option --release
  to resolve.py which provides the
  ability to filter the dependencies
  listed in packages.json file based
  on the specified release label.
* This is helpful for maintaining
  dependencies across different
  releases for a platform.

### How was this patch tested?
I tested it locally for the following cases -
* Ensured that the current functionality
  is maintained.
* Added a release entry and verified that
  it was filtered correctly.
* Verified that the filtering worked correctly
  when an incorrect release label was given.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

