### PR TITLE
HADOOP-17915. ABFS AbfsDelegationTokenManager to generate canonicalServiceName if DT plugin doesn't

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1363,8 +1363,9 @@ public class AzureBlobFileSystem extends FileSystem
   @Override
   public synchronized Token<?> getDelegationToken(final String renewer) throws IOException {
     statIncrement(CALL_GET_DELEGATION_TOKEN);
-    return this.delegationTokenEnabled ? this.delegationTokenManager.getDelegationToken(renewer)
-        : super.getDelegationToken(renewer);
+    return this.delegationTokenEnabled
+        ? this.delegationTokenManager.getDelegationToken(renewer)
+        : null;
   }
 
   /**
@@ -1374,11 +1375,12 @@ public class AzureBlobFileSystem extends FileSystem
    */
   @Override
   public String getCanonicalServiceName() {
-    String name = null;
     if (delegationTokenManager != null) {
-      name = delegationTokenManager.getCanonicalServiceName();
+      // ask the delegation token manager for the name.
+      return delegationTokenManager.getCanonicalServiceName();
     }
-    return name != null ? name : super.getCanonicalServiceName();
+    // no DT manager: No name.
+    return null;
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/ExtensionHelper.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/ExtensionHelper.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs.extensions;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -37,6 +38,31 @@ import org.apache.hadoop.io.IOUtils;
 public final class ExtensionHelper {
 
   private ExtensionHelper() {
+  }
+
+  /** Format string for a Canonical Service Name. */
+  public static final String SERVICE_NAME_FORMAT = "abfs://%s/";
+
+  /**
+   * Given a URI, build the Canonical Service Name.
+   * @param fsURI filesystem URI.
+   * @return Canonical Service Name
+   */
+  public static String buildCanonicalServiceName(URI fsURI) {
+    return String.format(SERVICE_NAME_FORMAT, fsURI.getHost());
+  }
+  /**
+   * Given a URI, build the Canonical Service Name.
+   * @param fsURI filesystem URI.
+   * @return URI built from Canonical Service name
+   * @throws RuntimeException if somehow the URI regeneration failes.
+   */
+  public static URI buildCanonicalServiceURI(URI fsURI) {
+    try {
+      return new URI(buildCanonicalServiceName(fsURI));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsClient.java
@@ -44,7 +44,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_A
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
- * Test continuation token which has equal sign.
+ * Test misc FS operations.
  */
 public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   private static final int LIST_MAX_RESULTS = 500;
@@ -168,5 +168,21 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
       task.get();
     }
     es.shutdownNow();
+  }
+
+  /**
+   * Test DT support when the FS doesn't have DTs enabled.
+   * No DTs. no service name.
+   */
+  @Test
+  public void testDelegationTokensInUnmanagedFS() throws Throwable {
+    final AzureBlobFileSystem fs = getFileSystem();
+
+    Assertions.assertThat(fs.getDelegationToken("yarn@EXAMPLE"))
+        .describedAs("fs.getDelegationToken()")
+        .isNull();
+    Assertions.assertThat(fs.getCanonicalServiceName())
+        .describedAs("fs.getCanonicalServiceName()")
+        .isNull();
   }
 }


### PR DESCRIPTION
This PR ensures that

* `FileSystem.getCanonicalServiceName()` is *never* used to build an abfs service name from the IPaddr of the storage account's endpoint.
* Instead, if DTs are enabled, the `AbfsDelegationTokenManager` gets it from the DT plugin if it implements `getCanonicalServiceName()` & returns a non-null value, else derives it from the FS URI.
* And if DTs are disabled: returns null.

The fallback calculation of the Canonical Service Name is `"abfs://" + fsURI.getHost() + "/"`

1. schema is always abfs, even for abfss stores
1. the container is stripped from the service name.
1. so all abfs containers for the same service a/c will have the same Canonical Service Name
1. share a single DT in job submission
1. *and*: if a DT is issued for one of the containers in job submission, all other containers for the same storage a/c will use that DT
1. Even if the caller didn't explicitly name it.

That is consistent with using the storage a/c's endpoint IPAddr to identify the storage account.

Today, `abfs://c1@storage1.dfs.core.windows.net/` and  `abfs://container2@storage1.dfs.core.windows.net/` will both have their CSN map to the same endpoint hostname *if the DT plugin doesn't return a schema*

If the DT plugin returns their own canonical name -which it should, this is all moot. This is a fallback if they don't.

Tests updated to match new behavior.

### How was this patch tested?

azure cardiff

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?

