### PR TITLE
HADOOP-17916. Fix compilation error of ITUseHadoopCodecs with -DskipS…

### DIFF
--- a/hadoop-client-modules/hadoop-client-integration-tests/pom.xml
+++ b/hadoop-client-modules/hadoop-client-integration-tests/pom.xml
@@ -173,6 +173,7 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>
           <scope>test</scope>
+          <type>test-jar</type>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17916

Compilation of ITUseHadoopCodecs was failed due to issue of dependency declaration.

```
$ mvn clean install -DskipTests -DskipShade
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile (default-testCompile) on project hadoop-client-integration-tests: Compilation failure: Compilation failure:
[ERROR] /home/centos/srcs/hadoop/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseHadoopCodecs.java:[34,28] cannot find symbol
[ERROR]   symbol:   class RandomDatum
[ERROR]   location: package org.apache.hadoop.io
[ERROR] /home/centos/srcs/hadoop/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseHadoopCodecs.java:[100,16] package RandomDatum does not exist
[ERROR] /home/centos/srcs/hadoop/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseHadoopCodecs.java:[100,54] package RandomDatum does not exist
[ERROR] /home/centos/srcs/hadoop/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseHadoopCodecs.java:[103,7] cannot find symbol
[ERROR]   symbol:   class RandomDatum
[ERROR]   location: class org.apache.hadoop.example.ITUseHadoopCodecs
[ERROR] /home/centos/srcs/hadoop/hadoop-client-modules/hadoop-client-integration-tests/src/test/java/org/apache/hadoop/example/ITUseHadoopCodecs.java:[104,7] cannot find symbol
[ERROR]   symbol:   class RandomDatum
[ERROR]   location: class org.apache.hadoop.example.ITUseHadoopCodecs
```