### PR TITLE
HDFS-16229.Remove the use of obsolete BLOCK_DELETION_INCREMENT.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3356,7 +3356,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
   /**
    * From the given list, incrementally remove the blocks from blockManager
-   * Writelock is dropped and reacquired every BLOCK_DELETION_INCREMENT to
+   * Writelock is dropped and reacquired every blockDeletionIncrement to
    * ensure that other waiters on the lock can get in. See HDFS-2938
    * 
    * @param blocks


### PR DESCRIPTION

### Description of PR
Remove the use of obsolete BLOCK_DELETION_INCREMENT.

Details: HDFS-16229

### How was this patch tested?
This jira is mainly to solve and comment-related, so there is no need for excessive testing.

