### PR TITLE
HDFS-16219. RBF: Set default map tasks and bandwidth in RouterFederationRename

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -725,7 +725,7 @@
 
   <property>
     <name>dfs.federation.router.federation.rename.bandwidth</name>
-    <value></value>
+    <value>10</value>
     <description>
       Specify bandwidth per map in MB.
     </description>
@@ -733,7 +733,7 @@
 
   <property>
     <name>dfs.federation.router.federation.rename.map</name>
-    <value></value>
+    <value>10</value>
     <description>
       Max number of concurrent maps to use for copy.
     </description>


### PR DESCRIPTION
### Description of PR
When dfs.federation.router.federation.rename.option is set to DISTCP, if dfs.federation.router.federation.rename.map and dfs.federation.router.federation.rename.bandwidth are not provided with default values, DFSRouter fails to launch.

### How was this patch tested?
Local dev testing.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

