### PR TITLE
HADOOP-17921. DistCp derives if XAttr is supported wrongly

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/util/DistCpUtils.java
@@ -508,10 +508,10 @@ public class DistCpUtils {
    * @throws XAttrsNotSupportedException if fs does not support XAttrs
    */
   public static void checkFileSystemXAttrSupport(FileSystem fs)
-      throws XAttrsNotSupportedException {
+      throws XAttrsNotSupportedException, IOException {
     try {
       fs.getXAttrs(new Path(Path.SEPARATOR));
-    } catch (Exception e) {
+    } catch (UnsupportedOperationException e) {
       throw new XAttrsNotSupportedException("XAttrs not supported for file system: "
         + fs.getUri());
     }


### PR DESCRIPTION

### Description of PR
The exception handling in distcp code during the check seems improper. In a FileSystem implementation which doesn't override getXAttrs(), it would throw UnsupportedOperationException(). However, in distCp while handling the code, it tries to catch Exception class. That would result in normal IOException also treated as if the feature is not supported. This will lead to wrong behavior.

### How was this patch tested?
:eyes:

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

