### PR TITLE
HDFS-16233. Do not use exception handler to implement copy-on-write for EnumCounters.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/QuotaCounts.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/QuotaCounts.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.util.ConstEnumCounters;
 import org.apache.hadoop.hdfs.util.EnumCounters;
-import org.apache.hadoop.hdfs.util.ConstEnumCounters.ConstEnumException;
 
 import java.util.function.Consumer;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/QuotaCounts.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/QuotaCounts.java
@@ -57,14 +57,10 @@ public class QuotaCounts {
    */
   static <T extends Enum<T>> EnumCounters<T> modify(EnumCounters<T> counter,
       Consumer<EnumCounters<T>> action) {
-    try {
-      action.accept(counter);
-    } catch (ConstEnumException cee) {
-      // We don't call clone here because ConstEnumCounters.clone() will return
-      // an object of class ConstEnumCounters. We want EnumCounters.
+    if (counter instanceof ConstEnumCounters) {
       counter = counter.deepCopyEnumCounter();
-      action.accept(counter);
     }
+    action.accept(counter);
     return counter;
   }
 


### PR DESCRIPTION
### Description of PR
Async profiler finds the COW of EnumCounters is expensive. Propose a new implementation to reduce the cost.

### How was this patch tested?
Performance optimization. No functional change so use existing unit tests.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

