### PR TITLE
HDFS-16235. Deadlock in LeaseRenewer for static remove method

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/LeaseRenewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/LeaseRenewer.java
@@ -96,7 +96,9 @@ public class LeaseRenewer {
    * @param renewer Instance to be cleared from Factory
    */
   public static void remove(LeaseRenewer renewer) {
-    Factory.INSTANCE.remove(renewer);
+    synchronized (renewer) {
+      Factory.INSTANCE.remove(renewer);
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR
Have Deadlock when backend LeaseRenewer thread call `LeaseRenewer.Factory.remove` and  task thread call `LeaseRenewer.remove`
![image](https://user-images.githubusercontent.com/46485123/134507597-739a0459-7cdf-4ea2-9ac4-86e977ec7d44.png)


### How was this patch tested?


### For code changes:
