### PR TITLE
YARN-10970. Standby RM should expose prom endpoint

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -295,7 +295,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     assertEquals(redirectURL,rm1Url + "/metrics");
 
 
-    // standby RM links /conf, /stacks, /logLevel, /static, /logs, /jmx
+    // standby RM links /conf, /stacks, /logLevel, /static, /logs, /jmx, /prom
     // /cluster/cluster as well as webService
     // /ws/v1/cluster/info should not be redirected to active RM
     redirectURL = getRedirectURL(rm2Url + "/cluster/cluster");
@@ -317,6 +317,9 @@ public class TestRMFailover extends ClientBaseWithFixes {
     assertNull(redirectURL);
 
     redirectURL = getRedirectURL(rm2Url + "/jmx?param1=value1+x&param2=y");
+    assertNull(redirectURL);
+
+    redirectURL = getRedirectURL(rm2Url + "/prom");
     assertNull(redirectURL);
 
     redirectURL = getRedirectURL(rm2Url + "/ws/v1/cluster/info");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
@@ -70,7 +70,7 @@ public class RMWebAppFilter extends GuiceContainer {
   // define a set of URIs which do not need to do redirection
   private static final Set<String> NON_REDIRECTED_URIS = Sets.newHashSet(
       "/conf", "/stacks", "/logLevel", "/logs", IsActiveServlet.PATH_SPEC,
-      "/jmx");
+      "/jmx", "/prom");
   private String path;
   private boolean ahsEnabled;
   private String ahsPageURLPrefix;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/YARN-10970
description detail: 
HADOOP-16398 exports Hadoop metrics to Prometheus. 

However, standby RM redirects prom metrics to the Active.  We need to separate out prom metrics displayed so the Standby RM can also be export metrics to prometheus.

### How was this patch tested?
change TestRMFailover$testRMWebAppRedirect test 

### For code changes:
add `/prom` endpoint  in RMWebAppFilter$NON_REDIRECTED_URIS 

