### PR TITLE
HADOOP-17936. Fix test failure after reverting HADOOP-16878

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFSCopyFromLocal.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFSCopyFromLocal.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.fs.contract.AbstractContractCopyFromLocalTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.localfs.LocalFSContract;
 
-import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-
 public class TestLocalFSCopyFromLocal extends AbstractContractCopyFromLocalTest {
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
@@ -38,7 +36,7 @@ public class TestLocalFSCopyFromLocal extends AbstractContractCopyFromLocalTest 
   @Test
   public void testDestinationFileIsToParentDirectory() throws Throwable {
     describe("Source is a file and destination is its own parent directory. " +
-      "Copying will cause the source file to be deleted.");
+        "Copying will cause the source file to be deleted.");
 
     File file = createTempFile("local");
     Path dest = new Path(file.getParentFile().toURI());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFSCopyFromLocal.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalFSCopyFromLocal.java
@@ -37,14 +37,15 @@ public class TestLocalFSCopyFromLocal extends AbstractContractCopyFromLocalTest 
 
   @Test
   public void testDestinationFileIsToParentDirectory() throws Throwable {
-    describe("Source is a file and destination is its own parent directory");
+    describe("Source is a file and destination is its own parent directory. " +
+      "Copying will cause the source file to be deleted.");
 
     File file = createTempFile("local");
     Path dest = new Path(file.getParentFile().toURI());
     Path src = new Path(file.toURI());
 
-    intercept(PathOperationException.class,
-        () -> getFileSystem().copyFromLocalFile( true, true, src, dest));
+    getFileSystem().copyFromLocalFile(true, true, src, dest);
+    assertPathDoesNotExist("Source found", src);
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

HADOOP-17936
### Description of PR

After reverting HADOOP-16878 from trunk, test `TestLocalFSCopyFromLocal.testDestinationFileIsToParentDirectory` started to fail since it depends on the behavior change in the JIRA. This fixed the test.

### How was this patch tested?

Existing tests.

