### PR TITLE
Fix winutils typos

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/winutils/task.c
+++ b/hadoop-common-project/hadoop-common/src/main/winutils/task.c
@@ -1330,11 +1330,11 @@ void TaskUsage()
   // jobobject's are being used.
   // ProcessTree.isSetsidSupported()
   fwprintf(stdout, L"\
-Usage: task create [OPTOINS] [TASKNAME] [COMMAND_LINE]\n\
+Usage: task create [OPTIONS] [TASKNAME] [COMMAND_LINE]\n\
          Creates a new task job object with taskname and options to set CPU\n\
          and memory limits on the job object\n\
 \n\
-         OPTIONS: -c [cup rate] set the cpu rate limit on the job object.\n\
+         OPTIONS: -c [cpu rate] set the cpu rate limit on the job object.\n\
                   -m [memory] set the memory limit on the job object.\n\
          The cpu limit is an integral value of percentage * 100. The memory\n\
          limit is an integral number of memory in MB. \n\

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -30,7 +30,6 @@ using ::testing::_;
 
 using namespace hdfs;
 
-
 namespace hdfs {
 
 TEST(ConfigurationTest, TestDegenerateInputs) {

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -30,6 +30,7 @@ using ::testing::_;
 
 using namespace hdfs;
 
+
 namespace hdfs {
 
 TEST(ConfigurationTest, TestDegenerateInputs) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fixed some typos in winutils.


### How was this patch tested?
Not needed.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

