### PR TITLE
HADOOP-17938. Print lockWarningThreshold in InstrumentedLock#logWarni…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/InstrumentedLock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/InstrumentedLock.java
@@ -150,23 +150,23 @@ public class InstrumentedLock implements Lock {
 
   @VisibleForTesting
   void logWarning(long lockHeldTime, SuppressedSnapshot stats) {
-    logger.warn(String.format("Lock held time above threshold: " +
+    logger.warn(String.format("Lock held time above threshold(%dms): " +
         "lock identifier: %s " +
         "lockHeldTimeMs=%d ms. Suppressed %d lock warnings. " +
         "Longest suppressed LockHeldTimeMs=%d. " +
         "The stack trace is: %s" ,
-        name, lockHeldTime, stats.getSuppressedCount(),
+        lockWarningThreshold, name, lockHeldTime, stats.getSuppressedCount(),
         stats.getMaxSuppressedWait(),
         StringUtils.getStackTrace(Thread.currentThread())));
   }
 
   @VisibleForTesting
   void logWaitWarning(long lockWaitTime, SuppressedSnapshot stats) {
-    logger.warn(String.format("Waited above threshold to acquire lock: " +
+    logger.warn(String.format("Waited above threshold(%dms) to acquire lock: " +
         "lock identifier: %s " +
         "waitTimeMs=%d ms. Suppressed %d lock wait warnings. " +
         "Longest suppressed WaitTimeMs=%d. " +
-        "The stack trace is: %s", name, lockWaitTime,
+        "The stack trace is: %s", lockWarningThreshold, name, lockWaitTime,
         stats.getSuppressedCount(), stats.getMaxSuppressedWait(),
         StringUtils.getStackTrace(Thread.currentThread())));
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/InstrumentedLock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/InstrumentedLock.java
@@ -150,7 +150,7 @@ public class InstrumentedLock implements Lock {
 
   @VisibleForTesting
   void logWarning(long lockHeldTime, SuppressedSnapshot stats) {
-    logger.warn(String.format("Lock held time above threshold(%dms): " +
+    logger.warn(String.format("Lock held time above threshold(%d ms): " +
         "lock identifier: %s " +
         "lockHeldTimeMs=%d ms. Suppressed %d lock warnings. " +
         "Longest suppressed LockHeldTimeMs=%d. " +
@@ -162,7 +162,7 @@ public class InstrumentedLock implements Lock {
 
   @VisibleForTesting
   void logWaitWarning(long lockWaitTime, SuppressedSnapshot stats) {
-    logger.warn(String.format("Waited above threshold(%dms) to acquire lock: " +
+    logger.warn(String.format("Waited above threshold(%d ms) to acquire lock: " +
         "lock identifier: %s " +
         "waitTimeMs=%d ms. Suppressed %d lock wait warnings. " +
         "Longest suppressed WaitTimeMs=%d. " +


### PR DESCRIPTION
JIRA: [HADOOP-17938](https://issues.apache.org/jira/browse/HADOOP-17938)

Print lockWarningThreshold in InstrumentedLock#logWarning and InstrumentedLock#logWaitWarning.

Before:
![before](https://user-images.githubusercontent.com/55134131/134805447-8f0b966a-c351-4ce6-bc2a-e4bfc302ce2d.jpg)

After:
![image](https://user-images.githubusercontent.com/55134131/134941500-c6b656e8-ea12-4bd1-939a-f4518e1fb4dc.png)
