### PR TITLE
MAPREDUCE-7363. Rename JobClientUnitTest to TestJobClients

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobClients.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobClients.java
@@ -44,7 +44,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 @SuppressWarnings("deprecation")
-public class JobClientUnitTest {
+public class TestJobClients {
   
   public class TestJobClient extends JobClient {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobClients.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobClients.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 
 @SuppressWarnings("deprecation")
 public class TestJobClients {
-  
+
   public class TestJobClient extends JobClient {
 
     TestJobClient(JobConf jobConf) throws IOException {
@@ -99,57 +99,57 @@ public class TestJobClients {
     Cluster mockCluster = mock(Cluster.class);
     client.setCluster(mockCluster);
     JobID id = new JobID("test",0);
-    
+
     when(mockCluster.getJob(id)).thenReturn(null);
-    
+
     TaskReport[] result = client.getMapTaskReports(id);
     assertEquals(0, result.length);
-    
+
     verify(mockCluster).getJob(id);
   }
-  
+
   @Test
   public void testReduceTaskReportsWithNullJob() throws Exception {
     TestJobClient client = new TestJobClient(new JobConf());
     Cluster mockCluster = mock(Cluster.class);
     client.setCluster(mockCluster);
     JobID id = new JobID("test",0);
-    
+
     when(mockCluster.getJob(id)).thenReturn(null);
-    
+
     TaskReport[] result = client.getReduceTaskReports(id);
     assertEquals(0, result.length);
-    
+
     verify(mockCluster).getJob(id);
   }
-  
+
   @Test
   public void testSetupTaskReportsWithNullJob() throws Exception {
     TestJobClient client = new TestJobClient(new JobConf());
     Cluster mockCluster = mock(Cluster.class);
     client.setCluster(mockCluster);
     JobID id = new JobID("test",0);
-    
+
     when(mockCluster.getJob(id)).thenReturn(null);
-    
+
     TaskReport[] result = client.getSetupTaskReports(id);
     assertEquals(0, result.length);
-    
+
     verify(mockCluster).getJob(id);
   }
-  
+
   @Test
   public void testCleanupTaskReportsWithNullJob() throws Exception {
     TestJobClient client = new TestJobClient(new JobConf());
     Cluster mockCluster = mock(Cluster.class);
     client.setCluster(mockCluster);
     JobID id = new JobID("test",0);
-    
+
     when(mockCluster.getJob(id)).thenReturn(null);
-    
+
     TaskReport[] result = client.getCleanupTaskReports(id);
     assertEquals(0, result.length);
-    
+
     verify(mockCluster).getJob(id);
   }
 
@@ -184,7 +184,7 @@ public class TestJobClients {
     when(mockCluster.getJob(jobID)).thenReturn(mockJob);
 
     client.setCluster(mockCluster);
-    
+
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     client.displayJobList(new JobStatus[] {mockJobStatus}, new PrintWriter(out));
     String commandLineOutput = out.toString();


### PR DESCRIPTION
### Description of PR

This PR aims to rename a test class from `JobClientUnitTest` to `TestJobClients` for consistency.
Although this is a minor PR on test case, it's helpful for the downstream to manage the builds and tests.

### How was this patch tested?

Pass the CI.

### For code changes:

- [v] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
