### PR TITLE
HDFS-16239. XAttr#toString doesnt print the attribute value in readab…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/fs/XAttr.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/fs/XAttr.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.fs;
 
-import java.util.Arrays;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
+
+import java.nio.charset.Charset;
 
 /**
  * XAttr is the POSIX Extended Attribute model similar to that found in
@@ -158,6 +158,6 @@ public class XAttr {
   @Override
   public String toString() {
     return "XAttr [ns=" + ns + ", name=" + name + ", value="
-        + Arrays.toString(value) + "]";
+        + new String(value, Charset.defaultCharset()) + "]";
   }
 }


### PR DESCRIPTION
…le format

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

