### PR TITLE
HDFS-16240. Replace unshaded guava in HttpFSServerWebServer.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServerWebServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/fs/http/server/HttpFSServerWebServer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.fs.http.server;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import static org.apache.hadoop.fs.http.server.HttpFSAuthenticationFilter.CONF_PREFIX;
 import static org.apache.hadoop.fs.http.server.HttpFSAuthenticationFilter.HADOOP_HTTP_CONF_PREFIX;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDFS-16240

[HDFS-16129](https://issues.apache.org/jira/browse/HDFS-16129) added use of com.google.common.annotations.VisibleForTesting to HttpFSServerWebServer. It is replaced by replace-guava replacer of [HADOOP-17288](https://issues.apache.org/jira/browse/HDFS-17288) on every build.
