### PR TITLE
HDFS-16242. JournalMetrics should add JournalId MetricTag.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -401,4 +401,29 @@ public class MetricsAsserts {
           geq(0l));
     }
   }
+
+  /**
+   * Assert a tag of metric as expected.
+   * @param name  of the metric tag
+   * @param expected  value of the metric tag
+   * @param rb  the record builder mock used to getMetrics
+   */
+  public static void assertTag(String name, String expected,
+      MetricsRecordBuilder rb) {
+    Assert.assertEquals("Bad Tag for metric " + name,
+        expected, getStringTag(name, rb));
+  }
+
+  /**
+   * get the value tag for the metric.
+   * @param name  of the metric tag
+   * @param rb value of the metric tag
+   * @return the value tag for the metric
+   */
+  public static String getStringTag(String name, MetricsRecordBuilder rb) {
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(rb).tag(eqName(info(name, "")), captor.capture());
+    checkCaptured(captor, name);
+    return captor.getValue();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
@@ -100,7 +100,7 @@ class JournalMetrics {
     return "Journal-" + journal.getJournalId();
   }
 
-  @Metric(value={"JournalId", "Current JournalId"}, type= Type.TAG)
+  @Metric(value={"JournalId", "Current JournalId"}, type=Type.TAG)
   public String getJournalId() {
     return journal.getJournalId();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalMetrics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.qjournal.server;
 import java.io.IOException;
 
 import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metric.Type;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
@@ -97,6 +98,11 @@ class JournalMetrics {
 
   String getName() {
     return "Journal-" + journal.getJournalId();
+  }
+
+  @Metric(value={"JournalId", "Current JournalId"}, type= Type.TAG)
+  public String getJournalId() {
+    return journal.getJournalId();
   }
 
   @Metric("Current writer's epoch")

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -300,6 +300,7 @@ public class TestJournalNode {
 
   }
 
+
   @Test(timeout=100000)
   public void testReturnsSegmentInfoAtEpochTransition() throws Exception {
     ch.newEpoch(1).get();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -300,7 +300,6 @@ public class TestJournalNode {
 
   }
 
-
   @Test(timeout=100000)
   public void testReturnsSegmentInfoAtEpochTransition() throws Exception {
     ch.newEpoch(1).get();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -299,8 +299,8 @@ public class TestJournalNode {
     assertTrue(lastJournalTimestamp > beginTimestamp);
 
   }
-
-
+  
+  
   @Test(timeout=100000)
   public void testReturnsSegmentInfoAtEpochTransition() throws Exception {
     ch.newEpoch(1).get();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -299,7 +299,8 @@ public class TestJournalNode {
     assertTrue(lastJournalTimestamp > beginTimestamp);
 
   }
-  
+
+
   @Test(timeout=100000)
   public void testReturnsSegmentInfoAtEpochTransition() throws Exception {
     ch.newEpoch(1).get();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -97,7 +97,8 @@ public class TestJournalNode {
       conf.set(DFSConfigKeys.DFS_JOURNALNODE_EDITS_DIR_KEY,
           editsDir.getAbsolutePath());
     } else if (testName.getMethodName().equals(
-        "testJournalDefaultDirForOneNameSpace")) {
+        "testJournalDefaultDirForOneNameSpace") ||
+        testName.getMethodName().equals("testJournalMetricTags")) {
       FileUtil.fullyDelete(new File(DFSConfigKeys
           .DFS_JOURNALNODE_EDITS_DIR_DEFAULT));
       setFederationConf();
@@ -151,7 +152,8 @@ public class TestJournalNode {
         testName.getMethodName().equals(
             "testJournalCommonDirAcrossNameSpace") ||
         testName.getMethodName().equals(
-            "testJournalDefaultDirForOneNameSpace")) {
+            "testJournalDefaultDirForOneNameSpace") ||
+        testName.getMethodName().equals("testJournalMetricTags")) {
       Collection<String> nameServiceIds = DFSUtilClient.getNameServiceIds(conf);
       for(String nsId: nameServiceIds) {
         journalId = "test-journalid-" + nsId;
@@ -240,6 +242,23 @@ public class TestJournalNode {
         File.separator + jid);
     assertEquals(editsDir.toString(), journalStorage.getRoot().toString());
   }
+
+  @Test(timeout=100000)
+  public void testJournalMetricTags() {
+    setupStaticHostResolution(2, "journalnode");
+    String jid = "test-journalid-ns1";
+    Journal nsJournal = jn.getJournal(jid);
+    MetricsRecordBuilder metrics = MetricsAsserts.getMetrics(
+        nsJournal.getMetrics().getName());
+    MetricsAsserts.assertTag("JournalId", jid, metrics);
+
+    jid = "test-journalid-ns2";
+    nsJournal = jn.getJournal(jid);
+    metrics = MetricsAsserts.getMetrics(
+        nsJournal.getMetrics().getName());
+    MetricsAsserts.assertTag("JournalId", jid, metrics);
+  }
+
   @Test(timeout=100000)
   public void testJournal() throws Exception {
     MetricsRecordBuilder metrics = MetricsAsserts.getMetrics(
@@ -280,7 +299,6 @@ public class TestJournalNode {
     assertTrue(lastJournalTimestamp > beginTimestamp);
 
   }
-  
   
   @Test(timeout=100000)
   public void testReturnsSegmentInfoAtEpochTransition() throws Exception {


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-16242
JournalMetrics should add JournalId MetricTag to distinguish different nameservice journal metrics  when JournalNode use ganglia sink or  prometheus sink.

JMX

Before this patch, journal' jmx :
```
// jmx json
    {
    "name" : "Hadoop:service=JournalNode,name=Journal-nntest1",
    "Syncs60sNumOps" : 0,
    ...
    },
    {
   "name" : "Hadoop:service=JournalNode,name=Journal-nntest2",
   "Syncs60sNumOps" : 0,
   ... 
   }
 ```

After this patch, journal' jmx :

 
```
// jmx json
    {
    "name" : "Hadoop:service=JournalNode,name=Journal-nntest1",
    "tag.JournalId" : "nntest1",  // add this tag
    "Syncs60sNumOps" : 0,
   ...
    },
    {
   "name" : "Hadoop:service=JournalNode,name=Journal-nntest2", 
    "tag.JournalId" : "nntest2",
   "Syncs60sNumOps" : 0,
  ... 
    }
 ```

PrometheusSink

Before this patch, journal' prometheus export :
```
journal_node_syncs60s_num_ops{context="dfs",hostname="host"} 2
```
After this patch, journal' prometheus export :
```
journal_node_syncs60s_num_ops{context="dfs",journalid="nntest2",hostname="host"} 2
journal_node_syncs60s_num_ops{context="dfs",journalid="nntest1",hostname="host"} 75
```
### How was this patch tested?
add test testJournalMetricTags

### For code changes:
add JournalMetrics$getJournalId

