### PR TITLE
HDFS-16244.Add the necessary write lock in Checkpointer#doCheckpoint().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/Checkpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/Checkpointer.java
@@ -244,9 +244,14 @@ class Checkpointer extends Daemon {
 
       if(needReloadImage) {
         LOG.info("Loading image with txid " + sig.mostRecentCheckpointTxId);
-        File file = bnStorage.findImageFile(NameNodeFile.IMAGE,
-            sig.mostRecentCheckpointTxId);
-        bnImage.reloadFromImageFile(file, backupNode.getNamesystem());
+        backupNode.namesystem.writeLock();
+        try {
+          File file = bnStorage.findImageFile(NameNodeFile.IMAGE,
+              sig.mostRecentCheckpointTxId);
+          bnImage.reloadFromImageFile(file, backupNode.getNamesystem());
+        } finally {
+          backupNode.namesystem.writeUnlock();
+        }
       }
       rollForwardByApplyingLogs(manifest, bnImage, backupNode.getNamesystem());
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In Checkpointer#doCheckpoint(), when you need to execute reloadFromImageFile(), you need to add the necessary write lock.
Details: HDFS-16244

### How was this patch tested?
Need to verify the correctness of Checkpointer#doCheckpoint().

