### PR TITLE
HADOOP-17947. Provide alternative to Guava VisibleForTesting

### DIFF
--- a/hadoop-common-project/hadoop-annotations/src/main/java/org/apache/hadoop/classification/VisibleForTesting.java
+++ b/hadoop-common-project/hadoop-annotations/src/main/java/org/apache/hadoop/classification/VisibleForTesting.java
@@ -16,11 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.util;
+package org.apache.hadoop.classification;
 
 /**
  * Annotates a program element that exists, or is more widely visible than
- * otherwise necessary, only for use in test code.
+ * otherwise necessary, specifically for use in test code.
+ * More precisely <i>test code within the hadoop-* modules</i>.
+ * Moreover, this gives the implicit scope and stability of:
+ * <pre>
+ *   {@link InterfaceAudience.Private}
+ *   {@link InterfaceStability.Unstable}
+ * </pre>
+ * If external modules need to access/override these methods, then
+ * they MUST be re-scoped as public/limited private.
  */
 public @interface VisibleForTesting {
 }

--- a/hadoop-common-project/hadoop-annotations/src/main/java/org/apache/hadoop/classification/VisibleForTesting.java
+++ b/hadoop-common-project/hadoop-annotations/src/main/java/org/apache/hadoop/classification/VisibleForTesting.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.classification;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Annotates a program element that exists, or is more widely visible than
  * otherwise necessary, specifically for use in test code.
@@ -30,5 +36,8 @@ package org.apache.hadoop.classification;
  * If external modules need to access/override these methods, then
  * they MUST be re-scoped as public/limited private.
  */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
 public @interface VisibleForTesting {
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/VisibleForTesting.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/VisibleForTesting.java
@@ -21,12 +21,6 @@ package org.apache.hadoop.util;
 /**
  * Annotates a program element that exists, or is more widely visible than
  * otherwise necessary, only for use in test code.
- *
- * <p><b>Do not use this interface</b> for public or protected declarations:
- * it is a fig leaf for bad design, and it does not prevent anyone from using
- * the declaration---and experience has shown that they will.
- * If the method breaks the encapsulation of its class, then its internal
- * representation will be hard to change.
  */
 public @interface VisibleForTesting {
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/VisibleForTesting.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/VisibleForTesting.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+/**
+ * Annotates a program element that exists, or is more widely visible than
+ * otherwise necessary, only for use in test code.
+ *
+ * <p><b>Do not use this interface</b> for public or protected declarations:
+ * it is a fig leaf for bad design, and it does not prevent anyone from using
+ * the declaration---and experience has shown that they will.
+ * If the method breaks the encapsulation of its class, then its internal
+ * representation will be hard to change.
+ */
+public @interface VisibleForTesting {
+}


### PR DESCRIPTION
### Description of PR
Provide alternative to Guava VisibleForTesting so that we can get rid of Guava dependency to represent testing scope for a class/method/field.