### PR TITLE
HADOOP-17925. BUILDING.txt should not encourage to activate docs profile on building binary artifacts.

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -336,25 +336,25 @@ Then, import to eclipse by specifying the root directory of the project via
 ----------------------------------------------------------------------------------
 Building distributions:
 
-Create binary distribution without native code and without documentation:
+Create binary distribution without native code and without Javadocs:
 
   $ mvn package -Pdist -DskipTests -Dtar -Dmaven.javadoc.skip=true
 
-Create binary distribution with native code and with documentation:
+Create binary distribution with native code:
 
-  $ mvn package -Pdist,native,docs -DskipTests -Dtar
+  $ mvn package -Pdist,native -DskipTests -Dtar
 
 Create source distribution:
 
   $ mvn package -Psrc -DskipTests
 
-Create source and binary distributions with native code and documentation:
+Create source and binary distributions with native code:
 
-  $ mvn package -Pdist,native,docs,src -DskipTests -Dtar
+  $ mvn package -Pdist,native,src -DskipTests -Dtar
 
 Create a local staging version of the website (in /tmp/hadoop-site)
 
-  $ mvn clean site -Preleasedocs; mvn site:stage -DstagingDirectory=/tmp/hadoop-site
+  $ mvn site site:stage -Preleasedocs,docs -DstagingDirectory=/tmp/hadoop-site
 
 Note that the site needs to be built in a second pass after other artifacts.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17925

If `-Pdocs` is activated, hadoop-client depends on xerces. The dependency was added by [HADOOP-14835](https://issues.apache.org/jira/browse/HADOOP-14835) to fix jdiff error. We are avoiding unwanted dependency by [building documentations alone in the second pass after building binary artifacts](https://github.com/apache/hadoop/blob/rel/release-3.3.1/dev-support/bin/create-release#L568-L606). The BUILDING.txt just should not encourage to activate `-Pdocs` on building binary artifacts.