### PR TITLE
YARN-10973. Remove Jersey version from application.wadl for Security …

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/RemoveGeneratedByJerseyFromApplicationWADLFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/RemoveGeneratedByJerseyFromApplicationWADLFilter.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.webapp;
+
+import com.google.inject.Injector;
+import com.sun.istack.NotNull;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+@Singleton
+public class RemoveGeneratedByJerseyFromApplicationWADLFilter extends GuiceContainer {
+
+  @Inject
+  public RemoveGeneratedByJerseyFromApplicationWADLFilter(Injector injector) {
+    super(injector);
+  }
+
+  @Override
+  public void doFilter(HttpServletRequest request,
+                       HttpServletResponse response, FilterChain chain) throws IOException,
+      ServletException {
+    ResponseBodyCopier copier = new ResponseBodyCopier(response);
+    chain.doFilter(request, copier);
+
+    String originalContent = copier.getResponseBody();
+    byte[] alteredContent = originalContent.replaceFirst("jersey:generatedBy=\".*\"", "")
+            .getBytes(StandardCharsets.UTF_8);
+
+    response.setContentLength(alteredContent.length);
+    response.resetBuffer();
+    response.getOutputStream().write(alteredContent);
+    response.getOutputStream().flush();
+  }
+
+  public static class ResponseBodyCopier extends HttpServletResponseWrapper {
+    private final ByteArrayOutputStream byteOutputStream;
+    private final ServletOutputStream out;
+    private final PrintWriter writer;
+
+    public ResponseBodyCopier(HttpServletResponse resp) {
+      super(resp);
+      this.byteOutputStream = new ByteArrayOutputStream();
+      this.out = new SubServletOutputStream(byteOutputStream);
+      this.writer = new PrintWriter(new OutputStreamWriter(byteOutputStream,
+          StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() {
+      return out;
+    }
+
+    @Override
+    public PrintWriter getWriter() {
+      return writer;
+    }
+
+    public String getResponseBody() throws IOException {
+      out.flush();
+      writer.flush();
+      return new String(byteOutputStream.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    static class SubServletOutputStream extends ServletOutputStream {
+      private final ByteArrayOutputStream byteOutputStream;
+
+      SubServletOutputStream(ByteArrayOutputStream byteOutputStream) {
+        this.byteOutputStream = byteOutputStream;
+      }
+
+      @Override
+      public void write(int b) {
+        byteOutputStream.write(b);
+      }
+
+      @Override
+      public void write(@NotNull byte[] b) {
+        byteOutputStream.write(b, 0, b.length);
+      }
+
+      @Override
+      public boolean isReady() {
+        return false;
+      }
+
+      @Override
+      public void setWriteListener(WriteListener writeListener) {
+      }
+    }
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/WebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/WebApp.java
@@ -190,6 +190,7 @@ public abstract class WebApp extends ServletModule {
       params.put(FeaturesAndProperties.FEATURE_XMLROOTELEMENT_PROCESSING, "true");
       params.put(ResourceConfig.PROPERTY_CONTAINER_REQUEST_FILTERS, GZIPContentEncodingFilter.class.getName());
       params.put(ResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS, GZIPContentEncodingFilter.class.getName());
+      filter("/application.wadl").through(RemoveGeneratedByJerseyFromApplicationWADLFilter.class);
       filter("/*").through(getWebAppFilterClass(), params);
     }
   }


### PR DESCRIPTION
…Reasons.

Change-Id: I1991763a7f78fb1c75e4a4c3f06374b8cfb4b2a5

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Please read the associated Jira ticket, do we really need a workaround like this?

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

