### PR TITLE
HDFS-16250. Refactor AllowSnapshotMock using GMock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/tools/hdfs-allow-snapshot-mock.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/tools/hdfs-allow-snapshot-mock.cc
@@ -17,17 +17,8 @@
   under the License.
 */
 
-#include <string>
-
-#include <gtest/gtest.h>
-
 #include "hdfs-allow-snapshot-mock.h"
 
 namespace hdfs::tools::test {
-bool AllowSnapshotMock::HandleHelp() const { return true; }
-
-bool AllowSnapshotMock::HandlePath(const std::string &path) const {
-  EXPECT_STREQ(path.c_str(), "a/b/c") << "Expecting the path a/b/c here";
-  return true;
-}
+AllowSnapshotMock::~AllowSnapshotMock() {}
 } // namespace hdfs::tools::test

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/tools/hdfs-allow-snapshot-mock.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/tools/hdfs-allow-snapshot-mock.h
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <gmock/gmock.h>
+
 #include "hdfs-allow-snapshot.h"
 
 namespace hdfs::tools::test {
@@ -36,21 +38,15 @@ public:
   AllowSnapshotMock(const int argc, char **argv) : AllowSnapshot(argc, argv) {}
 
   // Abiding to the Rule of 5
-  AllowSnapshotMock(const AllowSnapshotMock &) = default;
-  AllowSnapshotMock(AllowSnapshotMock &&) = default;
+  AllowSnapshotMock(const AllowSnapshotMock &) = delete;
+  AllowSnapshotMock(AllowSnapshotMock &&) = delete;
   AllowSnapshotMock &operator=(const AllowSnapshotMock &) = delete;
   AllowSnapshotMock &operator=(AllowSnapshotMock &&) = delete;
-  ~AllowSnapshotMock() override = default;
+  ~AllowSnapshotMock() override;
 
-  /**
-   * {@inheritdoc}
-   */
-  [[nodiscard]] bool HandleHelp() const override;
+  MOCK_METHOD(bool, HandleHelp, (), (const, override));
 
-  /**
-   * {@inheritdoc}
-   */
-  [[nodiscard]] bool HandlePath(const std::string &path) const override;
+  MOCK_METHOD(bool, HandlePath, (const std::string &), (const, override));
 };
 } // namespace hdfs::tools::test
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/tools/hdfs-tool-test.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/tools/hdfs-tool-test.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <tuple>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "hdfs-tool.h"
@@ -81,25 +82,35 @@ TEST_P(HdfsToolNegativeTest, RunTool) {
   EXPECT_ANY_THROW({ std::ignore = this->hdfs_tool_->Do(); });
 }
 
-template <class T> std::unique_ptr<hdfs::tools::HdfsTool> PassAPath() {
+template <class T> std::unique_ptr<T> PassAPath() {
   constexpr auto argc = 2;
   static std::string exe("hdfs_tool_name");
   static std::string arg1("a/b/c");
 
   static char *argv[] = {exe.data(), arg1.data()};
-  return std::make_unique<T>(argc, argv);
+
+  auto hdfs_tool = std::make_unique<T>(argc, argv);
+  EXPECT_CALL(*hdfs_tool, HandlePath(arg1))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  return hdfs_tool;
 }
 
-template <class T> std::unique_ptr<hdfs::tools::HdfsTool> CallHelp() {
+template <class T> std::unique_ptr<T> CallHelp() {
   constexpr auto argc = 2;
   static std::string exe("hdfs_tool_name");
   static std::string arg1("-h");
 
   static char *argv[] = {exe.data(), arg1.data()};
-  return std::make_unique<T>(argc, argv);
+
+  auto hdfs_tool = std::make_unique<T>(argc, argv);
+  EXPECT_CALL(*hdfs_tool, HandleHelp())
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  return hdfs_tool;
 }
 
-template <class T> std::unique_ptr<hdfs::tools::HdfsTool> Pass2Paths() {
+template <class T> std::unique_ptr<T> Pass2Paths() {
   constexpr auto argc = 3;
   static std::string exe("hdfs_tool_name");
   static std::string arg1("a/b/c");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
* Currently, the implementation
  of AllowSnapshotMock is quite
  basic. Need to replace this with
  GMock so that we can tap into
  the benefits offered by GMock.


### How was this patch tested?
The unit tests ran successfully.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

