### PR TITLE
HADOOP-16532: Fix TestViewFsTrash to use the correct homeDir.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
@@ -123,9 +123,10 @@ public class TestTrash {
 
   /**
    * Test trash for the shell's delete command for the default file system
-   * specified in the paramter conf
-   * @param conf 
+   * specified in the parameter conf
+   * @param conf - configuration object for the filesystem
    * @param base - the base path where files are created
+   * @param trashRootFs - the filesystem object to test trash
    * @param trashRoot - the expected place where the trashbin resides
    * @throws IOException
    */

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestTrash.java
@@ -794,7 +794,7 @@ public class TestTrash {
     }
   }
 
-  static class TestLFS extends LocalFileSystem {
+  public static class TestLFS extends LocalFileSystem {
     private URI uriName = null;
     Path home;
     TestLFS() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -19,12 +19,7 @@ package org.apache.hadoop.fs.viewfs;
 
 
 import java.io.IOException;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.fs.FsConstants;
@@ -35,12 +30,9 @@ import org.apache.hadoop.fs.TestTrash;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class TestViewFsTrash {
-  private static final Logger LOG = LoggerFactory.getLogger(TestViewFsTrash.class);
 
   FileSystem fsTarget;  // the target file system - the mount will point here
   FileSystem fsView;
@@ -48,7 +40,6 @@ public class TestViewFsTrash {
   private static FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper();
 
   static class TestLFS extends LocalFileSystem {
-    private static final Logger LOG = LoggerFactory.getLogger(TestLFS.class);
     Path home;
     TestLFS() throws IOException {
       this(new Path(fileSystemTestHelper.getTestRootDir()));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.fs.viewfs;
 
 
 import java.io.IOException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemTestHelper;
@@ -31,9 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class TestViewFsTrash {
-
   FileSystem fsTarget;  // the target file system - the mount will point here
   FileSystem fsView;
   Configuration conf;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -20,7 +20,11 @@ package org.apache.hadoop.fs.viewfs;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.fs.FsConstants;
@@ -30,14 +34,22 @@ import org.apache.hadoop.fs.TestTrash;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.*;
+
 
 public class TestViewFsTrash {
+  private static final Logger LOG = LoggerFactory.getLogger(TestViewFsTrash.class);
+
   FileSystem fsTarget;  // the target file system - the mount will point here
   FileSystem fsView;
   Configuration conf;
-  FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper();
+  static FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper();
 
-  class TestLFS extends LocalFileSystem {
+  static class TestLFS extends LocalFileSystem {
+    private static final Logger LOG = LoggerFactory.getLogger(TestLFS.class);
     Path home;
     TestLFS() throws IOException {
       this(new Path(fileSystemTestHelper.getTestRootDir()));
@@ -50,16 +62,68 @@ public class TestViewFsTrash {
     public Path getHomeDirectory() {
       return home;
     }
+
+    /*
+     * We need to override getTrashRoot and getTrashRoots.
+     * Otherwise, RawLocalFileSystem.getTrashRoot() will be called, which in turn calls
+     * FileSystem.getTrashRoot(), which will call RawLocalFileSystem.getHomeDirectory(),
+     * which returns the value from System.property("user.home").
+     */
+    @Override
+    public Path getTrashRoot(Path path) {
+      return this.makeQualified(new Path(getHomeDirectory().toUri().getPath(), TRASH_PREFIX));
+    }
+
+    @Override
+    public Collection<FileStatus> getTrashRoots(boolean allUsers) {
+      Path userHome = new Path(getHomeDirectory().toUri().getPath());
+      List<FileStatus> ret = new ArrayList<>();
+      try {
+        if (!allUsers) {
+          Path userTrash = new Path(userHome, TRASH_PREFIX);
+          if (exists(userTrash)) {
+            ret.add(getFileStatus(userTrash));
+          }
+        } else {
+          Path homeParent = userHome.getParent();
+          if (exists(homeParent)) {
+            FileStatus[] candidates = listStatus(homeParent);
+            for (FileStatus candidate : candidates) {
+              Path userTrash = new Path(candidate.getPath(), TRASH_PREFIX);
+              if (exists(userTrash)) {
+                candidate.setPath(userTrash);
+                ret.add(candidate);
+              }
+            }
+          }
+        }
+      } catch (IOException e) {
+        LOG.warn("Cannot get all trash roots", e);
+      }
+      return ret;
+    }
   }
 
   @Before
   public void setUp() throws Exception {
-    fsTarget = FileSystem.getLocal(new Configuration());
-    fsTarget.mkdirs(new Path(fileSystemTestHelper.
-        getTestRootPath(fsTarget), "dir1"));
+    Configuration targetFSConf = new Configuration();
+    // Trash with 12 second deletes and 6 seconds checkpoints
+    targetFSConf.set(FS_TRASH_INTERVAL_KEY, "0.2"); // 12 seconds
+    targetFSConf.set(FS_TRASH_CHECKPOINT_INTERVAL_KEY, "0.1"); // 6 seconds
+    targetFSConf.setClass("fs.file.impl", TestViewFsTrash.TestLFS.class, FileSystem.class);
+
+    fsTarget = FileSystem.getLocal(targetFSConf);
+
     conf = ViewFileSystemTestSetup.createConfig();
     fsView = ViewFileSystemTestSetup.setupForViewFileSystem(conf, fileSystemTestHelper, fsTarget);
     conf.set("fs.defaultFS", FsConstants.VIEWFS_URI.toString());
+
+    /*
+     * Need to set the fs.file.impl to TestViewFsTrash.TestLFS. Otherwise, it will load
+     * LocalFileSystem implementation which uses System.getProperty("user.home") for homeDirectory.
+     */
+    conf.setClass("fs.file.impl", TestViewFsTrash.TestLFS.class, FileSystem.class);
+
   }
  
   @After
@@ -72,7 +136,7 @@ public class TestViewFsTrash {
   @Test
   public void testTrash() throws Exception {
     TestTrash.trashShell(conf, fileSystemTestHelper.getTestRootPath(fsView),
-        fsTarget, new Path(fsTarget.getHomeDirectory(), ".Trash/Current"));
+        fsView, new Path(fileSystemTestHelper.getTestRootPath(fsView), ".Trash/Current"));
   }
   
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -17,16 +17,11 @@
  */
 package org.apache.hadoop.fs.viewfs;
 
-
-import java.io.IOException;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.fs.FsConstants;
-import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.TestTrash;
 import org.junit.After;
 import org.junit.Before;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -36,40 +36,15 @@ public class TestViewFsTrash {
   FileSystem fsTarget;  // the target file system - the mount will point here
   FileSystem fsView;
   Configuration conf;
-  private static FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper();
-
-  static class TestLFS extends LocalFileSystem {
-    Path home;
-    TestLFS() throws IOException {
-      this(new Path(fileSystemTestHelper.getTestRootDir()));
-    }
-    TestLFS(Path home) throws IOException {
-
-      super(new RawLocalFileSystem() {
-        @Override
-        protected Path getInitialWorkingDirectory() {
-          return makeQualified(home);
-        }
-
-        @Override
-        public Path getHomeDirectory() {
-          return makeQualified(home);
-        }
-      });
-      this.home = home;
-    }
-    @Override
-    public Path getHomeDirectory() {
-      return home;
-    }
-  }
+  private FileSystemTestHelper fileSystemTestHelper;
 
   @Before
   public void setUp() throws Exception {
     Configuration targetFSConf = new Configuration();
-    targetFSConf.setClass("fs.file.impl", TestViewFsTrash.TestLFS.class, FileSystem.class);
+    targetFSConf.setClass("fs.file.impl", TestTrash.TestLFS.class, FileSystem.class);
 
     fsTarget = FileSystem.getLocal(targetFSConf);
+    fileSystemTestHelper = new FileSystemTestHelper(fsTarget.getHomeDirectory().toUri().getPath());
 
     conf = ViewFileSystemTestSetup.createConfig();
     fsView = ViewFileSystemTestSetup.setupForViewFileSystem(conf, fileSystemTestHelper, fsTarget);
@@ -79,7 +54,7 @@ public class TestViewFsTrash {
      * Need to set the fs.file.impl to TestViewFsTrash.TestLFS. Otherwise, it will load
      * LocalFileSystem implementation which uses System.getProperty("user.home") for homeDirectory.
      */
-    conf.setClass("fs.file.impl", TestViewFsTrash.TestLFS.class, FileSystem.class);
+    conf.setClass("fs.file.impl", TestTrash.TestLFS.class, FileSystem.class);
 
   }
  

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -44,7 +44,7 @@ public class TestViewFsTrash {
   FileSystem fsTarget;  // the target file system - the mount will point here
   FileSystem fsView;
   Configuration conf;
-  static FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper();
+  private static FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper();
 
   static class TestLFS extends LocalFileSystem {
     private static final Logger LOG = LoggerFactory.getLogger(TestLFS.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsTrash.java
@@ -37,8 +37,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.*;
-
 
 public class TestViewFsTrash {
   private static final Logger LOG = LoggerFactory.getLogger(TestViewFsTrash.class);
@@ -107,9 +105,6 @@ public class TestViewFsTrash {
   @Before
   public void setUp() throws Exception {
     Configuration targetFSConf = new Configuration();
-    // Trash with 12 second deletes and 6 seconds checkpoints
-    targetFSConf.set(FS_TRASH_INTERVAL_KEY, "0.2"); // 12 seconds
-    targetFSConf.set(FS_TRASH_CHECKPOINT_INTERVAL_KEY, "0.1"); // 6 seconds
     targetFSConf.setClass("fs.file.impl", TestViewFsTrash.TestLFS.class, FileSystem.class);
 
     fsTarget = FileSystem.getLocal(targetFSConf);


### PR DESCRIPTION
Fixed the homeDir issue reported in HADOOP-16532. We are finally able to pass this test for ViewFS.

