### PR TITLE
HADOOP-17951 AccessPoint verifyBucketExistsV2 always returns false

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -216,6 +216,7 @@ import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.submit;
 import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.waitForCompletionIgnoringExceptions;
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.isObjectNotFound;
 import static org.apache.hadoop.fs.s3a.impl.ErrorTranslation.isUnknownBucket;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AP_INACCESSIBLE;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AP_REQUIRED_EXCEPTION;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AP_S3GUARD_INCOMPATIBLE;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.ARN_BUCKET_OPTION;
@@ -785,7 +786,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
                 s3.getBucketAcl(bucket);
               } catch (AmazonServiceException ex) {
                 int statusCode = ex.getStatusCode();
-                if (statusCode == SC_404 || (statusCode == SC_403 && accessPoint != null)) {
+                if (statusCode == SC_404 ||
+                    (statusCode == SC_403 && ex.getMessage().contains(AP_INACCESSIBLE))) {
                   return false;
                 }
               }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -155,6 +155,11 @@ public final class InternalConstants {
       " but not configured for the bucket.";
 
   /**
+   * Error message to indicate Access Points are not accessible or don't exist.
+   */
+  public static final String AP_INACCESSIBLE = "Could not access through this access point";
+
+  /**
    * AccessPoint ARN for the bucket. When set as a bucket override the requests for that bucket
    * will go through the AccessPoint.
    */


### PR DESCRIPTION
### Description of PR
Turns out there was a small issue with the previous implementation that
always returned `false` for `verifyBucketExistsV2`. The more "clearer"
way to check is for an error message when there's a 403. If that error
message is present then the AP doesn't exist (the only case when a 403
is returned for an AP), otherwise 404 means definite no.

### How was this patch tested?
Ran `mvn -Dparallel-tests -DtestsThreadCount=32 clean verify` on `eu-west-1` with access points enabled (i.e. bucket pointing to AP ARN).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

