### PR TITLE
HDFS-16254. Cleanup protobuf on exit of hdfs_allowSnapshot

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
@@ -341,6 +341,7 @@ TEST(BadDataNodeTest, InternalError) {
   ASSERT_TRUE(tracker->IsBadNode(failing_dn));
 }
 
+
 int main(int argc, char *argv[]) {
   // The following line must be executed to initialize Google Mock
   // (and Google Test) before running the tests.

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/bad_datanode_test.cc
@@ -341,7 +341,6 @@ TEST(BadDataNodeTest, InternalError) {
   ASSERT_TRUE(tracker->IsBadNode(failing_dn));
 }
 
-
 int main(int argc, char *argv[]) {
   // The following line must be executed to initialize Google Mock
   // (and Google Test) before running the tests.

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-allow-snapshot/hdfs-allow-snapshot.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-allow-snapshot/hdfs-allow-snapshot.cc
@@ -23,8 +23,6 @@
 #include <sstream>
 #include <string>
 
-#include <google/protobuf/stubs/common.h>
-
 #include "hdfs-allow-snapshot.h"
 #include "tools_common.h"
 
@@ -112,9 +110,6 @@ bool AllowSnapshot::HandlePath(const std::string &path) const {
     std::cerr << "Error: " << status.ToString() << std::endl;
     return false;
   }
-
-  // Clean up static data and prevent valgrind memory leaks
-  google::protobuf::ShutdownProtobufLibrary();
   return true;
 }
 } // namespace hdfs::tools

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-allow-snapshot/main.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-allow-snapshot/main.cc
@@ -21,9 +21,22 @@
 #include <exception>
 #include <iostream>
 
+#include <google/protobuf/stubs/common.h>
+
 #include "hdfs-allow-snapshot.h"
 
 int main(int argc, char *argv[]) {
+  const auto result = std::atexit([]() -> void {
+    // Clean up static data on exit and prevent valgrind memory leaks
+    google::protobuf::ShutdownProtobufLibrary();
+  });
+  if (result != 0) {
+    std::cerr << "Error: Unable to schedule clean-up tasks for HDFS allow "
+                 "snapshot tool, exiting"
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
   hdfs::tools::AllowSnapshot allow_snapshot(argc, argv);
   auto success = false;
 
@@ -35,7 +48,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (!success) {
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
   return 0;
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
* Moved the call
  google::protobuf::ShutdownProtobufLibrary()
  to main method instead of
  AllowSnapshot::HandlePath
  since we want the clean-up
  tasks to run only when the
  program exits.

### How was this patch tested?
Unit tests ran fine. Also, verified
by running the tool locally,
as shown below -

![image](https://user-images.githubusercontent.com/10280768/135907030-368dafb6-ff61-4095-a25a-2c379cf0e490.png)

The directory was marked as
snapshot-able without any
errors -
![image](https://user-images.githubusercontent.com/10280768/135907086-d73fdd87-d951-483e-8fa7-0a7ee7ea16ec.png)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

