### PR TITLE
HDFS-16257. Set initialCapacity for guava cache to solve performance issue

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -138,7 +138,8 @@ public class MountTableResolver
           FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE,
           FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE_DEFAULT);
       this.locationCache = CacheBuilder.newBuilder()
-          // To warkaround guava bug https://github.com/google/guava/issues/1055
+          // To workaround guava bug https://github.com/google/guava/issues/1055
+          // Fixed since guava 13.0
           .initialCapacity(maxCacheSize)
           .maximumSize(maxCacheSize)
           .build();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MountTableResolver.java
@@ -138,6 +138,8 @@ public class MountTableResolver
           FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE,
           FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE_DEFAULT);
       this.locationCache = CacheBuilder.newBuilder()
+          // To warkaround guava bug https://github.com/google/guava/issues/1055
+          .initialCapacity(maxCacheSize)
           .maximumSize(maxCacheSize)
           .build();
     } else {


### PR DESCRIPTION
### Description of PR

Branch 2.10.1 uses guava version of 11.0.2, which has a bug which affects the performance of cache, which was mentioned in HDFS-13821.

Since upgrading guava version seems affecting too much, this ticket is to add a configuration setting when initializing cache to walk around this issue.

### How was this patch tested?

Locally tested.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

