### PR TITLE
HADOOP-17953. S3A: Tests to lookup global or per-bucket configuration for encryption algorithm

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FCStatisticsBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FCStatisticsBaseTest.java
@@ -178,7 +178,8 @@ public abstract class FCStatisticsBaseTest {
    * 
    * @param stats
    */
-  protected abstract void verifyWrittenBytes(Statistics stats);
+  protected abstract void verifyWrittenBytes(Statistics stats)
+      throws IOException;
   
   /**
    * Returns the filesystem uri. Should be set

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.AccessDeniedException;
 
@@ -150,7 +151,8 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
       s3EncryptionMethod =
           getEncryptionAlgorithm(getTestBucketName(conf), conf).getMethod();
     } catch (IOException e) {
-      throw new RuntimeException("Failed to lookup encryption algorithm.");
+      throw new UncheckedIOException("Failed to lookup encryption algorithm.",
+          e);
     }
     String s3EncryptionKey = getS3EncryptionKey(getTestBucketName(conf), conf);
     removeBaseAndBucketOverrides(conf,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.DefaultS3ClientFactory;
 import org.apache.hadoop.fs.s3a.Invoker;
-import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.S3ClientFactory;
@@ -69,6 +68,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.unsetHadoopCredentialProviders;
+import static org.apache.hadoop.fs.s3a.S3AUtils.getEncryptionAlgorithm;
 import static org.apache.hadoop.fs.s3a.S3AUtils.getS3EncryptionKey;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.*;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationTokenIOException.TOKEN_MISMATCH;
@@ -145,9 +145,13 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
     // disable if assume role opts are off
     assumeSessionTestsEnabled(conf);
     disableFilesystemCaching(conf);
-    String s3EncryptionMethod =
-        conf.getTrimmed(Constants.S3_ENCRYPTION_ALGORITHM,
-            S3AEncryptionMethods.SSE_KMS.getMethod());
+    String s3EncryptionMethod;
+    try {
+      s3EncryptionMethod =
+          getEncryptionAlgorithm(getTestBucketName(conf), conf).getMethod();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to lookup encryption algorithm.");
+    }
     String s3EncryptionKey = getS3EncryptionKey(getTestBucketName(conf), conf);
     removeBaseAndBucketOverrides(conf,
         DELEGATION_TOKEN_BINDING,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
@@ -13,6 +13,7 @@
  */
 package org.apache.hadoop.fs.s3a.fileContext;
 
+import java.io.IOException;
 import java.net.URI;
 
 import com.amazonaws.services.s3.model.CryptoStorageMode;
@@ -32,9 +33,10 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
-import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_ALGORITHM;
-import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.KMS_KEY_GENERATION_REQUEST_PARAMS_BYTES_WRITTEN;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
+import static org.apache.hadoop.fs.s3a.S3AUtils.getEncryptionAlgorithm;
+import static org.apache.hadoop.fs.s3a.S3AUtils.getS3EncryptionKey;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.CSE_PADDING_LENGTH;
 
 /**
@@ -83,12 +85,14 @@ public class ITestS3AFileContextStatistics extends FCStatisticsBaseTest {
    * @param stats Filesystem statistics.
    */
   @Override
-  protected void verifyWrittenBytes(FileSystem.Statistics stats) {
+  protected void verifyWrittenBytes(FileSystem.Statistics stats)
+      throws IOException {
     //No extra bytes are written
     long expectedBlockSize = blockSize;
-    if (conf.get(S3_ENCRYPTION_ALGORITHM, "")
-        .equals(S3AEncryptionMethods.CSE_KMS.getMethod())) {
-      String keyId = conf.get(S3_ENCRYPTION_KEY, "");
+    if (S3AEncryptionMethods.CSE_KMS.getMethod()
+        .equals(getEncryptionAlgorithm(getTestBucketName(conf), conf)
+            .getMethod())) {
+      String keyId = getS3EncryptionKey(getTestBucketName(conf), conf);
       // Adding padding length and KMS key generation bytes written.
       expectedBlockSize += CSE_PADDING_LENGTH + keyId.getBytes().length +
           KMS_KEY_GENERATION_REQUEST_PARAMS_BYTES_WRITTEN;


### PR DESCRIPTION
Region: ap-south-1

### CSE:
`[WARNING] Tests run: 588, Failures: 0, Errors: 0, Skipped: 5`
```[ERROR] Errors: 
[ERROR]   ITestS3AMiscOperationCost.testGetContentSummaryRoot:96->AbstractS3ACostTest.verifyMetrics:391->lambda$testGetContentSummaryRoot$1:96->getContentSummary:140 » TestTimedOut
[ERROR]   ITestS3AMiscOperationCost.testGetContentSummaryRoot:96->AbstractS3ACostTest.verifyMetrics:391->lambda$testGetContentSummaryRoot$1:96->getContentSummary:140 » TestTimedOut
[INFO] 
[ERROR] Tests run: 1471, Failures: 0, Errors: 2, Skipped: 636
```
```
[ERROR] Errors: 
[ERROR]   ITestS3AContractRootDir>AbstractContractRootDirectoryTest.testRecursiveRootListing:267 » TestTimedOut
[INFO] 
[ERROR] Tests run: 151, Failures: 1, Errors: 1, Skipped: 28
```

### normal:
`[WARNING] Tests run: 588, Failures: 0, Errors: 0, Skipped: 5`
```
[ERROR] Errors: 
[ERROR]   ITestS3AMiscOperationCost.testGetContentSummaryRoot:96->AbstractS3ACostTest.verifyMetrics:391->lambda$testGetContentSummaryRoot$1:96->getContentSummary:140 » TestTimedOut
[ERROR]   ITestS3AMiscOperationCost.testGetContentSummaryRoot:96->AbstractS3ACostTest.verifyMetrics:391->lambda$testGetContentSummaryRoot$1:96->getContentSummary:140 » TestTimedOut
[INFO] 
[ERROR] Tests run: 1471, Failures: 0, Errors: 2, Skipped: 466
```
```
[ERROR]   ITestS3AContractRootDir>AbstractContractRootDirectoryTest.testRecursiveRootListing:267 » TestTimedOut
[INFO] 
[ERROR] Tests run: 151, Failures: 1, Errors: 1, Skipped: 28
```

### s3guard
`[WARNING] Tests run: 588, Failures: 0, Errors: 0, Skipped: 5`
`[INFO] 
[ERROR] Tests run: 1471, Failures: 1, Errors: 3, Skipped: 387`
`
[INFO] 
[ERROR] Tests run: 11, Failures: 0, Errors: 3, Skipped: 0
`

### CSE-S3Guard
`[WARNING] Tests run: 588, Failures: 0, Errors: 0, Skipped: 5`
`[WARNING] Tests run: 1471, Failures: 0, Errors: 0, Skipped: 1271`
`[WARNING] Tests run: 151, Failures: 0, Errors: 0, Skipped: 92`