### PR TITLE
YARN-6862. Nodemanager resource usage metrics should not show negativ…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainersMonitorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainersMonitorImpl.java
@@ -537,8 +537,6 @@ public class ContainersMonitorImpl extends AbstractService implements
             pTree.updateProcessTree();    // update process-tree
             long currentVmemUsage = pTree.getVirtualMemorySize();
             long currentPmemUsage = pTree.getRssMemorySize();
-            LOG.info("currentVmem {} currentPmem {} ", currentVmemUsage, currentPmemUsage);
-
             if (currentVmemUsage < 0 || currentPmemUsage < 0) {
               // YARN-6862/YARN-5021 If the container just exited or for
               // another reason the physical/virtual memory is UNAVAILABLE (-1)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainersMonitorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainersMonitorImpl.java
@@ -537,6 +537,16 @@ public class ContainersMonitorImpl extends AbstractService implements
             pTree.updateProcessTree();    // update process-tree
             long currentVmemUsage = pTree.getVirtualMemorySize();
             long currentPmemUsage = pTree.getRssMemorySize();
+            LOG.info("currentVmem {} currentPmem {} ", currentVmemUsage, currentPmemUsage);
+
+            if (currentVmemUsage < 0 || currentPmemUsage < 0) {
+              // YARN-6862/YARN-5021 If the container just exited or for
+              // another reason the physical/virtual memory is UNAVAILABLE (-1)
+              // the values shouldn't be aggregated.
+              LOG.info("Skipping monitoring container {} because "
+                  + "memory usage is not available.", containerId);
+              continue;
+            }
 
             // if machine has 6 cores and 3 are used,
             // cpuUsagePercentPerCore should be 300%

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/MockMemoryResourceCalculatorProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/MockMemoryResourceCalculatorProcessTree.java
@@ -25,8 +25,9 @@ import org.apache.hadoop.yarn.util.ResourceCalculatorProcessTree;
  */
 public class MockMemoryResourceCalculatorProcessTree
     extends ResourceCalculatorProcessTree {
+  private final long memorySize = 500000000L;
 
-  private long rssMemorySize = 500000000;
+  private long rssMemorySize = memorySize;
   private long virtualMemorySize = ResourceCalculatorProcessTree.UNAVAILABLE;
 
   /**
@@ -62,11 +63,11 @@ public class MockMemoryResourceCalculatorProcessTree
     long rssMemory = this.rssMemorySize;
     // First getter call will return with 500000000, and second call will
     // return -1, rest of the calls will return a valid value.
-    if (rssMemory == 500000000) {
+    if (rssMemory == memorySize) {
       this.rssMemorySize = ResourceCalculatorProcessTree.UNAVAILABLE;
     }
     if (rssMemory == ResourceCalculatorProcessTree.UNAVAILABLE) {
-      this.rssMemorySize = 700000000;
+      this.rssMemorySize = 2 * memorySize;
     }
     return rssMemory;
   }
@@ -77,7 +78,7 @@ public class MockMemoryResourceCalculatorProcessTree
     // First getter call will return with -1, and rest of the calls will
     // return a valid value.
     if (virtualMemory == ResourceCalculatorProcessTree.UNAVAILABLE) {
-      this.virtualMemorySize = 200000000;
+      this.virtualMemorySize = 3 * memorySize;
     }
     return virtualMemory;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/MockMemoryResourceCalculatorProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/MockMemoryResourceCalculatorProcessTree.java
@@ -21,19 +21,20 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor;
 import org.apache.hadoop.yarn.util.ResourceCalculatorProcessTree;
 
 /**
- * Mock class to obtain resource usage (CPU).
+ * Mock class to obtain resource usage (Memory).
  */
-public class MockCPUResourceCalculatorProcessTree
+public class MockMemoryResourceCalculatorProcessTree
     extends ResourceCalculatorProcessTree {
 
-  private long cpuPercentage = ResourceCalculatorProcessTree.UNAVAILABLE;
+  private long rssMemorySize = 500000000;
+  private long virtualMemorySize = ResourceCalculatorProcessTree.UNAVAILABLE;
 
   /**
-   * Constructor for MockCPUResourceCalculatorProcessTree with specified root
+   * Constructor for MockMemoryResourceCalculatorProcessTree with specified root
    * process.
    * @param root
    */
-  public MockCPUResourceCalculatorProcessTree(String root) {
+  public MockMemoryResourceCalculatorProcessTree(String root) {
     super(root);
   }
 
@@ -57,24 +58,32 @@ public class MockCPUResourceCalculatorProcessTree
   }
 
   @Override
-  public long getVirtualMemorySize(int olderThanAge) {
-    return 0;
+  public long getRssMemorySize(int olderThanAge) {
+    long rssMemory = this.rssMemorySize;
+    // First getter call will return with 500000000, and second call will
+    // return -1, rest of the calls will return a valid value.
+    if (rssMemory == 500000000) {
+      this.rssMemorySize = ResourceCalculatorProcessTree.UNAVAILABLE;
+    }
+    if (rssMemory == ResourceCalculatorProcessTree.UNAVAILABLE) {
+      this.rssMemorySize = 700000000;
+    }
+    return rssMemory;
   }
 
   @Override
-  public long getRssMemorySize(int olderThanAge) {
-    return 0;
+  public long getVirtualMemorySize(int olderThanAge) {
+    long virtualMemory = this.virtualMemorySize;
+    // First getter call will return with -1, and rest of the calls will
+    // return a valid value.
+    if (virtualMemory == ResourceCalculatorProcessTree.UNAVAILABLE) {
+      this.virtualMemorySize = 200000000;
+    }
+    return virtualMemory;
   }
 
   @Override
   public float getCpuUsagePercent() {
-    long cpu = this.cpuPercentage;
-    // First getter call will be returned with -1, and other calls will
-    // return non-zero value as defined below.
-    if (cpu == ResourceCalculatorProcessTree.UNAVAILABLE) {
-      // Set a default value other than 0 for test.
-      this.cpuPercentage = 50;
-    }
-    return cpu;
+    return 0;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/MockResourceCalculatorProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/MockResourceCalculatorProcessTree.java
@@ -51,8 +51,14 @@ public class MockResourceCalculatorProcessTree extends ResourceCalculatorProcess
     this.rssMemorySize = rssMemorySize;
   }
 
+  @Override
   public long getRssMemorySize() {
     return this.rssMemorySize;
+  }
+
+  @Override
+  public long getVirtualMemorySize() {
+    return 0;
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitorResourceChange.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitorResourceChange.java
@@ -296,12 +296,11 @@ public class TestContainersMonitorResourceChange {
   private void testContainerMonitoringInvalidResources(
       String processTreeClassName) throws Exception {
     Configuration newConf = new Configuration(conf);
-    // set container monitor interval to be 20s
+    // set container monitor interval to be 20ms
     newConf.setLong(YarnConfiguration.NM_CONTAINER_MON_INTERVAL_MS, 20L);
     containersMonitor = createContainersMonitor(executor, dispatcher, context);
     newConf.set(YarnConfiguration.NM_CONTAINER_MON_PROCESS_TREE,
         processTreeClassName);
-    // set container monitor interval to be 20ms
     containersMonitor.init(newConf);
     containersMonitor.start();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitorResourceChange.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitorResourceChange.java
@@ -282,12 +282,25 @@ public class TestContainersMonitorResourceChange {
 
   @Test
   public void testContainersCPUResourceForDefaultValue() throws Exception {
+    testContainerMonitoringInvalidResources(
+        MockCPUResourceCalculatorProcessTree.class.getCanonicalName());
+
+  }
+
+  @Test
+  public void testContainersMemoryResourceUnavailable() throws Exception {
+    testContainerMonitoringInvalidResources(
+        MockMemoryResourceCalculatorProcessTree.class.getCanonicalName());
+  }
+
+  private void testContainerMonitoringInvalidResources(
+      String processTreeClassName) throws Exception {
     Configuration newConf = new Configuration(conf);
     // set container monitor interval to be 20s
     newConf.setLong(YarnConfiguration.NM_CONTAINER_MON_INTERVAL_MS, 20L);
     containersMonitor = createContainersMonitor(executor, dispatcher, context);
     newConf.set(YarnConfiguration.NM_CONTAINER_MON_PROCESS_TREE,
-        MockCPUResourceCalculatorProcessTree.class.getCanonicalName());
+        processTreeClassName);
     // set container monitor interval to be 20ms
     containersMonitor.init(newConf);
     containersMonitor.start();
@@ -305,7 +318,7 @@ public class TestContainersMonitorResourceChange {
         0, containersMonitor.getContainersUtilization()
             .compareTo(ResourceUtilization.newInstance(0, 0, 0.0f)));
 
-    // Verify the container utilization value. Since atleast one round is done,
+    // Verify the container utilization value. Since at least one round is done,
     // we can expect a non-zero value for container utilization as
     // MockCPUResourceCalculatorProcessTree#getCpuUsagePercent will return 50.
     waitForContainerResourceUtilizationChange(containersMonitor, 100);
@@ -324,12 +337,13 @@ public class TestContainersMonitorResourceChange {
       }
 
       LOG.info(
-          "Monitor thread is waiting for resource utlization change.");
+          "Monitor thread is waiting for resource utilization change.");
       Thread.sleep(WAIT_MS_PER_LOOP);
       timeWaiting += WAIT_MS_PER_LOOP;
     }
 
-    assertTrue("Resource utilization is not changed from second run onwards",
+    assertTrue("Resource utilization is not changed after " +
+            timeoutMsecs / WAIT_MS_PER_LOOP + " updates",
         0 != containersMonitor.getContainersUtilization()
             .compareTo(ResourceUtilization.newInstance(0, 0, 0.0f)));
   }


### PR DESCRIPTION
…e values.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

