### PR TITLE
HDFS-16264.When adding block keys, the records come from the specific Block Pool.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenSecretManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/security/token/block/BlockTokenSecretManager.java
@@ -226,7 +226,7 @@ public class BlockTokenSecretManager extends
     if (isMaster || exportedKeys == null) {
       return;
     }
-    LOG.info("Setting block keys");
+    LOG.info("Setting block keys. BlockPool = {} .", blockPoolId);
     removeExpiredKeys();
     this.currentKey = exportedKeys.getCurrentKey();
     BlockKey[] receivedKeys = exportedKeys.getAllKeys();


### PR DESCRIPTION

### Description of PR
When adding block keys, the records come from the specific block pool.

### How was this patch tested?
This is related to logs, and unit testing is less stressful.

