### PR TITLE
YARN-10955. Add health check mechanism to improve troubleshooting skills for RM

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -1275,6 +1275,18 @@ public final class HttpServer2 implements FilterContainer {
     pool.setMaxThreads(max);
   }
 
+  public int getCurrentThreads() {
+    return webServer.getThreadPool().getThreads();
+  }
+
+  public int getIdleThreads() {
+    return webServer.getThreadPool().getIdleThreads();
+  }
+
+  public int getMaxThreads() {
+    return ((QueuedThreadPool) webServer.getThreadPool()).getMaxThreads();
+  }
+
   private void initSpnego(Configuration conf, String hostName,
       String usernameConfKey, String keytabConfKey) throws IOException {
     Map<String, String> params = new HashMap<>();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -50,18 +50,7 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -3996,5 +3985,14 @@ public abstract class Server {
 
   public String getServerName() {
     return serverName;
+  }
+
+  public Map<String, Long> getHandlerStateCount() {
+    return Arrays.stream(handlers).map(Thread::getState)
+            .collect(Collectors.groupingBy(Enum::toString, Collectors.counting()));
+  }
+
+  public boolean isRunning() {
+    return running;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -344,6 +344,10 @@ public class RpcMetrics {
     return deferredRpcProcessingTime.lastStat().stddev();
   }
 
+  public MutableRate getRpcQueueTime() {
+    return rpcQueueTime;
+  }
+
   @VisibleForTesting
   public MetricsTag getTag(String tagName) {
     return registry.getTag(tagName);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4614,6 +4614,17 @@ public class YarnConfiguration extends Configuration {
   public static final String DEFAULT_YARN_WORKFLOW_ID_TAG_PREFIX =
       "workflowid:";
 
+
+  public static final String HEALTH_PREFIX =
+          YARN_PREFIX + "health.";
+  public static final String HEALTH_AUTO_CHECK_PERIOD =
+          HEALTH_PREFIX + "auto-check-period";
+  public static final long DEFAULT_HEALTH_AUTO_CHECK_PERIOD = 1800;
+
+  public static final String HEALTH_MAX_TORRANCE_TIME =
+          HEALTH_PREFIX + "max-torrance-time";
+  public static final long DEFAULT_HEALTH_MAX_TORRANCE_TIME = 300;
+
   public YarnConfiguration() {
     super();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/health/HealthCheckService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/health/HealthCheckService.java
@@ -1,0 +1,211 @@
+package org.apache.hadoop.yarn.health;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ipc.metrics.RpcMetrics;
+import org.apache.hadoop.service.AbstractService;
+import org.apache.hadoop.service.CompositeService;
+import org.apache.hadoop.service.Service;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class HealthCheckService extends AbstractService {
+    private static final Logger LOG =
+        LoggerFactory.getLogger(HealthCheckService.class);
+
+    private final Map<String, Object> reporters;
+    private Thread healthCheckThread;
+    private volatile boolean stopped;
+    private volatile long autoCheckPeriod;
+    private volatile long maxTorranceTime;
+    private ReadWriteLock rwLock;
+    private volatile List<HealthReport> lastReports;
+    private volatile long lastTimestamp;
+    private Semaphore requestSemaphore;
+    private AtomicBoolean waiting;
+
+    /**
+     * Construct the service.
+     *
+     */
+    public HealthCheckService() {
+        super(HealthCheckService.class.getName());
+        reporters = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void serviceInit(Configuration conf) throws Exception {
+        rwLock = new ReentrantReadWriteLock();
+        requestSemaphore = new Semaphore(0);
+        waiting = new AtomicBoolean();
+        autoCheckPeriod = conf.getLong(YarnConfiguration.HEALTH_AUTO_CHECK_PERIOD,
+                YarnConfiguration.DEFAULT_HEALTH_AUTO_CHECK_PERIOD);
+        maxTorranceTime = conf.getLong(YarnConfiguration.HEALTH_MAX_TORRANCE_TIME,
+                YarnConfiguration.DEFAULT_HEALTH_MAX_TORRANCE_TIME);
+        super.serviceInit(conf);
+    }
+
+    @Override
+    public void serviceStart() throws Exception {
+        stopped = false;
+        healthCheckThread = new Thread(() -> {
+            while (!stopped && !Thread.currentThread().isInterrupted()) {
+                try {
+                    requestSemaphore.tryAcquire(autoCheckPeriod, TimeUnit.SECONDS);
+                    waiting.set(true);
+                    List<HealthReport> reports = innerHealthCheck();
+                    requestSemaphore.drainPermits();
+                    long timestamp = System.currentTimeMillis();
+                    try {
+                        rwLock.writeLock().lock();
+                        lastReports = reports;
+                        lastTimestamp = timestamp;
+                    } finally {
+                        rwLock.writeLock().unlock();
+                        waiting.set(false);
+                    }
+                    // TODO log and metrics
+                    for (HealthReport report : reports) {
+                        LOG.info(report.toString());
+                    }
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        });
+        healthCheckThread.setName("HealthCheckService Thread");
+        healthCheckThread.start();
+        requestSemaphore.release();
+        super.serviceStart();
+    }
+
+    @Override
+    public void serviceStop() throws Exception {
+        stopped = true;
+        if (healthCheckThread != null) {
+            healthCheckThread.interrupt();
+            try {
+                healthCheckThread.join();
+            } catch (InterruptedException ie) {
+                LOG.warn("Interrupted Exception while stopping", ie);
+            }
+        }
+        super.serviceStop();
+    }
+
+    public List<HealthReport> innerHealthCheck() {
+        List<HealthReport> results = new ArrayList<>();
+        Queue<Object> candidates = new LinkedBlockingQueue<>(reporters.values());
+        for (String key : reporters.keySet()) {
+            LOG.info("DEBUG health check: " + key);
+        }
+        while (!candidates.isEmpty()) {
+            Object s = candidates.poll();
+            if (s == null) {
+                continue;
+            }
+            if (s instanceof CompositeService) {
+                candidates.addAll(((CompositeService) s).getServices());
+            }
+            if (s instanceof HealthReporter) {
+                try {
+                    results.add(((HealthReporter) s).getHealthReport());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return results;
+    }
+
+    public void registerReporter(String name, Object reporter) {
+        if (reporters.containsKey(name)) {
+            LOG.info("Replacing reporter {} with a new one", name);
+        }
+        reporters.put(name, reporter);
+    }
+
+    public List<HealthReport> healthCheck() {
+        long now = System.currentTimeMillis();
+        try {
+            rwLock.readLock().lock();
+            if (lastReports != null && lastTimestamp + maxTorranceTime * 1000 >= now) {
+                return lastReports;
+            }
+        } finally {
+            rwLock.readLock().unlock();
+        }
+        requestSemaphore.release();
+        while (true) {
+            while (waiting.get()) {
+            }
+            try {
+                rwLock.readLock().lock();
+                if (lastReports != null && lastTimestamp + maxTorranceTime * 1000 >= now) {
+                    return lastReports;
+                }
+            } finally {
+                rwLock.readLock().unlock();
+            }
+        }
+    }
+
+    public long getAutoCheckPeriod() {
+        return autoCheckPeriod;
+    }
+
+    public void setAutoCheckPeriod(long autoCheckPeriod) {
+        this.autoCheckPeriod = autoCheckPeriod;
+    }
+
+    public long getMaxTorranceTime() {
+        return maxTorranceTime;
+    }
+
+    public void setMaxTorranceTime(long maxTorranceTime) {
+        this.maxTorranceTime = maxTorranceTime;
+    }
+
+    public void refresh() {
+        this.requestSemaphore.release();
+    }
+
+    public static HealthReport checkRPCServer(Server server) {
+        RpcMetrics rpcMetrics = server.getRpcMetrics();
+        int callQueueLength = rpcMetrics.callQueueLength();
+        double queueAvgTime = rpcMetrics.getRpcQueueTime().lastStat().mean();
+        double processingAvgTime = rpcMetrics.getProcessingMean();
+        double estimatedDelayTime = queueAvgTime + processingAvgTime;
+        Map<String, Long> threadCounts = server.getHandlerStateCount();
+        double handleUtilizationRatio = (threadCounts.getOrDefault(Thread.State.RUNNABLE.toString(), 0L)
+                + threadCounts.getOrDefault(Thread.State.RUNNABLE.toString(), 0L)) /
+                threadCounts.values().stream().mapToDouble(x -> x).sum();
+        // TODO: 需要考虑metrics存在单位转换，所以不一定是默认的ms
+        HealthReport report = HealthReport.getInstance(server.getServerName(), server.isRunning(),
+                estimatedDelayTime < 2000 ? HealthReport.WorkState.IDLE :
+                        estimatedDelayTime > 10000 ? HealthReport.WorkState.BUSY : HealthReport.WorkState.NORMAL);
+        report.putMetrics("callQueueLength", callQueueLength);
+        report.putMetrics("queueAvgTime", queueAvgTime);
+        report.putMetrics("processingAvgTime", processingAvgTime);
+        report.putMetrics("estimatedDelayTime", estimatedDelayTime);
+        report.putMetrics("handleUtilizationRatio", handleUtilizationRatio);
+        for (Map.Entry<String, Long> entry : threadCounts.entrySet()) {
+            report.putMetrics(entry.getKey().toLowerCase() + "HandlerThreads", entry.getValue());
+        }
+        return report;
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/health/HealthReport.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/health/HealthReport.java
@@ -1,0 +1,99 @@
+package org.apache.hadoop.yarn.health;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HealthReport {
+    public enum WorkState {
+        UNCHECKED, NORMAL, IDLE, BUSY
+    }
+    private String name;
+    private boolean healthy;
+    private WorkState workState;
+    private long updateTime;
+    private String diagnostics;
+    private Map<String, Object> metrics;
+
+    public static HealthReport getInstance(String name, boolean healthy, WorkState workState, String diagnostics) {
+        HealthReport report = new HealthReport();
+        report.name = name;
+        report.healthy = healthy;
+        report.workState = workState;
+        report.diagnostics = diagnostics;
+        report.updateTime = System.currentTimeMillis();
+        report.metrics = new HashMap<>();
+        return report;
+    }
+
+    public static HealthReport getInstance(String name, boolean healthy, WorkState workState) {
+        return getInstance(name, healthy, workState, "");
+    }
+
+    public static HealthReport getInstance(String name, boolean healthy) {
+        return getInstance(name, healthy, WorkState.UNCHECKED);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isHealthy() {
+        return healthy;
+    }
+
+    public void setHealthy(boolean healthy) {
+        this.healthy = healthy;
+    }
+
+    public WorkState getWorkState() {
+        return workState;
+    }
+
+    public void setWorkState(WorkState workState) {
+        this.workState = workState;
+    }
+
+    public long getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(long updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public String getDiagnostics() {
+        return diagnostics;
+    }
+
+    public void setDiagnostics(String diagnostics) {
+        this.diagnostics = diagnostics;
+    }
+
+    public Map<String, Object> getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(Map<String, Object> metrics) {
+        this.metrics = metrics;
+    }
+
+    public void putMetrics(String key, Object value) {
+        this.metrics.put(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return "HealthReport{" +
+                "name='" + name + '\'' +
+                ", healthy=" + healthy +
+                ", workState=" + workState +
+                ", updateTime=" + updateTime +
+                ", diagnostics='" + diagnostics + '\'' +
+                ", metrics=" + metrics +
+                '}';
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/health/HealthReporter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/health/HealthReporter.java
@@ -1,0 +1,6 @@
+package org.apache.hadoop.yarn.health;
+
+@FunctionalInterface
+public interface HealthReporter {
+    HealthReport getHealthReport();
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/dao/HealthReportInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/dao/HealthReportInfo.java
@@ -1,0 +1,51 @@
+package org.apache.hadoop.yarn.webapp.dao;
+
+import org.apache.hadoop.yarn.health.HealthReport;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@XmlRootElement(name = "report")
+public class HealthReportInfo {
+    @XmlElement(name = "componentHealth")
+    private List<HealthReportItemInfo> items = new ArrayList<>();
+
+    public HealthReportInfo() {
+    }
+
+    public HealthReportInfo(List<HealthReport> reports) {
+        if (reports != null) {
+            items = reports.stream().map(HealthReportItemInfo::new).collect(Collectors.toList());
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class HealthReportItemInfo {
+        public String name;
+        public boolean healthy;
+        public String workState;
+        public long updateTime;
+        public String diagnostics;
+        public Map<String, String> metrics;
+
+        HealthReportItemInfo() {
+        }
+
+        HealthReportItemInfo(HealthReport report) {
+            name = report.getName();
+            healthy = report.isHealthy();
+            workState = report.getWorkState().name();
+            updateTime = report.getUpdateTime();
+            diagnostics = report.getDiagnostics();
+            metrics = report.getMetrics().entrySet().stream().collect(Collectors.toMap(
+                    Map.Entry::getKey, x -> x.getValue().toString()
+            ));
+        }
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ActiveStandbyElectorBasedElectorService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ActiveStandbyElectorBasedElectorService.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.yarn.server.resourcemanager;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.protobuf.InvalidProtocolBufferException;
+import org.apache.hadoop.yarn.health.HealthReport;
+import org.apache.hadoop.yarn.health.HealthReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -51,7 +53,7 @@ import java.util.TimerTask;
 @InterfaceStability.Unstable
 public class ActiveStandbyElectorBasedElectorService extends AbstractService
     implements EmbeddedElector,
-    ActiveStandbyElector.ActiveStandbyElectorCallback {
+    ActiveStandbyElector.ActiveStandbyElectorCallback, HealthReporter {
   private static final Logger LOG = LoggerFactory.
       getLogger(ActiveStandbyElectorBasedElectorService.class.getName());
   private static final HAServiceProtocol.StateChangeRequestInfo req =
@@ -267,5 +269,11 @@ public class ActiveStandbyElectorBasedElectorService extends AbstractService
   @Override
   public String getZookeeperConnectionState() {
     return elector.getHAZookeeperConnectionState();
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return HealthReport.getInstance(getName(),
+            "CONNECTED".equals(elector.getHAZookeeperConnectionState()));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/AdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/AdminService.java
@@ -29,6 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hadoop.yarn.health.HealthCheckService;
+import org.apache.hadoop.yarn.health.HealthReport;
+import org.apache.hadoop.yarn.health.HealthReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -108,7 +111,7 @@ import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTest
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 
 public class AdminService extends CompositeService implements
-    HAServiceProtocol, ResourceManagerAdministrationProtocol {
+    HAServiceProtocol, ResourceManagerAdministrationProtocol, HealthReporter {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(AdminService.class);
@@ -1104,5 +1107,10 @@ public class AdminService extends CompositeService implements
           .anyMatch(inactiveNode -> inactiveNode.getHost().equals(node));
     }
     return isKnown;
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return HealthCheckService.checkRPCServer(server);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ApplicationMasterService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ApplicationMasterService.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.hadoop.yarn.health.HealthCheckService;
+import org.apache.hadoop.yarn.health.HealthReport;
+import org.apache.hadoop.yarn.health.HealthReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -82,7 +85,7 @@ import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTest
 @SuppressWarnings("unchecked")
 @Private
 public class ApplicationMasterService extends AbstractService implements
-    ApplicationMasterProtocol {
+    ApplicationMasterProtocol, HealthReporter {
   private static final Logger LOG = LoggerFactory.
       getLogger(ApplicationMasterService.class);
 
@@ -516,7 +519,12 @@ public class ApplicationMasterService extends AbstractService implements
     finishedAttemptCache.clear();
     super.serviceStop();
   }
-  
+
+  @Override
+  public HealthReport getHealthReport() {
+    return HealthCheckService.checkRPCServer(server);
+  }
+
   public static class AllocateResponseLock {
     private AllocateResponse response;
     

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
@@ -40,6 +40,9 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.commons.lang3.Range;
+import org.apache.hadoop.yarn.health.HealthCheckService;
+import org.apache.hadoop.yarn.health.HealthReport;
+import org.apache.hadoop.yarn.health.HealthReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -208,7 +211,7 @@ import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
  * interfaces to the resource manager from the client.
  */
 public class ClientRMService extends AbstractService implements
-    ApplicationClientProtocol {
+    ApplicationClientProtocol, HealthReporter {
   private static final ArrayList<ApplicationReport> EMPTY_APPS_REPORT = new ArrayList<ApplicationReport>();
 
   private static final Logger LOG =
@@ -1944,5 +1947,10 @@ public class ClientRMService extends AbstractService implements
   @VisibleForTesting
   public void setDisplayPerUserApps(boolean displayPerUserApps) {
     this.filterAppsByUser = displayPerUserApps;
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return HealthCheckService.checkRPCServer(server);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContext.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.conf.ConfigurationProvider;
 import org.apache.hadoop.yarn.event.Dispatcher;
+import org.apache.hadoop.yarn.health.HealthCheckService;
 import org.apache.hadoop.yarn.nodelabels.NodeAttributesManager;
 import org.apache.hadoop.yarn.proto.YarnServerCommonServiceProtos.SystemCredentialsForAppsProto;
 import org.apache.hadoop.yarn.server.resourcemanager.ahs.RMApplicationHistoryWriter;
@@ -101,6 +102,8 @@ public interface RMContext extends ApplicationMasterServiceContext {
   ClientToAMTokenSecretManagerInRM getClientToAMTokenSecretManager();
 
   AdminService getRMAdminService();
+
+  HealthCheckService getHealthCheckService();
 
   ClientRMService getClientRMService();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContextImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContextImpl.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.hadoop.yarn.health.HealthCheckService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -213,6 +214,15 @@ public class RMContextImpl implements RMContext {
 
   void setRMAdminService(AdminService adminService) {
     serviceContext.setRMAdminService(adminService);
+  }
+
+  @Override
+  public HealthCheckService getHealthCheckService() {
+    return serviceContext.getHealthCheckService();
+  }
+
+  void setHealthCheckService(HealthCheckService healthCheckService) {
+    serviceContext.setHealthCheckService(healthCheckService);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMServiceContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMServiceContext.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 import org.apache.hadoop.yarn.conf.ConfigurationProvider;
 import org.apache.hadoop.yarn.event.Dispatcher;
+import org.apache.hadoop.yarn.health.HealthCheckService;
 import org.apache.hadoop.yarn.server.resourcemanager.ahs.RMApplicationHistoryWriter;
 import org.apache.hadoop.yarn.server.resourcemanager.metrics.SystemMetricsPublisher;
 import org.apache.hadoop.yarn.server.resourcemanager.timelineservice.RMTimelineCollectorManager;
@@ -46,6 +47,7 @@ public class RMServiceContext {
   private HAServiceState haServiceState =
       HAServiceProtocol.HAServiceState.INITIALIZING;
   private AdminService adminService;
+  private HealthCheckService healthCheckService;
   private ConfigurationProvider configurationProvider;
   private Configuration yarnConfiguration;
   private RMApplicationHistoryWriter rmApplicationHistoryWriter;
@@ -94,6 +96,14 @@ public class RMServiceContext {
 
   void setRMAdminService(AdminService service) {
     this.adminService = service;
+  }
+
+  public HealthCheckService getHealthCheckService() {
+    return healthCheckService;
+  }
+
+  public void setHealthCheckService(HealthCheckService service) {
+    this.healthCheckService = service;
   }
 
   void setHAEnabled(boolean rmHAEnabled) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
@@ -33,6 +33,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.yarn.health.HealthCheckService;
+import org.apache.hadoop.yarn.health.HealthReport;
+import org.apache.hadoop.yarn.health.HealthReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -95,7 +98,7 @@ import org.apache.hadoop.yarn.util.YarnVersionInfo;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 public class ResourceTrackerService extends AbstractService implements
-    ResourceTracker {
+    ResourceTracker, HealthReporter {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ResourceTrackerService.class);
@@ -1060,5 +1063,10 @@ public class ResourceTrackerService extends AbstractService implements
     }
     nodeHeartBeatResponse.setTokenSequenceNo(
         this.rmContext.getTokenSequenceNo());
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return HealthCheckService.checkRPCServer(server);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.yarn.server.resourcemanager.recovery;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.yarn.health.HealthReport;
+import org.apache.hadoop.yarn.health.HealthReporter;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.SystemClock;
 import org.slf4j.Logger;
@@ -179,7 +181,7 @@ import java.util.Set;
  */
 @Private
 @Unstable
-public class ZKRMStateStore extends RMStateStore {
+public class ZKRMStateStore extends RMStateStore implements HealthReporter {
   private static final Logger LOG =
       LoggerFactory.getLogger(ZKRMStateStore.class);
 
@@ -239,6 +241,14 @@ public class ZKRMStateStore extends RMStateStore {
   private volatile Clock clock = SystemClock.getInstance();
   @VisibleForTesting
   protected ZKRMStateStoreOpDurations opDurations;
+
+  @Override
+  public HealthReport getHealthReport() {
+    boolean healthy = zkManager != null && zkManager.getCurator() != null
+            && zkManager.getCurator().getZookeeperClient() != null
+            && zkManager.getCurator().getZookeeperClient().isConnected();
+    return HealthReport.getInstance(getName(), healthy);
+  }
 
   /*
    * Indicates different app attempt state store operations.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWSConsts.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWSConsts.java
@@ -211,6 +211,8 @@ public final class RMWSConsts {
   public static final String SIGNAL_TO_CONTAINER =
       "/containers/{containerid}/signal/{command}";
 
+  public static final String HEALTH_CHECK = "/healthcheck";
+
   // ----------------QueryParams for RMWebServiceProtocol----------------
 
   public static final String TIME = "time";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -129,6 +129,7 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
+import org.apache.hadoop.yarn.health.HealthCheckService;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceRequest;
 import org.apache.hadoop.yarn.server.resourcemanager.AdminService;
@@ -214,6 +215,7 @@ import org.apache.hadoop.yarn.util.resource.Resources;
 import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.apache.hadoop.yarn.webapp.ForbiddenException;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
+import org.apache.hadoop.yarn.webapp.dao.HealthReportInfo;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import org.apache.hadoop.yarn.webapp.dao.ConfInfo;
 import org.apache.hadoop.yarn.webapp.dao.SchedConfUpdateInfo;
@@ -2933,6 +2935,33 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
       return Response.status(Status.INTERNAL_SERVER_ERROR)
           .entity(e.getMessage()).build();
     }
+    return Response.status(Status.OK).build();
+  }
+
+  @GET
+  @Path(RMWSConsts.HEALTH_CHECK)
+  @Produces({ MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
+          MediaType.APPLICATION_XML + "; " + JettyUtils.UTF_8 })
+  public HealthReportInfo healthCheck() {
+    return new HealthReportInfo(rm.getRMContext().getHealthCheckService().healthCheck());
+  }
+
+  @PUT
+  @Path(RMWSConsts.HEALTH_CHECK)
+  public Response configHealthCheck(
+          @QueryParam("autoCheckPeriod") Long autoCheckPeriod,
+          @QueryParam("maxTorranceTime") Long maxTorranceTime) {
+    if (autoCheckPeriod == null && maxTorranceTime == null) {
+      return Response.status(Status.OK).build();
+    }
+    HealthCheckService service = rm.getRMContext().getHealthCheckService();
+    if (autoCheckPeriod != null) {
+      service.setAutoCheckPeriod(autoCheckPeriod);
+    }
+    if (maxTorranceTime != null) {
+      service.setMaxTorranceTime(maxTorranceTime);
+    }
+    service.refresh();
     return Response.status(Status.OK).build();
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Add health check mechanism to improve troubleshooting skills for RM just like Kubernetes health endpoints for API server. This feature will improve our usalibity for troubleshooting and performance profiling.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

