### PR TITLE
HDFS-16269. [Fix] Improve NNThroughputBenchmark#blockReport operation.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNNThroughputBenchmark.java
@@ -166,4 +166,25 @@ public class TestNNThroughputBenchmark {
       }
     }
   }
+
+  /**
+   * This test runs {@link NNThroughputBenchmark} against a mini DFS cluster
+   * for block report operation.
+   */
+  @Test(timeout = 120000)
+  public void testNNThroughputForBlockReportOp() throws Exception {
+    final Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 16);
+    conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16);
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).
+        numDataNodes(3).build()) {
+      cluster.waitActive();
+      final Configuration benchConf = new HdfsConfiguration();
+      benchConf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 16);
+      benchConf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 16);
+      NNThroughputBenchmark.runBenchmark(benchConf,
+          new String[]{"-fs", cluster.getURI().toString(), "-op",
+              "blockReport", "-datanodes", "3", "-reports", "2"});
+    }
+  }
 }


### PR DESCRIPTION

### Description of PR
When using NNThroughputBenchmark to test blockReport, some exceptions will be prompted.
E.g:
![image](https://user-images.githubusercontent.com/6416939/136931038-f5a271b8-c905-4464-94cb-1b8b4e9bbe21.png)
The purpose of this issue is to solve this problem.

### How was this patch tested?
When using the same command, the same exception will not occur.

