### PR TITLE
HADOOP-17964. Increase Java heap size for running Maven in Dockerfile of branch-2.10.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -203,7 +203,7 @@ RUN curl -L -s -S \
 ###
 # Avoid out of memory errors in builds
 ###
-ENV MAVEN_OPTS -Xms256m -Xmx1536m -Dhttps.protocols=TLSv1.2 -Dhttps.cipherSuites=TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ENV MAVEN_OPTS -Xms256m -Xmx2048m -XX:MaxPermSize=512m -Dhttps.protocols=TLSv1.2 -Dhttps.cipherSuites=TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
 
 
 ###


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17964

I got OOM on running create-release script in branch-2.10.

```
$ ./dev-support/bin/create-release --docker --dockercache
$ tail -n 14 patchprocess/mvn_install.log
---------------------------------------------------
Exception in thread "main" java.lang.OutOfMemoryError: PermGen space
        at java.util.concurrent.CopyOnWriteArrayList.iterator(CopyOnWriteArrayList.java:961)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:877)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:607)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
```

I got no issue when I build the RC of 2.10.1 using the Dockerfile. JDK migration to Zulu by [HADOOP-17572](https://issues.apache.org/jira/browse/HADOOP-17572) might be related.