### PR TITLE
HDFS-16270.Improve NNThroughputBenchmark#printUsage() related to block size.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -1491,8 +1491,11 @@ public class NNThroughputBenchmark implements Tool {
     );
     System.err.println();
     GenericOptionsParser.printGenericCommandUsage(System.err);
-    System.err.println("If connecting to a remote NameNode with -fs option, " +
-        "dfs.namenode.fs-limits.min-block-size should be set to 16.");
+    int blockSize = config.getInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 0);
+    if (blockSize != BLOCK_SIZE) {
+      System.err.println("If connecting to a remote NameNode with -fs option, " +
+          "dfs.blocksize should be set to 16.");
+    }
     ExitUtil.terminate(-1);
   }
 


### PR DESCRIPTION
### Description of PR
When NNThroughputBenchmark#printUsage() is executed, some configurations are verified first, and the correct prompts are printed.

### How was this patch tested?
This is to print some information, the test pressure is not great.
