### PR TITLE
HDFS-16274. Improve error msg for FSNamesystem#startFileInt

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2722,11 +2722,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       iip = FSDirWriteFileOp.resolvePathForStartFile(
           dir, pc, src, flag, createParent);
 
-
       if (blockSize < minBlockSize) {
-        throw new IOException("Specified block size is less than configured" +
-            " minimum value (" + DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY
-            + "): " + blockSize + " < " + minBlockSize);
+        throw new IOException("Specified block size " + blockSize +
+            " is less than configured minimum value " +
+            DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY + "=" + minBlockSize);
       }
 
       if (shouldReplicate) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFileLimit.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFileLimit.java
@@ -210,8 +210,9 @@ public class TestFileLimit {
         assert false : "Expected IOException after creating a file with small" +
             " blocks ";
       } catch (IOException e) {
-        GenericTestUtils.assertExceptionContains("Specified block size is less",
-            e);
+        GenericTestUtils.assertExceptionContains(
+            "is less than configured minimum value " +
+                "dfs.namenode.fs-limits.min-block-size=", e);
       }
     } finally {
       cluster.shutdown();


### PR DESCRIPTION
JIRA: [HDFS-16274](https://issues.apache.org/jira/browse/HDFS-16274)

When the blocksize of a file is smaller than dfs.namenode.fs-limits.min-block-size, an IOE will be thrown. In current exception messages, it is easy to confuse the value of blocksize with the value of dfs.namenode.fs-limits.min-block-size. 

Before the change:
![image](https://user-images.githubusercontent.com/55134131/137355106-fb0ce6cb-7378-49da-b425-f41fa2bb2834.png)

After the change:
![image](https://user-images.githubusercontent.com/55134131/137355124-b79e638c-a3a3-47af-ad7f-b339cd39c426.png)

