### PR TITLE
HDFS-16275. Enable considerLoad for localWrite

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -621,7 +621,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
           (DatanodeDescriptor) localOrFavoredNode;
       // otherwise try local machine first
       if (excludedNodes.add(localOrFavoredNode) // was not in the excluded list
-          && isGoodDatanode(localDatanode, maxNodesPerRack, false,
+          && isGoodDatanode(localDatanode, maxNodesPerRack, considerLoad,
               results, avoidStaleNodes)) {
         for (Iterator<Map.Entry<StorageType, Integer>> iter = storageTypes
             .entrySet().iterator(); iter.hasNext(); ) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyConsiderLoad.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyConsiderLoad.java
@@ -137,7 +137,7 @@ public class TestReplicationPolicyConsiderLoad
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[0]),
           dataNodes[0].getCacheCapacity(),
           dataNodes[0].getCacheUsed(),
-          5, 0, null);
+          15, 0, null);
       dnManager.getHeartbeatManager().updateHeartbeat(dataNodes[1],
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[1]),
           dataNodes[1].getCacheCapacity(),
@@ -163,7 +163,7 @@ public class TestReplicationPolicyConsiderLoad
           BlockManagerTestUtil.getStorageReportsForDatanode(dataNodes[5]),
           dataNodes[5].getCacheCapacity(),
           dataNodes[5].getCacheUsed(),
-          15, 0, null);
+          5, 0, null);
       //Add values in above heartbeats
       double load = 5 + 10 + 15 + 10 + 15 + 5;
       // Call chooseTarget()


### PR DESCRIPTION
### Description of PR
Currently when client is on the same machine of a datanode, it will try to write to the local machine regardless of the load of the datanode, that is the xceiverCount.

In our production cluster, datanode and Nodemanager are running on the same server, so when there are heavy jobs running on a labeled queue, the corresponding datanodes will have higher xceiverCounts than other datanodes. When other clients are trying to write, the exception of "could only be replicated to 0 nodes" would be thrown.

This ticket is to enable considerLoad to avoid the hot local write.

Jira Ticket:  https://issues.apache.org/jira/browse/HDFS-16275

### How was this patch tested?
unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

