### PR TITLE
HDFS-16276. RBF: Remove the useless configuration of rpc isolation in md

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/site/markdown/HDFSRouterFederation.md
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/site/markdown/HDFSRouterFederation.md
@@ -500,7 +500,6 @@ Isolation and dedicated assignment of RPC handlers across all configured downstr
 
 | Property | Default | Description|
 |:---- |:---- |:---- |
-| dfs.federation.router.fairness.enable | `false` | If `true`, dedicated RPC handlers will be assigned to each nameservice based on the fairness assignment policy configured. |
 | dfs.federation.router.fairness.policy.controller.class | `org.apache.hadoop.hdfs.server.federation.fairness.NoRouterRpcFairnessPolicyController` | Default handler allocation model to be used if isolation feature is enabled. Recommend to use `org.apache.hadoop.hdfs.server.federation.fairness.StaticRouterRpcFairnessPolicyController` to fully use the feature. |
 | dfs.federation.router.fairness.handler.count.*EXAMPLENAMESERVICE* | | Dedicated handler assigned to a specific nameservice. If none is specified equal allocation is done across all nameservices. |
 | dfs.federation.router.fairness.handler.count.concurrent | | Dedicated handler assigned to fan out calls such as `renewLease`. |


### PR DESCRIPTION
[HDFS-16276](https://issues.apache.org/jira/browse/HDFS-16276)
### Description of PR
The dfs.federation.router.fairness.enable configuration is not used in the code, but there is it in md, we should delete it.
