### PR TITLE
YARN-10958. Use correct configuration for Group service init in CSMappingPlacementRule

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -493,4 +493,9 @@ public class Groups {
     GROUPS = new Groups(conf);
     return GROUPS;
   }
+  
+  @VisibleForTesting
+  public static void reset() {
+    GROUPS = null;
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -493,7 +493,7 @@ public class Groups {
     GROUPS = new Groups(conf);
     return GROUPS;
   }
-  
+
   @VisibleForTesting
   public static void reset() {
     GROUPS = null;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
@@ -133,7 +133,7 @@ public class CSMappingPlacementRule extends PlacementRule {
     overrideWithQueueMappings = conf.getOverrideWithQueueMappings();
 
     if (groups == null) {
-      groups = Groups.getUserToGroupsMappingService(conf);
+      groups = Groups.getUserToGroupsMappingService(csContext.getConf());
     }
 
     MappingRuleValidationContext validationContext = buildValidationContext();
@@ -534,5 +534,10 @@ public class CSMappingPlacementRule extends PlacementRule {
     } else {
       return name;
     }
+  }
+
+  @VisibleForTesting
+  public Groups getGroups() {
+    return groups;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
@@ -807,7 +807,7 @@ public class TestCSMappingPlacementRule {
    * original problem described in YARN-10597.<br>
    */
   @Test
-  public void testPlacementEngineSelectsCorrectConfigurationForGroupMapping() throws YarnException, IOException {
+  public void testPlacementEngineSelectsCorrectConfigurationForGroupMapping() throws IOException {
     Groups.reset();
     final String user = "testuser";
 
@@ -880,22 +880,22 @@ public class TestCSMappingPlacementRule {
   public static class MockUnixGroupsMapping implements GroupMappingServiceProvider {
 
     public MockUnixGroupsMapping() {
-      group.clear();
-      group.add("testGroup1");
-      group.add("testGroup2");
-      group.add("testGroup3");
+      GROUP.clear();
+      GROUP.add("testGroup1");
+      GROUP.add("testGroup2");
+      GROUP.add("testGroup3");
     }
 
-    private static final List<String> group = new ArrayList<>();
+    private static final List<String> GROUP = new ArrayList<>();
 
     @Override
     public List<String> getGroups(String user) throws IOException {
-      return group;
+      return GROUP;
     }
 
     @Override
     public void cacheGroupsRefresh() {
-      group.add(0, "testGroup0");
+      GROUP.add(0, "testGroup0");
     }
 
     @Override
@@ -905,7 +905,7 @@ public class TestCSMappingPlacementRule {
 
     @Override
     public Set<String> getGroupsSet(String user) {
-      return ImmutableSet.copyOf(group);
+      return ImmutableSet.copyOf(GROUP);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
@@ -54,11 +54,8 @@ import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_GROUP_MAPPING;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class TestCSMappingPlacementRule {
@@ -781,7 +778,7 @@ public class TestCSMappingPlacementRule {
   /**
    * 1. Invoke Groups.reset(). This make sure that the underlying singleton {@link Groups#GROUPS}
    * is set to null.<br>
-   * 2. Create a Configuration object in which the property "hadoop.security.group.mapping" 
+   * 2. Create a Configuration object in which the property "hadoop.security.group.mapping"
    * refers to an existing a test implementation.<br>
    * 3. Create a mock CapacityScheduler where getConf() and getConfiguration() contain different
    * settings for "hadoop.security.group.mapping". Since getConf() is the service config, this
@@ -813,10 +810,11 @@ public class TestCSMappingPlacementRule {
   public void testPlacementEngineSelectsCorrectConfigurationForGroupMapping() throws YarnException, IOException {
     Groups.reset();
     final String user = "testuser";
-    
+
     //Create service-wide configuration object
     Configuration yarnConf = new Configuration();
-    yarnConf.setClass(HADOOP_SECURITY_GROUP_MAPPING, MockUnixGroupsMapping.class, GroupMappingServiceProvider.class);
+    yarnConf.setClass(HADOOP_SECURITY_GROUP_MAPPING, MockUnixGroupsMapping.class,
+        GroupMappingServiceProvider.class);
 
     //Create CS configuration object with a single, primary group mapping rule
     List<MappingRule> mappingRules = new ArrayList<>();
@@ -833,9 +831,11 @@ public class TestCSMappingPlacementRule {
       }
     };
     csConf.setOverrideWithQueueMappings(true);
-    //Intentionally add a dummy implementation class - The "HADOOP_SECURITY_GROUP_MAPPING" should not be read from the CapacitySchedulerConfiguration instance!
+    //Intentionally add a dummy implementation class -
+    // The "HADOOP_SECURITY_GROUP_MAPPING" should not be read from the
+    // CapacitySchedulerConfiguration instance!
     csConf.setClass(HADOOP_SECURITY_GROUP_MAPPING, String.class, Object.class);
-    
+
     CapacityScheduler cs = createMockCS(yarnConf, csConf);
 
     //Create app, submit to placement engine, expecting queue=testGroup1
@@ -848,7 +848,7 @@ public class TestCSMappingPlacementRule {
     // CapacitySchedulerConfiguration instance!
     //This makes sure that the Groups instance is not recreated by CSMappingPlacementRule
     yarnConf.setClass(HADOOP_SECURITY_GROUP_MAPPING, String.class, Object.class);
-    
+
     //Refresh the groups, this makes testGroup0 as primary group for "testUser"
     engine.getGroups().refresh();
 
@@ -879,7 +879,7 @@ public class TestCSMappingPlacementRule {
 
   public static class MockUnixGroupsMapping implements
       GroupMappingServiceProvider {
-    
+
     public MockUnixGroupsMapping() {
       group.clear();
       group.add("testGroup1");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
@@ -877,8 +877,7 @@ public class TestCSMappingPlacementRule {
     return cs;
   }
 
-  public static class MockUnixGroupsMapping implements
-      GroupMappingServiceProvider {
+  public static class MockUnixGroupsMapping implements GroupMappingServiceProvider {
 
     public MockUnixGroupsMapping() {
       group.clear();
@@ -887,7 +886,7 @@ public class TestCSMappingPlacementRule {
       group.add("testGroup3");
     }
 
-    private static List<String> group = new ArrayList<>();
+    private static final List<String> group = new ArrayList<>();
 
     @Override
     public List<String> getGroups(String user) throws IOException {
@@ -895,17 +894,17 @@ public class TestCSMappingPlacementRule {
     }
 
     @Override
-    public void cacheGroupsRefresh() throws IOException {
+    public void cacheGroupsRefresh() {
       group.add(0, "testGroup0");
     }
 
     @Override
-    public void cacheGroupsAdd(List<String> groups) throws IOException {
+    public void cacheGroupsAdd(List<String> groups) {
       // Do nothing
     }
 
     @Override
-    public Set<String> getGroupsSet(String user) throws IOException {
+    public Set<String> getGroupsSet(String user) {
       return ImmutableSet.copyOf(group);
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

