### PR TITLE
YARN-10980:fix CVE-2020-8908

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreFileImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/driver/impl/StateStoreFileImpl.java
@@ -88,7 +88,7 @@ public class StateStoreFileImpl extends StateStoreFileBaseImpl {
     if (this.rootDirectory == null) {
       String dir = getConf().get(FEDERATION_STORE_FILE_DIRECTORY);
       if (dir == null) {
-        File tempDir = Files.createTempDir();
+        File tempDir = java.nio.file.Files.createTempDirectory().toFile();
         dir = tempDir.getAbsolutePath();
         LOG.warn("The root directory is not available, using {}", dir);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/client/ServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/client/ServiceClient.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
-import org.apache.curator.shaded.com.google.common.io.Files;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -1140,7 +1139,7 @@ public class ServiceClient extends AppAdminClient implements SliderExitCodes,
       return;
     }
     String buffer = ServiceApiUtil.jsonSerDeser.toJson(app);
-    File tmpDir = Files.createTempDir();
+    File tmpDir = java.nio.file.Files.createTempDirectory().toFile();
     if (tmpDir.exists()) {
       String serviceJsonPath = tmpDir.getAbsolutePath() + "/app.json";
       File localFile = new File(serviceJsonPath);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/VEDeviceDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/VEDeviceDiscoverer.java
@@ -60,7 +60,7 @@ class VEDeviceDiscoverer {
   public Set<Device> getDevicesFromPath(String path) throws IOException {
     MutableInt counter = new MutableInt(0);
     try (Stream<Path> stream = Files.walk(Paths.get(path), 1)) {
-        return stream.filter(p -> p.toFile().getName().startsWith("veslot"))
+      return stream.filter(p -> p.toFile().getName().startsWith("veslot"))
             .map(p -> toDevice(p, counter))
             .collect(Collectors.toSet());
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/VEDeviceDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/VEDeviceDiscoverer.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.hadoop.util.Shell;
@@ -58,11 +59,11 @@ class VEDeviceDiscoverer {
 
   public Set<Device> getDevicesFromPath(String path) throws IOException {
     MutableInt counter = new MutableInt(0);
-
-    return Files.walk(Paths.get(path), 1)
-      .filter(p -> p.toFile().getName().startsWith("veslot"))
-      .map(p -> toDevice(p, counter))
-      .collect(Collectors.toSet());
+    try (Stream<Path> stream = Files.walk(Paths.get(path), 1)) {
+        return stream.filter(p -> p.toFile().getName().startsWith("veslot"))
+            .map(p -> toDevice(p, counter))
+            .collect(Collectors.toSet());
+    }
   }
 
   private Device toDevice(Path p, MutableInt counter) {


### PR DESCRIPTION
see  https://www.cvedetails.com/cve/CVE-2020-8908/

 

A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.