### PR TITLE
HADOOP-17965. Fix documentation build failure using JDK 7 on branch-2.10.

### DIFF
--- a/hadoop-mapreduce-project/pom.xml
+++ b/hadoop-mapreduce-project/pom.xml
@@ -266,18 +266,4 @@
       </build>
     </profile>
   </profiles>
-
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <!-- until we have reporting management cf. MSITE-443 -->
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 </project>

--- a/hadoop-yarn-project/pom.xml
+++ b/hadoop-yarn-project/pom.xml
@@ -197,16 +197,4 @@
       </build>
     </profile>
   </profiles>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 </project>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-17965

`mvn site` by JDK 7 fails due to error related to spotbugs which does not support Java 7.

```
$ ./start-build-env.sh
ubuntu@2a660195e110:~/hadoop$ mvn clean install -DskipTests
ubuntu@2a660195e110:~/hadoop$ mvn site
...(snip)
[INFO] Apache Hadoop YARN Site ............................ SUCCESS [  2.138 s]
[INFO] Apache Hadoop YARN UI .............................. SUCCESS [  0.044 s]
[INFO] Apache Hadoop YARN Project ......................... FAILURE [  0.700 s]
...(snip)
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.5:site (default-site) on project hadoop-yarn-project: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.5:site failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-site-plugin:3.5:site: java.lang.UnsupportedClassVersionError: org/codehaus/mojo/spotbugs/SpotbugsViolationCheckMojo : Unsupported major.minor version 52.0
```

Since we are using JDK 7 in the Dockerfile, dev-support/bin/create-release is affected too.

The cause is obsolete <reporting> entries of pom.xml for already resolved [MSITE-443](https://issues.apache.org/jira/browse/MSITE-443).

We can safely remove the <reporting> entry. `mvn site` generates same contents without the entry. spotbugsXml.xml are generated regardless of it (on `mvn compile spotbugs:spotbugs` using JDK 8).