### PR TITLE
HDFS-16280. Fix typo for ShortCircuitReplica#isStale

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitReplica.java
@@ -160,7 +160,7 @@ public class ShortCircuitReplica {
       long deltaMs = Time.monotonicNow() - creationTimeMs;
       long staleThresholdMs = cache.getStaleThresholdMs();
       if (deltaMs > staleThresholdMs) {
-        LOG.trace("{} is stale because it's {} ms old and staleThreadholdMS={}",
+        LOG.trace("{} is stale because it's {} ms old and staleThresholdMs={}",
             this, deltaMs, staleThresholdMs);
         return true;
       } else {


### PR DESCRIPTION
JIRA: [HDFS-16280](https://issues.apache.org/jira/browse/HDFS-16280)

Fix typo for ShortCircuitReplica#isStale.