### PR TITLE
YARN-10985. Add some tests to verify ACL behaviour in CapacitySchedulerConfiguration

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -18,15 +18,30 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.AccessControlList;
+import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.QueueACL;
 import org.junit.Test;
 
+import java.util.Set;
+
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ROOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.getQueuePrefix;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestCapacitySchedulerConfiguration {
+
+  private static final String ROOT_TEST = ROOT + ".test";
+  private static final String EMPTY_ACL = "";
+  private static final String SPACE_ACL = " ";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String GROUP1 = "group1";
+  private static final String GROUP2 = "group2";
+  public static final String ONE_USER_ONE_GROUP_ACL = USER1 + " " + GROUP1;
+  public static final String TWO_USERS_TWO_GROUPS_ACL =
+      USER1 + "," + USER2 + " " + GROUP1 + ", " + GROUP2;
 
   private CapacitySchedulerConfiguration createDefaultCsConf() {
     return new CapacitySchedulerConfiguration(new Configuration(false), false);
@@ -44,10 +59,45 @@ public class TestCapacitySchedulerConfiguration {
     return getQueuePrefix(queue) + "acl_submit_applications";
   }
 
+  private void testWithGivenAclNoOneHasAccess(String queue, String aclValue) {
+    testWithGivenAclNoOneHasAccessInternal(queue, queue, aclValue);
+  }
+
+  private void testWithGivenAclNoOneHasAccess(String queueToSet, String queueToVerify, String aclValue) {
+    testWithGivenAclNoOneHasAccessInternal(queueToSet, queueToVerify, aclValue);
+  }
+
+  private void testWithGivenAclNoOneHasAccessInternal(String queueToSet, String queueToVerify, String aclValue) {
+    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
+    setSubmitAppsConfig(csConf, queueToSet, aclValue);
+    AccessControlList acl = getSubmitAcl(csConf, queueToVerify);
+    assertTrue(acl.getUsers().isEmpty());
+    assertTrue(acl.getGroups().isEmpty());
+    assertFalse(acl.isAllAllowed());
+  }
+
+  private void testWithGivenAclCorrectUserAndGroupHasAccess(String queue, String aclValue,
+      Set<String> expectedUsers, Set<String> expectedGroups) {
+    testWithGivenAclCorrectUserAndGroupHasAccessInternal(queue, queue, aclValue, expectedUsers, expectedGroups);
+  }
+
+  private void testWithGivenAclCorrectUserAndGroupHasAccessInternal(String queueToSet,
+      String queueToVerify, String aclValue, Set<String> expectedUsers,
+      Set<String> expectedGroups) {
+    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
+    setSubmitAppsConfig(csConf, queueToSet, aclValue);
+    AccessControlList acl = getSubmitAcl(csConf, queueToVerify);
+    assertFalse(acl.getUsers().isEmpty());
+    assertFalse(acl.getGroups().isEmpty());
+    assertEquals(expectedUsers, acl.getUsers());
+    assertEquals(expectedGroups, acl.getGroups());
+    assertFalse(acl.isAllAllowed());
+  }
+
   @Test
   public void testDefaultSubmitACLForRootAllAllowed() {
     CapacitySchedulerConfiguration csConf = createDefaultCsConf();
-    AccessControlList acl = csConf.getAcl(ROOT, QueueACL.SUBMIT_APPLICATIONS);
+    AccessControlList acl = getSubmitAcl(csConf, ROOT);
     assertTrue(acl.getUsers().isEmpty());
     assertTrue(acl.getGroups().isEmpty());
     assertTrue(acl.isAllAllowed());
@@ -56,7 +106,7 @@ public class TestCapacitySchedulerConfiguration {
   @Test
   public void testDefaultSubmitACLForRootChildNoneAllowed() {
     CapacitySchedulerConfiguration csConf = createDefaultCsConf();
-    AccessControlList acl = getSubmitAcl(csConf, ROOT + ".test");
+    AccessControlList acl = getSubmitAcl(csConf, ROOT_TEST);
     assertTrue(acl.getUsers().isEmpty());
     assertTrue(acl.getGroups().isEmpty());
     assertFalse(acl.isAllAllowed());
@@ -64,22 +114,41 @@ public class TestCapacitySchedulerConfiguration {
 
   @Test
   public void testSpecifiedEmptySubmitACLForRoot() {
-    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
-    setSubmitAppsConfig(csConf, ROOT, "");
-    AccessControlList acl = csConf.getAcl(ROOT, QueueACL.SUBMIT_APPLICATIONS);
-    assertTrue(acl.getUsers().isEmpty());
-    assertTrue(acl.getGroups().isEmpty());
-    assertFalse(acl.isAllAllowed());
+    testWithGivenAclNoOneHasAccess(ROOT, EMPTY_ACL);
   }
 
   @Test
   public void testSpecifiedEmptySubmitACLForRootIsNotInherited() {
-    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
-    setSubmitAppsConfig(csConf, ROOT, "");
-    AccessControlList acl = getSubmitAcl(csConf, ROOT + ".test");
-    assertTrue(acl.getUsers().isEmpty());
-    assertTrue(acl.getGroups().isEmpty());
-    assertFalse(acl.isAllAllowed());
+    testWithGivenAclNoOneHasAccess(ROOT, ROOT_TEST, EMPTY_ACL);
   }
-  
+
+  @Test
+  public void testSpecifiedSpaceSubmitACLForRoot() {
+    testWithGivenAclNoOneHasAccess(ROOT, SPACE_ACL);
+  }
+
+  @Test
+  public void testSpecifiedSpaceSubmitACLForRootIsNotInherited() {
+    testWithGivenAclNoOneHasAccess(ROOT, ROOT_TEST, SPACE_ACL);
+  }
+
+  @Test
+  public void testSpecifiedSubmitACLForRoot() {
+    Set<String> expectedUsers = Sets.newHashSet(USER1);
+    Set<String> expectedGroups = Sets.newHashSet(GROUP1);
+    testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, ONE_USER_ONE_GROUP_ACL, expectedUsers, expectedGroups);
+  }
+
+  @Test
+  public void testSpecifiedSubmitACLForRootIsNotInherited() {
+    testWithGivenAclNoOneHasAccess(ROOT, ROOT_TEST, ONE_USER_ONE_GROUP_ACL);
+  }
+
+  @Test
+  public void testSpecifiedSubmitACLTwoUsersTwoGroupsForRoot() {
+    Set<String> expectedUsers = Sets.newHashSet(USER1, USER2);
+    Set<String> expectedGroups = Sets.newHashSet(GROUP1, GROUP2);
+    testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, TWO_USERS_TWO_GROUPS_ACL, expectedUsers, expectedGroups);
+  }
+
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -51,7 +51,8 @@ public class TestCapacitySchedulerConfiguration {
     return csConf.getAcl(queue, QueueACL.SUBMIT_APPLICATIONS);
   }
 
-  private void setSubmitAppsConfig(CapacitySchedulerConfiguration csConf, String queue, String value) {
+  private void setSubmitAppsConfig(CapacitySchedulerConfiguration csConf, String queue,
+      String value) {
     csConf.set(getSubmitAppsConfigKey(queue), value);
   }
 
@@ -63,11 +64,13 @@ public class TestCapacitySchedulerConfiguration {
     testWithGivenAclNoOneHasAccessInternal(queue, queue, aclValue);
   }
 
-  private void testWithGivenAclNoOneHasAccess(String queueToSet, String queueToVerify, String aclValue) {
+  private void testWithGivenAclNoOneHasAccess(String queueToSet, String queueToVerify,
+      String aclValue) {
     testWithGivenAclNoOneHasAccessInternal(queueToSet, queueToVerify, aclValue);
   }
 
-  private void testWithGivenAclNoOneHasAccessInternal(String queueToSet, String queueToVerify, String aclValue) {
+  private void testWithGivenAclNoOneHasAccessInternal(String queueToSet, String queueToVerify,
+      String aclValue) {
     CapacitySchedulerConfiguration csConf = createDefaultCsConf();
     setSubmitAppsConfig(csConf, queueToSet, aclValue);
     AccessControlList acl = getSubmitAcl(csConf, queueToVerify);
@@ -78,7 +81,8 @@ public class TestCapacitySchedulerConfiguration {
 
   private void testWithGivenAclCorrectUserAndGroupHasAccess(String queue, String aclValue,
       Set<String> expectedUsers, Set<String> expectedGroups) {
-    testWithGivenAclCorrectUserAndGroupHasAccessInternal(queue, queue, aclValue, expectedUsers, expectedGroups);
+    testWithGivenAclCorrectUserAndGroupHasAccessInternal(queue, queue, aclValue, expectedUsers,
+        expectedGroups);
   }
 
   private void testWithGivenAclCorrectUserAndGroupHasAccessInternal(String queueToSet,
@@ -136,7 +140,8 @@ public class TestCapacitySchedulerConfiguration {
   public void testSpecifiedSubmitACLForRoot() {
     Set<String> expectedUsers = Sets.newHashSet(USER1);
     Set<String> expectedGroups = Sets.newHashSet(GROUP1);
-    testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, ONE_USER_ONE_GROUP_ACL, expectedUsers, expectedGroups);
+    testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, ONE_USER_ONE_GROUP_ACL, expectedUsers,
+        expectedGroups);
   }
 
   @Test
@@ -148,7 +153,8 @@ public class TestCapacitySchedulerConfiguration {
   public void testSpecifiedSubmitACLTwoUsersTwoGroupsForRoot() {
     Set<String> expectedUsers = Sets.newHashSet(USER1, USER2);
     Set<String> expectedGroups = Sets.newHashSet(GROUP1, GROUP2);
-    testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, TWO_USERS_TWO_GROUPS_ACL, expectedUsers, expectedGroups);
+    testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, TWO_USERS_TWO_GROUPS_ACL, expectedUsers,
+        expectedGroups);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.authorize.AccessControlList;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.yarn.api.records.QueueACL;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ROOT;
+import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.getQueuePrefix;
+
+public class TestCapacitySchedulerConfiguration {
+
+  @Test
+  public void testDefaultSubmitACLForRootAllAllowed() {
+    CapacitySchedulerConfiguration csConf =
+        new CapacitySchedulerConfiguration(new Configuration(false), false);
+    AccessControlList acl = csConf.getAcl(ROOT, QueueACL.SUBMIT_APPLICATIONS);
+    Assert.assertTrue(acl.getUsers().isEmpty());
+    Assert.assertTrue(acl.getGroups().isEmpty());
+    Assert.assertTrue(acl.isAllAllowed());
+  }
+
+  @Test
+  public void testDefaultSubmitACLForRootChildNoneAllowed() {
+    CapacitySchedulerConfiguration csConf =
+        new CapacitySchedulerConfiguration(new Configuration(false), false);
+    AccessControlList acl = csConf.getAcl(ROOT + ".test", QueueACL.SUBMIT_APPLICATIONS);
+    Assert.assertTrue(acl.getUsers().isEmpty());
+    Assert.assertTrue(acl.getGroups().isEmpty());
+    Assert.assertFalse(acl.isAllAllowed());
+  }
+
+  @Test
+  public void testSpecifiedEmptySubmitACLForRoot() {
+    CapacitySchedulerConfiguration csConf =
+        new CapacitySchedulerConfiguration(new Configuration(false), false);
+    String configKey = getQueuePrefix(ROOT) + "acl_submit_applications";
+    csConf.set(configKey, "");
+    AccessControlList acl = csConf.getAcl(ROOT, QueueACL.SUBMIT_APPLICATIONS);
+    Assert.assertTrue(acl.getUsers().isEmpty());
+    Assert.assertTrue(acl.getGroups().isEmpty());
+    Assert.assertFalse(acl.isAllAllowed());
+  }
+
+  @Test
+  public void testSpecifiedEmptySubmitACLForRootIsNotInherited() {
+    CapacitySchedulerConfiguration csConf =
+        new CapacitySchedulerConfiguration(new Configuration(false), false);
+    String configKey = getQueuePrefix(ROOT) + "acl_submit_applications";
+    csConf.set(configKey, "");
+    AccessControlList acl = csConf.getAcl(ROOT + ".test", QueueACL.SUBMIT_APPLICATIONS);
+    Assert.assertTrue(acl.getUsers().isEmpty());
+    Assert.assertTrue(acl.getGroups().isEmpty());
+    Assert.assertFalse(acl.isAllAllowed());
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -18,57 +18,68 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.AccessControlList;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.QueueACL;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ROOT;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.getQueuePrefix;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TestCapacitySchedulerConfiguration {
 
+  private CapacitySchedulerConfiguration createDefaultCsConf() {
+    return new CapacitySchedulerConfiguration(new Configuration(false), false);
+  }
+
+  private AccessControlList getSubmitAcl(CapacitySchedulerConfiguration csConf, String queue) {
+    return csConf.getAcl(queue, QueueACL.SUBMIT_APPLICATIONS);
+  }
+
+  private void setSubmitAppsConfig(CapacitySchedulerConfiguration csConf, String queue, String value) {
+    csConf.set(getSubmitAppsConfigKey(queue), value);
+  }
+
+  private String getSubmitAppsConfigKey(String queue) {
+    return getQueuePrefix(queue) + "acl_submit_applications";
+  }
+
   @Test
   public void testDefaultSubmitACLForRootAllAllowed() {
-    CapacitySchedulerConfiguration csConf =
-        new CapacitySchedulerConfiguration(new Configuration(false), false);
+    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
     AccessControlList acl = csConf.getAcl(ROOT, QueueACL.SUBMIT_APPLICATIONS);
-    Assert.assertTrue(acl.getUsers().isEmpty());
-    Assert.assertTrue(acl.getGroups().isEmpty());
-    Assert.assertTrue(acl.isAllAllowed());
+    assertTrue(acl.getUsers().isEmpty());
+    assertTrue(acl.getGroups().isEmpty());
+    assertTrue(acl.isAllAllowed());
   }
 
   @Test
   public void testDefaultSubmitACLForRootChildNoneAllowed() {
-    CapacitySchedulerConfiguration csConf =
-        new CapacitySchedulerConfiguration(new Configuration(false), false);
-    AccessControlList acl = csConf.getAcl(ROOT + ".test", QueueACL.SUBMIT_APPLICATIONS);
-    Assert.assertTrue(acl.getUsers().isEmpty());
-    Assert.assertTrue(acl.getGroups().isEmpty());
-    Assert.assertFalse(acl.isAllAllowed());
+    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
+    AccessControlList acl = getSubmitAcl(csConf, ROOT + ".test");
+    assertTrue(acl.getUsers().isEmpty());
+    assertTrue(acl.getGroups().isEmpty());
+    assertFalse(acl.isAllAllowed());
   }
 
   @Test
   public void testSpecifiedEmptySubmitACLForRoot() {
-    CapacitySchedulerConfiguration csConf =
-        new CapacitySchedulerConfiguration(new Configuration(false), false);
-    String configKey = getQueuePrefix(ROOT) + "acl_submit_applications";
-    csConf.set(configKey, "");
+    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
+    setSubmitAppsConfig(csConf, ROOT, "");
     AccessControlList acl = csConf.getAcl(ROOT, QueueACL.SUBMIT_APPLICATIONS);
-    Assert.assertTrue(acl.getUsers().isEmpty());
-    Assert.assertTrue(acl.getGroups().isEmpty());
-    Assert.assertFalse(acl.isAllAllowed());
+    assertTrue(acl.getUsers().isEmpty());
+    assertTrue(acl.getGroups().isEmpty());
+    assertFalse(acl.isAllAllowed());
   }
 
   @Test
   public void testSpecifiedEmptySubmitACLForRootIsNotInherited() {
-    CapacitySchedulerConfiguration csConf =
-        new CapacitySchedulerConfiguration(new Configuration(false), false);
-    String configKey = getQueuePrefix(ROOT) + "acl_submit_applications";
-    csConf.set(configKey, "");
-    AccessControlList acl = csConf.getAcl(ROOT + ".test", QueueACL.SUBMIT_APPLICATIONS);
-    Assert.assertTrue(acl.getUsers().isEmpty());
-    Assert.assertTrue(acl.getGroups().isEmpty());
-    Assert.assertFalse(acl.isAllAllowed());
+    CapacitySchedulerConfiguration csConf = createDefaultCsConf();
+    setSubmitAppsConfig(csConf, ROOT, "");
+    AccessControlList acl = getSubmitAcl(csConf, ROOT + ".test");
+    assertTrue(acl.getUsers().isEmpty());
+    assertTrue(acl.getGroups().isEmpty());
+    assertFalse(acl.isAllAllowed());
   }
+  
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

