### PR TITLE
HDFS-7612. Fix default cache directory in TestOfflineEditsViewer.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/TestOfflineEditsViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineEditsViewer/TestOfflineEditsViewer.java
@@ -164,7 +164,7 @@ public class TestOfflineEditsViewer {
   public void testStored() throws IOException {
     // reference edits stored with source code (see build.xml)
     final String cacheDir = System.getProperty("test.cache.data",
-        "build/test/cache");
+        "target/test-classes");
     // binary, XML, reparsed binary
     String editsStored = cacheDir + "/editsStored";
     String editsStoredParsedXml = cacheDir + "/editsStoredParsed.xml";


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fixes JIRA: https://issues.apache.org/jira/browse/HDFS-7612

The default path is incorrect, but maven sets the property during the build. 

### How was this patch tested?

*Automated*
`mvn test -Dtest=TestOfflineEditsViewer`

`mvn clean install -Pdist -Dtar -Ptest-patch`

*Manual*
Cleared `test.cache.data` property and confirmed the test worked.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

