### PR TITLE
HADOOP-17713. Update apache/hadoop:3 docker image to 3.3.1 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
+ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $HADOOP_URL -O hadoop.tar.gz && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
+ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 FROM apache/hadoop-runner
 ARG HADOOP_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 WORKDIR /opt
-RUN sudo rm -rf /opt/hadoop && wget $HADOOP_URL -O hadoop.tar.gz && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
+RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf
 WORKDIR /opt/hadoop
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*
+ENV HADOOP_CONF_DIR /opt/hadoop/etc/hadoop

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 mkdir -p build
 if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
-	curl -LSs "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
+	curl -LSs https://dlcdn.apache.org/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz -o "$DIR/build/apache-rat.tar.gz"
 	cd $DIR/build
 	tar zvxf apache-rat.tar.gz
 	cd -

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 mkdir -p build
 if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
-   wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+	curl -LSs "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
 	cd $DIR/build
 	tar zvxf apache-rat.tar.gz
 	cd -


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Update to Hadoop 3.3.1 release.
2. Change to `curl` for download because `wget` thinks `apache.org` certificate is expired.

https://issues.apache.org/jira/browse/HADOOP-17713

## How was this patch tested?

Built the new image locally:

```
$ ./build.sh
...
 => => writing image sha256:23f613502b2b883ee4978b997409ca6c24116722e67caa6a9f521aef04c0a6bc                                                                                                                   0.0s
 => => naming to docker.io/apache/hadoop:3                                                                                                                                                                     0.0s
```

and tested it with the included sample Docker Compose cluster:

```
$ docker-compose up -d --scale datanode=3 --scale nodemanager=3
$ docker-compose exec resourcemanager yarn jar \
    /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.3.1.jar pi 3 3
...
Job Finished in 36.514 seconds
Estimated value of Pi is 3.55555555555555555556
```