### PR TITLE
HADOOP-17977  FileOutputCommitter make PENDING_DIR_NAME configurable

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -56,14 +56,15 @@ public class FileOutputCommitter extends PathOutputCommitter {
    * Name of directory where pending data is placed.  Data that has not been
    * committed yet.
    */
-  public static final String PENDING_DIR_NAME = "_temporary";
+  public static String PENDING_DIR_NAME = "_temporary";
+  public static final String FILEOUTPUTCOMMITTER_PENDING_DIR_NAME = "mapreduce.fileoutputcommitter.pending.dir";
   /**
    * Temporary directory name 
    *
    * The static variable to be compatible with M/R 1.x
    */
   @Deprecated
-  protected static final String TEMP_DIR_NAME = PENDING_DIR_NAME;
+  protected static String TEMP_DIR_NAME = PENDING_DIR_NAME;
   public static final String SUCCEEDED_FILE_NAME = "_SUCCESS";
   public static final String SUCCESSFUL_JOB_OUTPUT_DIR_MARKER =
       "mapreduce.fileoutputcommitter.marksuccessfuljobs";
@@ -157,6 +158,9 @@ public class FileOutputCommitter extends PathOutputCommitter {
     LOG.info("FileOutputCommitter skip cleanup _temporary folders under " +
         "output directory:" + skipCleanup + ", ignore cleanup failures: " +
         ignoreCleanupFailures);
+
+    PENDING_DIR_NAME = conf.get(FILEOUTPUTCOMMITTER_PENDING_DIR_NAME, PENDING_DIR_NAME);
+    LOG.debug("Using {} as pending dir", PENDING_DIR_NAME);
 
     if (outputPath != null) {
       FileSystem fs = outputPath.getFileSystem(context.getConfiguration());


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
FileOutputCommitter enable concurrent writes by making PENDING_DIR_NAME configurable

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

