### PR TITLE
HADOOP-17968 Migrate checkstyle module illegalimport to maven enforcer banned-illegal-imports

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -121,11 +121,6 @@
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
-        <module name="IllegalImport">
-          <property name="regexp" value="true"/>
-          <property name="illegalPkgs" value="sun, com\.google\.common"/>
-          <property name="illegalClasses" value="^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.io\.BaseEncoding, ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.base\.(Optional|Function|Predicate|Supplier), ^org\.apache\.hadoop\.thirdparty\.com\.google\.common\.collect\.(ImmutableListMultimap)"/>
-        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 

--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -121,6 +121,10 @@
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="IllegalImport">
+            <property name="regexp" value="true"/>
+            <property name="illegalPkgs" value="sun"/>
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,55 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                       <bannedImport>com.google.common.annotations.VisibleForTesting</bannedImport>
                     </bannedImports>
                   </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>com.google.common package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>com.google.common.**</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>org.apache.hadoop.thirdparty.com.google.common.io.BaseEncoding package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.io.BaseEncoding</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Optional package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Optional</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Function package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Function</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Predicate package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Predicate</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Supplier package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Supplier</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                    <includeTestCode>true</includeTestCode>
+                    <reason>org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableListMultimap package usages are prohibited</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableListMultimap</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use hadoop-common provided Sets rather than Guava provided Sets</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.Sets</bannedImport>
-                      <bannedImport>com.google.common.collect.Sets</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -197,62 +196,60 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use hadoop-common provided Lists rather than Guava provided Lists</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.Lists</bannedImport>
-                      <bannedImport>com.google.common.collect.Lists</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>Use hadoop-common provided VisibleForTesting rather than the one provided by Guava</reason>
+                    <reason>Use hadoop-annotation provided VisibleForTesting rather than the one provided by Guava</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting</bannedImport>
-                      <bannedImport>com.google.common.annotations.VisibleForTesting</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>com.google.common package usages are prohibited</reason>
+                    <reason>Use alternatives to Guava common classes</reason>
                     <bannedImports>
                       <bannedImport>com.google.common.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>org.apache.hadoop.thirdparty.com.google.common.io.BaseEncoding package usages are prohibited</reason>
+                    <reason>Use alternative to Guava provided BaseEncoding</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.io.BaseEncoding</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Optional package usages are prohibited</reason>
+                    <reason>Use alternative to Guava provided Optional</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Optional</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Function package usages are prohibited</reason>
+                    <reason>Use alternative to Guava provided Function</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Function</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Predicate package usages are prohibited</reason>
+                    <reason>Use alternative to Guava provided Predicate</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Predicate</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>org.apache.hadoop.thirdparty.com.google.common.base.Supplier package usages are prohibited</reason>
+                    <reason>Use alternative to Guava provided Supplier</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Supplier</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
                     <includeTestCode>true</includeTestCode>
-                    <reason>org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableListMultimap package usages are prohibited</reason>
+                    <reason>Use alternative to Guava provided ImmutableListMultimap</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableListMultimap</bannedImport>
                     </bannedImports>


### PR DESCRIPTION
### Description of PR
As discussed on PR #3503, we should migrate existing imports provided in IllegalImport tag in checkstyle.xml to maven-enforcer-plugin's banned-illegal-imports enforcer rule so that build never succeeds in the presence of any of the illegal imports.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?