### PR TITLE
HDFS-16261 Configurable grace period around deletion of invalidated blocks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -473,6 +473,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String  DFS_NAMENODE_STARTUP_DELAY_BLOCK_DELETION_SEC_KEY = "dfs.namenode.startup.delay.block.deletion.sec";
   public static final long    DFS_NAMENODE_STARTUP_DELAY_BLOCK_DELETION_SEC_DEFAULT = 0L;
 
+  /** Grace period for replaced blocks, before being sent to DataNodes for invalidation */
+  public static final String DFS_NAMENODE_BLOCK_REPLACE_GRACE_PERIOD_MS_KEY = "dfs.namenode.block.replace.grace.period.ms";
+  public static final long DFS_NAMENODE_BLOCK_REPLACE_GRACE_PERIOD_MS_DEFAULT = 0;
+
   /** Block deletion increment. */
   public static final String DFS_NAMENODE_BLOCK_DELETION_INCREMENT_KEY =
       "dfs.namenode.block.deletion.increment";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ReplicaDeleteHint.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ReplicaDeleteHint.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * Provides a hint to excess redundancy processing as to which replica node to delete,
+ * and how long of a grace period to provide.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class ReplicaDeleteHint {
+  /**
+   * Represents an empty hint which contains neither a datanode hint nor grace period
+   */
+  public static ReplicaDeleteHint NONE = new ReplicaDeleteHint(null, 0);
+
+  private final DatanodeDescriptor datanode;
+  private final long gracePeriod;
+
+  ReplicaDeleteHint(DatanodeDescriptor datanode, long gracePeriod) {
+    this.datanode = datanode;
+    this.gracePeriod = gracePeriod;
+  }
+
+  /**
+   * Return a new ReplicaDeleteHint with the datanode nulled out, but gracePeriod retained.
+   */
+  ReplicaDeleteHint withNullDataNode() {
+    return new ReplicaDeleteHint(null, gracePeriod);
+  }
+
+  /**
+   * Get the underyling datanode
+   */
+  DatanodeDescriptor getDatanode() {
+    return datanode;
+  }
+
+  /**
+   * Get the underlying grace period
+   */
+  long getGracePeriod() {
+    return gracePeriod;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3453,6 +3453,16 @@
 </property>
 
 <property>
+  <name>dfs.namenode.block.replace.grace.period.ms</name>
+  <value>0</value>
+  <description>The delay in milliseconds before a replaced block replica is deemed eligible for
+  invalidation on the old DataNode. The NameNode will only send invalidate commands to DataNodes
+  for replaced blocks whose initial replacement time as at least this long ago. This is useful to
+  give clients time to refresh block locations before the block actually goes away and results
+  in ReplicaNotFoundExceptions.</description>
+</property>
+
+<property>
   <name>dfs.datanode.block.id.layout.upgrade.threads</name>
   <value>6</value>
   <description>The number of threads to use when creating hard links from

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -547,7 +547,7 @@ public class TestBlockManager {
       DatanodeStorageInfo[] pipeline) throws IOException {
     for (int i = 1; i < pipeline.length; i++) {
       DatanodeStorageInfo storage = pipeline[i];
-      bm.addBlock(storage, blockInfo, null);
+      bm.addBlock(storage, blockInfo, null, 0);
       blockInfo.addStorage(storage, blockInfo);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
@@ -292,7 +292,7 @@ public class TestPendingReconstruction {
       try {
         // Use a wrong gen stamp.
         blkManager.addBlock(desc[0].getStorageInfos()[0],
-            new Block(1, 1, 0), null);
+            new Block(1, 1, 0), null, 0);
       } finally {
         fsn.writeUnlock();
       }
@@ -306,7 +306,7 @@ public class TestPendingReconstruction {
       fsn.writeLock();
       try {
         blkManager.addBlock(desc[0].getStorageInfos()[0],
-            new Block(1, 1, 1), null);
+            new Block(1, 1, 1), null, 0);
       } finally {
         fsn.writeUnlock();
       }
@@ -546,7 +546,7 @@ public class TestPendingReconstruction {
       // not calling addBlock on block1 will make it timeout later.
       DatanodeStorageInfo[] storageInfos =
           DFSTestUtil.createDatanodeStorageInfos(1);
-      bm.addBlock(storageInfos[0], blockInfo0, null);
+      bm.addBlock(storageInfos[0], blockInfo0, null, 0);
 
       // call schedule replication on blockInfo2 will fail the re-replication.
       // because there is no source data to replicate from.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
@@ -59,7 +59,7 @@ public class TestUnderReplicatedBlocks {
       ExtendedBlock b = DFSTestUtil.getFirstBlock(fs, FILE_PATH);
       DatanodeDescriptor dn = bm.blocksMap.getStorages(b.getLocalBlock())
           .iterator().next().getDatanodeDescriptor();
-      bm.addToInvalidates(b.getLocalBlock(), dn);
+      bm.addToInvalidates(b.getLocalBlock(), dn, 0);
 
 
       // Compute the invalidate work in NN, and trigger the heartbeat from DN


### PR DESCRIPTION
### Description of PR
See https://issues.apache.org/jira/browse/HDFS-16261 for more details.

The most straightforward way to introduce a grace period for replaced blocks is in the InvalidateBlocks datastructure. Work is periodically pulled from this class to be divvied up to DataNodes. This class is also reported on with JMX metrics, so one can easily see how many blocks are currently pending deletion.

I achieved the grace period by adding a new `pollNWithFilter` method to `LightWeightHashSet`. InvalidateBlocks are added to the LightWeightHashSet with a calculated `readyForDeleteAt` time. When `getBlocksToInvalidateByLimit` is called, a filter is passed which only includes those blocks whose `readyForDeleteAt` is expired.

The default grace period for blocks added to InvalidateBlocks is 0, which effectively makes all blocks immediately ready for deletion per existing behavior. When a grace period is configured, it applies only to blocks deleted through the `delHintNode` passed in RECEIVED_BLOCK messages. This minimizes the impact of this feature on blocks deleted for other reasons (i.e. if a file is deleted or through other ongoing namenode auditing).

### How was this patch tested?

I've added tests for the relevant pieces, and have also been running this on 2 clusters internally.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

