### PR TITLE
HDFS-16283: RBF: improve renewLease() to call only a specific NameNod…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -113,6 +113,7 @@ public class DFSOutputStream extends FSOutputSummer
 
   protected final String src;
   protected final long fileId;
+  protected final String nsId;
   protected final long blockSize;
   protected final int bytesPerChecksum;
 
@@ -195,6 +196,7 @@ public class DFSOutputStream extends FSOutputSummer
     this.dfsClient = dfsClient;
     this.src = src;
     this.fileId = stat.getFileId();
+    this.nsId = stat.getNsId();
     this.blockSize = stat.getBlockSize();
     this.blockReplication = stat.getReplication();
     this.fileEncryptionInfo = stat.getFileEncryptionInfo();
@@ -818,7 +820,7 @@ public class DFSOutputStream extends FSOutputSummer
 
   void setClosed() {
     closed = true;
-    dfsClient.endFileLease(fileId);
+    dfsClient.endFileLease(fileId, nsId);
     getStreamer().release();
   }
 
@@ -921,7 +923,7 @@ public class DFSOutputStream extends FSOutputSummer
   protected void recoverLease(boolean recoverLeaseOnCloseException) {
     if (recoverLeaseOnCloseException) {
       try {
-        dfsClient.endFileLease(fileId);
+        dfsClient.endFileLease(fileId, nsId);
         dfsClient.recoverLease(src);
         leaseRecovered = true;
       } catch (Exception e) {
@@ -1082,6 +1084,11 @@ public class DFSOutputStream extends FSOutputSummer
   @VisibleForTesting
   public long getFileId() {
     return fileId;
+  }
+
+  @VisibleForTesting
+  public String getNsId() {
+    return nsId;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -1055,7 +1055,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
       }
     }
 
-    dfsClient.endFileLease(fileId);
+    dfsClient.endFileLease(fileId, nsId);
     final IOException ioe = b.build();
     if (ioe != null) {
       throw ioe;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -766,6 +766,14 @@ public interface ClientProtocol {
   void renewLease(String clientName) throws IOException;
 
   /**
+   * The functionality is the same as renewLease(clientName). This is to support
+   * router based FileSystem to newLease against a specific target FileSystem instead
+   * of all the target FileSystems in each call.
+   */
+  @Idempotent
+  void renewLease(String clientName, String nsId) throws IOException;
+
+  /**
    * Start lease recovery.
    * Lightweight NameNode operation to trigger lease recovery
    *

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsFileStatus.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsFileStatus.java
@@ -75,6 +75,7 @@ public interface HdfsFileStatus
     private byte[] symlink                 = null;
     private byte[] path                    = EMPTY_NAME;
     private long fileId                    = -1L;
+    private String nsId                    = null;
     private int childrenNum                = 0;
     private FileEncryptionInfo feInfo      = null;
     private byte storagePolicy             =
@@ -219,6 +220,16 @@ public interface HdfsFileStatus
     }
 
     /**
+     * Set the nsId for this entity (default = null).
+     * @param nsId nsId
+     * @return This Builder instance
+     */
+    public Builder nsId(String nsId) {
+      this.nsId = nsId;
+      return this;
+    }
+
+    /**
      * Set the number of children for this entity (default = 0).
      * @param childrenNum Number of children
      * @return This Builder instance
@@ -277,11 +288,11 @@ public interface HdfsFileStatus
       if (null == locations && !isdir && null == symlink) {
         return new HdfsNamedFileStatus(length, isdir, replication, blocksize,
             mtime, atime, permission, flags, owner, group, symlink, path,
-            fileId, childrenNum, feInfo, storagePolicy, ecPolicy);
+            fileId, nsId, childrenNum, feInfo, storagePolicy, ecPolicy);
       }
       return new HdfsLocatedFileStatus(length, isdir, replication, blocksize,
           mtime, atime, permission, flags, owner, group, symlink, path,
-          fileId, childrenNum, feInfo, storagePolicy, ecPolicy, locations);
+          fileId, nsId, childrenNum, feInfo, storagePolicy, ecPolicy, locations);
     }
 
   }
@@ -295,6 +306,20 @@ public interface HdfsFileStatus
    * @return inode ID.
    */
   long getFileId();
+
+  /**
+   * Name service the file is located on. The target name service if the file is
+   * created through router.
+   * @return name service ID.
+   */
+  String getNsId();
+
+  /**
+   * Set target name service Id where the file is located on. It's used for
+   * router FileSystem to identify which actual target name service the file
+   * is stored on.
+   */
+  void setNsId(String nsId);
 
   /**
    * Get metadata for encryption, if present.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsLocatedFileStatus.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsLocatedFileStatus.java
@@ -44,6 +44,7 @@ public class HdfsLocatedFileStatus
   private byte[] uPath;
   private byte[] uSymlink; // symlink target encoded in java UTF8/null
   private final long fileId;
+  private String nsId;
   private final FileEncryptionInfo feInfo;
   private final ErasureCodingPolicy ecPolicy;
 
@@ -68,6 +69,7 @@ public class HdfsLocatedFileStatus
    * @param symlink symlink target encoded in java UTF8 or null
    * @param path the local name in java UTF8 encoding the same as that in-memory
    * @param fileId the file id
+   * @param nsId name service id the file is on
    * @param childrenNum the number of children. Used by directory.
    * @param feInfo the file's encryption info
    * @param storagePolicy ID which specifies storage policy
@@ -78,7 +80,8 @@ public class HdfsLocatedFileStatus
                         long blocksize, long mtime, long atime,
                         FsPermission permission, EnumSet<Flags> flags,
                         String owner, String group,
-                        byte[] symlink, byte[] path, long fileId,
+                        byte[] symlink, byte[] path,
+                        long fileId, String nsId,
                         int childrenNum, FileEncryptionInfo feInfo,
                         byte storagePolicy, ErasureCodingPolicy ecPolicy,
                         LocatedBlocks hdfsloc) {
@@ -89,6 +92,7 @@ public class HdfsLocatedFileStatus
     this.uSymlink = symlink;
     this.uPath = path;
     this.fileId = fileId;
+    this.nsId = nsId;
     this.childrenNum = childrenNum;
     this.feInfo = feInfo;
     this.storagePolicy = storagePolicy;
@@ -149,6 +153,16 @@ public class HdfsLocatedFileStatus
   @Override
   public long getFileId() {
     return fileId;
+  }
+
+  @Override
+  public String getNsId() {
+    return nsId;
+  }
+
+  @Override
+  public void setNsId(String nsId) {
+    this.nsId = nsId;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsNamedFileStatus.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/HdfsNamedFileStatus.java
@@ -37,6 +37,7 @@ public class HdfsNamedFileStatus extends FileStatus implements HdfsFileStatus {
   private byte[] uPath;
   private byte[] uSymlink; // symlink target encoded in java UTF8/null
   private final long fileId;
+  private String nsId;
   private final FileEncryptionInfo feInfo;
   private final ErasureCodingPolicy ecPolicy;
 
@@ -58,6 +59,7 @@ public class HdfsNamedFileStatus extends FileStatus implements HdfsFileStatus {
    * @param symlink symlink target encoded in java UTF8 or null
    * @param path the local name in java UTF8 encoding the same as that in-memory
    * @param fileId the file id
+   * @param nsId name service id the file is on
    * @param childrenNum the number of children. Used by directory.
    * @param feInfo the file's encryption info
    * @param storagePolicy ID which specifies storage policy
@@ -67,7 +69,8 @@ public class HdfsNamedFileStatus extends FileStatus implements HdfsFileStatus {
                       long blocksize, long mtime, long atime,
                       FsPermission permission, Set<Flags> flags,
                       String owner, String group,
-                      byte[] symlink, byte[] path, long fileId,
+                      byte[] symlink, byte[] path,
+                      long fileId, String nsId,
                       int childrenNum, FileEncryptionInfo feInfo,
                       byte storagePolicy, ErasureCodingPolicy ecPolicy) {
     super(length, isdir, replication, blocksize, mtime, atime,
@@ -77,6 +80,7 @@ public class HdfsNamedFileStatus extends FileStatus implements HdfsFileStatus {
     this.uSymlink = symlink;
     this.uPath = path;
     this.fileId = fileId;
+    this.nsId = nsId;
     this.childrenNum = childrenNum;
     this.feInfo = feInfo;
     this.storagePolicy = storagePolicy;
@@ -137,6 +141,16 @@ public class HdfsNamedFileStatus extends FileStatus implements HdfsFileStatus {
   @Override
   public long getFileId() {
     return fileId;
+  }
+
+  @Override
+  public String getNsId() {
+    return nsId;
+  }
+
+  @Override
+  public void setNsId(String nsId) {
+    this.nsId = nsId;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -754,6 +754,19 @@ public class ClientNamenodeProtocolTranslatorPB implements
   }
 
   @Override
+  public void renewLease(String clientName, String nsId) throws IOException {
+    RenewLeaseRequestProto req = RenewLeaseRequestProto.newBuilder()
+            .setClientName(clientName)
+            .setNsId(nsId)
+            .build();
+    try {
+      rpcProxy.renewLease(null, req);
+    } catch (ServiceException e) {
+      throw ProtobufHelper.getRemoteException(e);
+    }
+  }
+
+  @Override
   public boolean recoverLease(String src, String clientName)
       throws IOException {
     RecoverLeaseRequestProto req = RecoverLeaseRequestProto.newBuilder()

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
@@ -1782,6 +1782,7 @@ public class PBHelperClient {
         .fileId(fs.hasFileId()
             ? fs.getFileId()
             : HdfsConstants.GRANDFATHER_INODE_ID)
+        .nsId(fs.getNsId())
         .locations(fs.hasLocations() ? convert(fs.getLocations()) : null)
         .children(fs.hasChildrenNum() ? fs.getChildrenNum() : -1)
         .feInfo(fs.hasFileEncryptionInfo()
@@ -2399,6 +2400,9 @@ public class PBHelperClient {
     flags |= fs.isSnapshotEnabled() ? HdfsFileStatusProto.Flags
         .SNAPSHOT_ENABLED_VALUE : 0;
     builder.setFlags(flags);
+    if (fs.getNsId() != null) {
+      builder.setNsId(fs.getNsId());
+    }
     return builder.build();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
@@ -332,6 +332,7 @@ message GetSnapshotDiffReportListingResponseProto {
 }
 message RenewLeaseRequestProto {
   required string clientName = 1;
+  optional string nsId = 2;
 }
 
 message RenewLeaseResponseProto { //void response

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/hdfs.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/hdfs.proto
@@ -481,6 +481,9 @@ message HdfsFileStatusProto {
 
   // Set of flags
   optional uint32 flags = 18 [default = 0];
+
+  // Optional field for nsId
+  optional string nsId = 19;
 }
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HAUtil;
+import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hadoop.thirdparty.com.google.common.cache.CacheLoader;
 import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
@@ -985,6 +986,20 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   @Override // ClientProtocol
   public void renewLease(String clientName) throws IOException {
     clientProto.renewLease(clientName);
+  }
+
+  @Override // ClientProtocol
+  public void renewLease(String clientName, String nsId) throws IOException {
+    if (Strings.isNullOrEmpty(nsId)) {
+      renewLease(clientName);
+      return;
+    }
+
+    checkOperation(OperationCategory.WRITE);
+
+    RemoteMethod method = new RemoteMethod("renewLease",
+            new Class<?>[] {String.class, String.class}, clientName, nsId);
+    rpcClient.invokeSingle(nsId, method);
   }
 
   @Override // ClientProtocol

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.protobuf.ByteString;
 import org.apache.hadoop.thirdparty.protobuf.ProtocolStringList;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -816,7 +817,11 @@ public class ClientNamenodeProtocolServerSideTranslatorPB implements
   public RenewLeaseResponseProto renewLease(RpcController controller,
       RenewLeaseRequestProto req) throws ServiceException {
     try {
-      server.renewLease(req.getClientName());
+      if (Strings.isNullOrEmpty(req.getNsId())) {
+        server.renewLease(req.getClientName());
+      } else {
+        server.renewLease(req.getClientName(), req.getNsId());
+      }
       return VOID_RENEWLEASE_RESPONSE;
     } catch (IOException e) {
       throw new ServiceException(e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1172,6 +1172,11 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   }
 
   @Override // ClientProtocol
+  public void renewLease(String clientName, String nsId) throws IOException {
+    renewLease(clientName);
+  }
+
+  @Override // ClientProtocol
   public DirectoryListing getListing(String src, byte[] startAfter,
       boolean needLocation) throws IOException {
     checkNNStartup();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSClientAdapter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/DFSClientAdapter.java
@@ -54,8 +54,8 @@ public class DFSClientAdapter {
     return dfs.dfs;
   }
 
-  public static ExtendedBlock getPreviousBlock(DFSClient client, long fileId) {
-    return client.getPreviousBlock(fileId);
+  public static ExtendedBlock getPreviousBlock(DFSClient client, long fileId, String nsId) {
+    return client.getPreviousBlock(fileId, nsId);
   }
 
   public static long getFileId(DFSOutputStream out) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSOutputStream.java
@@ -69,6 +69,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import org.mockito.Mockito;
+
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -352,7 +354,7 @@ public class TestDFSOutputStream {
         EnumSet.of(CreateFlag.CREATE), (short) 3, 1024, null , 1024, null);
     DFSOutputStream spyDFSOutputStream = Mockito.spy(dfsOutputStream);
     spyDFSOutputStream.closeThreads(anyBoolean());
-    verify(spyClient, times(1)).endFileLease(anyLong());
+    verify(spyClient, times(1)).endFileLease(anyLong(), anyString());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
@@ -848,13 +848,14 @@ public class TestHASafeMode {
           null);
       create.write(testData.getBytes());
       create.hflush();
-      long fileId = ((DFSOutputStream)create.
-          getWrappedStream()).getFileId();
+      DFSOutputStream stream = ((DFSOutputStream)create.getWrappedStream());
+      long fileId = stream.getFileId();
+      String nsId = stream.getNsId();
       FileStatus fileStatus = dfs.getFileStatus(filePath);
       DFSClient client = DFSClientAdapter.getClient(dfs);
       // add one dummy block at NN, but not write to DataNode
       ExtendedBlock previousBlock =
-          DFSClientAdapter.getPreviousBlock(client, fileId);
+          DFSClientAdapter.getPreviousBlock(client, fileId, nsId);
       DFSClientAdapter.getNamenode(client).addBlock(
           pathString,
           client.getClientName(),


### PR DESCRIPTION
HDFS-16283: RBF: improve renewLease() to call only a specific NameNode rather than make fan-out calls

Currently renewLease() is called against all the target name services on router while the file is only available on one name service and we only need to renew lease against that name service.

The patch adds name service id (nsId) when a new file is created and it's stored on the DFSClient project. A new API to renew lease against a particular nsId is implemented so the router renews lease for that name service.

### How was this patch tested?
unit tests and cluster testing.
