### PR TITLE
HDFS-16290.Make log more standardized when executing verifyAndSetNamespaceInfo().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -378,7 +378,7 @@ class BPOfferService {
 
     if(nsInfo.getState() == HAServiceState.ACTIVE
         && bpServiceToActive == null) {
-      LOG.info("Acknowledging ACTIVE Namenode during handshake" + actor);
+      LOG.info("Acknowledging ACTIVE Namenode during handshake {}", actor);
       bpServiceToActive = actor;
     }
 


### PR DESCRIPTION
### Description of PR
When the DataNode starting, BPOfferService#verifyAndSetNamespaceInfo() will be executed. If the namenode being connected is in Active state, the following information will be recorded:
'
2021-10-27 18:08:36,242 [50867]-INFO [Thread-33:BPOfferService@376]-Acknowledging ACTIVE Namenode during handshakeBlock pool BP-597961518-xxx.xxx.xxx.xxx-1534758275943 (Datanode Uuid 9b2aedc9-f8b2 -4ee2-b99f-877bc6e42c87) service to xxxx.xxx.xxx.org/xxxx.xxx.xxx.xxx:8021
'
Here, the connection between'handshake' and'Block pool' is too tight, and the readability is not good.

Details: HDFS-16290

### How was this patch tested?
This is related to the log, and there is less information to change. For testing, there is not much pressure.
