### PR TITLE
HDFS-16294.Remove invalid DataNode#CONFIG_PROPERTY_SIMULATED.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1383,7 +1383,7 @@ public class DataNode extends ReconfigurableBase
   /**
    * This method starts the data node with the specified conf.
    * 
-   * If conf's CONFIG_PROPERTY_SIMULATED property is set
+   * If conf's DFS_DATANODE_FSDATASET_FACTORY_KEY property is set
    * then a simulated storage based data node is created.
    * 
    * @param dataDirectories - only for a non-simulated storage data node


### PR DESCRIPTION
### Description of PR
As early as when HDFS-2907 was resolved, SimulatedFSDataset#CONFIG_PROPERTY_SIMULATED was removed. Replaced by: SimulatedFSDataset#Factory and DFSConfigKyes#DFS_DATANODE_FSDATASET_FACTORY_KEY.
However, the introduction to CONFIG_PROPERTY_SIMULATED is still retained in the DataNode.
Details: HDFS-16294

### How was this patch tested?
This pr mainly solves the changes related to annotations, and the test pressure is not great.
