### PR TITLE
HADOOP-17986. Disable JIRA plugin for YETUS on Hadoop

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -62,10 +62,7 @@ pipeline {
                 withCredentials(
                     [usernamePassword(credentialsId: 'apache-hadoop-at-github.com',
                                   passwordVariable: 'GITHUB_TOKEN',
-                                  usernameVariable: 'GITHUB_USER'),
-                    usernamePassword(credentialsId: 'hadoopqa-at-asf-jira',
-                                        passwordVariable: 'JIRA_PASSWORD',
-                                        usernameVariable: 'JIRA_USER')]) {
+                                  usernameVariable: 'GITHUB_USER')]) {
                         sh '''#!/usr/bin/env bash
 
                         set -e
@@ -107,10 +104,6 @@ pipeline {
                         # enable writing back to Github
                         YETUS_ARGS+=(--github-token="${GITHUB_TOKEN}")
 
-                        # enable writing back to ASF JIRA
-                        YETUS_ARGS+=(--jira-password="${JIRA_PASSWORD}")
-                        YETUS_ARGS+=(--jira-user="${JIRA_USER}")
-
                         # auto-kill any surefire stragglers during unit test runs
                         YETUS_ARGS+=("--reapermode=kill")
 
@@ -131,7 +124,7 @@ pipeline {
                         YETUS_ARGS+=("--build-url-artifacts=artifact/out")
 
                         # plugins to enable
-                        YETUS_ARGS+=("--plugins=all")
+                        YETUS_ARGS+=("--plugins=all,-jira")
 
                         # don't let these tests cause -1s because we aren't really paying that
                         # much attention to them


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The jira-json goes missing all of a sudden and we get the following error in the Jenkins CI run -
```
[2021-10-27T17:52:58.787Z] Processing: https://github.com/apache/hadoop/pull/3588
[2021-10-27T17:52:58.787Z] GITHUB PR #3588 is being downloaded from
[2021-10-27T17:52:58.787Z] https://api.github.com/repos/apache/hadoop/pulls/3588
[2021-10-27T17:52:58.787Z] JSON data at Wed Oct 27 17:52:55 UTC 2021
[2021-10-27T17:52:58.787Z] Patch data at Wed Oct 27 17:52:56 UTC 2021
[2021-10-27T17:52:58.787Z] Diff data at Wed Oct 27 17:52:56 UTC 2021
[2021-10-27T17:52:59.814Z] awk: cannot open /home/jenkins/jenkins-home/workspace/hadoop-multibranch_PR-3588/centos-7/out/jira-json (No such file or directory)
[2021-10-27T17:52:59.814Z] ERROR: https://github.com/apache/hadoop/pull/3588 issue status is not matched with "Patch Available".
[2021-10-27T17:52:59.814Z]
```

The hadoop-multibranch pipeline doesn't use ASF JIRA, thus, we're disabling the jira plugin to fix this issue.

### How was this patch tested?
In progress.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

