### PR TITLE
HDFS-16296. RouterRpcFairnessPolicyController add rejected permits for each nameservice

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMBean.java
@@ -120,4 +120,10 @@ public interface FederationRPCMBean {
    * @return Number of operations rejected due to lack of permits.
    */
   long getProxyOpPermitRejected();
+
+  /**
+   * Get the number of operations rejected due to lack of permits of each namespace.
+   * @return Number of operations rejected due to lack of permits of each namespace.
+   */
+  String getProxyOpPermitRejectedPerNs();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
@@ -286,4 +286,9 @@ public class FederationRPCMetrics implements FederationRPCMBean {
   public long getProxyOpPermitRejected() {
     return proxyOpPermitRejected.value();
   }
+
+  @Override
+  public String getProxyOpPermitRejectedPerNs() {
+    return rpcServer.getRPCClient().getRejectedPermitsPerNsJSON();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -54,6 +55,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -134,6 +136,7 @@ public class RouterRpcClient {
 
   /** Fairness manager to control handlers assigned per NS. */
   private RouterRpcFairnessPolicyController routerRpcFairnessPolicyController;
+  private Map<String, AtomicLong> rejectedPermitsPerNs = new ConcurrentHashMap<>();
 
   /**
    * Create a router RPC client to manage remote procedure calls to NNs.
@@ -317,6 +320,15 @@ public class RouterRpcClient {
     info.put("total", executorService.getPoolSize());
     info.put("max", executorService.getMaximumPoolSize());
     return JSON.toString(info);
+  }
+
+  /**
+   * JSON representation of the rejected permits for each nameservice
+   *
+   * @return String representation of the rejected permits for each nameservice.
+   */
+  public String getRejectedPermitsPerNsJSON() {
+    return JSON.toString(rejectedPermitsPerNs);
   }
 
   /**
@@ -1544,6 +1556,7 @@ public class RouterRpcClient {
       if (rpcMonitor != null) {
         rpcMonitor.getRPCMetrics().incrProxyOpPermitRejected();
       }
+      incrRejectedPermitForNs(nsId);
       LOG.debug("Permit denied for ugi: {} for method: {}",
           ugi, m.getMethodName());
       String msg =
@@ -1575,5 +1588,15 @@ public class RouterRpcClient {
       getRouterRpcFairnessPolicyController() {
     return (AbstractRouterRpcFairnessPolicyController
           )routerRpcFairnessPolicyController;
+  }
+
+  private void incrRejectedPermitForNs(String ns) {
+    rejectedPermitsPerNs.putIfAbsent(ns, new AtomicLong(0));
+    rejectedPermitsPerNs.get(ns).incrementAndGet();
+  }
+
+  public Long getRejectedPermitForNs(String ns) {
+    return rejectedPermitsPerNs.containsKey(ns) ?
+        rejectedPermitsPerNs.get(ns).get() : 0L;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -323,7 +323,7 @@ public class RouterRpcClient {
   }
 
   /**
-   * JSON representation of the rejected permits for each nameservice
+   * JSON representation of the rejected permits for each nameservice.
    *
    * @return String representation of the rejected permits for each nameservice.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -86,6 +86,8 @@ import org.apache.hadoop.hdfs.server.federation.resolver.FileSubclusterResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.NamenodeStatusReport;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
 import org.apache.hadoop.hdfs.server.federation.router.RouterClient;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcClient;
+import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
 import org.apache.hadoop.hdfs.server.namenode.FSImage;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider;
@@ -266,6 +268,14 @@ public class MiniRouterDFSCluster {
 
     public Configuration getConf() {
       return conf;
+    }
+
+    public RouterRpcServer getRouterRpcServer() {
+      return router.getRpcServer();
+    }
+
+    public RouterRpcClient getRouterRpcClient() {
+      return getRouterRpcServer().getRPCClient();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -215,11 +215,10 @@ public class TestRouterHandlersFairness {
   private int getTotalRejectedPermits(RouterContext routerContext) {
     int totalRejectedPermits = 0;
     for (String ns : cluster.getNameservices()) {
-      totalRejectedPermits += routerContext.getRouter().getRpcServer()
-          .getRPCClient().getRejectedPermitForNs(ns);
+      totalRejectedPermits += routerContext.getRouterRpcClient()
+          .getRejectedPermitForNs(ns);
     }
-    totalRejectedPermits += routerContext.getRouter().getRpcServer()
-        .getRPCClient()
+    totalRejectedPermits += routerContext.getRouterRpcClient()
         .getRejectedPermitForNs(RouterRpcFairnessConstants.CONCURRENT_NS);
     return totalRejectedPermits;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -146,6 +146,7 @@ public class TestRouterHandlersFairness {
     Configuration conf = new HdfsConfiguration();
     final int numOps = 10;
     final AtomicInteger overloadException = new AtomicInteger();
+    int originalRejectedPermits = getTotalRejectedPermits(routerContext);
 
     for (int i = 0; i < numOps; i++) {
       DFSClient routerClient = null;
@@ -177,15 +178,9 @@ public class TestRouterHandlersFairness {
       }
       overloadException.get();
     }
-    int totalRejectedPermits = 0;
-    for (String ns : cluster.getNameservices()) {
-      totalRejectedPermits += routerContext.getRouter().getRpcServer()
-              .getRPCClient().getRejectedPermitForNs(ns);
-    }
-    totalRejectedPermits += routerContext.getRouter().getRpcServer()
-            .getRPCClient().getRejectedPermitForNs("concurrent");
-
-    assertEquals(totalRejectedPermits, overloadException.get());
+    int latestRejectedPermits = getTotalRejectedPermits(routerContext);
+    assertEquals(latestRejectedPermits - originalRejectedPermits,
+        overloadException.get());
 
     if (fairness) {
       assertTrue(overloadException.get() > 0);
@@ -217,4 +212,15 @@ public class TestRouterHandlersFairness {
     routerProto.renewLease(clientName);
   }
 
+  private int getTotalRejectedPermits(RouterContext routerContext) {
+    int totalRejectedPermits = 0;
+    for (String ns : cluster.getNameservices()) {
+      totalRejectedPermits += routerContext.getRouter().getRpcServer()
+          .getRPCClient().getRejectedPermitForNs(ns);
+    }
+    totalRejectedPermits += routerContext.getRouter().getRpcServer()
+        .getRPCClient()
+        .getRejectedPermitForNs(RouterRpcFairnessConstants.CONCURRENT_NS);
+    return totalRejectedPermits;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -177,6 +177,15 @@ public class TestRouterHandlersFairness {
       }
       overloadException.get();
     }
+    int totalRejectedPermits = 0;
+    for (String ns : cluster.getNameservices()) {
+      totalRejectedPermits += routerContext.getRouter().getRpcServer()
+              .getRPCClient().getRejectedPermitForNs(ns);
+    }
+    totalRejectedPermits += routerContext.getRouter().getRpcServer()
+            .getRPCClient().getRejectedPermitForNs("concurrent");
+
+    assertEquals(totalRejectedPermits, overloadException.get());
 
     if (fairness) {
       assertTrue(overloadException.get() > 0);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Currently RouterRpcFairnessPolicyController has a metric of "getProxyOpPermitRejected" to show the total rejected invokes due to lack of permits.

This ticket is to add the metrics for each nameservice to have a better view of the load of each nameservice.

Jira ticket: https://issues.apache.org/jira/browse/HDFS-16296

### How was this patch tested?

unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

