### PR TITLE
YARN-10999. Make NodeQueueLoadMonitor pluggable in ResourceManager

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -451,6 +451,13 @@ public class YarnConfiguration extends Configuration {
   public static final String DEFAULT_NM_CONTAINER_QUEUING_LOAD_COMPARATOR =
       "QUEUE_LENGTH";
 
+  /** Class for ClusterMonitor */
+  @Unstable
+  public static final String OPP_CONTAINER_CLUSTER_MONITOR =
+      RM_PREFIX + "opp-container-cluster-monitor";
+  public static final String DEFAULT_OPP_CONTAINER_CLUSTER_MONITOR =
+      "org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed.NodeQueueLoadMonitor";
+
   /** Value of standard deviation used for calculation of queue limit
    * thresholds. */
   @Unstable

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClusterMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClusterMonitor.java
@@ -18,11 +18,14 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager;
 
+import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.ResourceOption;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NMContainerStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed.QueueLimitCalculator;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Implementations of this class are notified of changes to the cluster's state,
@@ -37,4 +40,18 @@ public interface ClusterMonitor {
   void updateNode(RMNode rmNode);
 
   void updateNodeResource(RMNode rmNode, ResourceOption resourceOption);
+
+  RMNode selectLocalNode(String hostName, Set<String> blacklist);
+
+  RMNode selectRackLocalNode(String rackName, Set<String> blacklist);
+
+  RMNode selectAnyNode(Set<String> blacklist);
+
+  void initThresholdCalculator(float sigma, int limitMin,
+      int limitMax);
+
+  void stop();
+  List<NodeId> selectLeastLoadedNodes(int k);
+
+  QueueLimitCalculator getThresholdCalculator();
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/CentralizedOpportunisticContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/CentralizedOpportunisticContainerAllocator.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.api.protocolrecords.RemoteNode;
 import org.apache.hadoop.yarn.server.metrics.OpportunisticSchedulerMetrics;
+import org.apache.hadoop.yarn.server.resourcemanager.ClusterMonitor;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.scheduler.OpportunisticContainerAllocator;
 import org.apache.hadoop.yarn.server.scheduler.OpportunisticContainerContext;
@@ -59,7 +60,7 @@ public class CentralizedOpportunisticContainerAllocator extends
   private static final Logger LOG =
       LoggerFactory.getLogger(CentralizedOpportunisticContainerAllocator.class);
 
-  private NodeQueueLoadMonitor nodeQueueLoadMonitor;
+  private ClusterMonitor clusterMonitor;
   private OpportunisticSchedulerMetrics metrics =
       OpportunisticSchedulerMetrics.getMetrics();
 
@@ -81,14 +82,14 @@ public class CentralizedOpportunisticContainerAllocator extends
   public CentralizedOpportunisticContainerAllocator(
       BaseContainerTokenSecretManager tokenSecretManager,
       int maxAllocationsPerAMHeartbeat,
-      NodeQueueLoadMonitor nodeQueueLoadMonitor) {
+      ClusterMonitor clusterMonitor) {
     super(tokenSecretManager, maxAllocationsPerAMHeartbeat);
-    this.nodeQueueLoadMonitor = nodeQueueLoadMonitor;
+    this.clusterMonitor = clusterMonitor;
   }
 
   @VisibleForTesting
-  void setNodeQueueLoadMonitor(NodeQueueLoadMonitor nodeQueueLoadMonitor) {
-    this.nodeQueueLoadMonitor = nodeQueueLoadMonitor;
+  void setNodeQueueLoadMonitor(ClusterMonitor clusterMonitor) {
+    this.clusterMonitor = clusterMonitor;
   }
 
   @Override
@@ -252,7 +253,7 @@ public class CentralizedOpportunisticContainerAllocator extends
       throws YarnException {
     List<Container> allocatedContainers = new ArrayList<>();
     while (toAllocate > 0) {
-      RMNode node = nodeQueueLoadMonitor.selectLocalNode(nodeLocation,
+      RMNode node = clusterMonitor.selectLocalNode(nodeLocation,
           blacklist);
       if (node != null) {
         toAllocate--;
@@ -281,7 +282,7 @@ public class CentralizedOpportunisticContainerAllocator extends
       throws YarnException {
     List<Container> allocatedContainers = new ArrayList<>();
     while (toAllocate > 0) {
-      RMNode node = nodeQueueLoadMonitor.selectRackLocalNode(rackLocation,
+      RMNode node = clusterMonitor.selectRackLocalNode(rackLocation,
           blacklist);
       if (node != null) {
         toAllocate--;
@@ -310,7 +311,7 @@ public class CentralizedOpportunisticContainerAllocator extends
       throws YarnException {
     List<Container> allocatedContainers = new ArrayList<>();
     while (toAllocate > 0) {
-      RMNode node = nodeQueueLoadMonitor.selectAnyNode(blacklist);
+      RMNode node = clusterMonitor.selectAnyNode(blacklist);
       if (node != null) {
         toAllocate--;
         Container container = createContainer(rmIdentifier, appParams,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/LoadComparator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/LoadComparator.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed;
+
+import java.util.Comparator;
+
+/**
+ * The comparator used to specify the metric against which the load
+ * of two Nodes are compared.
+ */
+public enum LoadComparator implements Comparator<ClusterNode> {
+  QUEUE_LENGTH, QUEUE_WAIT_TIME;
+
+  @Override public int compare(ClusterNode o1, ClusterNode o2) {
+    if (getMetric(o1) == getMetric(o2)) {
+      return (int) (o2.getTimestamp() - o1.getTimestamp());
+    }
+    return getMetric(o1) - getMetric(o2);
+  }
+
+  public int getMetric(ClusterNode c) {
+    return (this == QUEUE_LENGTH) ?
+        c.getQueueLength().get() :
+        c.getQueueWaitTime().get();
+  }
+
+  /**
+   * Increment the metric by a delta if it is below the threshold.
+   *
+   * @param c             ClusterNode
+   * @param incrementSize increment size
+   * @return true if the metric was below threshold and was incremented.
+   */
+  public boolean compareAndIncrement(ClusterNode c, int incrementSize) {
+    if (this == QUEUE_LENGTH) {
+      int ret = c.getQueueLength().addAndGet(incrementSize);
+      if (ret <= c.getQueueCapacity()) {
+        return true;
+      }
+      c.getQueueLength().addAndGet(-incrementSize);
+      return false;
+    }
+    // for queue wait time, we don't have any threshold.
+    return true;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
@@ -59,47 +59,6 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
   protected int numNodesForAnyAllocation =
       DEFAULT_OPP_CONTAINER_ALLOCATION_NODES_NUMBER_USED;
 
-  /**
-   * The comparator used to specify the metric against which the load
-   * of two Nodes are compared.
-   */
-  public enum LoadComparator implements Comparator<ClusterNode> {
-    QUEUE_LENGTH,
-    QUEUE_WAIT_TIME;
-
-    @Override
-    public int compare(ClusterNode o1, ClusterNode o2) {
-      if (getMetric(o1) == getMetric(o2)) {
-        return (int)(o2.getTimestamp() - o1.getTimestamp());
-      }
-      return getMetric(o1) - getMetric(o2);
-    }
-
-    public int getMetric(ClusterNode c) {
-      return (this == QUEUE_LENGTH) ?
-          c.getQueueLength().get() : c.getQueueWaitTime().get();
-    }
-
-    /**
-     * Increment the metric by a delta if it is below the threshold.
-     * @param c ClusterNode
-     * @param incrementSize increment size
-     * @return true if the metric was below threshold and was incremented.
-     */
-    public boolean compareAndIncrement(ClusterNode c, int incrementSize) {
-      if(this == QUEUE_LENGTH) {
-        int ret = c.getQueueLength().addAndGet(incrementSize);
-        if (ret <= c.getQueueCapacity()) {
-          return true;
-        }
-        c.getQueueLength().addAndGet(-incrementSize);
-        return false;
-      }
-      // for queue wait time, we don't have any threshold.
-      return true;
-    }
-  }
-
   private final ScheduledExecutorService scheduledExecutor;
 
   protected final List<NodeId> sortedNodes;
@@ -345,6 +304,7 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
     }
   }
 
+  @Override
   public RMNode selectLocalNode(String hostName, Set<String> blacklist) {
     if (blacklist.contains(hostName)) {
       return null;
@@ -359,6 +319,7 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
     return null;
   }
 
+  @Override
   public RMNode selectRackLocalNode(String rackName, Set<String> blacklist) {
     Set<NodeId> nodesOnRack = nodeIdsByRack.get(rackName);
     if (nodesOnRack != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/QueueLimitCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/QueueLimitCalculator.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed;
 
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.server.api.records.ContainerQueuingLimit;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed.NodeQueueLoadMonitor.LoadComparator;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestCentralizedOpportunisticContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestCentralizedOpportunisticContainerAllocator.java
@@ -603,8 +603,8 @@ public class TestCentralizedOpportunisticContainerAllocator {
 
   private NodeQueueLoadMonitor createNodeQueueLoadMonitor(int numNodes,
       int queueLength, int queueCapacity) {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
     for (int i = 1; i <= numNodes; ++i) {
       RMNode node = createRMNode("h" + i, 1234, queueLength, queueCapacity);
       selector.addNode(null, node);
@@ -617,8 +617,8 @@ public class TestCentralizedOpportunisticContainerAllocator {
   private NodeQueueLoadMonitor createNodeQueueLoadMonitor(List<String> hosts,
       List<String> racks, List<Integer> queueLengths,
       List<Integer> queueCapacities) {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
     for (int i = 0; i < hosts.size(); ++i) {
       RMNode node = createRMNode(hosts.get(i), 1234, racks.get(i),
           queueLengths.get(i), queueCapacities.get(i));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestNodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestNodeQueueLoadMonitor.java
@@ -72,8 +72,8 @@ public class TestNodeQueueLoadMonitor {
 
   @Test
   public void testWaitTimeSort() {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_WAIT_TIME);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_WAIT_TIME);
     selector.updateNode(createRMNode("h1", 1, 15, 10));
     selector.updateNode(createRMNode("h2", 2, 5, 10));
     selector.updateNode(createRMNode("h3", 3, 10, 10));
@@ -123,8 +123,8 @@ public class TestNodeQueueLoadMonitor {
 
   @Test
   public void testQueueLengthSort() {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
     selector.updateNode(createRMNode("h1", 1, -1, 15));
     selector.updateNode(createRMNode("h2", 2, -1, 5));
     selector.updateNode(createRMNode("h3", 3, -1, 10));
@@ -188,8 +188,8 @@ public class TestNodeQueueLoadMonitor {
 
   @Test
   public void testContainerQueuingLimit() {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
     selector.updateNode(createRMNode("h1", 1, -1, 15));
     selector.updateNode(createRMNode("h2", 2, -1, 5));
     selector.updateNode(createRMNode("h3", 3, -1, 10));
@@ -236,8 +236,8 @@ public class TestNodeQueueLoadMonitor {
    */
   @Test
   public void testSelectLocalNode() {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
 
     RMNode h1 = createRMNode("h1", 1, -1, 2, 5);
     RMNode h2 = createRMNode("h2", 2, -1, 5, 5);
@@ -275,8 +275,8 @@ public class TestNodeQueueLoadMonitor {
    */
   @Test
   public void testSelectRackLocalNode() {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
 
     RMNode h1 = createRMNode("h1", 1, "rack1", -1, 2, 5);
     RMNode h2 = createRMNode("h2", 2, "rack2", -1, 5, 5);
@@ -315,8 +315,8 @@ public class TestNodeQueueLoadMonitor {
    */
   @Test
   public void testSelectAnyNode() {
-    NodeQueueLoadMonitor selector = new NodeQueueLoadMonitor(
-        NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH);
+    NodeQueueLoadMonitor selector =
+        new NodeQueueLoadMonitor(LoadComparator.QUEUE_LENGTH);
 
     RMNode h1 = createRMNode("h1", 1, "rack1", -1, 2, 5);
     RMNode h2 = createRMNode("h2", 2, "rack2", -1, 5, 5);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

