### PR TITLE
HDFS-16298. Improve error msg for BlockMissingException

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1003,7 +1003,7 @@ public class DFSInputStream extends FSInputStream
       String description = "Could not obtain block: " + blockInfo;
       DFSClient.LOG.warn(description + errMsg
           + ". Throwing a BlockMissingException");
-      throw new BlockMissingException(src, description,
+      throw new BlockMissingException(src, description + errMsg,
           block.getStartOffset());
     }
 


### PR DESCRIPTION
JIRA: [HDFS-16298](https://issues.apache.org/jira/browse/HDFS-16298)

When the client fails to obtain a block, a BlockMissingException is thrown. To analyze the issues, we can add the relevant location information to error msg of BlockMissingException.

![image](https://user-images.githubusercontent.com/55134131/140273974-f5c726e3-02e7-4260-8149-4d68c510fc53.png)
