### PR TITLE
HADOOP-17990. Fix failing concurrent FS.initialize commands when fs.azure.createRemoteFileSystemDuringInitialization is enabled.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirEncryptionZoneOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirEncryptionZoneOp.java
@@ -75,7 +75,7 @@ final class FSDirEncryptionZoneOp {
    * Invoke KeyProvider APIs to generate an encrypted data encryption key for
    * an encryption zone. Should not be called with any locks held.
    *
-   * @param fsd fsdirectory
+   * @param fsd the namespace tree.
    * @param ezKeyName key name of an encryption zone
    * @return New EDEK, or null if ezKeyName is null
    * @throws IOException
@@ -142,11 +142,12 @@ final class FSDirEncryptionZoneOp {
   /**
    * Create an encryption zone on directory path using the specified key.
    *
-   * @param fsd fsdirectory
+   * @param fsd the namespace tree.
    * @param srcArg the path of a directory which will be the root of the
    *               encryption zone. The directory must be empty
    * @param pc permission checker to check fs permission
-   * @param cipher cipher
+   * @param cipher the name of the cipher suite, which will be used
+   *               when it is generated.
    * @param keyName name of a key which must be present in the configured
    *                KeyProvider
    * @param logRetryCache whether to record RPC ids in editlog for retry cache
@@ -180,7 +181,7 @@ final class FSDirEncryptionZoneOp {
   /**
    * Get the encryption zone for the specified path.
    *
-   * @param fsd fsdirectory
+   * @param fsd the namespace tree.
    * @param srcArg the path of a file or directory to get the EZ for
    * @param pc permission checker to check fs permission
    * @return the EZ with file status.
@@ -400,7 +401,7 @@ final class FSDirEncryptionZoneOp {
   /**
    * Set the FileEncryptionInfo for an INode.
    *
-   * @param fsd fsdirectory
+   * @param fsd the namespace tree.
    * @param info file encryption information
    * @param flag action when setting xattr. Either CREATE or REPLACE.
    * @throws IOException
@@ -430,7 +431,7 @@ final class FSDirEncryptionZoneOp {
    * returns a consolidated FileEncryptionInfo instance. Null is returned
    * for non-encrypted or raw files.
    *
-   * @param fsd fsdirectory
+   * @param fsd the namespace tree.
    * @param iip inodes in the path containing the file, passed in to
    *            avoid obtaining the list of inodes again
    * @return consolidated file encryption info; null for non-encrypted files
@@ -487,7 +488,7 @@ final class FSDirEncryptionZoneOp {
    * else throw a retry exception.  The startFile method generates the EDEK
    * outside of the lock so the zone must be reverified.
    *
-   * @param dir fsdirectory
+   * @param dir the namespace tree.
    * @param iip inodes in the file path
    * @param ezInfo the encryption key
    * @return FileEncryptionInfo for the file


### PR DESCRIPTION
…

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When fs.azure.createRemoteFileSystemDuringInitialization is enabled, the filesystem will create a container if it does not already exist inside the initialize method. The current flow of creating the container will fail in the case of concurrent initialize methods being executed simultaneously (only one request can create the container, the rest will fail instead of moving on). This PR is fixing this issue by also catching org.apache.Hadoop.fs.FileAlreadyExistsException generated by the createFilesystem command.

### How was this patch tested?

A new test in ITestAzureBlobFileSystemInitAndCreate is introduced which was breaking before the fox.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

