### PR TITLE
HADOOP-17990. Fix failing concurrent FS.initialize commands when fs.azure.createRemoteFileSystemDuringInitialization is enabled.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1415,11 +1415,11 @@ public class AzureBlobFileSystem extends FileSystem
     if (this.tryGetFileStatus(new Path(AbfsHttpConstants.ROOT_PATH), tracingContext) == null) {
       try {
         this.createFileSystem(tracingContext);
+      } catch (AzureBlobFileSystemException ex) {
+        checkException(null, (AzureBlobFileSystemException) ex,
+            AzureServiceErrorCode.FILE_SYSTEM_ALREADY_EXISTS);
       } catch (IOException ex) {
-        if (ex instanceof AzureBlobFileSystemException) {
-          checkException(null, (AzureBlobFileSystemException) ex,
-              AzureServiceErrorCode.FILE_SYSTEM_ALREADY_EXISTS);
-        } else if (ex.getCause() != null && ex.getCause() instanceof AzureBlobFileSystemException) {
+        if (ex.getCause() instanceof AzureBlobFileSystemException) {
           checkException(null, (AzureBlobFileSystemException) ex.getCause(),
               AzureServiceErrorCode.FILE_SYSTEM_ALREADY_EXISTS);
         } else {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -77,9 +77,9 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
    * exception when calling createFileSystem command.
    */
   static class MockAzureBlobFileSystemStore extends AzureBlobFileSystemStore {
-    boolean isCreateFileSystemCalled = false;
+    private boolean isCreateFileSystemCalled = false;
 
-    public MockAzureBlobFileSystemStore(Configuration config) throws IOException {
+    MockAzureBlobFileSystemStore(Configuration config) throws IOException {
       super(FileSystem.getDefaultUri(config), true, config, null);
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -59,15 +59,17 @@ public class ITestAzureBlobFileSystemInitAndCreate extends
 
   @Test
   public void ensureFilesystemWillBeCreatedIfCreationConfigIsSet() throws Exception {
-    final AzureBlobFileSystem fs = createFileSystem();
-    Configuration config = getRawConfiguration();
-    fs.initialize(FileSystem.getDefaultUri(config), config);
+    try (AzureBlobFileSystem fs = createFileSystem()) {
+      Configuration config = getRawConfiguration();
+      fs.initialize(FileSystem.getDefaultUri(config), config);
 
-    // Make sure createFileSystemIfNotExists is working as intended.
-    final MockAzureBlobFileSystemStore store = new MockAzureBlobFileSystemStore(config);
-    fs.setAbfsStore(store);
-    fs.createFileSystemIfNotExist(getTestTracingContext(fs, true));
-    assert(store.isCreateFileSystemCalled);
+      // Make sure createFileSystemIfNotExists is working as intended.
+      final MockAzureBlobFileSystemStore store = new MockAzureBlobFileSystemStore(config);
+      fs.setAbfsStore(store);
+      fs.createFileSystemIfNotExist(getTestTracingContext(fs, true));
+      assertTrue("Expected AzureBlobFileSystemStore.createFilesystem to be called",
+          store.isCreateFileSystemCalled);
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When fs.azure.createRemoteFileSystemDuringInitialization is enabled, the filesystem will create a container if it does not already exist inside the initialize method. The current flow of creating the container will fail in the case of concurrent initialize methods being executed simultaneously (only one request can create the container, the rest will fail instead of moving on). This PR is fixing this issue by also catching org.apache.Hadoop.fs.FileAlreadyExistsException generated by the createFilesystem command.

### How was this patch tested?

A new test in ITestAzureBlobFileSystemInitAndCreate is introduced which was breaking before the fox.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

