### PR TITLE
HDFS-16305.Record the remote NameNode address when the rolling log is triggered.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/EditLogTailer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/EditLogTailer.java
@@ -413,6 +413,8 @@ public class EditLogTailer {
     return new MultipleNameNodeProxy<Void>() {
       @Override
       protected Void doWork() throws IOException {
+        LOG.info("Triggering log rolling to the remote NameNode, " +
+            "active NameNode = {}", currentNN.getIpcAddress());
         cachedActiveProxy.rollEditLog();
         return null;
       }
@@ -424,7 +426,6 @@ public class EditLogTailer {
    */
   @VisibleForTesting
   void triggerActiveLogRoll() {
-    LOG.info("Triggering log roll on remote NameNode");
     Future<Void> future = null;
     try {
       future = rollEditsRpcExecutor.submit(getNameNodeProxy());


### PR DESCRIPTION

### Description of PR
When StandbyNN triggers the rolling log, it sends a request to the remote NameNode. But there is no way to know the specific information of the NameNode.
Here are some log information:
![image](https://user-images.githubusercontent.com/6416939/140687250-d064ae4d-62a5-42da-8fba-ff1ab710930f.png)

We can try to record the specific address.
This is the purpose of this pr.

### How was this patch tested?
Some log information has been changed here, which is not very stressful for testing.
