### PR TITLE
HADOOP-17997. RBF: Namespace usage of mount table with multi subclust…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterQuota.java
@@ -130,7 +130,7 @@ public class TestRouterQuota {
 
   @Test
   public void testNamespaceQuotaExceed() throws Exception {
-    long nsQuota = 3;
+    long nsQuota = 4;
     final FileSystem nnFs1 = nnContext1.getFileSystem();
     final FileSystem nnFs2 = nnContext2.getFileSystem();
 
@@ -168,6 +168,8 @@ public class TestRouterQuota {
       }
       return isNsQuotaViolated;
     }, 5000, 60000);
+    QuotaUsage quota = routerFs.getQuotaUsage(new Path("/nsquota"));
+    assertEquals(quota.getQuota(), quota.getFileAndDirectoryCount());
 
     // mkdir in real FileSystem should be okay
     nnFs1.mkdirs(new Path("/testdir1/" + UUID.randomUUID()));
@@ -184,7 +186,7 @@ public class TestRouterQuota {
 
   @Test
   public void testStorageSpaceQuotaExceed() throws Exception {
-    long ssQuota = 3071;
+    long ssQuota = 3072;
     final FileSystem nnFs1 = nnContext1.getFileSystem();
     final FileSystem nnFs2 = nnContext2.getFileSystem();
 
@@ -226,6 +228,9 @@ public class TestRouterQuota {
         return isDsQuotaViolated;
       }
     }, 5000, 60000);
+
+    QuotaUsage quota = routerContext.getFileSystem().getQuotaUsage(new Path("/ssquota"));
+    assertEquals(quota.getSpaceQuota(), quota.getSpaceConsumed());
 
     // append data to destination path in real FileSystem should be okay
     appendData("/testdir3/file", nnContext1.getClient(), BLOCK_SIZE);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -918,7 +918,7 @@ public class FSDirectory implements Closeable {
         if (Quota.isViolated(nsQuota, nsConsumed)) {
           LOG.warn("Namespace quota violation in image for "
               + dir.getFullPathName()
-              + " quota = " + nsQuota + " < consumed = " + nsConsumed);
+              + " quota = " + nsQuota + " <= consumed = " + nsConsumed);
         }
 
         final long ssConsumed = myCounts.getStorageSpace();
@@ -926,7 +926,7 @@ public class FSDirectory implements Closeable {
         if (Quota.isViolated(ssQuota, ssConsumed)) {
           LOG.warn("Storagespace quota violation in image for "
               + dir.getFullPathName()
-              + " quota = " + ssQuota + " < consumed = " + ssConsumed);
+              + " quota = " + ssQuota + " <= consumed = " + ssConsumed);
         }
 
         final EnumCounters<StorageType> tsConsumed = myCounts.getTypeSpaces();
@@ -937,7 +937,7 @@ public class FSDirectory implements Closeable {
             LOG.warn("Storage type quota violation in image for "
                 + dir.getFullPathName()
                 + " type = " + t.toString() + " quota = "
-                + typeQuota + " < consumed " + typeSpace);
+                + typeQuota + " <= consumed " + typeSpace);
           }
         }
         if (LOG.isDebugEnabled()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/Quota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/Quota.java
@@ -50,7 +50,7 @@ public enum Quota {
    * The quota is violated if quota is set and usage &gt; quota.
    */
   public static boolean isViolated(final long quota, final long usage) {
-    return quota >= 0 && usage > quota;
+    return quota >= 0 && usage >= quota;
   }
 
   /**


### PR DESCRIPTION
…ers can exceed quota

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

