### PR TITLE
HDFS-16311. Metric metadataOperationRate calculation error in DataNod…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/DataNodeVolumeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/DataNodeVolumeMetrics.java
@@ -284,6 +284,6 @@ public class DataNodeVolumeMetrics {
 
   public void addFileIoError(final long latency) {
     totalFileIoErrors.incr();
-    metadataOperationRate.add(latency);
+    fileIoErrorRate.add(latency);
   }
 }


### PR DESCRIPTION
JIRA: [HDFS-16311](https://issues.apache.org/jira/browse/HDFS-16311).

Metric metadataOperationRate calculation error in DataNodeVolumeMetrics#addFileIoError, causing MetadataOperationRateAvgTime is very large in some cases.

![image](https://user-images.githubusercontent.com/55134131/140923975-a60f6e25-a3af-4669-9e09-fe2801ae5a4b.png)
