### PR TITLE
HADOOP-17999: Do not initialize all target FileSystems for setWriteChecksum and setVerifyChecksum

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -239,8 +239,6 @@ public class ViewFileSystem extends FileSystem {
   Path homeDir = null;
   private boolean enableInnerCache = false;
   private InnerCache cache;
-  private Boolean setVerifyChecksum = null;
-  private Boolean setWriteChecksum = null;
   // Default to rename within same mountpoint
   private RenameStrategy renameStrategy = RenameStrategy.SAME_MOUNTPOINT;
   /**
@@ -340,12 +338,6 @@ public class ViewFileSystem extends FileSystem {
                     }
                   }
                 });
-                if (setVerifyChecksum != null) {
-                  fs.setVerifyChecksum(setVerifyChecksum);
-                }
-                if (setWriteChecksum != null) {
-                  fs.setWriteChecksum(setWriteChecksum);
-                }
                 return new ChRootedFileSystem(fs, uri);
               } catch (IOException | InterruptedException ex) {
                 LOG.error("Could not initialize the underlying FileSystem "
@@ -926,13 +918,8 @@ public class ViewFileSystem extends FileSystem {
 
   @Override
   public void setVerifyChecksum(final boolean verifyChecksum) {
-    //Set the value for filesystems to be lazily initialized later l
-    setVerifyChecksum = verifyChecksum;
-    // Set verifyChecksum for filesystems already initialized before
-    // This will only work if the inner cache is enabled
-    for (FileSystem childFileSystems : cache.map.values()) {
-      childFileSystems.setVerifyChecksum(verifyChecksum);
-    }
+    // This is a file system level operations, however ViewFileSystem
+    // points to many file systems. Noop for ViewFileSystem.
   }
 
   /**
@@ -1029,13 +1016,8 @@ public class ViewFileSystem extends FileSystem {
 
   @Override
   public void setWriteChecksum(final boolean writeChecksum) {
-    //Set the value for filesystems to be lazily initialized later
-    setWriteChecksum = writeChecksum;
-    // Set verifyChecksum for filesystems already initialized before
-    // This will only work if the inner cache is enabled
-    for (FileSystem childFileSystem : cache.map.values()) {
-      childFileSystem.setWriteChecksum(writeChecksum);
-    }
+    // This is a file system level operations, however ViewFileSystem
+    // points to many file systems. Noop for ViewFileSystem.
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemDelegation.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemDelegation.java
@@ -83,12 +83,6 @@ public class TestViewFileSystemDelegation { //extends ViewFileSystemTestSetup {
     assertEquals(new URI("fs2:/").getAuthority(), fs2.getUri().getAuthority());
   }
   
-  @Test
-  public void testVerifyChecksum() throws Exception {
-    checkVerifyChecksum(false);
-    checkVerifyChecksum(true);
-  }
-
   /**
    * Tests that ViewFileSystem dispatches calls for every ACL method through the
    * mount table to the correct underlying FileSystem with all Path arguments
@@ -142,12 +136,6 @@ public class TestViewFileSystemDelegation { //extends ViewFileSystemTestSetup {
     verify(mockFs1).getAclStatus(mockFsPath1);
     viewFs.getAclStatus(viewFsPath2);
     verify(mockFs2).getAclStatus(mockFsPath2);
-  }
-
-  void checkVerifyChecksum(boolean flag) {
-    viewFs.setVerifyChecksum(flag);
-    assertEquals(flag, fs1.getVerifyChecksum());
-    assertEquals(flag, fs2.getVerifyChecksum());
   }
 
   static class FakeFileSystem extends LocalFileSystem {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1472,4 +1472,47 @@ abstract public class ViewFileSystemBaseTest {
     // viewfs inner cache is disabled
     assertEquals(cacheSize + 2, TestFileUtil.getCacheSize());
   }
+
+  @Test
+  public void testTargetFileSystemLazyInitializationForChecksumMethods()
+      throws Exception {
+    final String clusterName = "cluster" + new Random().nextInt();
+    Configuration config = new Configuration(conf);
+    config.setBoolean(CONFIG_VIEWFS_ENABLE_INNER_CACHE, false);
+    config.setClass("fs.othermockfs.impl",
+        TestChRootedFileSystem.MockFileSystem.class, FileSystem.class);
+    ConfigUtil.addLink(config, clusterName, "/user",
+        URI.create("othermockfs://mockauth1/mockpath"));
+    ConfigUtil.addLink(config, clusterName,
+        "/mock", URI.create("othermockfs://mockauth/mockpath"));
+
+    final int cacheSize = TestFileUtil.getCacheSize();
+    ViewFileSystem viewFs = (ViewFileSystem) FileSystem.get(
+        new URI("viewfs://" + clusterName + "/"), config);
+
+    // As no inner file system instance has been initialized,
+    // cache size will remain the same
+    // cache is disabled for viewfs scheme, so the viewfs:// instance won't
+    // go in the cache even after the initialization
+    assertEquals(cacheSize, TestFileUtil.getCacheSize());
+
+    // This is not going to initialize any filesystem instance
+    viewFs.setVerifyChecksum(true);
+
+    // Cache size will remain the same
+    assertEquals(cacheSize, TestFileUtil.getCacheSize());
+
+    // This resolve path will initialize the file system corresponding
+    // to the mount table entry of the path "/user"
+    viewFs.getFileChecksum(
+        new Path(String.format("viewfs://%s/%s", clusterName, "/user")));
+
+    // Cache size will increase by 1.
+    assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
+
+    viewFs.close();
+    // Initialized FileSystem instances will not be removed from cache as
+    // viewfs inner cache is disabled
+    assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
+  }
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17999

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
All the target filesystems corresponding to mount points are initialized in setWriteChecksum and setVerifyChecksum methods. This PR initializes the filesystems lazily

### How was this patch tested?
Added unit tests. Also for large number of mount points, hadoop cli commands such as get, put or copyFromLocal were throwing OOM. With the fix, the commands were successful.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

