### PR TITLE
HADOOP-18003. Add a method appendIfAbsent for CallerContext

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/CallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/CallerContext.java
@@ -228,6 +228,26 @@ public final class CallerContext {
       return this;
     }
 
+    /**
+     * Append new field which contains key and value to the context
+     * if the key("key:") is absent.
+     * @param key the key of field.
+     * @param value the value of field.
+     * @return the builder.
+     */
+    public Builder appendIfAbsent(String key, String value) {
+      if (sb.toString().contains(key + KEY_VALUE_SEPARATOR)) {
+        return this;
+      }
+      if (isValid(key) && isValid(value)) {
+        if (sb.length() > 0) {
+          sb.append(fieldSeparator);
+        }
+        sb.append(key).append(KEY_VALUE_SEPARATOR).append(value);
+      }
+      return this;
+    }
+
     public CallerContext build() {
       return new CallerContext(this);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
@@ -42,6 +42,37 @@ public class TestCallerContext {
         builder.build().getContext());
   }
 
+  @Test
+  public void testBuilderAppendIfAbsent() {
+    Configuration conf = new Configuration();
+    conf.set(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY, "$");
+    CallerContext.Builder builder = new CallerContext.Builder(null, conf);
+    CallerContext context = builder.append("key1", "value1").build();
+    Assert.assertEquals("key1:value1",
+        builder.build().getContext());
+
+    // Append an existed key.
+    builder.appendIfAbsent("key1", "value1");
+    String[] items = context.getContext().split("\\$");
+    Assert.assertEquals(1, items.length);
+    Assert.assertEquals("key1:value1",
+        builder.build().getContext());
+
+    // Append an absent key.
+    builder.appendIfAbsent("key2", "value2");
+    String[] items2 = builder.build().getContext().split("\\$");
+    Assert.assertEquals(2, items2.length);
+    Assert.assertEquals("key1:value1$key2:value2",
+        builder.build().getContext());
+
+    // Append a key that is a substring of an existing key.
+    builder.appendIfAbsent("key", "value");
+    String[] items3 = builder.build().getContext().split("\\$");
+    Assert.assertEquals(3, items3.length);
+    Assert.assertEquals("key1:value1$key2:value2$key:value",
+        builder.build().getContext());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testNewBuilder() {
     Configuration conf = new Configuration();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
@@ -51,8 +51,8 @@ public class TestCallerContext {
     Assert.assertEquals("key1:value1",
         builder.build().getContext());
 
-    // Append an existed key.
-    builder.appendIfAbsent("key1", "value1");
+    // Append an existed key with different value.
+    builder.appendIfAbsent("key1", "value2");
     String[] items = context.getContext().split("\\$");
     Assert.assertEquals(1, items.length);
     Assert.assertEquals("key1:value1",

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
@@ -47,13 +47,13 @@ public class TestCallerContext {
     Configuration conf = new Configuration();
     conf.set(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY, "$");
     CallerContext.Builder builder = new CallerContext.Builder(null, conf);
-    CallerContext context = builder.append("key1", "value1").build();
+    builder.append("key1", "value1");
     Assert.assertEquals("key1:value1",
         builder.build().getContext());
 
     // Append an existed key with different value.
     builder.appendIfAbsent("key1", "value2");
-    String[] items = context.getContext().split("\\$");
+    String[] items = builder.build().getContext().split("\\$");
     Assert.assertEquals(1, items.length);
     Assert.assertEquals("key1:value1",
         builder.build().getContext());


### PR DESCRIPTION
JIRA: [HADOOP-18003](https://issues.apache.org/jira/browse/HADOOP-18003).

As we discussed here [#3635](https://github.com/apache/hadoop/pull/3635#discussion_r746873078).

In some cases, when we need to add a `key:value` to the `CallerContext`, we need to check whether the key already exists in the outer layer, which is a bit of a hassle. To solve this problem, we can add a new method `CallerContext#appendIfAbsent`.