### PR TITLE
HADOOP-18009. Reset UserGroupInformation after tests run

### DIFF
--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.registry.secure;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.ServiceOperations;
 import org.apache.hadoop.registry.client.impl.zk.ZKPathDumper;
 import org.apache.hadoop.registry.client.impl.zk.CuratorService;
@@ -52,6 +53,7 @@ public class TestSecureRegistry extends AbstractSecureRegistryTest {
   public void afterTestSecureZKService() throws Throwable {
     disableKerberosDebugging();
     RegistrySecurity.clearZKSaslClientProperties();
+    UserGroupInformation.reset();
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This pull request aims to reset shared state between TestSecureRegistry and TestRegistryOperationUtils, where TestRegistryOperationUtils (namely testUsernameExtractionEnvVarOverrride) fails when run afterwards in the same JVM. While currently test classes are run in separate JVMs, they can be run faster when run in the same JVM, and the shared state can be reset with the proposed patch in this pull request.

### How was this patch tested?
Before this patch, if the two test classes TestSecureRegistry and TestRegistryOperationUtils are run in this order within the same JVM (Surefire configuration reuseForks=true), TestRegistryOperationUtils fails. After the patch, the test passes in the order.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

