### PR TITLE
HDFS-16323. DatanodeHttpServer doesn't require handler state map while retrieving filter handlers

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -64,7 +64,6 @@ import java.nio.channels.ServerSocketChannel;
 import java.security.GeneralSecurityException;
 import java.util.Enumeration;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_ADMIN;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_HTTPS_ADDRESS_DEFAULT;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -77,8 +77,6 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_HTTP_INTERNAL_PR
  */
 public class DatanodeHttpServer implements Closeable {
   static final Logger LOG = LoggerFactory.getLogger(DatanodeHttpServer.class);
-  private static final ConcurrentHashMap<Class<?>, Object> HANDLER_STATE
-      = new ConcurrentHashMap<Class<?>, Object>() {};
   // HttpServer threads are only used for the web UI and basic servlets, so
   // set them to the minimum possible
   private static final int HTTP_SELECTOR_THREADS = 1;
@@ -281,11 +279,10 @@ public class DatanodeHttpServer implements Closeable {
       try {
         Method initializeState = classes[i].getDeclaredMethod("initializeState",
             Configuration.class);
-        Constructor constructor =
+        Constructor<?> constructor =
             classes[i].getDeclaredConstructor(initializeState.getReturnType());
         handlers[i] = (ChannelHandler) constructor.newInstance(
-            HANDLER_STATE.getOrDefault(classes[i],
-            initializeState.invoke(null, configuration)));
+            initializeState.invoke(null, configuration));
       } catch (NoSuchMethodException | InvocationTargetException
           | IllegalAccessException | InstantiationException
           | IllegalArgumentException e) {


### PR DESCRIPTION
### Description of PR
DatanodeHttpServer#getFilterHandlers use handler state map just to query if the given datanode httpserver filter handler class exists in the map and if not, initialize the Channel handler by invoking specific parameterized constructor of the class. However, this handler state map is never used to upsert any data.


### How was this patch tested?
Local testing with mini cluster.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
