### PR TITLE
MAPREDUCE-7368. DBOutputFormat.DBRecordWriter#write must throw except…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/db/DBOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/db/DBOutputFormat.java
@@ -122,7 +122,7 @@ extends OutputFormat<K,V> {
         key.write(statement);
         statement.addBatch();
       } catch (SQLException e) {
-        e.printStackTrace();
+        throw new RuntimeException("Failed to execute SQL statement for key " + key, e);
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/db/DBOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/db/DBOutputFormat.java
@@ -122,7 +122,7 @@ extends OutputFormat<K,V> {
         key.write(statement);
         statement.addBatch();
       } catch (SQLException e) {
-        throw new RuntimeException("Failed to execute SQL statement for key " + key, e);
+        throw new IOException("Failed to execute SQL statement for key " + key, e);
       }
     }
   }


### PR DESCRIPTION
### Description of PR
When the exception is caught and printed (instead of propagated) the consumer has no way to tell write failed. This hides the failure and leads to problems which are difficult to debug and at the same time can cause data corruption.

More details in the JIRA MAPREDUCE-7368.

### How was this patch tested?
Writing a well-contained test is not easy at the same time the change is straightforward so it may not be necessary.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

