### PR TITLE
HDFS-16332. Handle invalid token exception in sasl handshake

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.DataTransferEncr
 import org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.HandshakeSecretProto;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos.CipherOptionProto;
 import org.apache.hadoop.hdfs.protocolPB.PBHelperClient;
+import org.apache.hadoop.hdfs.security.token.block.InvalidBlockTokenException;
 import org.apache.hadoop.security.SaslPropertiesResolver;
 import org.apache.hadoop.security.SaslRpcServer.QualityOfProtection;
 import org.slf4j.Logger;
@@ -216,6 +217,8 @@ public final class DataTransferSaslUtil {
         DataTransferEncryptorMessageProto.parseFrom(vintPrefixed(in));
     if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_UNKNOWN_KEY) {
       throw new InvalidEncryptionKeyException(proto.getMessage());
+    } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN) {
+      throw new InvalidBlockTokenException(proto.getMessage());
     } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR) {
       throw new IOException(proto.getMessage());
     } else {
@@ -237,6 +240,8 @@ public final class DataTransferSaslUtil {
         DataTransferEncryptorMessageProto.parseFrom(vintPrefixed(in));
     if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_UNKNOWN_KEY) {
       throw new InvalidEncryptionKeyException(proto.getMessage());
+    } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN) {
+      throw new InvalidBlockTokenException(proto.getMessage());
     } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR) {
       throw new IOException(proto.getMessage());
     } else {
@@ -280,6 +285,8 @@ public final class DataTransferSaslUtil {
         DataTransferEncryptorMessageProto.parseFrom(vintPrefixed(in));
     if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_UNKNOWN_KEY) {
       throw new InvalidEncryptionKeyException(proto.getMessage());
+    } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN) {
+      throw new InvalidBlockTokenException(proto.getMessage());
     } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR) {
       throw new IOException(proto.getMessage());
     } else {
@@ -471,6 +478,8 @@ public final class DataTransferSaslUtil {
         DataTransferEncryptorMessageProto.parseFrom(vintPrefixed(in));
     if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_UNKNOWN_KEY) {
       throw new InvalidEncryptionKeyException(proto.getMessage());
+    } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN) {
+      throw new InvalidBlockTokenException(proto.getMessage());
     } else if (proto.getStatus() == DataTransferEncryptorStatus.ERROR) {
       throw new IOException(proto.getMessage());
     } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -221,7 +221,8 @@ public final class DataTransferSaslUtil {
     case SUCCESS:
       return handler.apply(proto);
     default:
-      throw new IOException("Unknown status: " + proto.getStatus() + ", message: " + proto.getMessage());
+      throw new IOException(
+          "Unknown status: " + proto.getStatus() + ", message: " + proto.getMessage());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -603,8 +603,9 @@ public class SaslDataTransferClient {
           conf, cipherOption, underlyingOut, underlyingIn, false) :
           sasl.createStreamPair(out, in);
     } catch (IOException ioe) {
+      String message = ioe.getMessage();
       try {
-        sendGenericSaslErrorMessage(out, ioe.getMessage());
+        sendGenericSaslErrorMessage(out, message);
       } catch (Exception e) {
         // If ioe is caused by error response from server, server will close peer connection.
         // So sendGenericSaslErrorMessage might cause IOException due to "Broken pipe".
@@ -612,6 +613,8 @@ public class SaslDataTransferClient {
         // and always throw `ioe` as top level.
         // `ioe` can be InvalidEncryptionKeyException or InvalidBlockTokenException
         // that indicates refresh key or token and are important for caller.
+        LOG.debug("Failed to send generic sasl error (server: {}, message: {}), suppress exception",
+            addr.toString(), message, e);
         ioe.addSuppressed(e);
       }
       throw ioe;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -605,14 +605,14 @@ public class SaslDataTransferClient {
     } catch (IOException ioe) {
       try {
         sendGenericSaslErrorMessage(out, ioe.getMessage());
-      } catch (Exception ioe2) {
+      } catch (Exception e) {
         // If ioe is caused by error response from server, server will close peer connection.
         // So sendGenericSaslErrorMessage might cause IOException due to "Broken pipe".
         // We suppress IOException from sendGenericSaslErrorMessage
         // and always throw `ioe` as top level.
         // `ioe` can be InvalidEncryptionKeyException or InvalidBlockTokenException
         // that indicates refresh key or token and are important for caller.
-        ioe.addSuppressed(ioe2);
+        ioe.addSuppressed(e);
       }
       throw ioe;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferClient.java
@@ -588,11 +588,11 @@ public class SaslDataTransferClient {
               // the client accepts some cipher suites, but the server does not.
               LOG.debug("Client accepts cipher suites {}, "
                       + "but server {} does not accept any of them",
-                  cipherSuites, addr.toString());
+                  cipherSuites, addr);
             }
           } else {
             LOG.debug("Client using cipher suite {} with server {}",
-                cipherOption.getCipherSuite().getName(), addr.toString());
+                cipherOption.getCipherSuite().getName(), addr);
           }
         }
       }
@@ -613,8 +613,8 @@ public class SaslDataTransferClient {
         // and always throw `ioe` as top level.
         // `ioe` can be InvalidEncryptionKeyException or InvalidBlockTokenException
         // that indicates refresh key or token and are important for caller.
-        LOG.debug("Failed to send generic sasl error (server: {}, message: {}), suppress exception",
-            addr.toString(), message, e);
+        LOG.debug("Failed to send generic sasl error to server {} (message: {}), "
+                + "suppress exception", addr, message, e);
         ioe.addSuppressed(e);
       }
       throw ioe;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/datatransfer.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/datatransfer.proto
@@ -38,6 +38,7 @@ message DataTransferEncryptorMessageProto {
     SUCCESS = 0;
     ERROR_UNKNOWN_KEY = 1;
     ERROR = 2;
+    ERROR_ACCESS_TOKEN = 3;
   }
   required DataTransferEncryptorStatus status = 1;
   optional bytes payload = 2;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/datatransfer.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/datatransfer.proto
@@ -38,13 +38,13 @@ message DataTransferEncryptorMessageProto {
     SUCCESS = 0;
     ERROR_UNKNOWN_KEY = 1;
     ERROR = 2;
-    ERROR_ACCESS_TOKEN = 3;
   }
   required DataTransferEncryptorStatus status = 1;
   optional bytes payload = 2;
   optional string message = 3;
   repeated CipherOptionProto cipherOption = 4;
   optional HandshakeSecretProto handshakeSecret = 5;
+  optional bool accessTokenError = 6;
 }
 
 message HandshakeSecretProto {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -52,10 +52,12 @@ import org.apache.hadoop.hdfs.protocol.datatransfer.InvalidEncryptionKeyExceptio
 import org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.DataTransferEncryptorMessageProto.DataTransferEncryptorStatus;
 import org.apache.hadoop.hdfs.security.token.block.BlockPoolTokenSecretManager;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
+import org.apache.hadoop.hdfs.security.token.block.InvalidBlockTokenException;
 import org.apache.hadoop.hdfs.server.datanode.DNConf;
 import org.apache.hadoop.security.SaslPropertiesResolver;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.util.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -441,6 +443,14 @@ public class SaslDataTransferServer {
         // error, the client will get a new encryption key from the NN and retry
         // connecting to this DN.
         sendInvalidKeySaslErrorMessage(out, ioe.getCause().getMessage());
+      } else if (ioe instanceof SaslException &&
+                 ioe.getCause() != null &&
+                 (ioe.getCause() instanceof InvalidBlockTokenException ||
+                  ioe.getCause() instanceof SecretManager.InvalidToken)) {
+        // This could be because the client is long-lived and block token is expired
+        // The client will get new block token from the NN, upon receiving this error
+        // and retry connecting to this DN
+        sendInvalidTokenSaslErrorMessage(out, ioe.getCause().getMessage());
       } else {
         sendGenericSaslErrorMessage(out, ioe.getMessage());
       }
@@ -459,5 +469,18 @@ public class SaslDataTransferServer {
       String message) throws IOException {
     sendSaslMessage(out, DataTransferEncryptorStatus.ERROR_UNKNOWN_KEY, null,
         message);
+  }
+
+  /**
+   * Sends a SASL negotiation message indicating an invalid token error.
+   *
+   * @param out stream to receive message
+   * @param message to send
+   * @throws IOException for any error
+   */
+  private static void sendInvalidTokenSaslErrorMessage(DataOutputStream out,
+                                                       String message) throws IOException {
+    sendSaslMessage(out, DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN, null,
+                    message);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -444,9 +444,9 @@ public class SaslDataTransferServer {
         // connecting to this DN.
         sendInvalidKeySaslErrorMessage(out, ioe.getCause().getMessage());
       } else if (ioe instanceof SaslException &&
-                 ioe.getCause() != null &&
-                 (ioe.getCause() instanceof InvalidBlockTokenException ||
-                  ioe.getCause() instanceof SecretManager.InvalidToken)) {
+          ioe.getCause() != null &&
+          (ioe.getCause() instanceof InvalidBlockTokenException ||
+              ioe.getCause() instanceof SecretManager.InvalidToken)) {
         // This could be because the client is long-lived and block token is expired
         // The client will get new block token from the NN, upon receiving this error
         // and retry connecting to this DN
@@ -474,13 +474,13 @@ public class SaslDataTransferServer {
   /**
    * Sends a SASL negotiation message indicating an invalid token error.
    *
-   * @param out stream to receive message
+   * @param out     stream to receive message
    * @param message to send
    * @throws IOException for any error
    */
   private static void sendInvalidTokenSaslErrorMessage(DataOutputStream out,
-                                                       String message) throws IOException {
+      String message) throws IOException {
     sendSaslMessage(out, DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN, null,
-                    message);
+        message);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -480,7 +480,6 @@ public class SaslDataTransferServer {
    */
   private static void sendInvalidTokenSaslErrorMessage(DataOutputStream out,
       String message) throws IOException {
-    sendSaslMessage(out, DataTransferEncryptorStatus.ERROR_ACCESS_TOKEN, null,
-        message);
+    sendSaslMessage(out, DataTransferEncryptorStatus.ERROR, null, message, null, true);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
@@ -41,7 +41,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 
 public class TestSaslDataTransferExpiredBlockToken extends SaslDataTransferTestCase {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.protocol.datatransfer.sasl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSInputStream;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.HedgedRead;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Retry;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.security.token.block.SecurityTestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+public class TestSaslDataTransferExpiredBlockToken extends SaslDataTransferTestCase {
+    private static final int BLOCK_SIZE = 4096;
+    private static final int FILE_SIZE = 2 * BLOCK_SIZE;
+    private static final Path PATH  = new Path("/file1");
+
+    private final byte[] rawData = new byte[FILE_SIZE];
+    private MiniDFSCluster cluster;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
+
+    @Before
+    public void before() throws Exception {
+        Random r = new Random();
+        r.nextBytes(rawData);
+
+        HdfsConfiguration conf = createSecureConfig(
+                "authentication,integrity,privacy");
+        cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+        cluster.waitActive();
+
+        try (FileSystem fs = cluster.getFileSystem()) {
+            createFile(fs);
+        }
+
+        // set a short token lifetime (1 second) initially
+        SecurityTestUtil.setBlockTokenLifetime(
+                cluster.getNameNode()
+                       .getNamesystem()
+                       .getBlockManager()
+                       .getBlockTokenSecretManager(), 1000L);
+    }
+
+    @After
+    public void shutdown() {
+        if (cluster != null) {
+            cluster.shutdown();
+            cluster = null;
+        }
+    }
+
+    private void createFile(FileSystem fs) throws IOException {
+        try (FSDataOutputStream out = fs.create(PATH)) {
+            out.write(rawData);
+        }
+    }
+
+    // read a file using blockSeekTo()
+    private boolean checkFile1(FSDataInputStream in) {
+        byte[] toRead = new byte[FILE_SIZE];
+        int totalRead = 0;
+        int nRead = 0;
+        try {
+            while ((nRead = in.read(toRead, totalRead, toRead.length - totalRead)) > 0) {
+                totalRead += nRead;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        assertEquals("Cannot read file.", toRead.length, totalRead);
+        return checkFile(toRead);
+    }
+
+    // read a file using fetchBlockByteRange()/hedgedFetchBlockByteRange
+    private boolean checkFile2(FSDataInputStream in) {
+        byte[] toRead = new byte[FILE_SIZE];
+        try {
+            assertEquals("Cannot read file", toRead.length, in.read(0, toRead, 0, toRead.length));
+        } catch (IOException e) {
+            return false;
+        }
+        return checkFile(toRead);
+    }
+
+    private boolean checkFile(byte[] fileToCheck) {
+        if (fileToCheck.length != rawData.length) {
+            return false;
+        }
+        for (int i = 0; i < fileToCheck.length; i++) {
+            if (fileToCheck[i] != rawData[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private FileSystem newFileSystem() throws IOException {
+        Configuration clientConf = new Configuration(cluster.getConfiguration(0));
+
+        clientConf.setInt(Retry.WINDOW_BASE_KEY, Integer.MAX_VALUE);
+
+        return FileSystem.newInstance(cluster.getURI(), clientConf);
+    }
+    private FileSystem newFileSystemHedgedRead() throws IOException {
+        Configuration clientConf = new Configuration(cluster.getConfiguration(0));
+
+        clientConf.setInt(Retry.WINDOW_BASE_KEY, 3000);
+        clientConf.setInt(HedgedRead.THREADPOOL_SIZE_KEY, 5);
+
+        return FileSystem.newInstance(cluster.getURI(), clientConf);
+    }
+
+    @Test
+    public void testBlockSeekToWithExpiredToken() throws Exception {
+        // read using blockSeekTo(). Acquired tokens are cached in in
+        try (FileSystem fs = newFileSystem();
+             FSDataInputStream in = fs.open(PATH)) {
+            waitBlockTokenExpired(in);
+            assertTrue(checkFile1(in));
+        }
+    }
+
+    @Test
+    public void testFetchBlockByteRangeWithExpiredToken() throws Exception {
+        // read using fetchBlockByteRange(). Acquired tokens are cached in in
+        try (FileSystem fs = newFileSystem();
+             FSDataInputStream in = fs.open(PATH)) {
+            waitBlockTokenExpired(in);
+            assertTrue(checkFile2(in));
+        }
+    }
+
+    @Test
+    public void testHedgedFetchBlockByteRangeWithExpiredToken() throws Exception {
+        // read using hedgedFetchBlockByteRange(). Acquired tokens are cached in in
+        try (FileSystem fs = newFileSystemHedgedRead();
+             FSDataInputStream in = fs.open(PATH)) {
+            waitBlockTokenExpired(in);
+            assertTrue(checkFile2(in));
+        }
+    }
+
+    private void waitBlockTokenExpired(FSDataInputStream in1) throws Exception {
+        DFSInputStream innerStream = (DFSInputStream) in1.getWrappedStream();
+        for (LocatedBlock block : innerStream.getAllBlocks()) {
+            while (!SecurityTestUtil.isBlockTokenExpired(block.getBlockToken())) {
+                Thread.sleep(100);
+            }
+        }
+    }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.HedgedRead;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Retry;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.security.token.block.SecurityTestUtil;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,146 +45,141 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 
 public class TestSaslDataTransferExpiredBlockToken extends SaslDataTransferTestCase {
-    private static final int BLOCK_SIZE = 4096;
-    private static final int FILE_SIZE = 2 * BLOCK_SIZE;
-    private static final Path PATH  = new Path("/file1");
+  private static final int BLOCK_SIZE = 4096;
+  private static final int FILE_SIZE = 2 * BLOCK_SIZE;
+  private static final Path PATH = new Path("/file1");
 
-    private final byte[] rawData = new byte[FILE_SIZE];
-    private MiniDFSCluster cluster;
+  private final byte[] rawData = new byte[FILE_SIZE];
+  private MiniDFSCluster cluster;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
 
-    @Rule
-    public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
+  @Rule
+  public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
 
-    @Before
-    public void before() throws Exception {
-        Random r = new Random();
-        r.nextBytes(rawData);
+  @Before
+  public void before() throws Exception {
+    Random r = new Random();
+    r.nextBytes(rawData);
 
-        HdfsConfiguration conf = createSecureConfig(
-                "authentication,integrity,privacy");
-        cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
-        cluster.waitActive();
+    HdfsConfiguration conf = createSecureConfig("authentication,integrity,privacy");
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    cluster.waitActive();
 
-        try (FileSystem fs = cluster.getFileSystem()) {
-            createFile(fs);
-        }
-
-        // set a short token lifetime (1 second) initially
-        SecurityTestUtil.setBlockTokenLifetime(
-                cluster.getNameNode()
-                       .getNamesystem()
-                       .getBlockManager()
-                       .getBlockTokenSecretManager(), 1000L);
+    try (FileSystem fs = cluster.getFileSystem()) {
+      createFile(fs);
     }
 
-    @After
-    public void shutdown() {
-        if (cluster != null) {
-            cluster.shutdown();
-            cluster = null;
-        }
+    // set a short token lifetime (1 second) initially
+    SecurityTestUtil.setBlockTokenLifetime(
+        cluster.getNameNode().getNamesystem().getBlockManager().getBlockTokenSecretManager(),
+        1000L);
+  }
+
+  @After
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
     }
+  }
 
-    private void createFile(FileSystem fs) throws IOException {
-        try (FSDataOutputStream out = fs.create(PATH)) {
-            out.write(rawData);
-        }
+  private void createFile(FileSystem fs) throws IOException {
+    try (FSDataOutputStream out = fs.create(PATH)) {
+      out.write(rawData);
     }
+  }
 
-    // read a file using blockSeekTo()
-    private boolean checkFile1(FSDataInputStream in) {
-        byte[] toRead = new byte[FILE_SIZE];
-        int totalRead = 0;
-        int nRead = 0;
-        try {
-            while ((nRead = in.read(toRead, totalRead, toRead.length - totalRead)) > 0) {
-                totalRead += nRead;
-            }
-        } catch (IOException e) {
-            return false;
-        }
-        assertEquals("Cannot read file.", toRead.length, totalRead);
-        return checkFile(toRead);
+  // read a file using blockSeekTo()
+  private boolean checkFile1(FSDataInputStream in) {
+    byte[] toRead = new byte[FILE_SIZE];
+    int totalRead = 0;
+    int nRead = 0;
+    try {
+      while ((nRead = in.read(toRead, totalRead, toRead.length - totalRead)) > 0) {
+        totalRead += nRead;
+      }
+    } catch (IOException e) {
+      return false;
     }
+    assertEquals("Cannot read file.", toRead.length, totalRead);
+    return checkFile(toRead);
+  }
 
-    // read a file using fetchBlockByteRange()/hedgedFetchBlockByteRange
-    private boolean checkFile2(FSDataInputStream in) {
-        byte[] toRead = new byte[FILE_SIZE];
-        try {
-            assertEquals("Cannot read file", toRead.length, in.read(0, toRead, 0, toRead.length));
-        } catch (IOException e) {
-            return false;
-        }
-        return checkFile(toRead);
+  // read a file using fetchBlockByteRange()/hedgedFetchBlockByteRange()
+  private boolean checkFile2(FSDataInputStream in) {
+    byte[] toRead = new byte[FILE_SIZE];
+    try {
+      assertEquals("Cannot read file", toRead.length, in.read(0, toRead, 0, toRead.length));
+    } catch (IOException e) {
+      return false;
     }
+    return checkFile(toRead);
+  }
 
-    private boolean checkFile(byte[] fileToCheck) {
-        if (fileToCheck.length != rawData.length) {
-            return false;
-        }
-        for (int i = 0; i < fileToCheck.length; i++) {
-            if (fileToCheck[i] != rawData[i]) {
-                return false;
-            }
-        }
-        return true;
+  private boolean checkFile(byte[] fileToCheck) {
+    if (fileToCheck.length != rawData.length) {
+      return false;
     }
-
-    private FileSystem newFileSystem() throws IOException {
-        Configuration clientConf = new Configuration(cluster.getConfiguration(0));
-
-        clientConf.setInt(Retry.WINDOW_BASE_KEY, Integer.MAX_VALUE);
-
-        return FileSystem.newInstance(cluster.getURI(), clientConf);
+    for (int i = 0; i < fileToCheck.length; i++) {
+      if (fileToCheck[i] != rawData[i]) {
+        return false;
+      }
     }
-    private FileSystem newFileSystemHedgedRead() throws IOException {
-        Configuration clientConf = new Configuration(cluster.getConfiguration(0));
+    return true;
+  }
 
-        clientConf.setInt(Retry.WINDOW_BASE_KEY, 3000);
-        clientConf.setInt(HedgedRead.THREADPOOL_SIZE_KEY, 5);
+  private FileSystem newFileSystem() throws IOException {
+    Configuration clientConf = new Configuration(cluster.getConfiguration(0));
 
-        return FileSystem.newInstance(cluster.getURI(), clientConf);
+    clientConf.setInt(Retry.WINDOW_BASE_KEY, Integer.MAX_VALUE);
+
+    return FileSystem.newInstance(cluster.getURI(), clientConf);
+  }
+
+  private FileSystem newFileSystemHedgedRead() throws IOException {
+    Configuration clientConf = new Configuration(cluster.getConfiguration(0));
+
+    clientConf.setInt(Retry.WINDOW_BASE_KEY, 3000);
+    clientConf.setInt(HedgedRead.THREADPOOL_SIZE_KEY, 5);
+
+    return FileSystem.newInstance(cluster.getURI(), clientConf);
+  }
+
+  @Test
+  public void testBlockSeekToWithExpiredToken() throws Exception {
+    // read using blockSeekTo(). Acquired tokens are cached in in
+    try (FileSystem fs = newFileSystem(); FSDataInputStream in = fs.open(PATH)) {
+      waitBlockTokenExpired(in);
+      assertTrue(checkFile1(in));
     }
+  }
 
-    @Test
-    public void testBlockSeekToWithExpiredToken() throws Exception {
-        // read using blockSeekTo(). Acquired tokens are cached in in
-        try (FileSystem fs = newFileSystem();
-             FSDataInputStream in = fs.open(PATH)) {
-            waitBlockTokenExpired(in);
-            assertTrue(checkFile1(in));
-        }
+  @Test
+  public void testFetchBlockByteRangeWithExpiredToken() throws Exception {
+    // read using fetchBlockByteRange(). Acquired tokens are cached in in
+    try (FileSystem fs = newFileSystem(); FSDataInputStream in = fs.open(PATH)) {
+      waitBlockTokenExpired(in);
+      assertTrue(checkFile2(in));
     }
+  }
 
-    @Test
-    public void testFetchBlockByteRangeWithExpiredToken() throws Exception {
-        // read using fetchBlockByteRange(). Acquired tokens are cached in in
-        try (FileSystem fs = newFileSystem();
-             FSDataInputStream in = fs.open(PATH)) {
-            waitBlockTokenExpired(in);
-            assertTrue(checkFile2(in));
-        }
+  @Test
+  public void testHedgedFetchBlockByteRangeWithExpiredToken() throws Exception {
+    // read using hedgedFetchBlockByteRange(). Acquired tokens are cached in in
+    try (FileSystem fs = newFileSystemHedgedRead(); FSDataInputStream in = fs.open(PATH)) {
+      waitBlockTokenExpired(in);
+      assertTrue(checkFile2(in));
     }
+  }
 
-    @Test
-    public void testHedgedFetchBlockByteRangeWithExpiredToken() throws Exception {
-        // read using hedgedFetchBlockByteRange(). Acquired tokens are cached in in
-        try (FileSystem fs = newFileSystemHedgedRead();
-             FSDataInputStream in = fs.open(PATH)) {
-            waitBlockTokenExpired(in);
-            assertTrue(checkFile2(in));
-        }
+  private void waitBlockTokenExpired(FSDataInputStream in1) throws Exception {
+    DFSInputStream innerStream = (DFSInputStream) in1.getWrappedStream();
+    for (LocatedBlock block : innerStream.getAllBlocks()) {
+      while (!SecurityTestUtil.isBlockTokenExpired(block.getBlockToken())) {
+        Thread.sleep(100);
+      }
     }
-
-    private void waitBlockTokenExpired(FSDataInputStream in1) throws Exception {
-        DFSInputStream innerStream = (DFSInputStream) in1.getWrappedStream();
-        for (LocatedBlock block : innerStream.getAllBlocks()) {
-            while (!SecurityTestUtil.isBlockTokenExpired(block.getBlockToken())) {
-                Thread.sleep(100);
-            }
-        }
-    }
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/TestSaslDataTransferExpiredBlockToken.java
@@ -53,9 +53,6 @@ public class TestSaslDataTransferExpiredBlockToken extends SaslDataTransferTestC
   private MiniDFSCluster cluster;
 
   @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Rule
   public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
 
   @Before


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
See https://issues.apache.org/jira/browse/HDFS-16332 description for the detail.

Due to missing handling of invalid token exception in sasl handshake, token refresh isn't triggered and all datanode is considered as dead nodes.
This causes retry of refetchLocations with sleep and we got bad hbase's response time.

### How was this patch tested?
- Tested by the intergration test
- Applied this patch to our hadoop and hbase cluster


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

