### PR TITLE
HDFS-16343. Add some debug logs when the dfsUsed are not used during Datanode startup.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -297,7 +297,7 @@ class BlockPoolSlice {
     try {
       sc = new Scanner(duCacheFile, "UTF-8");
     } catch (FileNotFoundException fnfe) {
-      LOG.warn("{} file missing in {}, will proceed with Du " +
+      FsDatasetImpl.LOG.warn("{} file missing in {}, will proceed with Du " +
               "for space computation calculation, ",
               DU_CACHE_FILE, currentDir);
       return -1;
@@ -308,16 +308,17 @@ class BlockPoolSlice {
       if (sc.hasNextLong()) {
         cachedDfsUsed = sc.nextLong();
       } else {
-        LOG.warn("cachedDfsUsed not found in file:{}, will proceed with Du " +
-                        "for space computation calculation, ", duCacheFile);
+        FsDatasetImpl.LOG.warn("cachedDfsUsed not found in file:{}, will " +
+                "proceed with Du for space computation calculation, ",
+                duCacheFile);
         return -1;
       }
       // Get the recorded mtime from the file.
       if (sc.hasNextLong()) {
         mtime = sc.nextLong();
       } else {
-        LOG.warn("mtime not found in file:{}, will proceed with Du " +
-                "for space computation calculation, ", duCacheFile);
+        FsDatasetImpl.LOG.warn("mtime not found in file:{}, will proceed" +
+                " with Du for space computation calculation, ", duCacheFile);
         return -1;
       }
 
@@ -328,9 +329,10 @@ class BlockPoolSlice {
             cachedDfsUsed);
         return cachedDfsUsed;
       }
-      LOG.warn("elapsed time:{} is greater than threshold:{} mtime:{} in " +
-              "file:{}, will proceed with Du for space computation calculation"
-              , elapsedTime, cachedDfsUsedCheckTime, mtime, duCacheFile);
+      FsDatasetImpl.LOG.warn("elapsed time:{} is greater than threshold:{}," +
+                      " mtime:{} in file:{}, will proceed with Du for space" +
+                      " computation calculation",
+              elapsedTime, cachedDfsUsedCheckTime, mtime, duCacheFile);
       return -1;
     } finally {
       sc.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -293,9 +293,13 @@ class BlockPoolSlice {
     long mtime;
     Scanner sc;
 
+    File duCacheFile = new File(currentDir, DU_CACHE_FILE);
     try {
-      sc = new Scanner(new File(currentDir, DU_CACHE_FILE), "UTF-8");
+      sc = new Scanner(duCacheFile, "UTF-8");
     } catch (FileNotFoundException fnfe) {
+      LOG.warn("{} file missing in {}, will proceed with Du " +
+              "for space computation calculation, ",
+              DU_CACHE_FILE, currentDir);
       return -1;
     }
 
@@ -304,21 +308,29 @@ class BlockPoolSlice {
       if (sc.hasNextLong()) {
         cachedDfsUsed = sc.nextLong();
       } else {
+        LOG.warn("cachedDfsUsed not found in file:{}, will proceed with Du " +
+                        "for space computation calculation, ", duCacheFile);
         return -1;
       }
       // Get the recorded mtime from the file.
       if (sc.hasNextLong()) {
         mtime = sc.nextLong();
       } else {
+        LOG.warn("mtime not found in file:{}, will proceed with Du " +
+                "for space computation calculation, ", duCacheFile);
         return -1;
       }
 
+      long elapsedTime = timer.now() - mtime;
       // Return the cached value if mtime is okay.
-      if (mtime > 0 && (timer.now() - mtime < cachedDfsUsedCheckTime)) {
+      if (mtime > 0 && (elapsedTime < cachedDfsUsedCheckTime)) {
         FsDatasetImpl.LOG.info("Cached dfsUsed found for " + currentDir + ": " +
             cachedDfsUsed);
         return cachedDfsUsed;
       }
+      LOG.warn("elapsed time:{} is greater than threshold:{} mtime:{} in " +
+              "file:{}, will proceed with Du for space computation calculation"
+              , elapsedTime, cachedDfsUsedCheckTime, mtime, duCacheFile);
       return -1;
     } finally {
       sc.close();


### PR DESCRIPTION
### Description of PR
  This PR adds debug logging around the datanode startup when the cached dfsUsed is not used during datanode startup.

### How was this patch tested?
   This is a simple logging patch, tested using existing tests.

### For code changes:
   https://issues.apache.org/jira/browse/HDFS-16343
 