### PR TITLE
YARN-11011. Make YARN Router throw Exception to client clearly

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -385,6 +385,8 @@ public class FederationClientInterceptor
 
     long startTime = clock.getTime();
 
+    Exception yarnResponseException = null;
+
     if (request == null || request.getApplicationSubmissionContext() == null
         || request.getApplicationSubmissionContext()
             .getApplicationId() == null) {
@@ -450,6 +452,8 @@ public class FederationClientInterceptor
       } catch (Exception e) {
         LOG.warn("Unable to submit the application " + applicationId
             + "to SubCluster " + subClusterId.getId(), e);
+        //Record yarn feedback error
+        yarnResponseException = e;
       }
 
       if (response != null) {
@@ -460,9 +464,14 @@ public class FederationClientInterceptor
         routerMetrics.succeededAppsSubmitted(stopTime - startTime);
         return response;
       } else {
-        // Empty response from the ResourceManager.
-        // Blacklist this subcluster for this request.
-        blacklist.add(subClusterId);
+        //If last try still can't submit, the last sub-cluster feedback
+        // error message is thrown
+        if(i == (numSubmitRetries - 1)){
+          routerMetrics.incrAppsFailedSubmitted();
+          RouterServerUtil.logAndThrowException("Unable to submit the " +
+              "application " + applicationId + " to SubCluster " +
+              subClusterId.getId(), yarnResponseException);
+        }
       }
     }
 


### PR DESCRIPTION
### Description of PR
When router submits job to yarn, the job is rejected by yarn for some reason. Yarn router just throw exception to log and return not enough info to client.

The router always throws the following non-obvious error to client:
Exception in thread "main" org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException:
No active SubCluster available to submit the request.

To make it easy for the user to locate the cause of a job submission failure, we need to make Router throw the true cause of the error to the client clearly.


