### PR TITLE
HDFS-16322. Fix that ClientProtocol.truncate(...) can cause data loss.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1100,28 +1100,29 @@ public class NameNodeRpcServer implements NamenodeProtocols {
   }
 
   @Override // ClientProtocol
-  public boolean truncate(String src, long newLength, String clientName)
-      throws IOException {
+  public boolean truncate(String src, long newLength, String clientName) throws IOException {
     checkNNStartup();
-    stateChangeLog
-        .debug("*DIR* NameNode.truncate: " + src + " to " + newLength);
-    CacheEntry cacheEntry = RetryCache.waitForCompletion(retryCache);
-    if (cacheEntry != null && cacheEntry.isSuccess()) {
-      return true; // Return previous result
+    if(stateChangeLog.isDebugEnabled()) {
+      stateChangeLog.debug("*DIR* NameNode.truncate: " + src + " to " +
+          newLength);
     }
-    
+    CacheEntryWithPayload cacheEntry = RetryCache.waitForCompletion(retryCache, null);
+    if (cacheEntry != null && cacheEntry.isSuccess()) {
+      return (boolean)cacheEntry.getPayload();
+    }
+
     String clientMachine = getClientMachine();
     boolean ret = false;
     try {
       ret = namesystem.truncate(
           src, newLength, clientName, clientMachine, now());
     } finally {
-      RetryCache.setState(cacheEntry, ret);
+      RetryCache.setState(cacheEntry, true, ret);
       metrics.incrFilesTruncated();
     }
     return ret;
   }
-
+  
   @Override // ClientProtocol
   public boolean delete(String src, boolean recursive) throws IOException {
     checkNNStartup();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNamenodeRetryCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNamenodeRetryCache.java
@@ -180,6 +180,26 @@ public class TestNamenodeRetryCache {
   }
   
   /**
+   * Tests for truncate call
+   */
+  @Test
+  public void testTruncate() throws Exception {
+    String src = "/testNamenodeRetryCache/testTruncate/src";
+    resetCall();
+
+    // Create a file
+    DFSTestUtil.createFile(filesystem, new Path(src), 1280, (short)1, 0L);
+
+    // Retried truncates requests should have no side-effect and not throw exception
+    newCall();
+    nnRpc.truncate(src, 128, "holder");
+
+    cluster.getNameNode().getNamesystem().delete(src, false, false);
+
+    nnRpc.truncate(src, 128, "holder");
+  }
+  
+  /**
    * Tests for delete call
    */
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR fix [HDFS-16322](https://issues.apache.org/jira/browse/HDFS-16322).

The NameNode implementation of ClientProtocol.truncate(...) can cause data loss. If dfsclient drops the first response of a truncate RPC call, the retry by retry cache will truncate the file again and cause data loss. Specifically, under concurrency, after the first execution of truncate(...), concurrent requests from other clients may append new data and change the file length. When truncate(...) is retried after that, it will truncate the file again, which causes data loss.

This patch utilized retry cache to avoid such data loss. When the truncate operation is applied for the first time, the status of this operation and the return value from server is recorded in retry cache. If this truncate is retried, server will directly read from retry cache and perform no operation that may cause non-idempotence.

See [HDFS-16322](https://issues.apache.org/jira/browse/HDFS-16322) description for more details.

### How was this patch tested?

We added a new unit test for the idempotency of truncate operation under hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNamenodeRetryCache.java. This test will issue a truncate operation on an existing file, remove the whole file and then issue a retry of previous operation. If the truncate is idempotent, the retry should return successfully and does not throw an exception saying it truncates on a non-existing file.
