### PR TITLE
HDFS-16350. Datanode start time should be set after RPC server starts successfully

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -412,7 +412,7 @@ public class DataNode extends ReconfigurableBase
 
   private ScheduledThreadPoolExecutor metricsLoggerTimer;
 
-  private final long startTime = now();
+  private long startTime = 0;
 
   /**
    * Creates a dummy DataNode for testing purpose.
@@ -2721,6 +2721,7 @@ public class DataNode extends ReconfigurableBase
     }
     ipcServer.setTracer(tracer);
     ipcServer.start();
+    startTime = now();
     startPlugins(getConf());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
@@ -77,6 +77,7 @@ public class TestDataNodeMXBean extends SaslDataTransferTestCase {
       Assert.assertEquals(datanode.getVersion(),version);
       // get attribute "DNStartedTimeInMillis"
       long startTime = (long) mbs.getAttribute(mxbeanName, "DNStartedTimeInMillis");
+      Assert.assertTrue("Datanode start time should not be 0", startTime > 0);
       Assert.assertEquals(datanode.getDNStartedTimeInMillis(), startTime);
       // get attribute "SotfwareVersion"
       String softwareVersion =


### PR DESCRIPTION
### Description of PR
We set start time of Datanode when the class is instantiated but it should be ideally set only after RPC server starts and RPC handlers are initialized to serve client requests.

### How was this patch tested?
Tested locally. UI screenshot:

<img width="643" alt="Screenshot 2021-11-23 at 4 32 04 PM" src="https://user-images.githubusercontent.com/34790606/143014810-4b80aee5-aa10-4bd0-8899-5a40485e5e5a.png">


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
