### PR TITLE
YARN-11005. Implement the core QUEUE_LENGTH_THEN_RESOURCES OContainer allocation policy

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DominantResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DominantResourceCalculator.java
@@ -404,16 +404,49 @@ public class DominantResourceCalculator extends ResourceCalculator {
 
   @Override
   public float ratio(Resource a, Resource b) {
-    float ratio = 0.0f;
+    return ratio(a, b, true);
+  }
+
+  /**
+   * Computes the ratio of resource a over resource b,
+   * where the boolean flag {@literal isDominantShare} allows
+   * specification of whether the max- or min-share should be computed.
+   * @param a the numerator resource.
+   * @param b the denominator resource.
+   * @param isDominantShare whether the dominant (max) share should be computed,
+   *                        computes the min-share if false.
+   * @return the max- or min-share ratio of the resources.
+   */
+  private float ratio(Resource a, Resource b, boolean isDominantShare) {
+    float ratio = isDominantShare ? 0.0f : 1.0f;
     int maxLength = ResourceUtils.getNumberOfCountableResourceTypes();
     for (int i = 0; i < maxLength; i++) {
       ResourceInformation aResourceInformation = a.getResourceInformation(i);
       ResourceInformation bResourceInformation = b.getResourceInformation(i);
       final float tmp = divideSafelyAsFloat(aResourceInformation.getValue(),
           bResourceInformation.getValue());
-      ratio = ratio > tmp ? ratio : tmp;
+      if (isDominantShare) {
+        ratio = Math.max(ratio, tmp);
+      } else {
+        ratio = Math.min(ratio, tmp);
+      }
     }
     return ratio;
+  }
+
+  /**
+   * Computes the ratio of resource a over resource b.
+   * However, different from {@link this#ratio(Resource, Resource)},
+   * this returns the min-share of the resources.
+   * For example, ratio(Resource(10, 50), Resource(100, 100)) would return 0.5,
+   * whereas minRatio(Resource(10, 50), Resource(100, 100)) would return 0.1.
+   * @param a the numerator resource.
+   * @param b the denominator resource.
+   * @return the min-share ratio of the resources.
+   */
+  @Unstable
+  public float minRatio(Resource a, Resource b) {
+    return ratio(a, b, false);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DominantResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/DominantResourceCalculator.java
@@ -436,7 +436,7 @@ public class DominantResourceCalculator extends ResourceCalculator {
 
   /**
    * Computes the ratio of resource a over resource b.
-   * However, different from {@link this#ratio(Resource, Resource)},
+   * However, different from ratio(Resource, Resource),
    * this returns the min-share of the resources.
    * For example, ratio(Resource(10, 50), Resource(100, 100)) would return 0.5,
    * whereas minRatio(Resource(10, 50), Resource(100, 100)) would return 0.1.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
@@ -257,7 +257,9 @@ public class OpportunisticContainerAllocatorAMService
 
     int limitMin, limitMax;
 
-    if (comparator == NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH) {
+    if (comparator == NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH ||
+        comparator ==
+            NodeQueueLoadMonitor.LoadComparator.QUEUE_LENGTH_THEN_RESOURCES) {
       limitMin = rmContext.getYarnConfiguration()
           .getInt(YarnConfiguration.NM_CONTAINER_QUEUING_MIN_QUEUE_LENGTH,
               YarnConfiguration.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/CentralizedOpportunisticContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/CentralizedOpportunisticContainerAllocator.java
@@ -322,9 +322,8 @@ public class CentralizedOpportunisticContainerAllocator extends
             resourceRequest, convertToRemoteNode(node));
         allocatedContainers.add(container);
         metrics.incrOffSwitchOppContainers();
-        LOG.info(
-            "Allocated [{}] as opportunistic at location [{}] by OFF_SWITCH",
-            container.getId(), node.getNodeID());
+        LOG.info("Allocated [{}] as opportunistic at location [{}]",
+            container.getId(), ResourceRequest.ANY);
       } else {
         // we couldn't allocate any - break the loop.
         break;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/CentralizedOpportunisticContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/CentralizedOpportunisticContainerAllocator.java
@@ -251,14 +251,15 @@ public class CentralizedOpportunisticContainerAllocator extends
       String userName, Map<Resource, List<Allocation>> allocations)
       throws YarnException {
     List<Container> allocatedContainers = new ArrayList<>();
+    final ResourceRequest resourceRequest = enrichedAsk.getRequest();
     while (toAllocate > 0) {
       RMNode node = nodeQueueLoadMonitor.selectLocalNode(nodeLocation,
-          blacklist);
+          blacklist, resourceRequest.getCapability());
       if (node != null) {
         toAllocate--;
         Container container = createContainer(rmIdentifier, appParams,
             idCounter, id, userName, allocations, nodeLocation,
-            enrichedAsk.getRequest(), convertToRemoteNode(node));
+            resourceRequest, convertToRemoteNode(node));
         allocatedContainers.add(container);
         LOG.info("Allocated [{}] as opportunistic at location [{}]",
             container.getId(), nodeLocation);
@@ -280,14 +281,15 @@ public class CentralizedOpportunisticContainerAllocator extends
       String userName, Map<Resource, List<Allocation>> allocations)
       throws YarnException {
     List<Container> allocatedContainers = new ArrayList<>();
+    final ResourceRequest resourceRequest = enrichedAsk.getRequest();
     while (toAllocate > 0) {
       RMNode node = nodeQueueLoadMonitor.selectRackLocalNode(rackLocation,
-          blacklist);
+          blacklist, resourceRequest.getCapability());
       if (node != null) {
         toAllocate--;
         Container container = createContainer(rmIdentifier, appParams,
             idCounter, id, userName, allocations, rackLocation,
-            enrichedAsk.getRequest(), convertToRemoteNode(node));
+            resourceRequest, convertToRemoteNode(node));
         allocatedContainers.add(container);
         metrics.incrRackLocalOppContainers();
         LOG.info("Allocated [{}] as opportunistic at location [{}]",
@@ -309,17 +311,20 @@ public class CentralizedOpportunisticContainerAllocator extends
       String userName, Map<Resource, List<Allocation>> allocations)
       throws YarnException {
     List<Container> allocatedContainers = new ArrayList<>();
+    final ResourceRequest resourceRequest = enrichedAsk.getRequest();
     while (toAllocate > 0) {
-      RMNode node = nodeQueueLoadMonitor.selectAnyNode(blacklist);
+      RMNode node = nodeQueueLoadMonitor.selectAnyNode(
+          blacklist, resourceRequest.getCapability());
       if (node != null) {
         toAllocate--;
         Container container = createContainer(rmIdentifier, appParams,
             idCounter, id, userName, allocations, ResourceRequest.ANY,
-            enrichedAsk.getRequest(), convertToRemoteNode(node));
+            resourceRequest, convertToRemoteNode(node));
         allocatedContainers.add(container);
         metrics.incrOffSwitchOppContainers();
-        LOG.info("Allocated [{}] as opportunistic at location [{}]",
-            container.getId(), ResourceRequest.ANY);
+        LOG.info(
+            "Allocated [{}] as opportunistic at location [{}] by OFF_SWITCH",
+            container.getId(), node.getNodeID());
       } else {
         // we couldn't allocate any - break the loop.
         break;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
@@ -60,8 +60,7 @@ public class ClusterNode {
         this.capability = nodeCapability;
       }
       return this;
-    }
-    finally {
+    } finally {
       writeLock.unlock();
     }
   }
@@ -76,8 +75,7 @@ public class ClusterNode {
         this.allocatedResource = allocResource;
       }
       return this;
-    }
-    finally {
+    } finally {
       writeLock.unlock();
     }
   }
@@ -86,8 +84,7 @@ public class ClusterNode {
     readLock.lock();
     try {
       return this.allocatedResource;
-    }
-    finally {
+    } finally {
       readLock.unlock();
     }
   }
@@ -105,8 +102,7 @@ public class ClusterNode {
     readLock.lock();
     try {
       return this.capability;
-    }
-      finally {
+    } finally {
       readLock.unlock();
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
@@ -227,8 +227,7 @@ public class ClusterNode {
     }
   }
 
-  public boolean compareAndIncrementAllocation(
-      final int incrementQLen) {
+  public boolean compareAndIncrementAllocation(final int incrementQLen) {
     writeLock.lock();
     try {
       final int added = queueLength + incrementQLen;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
@@ -63,9 +63,6 @@ public class ClusterNode {
     return this;
   }
 
-  /**
-   * The latest allocated resource, as reported by node heartbeats.
-   */
   public Resource getAllocatedResource() {
     return this.allocatedResource;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
@@ -20,105 +20,239 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.distributed;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 /**
  * Represents a node in the cluster from the NodeQueueLoadMonitor's perspective
  */
 public class ClusterNode {
-  private final AtomicInteger queueLength = new AtomicInteger(0);
-  private final AtomicInteger queueWaitTime = new AtomicInteger(-1);
+  private int queueLength = 0;
+  private int queueWaitTime = -1;
   private long timestamp;
   final NodeId nodeId;
   private int queueCapacity = 0;
   private final HashSet<String> labels;
   private Resource capability = Resources.none();
   private Resource allocatedResource = Resources.none();
+  private final ReentrantReadWriteLock.WriteLock writeLock;
+  private final ReentrantReadWriteLock.ReadLock readLock;
 
   public ClusterNode(NodeId nodeId) {
     this.nodeId = nodeId;
     this.labels = new HashSet<>();
+    final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    writeLock = lock.writeLock();
+    readLock = lock.readLock();
     updateTimestamp();
   }
 
   public ClusterNode setCapability(Resource nodeCapability) {
-    if (nodeCapability == null) {
-      this.capability = Resources.none();
-    } else {
-      this.capability = nodeCapability;
+    writeLock.lock();
+    try {
+      if (nodeCapability == null) {
+        this.capability = Resources.none();
+      } else {
+        this.capability = nodeCapability;
+      }
+      return this;
     }
-    return this;
+    finally {
+      writeLock.unlock();
+    }
   }
 
   public ClusterNode setAllocatedResource(
       Resource allocResource) {
-    if (allocResource == null) {
-      this.allocatedResource = Resources.none();
-    } else {
-      this.allocatedResource = allocResource;
+    writeLock.lock();
+    try {
+      if (allocResource == null) {
+        this.allocatedResource = Resources.none();
+      } else {
+        this.allocatedResource = allocResource;
+      }
+      return this;
     }
-    return this;
+    finally {
+      writeLock.unlock();
+    }
   }
 
   public Resource getAllocatedResource() {
-    return this.allocatedResource;
+    readLock.lock();
+    try {
+      return this.allocatedResource;
+    }
+    finally {
+      readLock.unlock();
+    }
+  }
+
+  public Resource getAvailableResource() {
+    readLock.lock();
+    try {
+      return Resources.subtractNonNegative(capability, allocatedResource);
+    } finally {
+      readLock.unlock();
+    }
   }
 
   public Resource getCapability() {
-    return this.capability;
+    readLock.lock();
+    try {
+      return this.capability;
+    }
+      finally {
+      readLock.unlock();
+    }
   }
 
   public ClusterNode setQueueLength(int qLength) {
-    this.queueLength.set(qLength);
-    return this;
+    writeLock.lock();
+    try {
+      this.queueLength = qLength;
+      return this;
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public ClusterNode setQueueWaitTime(int wTime) {
-    this.queueWaitTime.set(wTime);
-    return this;
+    writeLock.lock();
+    try {
+      this.queueWaitTime = wTime;
+      return this;
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public ClusterNode updateTimestamp() {
-    this.timestamp = System.currentTimeMillis();
-    return this;
+    writeLock.lock();
+    try {
+      this.timestamp = System.currentTimeMillis();
+      return this;
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public ClusterNode setQueueCapacity(int capacity) {
-    this.queueCapacity = capacity;
-    return this;
+    writeLock.lock();
+    try {
+      this.queueCapacity = capacity;
+      return this;
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public ClusterNode setNodeLabels(Collection<String> labelsToAdd) {
-    labels.clear();
-    labels.addAll(labelsToAdd);
-    return this;
+    writeLock.lock();
+    try {
+      labels.clear();
+      labels.addAll(labelsToAdd);
+      return this;
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public boolean hasLabel(String label) {
-    return this.labels.contains(label);
+    readLock.lock();
+    try {
+      return this.labels.contains(label);
+    } finally {
+      readLock.unlock();
+    }
   }
 
   public long getTimestamp() {
-    return this.timestamp;
+    readLock.lock();
+    try {
+      return this.timestamp;
+    } finally {
+      readLock.unlock();
+    }
   }
 
-  public AtomicInteger getQueueLength() {
-    return this.queueLength;
+  public int getQueueLength() {
+    readLock.lock();
+    try {
+      return this.queueLength;
+    } finally {
+      readLock.unlock();
+    }
   }
 
-  public AtomicInteger getQueueWaitTime() {
-    return this.queueWaitTime;
+  public int getQueueWaitTime() {
+    readLock.lock();
+    try {
+      return this.queueWaitTime;
+    } finally {
+      readLock.unlock();
+    }
   }
 
   public int getQueueCapacity() {
-    return this.queueCapacity;
+    readLock.lock();
+    try {
+      return this.queueCapacity;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  public boolean compareAndIncrementAllocation(
+      final int incrementQLen,
+      final ResourceCalculator resourceCalculator,
+      final Resource requested) {
+    writeLock.lock();
+    try {
+      final Resource currAvailable = Resources.subtractNonNegative(
+          capability, allocatedResource);
+      if (resourceCalculator.fitsIn(requested, currAvailable)) {
+        allocatedResource = Resources.add(allocatedResource, requested);
+        return true;
+      }
+
+      if (!resourceCalculator.fitsIn(requested, capability)) {
+        // If does not fit at all, do not allocate
+        return false;
+      }
+
+      return compareAndIncrementAllocation(incrementQLen);
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  public boolean compareAndIncrementAllocation(
+      final int incrementQLen) {
+    writeLock.lock();
+    try {
+      final int added = queueLength + incrementQLen;
+      if (added <= queueCapacity) {
+        queueLength = added;
+        return true;
+      }
+      return false;
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public boolean isQueueFull() {
-    return this.queueCapacity > 0 &&
-        this.queueLength.get() >= this.queueCapacity;
+    readLock.lock();
+    try {
+      return this.queueCapacity > 0 &&
+          this.queueLength >= this.queueCapacity;
+    } finally {
+      readLock.unlock();
+    }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.util.resource.Resources;
 
 /**
  * Represents a node in the cluster from the NodeQueueLoadMonitor's perspective
@@ -33,11 +35,43 @@ public class ClusterNode {
   final NodeId nodeId;
   private int queueCapacity = 0;
   private final HashSet<String> labels;
+  private Resource capability = Resources.none();
+  private Resource allocatedResource = Resources.none();
 
   public ClusterNode(NodeId nodeId) {
     this.nodeId = nodeId;
     this.labels = new HashSet<>();
     updateTimestamp();
+  }
+
+  public ClusterNode setCapability(Resource capability) {
+    if (capability == null) {
+      this.capability = Resources.none();
+    } else {
+      this.capability = capability;
+    }
+    return this;
+  }
+
+  public ClusterNode setAllocatedResource(
+    Resource allocatedResource) {
+    if (allocatedResource == null) {
+      this.allocatedResource = Resources.none();
+    } else {
+      this.allocatedResource = allocatedResource;
+    }
+    return this;
+  }
+
+  /**
+   * The latest allocated resource, as reported by node heartbeats.
+   */
+  public Resource getAllocatedResource() {
+    return this.allocatedResource;
+  }
+
+  public Resource getCapability() {
+    return this.capability;
   }
 
   public ClusterNode setQueueLength(int qLength) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/ClusterNode.java
@@ -44,21 +44,21 @@ public class ClusterNode {
     updateTimestamp();
   }
 
-  public ClusterNode setCapability(Resource capability) {
-    if (capability == null) {
+  public ClusterNode setCapability(Resource nodeCapability) {
+    if (nodeCapability == null) {
       this.capability = Resources.none();
     } else {
-      this.capability = capability;
+      this.capability = nodeCapability;
     }
     return this;
   }
 
   public ClusterNode setAllocatedResource(
-    Resource allocatedResource) {
-    if (allocatedResource == null) {
+      Resource allocResource) {
+    if (allocResource == null) {
       this.allocatedResource = Resources.none();
     } else {
-      this.allocatedResource = allocatedResource;
+      this.allocatedResource = allocResource;
     }
     return this;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
@@ -151,7 +151,7 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
       return diff;
     }
 
-    public void setClusterResource(Resource clusterResource) {
+    private void setClusterResource(Resource clusterResource) {
       this.clusterResource = clusterResource;
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
@@ -168,7 +168,8 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
       return diff;
     }
 
-    private void setClusterResource(Resource clusterResource) {
+    @VisibleForTesting
+    void setClusterResource(Resource clusterResource) {
       this.clusterResource = clusterResource;
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
@@ -393,14 +393,19 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
         (estimatedQueueWaitTime != -1 ||
             comparator == LoadComparator.QUEUE_LENGTH ||
             comparator == LoadComparator.QUEUE_LENGTH_THEN_RESOURCES)) {
-      this.clusterNodes.put(rmNode.getNodeID(),
-          new ClusterNode(rmNode.getNodeID())
+      final ClusterNode.Properties properties =
+          ClusterNode.Properties.newInstance()
               .setQueueWaitTime(estimatedQueueWaitTime)
               .setQueueLength(waitQueueLength)
               .setNodeLabels(rmNode.getNodeLabels())
               .setCapability(rmNode.getTotalCapability())
               .setAllocatedResource(rmNode.getAllocatedContainerResource())
-              .setQueueCapacity(opportQueueCapacity));
+              .setQueueCapacity(opportQueueCapacity)
+              .updateTimestamp();
+
+      this.clusterNodes.put(rmNode.getNodeID(),
+          new ClusterNode(rmNode.getNodeID()).setProperties(properties));
+
       LOG.info(
           "Inserting ClusterNode [{}] with queue wait time [{}] and "
               + "wait queue length [{}]",
@@ -430,13 +435,17 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
         (estimatedQueueWaitTime != -1 ||
             comparator == LoadComparator.QUEUE_LENGTH ||
             comparator == LoadComparator.QUEUE_LENGTH_THEN_RESOURCES)) {
-      clusterNode
-          .setQueueWaitTime(estimatedQueueWaitTime)
-          .setQueueLength(waitQueueLength)
-          .setNodeLabels(rmNode.getNodeLabels())
-          .setCapability(rmNode.getTotalCapability())
-          .setAllocatedResource(rmNode.getAllocatedContainerResource())
-          .updateTimestamp();
+      final ClusterNode.Properties properties =
+          ClusterNode.Properties.newInstance()
+              .setQueueWaitTime(estimatedQueueWaitTime)
+              .setQueueLength(waitQueueLength)
+              .setNodeLabels(rmNode.getNodeLabels())
+              .setCapability(rmNode.getTotalCapability())
+              .setAllocatedResource(rmNode.getAllocatedContainerResource())
+              .updateTimestamp();
+
+      clusterNode.setProperties(properties);
+
       LOG.debug("Updating ClusterNode [{}] with queue wait time [{}] and"
               + " wait queue length [{}]", rmNode.getNodeID(),
           estimatedQueueWaitTime, waitQueueLength);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestNodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestNodeQueueLoadMonitor.java
@@ -589,8 +589,7 @@ public class TestNodeQueueLoadMonitor {
   private RMNode createRMNode(String host, int port, String rack,
       int waitTime, int queueLength, int queueCapacity, NodeState state) {
     return createRMNode(host, port, rack, waitTime, queueLength, queueCapacity,
-        state, ResourceUtilization.newInstance(0, 0, 0),
-        Resources.none(), defaultCapacity);
+        state, Resources.none(), defaultCapacity);
   }
 
   private RMNode createRMNode(
@@ -604,15 +603,13 @@ public class TestNodeQueueLoadMonitor {
       String host, int port, int waitTime, int queueLength, int queueCapacity,
       Resource allocatedResource, Resource nodeResource) {
     return createRMNode(host, port, "default", waitTime, queueLength,
-        queueCapacity, NodeState.RUNNING,
-        ResourceUtilization.newInstance(0, 0, 0),
-        allocatedResource, nodeResource);
+        queueCapacity, NodeState.RUNNING, allocatedResource, nodeResource);
   }
 
+  @SuppressWarnings("parameternumber")
   private RMNode createRMNode(String host, int port, String rack,
       int waitTime, int queueLength, int queueCapacity, NodeState state,
-      ResourceUtilization utilization, Resource allocatedResource,
-      Resource nodeResource) {
+      Resource allocatedResource, Resource nodeResource) {
     RMNode node1 = Mockito.mock(RMNode.class);
     NodeId nID1 = new FakeNodeId(host, port);
     Mockito.when(node1.getHostName()).thenReturn(host);
@@ -621,7 +618,8 @@ public class TestNodeQueueLoadMonitor {
     Mockito.when(node1.getNodeID()).thenReturn(nID1);
     Mockito.when(node1.getState()).thenReturn(state);
     Mockito.when(node1.getTotalCapability()).thenReturn(nodeResource);
-    Mockito.when(node1.getNodeUtilization()).thenReturn(utilization);
+    Mockito.when(node1.getNodeUtilization()).thenReturn(
+        ResourceUtilization.newInstance(0, 0, 0));
     Mockito.when(node1.getAllocatedContainerResource()).thenReturn(
         allocatedResource);
     OpportunisticContainersStatus status1 =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestNodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/TestNodeQueueLoadMonitor.java
@@ -380,7 +380,7 @@ public class TestNodeQueueLoadMonitor {
     Assert.assertEquals(node.getNodeID(), selectedNode.getNodeID());
 
     clusterNode = selector.getClusterNodes().get(node.getNodeID());
-    Assert.assertEquals(1, clusterNode.getQueueLength().get());
+    Assert.assertEquals(1, clusterNode.getQueueLength());
 
     // Does not have enough resources and cannot queue
     selectedNode = selector.selectAnyNode(


### PR DESCRIPTION
### Description of PR
* Implement the `QUEUE_LENGTH_THEN_RESOURCES` `LoadComparator`
* Add `Resource` requested to select node methods when allocating
`OPPORTUNISTIC` containers
* Add node capacity and node allocated resources to `ClusterNode`
* Extend `DominantResourceCalculator` to be able to compute min-share
* Add tests and extend existing ones to consider 3 resource dimensions

### How was this patch tested?
* Unit tests
* Deployment to a production cluster

