### PR TITLE
YARN-9063. ATS 1.5 fails to start if RollingLevelDb files are corrupt or missing

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/main/java/org/apache/hadoop/yarn/server/timeline/RollingLevelDBTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/main/java/org/apache/hadoop/yarn/server/timeline/RollingLevelDBTimelineStore.java
@@ -37,6 +37,7 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 
 import org.apache.commons.collections.map.LRUMap;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -49,6 +50,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineDomain;
+import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineDomains;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntities;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
@@ -199,6 +201,11 @@ public class RollingLevelDBTimelineStore extends AbstractService implements
   static final String STARTTIME = "starttime-ldb";
   static final String OWNER = "owner-ldb";
 
+  @VisibleForTesting
+  //Extension to FILENAME where backup will be stored in case we need to
+  //call LevelDb recovery
+  static final String BACKUP_EXT = ".backup-";
+
   private static final byte[] DOMAIN_ID_COLUMN = "d".getBytes(UTF_8);
   private static final byte[] EVENTS_COLUMN = "e".getBytes(UTF_8);
   private static final byte[] PRIMARY_FILTERS_COLUMN = "f".getBytes(UTF_8);
@@ -238,6 +245,13 @@ public class RollingLevelDBTimelineStore extends AbstractService implements
 
   public RollingLevelDBTimelineStore() {
     super(RollingLevelDBTimelineStore.class.getName());
+  }
+
+  private JniDBFactory factory;
+
+  @VisibleForTesting
+  void setFactory(JniDBFactory fact) {
+    this.factory = fact;
   }
 
   @Override
@@ -284,7 +298,9 @@ public class RollingLevelDBTimelineStore extends AbstractService implements
     options.cacheSize(conf.getLong(
         TIMELINE_SERVICE_LEVELDB_READ_CACHE_SIZE,
         DEFAULT_TIMELINE_SERVICE_LEVELDB_READ_CACHE_SIZE));
-    JniDBFactory factory = new JniDBFactory();
+    if(factory == null) {
+      factory = new JniDBFactory();
+    }
     Path dbPath = new Path(
         conf.get(TIMELINE_SERVICE_LEVELDB_PATH), FILENAME);
     Path domainDBPath = new Path(dbPath, DOMAIN);
@@ -327,13 +343,46 @@ public class RollingLevelDBTimelineStore extends AbstractService implements
         TIMELINE_SERVICE_LEVELDB_WRITE_BUFFER_SIZE,
         DEFAULT_TIMELINE_SERVICE_LEVELDB_WRITE_BUFFER_SIZE));
     LOG.info("Using leveldb path " + dbPath);
-    domaindb = factory.open(new File(domainDBPath.toString()), options);
+    try{
+      domaindb = factory.open(new File(domainDBPath.toString()), options);
+    } catch (IOException ioe){
+      File domaindbFile = new File(domainDBPath.toString());
+      File domaindbBackupPath = new File(
+          domainDBPath.toString() + BACKUP_EXT + Time.monotonicNow());
+      LOG.warn("Incurred exception while loading LevelDb database. Backing " +
+          "up at "+ domaindbBackupPath, ioe);
+      FileUtils.copyDirectory(domaindbFile, domaindbBackupPath);
+      factory.repair(domaindbFile, options);
+      domaindb = factory.open(domaindbFile, options);
+    }
     entitydb = new RollingLevelDB(ENTITY);
     entitydb.init(conf);
     indexdb = new RollingLevelDB(INDEX);
     indexdb.init(conf);
-    starttimedb = factory.open(new File(starttimeDBPath.toString()), options);
-    ownerdb = factory.open(new File(ownerDBPath.toString()), options);
+    try{
+      starttimedb = factory.open(new File(starttimeDBPath.toString()), options);
+    } catch (IOException ioe){
+      File starttimedbFile = new File(starttimeDBPath.toString());
+      File starttimeBackupPath = new File(
+          starttimeDBPath.toString() + BACKUP_EXT + Time.monotonicNow());
+      LOG.warn("Incurred exception while loading LevelDb database. Backing " +
+          "up at "+ starttimeBackupPath, ioe);
+      FileUtils.copyDirectory(starttimedbFile, starttimeBackupPath);
+      factory.repair(starttimedbFile, options);
+      starttimedb = factory.open(starttimedbFile, options);
+    }
+    try{
+      ownerdb = factory.open(new File(ownerDBPath.toString()), options);
+    } catch (IOException ioe){
+      File ownerdbFile = new File(ownerDBPath.toString());
+      File ownerdbBackupPath = new File(
+          ownerDBPath.toString() + BACKUP_EXT + Time.monotonicNow());
+      LOG.warn("Incurred exception while loading LevelDb database. Backing " +
+          "up at "+ ownerdbBackupPath, ioe);
+      FileUtils.copyDirectory(ownerdbFile, ownerdbBackupPath);
+      factory.repair(ownerdbFile, options);
+      ownerdb = factory.open(ownerdbFile, options);
+    }
     checkVersion();
     startTimeWriteCache = Collections.synchronizedMap(new LRUMap(
         getStartTimeWriteCacheSize(conf)));
@@ -346,7 +395,7 @@ public class RollingLevelDBTimelineStore extends AbstractService implements
 
     super.serviceInit(conf);
   }
-  
+
   @Override
   protected void serviceStart() throws Exception {
     if (getConfig().getBoolean(TIMELINE_SERVICE_TTL_ENABLE, true)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -38,10 +40,14 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse;
 import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse.TimelinePutError;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.records.Version;
+
+import org.fusesource.leveldbjni.JniDBFactory;
+import org.iq80.leveldb.Options;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mortbay.log.Log;
 
 /** Test class to verify RollingLevelDBTimelineStore. */
@@ -415,6 +421,36 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
 
     long duration = System.currentTimeMillis() - start;
     Log.info("Duration for " + num + ": " + duration);
+  }
+
+  @Test
+  /**
+   * Test that RollingLevelDb repair is attempted at least once during
+   * serviceInit for RollingLeveldbTimelineStore in case open fails the
+   * first time.
+   */ public void testLevelDbRepair() throws IOException {
+    RollingLevelDBTimelineStore store = new RollingLevelDBTimelineStore();
+    JniDBFactory factory = Mockito.mock(JniDBFactory.class);
+    Mockito.when(factory.open(Mockito.any(File.class), Mockito.any(Options.class)))
+        .thenThrow(new IOException()).thenCallRealMethod();
+    store.setFactory(factory);
+
+    //Create the LevelDb in a different location
+    File path = new File("target", this.getClass().getSimpleName() + "-tmpDir2").getAbsoluteFile();
+    Configuration conf = new Configuration(this.config);
+    conf.set(YarnConfiguration.TIMELINE_SERVICE_LEVELDB_PATH, path.getAbsolutePath());
+    try {
+      store.init(conf);
+      Mockito.verify(factory, Mockito.times(1))
+          .repair(Mockito.any(File.class), Mockito.any(Options.class));
+      FilenameFilter fileFilter =
+          new WildcardFileFilter("*" + RollingLevelDBTimelineStore.BACKUP_EXT + "*");
+      Assert.assertTrue(new File(path.getAbsolutePath(), RollingLevelDBTimelineStore.FILENAME)
+          .list(fileFilter).length > 0);
+    } finally {
+      store.close();
+      fsContext.delete(new Path(path.getAbsolutePath()), true);
+    }
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
### Description of PR
Jira: https://issues.apache.org/jira/browse/YARN-9063
ATS 1.5 fails to start if RollingLevelDb files are corrupt or missing

### How was this patch tested?
Wrote a unit test case to check and manually tested it.

```
[INFO] --- maven-surefire-plugin:2.21.0:test (default-test) @ hadoop-yarn-server-applicationhistoryservice ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.TestMemoryApplicationHistoryStore
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.735 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.TestMemoryApplicationHistoryStore
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.webapp.TestAHSWebServices
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.125 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.webapp.TestAHSWebServices
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.webapp.TestAHSWebApp
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.204 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.webapp.TestAHSWebApp
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.TestFileSystemApplicationHistoryStore
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.878 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.TestFileSystemApplicationHistoryStore
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryClientService
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.653 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryClientService
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryManagerImpl
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.438 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryManagerImpl
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryServer
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.748 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryServer
[INFO] Running org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryManagerOnTimelineStore
[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.455 s - in org.apache.hadoop.yarn.server.applicationhistoryservice.TestApplicationHistoryManagerOnTimelineStore
[INFO] Running org.apache.hadoop.yarn.server.timeline.TestRollingLevelDB
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.89 s - in org.apache.hadoop.yarn.server.timeline.TestRollingLevelDB
[INFO] Running org.apache.hadoop.yarn.server.timeline.TestTimelineDataManager
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.059 s - in org.apache.hadoop.yarn.server.timeline.TestTimelineDataManager
[INFO] Running org.apache.hadoop.yarn.server.timeline.security.TestTimelineACLsManager
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.553 s - in org.apache.hadoop.yarn.server.timeline.security.TestTimelineACLsManager
[INFO] Running org.apache.hadoop.yarn.server.timeline.security.TestTimelineAuthenticationFilterForV1
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.173 s - in org.apache.hadoop.yarn.server.timeline.security.TestTimelineAuthenticationFilterForV1
[INFO] Running org.apache.hadoop.yarn.server.timeline.recovery.TestLeveldbTimelineStateStore
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.847 s - in org.apache.hadoop.yarn.server.timeline.recovery.TestLeveldbTimelineStateStore
[INFO] Running org.apache.hadoop.yarn.server.timeline.webapp.TestTimelineWebServicesWithSSL
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.554 s - in org.apache.hadoop.yarn.server.timeline.webapp.TestTimelineWebServicesWithSSL
[INFO] Running org.apache.hadoop.yarn.server.timeline.webapp.TestTimelineWebServices
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.214 s - in org.apache.hadoop.yarn.server.timeline.webapp.TestTimelineWebServices
[INFO] Running org.apache.hadoop.yarn.server.timeline.TestRollingLevelDBTimelineStore
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.338 s - in org.apache.hadoop.yarn.server.timeline.TestRollingLevelDBTimelineStore
[INFO] Running org.apache.hadoop.yarn.server.timeline.TestLeveldbTimelineStore
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.999 s - in org.apache.hadoop.yarn.server.timeline.TestLeveldbTimelineStore
[INFO] Running org.apache.hadoop.yarn.server.timeline.TestMemoryTimelineStore
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.397 s - in org.apache.hadoop.yarn.server.timeline.TestMemoryTimelineStore
[INFO] Running org.apache.hadoop.yarn.server.timeline.TestGenericObjectMapper
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.38 s - in org.apache.hadoop.yarn.server.timeline.TestGenericObjectMapper
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 208, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:45 min
[INFO] Finished at: 2021-11-25T10:05:41+05:30
[INFO] ------------------------------------------------------------------------

```