### PR TITLE
HADOOP-18025. Upgrade HBase version to 1.7.1 for hbase1 profile

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -297,10 +297,10 @@ org.apache.curator:curator-client:5.2.0
 org.apache.curator:curator-framework:5.2.0
 org.apache.curator:curator-recipes:5.2.0
 org.apache.geronimo.specs:geronimo-jcache_1.0_spec:1.0-alpha-1
-org.apache.hbase:hbase-annotations:1.4.8
-org.apache.hbase:hbase-client:1.4.8
-org.apache.hbase:hbase-common:1.4.8
-org.apache.hbase:hbase-protocol:1.4.8
+org.apache.hbase:hbase-annotations:1.7.1
+org.apache.hbase:hbase-client:1.7.1
+org.apache.hbase:hbase-common:1.7.1
+org.apache.hbase:hbase-protocol:1.7.1
 org.apache.htrace:htrace-core:3.1.0-incubating
 org.apache.htrace:htrace-core4:4.1.0-incubating
 org.apache.httpcomponents:httpclient:4.5.6

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -196,7 +196,7 @@
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.26</snakeyaml.version>
-    <hbase.one.version>1.4.8</hbase.one.version>
+    <hbase.one.version>1.7.1</hbase.one.version>
     <hbase.two.version>2.0.2</hbase.two.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.5.1</junit.jupiter.version>
@@ -2393,7 +2393,7 @@
       </activation>
       <properties>
         <hbase.version>${hbase.one.version}</hbase.version>
-        <hbase-compatible-hadoop.version>2.5.1</hbase-compatible-hadoop.version>
+        <hbase-compatible-hadoop.version>2.8.5</hbase-compatible-hadoop.version>
         <hbase-compatible-guava.version>12.0.1</hbase-compatible-guava.version>
         <hbase-server-artifactid>hadoop-yarn-server-timelineservice-hbase-server-1</hbase-server-artifactid>
       </properties>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -96,6 +96,10 @@
           <groupId>tomcat</groupId>
           <artifactId>jasper-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -106,6 +110,12 @@
       <artifactId>hadoop-auth</artifactId>
       <version>${hbase-compatible-hadoop.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -116,6 +126,10 @@
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -311,6 +325,12 @@
       <artifactId>hadoop-hdfs</artifactId>
       <version>${hbase-compatible-hadoop.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- 'mvn dependency:analyze' fails to detect use of this direct
@@ -320,6 +340,19 @@
       <artifactId>hadoop-hdfs</artifactId>
       <version>${hbase-compatible-hadoop.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <version>${hbase-compatible-hadoop.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -469,14 +502,6 @@
               <artifactId>hadoop-common</artifactId>
             </exclusion>
           </exclusions>
-        </dependency>
-        <!-- 'mvn dependency:analyze' fails to detect use of this direct
-             dependency -->
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-hdfs-client</artifactId>
-          <version>${hbase-compatible-hadoop.version}</version>
-          <scope>test</scope>
         </dependency>
         <!-- 'mvn dependency:analyze' fails to detect use of this direct
              dependency -->

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/ApplicationEntityReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/ApplicationEntityReader.java
@@ -406,7 +406,7 @@ class ApplicationEntityReader extends GenericEntityReader {
       }
 
       // set start row
-      scan.setStartRow(applicationRowKey.getRowKey());
+      scan.withStartRow(applicationRowKey.getRowKey());
 
       // get the bytes for stop row
       applicationRowKeyPrefix = new ApplicationRowKeyPrefix(
@@ -414,7 +414,7 @@ class ApplicationEntityReader extends GenericEntityReader {
           context.getFlowRunId());
 
       // set stop row
-      scan.setStopRow(
+      scan.withStopRow(
           HBaseTimelineStorageUtils.calculateTheClosestNextRowKeyForPrefix(
               applicationRowKeyPrefix.getRowKeyPrefix()));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/EntityTypeReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/EntityTypeReader.java
@@ -155,7 +155,9 @@ public final class EntityTypeReader extends AbstractTimelineStorageReader {
   private ResultScanner getResult(Configuration hbaseConf, Connection conn,
       FilterList filterList, byte[] startPrefix, byte[] endPrefix)
       throws IOException {
-    Scan scan = new Scan(startPrefix, endPrefix);
+    Scan scan = new Scan();
+    scan.withStartRow(startPrefix);
+    scan.withStopRow(endPrefix);
     scan.setFilter(filterList);
     scan.setSmall(true);
     return ENTITY_TABLE.getResultScanner(hbaseConf, conn, scan);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/EntityTypeReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/EntityTypeReader.java
@@ -158,11 +158,11 @@ public final class EntityTypeReader extends AbstractTimelineStorageReader {
   private ResultScanner getResult(Configuration hbaseConf, Connection conn,
       FilterList filterList, byte[] startPrefix, byte[] endPrefix)
       throws IOException {
-    Scan scan = new Scan();
-    scan.withStartRow(startPrefix);
-    scan.withStopRow(endPrefix);
-    scan.setFilter(filterList);
-    scan.setSmall(true);
+    Scan scan = new Scan()
+        .withStartRow(startPrefix)
+        .withStopRow(endPrefix)
+        .setFilter(filterList)
+        .setSmall(true);
     return ENTITY_TABLE.getResultScanner(hbaseConf, conn, scan);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/FlowActivityEntityReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/FlowActivityEntityReader.java
@@ -133,16 +133,16 @@ class FlowActivityEntityReader extends TimelineEntityReader {
         throw new BadRequestException(
             "fromid doesn't belong to clusterId=" + clusterId);
       }
-      scan.setStartRow(key.getRowKey());
-      scan.setStopRow(
+      scan.withStartRow(key.getRowKey());
+      scan.withStopRow(
           new FlowActivityRowKeyPrefix(clusterId,
               (getFilters().getCreatedTimeBegin() <= 0 ? 0
                   : (getFilters().getCreatedTimeBegin() - 1)))
                       .getRowKeyPrefix());
     } else {
-      scan.setStartRow(new FlowActivityRowKeyPrefix(clusterId, getFilters()
+      scan.withStartRow(new FlowActivityRowKeyPrefix(clusterId, getFilters()
           .getCreatedTimeEnd()).getRowKeyPrefix());
-      scan.setStopRow(new FlowActivityRowKeyPrefix(clusterId, (getFilters()
+      scan.withStopRow(new FlowActivityRowKeyPrefix(clusterId, (getFilters()
           .getCreatedTimeBegin() <= 0 ? 0
           : (getFilters().getCreatedTimeBegin() - 1))).getRowKeyPrefix());
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/FlowRunEntityReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/FlowRunEntityReader.java
@@ -236,14 +236,14 @@ class FlowRunEntityReader extends TimelineEntityReader {
             "fromid doesn't belong to clusterId=" + context.getClusterId());
       }
       // set start row
-      scan.setStartRow(flowRunRowKey.getRowKey());
+      scan.withStartRow(flowRunRowKey.getRowKey());
 
       // get the bytes for stop row
       flowRunRowKeyPrefix = new FlowRunRowKeyPrefix(context.getClusterId(),
           context.getUserId(), context.getFlowName());
 
       // set stop row
-      scan.setStopRow(
+      scan.withStopRow(
           HBaseTimelineStorageUtils.calculateTheClosestNextRowKeyForPrefix(
               flowRunRowKeyPrefix.getRowKeyPrefix()));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/GenericEntityReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/GenericEntityReader.java
@@ -514,7 +514,7 @@ class GenericEntityReader extends TimelineEntityReader {
       }
 
       // set start row
-      scan.setStartRow(entityRowKey.getRowKey());
+      scan.withStartRow(entityRowKey.getRowKey());
 
       // get the bytes for stop row
       entityRowKeyPrefix = new EntityRowKeyPrefix(context.getClusterId(),
@@ -522,7 +522,7 @@ class GenericEntityReader extends TimelineEntityReader {
           context.getAppId(), context.getEntityType(), null, null);
 
       // set stop row
-      scan.setStopRow(
+      scan.withStopRow(
           HBaseTimelineStorageUtils.calculateTheClosestNextRowKeyForPrefix(
               entityRowKeyPrefix.getRowKeyPrefix()));
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/SubApplicationEntityReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/reader/SubApplicationEntityReader.java
@@ -368,7 +368,7 @@ class SubApplicationEntityReader extends GenericEntityReader {
       }
 
       // set start row
-      scan.setStartRow(entityRowKey.getRowKey());
+      scan.withStartRow(entityRowKey.getRowKey());
 
       // get the bytes for stop row
       subApplicationRowKeyPrefix = new SubApplicationRowKeyPrefix(
@@ -376,7 +376,7 @@ class SubApplicationEntityReader extends GenericEntityReader {
           context.getEntityType(), null, null, null);
 
       // set stop row
-      scan.setStopRow(
+      scan.withStopRow(
           HBaseTimelineStorageUtils.calculateTheClosestNextRowKeyForPrefix(
               subApplicationRowKeyPrefix.getRowKeyPrefix()));
 


### PR DESCRIPTION
### Description of PR
Upgrade HBase version to 1.7.1 for hbase1 profile. The current version is quite old.
Also, replace old deprecated APIs of Scan with better alternatives.

### How was this patch tested?
Verified with some local testing. All CRUD unit tests are tested.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
