### PR TITLE
HDFS-16359. RBF: RouterRpcServer#invokeAtAvailableNs does not take effect when retrying

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -696,7 +696,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
             ioe.getClass().getSimpleName());
         throw ioe;
       }
-      Set<FederationNamespaceInfo> nssWithoutFailed = getNameSpaceInfo(nsId);
+      Set<FederationNamespaceInfo> nssWithoutFailed = getNameSpaceInfo(nss, nsId);
       return invokeOnNs(method, clazz, ioe, nssWithoutFailed);
     }
   }
@@ -726,9 +726,10 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
    * @return List of name spaces in the federation on
    * removing the already invoked namespaceinfo.
    */
-  private Set<FederationNamespaceInfo> getNameSpaceInfo(String nsId) {
+  private Set<FederationNamespaceInfo> getNameSpaceInfo(
+      Set<FederationNamespaceInfo> nss, String nsId) {
     Set<FederationNamespaceInfo> namespaceInfos = new HashSet<>();
-    for (FederationNamespaceInfo ns : namespaceInfos) {
+    for (FederationNamespaceInfo ns : nss) {
       if (!nsId.equals(ns.getNameserviceId())) {
         namespaceInfos.add(ns);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -722,12 +722,13 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
 
   /**
    * Get set of namespace info's removing the already invoked namespaceinfo.
-   * @param nsId already invoked namespace id
+   * @param nss List of namespaces in the federation.
+   * @param nsId Already invoked namespace id.
    * @return List of name spaces in the federation on
    * removing the already invoked namespaceinfo.
    */
-  private Set<FederationNamespaceInfo> getNameSpaceInfo(
-      Set<FederationNamespaceInfo> nss, String nsId) {
+  private static Set<FederationNamespaceInfo> getNameSpaceInfo(
+      final Set<FederationNamespaceInfo> nss, final String nsId) {
     Set<FederationNamespaceInfo> namespaceInfos = new HashSet<>();
     for (FederationNamespaceInfo ns : nss) {
       if (!nsId.equals(ns.getNameserviceId())) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -195,7 +195,7 @@ import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 public class RouterRpcServer extends AbstractService implements ClientProtocol,
     NamenodeProtocol, RefreshUserMappingsProtocol, GetUserMappingsProtocol {
 
-  static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RouterRpcServer.class);
 
 
@@ -697,7 +697,6 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
         throw ioe;
       }
       Set<FederationNamespaceInfo> nssWithoutFailed = getNameSpaceInfo(nss, nsId);
-      LOG.debug("Number of namespaces without failed: {}", nssWithoutFailed.size());
       return invokeOnNs(method, clazz, ioe, nssWithoutFailed);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -195,7 +195,7 @@ import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 public class RouterRpcServer extends AbstractService implements ClientProtocol,
     NamenodeProtocol, RefreshUserMappingsProtocol, GetUserMappingsProtocol {
 
-  private static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(RouterRpcServer.class);
 
 
@@ -697,6 +697,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
         throw ioe;
       }
       Set<FederationNamespaceInfo> nssWithoutFailed = getNameSpaceInfo(nss, nsId);
+      LOG.debug("Number of namespaces without failed: {}", nssWithoutFailed.size());
       return invokeOnNs(method, clazz, ioe, nssWithoutFailed);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCMultipleDestinationMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCMultipleDestinationMountTableResolver.java
@@ -63,8 +63,10 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.RemoveMountTableE
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.hdfs.tools.federation.RouterAdmin;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.ToolRunner;
+import org.slf4j.event.Level;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -649,6 +651,9 @@ public class TestRouterRPCMultipleDestinationMountTableResolver {
    */
   @Test
   public void testWriteWithUnavailableSubCluster() throws IOException {
+    GenericTestUtils.setLogLevel(RouterRpcServer.LOG, Level.DEBUG);
+    GenericTestUtils.LogCapturer log =
+        GenericTestUtils.LogCapturer.captureLogs(RouterRpcServer.LOG);
     //create a mount point with multiple destinations
     Path path = new Path("/testWriteWithUnavailableSubCluster");
     Map<String, String> destMap = new HashMap<>();
@@ -673,6 +678,7 @@ public class TestRouterRPCMultipleDestinationMountTableResolver {
       out.write("hello".getBytes());
       out.hflush();
       assertTrue(routerFs.exists(filePath));
+      assertTrue(log.getOutput().contains("Number of namespaces without failed: 1"));
     } finally {
       IOUtils.closeStream(out);
       dfsCluster.restartNameNode(0);


### PR DESCRIPTION
JIRA: [HDFS-16359](https://issues.apache.org/jira/browse/HDFS-16359).

RouterRpcServer#invokeAtAvailableNs does not take effect when retrying. See [HDFS-15543](https://issues.apache.org/jira/browse/HDFS-15543).

The original code of RouterRpcServer#getNameSpaceInfo looks like follwings, and `namespaceInfos` is always empty here.
```
private Set<FederationNamespaceInfo> getNameSpaceInfo(String nsId) {
  Set<FederationNamespaceInfo> namespaceInfos = new HashSet<>();
  for (FederationNamespaceInfo ns : namespaceInfos) {
    if (!nsId.equals(ns.getNameserviceId())) {
      namespaceInfos.add(ns);
    }
  }
  return namespaceInfos;
} 
```