### PR TITLE
HADOOP-18027. Include static imports in the maven plugin rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use hadoop-thirdparty shaded instead of curator shaded</reason>
                     <bannedImports>
                       <bannedImport>org.apache.curator.shaded.**</bannedImport>
+                      <bannedImport>static org.apache.curator.shaded.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -189,6 +190,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use hadoop-common provided Sets rather than Guava provided Sets</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.Sets</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.collect.Sets.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -196,6 +198,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use hadoop-common provided Lists rather than Guava provided Lists</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.Lists</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.collect.Lists.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -210,6 +213,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternatives to Guava common classes</reason>
                     <bannedImports>
                       <bannedImport>com.google.common.**</bannedImport>
+                      <bannedImport>static com.google.common.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -224,6 +228,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternative to Guava provided Optional</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Optional</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.base.Optional.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -231,6 +236,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternative to Guava provided Function</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Function</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.base.Function.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -238,6 +244,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternative to Guava provided Predicate</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Predicate</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.base.Predicate.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -245,6 +252,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternative to Guava provided Supplier</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.base.Supplier</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.base.Supplier.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
@@ -252,6 +260,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternative to Guava provided ImmutableListMultimap</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableListMultimap</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableListMultimap.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                     <reason>Use alternative to Guava provided BaseEncoding</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.io.BaseEncoding</bannedImport>
+                      <bannedImport>static org.apache.hadoop.thirdparty.com.google.common.io.BaseEncoding.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
                   <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">


### PR DESCRIPTION
### Description of PR
Maven enforcer plugin to ban illegal imports require explicit mention of static imports in order to evaluate whether any publicly accessible static entities from the banned classes are directly imported by Hadoop code.

### How was this patch tested?
Tested locally.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
