### PR TITLE
HDFS-16368. DFSadmin supports refresh topology info without restarting namenode

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopology.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopology.java
@@ -124,6 +124,29 @@ public class NetworkTopology {
     this.clusterMap = factory.newInnerNode(NodeBase.ROOT);
   }
 
+  /**
+   * Update a leaf node with new network location.
+   * @param node node to be updated;
+   * @param newNetworkLocations new network locations for node;
+   */
+  public void updateNodeNetworkLocation(Node node, String newNetworkLocations) {
+    if (node == null) {
+      return;
+    }
+    if (node instanceof InnerNode) {
+      throw new IllegalArgumentException(
+          "Not allow to update an inner node: " + NodeBase.getPath(node));
+    }
+    netlock.writeLock().lock();
+    try {
+      remove(node);
+      node.setNetworkLocation(newNetworkLocations);
+      add(node); // may throw InvalidTopologyException
+    } finally {
+      netlock.writeLock().unlock();
+    }
+  }
+
   /** Add a leaf node
    * Update node counter &amp; rack counter if necessary
    * @param node node to be added; can be null

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2452,6 +2452,13 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     }
   }
 
+  public void refreshTopology() throws IOException{
+    checkOpen();
+    try (TraceScope ignored = tracer.newScope("refreshTopology")) {
+      namenode.refreshTopology();
+    }
+  }
+
   /**
    * Dumps DFS data structures into specified file.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -1768,6 +1768,10 @@ public class DistributedFileSystem extends FileSystem
     dfs.refreshNodes();
   }
 
+  public void refreshTopology() throws IOException{
+    dfs.refreshTopology();
+  }
+
   /**
    * Finalize previously upgraded files system state.
    * @throws IOException

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -988,6 +988,14 @@ public interface ClientProtocol {
   void refreshNodes() throws IOException;
 
   /**
+   * Tells the namenode to refresh the network topology info
+   *
+   * @throws IOException
+   */
+  @Idempotent
+  void refreshTopology() throws IOException;
+
+  /**
    * Finalize previous upgrade.
    * Remove file system state saved during the upgrade.
    * The upgrade will become irreversible.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -175,6 +175,7 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MsyncR
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.OpenFilesBatchResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RecoverLeaseRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshNodesRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshTopologyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCacheDirectiveRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCachePoolRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.Rename2RequestProto;
@@ -293,6 +294,9 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   private final static RefreshNodesRequestProto VOID_REFRESH_NODES_REQUEST =
       RefreshNodesRequestProto.newBuilder().build();
+
+  private final static RefreshTopologyRequestProto VOID_REFRESH_TOPOLOGY_REQUEST =
+      RefreshTopologyRequestProto.newBuilder().build();
 
   private final static FinalizeUpgradeRequestProto
       VOID_FINALIZE_UPGRADE_REQUEST =
@@ -767,6 +771,15 @@ public class ClientNamenodeProtocolTranslatorPB implements
   @Override
   public void refreshNodes() throws IOException {
     ipc(() -> rpcProxy.refreshNodes(null, VOID_REFRESH_NODES_REQUEST));
+  }
+
+  @Override
+  public void refreshTopology() throws IOException {
+    try {
+      rpcProxy.refreshTopology(null, VOID_REFRESH_TOPOLOGY_REQUEST);
+    } catch (ServiceException e) {
+      throw ProtobufHelper.getRemoteException(e);
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -775,11 +775,7 @@ public class ClientNamenodeProtocolTranslatorPB implements
 
   @Override
   public void refreshTopology() throws IOException {
-    try {
-      rpcProxy.refreshTopology(null, VOID_REFRESH_TOPOLOGY_REQUEST);
-    } catch (ServiceException e) {
-      throw ProtobufHelper.getRemoteException(e);
-    }
+    ipc(() -> rpcProxy.refreshTopology(null, VOID_REFRESH_TOPOLOGY_REQUEST));
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
@@ -486,6 +486,12 @@ message RefreshNodesRequestProto { // no parameters
 message RefreshNodesResponseProto { // void response
 }
 
+message RefreshTopologyRequestProto { // no parameters
+}
+
+message RefreshTopologyResponseProto { // void response
+}
+
 message FinalizeUpgradeRequestProto { // no parameters
 }
 
@@ -947,6 +953,7 @@ service ClientNamenodeProtocol {
   rpc restoreFailedStorage(RestoreFailedStorageRequestProto)
       returns(RestoreFailedStorageResponseProto);
   rpc refreshNodes(RefreshNodesRequestProto) returns(RefreshNodesResponseProto);
+  rpc refreshTopology(RefreshTopologyRequestProto) returns(RefreshTopologyResponseProto);
   rpc finalizeUpgrade(FinalizeUpgradeRequestProto)
       returns(FinalizeUpgradeResponseProto);
   rpc upgradeStatus(UpgradeStatusRequestProto)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1216,10 +1216,11 @@ public class RouterClientProtocol implements ClientProtocol {
 
   @Override
   public void refreshTopology() throws IOException {
-    // Router not support this operation, because this maybe refresh multi namespaces
-    String methodName = RouterRpcServer.getMethodName();
-    throw new UnsupportedOperationException(
-        "Operation \"" + methodName + "\" is not supported");
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    RemoteMethod method = new RemoteMethod("refreshTopology", new Class<?>[] {});
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true, true);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1215,6 +1215,14 @@ public class RouterClientProtocol implements ClientProtocol {
   }
 
   @Override
+  public void refreshTopology() throws IOException {
+    // Router not support this operation, because this maybe refresh multi namespaces
+    String methodName = RouterRpcServer.getMethodName();
+    throw new UnsupportedOperationException(
+        "Operation \"" + methodName + "\" is not supported");
+  }
+
+  @Override
   public void finalizeUpgrade() throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -1221,6 +1221,11 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   }
 
   @Override // ClientProtocol
+  public void refreshTopology() throws IOException {
+    clientProto.refreshTopology();
+  }
+
+  @Override // ClientProtocol
   public void finalizeUpgrade() throws IOException {
     clientProto.finalizeUpgrade();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -175,6 +175,8 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.HAServ
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.HAServiceStateResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.IsFileClosedRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.IsFileClosedResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshTopologyRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshTopologyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpgradeStatusRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.UpgradeStatusResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.ListCacheDirectivesRequestProto;
@@ -377,6 +379,9 @@ public class ClientNamenodeProtocolServerSideTranslatorPB implements
 
   private static final RefreshNodesResponseProto VOID_REFRESHNODES_RESPONSE =
   RefreshNodesResponseProto.newBuilder().build();
+
+  private static final RefreshTopologyResponseProto VOID_REFRESHTOPOLOGY_RESPONSE =
+      RefreshTopologyResponseProto.newBuilder().build();
 
   private static final FinalizeUpgradeResponseProto VOID_FINALIZEUPGRADE_RESPONSE = 
   FinalizeUpgradeResponseProto.newBuilder().build();
@@ -974,6 +979,16 @@ public class ClientNamenodeProtocolServerSideTranslatorPB implements
       throw new ServiceException(e);
     }
 
+  }
+
+  @Override
+  public RefreshTopologyResponseProto refreshTopology(RpcController controller, RefreshTopologyRequestProto request) throws ServiceException {
+    try {
+      server.refreshTopology();
+      return VOID_REFRESHTOPOLOGY_RESPONSE;
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1361,11 +1361,7 @@ public class DatanodeManager {
         continue;
       }
       try {
-        synchronized (this) {
-          networktopology.remove(dnDescriptor);
-          dnDescriptor.setNetworkLocation(resolvedNetwork);
-          networktopology.add(dnDescriptor); // may throw InvalidTopologyException
-        }
+        networktopology.updateNodeNetworkLocation(dnDescriptor, resolvedNetwork);
       } catch (Throwable e) {
         LOG.error("{}.refreshTopology: update datanode: {} failed. reset from Rack: {} to Rack: {}.",
             getClass().getSimpleName(), dnDescriptor, resolvedNetwork, originNetwork);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5117,6 +5117,20 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     logAuditEvent(true, operationName, null);
   }
 
+  public void refreshTopology() throws IOException {
+    String operationName = "refreshTopology";
+    checkOperation(OperationCategory.UNCHECKED);
+    checkSuperuserPrivilege(operationName);
+    writeLock();
+    try {
+      checkOperation(OperationCategory.UNCHECKED);
+      getBlockManager().getDatanodeManager().refreshTopology();
+    } finally {
+      writeUnlock(operationName);
+    }
+    logAuditEvent(true, operationName, null);
+  }
+
   void setBalancerBandwidth(long bandwidth) throws IOException {
     String operationName = "setBalancerBandwidth";
     checkOperation(OperationCategory.WRITE);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1345,6 +1345,12 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     namesystem.refreshNodes();
   }
 
+  @Override // ClientProtocol
+  public void refreshTopology() throws IOException {
+    checkNNStartup();
+    namesystem.refreshTopology();
+  }
+
   @Override // NamenodeProtocol
   public long getTransactionID() throws IOException {
     String operationName = "getTransactionID";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -457,6 +457,7 @@ public class DFSAdmin extends FsShell {
       "\t[-reconfig <namenode|datanode> <host:ipc_port|livenodes|decomnodes>\n" +
         "\t<start|status|properties>]\n" +
     "\t[-printTopology]\n" +
+    "\t[-refreshTopology] <nsId>]\n" +
       "\t[-refreshNamenodes datanode_host:ipc_port]\n" +
       "\t[-getVolumeReport datanode_host:ipc_port]\n" +
     "\t[-deleteBlockPool datanode_host:ipc_port blockpoolId [force]]\n"+
@@ -1029,6 +1030,52 @@ public class DFSAdmin extends FsShell {
   }
 
   /**
+   * Command to refresh network topology info of this cluster.
+   * Usage: hdfs dfsadmin -refreshTopology <nsid>
+   *
+   * @param argv
+   * @throws IOException
+   */
+  public int refreshTopology(String[] argv) throws IOException {
+    int exitCode = -1;
+    String nsId = argv[1];
+    DistributedFileSystem dfs = getDFS();
+    Configuration dfsConf = dfs.getConf();
+    URI dfsUri = dfs.getUri();
+    boolean isHaEnabled = HAUtilClient.isLogicalUri(dfsConf, dfsUri);
+
+    if (isHaEnabled) {
+      List<ProxyAndInfo<ClientProtocol>> proxies =
+          HAUtil.getProxiesForAllNameNodesInNameservice(dfsConf,
+                                                        nsId, ClientProtocol.class);
+      if (proxies.size() == 0) {
+        throw new IOException("Can not get proxy for nameservice : " + nsId + ", please check it.");
+      }
+      List<IOException> exceptions = new ArrayList<>();
+      for (ProxyAndInfo<ClientProtocol> proxy : proxies) {
+        try {
+          proxy.getProxy().refreshTopology();
+          System.out.println("Refresh topology successful for " +
+                                 proxy.getAddress());
+        } catch (IOException ioe) {
+          System.err.println("Refresh topology failed for " +
+                                 proxy.getAddress());
+          exceptions.add(ioe);
+        }
+      }
+      if (!exceptions.isEmpty()) {
+        throw MultipleIOException.createIOException(exceptions);
+      }
+    } else {
+      dfs.refreshTopology();
+      System.out.println("Refresh topology successful");
+    }
+    exitCode = 0;
+
+    return exitCode;
+  }
+
+  /**
    * Command to list all the open files currently managed by NameNode.
    * Usage: hdfs dfsadmin -listOpenFiles
    *
@@ -1273,6 +1320,9 @@ public class DFSAdmin extends FsShell {
     String printTopology = "-printTopology: Print a tree of the racks and their\n" +
                            "\t\tnodes as reported by the Namenode\n";
     
+    String refreshTopology = "-refreshTopology: Refresh racks info according to\n" +
+        "\t\tthe new topology mappings file and no need to restart Namenode\n";
+
     String refreshNamenodes = "-refreshNamenodes: Takes a " +
             "datanodehost:ipc_port as argument,For the given datanode\n" +
             "\t\treloads the configuration files,stops serving the removed\n" +
@@ -1398,6 +1448,8 @@ public class DFSAdmin extends FsShell {
       System.out.println(reconfig);
     } else if ("printTopology".equals(cmd)) {
       System.out.println(printTopology);
+    } else if ("refreshTopology".equals(cmd)) {
+      System.out.println(refreshTopology);
     } else if ("refreshNamenodes".equals(cmd)) {
       System.out.println(refreshNamenodes);
     } else if ("getVolumeReport".equals(cmd)) {
@@ -1451,6 +1503,7 @@ public class DFSAdmin extends FsShell {
       System.out.println(genericRefresh);
       System.out.println(reconfig);
       System.out.println(printTopology);
+      System.out.println(refreshTopology);
       System.out.println(refreshNamenodes);
       System.out.println(deleteBlockPool);
       System.out.println(setBalancerBandwidth);
@@ -2334,6 +2387,9 @@ public class DFSAdmin extends FsShell {
     } else if ("-printTopology".equals(cmd)) {
       System.err.println("Usage: hdfs dfsadmin"
                          + " [-printTopology]");
+    } else if ("-refreshTopology".equals(cmd)) {
+      System.err.println("Usage: hdfs dfsadmin"
+          + " [-refreshTopology <nsid>]");
     } else if ("-refreshNamenodes".equals(cmd)) {
       System.err.println("Usage: hdfs dfsadmin"
                          + " [-refreshNamenodes datanode-host:ipc_port]");
@@ -2479,6 +2535,11 @@ public class DFSAdmin extends FsShell {
         printUsage(cmd);
         return exitCode;
       }
+    } else if ("-refreshTopology".equals(cmd)) {
+      if (argv.length != 2) {
+        printUsage(cmd);
+        return exitCode;
+      }
     } else if ("-refreshNamenodes".equals(cmd)) {
       if (argv.length != 2) {
         printUsage(cmd);
@@ -2588,6 +2649,8 @@ public class DFSAdmin extends FsShell {
         exitCode = genericRefresh(argv, i);
       } else if ("-printTopology".equals(cmd)) {
         exitCode = printTopology();
+      } else if ("-refreshTopology".equals(cmd)) {
+        exitCode = refreshTopology(argv);
       } else if ("-refreshNamenodes".equals(cmd)) {
         exitCode = refreshNamenodes(argv, i);
       } else if ("-getVolumeReport".equals(cmd)) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
@@ -341,6 +341,25 @@ public class TestDFSAdminWithHA {
   }
 
   @Test (timeout = 30000)
+  public void testRefreshTopology() throws Exception {
+    setUpHaCluster(false);
+    int exitCode = admin.run(new String[]{"-refreshTopology", NSID});
+    assertEquals(err.toString().trim(), 0, exitCode);
+    String message = "Refresh topology successful for.*";
+    assertOutputMatches(message + newLine + message + newLine);
+  }
+
+  @Test (timeout = 30000)
+  public void testRefreshTopologyUnknownNsid() throws Exception {
+    setUpHaCluster(false);
+    String unknownNsid = "unknown_nsid";
+    int exitCode = admin.run(new String[]{"-refreshTopology", unknownNsid});
+    assertEquals(err.toString().trim(), -1, exitCode);
+    String message = "refreshTopology: Can not get proxy for nameservice.*[\\s]*";
+    assertOutputMatches(message);
+  }
+
+  @Test (timeout = 30000)
   public void testRefreshNodesNN1UpNN2Down() throws Exception {
     setUpHaCluster(false);
     cluster.getDfsCluster().shutdownNameNode(1);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently in HDFS, if we update the rack info for rack-awareness, we may need to rolling restart namenodes to let it be effective. If cluster is large, the cost time of rolling restart namenodes is very log. So, we develope a method to refresh topology info without rolling restart namenodes.

### How was this patch tested?
1. hdfs dfsamin -printTopology
2. upload a file to HDFS, then use `fsck` to check its block location and rack info.

### For code changes:

https://issues.apache.org/jira/browse/HDFS-16368

