### PR TITLE
HDFS-16370. Fix assert message for BlockInfo

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
@@ -86,7 +86,7 @@ public abstract class BlockInfo extends Block
 
   public BlockInfo(Block blk, short size) {
     super(blk);
-    this.triplets = new Object[3*size];
+    this.triplets = new Object[3 * size];
     this.bcId = INVALID_INODE_ID;
     this.replication = isStriped() ? 0 : size;
   }
@@ -126,34 +126,34 @@ public abstract class BlockInfo extends Block
 
   DatanodeStorageInfo getStorageInfo(int index) {
     assert this.triplets != null : "BlockInfo is not initialized";
-    assert index >= 0 && index*3 < triplets.length : "Index is out of bound";
-    return (DatanodeStorageInfo)triplets[index*3];
+    assert index >= 0 && index * 3 < triplets.length : "Index is out of bound";
+    return (DatanodeStorageInfo)triplets[index * 3];
   }
 
   BlockInfo getPrevious(int index) {
     assert this.triplets != null : "BlockInfo is not initialized";
-    assert index >= 0 && index*3+1 < triplets.length : "Index is out of bound";
-    BlockInfo info = (BlockInfo)triplets[index*3+1];
+    assert index >= 0 && index * 3 + 1 < triplets.length : "Index is out of bound";
+    BlockInfo info = (BlockInfo)triplets[index * 3 + 1];
     assert info == null ||
         info.getClass().getName().startsWith(BlockInfo.class.getName()) :
-        "BlockInfo is expected at " + (index*3+1);
+        "BlockInfo is expected at " + (index * 3 + 1);
     return info;
   }
 
   BlockInfo getNext(int index) {
     assert this.triplets != null : "BlockInfo is not initialized";
-    assert index >= 0 && index*3+2 < triplets.length : "Index is out of bound";
-    BlockInfo info = (BlockInfo)triplets[index*3+2];
+    assert index >= 0 && index * 3 + 2 < triplets.length : "Index is out of bound";
+    BlockInfo info = (BlockInfo)triplets[index * 3 + 2];
     assert info == null || info.getClass().getName().startsWith(
         BlockInfo.class.getName()) :
-        "BlockInfo is expected at " + (index*3+2);
+        "BlockInfo is expected at " + (index * 3 + 2);
     return info;
   }
 
   void setStorageInfo(int index, DatanodeStorageInfo storage) {
     assert this.triplets != null : "BlockInfo is not initialized";
-    assert index >= 0 && index*3 < triplets.length : "Index is out of bound";
-    triplets[index*3] = storage;
+    assert index >= 0 && index * 3 < triplets.length : "Index is out of bound";
+    triplets[index * 3] = storage;
   }
 
   /**
@@ -166,9 +166,9 @@ public abstract class BlockInfo extends Block
    */
   BlockInfo setPrevious(int index, BlockInfo to) {
     assert this.triplets != null : "BlockInfo is not initialized";
-    assert index >= 0 && index*3+1 < triplets.length : "Index is out of bound";
-    BlockInfo info = (BlockInfo) triplets[index*3+1];
-    triplets[index*3+1] = to;
+    assert index >= 0 && index * 3 + 1 < triplets.length : "Index is out of bound";
+    BlockInfo info = (BlockInfo) triplets[index * 3 + 1];
+    triplets[index * 3 + 1] = to;
     return info;
   }
 
@@ -182,9 +182,9 @@ public abstract class BlockInfo extends Block
    */
   BlockInfo setNext(int index, BlockInfo to) {
     assert this.triplets != null : "BlockInfo is not initialized";
-    assert index >= 0 && index*3+2 < triplets.length : "Index is out of bound";
-    BlockInfo info = (BlockInfo) triplets[index*3+2];
-    triplets[index*3+2] = to;
+    assert index >= 0 && index * 3 + 2 < triplets.length : "Index is out of bound";
+    BlockInfo info = (BlockInfo) triplets[index * 3 + 2];
+    triplets[index * 3 + 2] = to;
     return info;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
@@ -136,7 +136,7 @@ public abstract class BlockInfo extends Block
     BlockInfo info = (BlockInfo)triplets[index*3+1];
     assert info == null ||
         info.getClass().getName().startsWith(BlockInfo.class.getName()) :
-        "BlockInfo is expected at " + index*3;
+        "BlockInfo is expected at " + (index*3+1);
     return info;
   }
 
@@ -146,7 +146,7 @@ public abstract class BlockInfo extends Block
     BlockInfo info = (BlockInfo)triplets[index*3+2];
     assert info == null || info.getClass().getName().startsWith(
         BlockInfo.class.getName()) :
-        "BlockInfo is expected at " + index*3;
+        "BlockInfo is expected at " + (index*3+2);
     return info;
   }
 


### PR DESCRIPTION
JIRA: [HDFS-16370](https://issues.apache.org/jira/browse/HDFS-16370).

In both methods BlockInfo#getPrevious and BlockInfo#getNext, the assert message is wrong. This may cause some misunderstanding and needs to be fixed.