### PR TITLE
HADOOP-16905. Update jackson-databind to 2.10.3 to relieve us from th…

### DIFF
--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -335,6 +335,13 @@
                       </excludes>
                     </relocation>
                     <relocation>
+                      <pattern>javax/xml/bind/</pattern>
+                      <shadedPattern>${shaded.dependency.prefix}.javax.xml.bind.</shadedPattern>
+                      <excludes>
+                        <exclude>**/pom.xml</exclude>
+                      </excludes>
+                    </relocation>
+                    <relocation>
                       <pattern>net/</pattern>
                       <shadedPattern>${shaded.dependency.prefix}.net.</shadedPattern>
                       <excludes>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -69,8 +69,8 @@
 
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.9.10</jackson2.version>
-    <jackson2.databind.version>2.9.10.4</jackson2.databind.version>
+    <jackson2.version>2.10.3</jackson2.version>
+    <jackson2.databind.version>2.10.3</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.13</httpclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
   <name>Apache Hadoop Main</name>
   <packaging>pom</packaging>
 
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
   <name>Apache Hadoop Main</name>
   <packaging>pom</packaging>
 
-
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
…e endless CVE patches. (#1876)

(cherry picked from commit 69faaa1d58ad7de18a8dfa477531653a2c061568)

 Conflicts:
	hadoop-project/pom.xml

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

PR for testing by Jenkins. Backport HADOOP-16905 to branch-3.2. I'll backport HADOOP-17534 next.

### How was this patch tested?

Not tested.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

