### PR TITLE
HDFS-16014: Fix an issue in checking native pmdk lib by 'hadoop check native' command

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
@@ -141,7 +141,7 @@ public class NativeIO {
       }
     }
 
-    // Denotes the state of supporting PMDK. The value is set by JNI.
+    // Denotes the state of supporting PMDK. The actual value is set via JNI.
     private static SupportState pmdkSupportState =
         SupportState.UNSUPPORTED;
 

--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/nativeio/pmdk_load.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/io/nativeio/pmdk_load.c
@@ -35,13 +35,14 @@
 #endif
 
 PmdkLibLoader * pmdkLoader;
+// 1 represents loaded. Otherwise, not loaded.
+int pmdkLoaded;
 
 /**
  *  pmdk_load.c
  *  Utility of loading the libpmem library and the required functions.
  *  Building of this codes won't rely on any libpmem source codes, but running
  *  into this will rely on successfully loading of the dynamic library.
- *
  */
 
 static const char* load_functions() {
@@ -56,6 +57,10 @@ static const char* load_functions() {
   return NULL;
 }
 
+/**
+ * It should be idempotent to call this function for checking
+ * whether PMDK lib is successfully loaded.
+ */
 void load_pmdk_lib(char* err, size_t err_len) {
   const char* errMsg;
   const char* library = NULL;
@@ -67,10 +72,13 @@ void load_pmdk_lib(char* err, size_t err_len) {
 
   err[0] = '\0';
 
-  if (pmdkLoader != NULL) {
+  if (pmdkLoaded == 1) {
     return;
   }
-  pmdkLoader = calloc(1, sizeof(PmdkLibLoader));
+
+  if (pmdkLoader == NULL) {
+    pmdkLoader = calloc(1, sizeof(PmdkLibLoader));
+  }
 
   // Load PMDK library
   #ifdef UNIX
@@ -103,4 +111,5 @@ void load_pmdk_lib(char* err, size_t err_len) {
   }
 
   pmdkLoader->libname = strdup(library);
+  pmdkLoaded = 1;
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fix an issue: 'hadoop check native' command doesn't correctly reflect the loading state of native pmdk lib when this lib is removed after building.

### How was this patch tested?
We tested the validity of the patch on our lab machine. The test depends on the installation of pmdk lib.

### For code changes:

- [Yes] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [N/A] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [N/A] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

