### PR TITLE
HADOOP-18039. Upgrade hbase2 version and fix TestTimelineWriterHBaseDown

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -200,7 +200,7 @@
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.26</snakeyaml.version>
     <hbase.one.version>1.7.1</hbase.one.version>
-    <hbase.two.version>2.0.2</hbase.two.version>
+    <hbase.two.version>2.2.4</hbase.two.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.5.1</junit.jupiter.version>
     <junit.vintage.version>5.5.1</junit.vintage.version>
@@ -2428,9 +2428,10 @@
       </activation>
       <properties>
         <hbase.version>${hbase.two.version}</hbase.version>
-        <hbase-compatible-hadoop.version>3.0.0</hbase-compatible-hadoop.version>
+        <hbase-compatible-hadoop.version>2.8.5</hbase-compatible-hadoop.version>
         <hbase-compatible-guava.version>11.0.2</hbase-compatible-guava.version>
         <hbase-server-artifactid>hadoop-yarn-server-timelineservice-hbase-server-2</hbase-server-artifactid>
+        <hbase-compatible-jetty.version>9.3.27.v20190418</hbase-compatible-jetty.version>
       </properties>
       <dependencyManagement>
         <dependencies>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -515,6 +515,30 @@
           <artifactId>mockito-core</artifactId>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-server</artifactId>
+          <scope>test</scope>
+          <version>${hbase-compatible-jetty.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+          <scope>test</scope>
+          <version>${hbase-compatible-jetty.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-webapp</artifactId>
+          <scope>test</scope>
+          <version>${hbase-compatible-jetty.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+          <scope>test</scope>
+          <version>${hbase-compatible-jetty.version}</version>
+        </dependency>
       </dependencies>
     </profile>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/TestTimelineWriterHBaseDown.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/TestTimelineWriterHBaseDown.java
@@ -43,12 +43,12 @@ public class TestTimelineWriterHBaseDown {
     HBaseTestingUtility util = new HBaseTestingUtility();
     HBaseTimelineWriterImpl writer = new HBaseTimelineWriterImpl();
     try {
+      util.startMiniCluster();
       Configuration c1 = util.getConfiguration();
       c1.setLong(TIMELINE_SERVICE_READER_STORAGE_MONITOR_INTERVAL_MS, 5000);
       writer.init(c1);
       writer.start();
 
-      util.startMiniCluster();
       DataGeneratorForTest.createSchema(util.getConfiguration());
 
       TimelineStorageMonitor storageMonitor = writer.


### PR DESCRIPTION
### Description of PR
As mentioned on HADOOP-17668, we can't upgrade hbase2 profile version beyond 2.2.4 until we either have hbase 2 artifacts available that are built with hadoop 3 profile by default or hbase 3 is rolled out (hbase 3 is compatible with hadoop 3 versions only).
This PR is to upgrade hbase2 profile version to 2.2.4 and also fix TestTimelineWriterHBaseDown to create connection only after mini cluster is up.

### How was this patch tested?
Local testing.
For unit testing, here is the test result with hbase2 profile:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.reader.TestTimelineReaderWebServicesHBaseStorage
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.996 s - in org.apache.hadoop.yarn.server.timelineservice.reader.TestTimelineReaderWebServicesHBaseStorage
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.TestTimelineWriterHBaseDown
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.288 s - in org.apache.hadoop.yarn.server.timelineservice.storage.TestTimelineWriterHBaseDown
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageApps
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.485 s - in org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageApps
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.TestTimelineReaderHBaseDown
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 201.434 s - in org.apache.hadoop.yarn.server.timelineservice.storage.TestTimelineReaderHBaseDown
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageSchema
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 59.86 s - in org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageSchema
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageDomain
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.672 s - in org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageDomain
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageEntities
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.734 s - in org.apache.hadoop.yarn.server.timelineservice.storage.TestHBaseTimelineStorageEntities
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.flow.TestHBaseStorageFlowActivity
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.285 s - in org.apache.hadoop.yarn.server.timelineservice.storage.flow.TestHBaseStorageFlowActivity
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.flow.TestHBaseStorageFlowRunCompaction
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.799 s - in org.apache.hadoop.yarn.server.timelineservice.storage.flow.TestHBaseStorageFlowRunCompaction
[INFO] Running org.apache.hadoop.yarn.server.timelineservice.storage.flow.TestHBaseStorageFlowRun
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 68.664 s - in org.apache.hadoop.yarn.server.timelineservice.storage.flow.TestHBaseStorageFlowRun
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 103, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:33 min
[INFO] Finished at: 2021-12-08T19:32:42+05:30
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
