### PR TITLE
HADOOP-13500. Synchronizing iteration of Configuration properties object

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2696,10 +2696,10 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     // methods that allow non-strings to be put into configurations are removed,
     // we could replace properties with a Map<String,String> and get rid of this
     // code.
-    Properties properties = getProps();
+    Properties props = getProps();
     Map<String, String> result = new HashMap<>();
-    synchronized (properties) {
-      for (Map.Entry<Object, Object> item : properties.entrySet()) {
+    synchronized (props) {
+      for (Map.Entry<Object, Object> item : props.entrySet()) {
         if (item.getKey() instanceof String && item.getValue() instanceof String) {
           result.put((String) item.getKey(), (String) item.getValue());
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2696,11 +2696,13 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     // methods that allow non-strings to be put into configurations are removed,
     // we could replace properties with a Map<String,String> and get rid of this
     // code.
-    Map<String,String> result = new HashMap<String,String>();
-    for(Map.Entry<Object,Object> item: getProps().entrySet()) {
-      if (item.getKey() instanceof String &&
-          item.getValue() instanceof String) {
+    Properties properties = getProps();
+    Map<String, String> result = new HashMap<>();
+    synchronized (properties) {
+      for (Map.Entry<Object, Object> item : properties.entrySet()) {
+        if (item.getKey() instanceof String && item.getValue() instanceof String) {
           result.put((String) item.getKey(), (String) item.getValue());
+        }
       }
     }
     return result.entrySet().iterator();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
@@ -2137,12 +2137,12 @@ public class TestConfiguration extends TestCase {
 
   @Test
   public void testConcurrentModificationDuringIteration() throws InterruptedException {
-    final Configuration conf = new Configuration();
+    final Configuration configuration = new Configuration();
     new Thread(new Runnable() {
       @Override
       public void run() {
         while (true) {
-          conf.set(String.valueOf(Math.random()), String.valueOf(Math.random()));
+          configuration.set(String.valueOf(Math.random()), String.valueOf(Math.random()));
         }
       }
     }).start();
@@ -2154,7 +2154,7 @@ public class TestConfiguration extends TestCase {
       public void run() {
         while (true) {
           try {
-            conf.iterator();
+            configuration.iterator();
           } catch (final ConcurrentModificationException e) {
             exceptionOccurred.set(true);
             break;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
@@ -36,12 +36,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import static java.util.concurrent.TimeUnit.*;
 
@@ -2131,6 +2133,39 @@ public class TestConfiguration extends TestCase {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     conf.writeXml(os);
     checkCDATA(os.toByteArray());
+  }
+
+  @Test
+  public void testConcurrentModificationDuringIteration() throws InterruptedException {
+    final Configuration conf = new Configuration();
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (true) {
+          conf.set(String.valueOf(Math.random()), String.valueOf(Math.random()));
+        }
+      }
+    }).start();
+
+    final AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
+
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (true) {
+          try {
+            conf.iterator();
+          } catch (final ConcurrentModificationException e) {
+            exceptionOccurred.set(true);
+            break;
+          }
+        }
+      }
+    }).start();
+
+    Thread.sleep(1000); //give enough time for threads to run
+
+    assertFalse("ConcurrentModificationException occurred", exceptionOccurred.get());
   }
 
   private static Configuration checkCDATA(byte[] bytes) {


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
It is possible to encounter a ConcurrentModificationException while trying to iterate a Configuration object. The iterator method tries to walk the underlying Property object without proper synchronization, so another thread simultaneously calling the set method can trigger it. setProperty method on Property object is also synchronized on the same property object.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

