### PR TITLE
HDFS-16376. Expose metrics of NodeNotChosenReason to JMX

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -5057,6 +5057,16 @@ public class BlockManager implements BlockStatsMXBean {
     blocksMap.close();
     MBeans.unregister(mxBeanName);
     mxBeanName = null;
+    BlockPlacementPolicy replicationPolicy =
+        placementPolicies.getPolicy(CONTIGUOUS);
+    if (replicationPolicy != null) {
+      replicationPolicy.clear();
+    }
+    BlockPlacementPolicy ecPolicy =
+        placementPolicies.getPolicy(STRIPED);
+    if (ecPolicy != null) {
+      ecPolicy.clear();
+    }
   }
   
   public void clear() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementMXBean.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+/**
+ * This is an interface used to retrieve statistic information related to
+ * block placement policy.
+ */
+public interface BlockPlacementMXBean {
+
+  /**
+   * The statistics of why the target nodes are not chosen.
+   *
+   * @return Get the number of reasons why the target nodes are not chosen.
+   */
+  BlockPlacementPolicyDefault.NodeNotChosenReasonMetrics getNumberOfEachNotChosenReason();
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicy.java
@@ -273,4 +273,9 @@ public abstract class BlockPlacementPolicy {
   public abstract void setExcludeSlowNodesEnabled(boolean enable);
 
   public abstract boolean getExcludeSlowNodesEnabled();
+
+  /**
+   * Clean up resources, such as MxBeans.
+   */
+  public abstract void clear();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -118,7 +118,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
   private FSClusterStats stats;
   protected long heartbeatInterval;   // interval for DataNode heartbeats
   private long staleInterval;   // interval used to identify stale DataNodes
-  private static ObjectName mxBeanName;
+  private volatile static ObjectName mxBeanName;
 
   public ObjectName getMxBeanName() {
     return mxBeanName;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -170,7 +170,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
         DFS_NAMENODE_BLOCKPLACEMENTPOLICY_EXCLUDE_SLOW_NODES_ENABLED_KEY,
         DFS_NAMENODE_BLOCKPLACEMENTPOLICY_EXCLUDE_SLOW_NODES_ENABLED_DEFAULT);
     if (mxBeanName == null) {
-      mxBeanName = MBeans.register("NameNode", "BlockPlacementStats", this);
+      registerMxBeans(this);
     }
   }
 
@@ -1401,6 +1401,14 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
 
   @Override
   public void clear() {
+    unregisterMxBeans();
+  }
+
+  private synchronized static void registerMxBeans(Object obj) {
+    mxBeanName = MBeans.register("NameNode", "BlockPlacementStats", obj);
+  }
+
+  private synchronized static void unregisterMxBeans() {
     MBeans.unregister(mxBeanName);
     mxBeanName = null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -84,7 +84,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
   private static final BlockPlacementStatus ONE_RACK_PLACEMENT =
       new BlockPlacementStatusDefault(1, 1, 1);
 
-  private static final ConcurrentHashMap<NodeNotChosenReason, LongAdder> notChosenReasonMap =
+  private static final ConcurrentHashMap<NodeNotChosenReason, LongAdder> NOT_CHOSEN_REASON_MAP =
       new ConcurrentHashMap<>();
 
   public enum NodeNotChosenReason {
@@ -1010,7 +1010,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
   }
 
   private static void incrNotChosenReasonNum(NodeNotChosenReason reason) {
-    notChosenReasonMap.computeIfAbsent(reason, k -> new LongAdder())
+    NOT_CHOSEN_REASON_MAP.computeIfAbsent(reason, k -> new LongAdder())
         .increment();
   }
 
@@ -1399,40 +1399,40 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
     return new NodeNotChosenReasonMetrics();
   }
 
-  public class NodeNotChosenReasonMetrics {
+  public static class NodeNotChosenReasonMetrics {
 
     public long getNotInService() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.NOT_IN_SERVICE, new LongAdder()).longValue();
     }
 
     public long getNodeStale() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.NODE_STALE, new LongAdder()).longValue();
     }
 
     public long getNodeTooBusy() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.NODE_TOO_BUSY, new LongAdder()).longValue();
     }
 
     public long getTooManyNodesOnRack() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.TOO_MANY_NODES_ON_RACK, new LongAdder()).longValue();
     }
 
     public long getNotEnoughStorageSpace() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.NOT_ENOUGH_STORAGE_SPACE, new LongAdder()).longValue();
     }
 
     public long getNoRequiredStorageType() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.NO_REQUIRED_STORAGE_TYPE, new LongAdder()).longValue();
     }
 
     public long getNodeSlow() {
-      return notChosenReasonMap
+      return NOT_CHOSEN_REASON_MAP
           .getOrDefault(NodeNotChosenReason.NODE_SLOW, new LongAdder()).longValue();
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -118,7 +118,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
   private FSClusterStats stats;
   protected long heartbeatInterval;   // interval for DataNode heartbeats
   private long staleInterval;   // interval used to identify stale DataNodes
-  private ObjectName mxBeanName;
+  private static ObjectName mxBeanName;
 
   public ObjectName getMxBeanName() {
     return mxBeanName;
@@ -1397,6 +1397,12 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy
   @Override
   public NodeNotChosenReasonMetrics getNumberOfEachNotChosenReason() {
     return new NodeNotChosenReasonMetrics();
+  }
+
+  @Override
+  public void clear() {
+    MBeans.unregister(mxBeanName);
+    mxBeanName = null;
   }
 
   public static class NodeNotChosenReasonMetrics {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyExcludeSlowNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyExcludeSlowNodes.java
@@ -26,6 +26,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeDataSupport;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
@@ -122,6 +126,17 @@ public class TestReplicationPolicyExcludeSlowNodes
         assertTrue(!slowPeers.contains(targets[i].getDatanodeDescriptor()
             .getDatanodeUuid()));
       }
+
+      // Fetch metrics.
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      ObjectName mxbeanNameFs =
+          new ObjectName("Hadoop:service=NameNode,name=BlockPlacementStats");
+      CompositeDataSupport metrics =
+          (CompositeDataSupport) mbs.getAttribute(mxbeanNameFs,
+              "NumberOfEachNotChosenReason");
+
+      // Assert NodeSlow.
+      assertTrue((long) metrics.get("nodeSlow") > 0);
     } finally {
       namenode.getNamesystem().writeUnlock();
     }


### PR DESCRIPTION
JIRA: [HDFS-16376](https://issues.apache.org/jira/browse/HDFS-16376).

In our cluster, we can see logs for nodes that are not chosen. But it's hard to see the percentages in each reason from the logs. It is best to add relevant metrics to monitor the entire cluster.

![image](https://user-images.githubusercontent.com/55134131/145429562-88b28729-4486-44fd-8d47-09b6a5c94864.png)

**JMX metrics:**
![block-placement-metrics](https://user-images.githubusercontent.com/55134131/145430372-d0282da3-586e-443a-87b9-7a079f31c675.jpg)
