### PR TITLE
HDFS-16377. Should CheckNotNull before access FsDatasetSpi

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -865,6 +865,7 @@ public class DataNode extends ReconfigurableBase
               .newFixedThreadPool(changedVolumes.newLocations.size());
           List<Future<IOException>> exceptions = Lists.newArrayList();
 
+          Preconditions.checkNotNull(data, "Storage not yet initialized");
           for (final StorageLocation location : changedVolumes.newLocations) {
             exceptions.add(service.submit(new Callable<IOException>() {
               @Override
@@ -967,6 +968,7 @@ public class DataNode extends ReconfigurableBase
     // Remove volumes and block infos from FsDataset.
     data.removeVolumes(storageLocations, clearFailure);
 
+    Preconditions.checkNotNull(data, "Storage not yet initialized");
     // Remove volumes from DataStorage.
     try {
       storage.removeVolumes(storageLocations);
@@ -2040,6 +2042,7 @@ public class DataNode extends ReconfigurableBase
     FileInputStream fis[] = new FileInputStream[2];
     
     try {
+      Preconditions.checkNotNull(data, "Storage not yet initialized");
       fis[0] = (FileInputStream)data.getBlockInputStream(blk, 0);
       fis[1] = DatanodeUtil.getMetaDataInputStream(blk, data);
     } catch (ClassCastException e) {
@@ -3069,6 +3072,7 @@ public class DataNode extends ReconfigurableBase
   @Override // InterDatanodeProtocol
   public ReplicaRecoveryInfo initReplicaRecovery(RecoveringBlock rBlock)
       throws IOException {
+    Preconditions.checkNotNull(data, "Storage not yet initialized");
     return data.initReplicaRecovery(rBlock);
   }
 
@@ -3079,6 +3083,7 @@ public class DataNode extends ReconfigurableBase
   public String updateReplicaUnderRecovery(final ExtendedBlock oldBlock,
       final long recoveryId, final long newBlockId, final long newLength)
       throws IOException {
+    Preconditions.checkNotNull(data, "Storage not yet initialized");
     final Replica r = data.updateReplicaUnderRecovery(oldBlock,
         recoveryId, newBlockId, newLength);
     // Notify the namenode of the updated block info. This is important
@@ -3360,7 +3365,7 @@ public class DataNode extends ReconfigurableBase
           "The block pool is still running. First do a refreshNamenodes to " +
           "shutdown the block pool service");
     }
-   
+    Preconditions.checkNotNull(data, "Storage not yet initialized");
     data.deleteBlockPool(blockPoolId, force);
   }
 
@@ -3804,6 +3809,7 @@ public class DataNode extends ReconfigurableBase
   @Override
   public List<DatanodeVolumeInfo> getVolumeReport() throws IOException {
     checkSuperuserPrivilege();
+    Preconditions.checkNotNull(data, "Storage not yet initialized");
     Map<String, Object> volumeInfoMap = data.getVolumeInfoMap();
     if (volumeInfoMap == null) {
       LOG.warn("DataNode volume info not available.");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -965,10 +965,10 @@ public class DataNode extends ReconfigurableBase
         clearFailure, Joiner.on(",").join(storageLocations)));
 
     IOException ioe = null;
+    Preconditions.checkNotNull(data, "Storage not yet initialized");
     // Remove volumes and block infos from FsDataset.
     data.removeVolumes(storageLocations, clearFailure);
 
-    Preconditions.checkNotNull(data, "Storage not yet initialized");
     // Remove volumes from DataStorage.
     try {
       storage.removeVolumes(storageLocations);


### PR DESCRIPTION
JIRA: [HDFS-16377](https://issues.apache.org/jira/browse/HDFS-16377).

When starting the DN, we found NPE in the **staring DN's log**, as follows:
![image](https://user-images.githubusercontent.com/55134131/145567811-be577f4a-169b-40a8-b1b0-90ef69cc38ba.png)

The logs of the **upstream DN** are as follows:
![image](https://user-images.githubusercontent.com/55134131/145567828-fe5677f3-6929-46b3-a095-9f0b10287961.png)

This is mainly because `FsDatasetSpi` has not been initialized at the time of access. 

I noticed that checkNotNull is already done in these two method(`DataNode#getBlockLocalPathInfo` and `DataNode#getVolumeInfo`). So we should add it to other places(interfaces that clients and other DN can access directly) so that we can add a message(`Storage not yet initialized`) when throwing exceptions.

Therefore, the client and the upstream DN know that `FsDatasetSpi` has not been initialized, rather than blindly unaware of the specific cause of the NPE.