### PR TITLE
HDFS-16378. Add datanode address to BlockReportLeaseManager logs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockReportLeaseManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockReportLeaseManager.java
@@ -224,17 +224,17 @@ class BlockReportLeaseManager {
     NodeData node = nodes.get(dn.getDatanodeUuid());
     if (node == null) {
       LOG.warn("DN {} ({}) requested a lease even though it wasn't yet " +
-          "registered.  Registering now.", dn.getDatanodeUuid(),
-          dn.getXferAddr());
+          "registered. Registering now.", dn.getDatanodeUuid(),
+          dn.getXferAddrWithHostname());
       node = registerNode(dn);
     }
     if (node.leaseId != 0) {
       // The DataNode wants a new lease, even though it already has one.
       // This can happen if the DataNode is restarted in between requesting
       // a lease and using it.
-      LOG.debug("Removing existing BR lease 0x{} for DN {} in order to " +
+      LOG.debug("Removing existing BR lease 0x{} for DN {} ({}) in order to " +
                "issue a new one.", Long.toHexString(node.leaseId),
-               dn.getDatanodeUuid());
+               dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
     }
     remove(node);
     long monotonicNowMs = Time.monotonicNow();
@@ -248,9 +248,9 @@ class BlockReportLeaseManager {
           allLeases.append(prefix).append(cur.datanodeUuid);
           prefix = ", ";
         }
-        LOG.debug("Can't create a new BR lease for DN {}, because " +
-              "numPending equals maxPending at {}.  Current leases: {}",
-              dn.getDatanodeUuid(), numPending, allLeases.toString());
+        LOG.debug("Can't create a new BR lease for DN {} ({}), because " +
+              "numPending equals maxPending at {}. Current leases: {}",
+              dn.getDatanodeUuid(), dn.getXferAddrWithHostname(), numPending, allLeases);
       }
       return 0;
     }
@@ -259,8 +259,9 @@ class BlockReportLeaseManager {
     node.leaseTimeMs = monotonicNowMs;
     pendingHead.addToEnd(node);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Created a new BR lease 0x{} for DN {}.  numPending = {}",
-          Long.toHexString(node.leaseId), dn.getDatanodeUuid(), numPending);
+      LOG.debug("Created a new BR lease 0x{} for DN {} ({}). numPending = {}",
+          Long.toHexString(node.leaseId), dn.getDatanodeUuid(),
+          dn.getXferAddrWithHostname(), numPending);
     }
     return node.leaseId;
   }
@@ -293,36 +294,36 @@ class BlockReportLeaseManager {
   public synchronized boolean checkLease(DatanodeDescriptor dn,
                                          long monotonicNowMs, long id) {
     if (id == 0) {
-      LOG.debug("Datanode {} is using BR lease id 0x0 to bypass " +
-          "rate-limiting.", dn.getDatanodeUuid());
+      LOG.debug("Datanode {} ({}) is using BR lease id 0x0 to bypass " +
+          "rate-limiting.", dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
       return true;
     }
     NodeData node = nodes.get(dn.getDatanodeUuid());
     if (node == null) {
-      LOG.info("BR lease 0x{} is not valid for unknown datanode {}",
-          Long.toHexString(id), dn.getDatanodeUuid());
+      LOG.info("BR lease 0x{} is not valid for unknown datanode {} ({})",
+          Long.toHexString(id), dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
       return false;
     }
     if (node.leaseId == 0) {
-      LOG.warn("BR lease 0x{} is not valid for DN {}, because the DN " +
+      LOG.warn("BR lease 0x{} is not valid for DN {} ({}), because the DN " +
                "is not in the pending set.",
-               Long.toHexString(id), dn.getDatanodeUuid());
+               Long.toHexString(id), dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
       return false;
     }
     if (pruneIfExpired(monotonicNowMs, node)) {
-      LOG.warn("BR lease 0x{} is not valid for DN {}, because the lease " +
-               "has expired.", Long.toHexString(id), dn.getDatanodeUuid());
+      LOG.warn("BR lease 0x{} is not valid for DN {} ({}), because the lease " +
+          "has expired.", Long.toHexString(id), dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
       return false;
     }
     if (id != node.leaseId) {
-      LOG.warn("BR lease 0x{} is not valid for DN {}.  Expected BR lease 0x{}.",
-          Long.toHexString(id), dn.getDatanodeUuid(),
+      LOG.warn("BR lease 0x{} is not valid for DN {} ({}). Expected BR lease 0x{}.",
+          Long.toHexString(id), dn.getDatanodeUuid(), dn.getXferAddrWithHostname(),
           Long.toHexString(node.leaseId));
       return false;
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace("BR lease 0x{} is valid for DN {}.",
-          Long.toHexString(id), dn.getDatanodeUuid());
+      LOG.trace("BR lease 0x{} is valid for DN {} ({}).",
+          Long.toHexString(id), dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
     }
     return true;
   }
@@ -330,20 +331,21 @@ class BlockReportLeaseManager {
   public synchronized long removeLease(DatanodeDescriptor dn) {
     NodeData node = nodes.get(dn.getDatanodeUuid());
     if (node == null) {
-      LOG.info("Can't remove lease for unknown datanode {}",
-               dn.getDatanodeUuid());
+      LOG.info("Can't remove lease for unknown datanode {} ({})",
+               dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
       return 0;
     }
     long id = node.leaseId;
     if (id == 0) {
-      LOG.debug("DN {} has no lease to remove.", dn.getDatanodeUuid());
+      LOG.debug("DN {} ({}) has no lease to remove.",
+          dn.getDatanodeUuid(), dn.getXferAddrWithHostname());
       return 0;
     }
     remove(node);
     deferredHead.addToEnd(node);
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Removed BR lease 0x{} for DN {}.  numPending = {}",
-                Long.toHexString(id), dn.getDatanodeUuid(), numPending);
+      LOG.trace("Removed BR lease 0x{} for DN {} ({}). numPending = {}",
+          Long.toHexString(id), dn.getDatanodeUuid(), dn.getXferAddrWithHostname(), numPending);
     }
     return id;
   }


### PR DESCRIPTION
JIRA: [HDFS-16378](https://issues.apache.org/jira/browse/HDFS-16378).

We should add datanode address to `BlockReportLeaseManager` logs. Because the `datanodeuuid` is not convenient for tracking.

![image](https://user-images.githubusercontent.com/55134131/145660149-8b215301-753a-49b8-b471-65f574589032.png)
