### PR TITLE
HDFS-16379. Reset fullBlockReportLeaseId after any exceptions

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -449,6 +449,8 @@ class BPServiceActor implements Runnable {
       }
       success = true;
     } finally {
+      // Reset fullBlockReportLeaseId to 0 regardless of success or failure.
+      fullBlockReportLeaseId = 0;
       // Log the block report processing stats from Datanode perspective
       long brSendCost = monotonicNow() - brSendStartTime;
       long brCreateCost = brSendStartTime - brCreateStartTime;
@@ -744,7 +746,6 @@ class BPServiceActor implements Runnable {
         }
         if ((fullBlockReportLeaseId != 0) || forceFullBr) {
           cmds = blockReport(fullBlockReportLeaseId);
-          fullBlockReportLeaseId = 0;
         }
         commandProcessingThread.enqueue(cmds);
 


### PR DESCRIPTION
JIRA: [HDFS-16379](https://issues.apache.org/jira/browse/HDFS-16379).

Recently we encountered FBR-related problems in the production environment, which were solved by introducing HDFS-12914 and HDFS-14314.

But there may be situations like this:
1 DN got `fullBlockReportLeaseId` via heartbeat.

2 DN trigger a blockReport, but some exception occurs (this may be rare, but it may exist), and then DN does multiple retries without resetting fullBlockReportLeaseId. Because fullBlockReportLeaseId is reset only if it succeeds currently.

3 After a while, the exception is cleared, but the `fullBlockReportLeaseId` has expired. Since NN did not throw an exception after the lease expired, the DN considered that the blockReport was successful. So the blockReport was not actually executed this time and needs to wait until the next time.

Therefore, should we consider resetting the `fullBlockReportLeaseId` in the finally block? The advantage of this is that lease expiration can be avoided. The downside is that each heartbeat will apply for a new `fullBlockReportLeaseId` during the exception, but I think this cost is negligible.