### PR TITLE
HDFS-11242. Support refreshTopology

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2427,6 +2427,21 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
   }
 
   /**
+   * Refresh cluster's network topology.
+   * See {@link ClientProtocol#refreshTopology(String)}
+   * for more details.
+   * @param ipAddr the IP-address of the node to refresh
+   * @return true if refresh is successful, false otherwise.
+   * @throws IOException
+   */
+  public boolean refreshTopology(String ipAddr) throws IOException {
+    checkOpen();
+    try (TraceScope ignored = tracer.newScope("refreshTopology")) {
+      return namenode.refreshTopology(ipAddr);
+    }
+  }
+
+  /**
    * Dumps DFS data structures into specified file.
    *
    * @see ClientProtocol#metaSave(String)

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -1692,6 +1692,17 @@ public class DistributedFileSystem extends FileSystem
   }
 
   /**
+   * Refresh the cluster's network topology. Requires super-user privileges.
+   * @param ipAddr the IP-address of the node to refresh
+   * @return true if refresh succeeds. false otherwise.
+   *         in this case.
+   * @throws IOException
+   */
+  public boolean refreshTopology(String ipAddr) throws IOException {
+    return dfs.refreshTopology(ipAddr);
+  }
+
+  /**
    * Finalize previously upgraded files system state.
    * @throws IOException
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -981,7 +981,8 @@ public interface ClientProtocol {
   /**
    * Tells the namenode to refresh cluster's network topology.
    * @param ipAddr the IP-address of the node to refresh
-   * @throws IOException
+   * @return true if refresh is successful, false otherwise.
+   * @throws IOException If an I/O error occurred
    */
   @Idempotent
   boolean refreshTopology(String ipAddr) throws IOException;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -979,6 +979,14 @@ public interface ClientProtocol {
   void refreshNodes() throws IOException;
 
   /**
+   * Tells the namenode to refresh cluster's network topology.
+   * @param ipAddr the IP-address of the node to refresh
+   * @throws IOException
+   */
+  @Idempotent
+  boolean refreshTopology(String ipAddr) throws IOException;
+
+  /**
    * Finalize previous upgrade.
    * Remove file system state saved during the upgrade.
    * The upgrade will become irreversible.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -171,6 +171,7 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.MsyncR
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.OpenFilesBatchResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RecoverLeaseRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshNodesRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshTopologyRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCacheDirectiveRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCachePoolRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.Rename2RequestProto;
@@ -889,6 +890,19 @@ public class ClientNamenodeProtocolTranslatorPB implements
   public void refreshNodes() throws IOException {
     try {
       rpcProxy.refreshNodes(null, VOID_REFRESH_NODES_REQUEST);
+    } catch (ServiceException e) {
+      throw ProtobufHelper.getRemoteException(e);
+    }
+  }
+
+  @Override
+  public boolean refreshTopology(String ipAddr) throws IOException {
+    RefreshTopologyRequestProto req = RefreshTopologyRequestProto
+        .newBuilder()
+        .setIpAddr(ipAddr)
+        .build();
+    try {
+      return rpcProxy.refreshTopology(null, req).getResult();
     } catch (ServiceException e) {
       throw ProtobufHelper.getRemoteException(e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
@@ -470,6 +470,14 @@ message RefreshNodesRequestProto { // no parameters
 message RefreshNodesResponseProto { // void response
 }
 
+message RefreshTopologyRequestProto {
+  required string ipAddr = 1;
+}
+
+message RefreshTopologyResponseProto {
+  required bool result = 1;
+}
+
 message FinalizeUpgradeRequestProto { // no parameters
 }
 
@@ -931,6 +939,7 @@ service ClientNamenodeProtocol {
   rpc restoreFailedStorage(RestoreFailedStorageRequestProto)
       returns(RestoreFailedStorageResponseProto);
   rpc refreshNodes(RefreshNodesRequestProto) returns(RefreshNodesResponseProto);
+  rpc refreshTopology(RefreshTopologyRequestProto) returns(RefreshTopologyResponseProto);
   rpc finalizeUpgrade(FinalizeUpgradeRequestProto)
       returns(FinalizeUpgradeResponseProto);
   rpc upgradeStatus(UpgradeStatusRequestProto)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1130,6 +1130,26 @@ public class RouterClientProtocol implements ClientProtocol {
   }
 
   @Override
+  public boolean refreshTopology(String ipAddr) throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    RemoteMethod method = new RemoteMethod(
+        "refreshTopology", new Class<?>[] {String.class}, ipAddr);
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    Map<FederationNamespaceInfo, Boolean> ret =
+        rpcClient.invokeConcurrent(nss, method, true, true, boolean.class);
+
+    boolean success = true;
+    for (boolean s : ret.values()) {
+      if (!s) {
+        success = false;
+        break;
+      }
+    }
+    return success;
+  }
+
+  @Override
   public void finalizeUpgrade() throws IOException {
     rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -1195,6 +1195,11 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   }
 
   @Override // ClientProtocol
+  public boolean refreshTopology(String ipAddr) throws IOException {
+    return clientProto.refreshTopology(ipAddr);
+  }
+
+  @Override // ClientProtocol
   public void finalizeUpgrade() throws IOException {
     clientProto.finalizeUpgrade();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -196,6 +196,8 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.Recove
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RecoverLeaseResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshNodesRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshNodesResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshTopologyRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RefreshTopologyResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCacheDirectiveRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCacheDirectiveResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RemoveCachePoolRequestProto;
@@ -970,6 +972,17 @@ public class ClientNamenodeProtocolServerSideTranslatorPB implements
       throw new ServiceException(e);
     }
 
+  }
+
+  @Override
+  public RefreshTopologyResponseProto refreshTopology(RpcController controller,
+      RefreshTopologyRequestProto request) throws ServiceException {
+    try {
+      boolean result = server.refreshTopology(request.getIpAddr());
+      return RefreshTopologyResponseProto.newBuilder().setResult(result).build();
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5052,6 +5052,13 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     logAuditEvent(true, operationName, null);
   }
 
+  boolean refreshTopology(String ipAddr) throws IOException {
+    checkOperation(OperationCategory.UNCHECKED);
+    checkSuperuserPrivilege();
+    return getBlockManager().getDatanodeManager()
+        .refreshTopology(new HdfsConfiguration(), ipAddr);
+  }
+
   void setBalancerBandwidth(long bandwidth) throws IOException {
     String operationName = "setBalancerBandwidth";
     checkOperation(OperationCategory.WRITE);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1327,6 +1327,12 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     namesystem.refreshNodes();
   }
 
+  @Override // ClientProtocol
+  public boolean refreshTopology(String ipAddr) throws IOException {
+    checkNNStartup();
+    return namesystem.refreshTopology(ipAddr);
+  }
+
   @Override // NamenodeProtocol
   public long getTransactionID() throws IOException {
     String operationName = "getTransactionID";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -439,7 +439,7 @@ public class DFSAdmin extends FsShell {
     "\t[-rollEdits]\n" +
     "\t[-restoreFailedStorage true|false|check]\n" +
     "\t[-refreshNodes]\n" +
-    "\t[-refreshTopology <ipAddr>]\n" +
+      "\t[-refreshTopology <ipAddr>]\n" +
     "\t[" + SetQuotaCommand.USAGE + "]\n" +
     "\t[" + ClearQuotaCommand.USAGE +"]\n" +
     "\t[" + SetSpaceQuotaCommand.USAGE + "]\n" +

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRefreshTopology.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRefreshTopology.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.namenode;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology.NNConf;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology.NSConf;
+import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
+import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
+import org.apache.hadoop.net.StaticMapping;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestRefreshTopology {
+  private MiniDFSCluster cluster = null;
+  private final String[] locations =
+      {"/r1/d1", "/r1/d2", "/r1/d3", "/r2/d4", "/r2/d5" };
+  private final Configuration conf = new Configuration();
+  private StaticMapping mapping;
+
+  @Before
+  public void setUp() throws IOException {
+    MiniDFSNNTopology topology = new MiniDFSNNTopology().addNameservice(
+        new NSConf("ns").addNN(new NNConf(null)));
+    mapping = newInstance();
+    conf.set(StaticMapping.KEY_HADOOP_CONFIGURED_NODE_MAPPING,
+        "dn1=/r1/d1,dn2=/r1/d2,dn3=/r1/d3,dn4=/r2/d4,dn5=/r2/d5");
+    mapping.setconf(conf);
+    final String[] hosts = {"dn1", "dn2", "dn3", "dn4", "dn5"};
+    cluster = new MiniDFSCluster.Builder(conf).nnTopology(topology)
+        .numDataNodes(5).hosts(hosts).build();
+  }
+
+  @Test
+  public void testOriginalTopology() {
+    int matchCount = 0;
+    DatanodeManager dnManager = cluster.getNameNode().getNamesystem()
+        .getBlockManager().getDatanodeManager();
+    for (DatanodeDescriptor descriptor : dnManager.getDatanodes()) {
+      if (descriptor.getNetworkLocation().equals(locations[0])
+          || descriptor.getNetworkLocation().equals(locations[1])
+          || descriptor.getNetworkLocation().equals(locations[2])
+          || descriptor.getNetworkLocation().equals(locations[3])
+          || descriptor.getNetworkLocation().equals(locations[4])) {
+        matchCount++;
+      }
+    }
+    Assert.assertEquals(matchCount, locations.length);
+  }
+
+  @Test
+  public void testRefreshTopology() throws IOException {
+    Map<String, String> oldMapping = mapping.getSwitchMap();
+    StaticMapping.resetMap();
+    StaticMapping.addNodeToRack("dn1", "/r2/d1");
+    StaticMapping.addNodeToRack("dn2", "/r2/d2");
+    StaticMapping.addNodeToRack("dn3", "/r1/d3"); // dn3's topology remains.
+    StaticMapping.addNodeToRack("dn4", "/r1/d4");
+    StaticMapping.addNodeToRack("dn5", "/r3/d5");
+
+    DatanodeManager dnManager = cluster.getNameNode().getNamesystem()
+        .getBlockManager().getDatanodeManager();
+    // refresh topology
+    Assert.assertTrue(dnManager.refreshTopology(conf, "dn1"));
+    Assert.assertTrue(dnManager.refreshTopology(conf, "dn2"));
+    Assert.assertTrue(dnManager.refreshTopology(conf, "dn3"));
+    Assert.assertTrue(dnManager.refreshTopology(conf, "dn4"));
+    Assert.assertTrue(dnManager.refreshTopology(conf, "dn5"));
+
+    int match = 0;
+    for (DatanodeDescriptor descriptor : dnManager.getDatanodes()) {
+      if (descriptor.getNetworkLocation().equals("/r2/d1")
+          || descriptor.getNetworkLocation().equals("/r2/d2")
+          || descriptor.getNetworkLocation().equals("/r1/d3")
+          || descriptor.getNetworkLocation().equals("/r1/d4")
+          || descriptor.getNetworkLocation().equals("/r3/d5")) {
+        match++;
+      }
+    }
+    Assert.assertEquals(match, 5);
+
+    int changed = 0;
+    for (DatanodeDescriptor descriptor : dnManager.getDatanodes()) {
+      if (!oldMapping.containsValue(descriptor.getNetworkLocation())) {
+        changed++;
+      }
+    }
+    Assert.assertEquals(changed, 4);
+  }
+
+  private StaticMapping newInstance() {
+    StaticMapping.resetMap();
+    return new StaticMapping();
+  }
+}


### PR DESCRIPTION
### Description of PR

1. Support refreshing topology of clients/datanodes in NameNode
2. Usage: `hdfs dfsadmin -refreshTopology <ipAddr>`
3. Based on the patch `HDFS-11242.002.patch` at https://issues.apache.org/jira/browse/HDFS-11242 with the following changes
    - Rebase to `trunk`
    - Change from refreshing all nodes to a specific node, as the former holds the lock for a long time 

### How was this patch tested?

1. Tested with UT
2. Tested in a real HDFS cluster
```
$ hdfs dfsadmin -fs hdfs://test -refreshTopology 1.2.3.4
Refresh topology successful at active-namenode/1.1.1.1:8020 for 1.2.3.4
Refresh topology successful at standby-namenode/1.1.1.2:8020 for 1.2.3.4
Refresh topology successful at observer-namenode/1.1.1.3:8020 for 1.2.3.4
```

### Note

1. It is also ok to pass in a hostname instead of an IP address, as keys of the cache may be hostnames sometimes.

