### PR TITLE
HADOOP-18043. Use mina-core 2.0.22 to fix LDAP unit test failures

### DIFF
--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -276,3 +276,4 @@
     </profile>
   </profiles>
 </project>
+

--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -276,4 +276,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1015,7 +1015,7 @@
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.1.5</version>
+        <version>2.0.22</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-18043 Use mina-core 2.0.22 to fix unit test failures in hadoop-auth module.

### How was this patch tested?

Ran unit tests manually

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- n/a Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
