### PR TITLE
HADOOP-18048. [branch-3.3] Dockerfile_aarch64 build fails with fatal error: Python.h: No such file or directory

### DIFF
--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -74,6 +74,7 @@ RUN apt-get -q update \
         pkg-config \
         python2.7 \
         python3 \
+        python3-dev \
         python3-pip \
         python3-pkg-resources \
         python3-setuptools \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18048

Explicitly include package `python3-dev` to ensure that `Python.h` would be in the header search path.