### PR TITLE
HDFS-16385. Fix Datanode retrieve slownode information bug.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
@@ -152,6 +152,7 @@ public class DatanodeProtocolServerSideTranslatorPB implements
     }
 
     builder.setFullBlockReportLeaseId(response.getFullBlockReportLeaseId());
+    builder.setIsSlownode(response.getIsSlownode());
     return builder.build();
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
in HDFS-16320, the DataNode will retrieve the SLOW status from each NameNode. But it didn't set isSlowNode to HeartbeatResponseProto in DatanodeProtocolServerSideTranslatorPB#sendHeartbeat.

### How was this patch tested?
I constructed some slownode scenarios to test getting the slownode results correctly.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

