### PR TITLE
HDFS-16387.[FGL]Access to Create File is more secure.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirWriteFileOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirWriteFileOp.java
@@ -402,10 +402,16 @@ class FSDirWriteFileOp {
     INodesInPath parent = FSDirMkdirOp.createMissingDirs(fsd,
         iip.getParentINodesInPath(), permissions, true);
     if (parent != null) {
-      iip = addFile(fsd, parent, iip.getLastLocalName(), permissions,
-          replication, blockSize, holder, clientMachine, shouldReplicate,
-          ecPolicyName, storagePolicy);
-      newNode = iip != null ? iip.getLastINode().asFile() : null;
+      try {
+        fsn.writeUnlock();
+        fsn.writeLock();
+        iip = addFile(fsd, parent, iip.getLastLocalName(), permissions,
+            replication, blockSize, holder, clientMachine, shouldReplicate,
+            ecPolicyName, storagePolicy);
+        newNode = iip != null ? iip.getLastINode().asFile() : null;
+      } finally {
+        fsn.writeUnlock();
+      }
     }
     if (newNode == null) {
       throw new IOException("Unable to add " + src +  " to namespace");


### PR DESCRIPTION

### Description of PR
When creating files through RPC, sometimes a deadlock is triggered.
The purpose of this pr is to make it more secure.
Details: HDFS-16387

### How was this patch tested?
Use the existing test, that's ok.

