### PR TITLE
HADOOP-18049. Pin python lazy-object-proxy to 1.6.0 in Docker file as newer versions are incompatible with python2.7

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -183,7 +183,8 @@ RUN apt-get -q update \
 RUN pip2 install \
     configparser==4.0.2 \
     pylint==1.9.2 \
-    isort==4.3.21
+    isort==4.3.21 \
+    lazy-object-proxy==1.6.0
 
 ####
 # Install dateutil.parser

--- a/dev-support/docker/pkg-resolver/install-common-pkgs.sh
+++ b/dev-support/docker/pkg-resolver/install-common-pkgs.sh
@@ -19,4 +19,4 @@
 ######
 # Install pylint and python-dateutil
 ######
-pip2 install configparser==4.0.2 pylint==1.9.2 isort==4.3.21 python-dateutil==2.7.3
+pip2 install configparser==4.0.2 pylint==1.9.2 isort==4.3.21 lazy-object-proxy==1.6.0 python-dateutil==2.7.3


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?
`./start-build-env.sh` executes without failure.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

