### PR TITLE
HDFS-16168. Fix TestHDFSFileSystemContract.testAppend timeout

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHDFSFileSystemContract.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestHDFSFileSystemContract.java
@@ -63,7 +63,12 @@ public class TestHDFSFileSystemContract extends FileSystemContractBaseTest {
     return defaultWorkingDirectory;
   }
 
-  @Test(timeout = 60000)
+  @Override
+  protected int getGlobalTimeout() {
+    return 60 * 1000;
+  }
+
+  @Test
   public void testAppend() throws IOException {
     AppendTestUtil.testAppend(fs, new Path("/testAppend/f"));
   }


### PR DESCRIPTION
### Description of PR

1. Fix random timeout failures of TestHDFSFileSystemContract.testAppend

### How was this patch tested?

1. UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

