### PR TITLE
YARN-11053. AuxService should not use class name as default system classes

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/AuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/AuxServices.java
@@ -240,7 +240,7 @@ public class AuxServices extends AbstractService
     }
 
     return AuxiliaryServiceWithCustomClassLoader.getInstance(conf, className,
-        appLocalClassPath, getSystemClasses(service, className));
+        appLocalClassPath, getSystemClasses(service));
   }
 
   /**
@@ -292,7 +292,7 @@ public class AuxServices extends AbstractService
           + " is using the custom classloader with classpath " + destFiles);
       return AuxiliaryServiceWithCustomClassLoader.getInstance(conf,
           className, StringUtils.join(File.pathSeparatorChar, destFiles),
-          getSystemClasses(service, className));
+          getSystemClasses(service));
     } else {
       return createAuxServiceFromConfiguration(service);
     }
@@ -681,15 +681,12 @@ public class AuxServices extends AbstractService
     return serviceConf.getProperty(CLASS_NAME);
   }
 
-  private static String[] getSystemClasses(AuxServiceRecord service, String
-      className) {
-    AuxServiceConfiguration serviceConf =
-        service.getConfiguration();
-    if (serviceConf == null) {
-      return new String[]{className};
+  private static String[] getSystemClasses(AuxServiceRecord service) {
+    AuxServiceConfiguration serviceConf = service.getConfiguration();
+    if (serviceConf == null || serviceConf.getProperty(SYSTEM_CLASSES) == null) {
+      return new String[]{};
     }
-    return StringUtils.split(serviceConf.getProperty(SYSTEM_CLASSES,
-        className));
+    return StringUtils.split(serviceConf.getProperty(SYSTEM_CLASSES));
   }
 
   /**


### PR DESCRIPTION
### Description of PR

[YARN-11053] AuxService should not use class name as default system classes

Currently, if `yarn.nodemanager.aux-services.spark_shuffle.system-classes` is absent, yarn will treat `yarn.nodemanager.aux-services.spark_shuffle.class` as the system classes, and use system ClassLoader rather than AuxServiceClassLoader to load aux service entry class, then cause ClassNotFound exception.

### How was this patch tested?

Existing UTs.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

