### PR TITLE
HADOOP-18052. Support Apple Silicon in start-build-env.sh

### DIFF
--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -23,7 +23,7 @@ DOCKER_DIR=dev-support/docker
 DOCKER_FILE="${DOCKER_DIR}/Dockerfile"
 
 CPU_ARCH=$(echo "$MACHTYPE" | cut -d- -f1)
-if [ "$CPU_ARCH" = "aarch64" ]; then
+if [[ "$CPU_ARCH" = "aarch64" || "$CPU_ARCH" = "arm64" ]]; then
   DOCKER_FILE="${DOCKER_DIR}/Dockerfile_aarch64"
 fi
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Use Dockerfile_aarch64 in Apple Silicon.

### How was this patch tested?

Manually tested in M1 Pro MBP. However, Docker for Mac with Apple Silicon is too slow to develop.

```
bash-3.2$ echo $MACHTYPE
arm64-apple-darwin21
bash-3.2$ echo "$MACHTYPE" | cut -d- -f1
arm64
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- n/a Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
