### PR TITLE
HDFS-16395. Remove useless NNThroughputBenchmark#dummyActionNoSynch().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/NNThroughputBenchmark.java
@@ -578,11 +578,6 @@ public class NNThroughputBenchmark implements Tool {
       }
     }
 
-    void dummyActionNoSynch(int daemonId, int fileIdx) {
-      for(int i=0; i < 2000; i++)
-        fileNames[daemonId][fileIdx].contains(""+i);
-    }
-
     /**
      * returns client name
      */
@@ -598,7 +593,6 @@ public class NNThroughputBenchmark implements Tool {
     long executeOp(int daemonId, int inputIdx, String clientName) 
     throws IOException {
       long start = Time.now();
-      // dummyActionNoSynch(fileIdx);
       clientProto.create(fileNames[daemonId][inputIdx],
           FsPermission.getDefault(), clientName,
           new EnumSetWritable<CreateFlag>(EnumSet


### PR DESCRIPTION
HDFS-16395

### Description of PR
It looks like NNThroughputBenchmark#dummyActionNoSynch() has been deprecated and it should be deleted.

### How was this patch tested?
For testing, there is not much pressure.

