### PR TITLE
HADOOP-18057. Fix typo: validateEncrytionSecrets -> validateEncryptio…

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -104,7 +104,7 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
   @Test
   public void testEncryption() throws Throwable {
     requireEncryptedFileSystem();
-    validateEncrytionSecrets(getFileSystem().getEncryptionSecrets());
+    validateEncryptionSecrets(getFileSystem().getEncryptionSecrets());
     for (int size: SIZES) {
       validateEncryptionForFilesize(size);
     }
@@ -116,7 +116,7 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     byte[] data = dataset(1024, 'a', 'z');
     S3AFileSystem fs = getFileSystem();
     EncryptionSecrets secrets = fs.getEncryptionSecrets();
-    validateEncrytionSecrets(secrets);
+    validateEncryptionSecrets(secrets);
     writeDataset(fs, src, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, src, data);
     // this file will be encrypted
@@ -135,7 +135,7 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
    * This makes sure that the settings have propagated properly.
    * @param secrets encryption secrets of the filesystem.
    */
-  protected void validateEncrytionSecrets(final EncryptionSecrets secrets) {
+  protected void validateEncryptionSecrets(final EncryptionSecrets secrets) {
     assertNotNull("No encryption secrets for filesystem", secrets);
     S3AEncryptionMethods sseAlgorithm = getSSEAlgorithm();
     assertEquals("Filesystem has wrong encryption algorithm",

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionWithDefaultS3Settings.java
@@ -135,7 +135,7 @@ public class ITestS3AEncryptionWithDefaultS3Settings extends
     Path src = path(createFilename(1024));
     byte[] data = dataset(1024, 'a', 'z');
     EncryptionSecrets secrets = fs.getEncryptionSecrets();
-    validateEncrytionSecrets(secrets);
+    validateEncryptionSecrets(secrets);
     writeDataset(fs, src, data, data.length, 1024 * 1024, true);
     ContractTestUtils.verifyFileContents(fs, src, data);
 


### PR DESCRIPTION
### Description of PR
Fix typo: `validateEncrytionSecrets` -> `validateEncryptionSecrets`

* JIRA: https://issues.apache.org/jira/browse/HADOOP-18057
