### PR TITLE
HADOOP-18045. Disable TestDynamometerInfra

### DIFF
--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
@@ -76,6 +76,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,6 +112,7 @@ import static org.junit.Assert.fail;
  * property to point directly to a Hadoop tarball which is present locally and
  * no download will occur.
  */
+@Ignore
 public class TestDynamometerInfra {
 
   private static final Logger LOG =


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Disable TestDynamometerInfra.
JIRA: HADOOP-18045

### How was this patch tested?

Ran the following command after applying the patch:
```
% mvn clean test -Dtest=TestDynamometerInfra
(snip)
[INFO] Running org.apache.hadoop.tools.dynamometer.TestDynamometerInfra
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.007 s - in org.apache.hadoop.tools.dynamometer.TestDynamometerInfra
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- n/a Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
