### PR TITLE
YARN-11054. Alleviate LocalJobRunnerMetricName Conflicts

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerMetrics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerMetrics.java
@@ -44,7 +44,7 @@ final class LocalJobRunnerMetrics {
   public static LocalJobRunnerMetrics create() {
     MetricsSystem ms = DefaultMetricsSystem.initialize("JobTracker");
     return ms.register("LocalJobRunnerMetrics-" +
-            ThreadLocalRandom.current().nextInt(), null,
+            ThreadLocalRandom.current().nextLong(), null,
         new LocalJobRunnerMetrics());
   }
 


### PR DESCRIPTION
### Description of PR
In some scenarios, Sqoop will use LocalJobRuner (YarnLocal mode) to run massive jobs,  assuming  2 million jobs have been run. Considering LocalJobRunner MetricName generated by nextInt function is in the range of (0, 2147483647),
The conflict probability will be about 2000000/2147483647 = 1/1000, which means that an average of one fail task for every more 1000 jobs run.
If LocalJobRunner MetricName is generated by nextLong() whose range is (0, 9223372036854775807), considering that Long's range is 1 billion times that of Int, the conflict probability is also decreased by one trillionth times.
the conflict probability goes to 1/1000000000 from 1/1000, which alleviate LocalJobRunnerMetricName conflicts a lot.

### How was this patch tested?
With long-time test, the conflict probability decreases a lot

### For code changes:

- [Y] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [Y] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [Y] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [y] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

