### PR TITLE
HADOOP-18059. Make reloadCachedMappings and resolve consistent

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/CachedDNSToSwitchMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/CachedDNSToSwitchMapping.java
@@ -156,6 +156,8 @@ public class CachedDNSToSwitchMapping extends AbstractDNSToSwitchMapping {
 
   @Override
   public void reloadCachedMappings(List<String> names) {
+    // normalize all input names to be in the form of IP addresses
+    names = NetUtils.normalizeHostNames(names);
     for (String name : names) {
       cache.remove(name);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestCachedDNSToSwitchMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestCachedDNSToSwitchMapping.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.net;
 
 import org.junit.Assert;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestCachedDNSToSwitchMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestCachedDNSToSwitchMapping.java
@@ -1,0 +1,27 @@
+package org.apache.hadoop.net;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestCachedDNSToSwitchMapping {
+
+  @Test
+  public void testReloadCachedMappings() {
+    StaticMapping.resetMap();
+    StaticMapping.addNodeToRack("127.0.0.1", "/rack0");
+    StaticMapping.addNodeToRack("notexisit.host.com", "/rack1");
+    CachedDNSToSwitchMapping cacheMapping =
+        new CachedDNSToSwitchMapping(new StaticMapping());
+    List<String> names = new ArrayList<>();
+    names.add("localhost");
+    names.add("notexisit.host.com");
+    cacheMapping.resolve(names);
+    Assert.assertTrue(cacheMapping.getSwitchMap().containsKey("127.0.0.1"));
+    Assert.assertTrue(cacheMapping.getSwitchMap().containsKey("notexisit.host.com"));
+    cacheMapping.reloadCachedMappings(names);
+    Assert.assertEquals(0, cacheMapping.getSwitchMap().keySet().size());
+  }
+}


### PR DESCRIPTION
### Description of PR

1. Make CachedDNSToSwitchMapping#reloadCachedMappings and CachedDNSToSwitchMapping#resolve consistent

### How was this patch tested?

1. UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

