### PR TITLE
HDFS-16401.Remove the worthless DatasetVolumeChecker#numAsyncDatasetChecks.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/checker/DatasetVolumeChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/checker/DatasetVolumeChecker.java
@@ -77,7 +77,6 @@ public class DatasetVolumeChecker {
 
   private final AtomicLong numVolumeChecks = new AtomicLong(0);
   private final AtomicLong numSyncDatasetChecks = new AtomicLong(0);
-  private final AtomicLong numAsyncDatasetChecks = new AtomicLong(0);
   private final AtomicLong numSkippedChecks = new AtomicLong(0);
 
   /**


### PR DESCRIPTION
### Description of PR
It seems that cleaning up DatasetVolumeChecker#numAsyncDatasetChecks was ignored before this.
Details: HDFS-16401

### How was this patch tested?
For testing, there is not much pressure.
