### PR TITLE
HDFS-16169. Fix TestBlockTokenWithDFSStriped#testEnd2End failure

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
@@ -1687,6 +1687,11 @@ public class TestBalancer {
       BalancerParameters p = BalancerParameters.DEFAULT;
       runBalancer(conf, totalUsedSpace, totalCapacity, p, 0);
 
+      // namenode will ask datanode to delete replicas in heartbeat response
+      cluster.triggerHeartbeats();
+      // namenode will update block locations according to the report
+      cluster.triggerDeletionReports();
+
       // verify locations of striped blocks
       locatedBlocks = client.getBlockLocations(fileName, 0, fileLen);
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks, groupSize);


### PR DESCRIPTION
### Description of PR

1. Fix TestBlockTokenWithDFSStriped#testEnd2End failure

### How was this patch tested?

1. Run TestBlockTokenWithDFSStriped#testEnd2End 30 times, the `trunk` version failed `5` times, the version with this patch failed `0` times.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

