### PR TITLE
YARN-11055. Add missing newline in cgroups-operations.c

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/modules/cgroups/cgroups-operations.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/modules/cgroups/cgroups-operations.c
@@ -114,7 +114,7 @@ int update_cgroups_parameters(
 
   if (!full_path) {
     fprintf(ERRORFILE,
-      "Failed to get cgroups path to write, it should be a configuration issue");
+      "Failed to get cgroups path to write, it should be a configuration issue\n");
     failure = 1;
     goto cleanup;
   }
@@ -127,7 +127,7 @@ int update_cgroups_parameters(
   // Make sure file exists
   struct stat sb;
   if (stat(full_path, &sb) != 0) {
-    fprintf(ERRORFILE, "CGroups: Could not find file to write, %s", full_path);
+    fprintf(ERRORFILE, "CGroups: Could not find file to write, %s\n", full_path);
     failure = 1;
     goto cleanup;
   }
@@ -139,18 +139,18 @@ int update_cgroups_parameters(
   FILE *f;
   f = fopen(full_path, "a");
   if (!f) {
-    fprintf(ERRORFILE, "CGroups: Failed to open cgroups file, %s", full_path);
+    fprintf(ERRORFILE, "CGroups: Failed to open cgroups file, %s\n", full_path);
     failure = 1;
     goto cleanup;
   }
   if (fprintf(f, "%s", value) < 0) {
-    fprintf(ERRORFILE, "CGroups: Failed to write cgroups file, %s", full_path);
+    fprintf(ERRORFILE, "CGroups: Failed to write cgroups file, %s\n", full_path);
     fclose(f);
     failure = 1;
     goto cleanup;
   }
   if (fclose(f) != 0) {
-    fprintf(ERRORFILE, "CGroups: Failed to close cgroups file, %s", full_path);
+    fprintf(ERRORFILE, "CGroups: Failed to close cgroups file, %s\n", full_path);
     failure = 1;
     goto cleanup;
   }


### PR DESCRIPTION
### Description of PR
Adding missing newline characters in the end of fprintf format strings in cgroups-operations.c

### How was this patch tested?
pseudo-distributed deploy https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/UsingGpus.md#distributed-shell--gpu-with-docker
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

