### PR TITLE
HDFS-16408. Negative LeaseRecheckIntervalMs will let LeaseMonitor loop forever and print huge amount of log

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1014,6 +1014,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       this.leaseRecheckIntervalMs = conf.getLong(
           DFS_NAMENODE_LEASE_RECHECK_INTERVAL_MS_KEY,
           DFS_NAMENODE_LEASE_RECHECK_INTERVAL_MS_DEFAULT);
+      Preconditions.checkArgument(
+              leaseRecheckIntervalMs > 0,
+              DFSConfigKeys.DFS_NAMENODE_LEASE_RECHECK_INTERVAL_MS_KEY +
+                      " must be greater than zero");
       this.maxLockHoldToReleaseLeaseMs = conf.getLong(
           DFS_NAMENODE_MAX_LOCK_HOLD_TO_RELEASE_LEASE_MS_KEY,
           DFS_NAMENODE_MAX_LOCK_HOLD_TO_RELEASE_LEASE_MS_DEFAULT);


### PR DESCRIPTION

### Description of PR
Add Preconditions.checkArgument() to ensure the leaseRecheckIntervalMs cannot get set to a value less than or equal to zero. 

It avoids negative intervals that cause LeaseMonitor to be in a constant state of fast printing exception logs

JIRA: [HDFS-16408](https://issues.apache.org/jira/browse/HDFS-16408)

### How was this patch tested?
when the configuration item 'dfs.namenode.lease-recheck-interval-ms' is accidentally set to a negative number, origin code will print warning log again and again immediately. This problem can be eliminated after using this patch.

