### PR TITLE
YARN-10922. Verify if legacy AQC works as documented

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -331,7 +331,7 @@ public class TestAppManager extends AppManagerTestBase{
     csConf.set(PREFIX + "root.test.acl_submit_applications", "test");
     csConf.set(PREFIX + "root.test.acl_administer_queue", "test");
 
-    asContext.setQueue("test");
+    asContext.setQueue("oldQueue");
 
     MockRM newMockRM = new MockRM(csConf);
     RMContext newMockRMContext = newMockRM.getRMContext();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -358,7 +358,7 @@ public class TestAppManager extends AppManagerTestBase{
   }
 
   @Test
-  public void testQueueSubmitWithACLsEnabledWithQueueMappingForAutoCreatedQueue()
+  public void testQueueSubmitWithACLsEnabledWithQueueMappingForLegacyAutoCreatedQueue()
       throws IOException, YarnException {
     YarnConfiguration conf = new YarnConfiguration();
     conf.set(YarnConfiguration.YARN_ACL_ENABLE, "true");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/CapacityScheduler.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/CapacityScheduler.md
@@ -642,9 +642,9 @@ support other pre-configured queues to co-exist along with auto-created queues. 
 
 The parent queue which has been enabled for auto leaf queue creation, supports
  the configuration of template parameters for automatic configuration of the auto-created leaf queues. The auto-created queues support all the
- leaf queue configuration parameters. There is one caveat to the QueueACLs: at auto queue creation the Queue ACLs in the leaf queue templates are not in effect yet,
- the parent's QueueACLs determines whether the queue can be created by the user. When the auto-created leaf queue already exists then the QueueACLs in the leaf queue template
- also applies.
+ leaf queue configuration parameters. There is one caveat to the QueueACLs: at the time of queue auto creation the Queue ACLs in the leaf queue templates are not in effect yet,
+ hence the parent's QueueACLs control the queue creation at application submission. When the auto-created leaf queue already exists then the QueueACLs in the leaf queue template
+ are also evaluated.
 
 | Property | Description |
 |:---- |:---- |

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/CapacityScheduler.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/CapacityScheduler.md
@@ -640,11 +640,11 @@ support other pre-configured queues to co-exist along with auto-created queues. 
 
 * Configuring **legacy** `Auto-Created Leaf Queues` with `CapacityScheduler`
 
-The parent queue which has been enabled for auto leaf queue creation,supports
- the configuration of template parameters for automatic configuration of the auto-created leaf queues. The auto-created queues support all of the
- leaf queue configuration parameters except for **Queue ACL**, **Absolute
- Resource** configurations. Queue ACLs are
- currently inherited from the parent queue i.e they are not configurable on the leaf queue template
+The parent queue which has been enabled for auto leaf queue creation, supports
+ the configuration of template parameters for automatic configuration of the auto-created leaf queues. The auto-created queues support all the
+ leaf queue configuration parameters. There is one caveat to the QueueACLs: at auto queue creation the Queue ACLs in the leaf queue templates are not in effect yet,
+ the parent's QueueACLs determines whether the queue can be created by the user. When the auto-created leaf queue already exists then the QueueACLs in the leaf queue template
+ also applies.
 
 | Property | Description |
 |:---- |:---- |


### PR DESCRIPTION
 - Absolute resource can be configured for dynamically created queues with Legacy AQC, see the new test case in (YARN-11033). It is possible to configure the parent with Absolute resource and the child with Percentage mode using the leaf-queue-template, that leads to this bug (YARN-11010). 

 - QueueACL are partially supported, they can be configured for dynamically created queues with Legacy AQC leaf-queue-template. If a dynamically created queue exists already, then the ACLs configured with the leaf-queue-template applies for that queue. However at queue creation those ACLs are not in effect, that's why I call it partial support. Also the scheduler response doesn't show the ACLs in auto created queue's configuration, which is misleading.

Absolute Resource:

  Question#1: Should I report a bug for a missing config validation for the Absolute+Percentage mix?

QueueACL:

  Question#2-a: Should the documentation be updated with the QueueACLs current behaviour? IMHO it's hard to explain and I don't think this behaviour was intended.

  Question#2-b: Should I report a bug to eliminate this partial support for QueueACL? The new Flexible Auto Queue Creation doesn't support it either, that works as it is documented.

  Question#3b: Should I report bugs to improve the QueueACL support on the Legacy AQC? One for the queue creation and one for the scheduler response? IMHO if this is a Legacy feature then it would make sense to introduce this feature in the Flexible AQC instead.