### PR TITLE
HADOOP-14334. S3 SSEC tests to downgrade when running against a mandatory encryption object store

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -84,7 +84,9 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
 
   /**
    * Skipping tests when running against mandatory encryption bucket
-   * which allows only certain encryption method
+   * which allows only certain encryption method.
+   * S3 throw AmazonS3Exception with status 403 AccessDenied
+   * then it is translated into AccessDeniedException by S3AUtils.translateException(...)
    */
   @Override
   public void setup() throws Exception {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 
 import org.junit.Test;
 
@@ -81,10 +82,18 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
     skipIfEncryptionTestsDisabled(getFileSystem().getConf());
   }
 
+  /**
+   * Skipping tests when running against mandatory encryption bucket
+   * which allows only certain encryption method
+   */
   @Override
   public void setup() throws Exception {
-    super.setup();
-    requireEncryptedFileSystem();
+    try {
+      super.setup();
+      requireEncryptedFileSystem();
+    } catch (AccessDeniedException e) {
+      skip("Bucket does not allow " + getSSEAlgorithm() + " encryption method");
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
@@ -46,7 +46,9 @@ public class ITestS3AHugeFilesSSECDiskBlocks
 
   /**
    * Skipping tests when running against mandatory encryption bucket
-   * which allows only certain encryption method
+   * which allows only certain encryption method.
+   * S3 throw AmazonS3Exception with status 403 AccessDenied
+   * then it is translated into AccessDeniedException by S3AUtils.translateException(...)
    */
   @Override
   public void setup() throws Exception {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
@@ -23,6 +23,9 @@ import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 
+import java.nio.file.AccessDeniedException;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
@@ -41,10 +44,18 @@ public class ITestS3AHugeFilesSSECDiskBlocks
   private static final String KEY_1
       = "4niV/jPK5VFRHY+KNb6wtqYd4xXyMgdJ9XQJpcQUVbs=";
 
+  /**
+   * Skipping tests when running against mandatory encryption bucket
+   * which allows only certain encryption method
+   */
   @Override
   public void setup() throws Exception {
-    super.setup();
-    skipIfEncryptionTestsDisabled(getConfiguration());
+    try {
+      super.setup();
+      skipIfEncryptionTestsDisabled(getConfiguration());
+    } catch (AccessDeniedException e) {
+      skip("Bucket does not allow " + S3AEncryptionMethods.SSE_C + " encryption method");
+    }
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
If you run the S3A tests against a bucket with mandatory encryption, you need to set the encryption in auth keys. This breaks the SSEC tests because the encryption.key property being set breaks them. 

This changes catch `AccessDeniedException` in the setup step of SSE tests, if it occurs then the test will be skipped. This exception is thrown by S3A when using encryption method that is not allowed by the bucket.

Tested in `eu-west-1` with `mvn -Dparallel-tests -DtestsThreadCount=32 clean verify`

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ITestS3AContractUnbuffer>AbstractContractUnbufferTest.testMultipleUnbuffers:100->AbstractContractUnbufferTest.validateFullFileContents:132->AbstractContractUnbufferTest.validateFileContents:139->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 failed to read expected number of bytes from stream. This may be transient expected:<1024> but was:<605>
[ERROR]   ITestS3AInconsistency.testGetFileStatus:123->Assert.fail:89 getFileStatus should fail due to delayed visibility.
[INFO] 
[ERROR] Tests run: 1475, Failures: 2, Errors: 0, Skipped: 509
```

Rerun failures individually
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractUnbuffer
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.894 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractUnbuffer
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AInconsistency
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.108 s - in org.apache.hadoop.fs.s3a.ITestS3AInconsistency
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```
