### PR TITLE
HDFS-16417. RBF: StaticRouterRpcFairnessPolicyController init fails with division by 0 if concurrent ns handler count is configured

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
@@ -96,7 +96,8 @@ public class StaticRouterRpcFairnessPolicyController extends
     }
 
     // Assign remaining handlers if any to fan out calls.
-    int leftOverHandlers = handlerCount % unassignedNS.size();
+    int leftOverHandlers = unassignedNS.isEmpty() ? handlerCount :
+        handlerCount % unassignedNS.size();
     int existingPermits = getAvailablePermits(CONCURRENT_NS);
     if (leftOverHandlers > 0) {
       LOG.info("Assigned extra {} handlers to commons pool", leftOverHandlers);


### PR DESCRIPTION
If `dfs.federation.router.fairness.handler.count.concurrent` is configured, `unassignedNS` is thus empty and `handlerCount % unassignedNS.size()` will throw a /0 exception.

Changed it to assigning extra handlers to concurrent ns in case it's configured.