### PR TITLE
HADOOP-18046. TestIPC#testIOEOnListenerAccept fails

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -647,6 +647,9 @@ public class TestIPC {
         fail("Expected an exception to have been thrown");
       } catch (EOFException e) {
         LOG.info("Got expected exception", e);
+      } catch (IOException e) {
+        Assert.assertTrue(e.getMessage().contains("java.io.IOException: Connection reset by peer"));
+        LOG.info("Got expected exception", e);
       } catch (Throwable t) {
         LOG.warn("Got unexpected error", t);
         fail("Expected an EOFException to have been thrown");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HADOOP-18046](https://issues.apache.org/jira/browse/HADOOP-18046)

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

