### PR TITLE
HADOOP-18077. ProfileOutputServlet unable to proceed due to NPE

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/HttpServer2.java
@@ -772,10 +772,11 @@ public final class HttpServer2 implements FilterContainer {
 
     addDefaultServlets();
     addPrometheusServlet(conf);
-    addAsyncProfilerServlet(contexts);
+    addAsyncProfilerServlet(contexts, conf);
   }
 
-  private void addAsyncProfilerServlet(ContextHandlerCollection contexts) throws IOException {
+  private void addAsyncProfilerServlet(ContextHandlerCollection contexts, Configuration conf)
+      throws IOException {
     final String asyncProfilerHome = ProfileServlet.getAsyncProfilerHome();
     if (asyncProfilerHome != null && !asyncProfilerHome.trim().isEmpty()) {
       addServlet("prof", "/prof", ProfileServlet.class);
@@ -787,6 +788,7 @@ public final class HttpServer2 implements FilterContainer {
       genCtx.addServlet(ProfileOutputServlet.class, "/*");
       genCtx.setResourceBase(tmpDir.toAbsolutePath().toString());
       genCtx.setDisplayName("prof-output-hadoop");
+      setContextAttributes(genCtx, conf);
     } else {
       addServlet("prof", "/prof", ProfilerDisabledServlet.class);
       LOG.info("ASYNC_PROFILER_HOME environment variable and async.profiler.home system property "

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/ProfilerDisabledServlet.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/http/ProfilerDisabledServlet.java
@@ -36,9 +36,15 @@ public class ProfilerDisabledServlet extends HttpServlet {
       throws IOException {
     resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     ProfileServlet.setResponseHeader(resp);
+    // TODO : Replace github.com link with
+    //  https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/
+    //  AsyncProfilerServlet.html once Async profiler changes are released
+    //  in 3.x (3.4.0 as of today).
     resp.getWriter().write("The profiler servlet was disabled at startup.\n\n"
         + "Please ensure the prerequisites for the Profiler Servlet have been installed and the\n"
-        + "environment is properly configured.");
+        + "environment is properly configured. \n\n"
+        + "For more details, please refer to: https://github.com/apache/hadoop/blob/trunk/"
+        + "hadoop-common-project/hadoop-common/src/site/markdown/AsyncProfilerServlet.md");
   }
 
 }


### PR DESCRIPTION
### Description of PR
ProfileOutputServlet context doesn't have Hadoop configs available and hence async profiler redirection to output servlet is failing to identify if admin access is allowed:
```
HTTP ERROR 500 java.lang.NullPointerException
URI:	/prof-output-hadoop/async-prof-pid-98613-cpu-2.html
STATUS:	500
MESSAGE:	java.lang.NullPointerException
SERVLET:	org.apache.hadoop.http.ProfileOutputServlet-58c34bb3
CAUSED BY:	java.lang.NullPointerException
Caused by:
java.lang.NullPointerException
	at org.apache.hadoop.http.HttpServer2.isInstrumentationAccessAllowed(HttpServer2.java:1619)
	at org.apache.hadoop.http.ProfileOutputServlet.doGet(ProfileOutputServlet.java:51)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1434)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1349)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:234)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:179)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:400)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:645)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:392)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	at java.lang.Thread.run(Thread.java:748)
```

### How was this patch tested?
Locally.

Few screenshots:
<img width="1243" alt="Screenshot 2022-01-10 at 9 35 53 PM" src="https://user-images.githubusercontent.com/34790606/148819346-460bf7fb-8fc7-41a3-8331-cf2cb42a5e8c.png">
<img width="991" alt="Screenshot 2022-01-10 at 11 50 43 PM" src="https://user-images.githubusercontent.com/34790606/148819355-608f9082-3751-4bf1-8a80-84bc19874a48.png">


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
