### PR TITLE
HADOOP-12020. Add configurable storage class option to s3a files

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -433,7 +433,7 @@ public final class Constants {
    * S3 storage class: standard, reduced_redundancy, intelligent_tiering etc.
    * Value {@value }.
    */
-  public static final String STORAGE_CLASS = "fs.s3a.storage.class";
+  public static final String STORAGE_CLASS = "fs.s3a.create.storage.class";
 
   /**
    * S3 Storage option: {@value}.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -429,6 +429,11 @@ public final class Constants {
    */
   public static final String CONTENT_ENCODING = "fs.s3a.object.content.encoding";
 
+  /**
+   * S3 storage class: STANDARD, REDUCED_REDUNDANCY, INTELLIGENT_TIERING etc.
+   */
+  public static final String STORAGE_CLASS = "fs.s3a.storage.class";
+
   // should we try to purge old multipart uploads when starting up
   public static final String PURGE_EXISTING_MULTIPART =
       "fs.s3a.multipart.purge";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -434,6 +434,19 @@ public final class Constants {
    */
   public static final String STORAGE_CLASS = "fs.s3a.storage.class";
 
+  /**
+   * All possible values for storage class.
+   */
+  public static final String STORAGE_CLASS_STANDARD = "standard";
+  public static final String STORAGE_CLASS_REDUCED_REDUNDANCY = "reduced_redundancy";
+  public static final String STORAGE_CLASS_GLACIER = "glacier";
+  public static final String STORAGE_CLASS_STANDARD_INFREQUENT_ACCESS = "standard_ia";
+  public static final String STORAGE_CLASS_ONEZONE_INFREQUENT_ACCESS = "onezone_ia";
+  public static final String STORAGE_CLASS_INTELLIGENT_TIERING = "intelligent_tiering";
+  public static final String STORAGE_CLASS_DEEP_ARCHIVE = "deep_archive";
+  public static final String STORAGE_CLASS_OUTPOSTS = "outposts";
+  public static final String STORAGE_CLASS_GLACIER_INSTANT_RETRIEVAL = "glacier_ir";
+
   // should we try to purge old multipart uploads when starting up
   public static final String PURGE_EXISTING_MULTIPART =
       "fs.s3a.multipart.purge";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -430,7 +430,7 @@ public final class Constants {
   public static final String CONTENT_ENCODING = "fs.s3a.object.content.encoding";
 
   /**
-   * S3 storage class: STANDARD, REDUCED_REDUNDANCY, INTELLIGENT_TIERING etc.
+   * S3 storage class: standard, reduced_redundancy, intelligent_tiering etc.
    */
   public static final String STORAGE_CLASS = "fs.s3a.storage.class";
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -431,20 +431,53 @@ public final class Constants {
 
   /**
    * S3 storage class: standard, reduced_redundancy, intelligent_tiering etc.
+   * Value {@value }.
    */
   public static final String STORAGE_CLASS = "fs.s3a.storage.class";
 
   /**
-   * All possible values for storage class.
+   * S3 Storage option: {@value}.
    */
   public static final String STORAGE_CLASS_STANDARD = "standard";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_REDUCED_REDUNDANCY = "reduced_redundancy";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_GLACIER = "glacier";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_STANDARD_INFREQUENT_ACCESS = "standard_ia";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_ONEZONE_INFREQUENT_ACCESS = "onezone_ia";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_INTELLIGENT_TIERING = "intelligent_tiering";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_DEEP_ARCHIVE = "deep_archive";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_OUTPOSTS = "outposts";
+
+  /**
+   * S3 Storage option: {@value}.
+   */
   public static final String STORAGE_CLASS_GLACIER_INSTANT_RETRIEVAL = "glacier_ir";
 
   // should we try to purge old multipart uploads when starting up

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -66,6 +67,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.amazonaws.services.s3.transfer.Copy;
@@ -963,7 +965,15 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // Any encoding type
     String contentEncoding = getConf().getTrimmed(CONTENT_ENCODING, null);
 
-    String storageClass = getConf().getTrimmed(STORAGE_CLASS, null);
+    StorageClass storageClass;
+    try {
+      String storageClassConf = getConf()
+          .getTrimmed(STORAGE_CLASS, "")
+          .toUpperCase(Locale.US);
+      storageClass = StorageClass.fromValue(storageClassConf);
+    } catch (IllegalArgumentException e) {
+      storageClass = null;
+    }
 
     return RequestFactoryImpl.builder()
         .withBucket(requireNonNull(bucket))

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -965,13 +965,15 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // Any encoding type
     String contentEncoding = getConf().getTrimmed(CONTENT_ENCODING, null);
 
+    String storageClassConf = getConf()
+        .getTrimmed(STORAGE_CLASS, "")
+        .toUpperCase(Locale.US);
     StorageClass storageClass;
     try {
-      String storageClassConf = getConf()
-          .getTrimmed(STORAGE_CLASS, "")
-          .toUpperCase(Locale.US);
       storageClass = StorageClass.fromValue(storageClassConf);
     } catch (IllegalArgumentException e) {
+      LOG.warn("Unknown storage class property {}: {}; falling back to default storage class",
+          STORAGE_CLASS, storageClassConf);
       storageClass = null;
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -963,6 +963,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // Any encoding type
     String contentEncoding = getConf().getTrimmed(CONTENT_ENCODING, null);
 
+    String storageClass = getConf().getTrimmed(STORAGE_CLASS, null);
+
     return RequestFactoryImpl.builder()
         .withBucket(requireNonNull(bucket))
         .withCannedACL(getCannedACL())
@@ -970,6 +972,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withMultipartPartCountLimit(partCountLimit)
         .withRequestPreparer(getAuditManager()::requestCreated)
         .withContentEncoding(contentEncoding)
+        .withStorageClass(storageClass)
         .build();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -108,7 +108,7 @@ public interface RequestFactory {
   String getContentEncoding();
 
   /**
-   * Get the object storage class (e.g. STANDARD, REDUCED_REDUNDANCY) or return null if none.
+   * Get the object storage class, return null if none.
    * @return storage class
    */
   StorageClass getStorageClass();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -107,6 +107,12 @@ public interface RequestFactory {
   String getContentEncoding();
 
   /**
+   * Get the object storage class (e.g. STANDARD, REDUCED_REDUNDANCY) or return null if none.
+   * @return storage class
+   */
+  String getStorageClass();
+
+  /**
    * Create a new object metadata instance.
    * Any standard metadata headers are added here, for example:
    * encryption.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -44,6 +44,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.SelectObjectContentRequest;
+import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 
 import org.apache.hadoop.fs.PathIOException;
@@ -110,7 +111,7 @@ public interface RequestFactory {
    * Get the object storage class (e.g. STANDARD, REDUCED_REDUNDANCY) or return null if none.
    * @return storage class
    */
-  String getStorageClass();
+  StorageClass getStorageClass();
 
   /**
    * Create a new object metadata instance.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -46,6 +46,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.SelectObjectContentRequest;
+import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
@@ -119,7 +120,7 @@ public class RequestFactoryImpl implements RequestFactory {
   /**
    * Storage class.
    */
-  private final String storageClass;
+  private final StorageClass storageClass;
 
   /**
    * Constructor.
@@ -211,7 +212,7 @@ public class RequestFactoryImpl implements RequestFactory {
    * @return storage class
    */
   @Override
-  public String getStorageClass() {
+  public StorageClass getStorageClass() {
     return storageClass;
   }
 
@@ -372,7 +373,9 @@ public class RequestFactoryImpl implements RequestFactory {
         srcfile);
     setOptionalPutRequestParameters(putObjectRequest);
     putObjectRequest.setCannedAcl(cannedACL);
-    putObjectRequest.setStorageClass(storageClass);
+    if (storageClass != null) {
+      putObjectRequest.setStorageClass(storageClass);
+    }
     putObjectRequest.setMetadata(metadata);
     return prepareRequest(putObjectRequest);
   }
@@ -447,7 +450,9 @@ public class RequestFactoryImpl implements RequestFactory {
             destKey,
             newObjectMetadata(-1));
     initiateMPURequest.setCannedACL(getCannedACL());
-    initiateMPURequest.withStorageClass(getStorageClass());
+    if (getStorageClass() != null) {
+      initiateMPURequest.withStorageClass(getStorageClass());
+    }
     setOptionalMultipartUploadRequestParameters(initiateMPURequest);
     return prepareRequest(initiateMPURequest);
   }
@@ -630,7 +635,7 @@ public class RequestFactoryImpl implements RequestFactory {
     /**
      * Storage class.
      */
-    private String storageClass;
+    private StorageClass storageClass;
 
     /**
      * Multipart limit.
@@ -668,7 +673,7 @@ public class RequestFactoryImpl implements RequestFactory {
      * @param value new value
      * @return the builder
      */
-    public RequestFactoryBuilder withStorageClass(final String value) {
+    public RequestFactoryBuilder withStorageClass(final StorageClass value) {
       storageClass = value;
       return this;
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -208,7 +208,7 @@ public class RequestFactoryImpl implements RequestFactory {
   }
 
   /**
-   * Get the object storage class (e.g. STANDARD, REDUCED_REDUNDANCY) or return null if none.
+   * Get the object storage class, return null if none.
    * @return storage class
    */
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -117,6 +117,11 @@ public class RequestFactoryImpl implements RequestFactory {
   private final String contentEncoding;
 
   /**
+   * Storage class.
+   */
+  private final String storageClass;
+
+  /**
    * Constructor.
    * @param builder builder with all the configuration.
    */
@@ -128,6 +133,7 @@ public class RequestFactoryImpl implements RequestFactory {
     this.multipartPartCountLimit = builder.multipartPartCountLimit;
     this.requestPreparer = builder.requestPreparer;
     this.contentEncoding = builder.contentEncoding;
+    this.storageClass = builder.storageClass;
   }
 
   /**
@@ -198,6 +204,15 @@ public class RequestFactoryImpl implements RequestFactory {
   @Override
   public String getContentEncoding() {
     return contentEncoding;
+  }
+
+  /**
+   * Get the object storage class (e.g. STANDARD, REDUCED_REDUNDANCY) or return null if none.
+   * @return storage class
+   */
+  @Override
+  public String getStorageClass() {
+    return storageClass;
   }
 
   /**
@@ -343,7 +358,7 @@ public class RequestFactoryImpl implements RequestFactory {
   }
   /**
    * Create a putObject request.
-   * Adds the ACL and metadata
+   * Adds the ACL, storage class and metadata
    * @param key key of object
    * @param metadata metadata header
    * @param srcfile source file
@@ -357,6 +372,7 @@ public class RequestFactoryImpl implements RequestFactory {
         srcfile);
     setOptionalPutRequestParameters(putObjectRequest);
     putObjectRequest.setCannedAcl(cannedACL);
+    putObjectRequest.setStorageClass(storageClass);
     putObjectRequest.setMetadata(metadata);
     return prepareRequest(putObjectRequest);
   }
@@ -431,6 +447,7 @@ public class RequestFactoryImpl implements RequestFactory {
             destKey,
             newObjectMetadata(-1));
     initiateMPURequest.setCannedACL(getCannedACL());
+    initiateMPURequest.withStorageClass(getStorageClass());
     setOptionalMultipartUploadRequestParameters(initiateMPURequest);
     return prepareRequest(initiateMPURequest);
   }
@@ -611,6 +628,11 @@ public class RequestFactoryImpl implements RequestFactory {
     private String contentEncoding;
 
     /**
+     * Storage class.
+     */
+    private String storageClass;
+
+    /**
      * Multipart limit.
      */
     private long multipartPartCountLimit = DEFAULT_UPLOAD_PART_COUNT_LIMIT;
@@ -638,6 +660,16 @@ public class RequestFactoryImpl implements RequestFactory {
      */
     public RequestFactoryBuilder withContentEncoding(final String value) {
       contentEncoding = value;
+      return this;
+    }
+
+    /**
+     * Storage class.
+     * @param value new value
+     * @return the builder
+     */
+    public RequestFactoryBuilder withStorageClass(final String value) {
+      storageClass = value;
       return this;
     }
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1083,10 +1083,10 @@ options are covered in [Testing](./testing.md).
   <name>fs.s3a.storage.class</name>
   <value></value>
   <description>
-      Storage class: STANDARD, REDUCED_REDUNDANCY, INTELLIGENT_TIERING, etc.
-      Specify the storage class for S3A put object requests.
+      Storage class: standard, reduced_redundancy, intelligent_tiering, etc.
+      Specify the storage class for S3A PUT object requests.
       If not set the storage class will be null
-      and mapped to default STANDARD class on S3.
+      and mapped to default standard class on S3.
   </description>
 </property>
 
@@ -1670,6 +1670,25 @@ To enable this feature within S3A, configure the `fs.s3a.requester.pays.enabled`
     <value>true</value>
 </property>
 ```
+
+## <a name="storage_classes"></a>Storage Classes
+
+Amazon S3 offers a range of [Storage Classes](https://aws.amazon.com/s3/storage-classes/) 
+that you can choose from based on behavior of your applications. By using the right 
+storage class, you can reduce the cost of your bucket.
+
+S3A uses Standard storage class for PUT object requests by default, which is suitable for 
+general use cases. To use a specific storage class, set the value in `fs.s3a.storage.class` property to
+the storage class you want.
+
+```xml
+<property>
+    <name>fs.s3a.storage.class</name>
+    <value>intelligent_tiering</value>
+</property>
+```
+
+Please note that S3A does not support reading from archive storage classes at the moment.
 
 ## <a name="upload"></a>How S3A writes data to S3
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1673,11 +1673,11 @@ To enable this feature within S3A, configure the `fs.s3a.requester.pays.enabled`
 
 ## <a name="storage_classes"></a>Storage Classes
 
-Amazon S3 offers a range of [Storage Classes](https://aws.amazon.com/s3/storage-classes/) 
-that you can choose from based on behavior of your applications. By using the right 
+Amazon S3 offers a range of [Storage Classes](https://aws.amazon.com/s3/storage-classes/)
+that you can choose from based on behavior of your applications. By using the right
 storage class, you can reduce the cost of your bucket.
 
-S3A uses Standard storage class for PUT object requests by default, which is suitable for 
+S3A uses Standard storage class for PUT object requests by default, which is suitable for
 general use cases. To use a specific storage class, set the value in `fs.s3a.create.storage.class` property to
 the storage class you want.
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1079,6 +1079,17 @@ options are covered in [Testing](./testing.md).
   </description>
 </property>
 
+<property>
+  <name>fs.s3a.storage.class</name>
+  <value></value>
+  <description>
+      Storage class: STANDARD, REDUCED_REDUNDANCY, INTELLIGENT_TIERING, etc.
+      Specify the storage class for S3A put object requests.
+      If not set the storage class will be null
+      and mapped to default STANDARD class on S3.
+  </description>
+</property>
+
 ```
 
 ## <a name="retry_and_recovery"></a>Retry and Recovery

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1689,6 +1689,7 @@ the storage class you want.
 ```
 
 Please note that S3A does not support reading from archive storage classes at the moment.
+`AccessDeniedException` with InvalidObjectState will be thrown if you're trying to do so.
 
 ## <a name="upload"></a>How S3A writes data to S3
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1080,7 +1080,7 @@ options are covered in [Testing](./testing.md).
 </property>
 
 <property>
-  <name>fs.s3a.storage.class</name>
+  <name>fs.s3a.create.storage.class</name>
   <value></value>
   <description>
       Storage class: standard, reduced_redundancy, intelligent_tiering, etc.
@@ -1678,12 +1678,12 @@ that you can choose from based on behavior of your applications. By using the ri
 storage class, you can reduce the cost of your bucket.
 
 S3A uses Standard storage class for PUT object requests by default, which is suitable for 
-general use cases. To use a specific storage class, set the value in `fs.s3a.storage.class` property to
+general use cases. To use a specific storage class, set the value in `fs.s3a.create.storage.class` property to
 the storage class you want.
 
 ```xml
 <property>
-    <name>fs.s3a.storage.class</name>
+    <name>fs.s3a.create.storage.class</name>
     <value>intelligent_tiering</value>
 </property>
 ```

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -574,7 +574,7 @@ their classname.
 
 ### Disabling the storage class tests
 
-When running storage class tests against third party object store that doesn't support 
+When running storage class tests against third party object store that doesn't support
 S3 storage class, these tests might fail. They can be disabled.
 
 ```xml

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -579,7 +579,7 @@ S3 storage class, these tests might fail. They can be disabled.
 
 ```xml
 <property>
-  <name>test.fs.s3a.storage.class.enabled</name>
+  <name>test.fs.s3a.create.storage.class.enabled</name>
   <value>false</value>
 </property>
 ```

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/testing.md
@@ -572,6 +572,18 @@ can be turned off.
 Encryption is only used for those specific test suites with `Encryption` in
 their classname.
 
+### Disabling the storage class tests
+
+When running storage class tests against third party object store that doesn't support 
+S3 storage class, these tests might fail. They can be disabled.
+
+```xml
+<property>
+  <name>test.fs.s3a.storage.class.enabled</name>
+  <value>false</value>
+</property>
+```
+
 ### Configuring the CSV file read tests**
 
 To test on alternate infrastructures supporting

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -572,9 +572,7 @@ Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Operation is not v
 This happens when you're trying to read or copy files that have archive storage class such as
 Glacier.
 
-If you want to access the file with S3A after writes, do not set `fs.s3a.storage.class` to `glacier`
-,
-`glacier_ir` or `deep_archive`.
+If you want to access the file with S3A after writes, do not set `fs.s3a.storage.class` to `glacier` or `deep_archive`.
 
 ### <a name="no_region_session_credentials"></a> "Unable to find a region via the region provider chain." when using session credentials.
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -572,7 +572,7 @@ Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Operation is not v
 This happens when you're trying to read or copy files that have archive storage class such as
 Glacier.
 
-If you want to access the file with S3A after writes, do not set `fs.s3a.storage.class` to `glacier` or `deep_archive`.
+If you want to access the file with S3A after writes, do not set `fs.s3a.create.storage.class` to `glacier` or `deep_archive`.
 
 ### <a name="no_region_session_credentials"></a> "Unable to find a region via the region provider chain." when using session credentials.
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/troubleshooting_s3a.md
@@ -561,24 +561,43 @@ Error Code: 403 Forbidden; Request ID: myshortreqid; S3 Extended Request ID: myl
 
 To enable requester pays, set `fs.s3a.requester.pays.enabled` property to `true`.
 
+### <a name="access_denied_archive_storage_class"></a>`AccessDeniedException` "InvalidObjectState" when trying to read files
+
+```
+java.nio.file.AccessDeniedException: file1: copyFile(file1, file2) on file1: com.amazonaws.services.s3.model.AmazonS3Exception: Operation is not valid for the source object's storage class (Service: Amazon S3; Status Code: 403; Error Code: InvalidObjectState; Request ID: SK9EMPC1YRX75VZR; S3 Extended Request ID: /nhUfdwJ+y5DLz6B4YR2FdA0FnQWwhDAkSCakn42zs2JssK3qWTrfwdNDiy6bOyXHOvJY0VAlHw=; Proxy: null), S3 Extended Request ID: /nhUfdwJ+y5DLz6B4YR2FdA0FnQWwhDAkSCakn42zs2JssK3qWTrfwdNDiy6bOyXHOvJY0VAlHw=:InvalidObjectState
+
+Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Operation is not valid for the source object's storage class (Service: Amazon S3; Status Code: 403; Error Code: InvalidObjectState; Request ID: SK9EMPC1YRX75VZR; S3 Extended Request ID: /nhUfdwJ+y5DLz6B4YR2FdA0FnQWwhDAkSCakn42zs2JssK3qWTrfwdNDiy6bOyXHOvJY0VAlHw=; Proxy: null), S3 Extended Request ID: /nhUfdwJ+y5DLz6B4YR2FdA0FnQWwhDAkSCakn42zs2JssK3qWTrfwdNDiy6bOyXHOvJY0VAlHw=
+```
+
+This happens when you're trying to read or copy files that have archive storage class such as
+Glacier.
+
+If you want to access the file with S3A after writes, do not set `fs.s3a.storage.class` to `glacier`
+,
+`glacier_ir` or `deep_archive`.
+
 ### <a name="no_region_session_credentials"></a> "Unable to find a region via the region provider chain." when using session credentials.
 
-Region must be provided when requesting session credentials, or an exception will be thrown with the message:
+Region must be provided when requesting session credentials, or an exception will be thrown with the
+message:
+
 ```
 com.amazonaws.SdkClientException: Unable to find a region via the region provider
 chain. Must provide an explicit region in the builder or setup environment to supply a region.
 ```
-In this case you have to set the `fs.s3a.assumed.role.sts.endpoint` property to a valid
-S3 sts endpoint and region like the following:
+
+In this case you have to set the `fs.s3a.assumed.role.sts.endpoint` property to a valid S3 sts
+endpoint and region like the following:
 
 ```xml
+
 <property>
     <name>fs.s3a.assumed.role.sts.endpoint</name>
     <value>${sts.endpoint}</value>
 </property>
 <property>
-    <name>fs.s3a.assumed.role.sts.endpoint.region</name>
-    <value>${sts.region}</value>
+<name>fs.s3a.assumed.role.sts.endpoint.region</name>
+<value>${sts.region}</value>
 </property>
 ```
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
@@ -35,6 +35,7 @@ import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_GLACIER;
 import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_REDUCED_REDUNDANCY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfStorageClassTestsDisabled;
 import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_STORAGE_CLASS;
 import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.decodeBytes;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -51,6 +52,12 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
     removeBaseAndBucketOverrides(conf, STORAGE_CLASS);
 
     return conf;
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    skipIfStorageClassTestsDisabled(getConfiguration());
   }
 
   /*

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
@@ -133,7 +133,7 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * with completely invalid storage class
    */
   @Test
-  public void testCreateAndCopyObjectWithInvalidStorageClass() throws Throwable {
+  public void testCreateAndCopyObjectWithStorageClassInvalid() throws Throwable {
     Configuration conf = this.createConfiguration();
     conf.set(STORAGE_CLASS, "testing");
     S3AContract contract = (S3AContract) createContract(conf);
@@ -158,7 +158,7 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * with empty string configuration
    */
   @Test
-  public void testCreateAndCopyObjectWithEmptyStorageClass() throws Throwable {
+  public void testCreateAndCopyObjectWithStorageClassEmpty() throws Throwable {
     Configuration conf = this.createConfiguration();
     conf.set(STORAGE_CLASS, "");
     S3AContract contract = (S3AContract) createContract(conf);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a;
 import java.nio.file.AccessDeniedException;
 import java.util.Map;
 
-import com.amazonaws.services.s3.model.StorageClass;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -32,6 +31,8 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
 
 import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_GLACIER;
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_REDUCED_REDUNDANCY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_STORAGE_CLASS;
@@ -81,7 +82,7 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
   @Test
   public void testCreateAndCopyObjectWithStorageClassReducedRedundancy() throws Throwable {
     Configuration conf = this.createConfiguration();
-    conf.set(STORAGE_CLASS, StorageClass.ReducedRedundancy.toString());
+    conf.set(STORAGE_CLASS, STORAGE_CLASS_REDUCED_REDUNDANCY);
     S3AContract contract = (S3AContract) createContract(conf);
     contract.init();
 
@@ -93,10 +94,10 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
     assertObjectHasNoStorageClass(dir);
     Path path = new Path(dir, "file1");
     ContractTestUtils.touch(fs, path);
-    assertObjectHasStorageClass(path, StorageClass.ReducedRedundancy.toString());
+    assertObjectHasStorageClass(path, STORAGE_CLASS_REDUCED_REDUNDANCY);
     Path path2 = new Path(dir, "file1");
     fs.rename(path, path2);
-    assertObjectHasStorageClass(path2, StorageClass.ReducedRedundancy.toString());
+    assertObjectHasStorageClass(path2, STORAGE_CLASS_REDUCED_REDUNDANCY);
   }
 
   /*
@@ -106,7 +107,7 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
   @Test
   public void testCreateAndCopyObjectWithStorageClassGlacier() throws Throwable {
     Configuration conf = this.createConfiguration();
-    conf.set(STORAGE_CLASS, StorageClass.Glacier.toString());
+    conf.set(STORAGE_CLASS, STORAGE_CLASS_GLACIER);
     S3AContract contract = (S3AContract) createContract(conf);
     contract.init();
 
@@ -118,7 +119,7 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
     assertObjectHasNoStorageClass(dir);
     Path path = new Path(dir, "file1");
     ContractTestUtils.touch(fs, path);
-    assertObjectHasStorageClass(path, StorageClass.Glacier.toString());
+    assertObjectHasStorageClass(path, STORAGE_CLASS_GLACIER);
     Path path2 = new Path(dir, "file2");
 
     // this is the current behavior
@@ -204,6 +205,6 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
     String actualStorageClass = decodeBytes(xAttrs.get(XA_STORAGE_CLASS));
 
     Assertions.assertThat(actualStorageClass).describedAs("Storage class of object %s", path)
-        .isEqualTo(expectedStorageClass);
+        .isEqualToIgnoringCase(expectedStorageClass);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.nio.file.AccessDeniedException;
+import java.util.Map;
+
+import com.amazonaws.services.s3.model.StorageClass;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.contract.s3a.S3AContract;
+import org.apache.hadoop.test.GenericTestUtils;
+
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.XA_STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.decodeBytes;
+
+/**
+ * Tests of storage class.
+ */
+public class ITestS3AStorageClass extends AbstractS3ATestBase {
+
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    disableFilesystemCaching(conf);
+    removeBaseAndBucketOverrides(conf, STORAGE_CLASS);
+
+    return conf;
+  }
+
+  /*
+   * This test ensures the default storage class configuration (no config or null)
+   * works well with create and copy operations
+   */
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassDefault() throws Throwable {
+    Configuration conf = this.createConfiguration();
+    S3AContract contract = (S3AContract) createContract(conf);
+    contract.init();
+
+    FileSystem fs = contract.getTestFileSystem();
+    Path dir = methodPath();
+    fs.mkdirs(dir);
+    assertObjectHasNoStorageClass(dir);
+    Path path = new Path(dir, "file1");
+    ContractTestUtils.touch(fs, path);
+    assertObjectHasNoStorageClass(path);
+    Path path2 = new Path(dir, "file1");
+    fs.rename(path, path2);
+    assertObjectHasNoStorageClass(path2);
+  }
+
+  /*
+   * Verify object can be created and copied correctly
+   * with specified storage class
+   */
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassReducedRedundancy() throws Throwable {
+    Configuration conf = this.createConfiguration();
+    conf.set(STORAGE_CLASS, StorageClass.ReducedRedundancy.toString());
+    S3AContract contract = (S3AContract) createContract(conf);
+    contract.init();
+
+    FileSystem fs = contract.getTestFileSystem();
+    Path dir = methodPath();
+    fs.mkdirs(dir);
+    // even with storage class specified
+    // directories do not have storage class
+    assertObjectHasNoStorageClass(dir);
+    Path path = new Path(dir, "file1");
+    ContractTestUtils.touch(fs, path);
+    assertObjectHasStorageClass(path, StorageClass.ReducedRedundancy.toString());
+    Path path2 = new Path(dir, "file1");
+    fs.rename(path, path2);
+    assertObjectHasStorageClass(path2, StorageClass.ReducedRedundancy.toString());
+  }
+
+  /*
+   * Archive storage classes have different behavior
+   * from general storage classes
+   */
+  @Test(expected = AccessDeniedException.class)
+  public void testCreateAndCopyObjectWithStorageClassGlacier() throws Throwable {
+    Configuration conf = this.createConfiguration();
+    conf.set(STORAGE_CLASS, StorageClass.Glacier.toString());
+    S3AContract contract = (S3AContract) createContract(conf);
+    contract.init();
+
+    FileSystem fs = contract.getTestFileSystem();
+    Path dir = methodPath();
+    fs.mkdirs(dir);
+    // even with storage class specified
+    // directories do not have storage class
+    assertObjectHasNoStorageClass(dir);
+    Path path = new Path(dir, "file1");
+    ContractTestUtils.touch(fs, path);
+    assertObjectHasStorageClass(path, StorageClass.Glacier.toString());
+    Path path2 = new Path(dir, "file2");
+    try {
+      // this is the current behavior
+      // object with archive storage class can't be read directly
+      // when trying to read it, AccessDeniedException will be thrown
+      // with message InvalidObjectState
+      fs.rename(path, path2);
+    } catch (AccessDeniedException e) {
+      GenericTestUtils.assertExceptionContains("InvalidObjectState", e);
+      throw e;
+    }
+  }
+
+  /**
+   * Assert that a given object has no storage class specified.
+   *
+   * @param path path
+   */
+  protected void assertObjectHasNoStorageClass(Path path) throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    Map<String, byte[]> xAttrs = fs.getXAttrs(path);
+    String storageClass = decodeBytes(xAttrs.get(XA_STORAGE_CLASS));
+
+    Assertions.assertThat(storageClass).describedAs("Storage class of object %s", path).isNull();
+  }
+
+  /**
+   * Assert that a given object has the given storage class specified.
+   *
+   * @param path                 path
+   * @param expectedStorageClass expected storage class for the object
+   */
+  protected void assertObjectHasStorageClass(Path path, String expectedStorageClass)
+      throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    Map<String, byte[]> xAttrs = fs.getXAttrs(path);
+    String actualStorageClass = decodeBytes(xAttrs.get(XA_STORAGE_CLASS));
+
+    Assertions.assertThat(actualStorageClass).describedAs("Storage class of object %s", path)
+        .isEqualTo(expectedStorageClass);
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -54,6 +54,11 @@ public interface S3ATestConstants {
   String KEY_ENCRYPTION_TESTS = TEST_FS_S3A + "encryption.enabled";
 
   /**
+   * A property set to true if storage class tests are enabled: {@value }
+   */
+  String KEY_STORAGE_CLASS_TESTS_ENABLED = TEST_FS_S3A + "storage.class.enabled";
+
+  /**
    * Tell tests that they are being executed in parallel: {@value}.
    */
   String KEY_PARALLEL_TEST_EXECUTION = "test.parallel.execution";

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -54,7 +54,7 @@ public interface S3ATestConstants {
   String KEY_ENCRYPTION_TESTS = TEST_FS_S3A + "encryption.enabled";
 
   /**
-   * A property set to true if storage class tests are enabled: {@value }
+   * A property set to true if storage class tests are enabled: {@value }.
    */
   String KEY_STORAGE_CLASS_TESTS_ENABLED = TEST_FS_S3A + "create.storage.class.enabled";
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -56,7 +56,7 @@ public interface S3ATestConstants {
   /**
    * A property set to true if storage class tests are enabled: {@value }
    */
-  String KEY_STORAGE_CLASS_TESTS_ENABLED = TEST_FS_S3A + "storage.class.enabled";
+  String KEY_STORAGE_CLASS_TESTS_ENABLED = TEST_FS_S3A + "create.storage.class.enabled";
 
   /**
    * Tell tests that they are being executed in parallel: {@value}.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -466,6 +466,17 @@ public final class S3ATestUtils {
   }
 
   /**
+   * Skip a test if storage class tests are disabled.
+   * @param configuration configuration to probe
+   */
+  public static void skipIfStorageClassTestsDisabled(
+      Configuration configuration) {
+    if (!configuration.getBoolean(KEY_STORAGE_CLASS_TESTS_ENABLED, true)) {
+      skip("Skipping storage class tests");
+    }
+  }
+
+  /**
    * Create a test path, using the value of
    * {@link S3ATestConstants#TEST_UNIQUE_FORK_ID} if it is set.
    * @param defVal default value

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
@@ -708,7 +708,8 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
     S3AFileSystem fs = getFileSystem();
     String actualStorageClass = fs.getObjectMetadata(expectedFile).getStorageClass();
 
-    Assertions.assertThat(actualStorageClass).describedAs("Storage class of object %s", expectedFile)
+    Assertions.assertThat(actualStorageClass)
+        .describedAs("Storage class of object %s", expectedFile)
         .isEqualToIgnoringCase(expectedStorageClass);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
@@ -819,6 +819,7 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
         " expect the final file has correct storage class.");
 
     Configuration conf = getConfiguration();
+    skipIfStorageClassTestsDisabled(conf);
     conf.set(STORAGE_CLASS, STORAGE_CLASS_INTELLIGENT_TIERING);
 
     JobData jobData = startJob(false);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
@@ -71,6 +71,8 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_INTELLIGENT_TIERING;
 import static org.apache.hadoop.fs.s3a.S3AUtils.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
 import static org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitter.E_SELF_GENERATED_JOB_UUID;
@@ -696,6 +698,21 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
   }
 
   /**
+   * Verify storage class of output file matches the expected storage class.
+   * @param dir output directory.
+   * @param expectedStorageClass expected storage class value.
+   * @throws Exception failure.
+   */
+  private void validateStorageClass(Path dir, String expectedStorageClass) throws Exception {
+    Path expectedFile = getPart0000(dir);
+    S3AFileSystem fs = getFileSystem();
+    String actualStorageClass = fs.getObjectMetadata(expectedFile).getStorageClass();
+
+    Assertions.assertThat(actualStorageClass).describedAs("Storage class of object %s", expectedFile)
+        .isEqualToIgnoringCase(expectedStorageClass);
+  }
+
+  /**
    * Identify any path under the directory which begins with the
    * {@code "part-m-00000"} sequence.
    * @param dir directory to scan
@@ -794,6 +811,40 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
     validateContent(outDir, shouldExpectSuccessMarker(),
         committer.getUUID());
     assertNoMultipartUploadsPending(outDir);
+  }
+
+  @Test
+  public void testCommitWithStorageClassConfig() throws Exception {
+    describe("Commit with specific storage class configuration;" +
+        " expect the final file has correct storage class.");
+
+    Configuration conf = getConfiguration();
+    conf.set(STORAGE_CLASS, STORAGE_CLASS_INTELLIGENT_TIERING);
+
+    JobData jobData = startJob(false);
+    JobContext jContext = jobData.jContext;
+    TaskAttemptContext tContext = jobData.tContext;
+    AbstractS3ACommitter committer = jobData.committer;
+    validateTaskAttemptWorkingDirectory(committer, tContext);
+
+    // write output
+    writeTextOutput(tContext);
+
+    // commit task
+    dumpMultipartUploads();
+    commitTask(committer, tContext);
+
+    // commit job
+    assertMultipartUploadsPending(outDir);
+    commitJob(committer, jContext);
+
+    // validate output
+    validateContent(outDir, shouldExpectSuccessMarker(),
+        committer.getUUID());
+    assertNoMultipartUploadsPending(outDir);
+
+    // validate storage class
+    validateStorageClass(outDir, STORAGE_CLASS_INTELLIGENT_TIERING);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -255,6 +255,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
       assertEquals("actively allocated blocks in " + streamStatistics,
           0, streamStatistics.getBlocksActivelyAllocated());
     }
+    assertStorageClass(fileToCreate);
   }
 
   /**
@@ -393,6 +394,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     FileStatus status = fs.getFileStatus(hugefile);
     ContractTestUtils.assertIsFile(hugefile, status);
     assertEquals("File size in " + status, filesize, status.getLen());
+    assertStorageClass(hugefile);
   }
 
   /**
@@ -482,7 +484,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
    */
   @Test
   public void test_090_verifyRenameSourceEncryption() throws IOException {
-    if(isEncrypted(getFileSystem())) {
+    if (isEncrypted(getFileSystem())) {
       assertEncrypted(getHugefile());
     }
   }
@@ -491,8 +493,20 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     //Concrete classes will have implementation.
   }
 
+  protected void assertStorageClass(Path hugeFile) throws IOException {
+    Configuration conf = getConfiguration();
+    String expected = conf.get(STORAGE_CLASS);
+
+    S3AFileSystem fs = getFileSystem();
+    String actual = fs.getObjectMetadata(hugeFile).getStorageClass();
+
+    assertEquals("Storage class of object is " + actual + ", expected " + expected, expected,
+        actual);
+  }
+
   /**
    * Checks if the encryption is enabled for the file system.
+   *
    * @param fileSystem
    * @return
    */
@@ -518,6 +532,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     logFSState();
     FileStatus destFileStatus = fs.getFileStatus(hugefileRenamed);
     assertEquals(size, destFileStatus.getLen());
+    assertStorageClass(hugefileRenamed);
 
     // rename back
     ContractTestUtils.NanoTimer timer2 = new ContractTestUtils.NanoTimer();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/AbstractSTestS3AHugeFiles.java
@@ -255,7 +255,6 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
       assertEquals("actively allocated blocks in " + streamStatistics,
           0, streamStatistics.getBlocksActivelyAllocated());
     }
-    assertStorageClass(fileToCreate);
   }
 
   /**
@@ -394,7 +393,6 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     FileStatus status = fs.getFileStatus(hugefile);
     ContractTestUtils.assertIsFile(hugefile, status);
     assertEquals("File size in " + status, filesize, status.getLen());
-    assertStorageClass(hugefile);
   }
 
   /**
@@ -484,7 +482,7 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
    */
   @Test
   public void test_090_verifyRenameSourceEncryption() throws IOException {
-    if (isEncrypted(getFileSystem())) {
+    if(isEncrypted(getFileSystem())) {
       assertEncrypted(getHugefile());
     }
   }
@@ -493,20 +491,8 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     //Concrete classes will have implementation.
   }
 
-  protected void assertStorageClass(Path hugeFile) throws IOException {
-    Configuration conf = getConfiguration();
-    String expected = conf.get(STORAGE_CLASS);
-
-    S3AFileSystem fs = getFileSystem();
-    String actual = fs.getObjectMetadata(hugeFile).getStorageClass();
-
-    assertEquals("Storage class of object is " + actual + ", expected " + expected, expected,
-        actual);
-  }
-
   /**
    * Checks if the encryption is enabled for the file system.
-   *
    * @param fileSystem
    * @return
    */
@@ -532,7 +518,6 @@ public abstract class AbstractSTestS3AHugeFiles extends S3AScaleTestBase {
     logFSState();
     FileStatus destFileStatus = fs.getFileStatus(hugefileRenamed);
     assertEquals(size, destFileStatus.getLen());
-    assertStorageClass(hugefileRenamed);
 
     // rename back
     ContractTestUtils.NanoTimer timer2 = new ContractTestUtils.NanoTimer();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
@@ -36,6 +36,7 @@ import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
 import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_REDUCED_REDUNDANCY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfStorageClassTestsDisabled;
 
 /**
  * Class to verify that {@link Constants#STORAGE_CLASS} is set correctly
@@ -44,6 +45,12 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides
 public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
 
   private static final Logger LOG = LoggerFactory.getLogger(ITestS3AHugeFilesStorageClass.class);
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    skipIfStorageClassTestsDisabled(getConfiguration());
+  }
 
   @Override
   protected Configuration createScaleConfiguration() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
@@ -20,18 +20,30 @@ package org.apache.hadoop.fs.s3a.scale;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.bandwidth;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.toHuman;
 import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS_REDUCED_REDUNDANCY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 
+/**
+ * Class to verify that {@link Constants#STORAGE_CLASS} is set correctly
+ * for creating and renaming huge files with multipart upload requests.
+ */
 public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
 
-  private static final String TEST_STORAGE_CLASS = "REDUCED_REDUNDANCY";
+  private static final Logger LOG = LoggerFactory.getLogger(ITestS3AHugeFilesStorageClass.class);
 
   @Override
   protected Configuration createScaleConfiguration() {
@@ -39,7 +51,7 @@ public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
     disableFilesystemCaching(conf);
     removeBaseAndBucketOverrides(conf, STORAGE_CLASS);
 
-    conf.set(STORAGE_CLASS, TEST_STORAGE_CLASS);
+    conf.set(STORAGE_CLASS, STORAGE_CLASS_REDUCED_REDUNDANCY);
     return conf;
   }
 
@@ -49,13 +61,68 @@ public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
   }
 
   @Override
-  protected void assertStorageClass(Path hugeFile) throws IOException {
-    String expected = TEST_STORAGE_CLASS;
+  public void test_010_CreateHugeFile() throws IOException {
+    super.test_010_CreateHugeFile();
+    assertStorageClass(getPathOfFileToCreate());
+  }
 
+  @Override
+  public void test_030_postCreationAssertions() throws Throwable {
+    super.test_030_postCreationAssertions();
+    assertStorageClass(getPathOfFileToCreate());
+  }
+
+  @Override
+  public void test_040_PositionedReadHugeFile() throws Throwable {
+    skipQuietly("PositionedReadHugeFile");
+  }
+
+  @Override
+  public void test_050_readHugeFile() throws Throwable {
+    skipQuietly("readHugeFile");
+  }
+
+  @Override
+  public void test_090_verifyRenameSourceEncryption() throws IOException {
+    skipQuietly("verifyRenameSourceEncryption");
+  }
+
+  @Override
+  public void test_100_renameHugeFile() throws Throwable {
+    Path hugefile = getHugefile();
+    Path hugefileRenamed = getHugefileRenamed();
+    assumeHugeFileExists();
+    describe("renaming %s to %s", hugefile, hugefileRenamed);
+    S3AFileSystem fs = getFileSystem();
+    FileStatus status = fs.getFileStatus(hugefile);
+    long size = status.getLen();
+    fs.delete(hugefileRenamed, false);
+    ContractTestUtils.NanoTimer timer = new ContractTestUtils.NanoTimer();
+    fs.rename(hugefile, hugefileRenamed);
+    long mb = Math.max(size / _1MB, 1);
+    timer.end("time to rename file of %d MB", mb);
+    LOG.info("Time per MB to rename = {} nS", toHuman(timer.nanosPerOperation(mb)));
+    bandwidth(timer, size);
+    FileStatus destFileStatus = fs.getFileStatus(hugefileRenamed);
+    assertEquals(size, destFileStatus.getLen());
+    assertStorageClass(hugefileRenamed);
+  }
+
+  @Override
+  public void test_110_verifyRenameDestEncryption() throws IOException {
+    skipQuietly("verifyRenameDestEncryption");
+  }
+
+  private void skipQuietly(String text) {
+    describe("Skipping: %s", text);
+  }
+
+  protected void assertStorageClass(Path hugeFile) throws IOException {
     S3AFileSystem fs = getFileSystem();
     String actual = fs.getObjectMetadata(hugeFile).getStorageClass();
 
-    assertEquals("Storage class of object is " + actual + ", expected " + expected, expected,
-        actual);
+    assertTrue(
+        "Storage class of object is " + actual + ", expected " + STORAGE_CLASS_REDUCED_REDUNDANCY,
+        STORAGE_CLASS_REDUCED_REDUNDANCY.equalsIgnoreCase(actual));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.scale;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+
+public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
+
+  private static final String TEST_STORAGE_CLASS = "REDUCED_REDUNDANCY";
+
+  @Override
+  protected Configuration createScaleConfiguration() {
+    Configuration conf = super.createScaleConfiguration();
+    disableFilesystemCaching(conf);
+    removeBaseAndBucketOverrides(conf, STORAGE_CLASS);
+
+    conf.set(STORAGE_CLASS, TEST_STORAGE_CLASS);
+    return conf;
+  }
+
+  @Override
+  protected String getBlockOutputBufferName() {
+    return Constants.FAST_UPLOAD_BUFFER_ARRAY;
+  }
+
+  @Override
+  protected void assertStorageClass(Path hugeFile) throws IOException {
+    String expected = TEST_STORAGE_CLASS;
+
+    S3AFileSystem fs = getFileSystem();
+    String actual = fs.getObjectMetadata(hugeFile).getStorageClass();
+
+    assertEquals("Storage class of object is " + actual + ", expected " + expected, expected,
+        actual);
+  }
+}


### PR DESCRIPTION
### Description of PR

HADOOP-12020 Amazon S3 uses, by default, the NORMAL_STORAGE class for s3 objects.
This offers 99.99999999% reliability.

For many applications, however, the 99.99% reliability offered by the REDUCED_REDUNDANCY storage class is amply sufficient, and comes with a significant cost saving.

This changes

- Add new configuration `fs.s3a.storage.class` for S3A
- Add integration tests to verify objects can be created and copied with specified storage class
- It also enable applications to write in other storage classes, including archive, which current behavior produces errors on read
- Update documentation about the new config

### How was this patch tested?

Run integration tests in `eu-west-1` passed with
`mvn -Dparallel-tests -DtestsThreadCount=32 clean verify`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

