### PR TITLE
HDFS-16411 RBF: RouterId is NULL when disable RourterRpcServer

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -195,7 +195,9 @@ public class Router extends CompositeService implements
       addService(this.rpcServer);
       this.setRpcServerAddress(rpcServer.getRpcAddress());
     }
+
     checkRouterId();
+
     if (conf.getBoolean(
         RBFConfigKeys.DFS_ROUTER_ADMIN_ENABLE,
         RBFConfigKeys.DFS_ROUTER_ADMIN_ENABLE_DEFAULT)) {
@@ -308,19 +310,18 @@ public class Router extends CompositeService implements
     }
   }
 
+  /**
+   * Set the router id if not set to prevent RouterHeartbeatService
+   * update state store with a null router id
+   */
   private void checkRouterId() {
     if (this.routerId == null) {
-      try {
-        String hostname = InetAddress.getLocalHost().getHostName();
-        InetSocketAddress confRpcAddress = conf.getSocketAddr(
-                RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
-                RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
-                RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
-                RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
-        setRouterId(hostname + ":" + confRpcAddress.getPort());
-      } catch (UnknownHostException ex) {
-        LOG.error("Cannot set unique router ID, address not resolvable");
-      }
+      InetSocketAddress rpcAddress = conf.getSocketAddr(
+          RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
+          RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
+          RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
+          RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
+      setRpcServerAddress(rpcAddress);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -187,23 +187,8 @@ public class Router extends CompositeService implements
       throw new IOException("Cannot find subcluster resolver");
     }
 
-    if (conf.getBoolean(
-        RBFConfigKeys.DFS_ROUTER_RPC_ENABLE,
-        RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_DEFAULT)) {
-      // Create RPC server
-      this.rpcServer = createRpcServer();
-      addService(this.rpcServer);
-      this.setRpcServerAddress(rpcServer.getRpcAddress());
-    } else {
-      InetSocketAddress confRpcAddress = conf.getSocketAddr(
-              RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
-              RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
-              RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
-              RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
-
-      String hostname = InetAddress.getLocalHost().getHostName();
-      setRouterId(hostname + ":" + confRpcAddress.getPort());
-    }
+    // whether create rpc server or not, set routerId anyway.
+    setRpcServer();
 
     if (conf.getBoolean(
         RBFConfigKeys.DFS_ROUTER_ADMIN_ENABLE,
@@ -394,6 +379,26 @@ public class Router extends CompositeService implements
   /////////////////////////////////////////////////////////
   // RPC Server
   /////////////////////////////////////////////////////////
+
+  private void setRpcServer() throws IOException {
+    if (conf.getBoolean(
+            RBFConfigKeys.DFS_ROUTER_RPC_ENABLE,
+            RBFConfigKeys.DFS_ROUTER_RPC_ENABLE_DEFAULT)) {
+      // Create RPC server
+      this.rpcServer = createRpcServer();
+      addService(this.rpcServer);
+      this.setRpcServerAddress(rpcServer.getRpcAddress());
+    } else {
+      InetSocketAddress confRpcAddress = conf.getSocketAddr(
+              RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
+              RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
+              RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
+              RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
+
+      String hostname = InetAddress.getLocalHost().getHostName();
+      setRouterId(hostname + ":" + confRpcAddress.getPort());
+    }
+  }
 
   /**
    * Create a new Router RPC server to proxy ClientProtocol requests.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -316,12 +316,12 @@ public class Router extends CompositeService implements
    */
   private void checkRouterId() {
     if (this.routerId == null) {
-      InetSocketAddress ConfRpcAddress = conf.getSocketAddr(
+      InetSocketAddress confRpcAddress = conf.getSocketAddr(
           RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
           RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
           RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
           RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
-      setRpcServerAddress(ConfRpcAddress);
+      setRpcServerAddress(confRpcAddress);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -430,12 +430,6 @@ public class Router extends CompositeService implements
   protected void setRpcServerAddress(InetSocketAddress address) {
     this.rpcAddress = address;
 
-    try {
-      InetAddress.getLocalHost();
-    } catch (UnknownHostException e) {
-      e.printStackTrace();
-    }
-
     // Use the RPC address as our unique router Id
     if (this.rpcAddress != null) {
       try {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -312,16 +312,16 @@ public class Router extends CompositeService implements
 
   /**
    * Set the router id if not set to prevent RouterHeartbeatService
-   * update state store with a null router id
+   * update state store with a null router id.
    */
   private void checkRouterId() {
     if (this.routerId == null) {
-      InetSocketAddress rpcAddress = conf.getSocketAddr(
+      InetSocketAddress ConfRpcAddress = conf.getSocketAddr(
           RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
           RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
           RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
           RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
-      setRpcServerAddress(rpcAddress);
+      setRpcServerAddress(ConfRpcAddress);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -194,6 +194,15 @@ public class Router extends CompositeService implements
       this.rpcServer = createRpcServer();
       addService(this.rpcServer);
       this.setRpcServerAddress(rpcServer.getRpcAddress());
+    } else {
+      InetSocketAddress confRpcAddress = conf.getSocketAddr(
+              RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY,
+              RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_KEY,
+              RBFConfigKeys.DFS_ROUTER_RPC_ADDRESS_DEFAULT,
+              RBFConfigKeys.DFS_ROUTER_RPC_PORT_DEFAULT);
+
+      String hostname = InetAddress.getLocalHost().getHostName();
+      setRouterId(hostname + ":" + confRpcAddress.getPort());
     }
 
     if (conf.getBoolean(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -238,12 +238,16 @@ public class TestRouter {
   private void assertRouterHeartbeater(boolean expectedRouterHeartbeat,
       boolean expectedNNHeartbeat) throws IOException {
     final Router router = new Router();
-    Configuration baseCfg = new RouterConfigBuilder(conf).rpc().build();
+    Configuration baseCfg = new RouterConfigBuilder(conf).rpc(false).build();
     baseCfg.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE,
         expectedRouterHeartbeat);
     baseCfg.setBoolean(RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_ENABLE,
         expectedNNHeartbeat);
     router.init(baseCfg);
+
+    // RouterId can not be null , used by RouterHeartbeatService.updateStateStore()
+    assertNotNull(router.getRouterId());
+
     RouterHeartbeatService routerHeartbeatService =
         router.getRouterHeartbeatService();
     if (expectedRouterHeartbeat) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -223,14 +223,14 @@ public class TestRouter {
 
   @Test
   public void testSwitchRouter() throws IOException {
-    assertRouterHeartbeater(true,true, true);
-    assertRouterHeartbeater(true,true, false);
-    assertRouterHeartbeater(true,false, true);
-    assertRouterHeartbeater(true,false, false);
-    assertRouterHeartbeater(false,true, true);
-    assertRouterHeartbeater(false,true, false);
-    assertRouterHeartbeater(false,false, true);
-    assertRouterHeartbeater(false,false, false);
+    assertRouterHeartbeater(true, true, true);
+    assertRouterHeartbeater(true, true, false);
+    assertRouterHeartbeater(true, false, true);
+    assertRouterHeartbeater(true, false, false);
+    assertRouterHeartbeater(false, true, true);
+    assertRouterHeartbeater(false, true, false);
+    assertRouterHeartbeater(false, false, true);
+    assertRouterHeartbeater(false, false, false);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouter.java
@@ -223,10 +223,14 @@ public class TestRouter {
 
   @Test
   public void testSwitchRouter() throws IOException {
-    assertRouterHeartbeater(true, true);
-    assertRouterHeartbeater(true, false);
-    assertRouterHeartbeater(false, true);
-    assertRouterHeartbeater(false, false);
+    assertRouterHeartbeater(true,true, true);
+    assertRouterHeartbeater(true,true, false);
+    assertRouterHeartbeater(true,false, true);
+    assertRouterHeartbeater(true,false, false);
+    assertRouterHeartbeater(false,true, true);
+    assertRouterHeartbeater(false,true, false);
+    assertRouterHeartbeater(false,false, true);
+    assertRouterHeartbeater(false,false, false);
   }
 
   /**
@@ -235,10 +239,10 @@ public class TestRouter {
    * @param expectedRouterHeartbeat expect the routerHeartbeat enable state.
    * @param expectedNNHeartbeat expect the nnHeartbeat enable state.
    */
-  private void assertRouterHeartbeater(boolean expectedRouterHeartbeat,
+  private void assertRouterHeartbeater(boolean enableRpcServer, boolean expectedRouterHeartbeat,
       boolean expectedNNHeartbeat) throws IOException {
     final Router router = new Router();
-    Configuration baseCfg = new RouterConfigBuilder(conf).rpc(false).build();
+    Configuration baseCfg = new RouterConfigBuilder(conf).rpc(enableRpcServer).build();
     baseCfg.setBoolean(RBFConfigKeys.DFS_ROUTER_HEARTBEAT_ENABLE,
         expectedRouterHeartbeat);
     baseCfg.setBoolean(RBFConfigKeys.DFS_ROUTER_NAMENODE_HEARTBEAT_ENABLE,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
@@ -57,6 +57,7 @@ public class TestRouterHeartbeatService {
   @Before
   public void setup() throws Exception {
     router = new Router();
+    router.setRouterId(routerId);
     Configuration conf = new Configuration();
     conf.setInt(RBFConfigKeys.DFS_ROUTER_CACHE_TIME_TO_LIVE_MS, 1);
     Configuration routerConfig =
@@ -75,8 +76,6 @@ public class TestRouterHeartbeatService {
     curatorFramework.start();
     routerConfig.set(CommonConfigurationKeys.ZK_ADDRESS, connectStr);
     router.init(routerConfig);
-    // set custom routerid after router.init()
-    router.setRouterId(routerId);
     router.start();
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterHeartbeatService.java
@@ -57,7 +57,6 @@ public class TestRouterHeartbeatService {
   @Before
   public void setup() throws Exception {
     router = new Router();
-    router.setRouterId(routerId);
     Configuration conf = new Configuration();
     conf.setInt(RBFConfigKeys.DFS_ROUTER_CACHE_TIME_TO_LIVE_MS, 1);
     Configuration routerConfig =
@@ -76,6 +75,8 @@ public class TestRouterHeartbeatService {
     curatorFramework.start();
     routerConfig.set(CommonConfigurationKeys.ZK_ADDRESS, connectStr);
     router.init(routerConfig);
+    // set custom routerid after router.init()
+    router.setRouterId(routerId);
     router.start();
 
 


### PR DESCRIPTION
JIRA: [HDFS-16411](https://issues.apache.org/jira/browse/HDFS-16411)

When dfs.federation.router.rpc.enable=false, routerid is null, but RouterHeartbeatService need updateStateStore() with routerId.
