### PR TITLE
HADOOP-16223. Remove misleading fs.s3a.delegation.tokens.enabled prompt

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1359,12 +1359,6 @@
 </property>
 
 <property>
-  <name>fs.s3a.delegation.tokens.enabled</name>
-  <value>false</value>
-  <description></description>
-</property>
-
-<property>
   <name>fs.s3a.delegation.token.binding</name>
   <value></value>
   <description>


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/HADOOP-16223

### Description of PR

This PR removes `fs.s3a.delegation.tokens.enabled` option from `core-default.xml` as this option is not used.

### How was this patch tested?

Tested in `eu-west-1` with `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify`

