### PR TITLE
HDFS-16422. Fix thread safety of EC decoding during concurrent preads

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/RawErasureDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/RawErasureDecoder.java
@@ -81,7 +81,7 @@ public abstract class RawErasureDecoder {
    * @param outputs output buffers to put decoded data into according to
    *                erasedIndexes, ready for read after the call
    */
-  public void decode(ByteBuffer[] inputs, int[] erasedIndexes,
+  public synchronized void decode(ByteBuffer[] inputs, int[] erasedIndexes,
                      ByteBuffer[] outputs) throws IOException {
     ByteBufferDecodingState decodingState = new ByteBufferDecodingState(this,
         inputs, erasedIndexes, outputs);
@@ -130,7 +130,7 @@ public abstract class RawErasureDecoder {
    *                erasedIndexes, ready for read after the call
    * @throws IOException if the decoder is closed.
    */
-  public void decode(byte[][] inputs, int[] erasedIndexes, byte[][] outputs)
+  public synchronized void decode(byte[][] inputs, int[] erasedIndexes, byte[][] outputs)
       throws IOException {
     ByteArrayDecodingState decodingState = new ByteArrayDecodingState(this,
         inputs, erasedIndexes, outputs);
@@ -163,7 +163,7 @@ public abstract class RawErasureDecoder {
    *                erasedIndexes, ready for read after the call
    * @throws IOException if the decoder is closed
    */
-  public void decode(ECChunk[] inputs, int[] erasedIndexes,
+  public synchronized void decode(ECChunk[] inputs, int[] erasedIndexes,
                      ECChunk[] outputs) throws IOException {
     ByteBuffer[] newInputs = CoderUtil.toBuffers(inputs);
     ByteBuffer[] newOutputs = CoderUtil.toBuffers(outputs);


### PR DESCRIPTION
Reading data on an erasure-coded file with missing replicas(internal block of block group) will cause online reconstruction: read `dataUnits` part of data and decode them into the target missing data. Each `DFSStripedInputStream` object has a `RawErasureDecoder` object, and when we doing pread concurrently, `RawErasureDecoder.decode` will be invoked concurrently too. `RawErasureDecoder.decode` is not thread safe, as a result of that we get wrong data from pread occasionally.