### PR TITLE
HDFS-16424. Add a new requeue rpcmetric

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProcessingDetails.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProcessingDetails.java
@@ -48,7 +48,8 @@ public class ProcessingDetails {
     LOCKWAIT,         // processing while waiting for lock.
     LOCKSHARED,       // processing with a read lock.
     LOCKEXCLUSIVE,    // processing with a write lock.
-    RESPONSE;         // time to encode and send response.
+    RESPONSE,         // time to encode and send response.
+    REQUEUE;          // time in the call queue, but was requeuqed
   }
 
   private long[] timings = new long[Timing.values().length];

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -128,6 +128,7 @@ public class RpcMetrics {
   MutableCounterLong rpcClientBackoff;
   @Metric("Number of Slow RPC calls")
   MutableCounterLong rpcSlowCalls;
+  @Metric("Requeue time") MutableRate rpcRequeueTime;
 
   @Metric("Number of open connections") public int numOpenConnections() {
     return server.getNumOpenConnections();
@@ -247,6 +248,15 @@ public class RpcMetrics {
       }
     }
   }
+
+  /**
+   * Add an RPC Requeue time sample
+   * @param requeueTime the requeue time
+   */
+  public void addRpcRequeueTime(long requeueTime) {
+    rpcRequeueTime.add(requeueTime);
+  }
+
 
   public void addRpcLockWaitTime(long waitTime) {
     rpcLockWaitTime.add(waitTime);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProcessingDetails.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProcessingDetails.java
@@ -56,6 +56,6 @@ public class TestProcessingDetails {
 
     assertEquals("enqueueTime=10 queueTime=20000 handlerTime=0 " +
         "processingTime=0 lockfreeTime=0 lockwaitTime=0 locksharedTime=0 " +
-        "lockexclusiveTime=0 responseTime=0", details.toString());
+        "lockexclusiveTime=0 responseTime=0 requeueTime=0", details.toString());
   }
 }


### PR DESCRIPTION
### Description of PR

When observer namenode read enabled,  if `call.getClientStateId() > alignmentContext.getLastSeenStateId()`, the rpc call will be requeued to callQueue. We need to know rpc requeue metrics to monitor requeue call and its performance.

If we don't expose this requeue metric directly, we will find it in flame graph, that is too bothersome.

###
https://issues.apache.org/jira/browse/HDFS-16424