### PR TITLE
HDFS-16426. Fix nextBlockReportTime when trigger full block report force

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1271,6 +1271,7 @@ class BPServiceActor implements Runnable {
 
     void forceFullBlockReportNow() {
       forceFullBlockReport.set(true);
+      resetBlockReportTime = true;
     }
 
     /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBpServiceActorScheduler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBpServiceActorScheduler.java
@@ -141,6 +141,23 @@ public class TestBpServiceActorScheduler {
     }
   }
 
+  /**
+   * force trigger full block report multi times, the next block report
+   * must be scheduled in the range (now + BLOCK_REPORT_INTERVAL_SEC).
+   */
+  @Test
+  public void testScheduleNextBlockReport4() {
+    for (final long now : getTimestamps()) {
+      Scheduler scheduler = makeMockScheduler(now);
+      for (int i = 0; i < getTimestamps().size(); ++i) {
+        scheduler.forceFullBlockReportNow();
+        scheduler.scheduleNextBlockReport();
+      }
+      assertTrue(scheduler.getNextBlockReportTime() - now >= 0);
+      assertTrue(scheduler.getNextBlockReportTime() - now <= BLOCK_REPORT_INTERVAL_MS);
+    }
+  }
+
   @Test
   public void testScheduleHeartbeat() {
     for (final long now : getTimestamps()) {


### PR DESCRIPTION
jira: [HDFS-16426](https://issues.apache.org/jira/browse/HDFS-16426)

When we trigger full block report force by command line, the next block report time will be set like this:

nextBlockReportTime.getAndAdd(blockReportIntervalMs);

nextBlockReportTime will larger than blockReportIntervalMs.

If we trigger full block report twice, the nextBlockReportTime will larger than 2 * blockReportIntervalMs. This is obviously not what we want.

We fix the nextBlockReportTime = now + blockReportIntervalMs after full block report trigger by command line.