### PR TITLE
HDFS-16427. Add debug log for BlockManager#chooseExcessRedundancyStriped

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4047,6 +4047,13 @@ public class BlockManager implements BlockStatsMXBean {
         List<DatanodeStorageInfo> replicasToDelete = placementPolicy
             .chooseReplicasToDelete(nonExcess, candidates, (short) 1,
                 excessTypes, null, null);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Choose redundant EC replicas to delete, blockId: {}, targetIndex: {}, " +
+                  "nonExcess: {}, found: {}, duplicated: {}, storage2index: {}, " +
+                  "candidates: {}, replicasToDelete: {}",
+              sblk.getBlockId(), targetIndex, new ArrayList<>(nonExcess), found, duplicated,
+              storage2index, candidates, replicasToDelete);
+        }
         for (DatanodeStorageInfo chosen : replicasToDelete) {
           processChosenExcessRedundancy(nonExcess, chosen, storedBlock);
           candidates.remove(chosen);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4048,12 +4048,13 @@ public class BlockManager implements BlockStatsMXBean {
             .chooseReplicasToDelete(nonExcess, candidates, (short) 1,
                 excessTypes, null, null);
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Choose redundant EC replicas to delete, blockId: {}, targetIndex: {}, " +
-                  "found: {}, duplicated: {}, storage2index: {}, " +
-                  "candidates: {}, replicasToDelete: {}",
-              sblk.getBlockId(), targetIndex, found, duplicated,
-              storage2index, candidates, replicasToDelete);
+          LOG.debug("Choose redundant EC replicas to delete from blk_{} which is located in {}",
+              sblk.getBlockId(), storage2index);
+          LOG.debug("Storages with candidate blocks to be deleted: {}", candidates);
+          LOG.debug("Storages with blocks to be deleted: {}", replicasToDelete);
         }
+        Preconditions.checkArgument(candidates.containsAll(replicasToDelete),
+            "The EC replicas to be deleted is not in the candidate list");
         for (DatanodeStorageInfo chosen : replicasToDelete) {
           processChosenExcessRedundancy(nonExcess, chosen, storedBlock);
           candidates.remove(chosen);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4054,7 +4054,7 @@ public class BlockManager implements BlockStatsMXBean {
           LOG.debug("Storages with blocks to be deleted: {}", replicasToDelete);
         }
         Preconditions.checkArgument(candidates.containsAll(replicasToDelete),
-            "The EC replicas to be deleted is not in the candidate list");
+            "The EC replicas to be deleted are not in the candidate list");
         for (DatanodeStorageInfo chosen : replicasToDelete) {
           processChosenExcessRedundancy(nonExcess, chosen, storedBlock);
           candidates.remove(chosen);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -4049,9 +4049,9 @@ public class BlockManager implements BlockStatsMXBean {
                 excessTypes, null, null);
         if (LOG.isDebugEnabled()) {
           LOG.debug("Choose redundant EC replicas to delete, blockId: {}, targetIndex: {}, " +
-                  "nonExcess: {}, found: {}, duplicated: {}, storage2index: {}, " +
+                  "found: {}, duplicated: {}, storage2index: {}, " +
                   "candidates: {}, replicasToDelete: {}",
-              sblk.getBlockId(), targetIndex, new ArrayList<>(nonExcess), found, duplicated,
+              sblk.getBlockId(), targetIndex, found, duplicated,
               storage2index, candidates, replicasToDelete);
         }
         for (DatanodeStorageInfo chosen : replicasToDelete) {


### PR DESCRIPTION
JIRA: [HDFS-16427](https://issues.apache.org/jira/browse/HDFS-16427).

To solve this issue [HDFS-16420](https://issues.apache.org/jira/browse/HDFS-16420) , we added some debug logs, which were also necessary. If there are other problems, we set the log level to DEBUG, which is convenient to analyze it.