### PR TITLE
HADOOP-18082.Add debug log when RPC#Reader gets a Call.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -3046,6 +3046,9 @@ public abstract class Server {
       } else {
         callQueue.add(call);
       }
+
+      LOG.debug("Call has entered the CallQueue and is waiting to be processed. " +
+          "Call details: {}", call);
       long deltaNanos = Time.monotonicNowNanos() - call.timestampNanos;
       call.getProcessingDetails().set(Timing.ENQUEUE, deltaNanos,
           TimeUnit.NANOSECONDS);


### PR DESCRIPTION

### Description of PR
Log some information from the moment Call enters the RPC inside, which will help us understand more about Call.
The records here should be in the form of logs. The priority of the logs should not be too high, and debugging is the best.
Details: HADOOP-18082

### How was this patch tested?
Corresponding to the test, the pressure is not large.

