### PR TITLE
HDFS-16430. Validate maximum blocks in EC group when adding an EC policy

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ErasureCodingPolicyManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ErasureCodingPolicyManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -302,6 +303,12 @@ public final class ErasureCodingPolicyManager {
     if (!CodecUtil.hasCodec(policy.getCodecName())) {
       throw new HadoopIllegalArgumentException("Codec name "
           + policy.getCodecName() + " is not supported");
+    }
+
+    int blocksInGroup = policy.getNumDataUnits() + policy.getNumParityUnits();
+    if (blocksInGroup > HdfsServerConstants.MAX_BLOCKS_IN_GROUP) {
+      throw new HadoopIllegalArgumentException("Number of data and parity blocks in an EC group " +
+          blocksInGroup + " should not exceed maximum " + HdfsServerConstants.MAX_BLOCKS_IN_GROUP);
     }
 
     if (policy.getCellSize() > maxCellSize) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestErasureCodingPolicies.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestErasureCodingPolicies.java
@@ -747,6 +747,15 @@ public class TestErasureCodingPolicies {
     assertEquals(1, responses.length);
     assertFalse(responses[0].isSucceed());
 
+    // Test numDataUnits + numParityUnits > 16
+    toAddSchema = new ECSchema("rs", 14, 4);
+    newPolicy =
+        new ErasureCodingPolicy(toAddSchema, 128 * 1024 * 1024);
+    policyArray = new ErasureCodingPolicy[]{newPolicy};
+    responses = fs.addErasureCodingPolicies(policyArray);
+    assertEquals(1, responses.length);
+    assertFalse(responses[0].isSucceed());
+
     // Test too big cell size
     toAddSchema = new ECSchema("rs", 3, 2);
     newPolicy =


### PR DESCRIPTION
HDFS EC adopts the last 4 bits of block ID to store the block index in EC block group. Therefore maximum blocks in EC block group is `2^4=16`, and which is defined here: `HdfsServerConstants#MAX_BLOCKS_IN_GROUP`.

Currently there is no limitation or warning when adding a bad EC policy with `numDataUnits + numParityUnits > 16`. It only results in read/write error on EC file with bad EC policy. To users this is not very straightforward.