### PR TITLE
Hadoop-18032: ABFS: Support for secondary accounts on ABFS Driver for SharedKey Auth

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -82,6 +82,7 @@ public class AbfsConfiguration{
 
   private final Configuration rawConfig;
   private final String accountName;
+  private final String primaryAccountName;
   private final boolean isSecure;
   private static final Logger LOG = LoggerFactory.getLogger(AbfsConfiguration.class);
 
@@ -311,6 +312,11 @@ public class AbfsConfiguration{
     this.rawConfig = ProviderUtils.excludeIncompatibleCredentialProviders(
         rawConfig, AzureBlobFileSystem.class);
     this.accountName = accountName;
+    if (accountName.contains("-secondary")) {
+      this.primaryAccountName = accountName.replace("-secondary", "");
+    } else {
+      this.primaryAccountName = accountName;
+    }
     this.isSecure = getBoolean(FS_AZURE_SECURE_MODE, false);
 
     Field[] fields = this.getClass().getDeclaredFields();
@@ -343,6 +349,16 @@ public class AbfsConfiguration{
   public String getAccountName() {
     return accountName;
   }
+
+  /**
+   * Gets the Azure Storage account primary name corresponding to this instance of configuration.
+   *
+   * @return the Azure Storage primary account name
+   */
+  public String getPrimaryAccountName() {
+    return primaryAccountName;
+  }
+
 
   /**
    * Gets client correlation ID provided in config.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1574,12 +1574,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
     if (authType == AuthType.SharedKey) {
       LOG.trace("Fetching SharedKey credentials");
-      int dotIndex = accountName.indexOf(AbfsHttpConstants.DOT);
+      final String primaryAccountName = abfsConfiguration.getPrimaryAccountName();
+      int dotIndex = primaryAccountName.indexOf(AbfsHttpConstants.DOT);
       if (dotIndex <= 0) {
         throw new InvalidUriException(
                 uri.toString() + " - account name is not fully qualified.");
       }
-      creds = new SharedKeyCredentials(accountName.substring(0, dotIndex),
+      creds = new SharedKeyCredentials(primaryAccountName.substring(0, dotIndex),
             abfsConfiguration.getStorageAccountKey());
     } else if (authType == AuthType.SAS) {
       LOG.trace("Fetching SAS token provider");

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -92,6 +92,7 @@ public class AbfsClient implements Closeable {
   private final String clientProvidedEncryptionKeySHA;
 
   private final String accountName;
+  private final String primaryAccountName;
   private final AuthType authType;
   private AccessTokenProvider tokenProvider;
   private SASTokenProvider sasTokenProvider;
@@ -110,6 +111,8 @@ public class AbfsClient implements Closeable {
     this.abfsConfiguration = abfsConfiguration;
     this.retryPolicy = abfsClientContext.getExponentialRetryPolicy();
     this.accountName = abfsConfiguration.getAccountName().substring(0, abfsConfiguration.getAccountName().indexOf(AbfsHttpConstants.DOT));
+    this.primaryAccountName = abfsConfiguration.getPrimaryAccountName().substring(0, abfsConfiguration.getPrimaryAccountName().
+            indexOf(AbfsHttpConstants.DOT));
     this.authType = abfsConfiguration.getAuthType(accountName);
 
     String encryptionKey = this.abfsConfiguration
@@ -986,7 +989,7 @@ public class AbfsClient implements Closeable {
       try {
         LOG.trace("Fetch SAS token for {} on {}", operation, path);
         if (cachedSasToken == null) {
-          sasToken = sasTokenProvider.getSASToken(this.accountName,
+          sasToken = sasTokenProvider.getSASToken(this.primaryAccountName,
               this.filesystem, path, operation);
           if ((sasToken == null) || sasToken.isEmpty()) {
             throw new UnsupportedOperationException("SASToken received is empty or null");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -144,6 +144,9 @@ public abstract class AbstractAbfsIntegrationTest extends
     }
   }
 
+  protected boolean getIsSecondaryAccount() {
+    return !(abfsConfig.getAccountName().equals(abfsConfig.getPrimaryAccountName()));
+  }
   protected boolean getIsNamespaceEnabled(AzureBlobFileSystem fs)
       throws IOException {
     return fs.getIsNamespaceEnabled(getTestTracingContext(fs, false));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBackCompat.java
@@ -42,6 +42,7 @@ public class ITestAzureBlobFileSystemBackCompat extends
   @Test
   public void testBlobBackCompat() throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
+    Assume.assumeFalse("Secondary account does not support this test,", getIsSecondaryAccount());
     Assume.assumeFalse("This test does not support namespace enabled account",
         getIsNamespaceEnabled(getFileSystem()));
     String storageConnectionString = getBlobConnectionString();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -113,6 +113,7 @@ public class ITestAzureBlobFileSystemRandomRead extends
    */
   @Test
   public void testRandomRead() throws Exception {
+    Assume.assumeFalse("Secondary account does not support this test,", getIsSecondaryAccount());
     Assume.assumeFalse("This test does not support namespace enabled account",
         getIsNamespaceEnabled(getFileSystem()));
     Path testPath = path(TEST_FILE_PREFIX + "_testRandomRead");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
@@ -49,6 +49,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
       LoggerFactory.getLogger(ITestWasbAbfsCompatibility.class);
 
   public ITestWasbAbfsCompatibility() throws Exception {
+    Assume.assumeFalse("Secondary account does not support this test,", getIsSecondaryAccount());
     Assume.assumeFalse("Emulator is not supported", isIPAddress());
   }
 


### PR DESCRIPTION
In this PR, we have added support for secondary accounts on ABFS Driver mainly for SharedKey Authorization Type.
So we have created a separate field as primaryAccountName for getting the sharedKey credentials which is the same as accountName for primary accounts but we replace "-secondary" string from the accountName for the secondary accounts,

