### PR TITLE
HADOOP-18084 ABFS: Add testfilePath while verifying test contents are read correctly

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStream.java
@@ -81,7 +81,7 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
         }
         assertEquals(length, bytesRead);
         assertContentReadCorrectly(fileContent,
-            (int) (seekPos + totalBytesRead - length), length, buffer);
+            (int) (seekPos + totalBytesRead - length), length, buffer, testFilePath);
 
         assertTrue(abfsInputStream.getFCursor() >= seekPos + totalBytesRead);
         assertTrue(abfsInputStream.getFCursorAfterLastRead() >= seekPos + totalBytesRead);
@@ -133,7 +133,7 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
         actualLength = length - delta;
       }
       assertEquals(bytesRead, actualLength);
-      assertContentReadCorrectly(fileContent, seekPos, (int) actualLength, buffer);
+      assertContentReadCorrectly(fileContent, seekPos, (int) actualLength, buffer, testFilePath);
       assertEquals(fileContent.length, abfsInputStream.getFCursor());
       assertEquals(fileContent.length, abfsInputStream.getFCursorAfterLastRead());
       assertEquals(actualLength, abfsInputStream.getBCursor());
@@ -200,24 +200,24 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
   }
 
   protected void assertContentReadCorrectly(byte[] actualFileContent, int from,
-      int len, byte[] contentRead) {
+      int len, byte[] contentRead, Path testFilePath) {
     for (int i = 0; i < len; i++) {
-      assertEquals(contentRead[i], actualFileContent[i + from]);
+      assertEquals("The test file path is " + testFilePath, contentRead[i], actualFileContent[i + from]);
     }
   }
 
   protected void assertBuffersAreNotEqual(byte[] actualContent,
-      byte[] contentRead, AbfsConfiguration conf) {
-    assertBufferEquality(actualContent, contentRead, conf, false);
+      byte[] contentRead, AbfsConfiguration conf, Path testFilePath) {
+    assertBufferEquality(actualContent, contentRead, conf, false, testFilePath);
   }
 
   protected void assertBuffersAreEqual(byte[] actualContent, byte[] contentRead,
-      AbfsConfiguration conf) {
-    assertBufferEquality(actualContent, contentRead, conf, true);
+      AbfsConfiguration conf, Path testFilePath) {
+    assertBufferEquality(actualContent, contentRead, conf, true, testFilePath);
   }
 
   private void assertBufferEquality(byte[] actualContent, byte[] contentRead,
-      AbfsConfiguration conf, boolean assertEqual) {
+      AbfsConfiguration conf, boolean assertEqual, Path testFilePath) {
     int bufferSize = conf.getReadBufferSize();
     int actualContentSize = actualContent.length;
     int n = (actualContentSize < bufferSize) ? actualContentSize : bufferSize;
@@ -228,9 +228,9 @@ public class ITestAbfsInputStream extends AbstractAbfsIntegrationTest {
       }
     }
     if (assertEqual) {
-      assertEquals(n, matches);
+      assertEquals("The test file path is " + testFilePath, n, matches);
     } else {
-      assertNotEquals(n, matches);
+      assertNotEquals("The test file path is " + testFilePath, n, matches);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStreamReadFooter.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStreamReadFooter.java
@@ -235,14 +235,14 @@ public class ITestAbfsInputStreamReadFooter extends ITestAbfsInputStream {
       assertEquals(expectedBCurson, abfsInputStream.getBCursor());
       assertEquals(actualLength, bytesRead);
       //  Verify user-content read
-      assertContentReadCorrectly(fileContent, seekPos, (int) actualLength, buffer);
+      assertContentReadCorrectly(fileContent, seekPos, (int) actualLength, buffer, testFilePath);
       //  Verify data read to AbfsInputStream buffer
       int from = seekPos;
       if (optimizationOn) {
         from = (int) max(0, actualContentLength - bufferSize);
       }
       assertContentReadCorrectly(fileContent, from, (int) abfsInputStream.getLimit(),
-          abfsInputStream.getBuffer());
+          abfsInputStream.getBuffer(), testFilePath);
     }
   }
 
@@ -280,7 +280,7 @@ public class ITestAbfsInputStreamReadFooter extends ITestAbfsInputStream {
       byte[] buffer = new byte[length];
       int bytesRead = iStream.read(buffer, 0, length);
       assertEquals(length, bytesRead);
-      assertContentReadCorrectly(fileContent, seekPos, length, buffer);
+      assertContentReadCorrectly(fileContent, seekPos, length, buffer, testFilePath);
       assertEquals(fileContent.length, abfsInputStream.getFCursor());
       assertEquals(length, abfsInputStream.getBCursor());
       assertTrue(abfsInputStream.getLimit() >= length);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStreamSmallFileReads.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsInputStreamSmallFileReads.java
@@ -189,7 +189,7 @@ public class ITestAbfsInputStreamSmallFileReads extends ITestAbfsInputStream {
       byte[] buffer = new byte[length];
       int bytesRead = iStream.read(buffer, 0, length);
       assertEquals(bytesRead, length);
-      assertContentReadCorrectly(fileContent, seekPos, length, buffer);
+      assertContentReadCorrectly(fileContent, seekPos, length, buffer, testFilePath);
       AbfsInputStream abfsInputStream = (AbfsInputStream) iStream
           .getWrappedStream();
 
@@ -199,16 +199,16 @@ public class ITestAbfsInputStreamSmallFileReads extends ITestAbfsInputStream {
       int expectedLimit, expectedFCursor;
       int expectedBCursor;
       if (conf.readSmallFilesCompletely() && smallFile) {
-        assertBuffersAreEqual(fileContent, abfsInputStream.getBuffer(), conf);
+        assertBuffersAreEqual(fileContent, abfsInputStream.getBuffer(), conf, testFilePath);
         expectedFCursor = fileContentLength;
         expectedLimit = fileContentLength;
         expectedBCursor = seekPos + length;
       } else {
         if ((seekPos == 0)) {
-          assertBuffersAreEqual(fileContent, abfsInputStream.getBuffer(), conf);
+          assertBuffersAreEqual(fileContent, abfsInputStream.getBuffer(), conf, testFilePath);
         } else {
           assertBuffersAreNotEqual(fileContent, abfsInputStream.getBuffer(),
-              conf);
+              conf, testFilePath);
         }
         expectedBCursor = length;
         expectedFCursor = (fileContentLength < (seekPos + readBufferSize))
@@ -260,7 +260,7 @@ public class ITestAbfsInputStreamSmallFileReads extends ITestAbfsInputStream {
       byte[] buffer = new byte[length];
       int bytesRead = iStream.read(buffer, 0, length);
       assertEquals(bytesRead, length);
-      assertContentReadCorrectly(fileContent, seekPos, length, buffer);
+      assertContentReadCorrectly(fileContent, seekPos, length, buffer, testFilePath);
       assertEquals(fileContent.length, abfsInputStream.getFCursor());
       assertEquals(fileContent.length,
           abfsInputStream.getFCursorAfterLastRead());


### PR DESCRIPTION
Add testfilePath as a param to get the file path for which the contents were not read correctly or the buffer size didn't match the expected one.
