### PR TITLE
HADOOP-16155. S3AInputStream read(bytes[]) to not retry on read failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -513,7 +513,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
           // by onReadFailure, then wrappedStream will be null. But the **retry** may
           // re-execute this block and cause NPE if we don't check wrappedStream
           if (wrappedStream == null) {
-            reopen("failure recovery", getPos(), 1, false);
+            return 0;
           }
           try {
             bytes = wrappedStream.read(buf, off, len);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -509,9 +509,8 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     int bytesRead = invoker.retry("read", pathStr, true,
         () -> {
           int bytes;
-          // When exception happens before re-setting wrappedStream in "reopen" called
-          // by onReadFailure, then wrappedStream will be null. But the **retry** may
-          // re-execute this block and cause NPE if we don't check wrappedStream
+          // When exception happens, onReadFailure closes the stream and
+          // sets wrappedStream to null. In this case, do not reopen the stream.
           if (wrappedStream == null) {
             return 0;
           }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -121,7 +121,8 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
    * @param triggerGetObjectFailure true when getObject failure is enabled.
    * @return mocked object.
    */
-  private S3AInputStream.InputStreamCallbacks getMockedInputStreamCallback(boolean triggerGetObjectFailure) {
+  private S3AInputStream.InputStreamCallbacks getMockedInputStreamCallback(
+      boolean triggerGetObjectFailure) {
     return new S3AInputStream.InputStreamCallbacks() {
 
       private final S3Object mockedS3Object = getMockedS3Object();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -118,6 +118,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
   /**
    * Get mocked InputStreamCallbacks where we return mocked S3Object.
    *
+   * @param triggerGetObjectFailure true when getObject failure is enabled.
    * @return mocked object.
    */
   private S3AInputStream.InputStreamCallbacks getMockedInputStreamCallback(boolean triggerGetObjectFailure) {


### PR DESCRIPTION
### Description of PR

Jira: https://issues.apache.org/jira/browse/HADOOP-16155

When an error happens on read, do not reopen the stream.

For the unit tests I've changed the order of super.read() and trigger failure. This is because previously the failure would happen after the read actually executed and so the buffer would not be empty and we couldn't assert on the buffer being empty in case of failures.

I've also added a new variable triggerGetObjectFailure. This will not trigger a get object failure in case of testInputStreamReadFullyRetryForException. This is because since we are removing retries from read(bytes[]), readFully() will call read(bytes[]) after each failure which will then call lazySeek() every time. The get object failure ends up being thrown in lazySeek() which does not retry and so readFully does not complete.

### How was this patch tested?

Tested in eu-west-1 by running

```
mvn -Dparallel-tests -DtestsThreadCount=16 clean verify
```


