### PR TITLE
HDFS-16431. Truncate CallerContext in client side.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/CallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/CallerContext.java
@@ -147,7 +147,7 @@ public final class CallerContext {
         Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList("\t", "\n", "=")));
 
-    private static volatile Configs INSTANCE;
+    private static volatile Configs instance;
 
     private Configs(Configuration conf) {
       this.init(conf);
@@ -175,17 +175,17 @@ public final class CallerContext {
     }
 
     private static Configs getInstance(Configuration conf) {
-      if (INSTANCE == null) {
+      if (instance == null) {
         synchronized (Configs.class) {
-          if (INSTANCE == null) {
+          if (instance == null) {
             if (conf == null) {
               conf = new Configuration();
             }
-            INSTANCE = new Configs(conf);
+            instance = new Configs(conf);
           }
         }
       }
-      return INSTANCE;
+      return instance;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.hdfs.server.federation.router;
 
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_SEPARATOR_DEFAULT;
-import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_SEPARATOR_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_ON_SOCKET_TIMEOUTS_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_TIMEOUT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
@@ -124,8 +122,6 @@ public class RouterRpcClient {
   private final RetryPolicy retryPolicy;
   /** Optional perf monitor. */
   private final RouterRpcMonitor rpcMonitor;
-  /** Field separator of CallerContext. */
-  private final String contextFieldSeparator;
 
   /** Pattern to parse a stack trace line. */
   private static final Pattern STACK_TRACE_PATTERN =
@@ -154,9 +150,6 @@ public class RouterRpcClient {
     this.namenodeResolver = resolver;
 
     Configuration clientConf = getClientConfiguration(conf);
-    this.contextFieldSeparator =
-        clientConf.get(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY,
-            HADOOP_CALLER_CONTEXT_SEPARATOR_DEFAULT);
     this.connectionManager = new ConnectionManager(clientConf);
     this.connectionManager.start();
     this.routerRpcFairnessPolicyController =
@@ -595,7 +588,7 @@ public class RouterRpcClient {
     String origContext = ctx == null ? null : ctx.getContext();
     byte[] origSignature = ctx == null ? null : ctx.getSignature();
     CallerContext.setCurrent(
-        new CallerContext.Builder(origContext, contextFieldSeparator)
+        new CallerContext.Builder(origContext)
             .appendIfAbsent(CLIENT_IP_STR, Server.getRemoteAddress())
             .appendIfAbsent(CLIENT_PORT_STR,
                 Integer.toString(Server.getRemotePort()))

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/DefaultAuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/DefaultAuditLogger.java
@@ -48,10 +48,6 @@ public abstract class DefaultAuditLogger extends HdfsAuditLogger {
 
   protected volatile boolean isCallerContextEnabled;
 
-  /** The maximum bytes a caller context string can have. */
-  protected int callerContextMaxLen;
-  protected int callerSignatureMaxLen;
-
   /** adds a tracking ID for all audit log events. */
   protected boolean logTokenTrackingId;
 


### PR DESCRIPTION
JIRA https://issues.apache.org/jira/browse/HDFS-16431

### Description of PR

The context of CallerContext would be truncated  when  it exceeds the maximum allowed length in server side. I think it's better to do check and truncate in client side to reduce the unnecessary overhead of network and memory for NN.

### How was this patch tested?

Add some UTs to test the context would be truncated correctly .

### For code changes:

1. Refactor CallerContext.Builder constrctor to simplify usage
2. Do context truncate before CallerContext.Builder.build()



