### PR TITLE
HDFS-16435. Remove no need TODO comment for ObserverReadProxyProvider

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -214,7 +214,6 @@ public class ObserverReadProxyProvider<T>
         OBSERVER_PROBE_RETRY_PERIOD_KEY,
         OBSERVER_PROBE_RETRY_PERIOD_DEFAULT, TimeUnit.MILLISECONDS);
 
-    // TODO : make this configurable or remove this variable
     if (wrappedProxy instanceof ClientProtocol) {
       this.observerReadEnabled = true;
     } else {


### PR DESCRIPTION
JIRA: [HDFS-16435](https://issues.apache.org/jira/browse/HDFS-16435).

Based on discussion in [HDFS-13923](https://issues.apache.org/jira/browse/HDFS-13923), we don't think need to add a configuration to turn on/off observer reads.

So I suggest removing the `TODO comment` that are not needed.
