### PR TITLE
HADOOP-18080. ABFS: Skip testEtagConsistencyAcrossRename for Non-HNS accounts

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1534,8 +1534,8 @@ public class AzureBlobFileSystem extends FileSystem
     case CommonPathCapabilities.FS_PERMISSIONS:
     case CommonPathCapabilities.FS_APPEND:
     case CommonPathCapabilities.ETAGS_AVAILABLE:
-    case CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME:
       return true;
+    case CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME:
     case CommonPathCapabilities.FS_ACLS:
       return getIsNamespaceEnabled(
           new TracingContext(clientCorrelationId, fileSystemId,


### PR DESCRIPTION
The rename operation is not supported for non-HNS accounts. Hence, tests verifying matching etag for file before and after rename should not be run against non-HNS accounts. PR modifies the `hasPathCapability` method to return true only for HNS-enabled accounts for the ETAGS_PRESERVED_IN_RENAME probe.