### PR TITLE
HADOOP-18092. Exclude log4j2 dependency from hadoop-huaweicloud module

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -158,6 +158,14 @@
       <version>${esdk.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+        <exclusion>
           <artifactId>okio</artifactId>
           <groupId>com.squareup.okio</groupId>
         </exclusion>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-18092

Exclude log4j2 dependency from hadoop-huaweicloud module.

### How was this patch tested?

Manually checked that the dependencies are excluded.

```
% mvn clean dependency:tree -pl hadoop-cloud-storage-project/hadoop-huaweicloud/
(snip)
[INFO] +- com.huaweicloud:esdk-obs-java:jar:3.20.4.2:compile
[INFO] |  +- com.jamesmurty.utils:java-xmlbuilder:jar:1.2:compile
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:3.14.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.13.0:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.0:compile
```

I didn't run integration tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

