### PR TITLE
HADOOP-18093: Better exception handling for testFileStatusOnMountLink

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFsBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFsBaseTest.java
@@ -522,7 +522,7 @@ abstract public class ViewFsBaseTest {
         Assert.assertTrue("A mount should appear as symlink", fs.isSymlink());
   }
       
-  @Test
+  @Test(expected = FileNotFoundException.class)
   public void testFileStatusOnMountLink() throws IOException {
     Assert.assertTrue("Slash should appear as dir", 
         fcView.getFileStatus(new Path("/")).isDirectory());
@@ -534,12 +534,7 @@ abstract public class ViewFsBaseTest {
     checkFileStatus(fcView, "/internalDir/internalDir2/linkToDir3", fileType.isDir);
     checkFileStatus(fcView, "/linkToAFile", fileType.isFile);
 
-    try {
-      fcView.getFileStatus(new Path("/danglingLink"));
-      Assert.fail("Excepted a not found exception here");
-    } catch ( FileNotFoundException e) {
-      // as excepted
-    }
+    fcView.getFileStatus(new Path("/danglingLink"));
   }
   
   @Test


### PR DESCRIPTION
### Description of PR

Use `@Test(expected = FileNotFoundException.class)` to indicate we are expecting a FileNotFound exception. This makes it consistent with how similar exceptions are handled in this class as well.

### How was this patch tested?

mvn test -Dtest=TestViewFsLocalFs


