### PR TITLE
HDFS-16437 ReverseXML processor doesn't accept XML files without the …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
@@ -1761,7 +1761,8 @@ class OfflineImageReconstructor {
       XMLEvent ev = expectTag("[section header]", true);
       if (ev.getEventType() == XMLStreamConstants.END_ELEMENT) {
         if (ev.asEndElement().getName().getLocalPart().equals("fsimage")) {
-          if(unprocessedSections.size() == 1 && unprocessedSections.contains(SnapshotDiffSectionProcessor.NAME)){
+          if(unprocessedSections.size() == 1 && unprocessedSections.contains
+                  (SnapshotDiffSectionProcessor.NAME)){
             break;
           }
           throw new IOException("FSImage XML ended prematurely, without " +

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageReconstructor.java
@@ -1761,6 +1761,9 @@ class OfflineImageReconstructor {
       XMLEvent ev = expectTag("[section header]", true);
       if (ev.getEventType() == XMLStreamConstants.END_ELEMENT) {
         if (ev.asEndElement().getName().getLocalPart().equals("fsimage")) {
+          if(unprocessedSections.size() == 1 && unprocessedSections.contains(SnapshotDiffSectionProcessor.NAME)){
+            break;
+          }
           throw new IOException("FSImage XML ended prematurely, without " +
               "including section(s) " + StringUtils.join(", ",
               unprocessedSections));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -1120,17 +1120,17 @@ public class TestOfflineImageViewer {
     LOG.info("Creating reverseImage.xml=" + reverseImageXml.getAbsolutePath() +
         ", reverseImage=" + reverseImage.getAbsolutePath() +
         ", reverseImage2Xml=" + reverseImage2Xml.getAbsolutePath());
-    if (OfflineImageViewerPB.run(new String[] { "-p", "XML",
+    if (OfflineImageViewerPB.run(new String[] {"-p", "XML",
          "-i", originalFsimage.getAbsolutePath(),
          "-o", reverseImageXml.getAbsolutePath() }) != 0) {
       throw new IOException("oiv returned failure creating first XML file.");
     }
-    if (OfflineImageViewerPB.run(new String[] { "-p", "ReverseXML",
+    if (OfflineImageViewerPB.run(new String[] {"-p", "ReverseXML",
           "-i", reverseImageXml.getAbsolutePath(),
           "-o", reverseImage.getAbsolutePath() }) != 0) {
       throw new IOException("oiv returned failure recreating fsimage file.");
     }
-    if (OfflineImageViewerPB.run(new String[] { "-p", "XML",
+    if (OfflineImageViewerPB.run(new String[] {"-p", "XML",
         "-i", reverseImage.getAbsolutePath(),
         "-o", reverseImage2Xml.getAbsolutePath() }) != 0) {
       throw new IOException("oiv returned failure creating second " +
@@ -1139,7 +1139,7 @@ public class TestOfflineImageViewer {
     // The XML file we wrote based on the re-created fsimage should be the
     // same as the one we dumped from the original fsimage.
     Assert.assertEquals("",
-      GenericTestUtils.getFilesDiff(reverseImageXml, reverseImage2Xml));
+        GenericTestUtils.getFilesDiff(reverseImageXml, reverseImage2Xml));
   }
 
   /**
@@ -1180,8 +1180,7 @@ public class TestOfflineImageViewer {
   @Test
   public void testReverseXmlWithoutSnapshotDiffSection() throws Throwable {
     File imageWSDS = new File(tempDir, "imageWithoutSnapshotDiffSection.xml");
-    PrintWriter writer = new PrintWriter(imageWSDS, "UTF-8");
-    try {
+    try(PrintWriter writer = new PrintWriter(imageWSDS, "UTF-8")) {
       writer.println("<?xml version=\"1.0\"?>");
       writer.println("<fsimage>");
       writer.println("<version>");
@@ -1191,16 +1190,19 @@ public class TestOfflineImageViewer {
       writer.println("</version>");
       writer.println("<FileUnderConstructionSection></FileUnderConstructionSection>");
       writer.println("<ErasureCodingSection></ErasureCodingSection>");
-      writer.println("<INodeSection><lastInodeId>91488</lastInodeId><numInodes>0</numInodes></INodeSection>");
-      writer.println("<SecretManagerSection><currentId>90</currentId><tokenSequenceNumber>35</tokenSequenceNumber><numDelegationKeys>0</numDelegationKeys><numTokens>0</numTokens></SecretManagerSection>");
+      writer.println("<INodeSection><lastInodeId>91488</lastInodeId><numInodes>0</numInodes>" +
+              "</INodeSection>");
+      writer.println("<SecretManagerSection><currentId>90</currentId><tokenSequenceNumber>35" +
+              "</tokenSequenceNumber><numDelegationKeys>0</numDelegationKeys><numTokens>0" +
+              "</numTokens></SecretManagerSection>");
       writer.println("<INodeReferenceSection></INodeReferenceSection>");
-      writer.println("<SnapshotSection><snapshotCounter>0</snapshotCounter><numSnapshots>0</numSnapshots></SnapshotSection>");
+      writer.println("<SnapshotSection><snapshotCounter>0</snapshotCounter><numSnapshots>0" +
+              "</numSnapshots></SnapshotSection>");
       writer.println("<NameSection><namespaceId>326384987</namespaceId></NameSection>");
-      writer.println("<CacheManagerSection><nextDirectiveId>1</nextDirectiveId><numPools>0</numPools><numDirectives>0</numDirectives></CacheManagerSection>");
+      writer.println("<CacheManagerSection><nextDirectiveId>1</nextDirectiveId><numPools>0" +
+              "</numPools><numDirectives>0</numDirectives></CacheManagerSection>");
       writer.println("<INodeDirectorySection></INodeDirectorySection>");
       writer.println("</fsimage>");
-    } finally {
-      writer.close();
     }
     try {
       OfflineImageReconstructor.run(imageWSDS.getAbsolutePath(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -1185,7 +1185,7 @@ public class TestOfflineImageViewer {
       writer.println("<?xml version=\"1.0\"?>");
       writer.println("<fsimage>");
       writer.println("<version>");
-      writer.println("<layoutVersion>-64</layoutVersion>");
+      writer.println("<layoutVersion>-67</layoutVersion>");
       writer.println("<onDiskVersion>1</onDiskVersion>");
       writer.println("<oivRevision>545bbef596c06af1c3c8dca1ce29096a64608478</oivRevision>");
       writer.println("</version>");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -1185,21 +1185,19 @@ public class TestOfflineImageViewer {
       writer.println("<?xml version=\"1.0\"?>");
       writer.println("<fsimage>");
       writer.println("<version>");
-      writer.println("<layoutVersion>-65</layoutVersion>");
+      writer.println("<layoutVersion>-64</layoutVersion>");
       writer.println("<onDiskVersion>1</onDiskVersion>");
-      writer.println("<oivRevision>" +
-              "545bbef596c06af1c3c8dca1ce29096a64608478</oivRevision>");
+      writer.println("<oivRevision>545bbef596c06af1c3c8dca1ce29096a64608478</oivRevision>");
       writer.println("</version>");
-      writer.println(
-              "<FileUnderConstructionSection></FileUnderConstructionSection>\n" +
-                      "<ErasureCodingSection></ErasureCodingSection>\n" +
-                      "<INodeSection><lastInodeId>91488</lastInodeId><numInodes>0</numInodes></INodeSection>\n" +
-                      "<SecretManagerSection><currentId>90</currentId><tokenSequenceNumber>35</tokenSequenceNumber></SecretManagerSection>\n" +
-                      "<INodeReferenceSection></INodeReferenceSection>\n" +
-                      "<SnapshotSection><snapshotCounter>0</snapshotCounter><numSnapshots>0</numSnapshots></SnapshotSection>\n" +
-                      "<NameSection><namespaceId>326384987</namespaceId></NameSection>\n" +
-                      "<CacheManagerSection><nextDirectiveId>1</nextDirectiveId><numDirectives>0</numDirectives><numPools>0</numPools></CacheManagerSection>\n" +
-                      "<INodeDirectorySection></INodeDirectorySection>");
+      writer.println("<FileUnderConstructionSection></FileUnderConstructionSection>");
+      writer.println("<ErasureCodingSection></ErasureCodingSection>");
+      writer.println("<INodeSection><lastInodeId>91488</lastInodeId><numInodes>0</numInodes></INodeSection>");
+      writer.println("<SecretManagerSection><currentId>90</currentId><tokenSequenceNumber>35</tokenSequenceNumber><numDelegationKeys>0</numDelegationKeys><numTokens>0</numTokens></SecretManagerSection>");
+      writer.println("<INodeReferenceSection></INodeReferenceSection>");
+      writer.println("<SnapshotSection><snapshotCounter>0</snapshotCounter><numSnapshots>0</numSnapshots></SnapshotSection>");
+      writer.println("<NameSection><namespaceId>326384987</namespaceId></NameSection>");
+      writer.println("<CacheManagerSection><nextDirectiveId>1</nextDirectiveId><numPools>0</numPools><numDirectives>0</numDirectives></CacheManagerSection>");
+      writer.println("<INodeDirectorySection></INodeDirectorySection>");
       writer.println("</fsimage>");
     } finally {
       writer.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -1204,12 +1204,8 @@ public class TestOfflineImageViewer {
       writer.println("<INodeDirectorySection></INodeDirectorySection>");
       writer.println("</fsimage>");
     }
-    try {
       OfflineImageReconstructor.run(imageWSDS.getAbsolutePath(),
               imageWSDS.getAbsolutePath() + ".out");
-    } catch (Throwable t) {
-      GenericTestUtils.assertExceptionContains("without SnapshotDiffSection.", t);
-    }
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -1174,6 +1174,44 @@ public class TestOfflineImageViewer {
     }
   }
 
+  /**
+   * Tests that the ReverseXML processor doesn't accept XML files without the SnapshotDiffSection.
+   */
+  @Test
+  public void testReverseXmlWithoutSnapshotDiffSection() throws Throwable {
+    File imageWSDS = new File(tempDir, "imageWithoutSnapshotDiffSection.xml");
+    PrintWriter writer = new PrintWriter(imageWSDS, "UTF-8");
+    try {
+      writer.println("<?xml version=\"1.0\"?>");
+      writer.println("<fsimage>");
+      writer.println("<version>");
+      writer.println("<layoutVersion>-65</layoutVersion>");
+      writer.println("<onDiskVersion>1</onDiskVersion>");
+      writer.println("<oivRevision>" +
+              "545bbef596c06af1c3c8dca1ce29096a64608478</oivRevision>");
+      writer.println("</version>");
+      writer.println(
+              "<FileUnderConstructionSection></FileUnderConstructionSection>\n" +
+                      "<ErasureCodingSection></ErasureCodingSection>\n" +
+                      "<INodeSection><lastInodeId>91488</lastInodeId><numInodes>0</numInodes></INodeSection>\n" +
+                      "<SecretManagerSection><currentId>90</currentId><tokenSequenceNumber>35</tokenSequenceNumber></SecretManagerSection>\n" +
+                      "<INodeReferenceSection></INodeReferenceSection>\n" +
+                      "<SnapshotSection><snapshotCounter>0</snapshotCounter><numSnapshots>0</numSnapshots></SnapshotSection>\n" +
+                      "<NameSection><namespaceId>326384987</namespaceId></NameSection>\n" +
+                      "<CacheManagerSection><nextDirectiveId>1</nextDirectiveId><numDirectives>0</numDirectives><numPools>0</numPools></CacheManagerSection>\n" +
+                      "<INodeDirectorySection></INodeDirectorySection>");
+      writer.println("</fsimage>");
+    } finally {
+      writer.close();
+    }
+    try {
+      OfflineImageReconstructor.run(imageWSDS.getAbsolutePath(),
+              imageWSDS.getAbsolutePath() + ".out");
+    } catch (Throwable t) {
+      GenericTestUtils.assertExceptionContains("without SnapshotDiffSection.", t);
+    }
+  }
+
   @Test
   public void testFileDistributionCalculatorForException() throws Exception {
     File fsimageFile = null;


### PR DESCRIPTION
…SnapshotDiffSection

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

