### PR TITLE
HADOOP-15245. S3AInputStream.skip() to use lazy seek

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -455,6 +455,13 @@ public final class StreamStatisticNames {
   public static final String STREAM_READ_BLOCK_ACQUIRE_AND_READ
       = "stream_read_block_acquire_read";
 
+  /**
+   * Count of skip() operations in an input stream.
+   * Value: {@value}.
+   */
+  public static final String STREAM_SKIP_OPERATIONS
+          = "stream_skip_operations";
+
   private StreamStatisticNames() {
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -294,7 +294,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     }
 
     this.pos = targetPos;
-    nextReadPos = targetPos;
   }
 
   @Override
@@ -369,7 +368,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
         long skipped = wrappedStream.skip(diff);
         if (skipped > 0) {
           pos += skipped;
-          nextReadPos += skipped;
         }
         streamStatistics.seekForwards(diff, skipped);
 
@@ -409,7 +407,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     // close the stream; if read the object will be opened at the new pos
     closeStream("seekInStream()", false, false);
     pos = targetPos;
-    nextReadPos = targetPos;
   }
 
   @Override
@@ -1190,6 +1187,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     try {
       lazySeek(targetPos, 1);
       skipped = bytesToSkip;
+      nextReadPos += skipped;
     } catch (EOFException e) {
       LOG.debug("Lazy seek failed, attempting default skip", e);
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -1179,14 +1179,16 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     checkNotClosed();
     streamStatistics.skipOperationStarted();
 
-    long targetPos = pos + n;
+    // target pos should be less than EOF
+    long targetPos = Math.min(contentLength, pos + n);
+    long bytesToSkip = targetPos - pos;
     long skipped;
 
     try {
       lazySeek(targetPos, 1);
-      skipped = n;
+      skipped = bytesToSkip;
     } catch (EOFException e) {
-      LOG.debug("Lazy seek failed, attempting default skip");
+      LOG.debug("Lazy seek failed, attempting default skip", e);
 
       skipped = wrappedStream.skip(n);
       if (skipped > 0) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -1161,7 +1161,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
    * {@inheritDoc}
    *
    * This implements a more efficient method for skip. It calls lazy seek
-   * which will then either make a new get request or do a default skip.
+   * which will either make a new get request or do a default skip.
    * If lazy seek fails, try doing a default skip.
    *
    * @param n Number of bytes to be skipped

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -294,6 +294,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     }
 
     this.pos = targetPos;
+    nextReadPos = targetPos;
   }
 
   @Override
@@ -368,6 +369,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
         long skipped = wrappedStream.skip(diff);
         if (skipped > 0) {
           pos += skipped;
+          nextReadPos += skipped;
         }
         streamStatistics.seekForwards(diff, skipped);
 
@@ -407,6 +409,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     // close the stream; if read the object will be opened at the new pos
     closeStream("seekInStream()", false, false);
     pos = targetPos;
+    nextReadPos = targetPos;
   }
 
   @Override
@@ -1180,8 +1183,8 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     streamStatistics.skipOperationStarted();
 
     // target pos should be less than EOF
-    long targetPos = Math.min(contentLength, pos + n);
-    long bytesToSkip = targetPos - pos;
+    long targetPos = Math.min(contentLength, getPos() + n);
+    long bytesToSkip = targetPos - getPos();
     long skipped;
 
     try {
@@ -1193,6 +1196,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
       skipped = wrappedStream.skip(n);
       if (skipped > 0) {
         pos += skipped;
+        nextReadPos += skipped;
       }
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -1158,6 +1158,46 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * This implements a more efficient method for skip. It calls lazy seek
+   * which will then either make a new get request or do a default skip.
+   * If lazy seek fails, try doing a default skip.
+   *
+   * @param n Number of bytes to be skipped
+   * @return Number of bytes skipped
+   * @throws IOException on any problem
+   */
+  @Override
+  @Retries.OnceTranslated
+  public long skip(final long n) throws IOException {
+
+    if (n <= 0) {
+      return 0;
+    }
+
+    checkNotClosed();
+    streamStatistics.skipOperationStarted();
+
+    long targetPos = pos + n;
+    long skipped;
+
+    try {
+      lazySeek(targetPos, 1);
+      skipped = n;
+    } catch (EOFException e) {
+      LOG.debug("Lazy seek failed, attempting default skip");
+
+      skipped = wrappedStream.skip(n);
+      if (skipped > 0) {
+        pos += skipped;
+      }
+    }
+
+    return skipped;
+  }
+
+  /**
    * Access the input stream statistics.
    * This is for internal testing and may be removed without warning.
    * @return the statistics for this input stream

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -807,6 +807,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     private final AtomicLong bytesDiscardedInVectoredIO;
     private final AtomicLong readVectoredIncomingRanges;
     private final AtomicLong readVectoredCombinedRanges;
+    private final AtomicLong skipOperations;
 
     /** Bytes read by the application and any when draining streams . */
     private final AtomicLong totalBytesRead;
@@ -857,7 +858,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
               StreamStatisticNames.STREAM_READ_REMOTE_STREAM_DRAINED,
               StreamStatisticNames.STREAM_READ_PREFETCH_OPERATIONS,
               StreamStatisticNames.STREAM_READ_REMOTE_BLOCK_READ,
-              StreamStatisticNames.STREAM_READ_BLOCK_ACQUIRE_AND_READ)
+              StreamStatisticNames.STREAM_READ_BLOCK_ACQUIRE_AND_READ,
+              StreamStatisticNames.STREAM_SKIP_OPERATIONS)
           .build();
       setIOStatistics(st);
       aborted = st.getCounterReference(
@@ -902,6 +904,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
           StreamStatisticNames.STREAM_READ_SEEK_OPERATIONS);
       totalBytesRead = st.getCounterReference(
           StreamStatisticNames.STREAM_READ_TOTAL_BYTES);
+      skipOperations = st.getCounterReference(
+              StreamStatisticNames.STREAM_SKIP_OPERATIONS);
       setIOStatistics(st);
       // create initial snapshot of merged statistics
       mergedStats = snapshotIOStatistics(st);
@@ -1070,6 +1074,11 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     public void executorAcquired(Duration timeInQueue) {
       // update the duration fields in the IOStatistics.
       localIOStatistics().addTimedOperation(ACTION_EXECUTOR_ACQUIRED, timeInQueue);
+    }
+
+    @Override
+    public void skipOperationStarted() {
+      skipOperations.incrementAndGet();
     }
 
     /**
@@ -1323,6 +1332,12 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     public long getInputPolicy() {
       return localIOStatistics().gauges()
           .get(STREAM_READ_GAUGE_INPUT_POLICY);
+    }
+
+    @Override
+    public long getSkipOperations() {
+      return lookupCounterValue(
+              StreamStatisticNames.STREAM_SKIP_OPERATIONS);
     }
 
     @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/S3AInputStreamStatistics.java
@@ -120,6 +120,8 @@ public interface S3AInputStreamStatistics extends AutoCloseable,
    */
   void inputPolicySet(int updatedPolicy);
 
+  void skipOperationStarted();
+
   /**
    * Get a reference to the change tracker statistics for this
    * stream.
@@ -182,6 +184,8 @@ public interface S3AInputStreamStatistics extends AutoCloseable,
   long getVersionMismatches();
 
   long getInputPolicy();
+
+  long getSkipOperations();
 
   /**
    * Get the value of a counter.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
@@ -207,6 +207,11 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
     }
 
     @Override
+    public void skipOperationStarted() {
+
+    }
+
+    @Override
     public void close() {
 
     }
@@ -362,6 +367,11 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
 
     @Override
     public long getInputPolicy() {
+      return 0;
+    }
+
+    @Override
+    public long getSkipOperations() {
       return 0;
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
@@ -371,7 +371,9 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
     }
 
     @Override
-    public long getSkipOperations() { return 0; }
+    public long getSkipOperations() {
+      return 0;
+    }
 
     @Override
     public Long lookupCounterValue(final String name) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
@@ -371,9 +371,7 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
     }
 
     @Override
-    public long getSkipOperations() {
-      return 0;
-    }
+    public long getSkipOperations() { return 0; }
 
     @Override
     public Long lookupCounterValue(final String name) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
@@ -493,11 +493,13 @@ public class ITestS3AInputStreamPerformance extends S3AScaleTestBase {
 
     in = openTestFile(S3AInputPolicy.Random, DEFAULT_READAHEAD_RANGE);
 
-    in.skip(_4K);
+    assertEquals("bytes skipped", _4K, in.skip(_4K));
+
     // Skip within read ahead range, will not make a new get request
-    in.skip(_8K);
+    assertEquals("bytes skipped", _8K, in.skip(_8K));
+
     // Skip outside read ahead range, should make a new get request
-    in.skip(_256K);
+    assertEquals("bytes skipped", _256K, in.skip(_256K));
 
     IOStatistics ioStatistics = streamStatistics.getIOStatistics();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
@@ -490,32 +490,56 @@ public class ITestS3AInputStreamPerformance extends S3AScaleTestBase {
 
   @Test
   public void testSkip() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
 
-    in = openTestFile(S3AInputPolicy.Random, DEFAULT_READAHEAD_RANGE);
+    byte[] skipDataset = dataset(256, 0, 64);
+    Path baseDir = methodPath();
+    Path dataFile = new Path(baseDir, "skip_data.txt");
+    int readahead = 32;
 
-    assertEquals("bytes skipped", _4K, in.skip(_4K));
+
+    writeDataset(fs, dataFile, skipDataset, skipDataset.length, 1024,
+        false);
+
+    in = openDataFile(fs, dataFile, S3AInputPolicy.Random, readahead);
+
+    in.seek(10);
+    assertEquals("current byte read", 10, in.read());
 
     // Skip within read ahead range, will not make a new get request
-    assertEquals("bytes skipped", _8K, in.skip(_8K));
+    assertEquals("bytes skipped", 9, in.skip(9));
+    assertEquals("current byte read", 20, in.read());
+    assertEquals("current position after read", 21, in.getPos());
 
-    // Skip outside read ahead range, should make a new get request
-    assertEquals("bytes skipped", _256K, in.skip(_256K));
+    // Skip outside read ahead range, should make a new get request.
+    // New position will be 71, and expected value will be 71 % 64 = 7
+    assertEquals("bytes skipped", 50, in.skip(50));
+    assertEquals("current byte read", 7, in.read());
+    assertEquals("current position after read", 72, in.getPos());
+
+    //Skip outside EOF, should only skip till EOF
+    assertEquals("bytes skipped", 256 - 72, in.skip(200));
+    assertEquals("current byte read", -1, in.read());
+    assertEquals("current position after read", 256, in.getPos());
 
     IOStatistics ioStatistics = streamStatistics.getIOStatistics();
 
     verifyStatisticCounterValue(
-            ioStatistics,
-            StreamStatisticNames.STREAM_SKIP_OPERATIONS,
-            3);
+        ioStatistics,
+        StreamStatisticNames.STREAM_SKIP_OPERATIONS,
+        3);
+
+    // Opened once during in.seek() and twice during in.skip()
     verifyStatisticCounterValue(
-            ioStatistics,
-            StreamStatisticNames.STREAM_READ_OPENED,
-            2
+        ioStatistics,
+        StreamStatisticNames.STREAM_READ_OPENED,
+        3
     );
+
     verifyStatisticCounterValue(
-            ioStatistics,
-            StreamStatisticNames.STREAM_READ_SEEK_BYTES_DISCARDED,
-            _8K
+        ioStatistics,
+        StreamStatisticNames.STREAM_READ_SEEK_BYTES_DISCARDED,
+        9
     );
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
@@ -501,7 +501,7 @@ public class ITestS3AInputStreamPerformance extends S3AScaleTestBase {
     writeDataset(fs, dataFile, skipDataset, skipDataset.length, 1024,
         false);
 
-    in = openDataFile(fs, dataFile, S3AInputPolicy.Random, readahead);
+    in = openDataFile(fs, dataFile, S3AInputPolicy.Random, readahead, 256);
 
     in.seek(10);
     assertEquals("current byte read", 10, in.read());


### PR DESCRIPTION
### Description of PR

Jira: https://issues.apache.org/jira/browse/HADOOP-15245

Implements an optimised skip() that calls lazySeek which will decided when to do a default skip vs do a new get. Also adds in instrumentation to count number of times skip is called.

### How was this patch tested?

Tested in eu-west-1 by running
```
mvn -Dparallel-tests -DtestsThreadCount=16 clean verify
```

