### PR TITLE
HDFS-16438. Avoid holding read locks for a long time when scanDatanodeStorage

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 import org.apache.hadoop.hdfs.server.namenode.INodeId;
 import org.apache.hadoop.hdfs.util.LightWeightHashSet;
 import org.apache.hadoop.hdfs.util.LightWeightLinkedSet;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.HashMap;
@@ -91,6 +92,11 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
    * The maximum number of blocks to hold in PendingRep at any time.
    */
   private int pendingRepLimit;
+
+  /**
+   * The lock holding time threshold for {@link #scanDatanodeStorage}.
+   */
+  private final long scanDatanodeStorageLockTimeMs = 300;
 
   /**
    * The list of blocks which have been placed onto the replication queue
@@ -618,7 +624,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
    *
    * As this method does not schedule any blocks for reconstuction, this
    * scan can be performed under the namenode readlock, and the lock is
-   * dropped and reaquired for each storage on the DN.
+   * dropped and reaquired for a batch of blocks on each storage on the DN.
    *
    * @param dn - The datanode to process
    * @param initialScan - True is this is the first time scanning the node
@@ -650,6 +656,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
           continue;
         }
         Iterator<BlockInfo> it = s.getBlockIterator();
+        long beginTime = Time.monotonicNow();
         while (it.hasNext()) {
           BlockInfo b = it.next();
           if (!initialScan || dn.isEnteringMaintenance()) {
@@ -665,6 +672,16 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
             blockList.put(b, null);
           }
           numBlocksChecked++;
+          if (Time.monotonicNow() - beginTime > scanDatanodeStorageLockTimeMs) {
+            namesystem.readUnlock();
+            try {
+              Thread.sleep(1);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+            namesystem.readLock();
+            beginTime = Time.monotonicNow();
+          }
         }
       } finally {
         namesystem.readUnlock();


### PR DESCRIPTION
JIRA: [HDFS-16438](https://issues.apache.org/jira/browse/HDFS-16438).

At the time of decommission, if use `DatanodeAdminBackoffMonitor`, there is a heavy operation: `scanDatanodeStorage`. If the number of blocks on a storage is large(more than 5 hundred thousand), and GC performance is also poor, it may hold **read lock** for a long time, we should optimize it.

![image](https://user-images.githubusercontent.com/55134131/151006515-c47ad5d9-96a6-44d1-9244-5b74a4f11f45.png)

```
2021-12-22 07:49:01,279 INFO  namenode.FSNamesystem (FSNamesystemLock.java:readUnlock(220)) - FSNamesystem scanDatanodeStorage read lock held for 5491 ms via
java.lang.Thread.getStackTrace(Thread.java:1552)
org.apache.hadoop.util.StringUtils.getStackTrace(StringUtils.java:1032)
org.apache.hadoop.hdfs.server.namenode.FSNamesystemLock.readUnlock(FSNamesystemLock.java:222)
org.apache.hadoop.hdfs.server.namenode.FSNamesystem.readUnlock(FSNamesystem.java:1641)
org.apache.hadoop.hdfs.server.blockmanagement.DatanodeAdminBackoffMonitor.scanDatanodeStorage(DatanodeAdminBackoffMonitor.java:646)
org.apache.hadoop.hdfs.server.blockmanagement.DatanodeAdminBackoffMonitor.checkForCompletedNodes(DatanodeAdminBackoffMonitor.java:417)
org.apache.hadoop.hdfs.server.blockmanagement.DatanodeAdminBackoffMonitor.check(DatanodeAdminBackoffMonitor.java:300)
org.apache.hadoop.hdfs.server.blockmanagement.DatanodeAdminBackoffMonitor.run(DatanodeAdminBackoffMonitor.java:201)
java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:745)
    Number of suppressed read-lock reports: 0
    Longest read-lock held interval: 5491 
```