### PR TITLE
HADOOP-18087. fix bugs when looking up record from upstream DNS servers.

### DIFF
--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/LookupTask.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/LookupTask.java
@@ -22,7 +22,7 @@ import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Name;
 import org.xbill.DNS.Record;
 
-public class LookupTask implements Callable<Record[]> {
+public class LookupTask implements Callable<Lookup> {
 
   private Name name;
   private int type;
@@ -33,7 +33,9 @@ public class LookupTask implements Callable<Record[]> {
   }
 
   @Override
-  public Record[] call() throws Exception {
-    return new Lookup(name, type).run();
+  public Lookup call() throws Exception {
+    Lookup lookup = new Lookup(name, type);
+    lookup.run();
+    return lookup;
   }
 }

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
@@ -1101,7 +1101,7 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
     LOG.debug("calling addAnswer");
     byte rcode = addAnswer(response, name, type, dclass, 0, flags);
     if (rcode != Rcode.NOERROR) {
-      rcode = remoteLookup(response, name, type, 0);
+      rcode = remoteLookup(response, name, type);
       response.getHeader().setRcode(rcode);
     }
     addAdditional(response, flags);
@@ -1119,55 +1119,44 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
   /**
    * Lookup record from upstream DNS servers.
    */
-  private byte remoteLookup(Message response, Name name, int type,
-      int iterations) {
+  private byte remoteLookup(Message response, Name name, int type) {
     // If retrieving the root zone, query for NS record type
     if (name.toString().equals(".")) {
       type = Type.NS;
     }
 
-    // Support for CNAME chaining
-    if (type != Type.CNAME) {
-      Name targetName = name;
-      while (iterations < 6) {
-        Record[] cnameAnswers = getRecords(targetName, Type.CNAME).answers;
-        if (cnameAnswers == null) {
-          break;
-        }
-        for (Record cnameR : cnameAnswers) {
-          if (!response.findRecord(cnameR)) {
-            response.addRecord(cnameR, Section.ANSWER);
-            targetName = ((CNAMERecord) cnameR).getTarget();
-          }
-        }
-        iterations++;
-      }
-      if (iterations < 6 && !targetName.equals(name)) {
-        return remoteLookup(response, targetName, type, iterations + 1);
-      }
-    }
-
     // Forward lookup to primary DNS servers
     RemoteAnswer ra = getRecords(name, type);
+
+    // Support for CNAME/DNAME chaining
+    if (ra.aliases != null) {
+      for (Name targetName : ra.aliases) {
+        Record[] answers = getRecords(targetName, Type.CNAME).answers;
+        if (answers == null) {
+          answers = getRecords(targetName, Type.DNAME).answers;
+        }
+        if (answers != null) {
+          for (Record r : answers) {
+            if (!response.findRecord(r)) {
+              response.addRecord(r, Section.ANSWER);
+            }
+          }
+        }
+      }
+    }
     Record[] answers = ra.answers;
     // no answer
     if (answers == null) {
       return (byte)ra.rcode;
     }
-    try {
-      for (Record r : answers) {
-        if (!response.findRecord(r)) {
-          if (r.getType() == Type.SOA) {
-            response.addRecord(r, Section.AUTHORITY);
-          } else {
-            response.addRecord(r, Section.ANSWER);
-          }
+    for (Record r : answers) {
+      if (!response.findRecord(r)) {
+        if (r.getType() == Type.SOA) {
+          response.addRecord(r, Section.AUTHORITY);
+        } else {
+          response.addRecord(r, Section.ANSWER);
         }
       }
-    } catch (NullPointerException e) {
-      return Rcode.NXDOMAIN;
-    } catch (Throwable e) {
-      return Rcode.SERVFAIL;
     }
     return Rcode.NOERROR;
   }
@@ -1197,12 +1186,12 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
           LOG.warn("Unexpected result from lookup: {} type: {} error: {}", name, Type.string(type), lookup.getErrorString());
           break;
       }
-      return new RemoteAnswer(lookup.getAnswers(), rcode);
+      return new RemoteAnswer(lookup.getAnswers(), lookup.getAliases(), rcode);
     } catch (InterruptedException | ExecutionException |
         TimeoutException | NullPointerException |
         ExceptionInInitializerError e) {
       LOG.warn("Failed to lookup: {} type: {}", name, Type.string(type), e);
-      return new RemoteAnswer(null, Rcode.NXDOMAIN);
+      return new RemoteAnswer(null, null, Rcode.NXDOMAIN);
     } finally {
       executor.shutdown();
     }
@@ -1802,10 +1791,12 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
 
   public static class RemoteAnswer {
     public Record[] answers;
+    public Name[] aliases;
     public int rcode;
 
-    public RemoteAnswer(Record[] answers, int rcode) {
+    public RemoteAnswer(Record[] answers, Name[] aliases, int rcode) {
       this.answers = answers;
+      this.aliases = aliases;
       this.rcode = rcode;
     }
   }

--- a/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/main/java/org/apache/hadoop/registry/server/dns/RegistryDNS.java
@@ -1126,20 +1126,34 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
       type = Type.NS;
     }
 
-    // Always add any CNAMEs to the response first
+    // Support for CNAME chaining
     if (type != Type.CNAME) {
-      Record[] cnameAnswers = getRecords(name, Type.CNAME);
-      if (cnameAnswers != null) {
+      Name targetName = name;
+      while (iterations < 6) {
+        Record[] cnameAnswers = getRecords(targetName, Type.CNAME).answers;
+        if (cnameAnswers == null) {
+          break;
+        }
         for (Record cnameR : cnameAnswers) {
           if (!response.findRecord(cnameR)) {
             response.addRecord(cnameR, Section.ANSWER);
+            targetName = ((CNAMERecord) cnameR).getTarget();
           }
         }
+        iterations++;
+      }
+      if (iterations < 6 && !targetName.equals(name)) {
+        return remoteLookup(response, targetName, type, iterations + 1);
       }
     }
 
     // Forward lookup to primary DNS servers
-    Record[] answers = getRecords(name, type);
+    RemoteAnswer ra = getRecords(name, type);
+    Record[] answers = ra.answers;
+    // no answer
+    if (answers == null) {
+      return (byte)ra.rcode;
+    }
     try {
       for (Record r : answers) {
         if (!response.findRecord(r)) {
@@ -1147,12 +1161,6 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
             response.addRecord(r, Section.AUTHORITY);
           } else {
             response.addRecord(r, Section.ANSWER);
-          }
-        }
-        if (r.getType() == Type.CNAME) {
-          Name cname = r.getName();
-          if (iterations < 6) {
-            remoteLookup(response, cname, type, iterations + 1);
           }
         }
       }
@@ -1169,20 +1177,32 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
    *
    * @param name - query string
    * @param type - type of DNS record to lookup
-   * @return DNS records
+   * @return DNS records and return code from remote DNS server
    */
-  protected Record[] getRecords(Name name, int type) {
-    Record[] result = null;
+  protected RemoteAnswer getRecords(Name name, int type) {
     ExecutorService executor = Executors.newSingleThreadExecutor();
-    Future<Record[]> future = executor.submit(new LookupTask(name, type));
+    Future<Lookup> future = executor.submit(new LookupTask(name, type));
     try {
-      result = future.get(1500, TimeUnit.MILLISECONDS);
-      return result;
+      Lookup lookup = future.get(1500, TimeUnit.MILLISECONDS);
+      int result = lookup.getResult();
+      int rcode = Rcode.NXDOMAIN;
+      switch (result) {
+        case Lookup.SUCCESSFUL:
+        case Lookup.TYPE_NOT_FOUND:
+          rcode = Rcode.NOERROR;
+          break;
+        case Lookup.HOST_NOT_FOUND:
+          break;
+        default:
+          LOG.warn("Unexpected result from lookup: {} type: {} error: {}", name, Type.string(type), lookup.getErrorString());
+          break;
+      }
+      return new RemoteAnswer(lookup.getAnswers(), rcode);
     } catch (InterruptedException | ExecutionException |
         TimeoutException | NullPointerException |
         ExceptionInInitializerError e) {
       LOG.warn("Failed to lookup: {} type: {}", name, Type.string(type), e);
-      return result;
+      return new RemoteAnswer(null, Rcode.NXDOMAIN);
     } finally {
       executor.shutdown();
     }
@@ -1777,6 +1797,16 @@ public class RegistryDNS extends AbstractService implements DNSOperations,
     @Override
     public void close() {
       lock.unlock();
+    }
+  }
+
+  public static class RemoteAnswer {
+    public Record[] answers;
+    public int rcode;
+
+    public RemoteAnswer(Record[] answers, int rcode) {
+      this.answers = answers;
+      this.rcode = rcode;
     }
   }
 }

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
@@ -637,7 +637,7 @@ public class TestRegistryDNS extends Assertions {
   @Test
   public void testExampleDotCom() throws Exception {
     Name name = Name.fromString("example.com.");
-    Record[] records = getRegistryDNS().getRecords(name, Type.SOA);
+    Record[] records = getRegistryDNS().getRecords(name, Type.SOA).answers;
     assertNotNull(records, "example.com exists:");
   }
 
@@ -699,7 +699,7 @@ public class TestRegistryDNS extends Assertions {
   @Timeout(value = 5)
   public void testUpstreamFault() throws Exception {
     Name name = Name.fromString("19.0.17.172.in-addr.arpa.");
-    Record[] recs = getRegistryDNS().getRecords(name, Type.CNAME);
+    Record[] recs = getRegistryDNS().getRecords(name, Type.CNAME).answers;
     assertNull(recs, "Record is not null");
   }
 
@@ -707,8 +707,8 @@ public class TestRegistryDNS extends Assertions {
   public void testNODATA() throws Exception {
     Name name = Name.fromString("example.com.");
     RegistryDNS.RemoteAnswer ra = getRegistryDNS().getRecords(name, Type.CNAME);
-    assertNull("CNAME record for example.com. should be null.", ra.answers);
-    assertEquals("The result of DNS query for example.com. should be NOERROR.", Rcode.NOERROR, ra.rcode);
+    assertNull(ra.answers, "CNAME record for example.com. should be null.");
+    assertEquals(Rcode.NOERROR, ra.rcode, "The result of DNS query for example.com. should be NOERROR.");
   }
 
   public RegistryDNS getRegistryDNS() {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
@@ -703,6 +703,14 @@ public class TestRegistryDNS extends Assertions {
     assertNull(recs, "Record is not null");
   }
 
+  @Test
+  public void testNODATA() throws Exception {
+    Name name = Name.fromString("example.com.");
+    RegistryDNS.RemoteAnswer ra = getRegistryDNS().getRecords(name, Type.CNAME);
+    assertNull("CNAME record for example.com. should be null.", ra.answers);
+    assertEquals("The result of DNS query for example.com. should be NOERROR.", Rcode.NOERROR, ra.rcode);
+  }
+
   public RegistryDNS getRegistryDNS() {
     return registryDNS;
   }


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When query A record which is chained by CNAME, YARN Registry DNS Server does not properly respond. Some CNAME records are missing.

For example, "repo.maven.apache.org" is chaned as follows:

repo.maven.apache.org.	21317	IN	CNAME	repo.apache.maven.org.
repo.apache.maven.org.	20114	IN	CNAME	maven.map.fastly.net.
maven.map.fastly.net.	7	IN	A	199.232.192.215
maven.map.fastly.net.	7	IN	A	199.232.196.215

If ask A record for "repo.maven.apache.org" using "dig" or "nslookup", YARN Registry DNS Server will give answers similar to this:
(10.1.2.3, 10.8.8.8 IP is virtual)


```
$ nslookup repo.maven.apache.org 10.1.2.3
Server:		10.1.2.3
Address:	10.1.2.3#53

Non-authoritative answer:
repo.maven.apache.org	canonical name = repo.apache.maven.org.
Name:	maven.map.fastly.net
Address: 151.101.196.215
** server can't find repo.apache.maven.org: NXDOMAIN
```

The reason why you can see "NXDOMAIN", "nslookup" will query "A" & "AAAA" records.
If there is no answer from other dns server, "answers == null" but YARN Registry DNS Server has a bug. There is no null handling.


```java
    // Forward lookup to primary DNS servers
    Record[] answers = getRecords(name, type);
    try {
      for (Record r : answers) {
        if (!response.findRecord(r)) {
          if (r.getType() == Type.SOA) {
            response.addRecord(r, Section.AUTHORITY);
          } else {
            response.addRecord(r, Section.ANSWER);
          }
        }
        if (r.getType() == Type.CNAME) {
          Name cname = r.getName();
          if (iterations < 6) {
            remoteLookup(response, cname, type, iterations + 1);
          }
        }
      }
    } catch (NullPointerException e) {
      return Rcode.NXDOMAIN;
    } catch (Throwable e) {
      return Rcode.SERVFAIL;
    }
    return Rcode.NOERROR;
```





It should be like this:

```
nslookup repo.maven.apache.org 10.8.8.8
Server:		10.8.8.8
Address:	10.8.8.8#53

Non-authoritative answer:
repo.maven.apache.org	canonical name = repo.apache.maven.org.
repo.apache.maven.org	canonical name = maven.map.fastly.net.
Name:	maven.map.fastly.net
Address: 151.101.196.215
```



### How was this patch tested?

- apply this patch to YARN Registry DNS Server in our cluster & test with `dig` and `nslookup`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

