### PR TITLE
HDFS-16439.Makes calculating maxNodesPerRack simpler.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -381,7 +381,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
     int clusterSize = clusterMap.getNumOfLeaves();
     int totalNumOfReplicas = numOfChosen + numOfReplicas;
     if (totalNumOfReplicas > clusterSize) {
-      numOfReplicas -= (totalNumOfReplicas-clusterSize);
+      numOfReplicas = clusterSize - numOfChosen;
       totalNumOfReplicas = clusterSize;
     }
     // No calculation needed when there is only one rack or picking one node.


### PR DESCRIPTION

### Description of PR
It should be simpler to compute numOfReplicas when BlockPlacementPolicyDefault#getMaxNodesPerRack() is executed. This is the purpose of this pr.
Details: HDFS-16439

### How was this patch tested?
For testing, there is not much pressure.
