### PR TITLE
 HADOOP-17415. Use S3 content-range header to update length of an object during reads

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1412,7 +1412,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     // this span is passed into the stream.
     final AuditSpan auditSpan = entryPoint(INVOCATION_OPEN, path);
     S3AFileStatus fileStatus = extractOrFetchSimpleFileStatus(path,
-        providedStatus);
+        providedStatus, true);
 
     S3AReadOpContext readContext;
     if (options.isPresent()) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -263,7 +263,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
           + " " + targetPos);
     }
 
-    if (this.contentLength <= 0) {
+    if (this.contentLength == 0) {
       return;
     }
 
@@ -831,12 +831,10 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
       long contentLength,
       long readahead) {
     // if content length is unknown
-    // range limit should be set to more than 0
-    // since readahead and length can be 0
-    // we should select from the one with higher value
+    // set content length to be as far as possible
     // SDK will handle it and response within content length limit
     if (contentLength < 0) {
-      contentLength = Math.max(readahead, length);
+      contentLength = targetPos + Math.max(readahead, length);
     }
 
     long rangeLimit;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -153,7 +153,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
         "No Bucket");
     Preconditions.checkArgument(isNotEmpty(s3Attributes.getKey()), "No Key");
     long l = s3Attributes.getLen();
-    Preconditions.checkArgument(l >= 0, "Negative content length");
     this.context = ctx;
     this.bucket = s3Attributes.getBucket();
     this.key = s3Attributes.getKey();
@@ -406,7 +405,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   @Retries.RetryTranslated
   public synchronized int read() throws IOException {
     checkNotClosed();
-    if (this.contentLength == 0 || (nextReadPos >= contentLength)) {
+    if (this.contentLength == 0 || (contentLength > 0 && nextReadPos >= contentLength)) {
       return -1;
     }
 
@@ -490,7 +489,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
       return 0;
     }
 
-    if (this.contentLength == 0 || (nextReadPos >= contentLength)) {
+    if (this.contentLength == 0 || (contentLength > 0 && nextReadPos >= contentLength)) {
       return -1;
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -101,6 +101,9 @@ public final class InternalConstants {
   /** 404 error code. */
   public static final int SC_404 = 404;
 
+  /** 416 Range Not Satisfiable error code. */
+  public static final int SC_416 = 416;
+
   /** Name of the log for throttling events. Value: {@value}. */
   public static final String THROTTLE_LOG_NAME =
       "org.apache.hadoop.fs.s3a.throttled";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/StatusProbeEnum.java
@@ -48,6 +48,12 @@ public enum StatusProbeEnum {
   public static final Set<StatusProbeEnum> LIST_ONLY =
       EnumSet.of(List);
 
+  /**
+   * No probe.
+   */
+  public static final Set<StatusProbeEnum> NONE =
+      EnumSet.noneOf(StatusProbeEnum.class);
+
   /** Look for files and directories. */
   public static final Set<StatusProbeEnum> FILE =
       HEAD_ONLY;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractOpen.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractOpen.java
@@ -19,13 +19,21 @@
 package org.apache.hadoop.fs.contract.s3a;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Ignore;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
  * S3A contract tests opening files.
  */
 public class ITestS3AContractOpen extends AbstractContractOpenTest {
+  private FSDataInputStream instream;
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
@@ -39,5 +47,92 @@ public class ITestS3AContractOpen extends AbstractContractOpenTest {
   @Override
   protected boolean areZeroByteFilesEncrypted() {
     return true;
+  }
+
+  /**
+   * From HADOOP-17415, S3A will skip HEAD request to get file status when open file.
+   * Therefore, FileNotFoundException will be delayed until the first read occur.
+   */
+  @Override
+  public void testOpenReadDir() throws Throwable {
+    describe("create & read a directory");
+    Path path = path("zero.dir");
+    mkdirs(path);
+
+    try {
+      instream = getFileSystem().open(path);
+      int c = instream.read();
+      fail("A directory has been opened for reading");
+    } catch (FileNotFoundException e) {
+      handleExpectedException(e);
+    } catch (IOException e) {
+      handleRelaxedException("opening a directory for reading", "FileNotFoundException", e);
+    }
+  }
+
+  @Override
+  public void testOpenReadDirWithChild() throws Throwable {
+    describe("create & read a directory which has a child");
+    Path path = path("zero.dir");
+    mkdirs(path);
+    Path path2 = new Path(path, "child");
+    mkdirs(path2);
+
+    try {
+      instream = getFileSystem().open(path);
+      int c = instream.read();
+      fail("A directory has been opened for reading");
+    } catch (FileNotFoundException e) {
+      handleExpectedException(e);
+    } catch (IOException e) {
+      handleRelaxedException("opening a directory for reading", "FileNotFoundException", e);
+    }
+  }
+
+  @Override
+  public void testOpenFileLazyFail() throws Throwable {
+    describe("openFile fails on a missing file in the read() and not before");
+    FutureDataInputStreamBuilder builder =
+        getFileSystem().openFile(path("testOpenFileLazyFail")).opt("fs.test.something", true);
+
+    try {
+      instream = builder.build().get();
+      int c = instream.read();
+      fail("A non existing file has been opened for reading");
+    } catch (FileNotFoundException e) {
+      handleExpectedException(e);
+    } catch (IOException e) {
+      handleRelaxedException("opening a non existing file for reading", "FileNotFoundException", e);
+    }
+  }
+
+  @Override
+  @Ignore
+  public void testOpenFileFailExceptionally() throws Throwable {
+    // does not fail on openFile
+  }
+
+  @Override
+  @Ignore
+  public void testAwaitFutureFailToFNFE() throws Throwable {
+    // does not fail on openFile
+  }
+
+  @Override
+  @Ignore
+  public void testAwaitFutureTimeoutFailToFNFE() throws Throwable {
+    // does not fail on openFile
+  }
+
+  @Override
+  @Ignore
+  public void testOpenFileExceptionallyTranslating() throws Throwable {
+    // does not fail on openFile
+  }
+
+  @Override
+  @Ignore
+  public void testChainedFailureAwaitFuture() throws Throwable {
+    // does not fail on openFile
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileOperationCost.java
@@ -336,10 +336,11 @@ public class ITestS3AFileOperationCost extends AbstractS3ACostTest {
         FILE_STATUS_DIR_PROBE);
     assertEmptyDirStatus(status, Tristate.TRUE);
 
-    // skip all probes and expect no operations to take place
-    interceptGetFileStatusFNFE(emptydir, false,
+    // skip all probes and return file status with no content length
+    status = verifyInnerGetFileStatus(emptydir, false,
         EnumSet.noneOf(StatusProbeEnum.class),
         NO_IO);
+    assertEmptyDirStatus(status, Tristate.FALSE);
 
     // now add a trailing slash to the key and use the
     // deep internal s3GetFileStatus method call.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
@@ -64,18 +64,26 @@ public class TestS3AInputPolicies {
     return Arrays.asList(new Object[][]{
         {S3AInputPolicy.Normal, 0, -1, 0, _64K, 0},
         {S3AInputPolicy.Normal, 0, -1, _10MB, _64K, _10MB},
+        {S3AInputPolicy.Normal, 0, -1, -1, _64K, _64K},
         {S3AInputPolicy.Normal, _64K, _64K, _10MB, _64K, _10MB},
         {S3AInputPolicy.Sequential, 0, -1, 0, _64K, 0},
         {S3AInputPolicy.Sequential, 0, -1, _10MB, _64K, _10MB},
+        {S3AInputPolicy.Sequential, 0, -1, -1, _64K, _64K},
         {S3AInputPolicy.Random, 0, -1, 0, _64K, 0},
         {S3AInputPolicy.Random, 0, -1, _10MB, _64K, _10MB},
+        {S3AInputPolicy.Random, 0, -1, -1, _64K, _64K},
         {S3AInputPolicy.Random, 0, _128K, _10MB, _64K, _128K},
         {S3AInputPolicy.Random, 0, _128K, _10MB, _256K, _256K},
+        {S3AInputPolicy.Random, 0, _128K, -1, _64K, _128K},
+        {S3AInputPolicy.Random, 0, _128K, -1, _256K, _256K},
         {S3AInputPolicy.Random, 0, 0, _10MB, _256K, _256K},
         {S3AInputPolicy.Random, 0, 1, _10MB, _256K, _256K},
         {S3AInputPolicy.Random, 0, _1MB, _10MB, _256K, _1MB},
         {S3AInputPolicy.Random, 0, _1MB, _10MB, 0, _1MB},
+        {S3AInputPolicy.Random, 0, _1MB, -1, _256K, _1MB},
+        {S3AInputPolicy.Random, 0, _1MB, -1, 0, _1MB},
         {S3AInputPolicy.Random, _10MB + _64K, _1MB, _10MB, _256K, _10MB},
+
     });
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
@@ -83,7 +83,8 @@ public class TestS3AInputPolicies {
         {S3AInputPolicy.Random, 0, _1MB, -1, _256K, _1MB},
         {S3AInputPolicy.Random, 0, _1MB, -1, 0, _1MB},
         {S3AInputPolicy.Random, _10MB + _64K, _1MB, _10MB, _256K, _10MB},
-
+        {S3AInputPolicy.Random, _10MB, _64K, -1, _256K, _10MB + _256K},
+        {S3AInputPolicy.Random, _10MB, _1MB, -1, _256K, _10MB + _1MB},
     });
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AUnbuffer.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AUnbuffer.java
@@ -52,6 +52,7 @@ public class TestS3AUnbuffer extends AbstractS3AMockTest {
     Path path = new Path("/file");
     ObjectMetadata meta = mock(ObjectMetadata.class);
     when(meta.getContentLength()).thenReturn(1L);
+    when(meta.getRawMetadataValue("Content-Range")).thenReturn("bytes 0-0/1");
     when(meta.getLastModified()).thenReturn(new Date(2L));
     when(meta.getETag()).thenReturn("mock-etag");
     when(s3.getObjectMetadata(any())).thenReturn(meta);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextMainOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextMainOperations.java
@@ -63,4 +63,9 @@ public class ITestS3AFileContextMainOperations
     //checksums ignored, so test removed
   }
 
+  @Test
+  @Ignore
+  public void testOpenFileLazyFail() throws Throwable {
+    // FileNotFoundException with be delayed until first read
+  }
 }


### PR DESCRIPTION
### Description of PR

As part of all the openFile work, knowing full length of an object allows for a HEAD to be skipped. But: code knowing only the splits don't know the final length of the file.

If the content-range header is used, then as soon as a single GET is initiated against an object, if the field is returned then we can update the length of the S3A stream to its real/final length

* Skip file status probe on openFile. Content length will be updated on first read.
* As a side effect, modification time, etag and version id also be unknown as there is no probe on openFile.
* Allow content length to be negative value, it means content length is unknown.
* On read file, use information from Content-Range header to update content length.
* If out of range exception occurs on read, ActualObjectSize from exception details can be used to update content length.

### How was this patch tested?

Tested in `eu-west-1` with `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify` (AP tests failed from previous SDK upgrade)

```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ITestS3ABucketExistence.testAccessPointProbingV2:171->expectUnknownStore:103->lambda$testAccessPointProbingV2$12:172 » IllegalArgument
[ERROR]   ITestS3ABucketExistence.testAccessPointRequired:188->expectUnknownStore:103->lambda$testAccessPointRequired$14:189 » IllegalArgument
[INFO] 
[ERROR] Tests run: 1063, Failures: 0, Errors: 2, Skipped: 186
[INFO] Results:
[INFO] 
[WARNING] Tests run: 108, Failures: 0, Errors: 0, Skipped: 68
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

