### PR TITLE
HADOOP-18096. Distcp: Sync moves filtered file to home directory rather than deleting.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
@@ -260,7 +260,7 @@ class DistCpSync {
               list.add(new DiffInfo(source, target, dt));
             } else {
               list = diffMap.get(SnapshotDiffReport.DiffType.DELETE);
-              DiffInfo info = new DiffInfo(source, target,
+              DiffInfo info = new DiffInfo(source, null,
                   SnapshotDiffReport.DiffType.DELETE);
               list.add(info);
               if (deletedByExclusionDiffs == null) {

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
@@ -54,9 +55,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class TestDistCpSync {
   private MiniDFSCluster cluster;
@@ -1184,8 +1182,12 @@ public class TestDistCpSync {
       new DistCp(conf, builder.build()).execute();
 
       // Check the two directories get copied.
-      assertTrue(dfs.exists(new Path(target, "dir1")));
-      assertTrue(dfs.exists(new Path(target, "dir2")));
+      ContractTestUtils
+          .assertPathExists(dfs, "dir1 should get copied to target",
+              new Path(target, "dir1"));
+      ContractTestUtils
+          .assertPathExists(dfs, "dir2 should get copied to target",
+              new Path(target, "dir2"));
 
       // Allow & create initial snapshots on target.
       dfs.allowSnapshot(target);
@@ -1205,16 +1207,23 @@ public class TestDistCpSync {
       new DistCp(conf, diffBuilder.build()).execute();
 
       // Check the only qualified directory dir2 is there in target
-      assertTrue(dfs.exists(new Path(target, "dir2")));
+      ContractTestUtils.assertPathExists(dfs, "dir2 should be there on target",
+          new Path(target, "dir2"));
 
       // Check the filtered directory is not there.
-      assertFalse(dfs.exists(new Path(target, "filterDir1")));
+      ContractTestUtils.assertPathDoesNotExist(dfs,
+          "Filtered directory 'filterDir1' shouldn't get copied",
+          new Path(target, "filterDir1"));
 
-      // Check the filtered directory gets deleted.
-      assertFalse(dfs.exists(new Path(target, "dir1")));
+      // Check the renamed directory gets deleted.
+      ContractTestUtils.assertPathDoesNotExist(dfs,
+          "Renamed directory 'dir1' should get deleted",
+          new Path(target, "dir1"));
 
       // Check the filtered directory isn't there in the home directory.
-      assertFalse(dfs.exists(new Path("filterDir1")));
+      ContractTestUtils.assertPathDoesNotExist(dfs,
+          "Filtered directory 'filterDir1' shouldn't get copied to home directory",
+          new Path("filterDir1"));
     } finally {
       deleteFilterFile(filterFile);
     }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpSync.java
@@ -1197,6 +1197,10 @@ public class TestDistCpSync {
       dfs.rename(new Path(sourcePath, "dir1"),
           new Path(sourcePath, "filterDir1"));
 
+      ContractTestUtils
+          .assertPathExists(dfs, "'filterDir1' should be there on source",
+              new Path(sourcePath, "filterDir1"));
+
       // Create the incremental snapshot.
       dfs.createSnapshot(sourcePath, "s2");
 


### PR DESCRIPTION
### Description of PR
Fixes creation of Delete Diff entry, the target in the delete diff should be null.

### How was this patch tested?
Added a UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?