### PR TITLE
HADOOP-18100: Change scope of inner classes in InodeTree to make them accessible outside package

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ChRootedFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ChRootedFileSystem.java
@@ -102,7 +102,7 @@ class ChRootedFileSystem extends FilterFileSystem {
    * @param uri base uri
    * @throws IOException 
    */
-  public ChRootedFileSystem(final FileSystem fs, URI uri) throws IOException {
+  ChRootedFileSystem(final FileSystem fs, URI uri) throws IOException {
     super(fs);
     String pathString = uri.getPath();
     if (pathString.isEmpty()) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ChRootedFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ChRootedFileSystem.java
@@ -102,7 +102,7 @@ class ChRootedFileSystem extends FilterFileSystem {
    * @param uri base uri
    * @throws IOException 
    */
-  ChRootedFileSystem(final FileSystem fs, URI uri) throws IOException {
+  public ChRootedFileSystem(final FileSystem fs, URI uri) throws IOException {
     super(fs);
     String pathString = uri.getPath();
     if (pathString.isEmpty()) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/FsGetter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/FsGetter.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.FileSystem;
  * File system instance getter.
  */
 @InterfaceAudience.LimitedPrivate({"Common"})
-@InterfaceStability.Evolving /*Evolving for a release,to be changed to Stable */
+@InterfaceStability.Unstable
 public class FsGetter {
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/FsGetter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/FsGetter.java
@@ -20,15 +20,15 @@ package org.apache.hadoop.fs.viewfs;
 import java.io.IOException;
 import java.net.URI;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
 /**
  * File system instance getter.
  */
-@Private
-class FsGetter {
+@InterfaceAudience.Public
+public class FsGetter {
 
   /**
    * Gets new file system instance of given uri.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/FsGetter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/FsGetter.java
@@ -21,13 +21,15 @@ import java.io.IOException;
 import java.net.URI;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
 /**
  * File system instance getter.
  */
-@InterfaceAudience.Public
+@InterfaceAudience.LimitedPrivate({"Common"})
+@InterfaceStability.Evolving /*Evolving for a release,to be changed to Stable */
 public class FsGetter {
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -82,12 +82,28 @@ abstract class InodeTree<T> {
       new ArrayList<RegexMountPoint<T>>();
 
   public static class MountPoint<T> {
-    public String src;
-    public INodeLink<T> target;
+    String src;
+    INodeLink<T> target;
 
     MountPoint(String srcPath, INodeLink<T> mountLink) {
       src = srcPath;
       target = mountLink;
+    }
+
+    /**
+     * Returns the source of mount point.
+     * @return The source
+     */
+    public String getSource() {
+      return this.src;
+    }
+
+    /**
+     * Returns the target link.
+     * @return The target INode link
+     */
+    public INodeLink<T> getTarget() {
+      return this.target;
     }
   }
 
@@ -257,7 +273,7 @@ abstract class InodeTree<T> {
    * is changed later it is then ignored (a dir with null entries)
    */
   public static class INodeLink<T> extends INode<T> {
-    public final URI[] targetDirLinkList;
+    final URI[] targetDirLinkList;
     private T targetFileSystem;   // file system object created from the link.
     // Function to initialize file system. Only applicable for simple links
     private Function<URI, T> fileSystemInitMethod;
@@ -290,7 +306,7 @@ abstract class InodeTree<T> {
      * Get the target of the link. If a merge link then it returned
      * as "," separated URI list.
      */
-    Path getTargetLink() {
+    public Path getTargetLink() {
       StringBuilder result = new StringBuilder(targetDirLinkList[0].toString());
       // If merge link, use "," as separator between the merged URIs
       for (int i = 1; i < targetDirLinkList.length; ++i) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -81,9 +81,9 @@ abstract class InodeTree<T> {
   private List<RegexMountPoint<T>> regexMountPointList =
       new ArrayList<RegexMountPoint<T>>();
 
-  static class MountPoint<T> {
-    String src;
-    INodeLink<T> target;
+  public static class MountPoint<T> {
+    public String src;
+    public INodeLink<T> target;
 
     MountPoint(String srcPath, INodeLink<T> mountLink) {
       src = srcPath;
@@ -256,8 +256,8 @@ abstract class InodeTree<T> {
    * For a merge, each target is checked to be dir when created but if target
    * is changed later it is then ignored (a dir with null entries)
    */
-  static class INodeLink<T> extends INode<T> {
-    final URI[] targetDirLinkList;
+  public static class INodeLink<T> extends INode<T> {
+    public final URI[] targetDirLinkList;
     private T targetFileSystem;   // file system object created from the link.
     // Function to initialize file system. Only applicable for simple links
     private Function<URI, T> fileSystemInitMethod;
@@ -932,7 +932,7 @@ abstract class InodeTree<T> {
     }
   }
 
-  List<MountPoint<T>> getMountPoints() {
+  public List<MountPoint<T>> getMountPoints() {
     return mountPoints;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -113,7 +113,7 @@ public class ViewFileSystem extends FileSystem {
   /**
    * Caching children filesystems. HADOOP-15565.
    */
-  static class InnerCache {
+  public static class InnerCache {
     private Map<Key, FileSystem> map = new HashMap<>();
     private FsGetter fsCreator;
     private ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
@@ -122,7 +122,7 @@ public class ViewFileSystem extends FileSystem {
       this.fsCreator = fsCreator;
     }
 
-    FileSystem get(URI uri, Configuration config) throws IOException {
+    public FileSystem get(URI uri, Configuration config) throws IOException {
       Key key = new Key(uri);
       FileSystem fs = null;
       try {
@@ -1055,6 +1055,15 @@ public class ViewFileSystem extends FileSystem {
           mountPoints.get(i).target.targetDirLinkList);
     }
     return result;
+  }
+
+  /*
+  ViewFileSystem will always have child filesystems.
+  So getCanonicalServiceName should return null.
+   */
+  @Override
+  public String getCanonicalServiceName() {
+    return null;
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -113,7 +113,7 @@ public class ViewFileSystem extends FileSystem {
   /**
    * Caching children filesystems. HADOOP-15565.
    */
-  public static class InnerCache {
+  static class InnerCache {
     private Map<Key, FileSystem> map = new HashMap<>();
     private FsGetter fsCreator;
     private ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
@@ -122,7 +122,7 @@ public class ViewFileSystem extends FileSystem {
       this.fsCreator = fsCreator;
     }
 
-    public FileSystem get(URI uri, Configuration config) throws IOException {
+    FileSystem get(URI uri, Configuration config) throws IOException {
       Key key = new Key(uri);
       FileSystem fs = null;
       try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18100

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

