### PR TITLE
HADOOP-18101. Bump aliyun-sdk-oss to 3.13.2 and jdom2 to 2.0.6.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -514,7 +514,7 @@ org.hsqldb:hsqldb:2.3.4
 JDOM License
 ------------
 
-org.jdom:jdom:1.1
+org.jdom:jdom2:2.0.6.1
 
 
 Public Domain

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -214,7 +214,7 @@ com.aliyun:aliyun-java-sdk-core:3.4.0
 com.aliyun:aliyun-java-sdk-ecs:4.2.0
 com.aliyun:aliyun-java-sdk-ram:3.0.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
-com.aliyun.oss:aliyun-sdk-oss:3.13.1
+com.aliyun.oss:aliyun-sdk-oss:3.13.2
 com.amazonaws:aws-java-sdk-bundle:1.11.901
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -214,7 +214,7 @@ com.aliyun:aliyun-java-sdk-core:3.4.0
 com.aliyun:aliyun-java-sdk-ecs:4.2.0
 com.aliyun:aliyun-java-sdk-ram:3.0.0
 com.aliyun:aliyun-java-sdk-sts:3.0.0
-com.aliyun.oss:aliyun-sdk-oss:3.13.0
+com.aliyun.oss:aliyun-sdk-oss:3.13.1
 com.amazonaws:aws-java-sdk-bundle:1.11.901
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1495,7 +1495,7 @@
       <dependency>
         <groupId>com.aliyun.oss</groupId>
         <artifactId>aliyun-sdk-oss</artifactId>
-        <version>3.13.0</version>
+        <version>3.13.1</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -135,7 +135,7 @@
     <hikari.version>4.0.3</hikari.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp.version>2.7.5</okhttp.version>
-    <jdom.version>1.1</jdom.version>
+    <jdom.version>2.0.6.1</jdom.version>
     <jna.version>5.2.0</jna.version>
     <grizzly.version>2.2.21</grizzly.version>
     <gson.version>2.8.9</gson.version>
@@ -1289,7 +1289,7 @@
       </dependency>
       <dependency>
         <groupId>org.jdom</groupId>
-        <artifactId>jdom</artifactId>
+        <artifactId>jdom2</artifactId>
         <version>${jdom.version}</version>
       </dependency>
       <dependency>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -135,7 +135,7 @@
     <hikari.version>4.0.3</hikari.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp.version>2.7.5</okhttp.version>
-    <jdom.version>2.0.6.1</jdom.version>
+    <jdom2.version>2.0.6.1</jdom2.version>
     <jna.version>5.2.0</jna.version>
     <grizzly.version>2.2.21</grizzly.version>
     <gson.version>2.8.9</gson.version>
@@ -1290,7 +1290,7 @@
       <dependency>
         <groupId>org.jdom</groupId>
         <artifactId>jdom2</artifactId>
-        <version>${jdom.version}</version>
+        <version>${jdom2.version}</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>
@@ -1495,7 +1495,7 @@
       <dependency>
         <groupId>com.aliyun.oss</groupId>
         <artifactId>aliyun-sdk-oss</artifactId>
-        <version>3.13.1</version>
+        <version>3.13.2</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### Description of PR

See discription: [HADOOP-18101](https://issues.apache.org/jira/browse/HADOOP-18101)

### How was this patch tested?

Confirmed that it has been fixed in v3.13.1 with the following [patch](https://github.com/aliyun/aliyun-oss-java-sdk/pull/381)

Confirmed with maven dependency tree.
```
mvn dependency:tree | grep jdom
[INFO] |  +- org.jdom:jdom2:jar:2.0.6.1:provided
[INFO] |  +- org.jdom:jdom2:jar:2.0.6.1:compile
[INFO] |     +- org.jdom:jdom2:jar:2.0.6.1:compile
[INFO] |     +- org.jdom:jdom2:jar:2.0.6.1:compile
```

