### PR TITLE
YARN-11071. AutoCreatedQueueTemplate incorrect wildcard level.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedQueueTemplate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedQueueTemplate.java
@@ -170,8 +170,7 @@ public class AutoCreatedQueueTemplate {
     int wildcardLevel = 0;
     // root can not be wildcarded
     // MAX_WILDCARD_LEVEL will be configurable in the future
-    int supportedWildcardLevel = Math.min(queuePathMaxIndex - 1,
-        MAX_WILDCARD_LEVEL);
+    int supportedWildcardLevel = Math.min(queuePathMaxIndex, MAX_WILDCARD_LEVEL);
     // Allow root to have template properties
     if (queuePath.isRoot()) {
       supportedWildcardLevel = 0;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAutoCreatedQueueTemplate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAutoCreatedQueueTemplate.java
@@ -89,6 +89,17 @@ public class TestAutoCreatedQueueTemplate {
   }
 
   @Test
+  public void testWildcardAfterRoot() {
+    conf.set(getTemplateKey("root.*", "acl_submit_applications"), "user");
+    AutoCreatedQueueTemplate template =
+        new AutoCreatedQueueTemplate(conf, new QueuePath("root.a"));
+    template.setTemplateEntriesForChild(conf, "root.a");
+
+    Assert.assertEquals("acl_submit_applications is set", "user",
+        template.getTemplateProperties().get("acl_submit_applications"));
+  }
+
+  @Test
   public void testTemplatePrecedence() {
     conf.set(getTemplateKey("root.a.b", "capacity"), "6w");
     conf.set(getTemplateKey("root.a.*", "capacity"), "4w");


### PR DESCRIPTION
Change-Id: Iea0dd6b54d7e1e0d906928b768668a753900f81c

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

