### PR TITLE
HADOOP-18109. Ensure that default permissions of directories under internal ViewFS directories are the same as directories on target filesystems

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1575,11 +1575,6 @@ public class ViewFileSystem extends FileSystem {
     }
 
     @Override
-    public boolean mkdirs(Path dir) throws IOException {
-      return mkdirs(dir, null);
-    }
-
-    @Override
     public FSDataInputStream open(Path f, int bufferSize)
         throws AccessControlException, FileNotFoundException, IOException {
       checkPathIsSlash(f);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
@@ -479,4 +479,23 @@ public class TestViewFileSystemHdfs extends ViewFileSystemBaseTest {
     assertEquals("The owner did not match ", owner, userUgi.getShortUserName());
     otherfs.delete(user1Path, false);
   }
+
+  @Test
+  public void testInternalDirectoryPermissions() throws IOException {
+    LOG.info("Starting testInternalDirectoryPermissions!");
+    Configuration localConf = new Configuration(conf);
+    ConfigUtil.addLinkFallback(
+        localConf, new Path(targetTestRoot, "fallbackDir").toUri());
+    FileSystem fs = FileSystem.get(FsConstants.VIEWFS_URI, localConf);
+    // check that the default permissions on a sub-folder of an internal
+    // directory are the same as those created on non-internal directories.
+    Path subDirOfInternalDir = new Path("/internalDir/dir1");
+    fs.mkdirs(subDirOfInternalDir);
+
+    Path subDirOfRealDir = new Path("/internalDir/linkToDir2/dir1");
+    fs.mkdirs(subDirOfRealDir);
+
+    assertEquals(fs.getFileStatus(subDirOfInternalDir).getPermission(),
+        fs.getFileStatus(subDirOfRealDir).getPermission());
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18109

### Description of PR
- Ensure that default permissions of directories under internal ViewFS directories are the same as directories on target filesystems
- Add new unit test

### How was this patch tested?
- mvn test -Dtest=TestViewFileSystem*

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

