### PR TITLE
HADOOP-18110. ViewFileSystem: Add Support for Localized Trash Root

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -132,4 +132,10 @@ public interface Constants {
   Class<? extends MountTableConfigLoader>
       DEFAULT_MOUNT_TABLE_CONFIG_LOADER_IMPL =
       HCFSMountTableConfigLoader.class;
+
+  /**
+   * Enable ViewFileSystem to return a trashRoot which is local to mount point.
+   */
+  String CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH = "fs.viewfs.mount.point.local.trash";
+  boolean CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH_DEFAULT = false;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1187,7 +1187,7 @@ public class ViewFileSystem extends FileSystem {
               TRASH_PREFIX + "/" + ugi.getShortUserName());
         }
       }
-    } catch (IOException|IllegalArgumentException e) {
+    } catch (IOException | IllegalArgumentException e) {
       throw new NotInMountpointException(path, "getTrashRoot");
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1174,14 +1174,13 @@ public class ViewFileSystem extends FileSystem {
           trashRoot)) {
         return trashRoot;
       } else {
-        // If Path p is in the default volume, return a trash in home dir in
-        // default volume.
-        // When Path p is in the default volume, we don't have any match in
-        // mount points and thus couldn't resolve any component for Path p.
-        if (res.remainingPath.equals(path)) {
+        // Path p is either in a mount point or in the fallback FS
+        if (ROOT_PATH.equals(new Path(res.resolvedPath))) {
+          // Path p is in the fallback FS
           return new Path(res.targetFileSystem.getHomeDirectory(),
               TRASH_PREFIX);
         } else {
+          // Path p is in a mount point
           Path mountPointRoot =
               res.targetFileSystem.getFileStatus(new Path("/")).getPath();
           return new Path(mountPointRoot,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1169,8 +1169,7 @@ public class ViewFileSystem extends FileSystem {
           fsState.resolve(getUriPath(path), true);
 
       Path trashRoot = res.targetFileSystem.getTrashRoot(res.remainingPath);
-      if (!useMountPointLocalTrash || isEZPath(res.targetFileSystem,
-          trashRoot)) {
+      if (!useMountPointLocalTrash) {
         return trashRoot;
       } else {
         // Path p is either in a mount point or in the fallback FS
@@ -1180,10 +1179,17 @@ public class ViewFileSystem extends FileSystem {
               TRASH_PREFIX);
         } else {
           // Path p is in a mount point
-          Path mountPointRoot =
-              res.targetFileSystem.getFileStatus(new Path("/")).getPath();
-          return new Path(mountPointRoot,
-              TRASH_PREFIX + "/" + ugi.getShortUserName());
+
+          if (trashRoot.toUri().getPath().startsWith(res.resolvedPath)) {
+            // targetFileSystem.trashRoot is in the same mount point as Path p
+            return trashRoot;
+          } else {
+            // targetFileSystem.trashRoot is in a different mount point from
+            // Path p. Return the trash root for the mount point.
+            Path mountPointRoot =
+                res.targetFileSystem.getFileStatus(new Path("/")).getPath();
+            return new Path(mountPointRoot, TRASH_PREFIX + "/" + ugi.getShortUserName());
+          }
         }
       }
     } catch (IOException | IllegalArgumentException e) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1160,9 +1160,8 @@ public class ViewFileSystem extends FileSystem {
       } else {
         // Path p is either in a mount point or in the fallback FS
 
-        if (ROOT_PATH.equals(new Path(res.resolvedPath)) || trashRoot.toUri()
-            .getPath()
-            .startsWith(res.resolvedPath)) {
+        if (ROOT_PATH.equals(new Path(res.resolvedPath))
+            || trashRoot.toUri().getPath().startsWith(res.resolvedPath)) {
           // Path p is in the fallback FS or targetFileSystem.trashRoot is in
           // the same mount point as Path p
           return trashRoot;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1129,20 +1129,6 @@ public class ViewFileSystem extends FileSystem {
   }
 
   /**
-   * Check whether a path is inside a encryption zone.
-   * @return true if a path is either in an encryption zone
-   */
-  private boolean isEZPath(FileSystem fs, Path path) throws IOException {
-    try {
-      FileStatus fileStatus = fs.getFileStatus(path);
-      return fileStatus.isEncrypted();
-    } catch (FileNotFoundException e) {
-      // Return true if path does not exist
-      return false;
-    }
-  }
-
-  /**
    * Get the trash root directory for current user when the path
    * specified is deleted.
    *

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1139,7 +1139,7 @@ public class ViewFileSystem extends FileSystem {
    * 1) If path p is in fallback FS or from the same mount point as the default
    *    trash root for targetFS, return the default trash root for targetFS.
    * 2) else, return a trash root in the mounted targetFS
-   *    (/mntpoint/.Trash/<user>)
+   *    (/mntpoint/.Trash/{user})
    *
    * @param path the trash root of the path to be determined.
    * @return the trash root path.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1129,14 +1129,13 @@ public class ViewFileSystem extends FileSystem {
   }
 
   /**
-   * Check whether a path is inside a snapshot or EZ.
-   * @return true if a path is either in a snapshot or in an EZ
+   * Check whether a path is inside a encryption zone.
+   * @return true if a path is either in an encryption zone
    */
-  private boolean snapshotOrEZPath(FileSystem fs, Path path)
-      throws IOException {
+  private boolean isEZPath(FileSystem fs, Path path) throws IOException {
     try {
       FileStatus fileStatus = fs.getFileStatus(path);
-      return fileStatus.isEncrypted() || fileStatus.isSnapshotEnabled();
+      return fileStatus.isEncrypted();
     } catch (FileNotFoundException e) {
       // Return true if path does not exist
       return false;
@@ -1170,7 +1169,7 @@ public class ViewFileSystem extends FileSystem {
           fsState.resolve(getUriPath(path), true);
 
       Path trashRoot = res.targetFileSystem.getTrashRoot(res.remainingPath);
-      if (!useMountPointLocalTrash || snapshotOrEZPath(res.targetFileSystem,
+      if (!useMountPointLocalTrash || isEZPath(res.targetFileSystem,
           trashRoot)) {
         return trashRoot;
       } else {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1160,6 +1160,35 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
+   * A mocked FileSystem which returns a deep trash dir.
+   */
+  static class MockTrashRootFS extends MockFileSystem {
+    public static final Path TRASH =
+        new Path("/mnt/very/deep/deep/trash/dir/.Trash");
+
+    @Override
+    public Path getTrashRoot(Path path) {
+      return TRASH;
+    }
+  }
+
+  /**
+   * Test a trash root that is inside a mount point for getTrashRoot
+   */
+  @Test
+  public void testTrashRootDeepTrashDir() throws IOException {
+
+    Configuration conf2 = ViewFileSystemTestSetup.createConfig();
+    conf2.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, true);
+    conf2.setClass("fs.mocktrashfs.impl", MockTrashRootFS.class,
+        FileSystem.class);
+    ConfigUtil.addLink(conf2, "/mnt", URI.create("mocktrashfs://mnt/path"));
+    Path testPath = new Path(MockTrashRootFS.TRASH, "projs/proj");
+    FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
+    Assert.assertEquals(MockTrashRootFS.TRASH, fsView2.getTrashRoot(testPath));
+  }
+
+  /**
    * Test localized trash roots in getTrashRoots() for all users.
    */
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1124,15 +1124,23 @@ abstract public class ViewFileSystemBaseTest {
 
     // Case 2: path p not found in mount table, fall back to the default FS
     // Return a trash root in user home dir
-    Path userTestPath = new Path("/nonExistingDir/nonExistingFile");
+    Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
     Path userTrashRoot = new Path(fsTarget.getHomeDirectory(), TRASH_PREFIX);
-    Assert.assertEquals(userTrashRoot, fsView2.getTrashRoot(userTestPath));
+    Assert.assertEquals(userTrashRoot, fsView2.getTrashRoot(nonExistentPath));
 
     // Case 3: turn off the CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH flag.
     // Return a trash root in user home dir.
     newConf.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, newConf);
     Assert.assertEquals(userTrashRoot, fsView2.getTrashRoot(dataTestPath));
+
+    // Case 4: viewFS without fallback. Expect exception for a nonExistent path
+    newConf = new Configuration(conf);
+    fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, newConf);
+    try {
+      fsView2.getTrashRoot(nonExistentPath);
+    } catch (NotInMountpointException ignored) {
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

We modified getTrashRoot()/getTrashRoots() in ViewFileSystem to return a localized trash root that is within a mount point when CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH is set.
 
### How was this patch tested?

mvn test -Dtest=TestView*

Manually ran three newly added unit tests using intellij. 


