### PR TITLE
YARN-11072. Cannot display hadoop-st.png when using reverse proxy and applying APPLICATION_WEB_PROXY_BASE

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -205,11 +205,6 @@
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-lambda</artifactId>
-      <version>1.2.1</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -205,6 +205,11 @@
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <version>1.2.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/HeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/HeaderBlock.java
@@ -33,7 +33,7 @@ public class HeaderBlock extends HtmlBlock {
         div("#user").
         __(loggedIn).__().
         div("#logo").
-          img("/static/hadoop-st.png").__().
+          img(root_url("static/hadoop-st.png")).__().
         h1($(TITLE)).__();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
@@ -37,7 +37,7 @@ public class TestHeaderBlock {
       Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
       String fieldname = "theEnvironment";
       Field theEnvironmentField = processEnvironmentClass.getDeclaredField(fieldname);
-      // reset environment accessibility
+
       theEnvironmentField.setAccessible(true);
       if(theEnvironmentField.getType().equals(Map.class)) {
         Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
@@ -45,7 +45,7 @@ public class TestHeaderBlock {
       }
       fieldname = "theCaseInsensitiveEnvironment";
       Field theCaseInsensitiveEnvField = processEnvironmentClass.getDeclaredField(fieldname);
-      // reset environment accessibility
+
       theCaseInsensitiveEnvField.setAccessible(true);
       if(theCaseInsensitiveEnvField.getType().equals(Map.class)) {
         Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvField.get(null);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.hadoop.yarn.webapp.WebAppException;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
 
 import org.junit.Test;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
@@ -1,0 +1,48 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.hadoop.yarn.webapp.view;
+
+import com.google.inject.Injector;
+
+import java.io.PrintWriter;
+
+import org.apache.hadoop.yarn.webapp.WebAppException;
+import org.apache.hadoop.yarn.webapp.test.WebAppTests;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.*;
+
+public class TestHeaderBlock {
+  private String envkey = "APPLICATION_WEB_PROXY_BASE";
+  private String envvalue = "/hadoop";
+
+  public void checkImgPath() {
+    Injector injector = WebAppTests.testBlock(HeaderBlock.class);
+    PrintWriter out = injector.getInstance(PrintWriter.class);
+    String expectation = " src=\""+envvalue+"/static/hadoop-st.png\"";
+    verify(out).print(expectation);
+  }
+
+  @Test 
+  public void testImgPath() throws Exception {
+    withEnvironmentVariable(envkey, envvalue).execute(() -> checkImgPath());
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
@@ -29,22 +29,19 @@ import org.apache.hadoop.yarn.webapp.WebAppException;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
 
 import org.junit.Test;
-
 import static org.mockito.Mockito.*;
 
-  public class TestHeaderBlock {
-    private String envkey = "APPLICATION_WEB_PROXY_BASE";
-    private String envvalue = "/hadoop";
+public class TestHeaderBlock {
+  private String envkey = "APPLICATION_WEB_PROXY_BASE";
+  private String envvalue = "/hadoop";
 
-    public void setEnv(Map<String, String> newenv) throws Exception {
+  public void setEnv(Map<String, String> newenv) throws Exception {
     try {
       Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
-
       Field theEnvironmentField = processEnvironmentClass.getDeclaredField("theEnvironment");
       theEnvironmentField.setAccessible(true);
       Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
       env.putAll(newenv);
-
       Field theCaseInsensitiveEnvironmentField = processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment");
       theCaseInsensitiveEnvironmentField.setAccessible(true);
       Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
@@ -52,7 +49,6 @@ import static org.mockito.Mockito.*;
     } catch (NoSuchFieldException e) {
       Class[] classes = Collections.class.getDeclaredClasses();
       Map<String, String> env = System.getenv();
-
       for(Class cl : classes) {
         if("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
           Field field = cl.getDeclaredField("m");
@@ -66,8 +62,7 @@ import static org.mockito.Mockito.*;
     }
   }
 
-  @Test 
-  public void testImgPath() throws Exception {
+  @Test public void testImgPath() throws Exception {
     setEnv(Collections.singletonMap(envkey, envvalue));
     Injector injector = WebAppTests.testBlock(HeaderBlock.class);
     PrintWriter out = injector.getInstance(PrintWriter.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/TestHeaderBlock.java
@@ -24,7 +24,6 @@ import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Map;
-import java.util.HashMap;
 
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
 


### PR DESCRIPTION
### Description of PR

Scenario: 
When I want to use reverse proxy and apply APPLICATION_WEB_PROXY_BASE to change the base path, it can not find the hadoop-st.png.

(file: hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/HeaderBlock.java)

Issues:
1. Cannot display the image when you apply APPLICATION_WEB_PROXY_BASE=base_path/.
The image path should be /base_path/static/hadoop-st.png.
2. Should not use a fixed path.

[JIRA YARN-11072](https://issues.apache.org/jira/browse/YARN-11072)

### How was this patch tested?

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

