### PR TITLE
HDFS-16446. Consider ioutils of disk when choosing volume

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
@@ -1132,4 +1132,6 @@ public class NativeIO {
 
   private static native void copyFileUnbuffered0(String src, String dst)
       throws NativeIOException;
+
+  public static native String getDiskName(String path) throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -2007,5 +2007,13 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_LEASE_HARDLIMIT_DEFAULT =
       HdfsClientConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT;
 
+  public static final String DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_KEY =
+      "dfs.datanode.disk.stat.interval.seconds";
+  public static final long DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_DEFAULT = 1L;
 
+  public static final String
+      DFS_DATANODE_AVAILABLE_SPACE_VOLUME_CHOOSING_POLICY_IO_UTIL_PREFERENCE_ENABLE_KEY =
+      "dfs.datanode.available-space-volume-choosing-policy.io.util.preference.enable";
+  public static final boolean
+      DFS_DATANODE_AVAILABLE_SPACE_VOLUME_CHOOSING_POLICY_IO_UTIL_PREFERENCE_ENABLE_DEFAULT = false;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -443,6 +443,7 @@ public class DataNode extends ReconfigurableBase
   private static final double CONGESTION_RATIO = 1.5;
   private DiskBalancer diskBalancer;
   private DataSetLockManager dataSetLockManager;
+  private DiskIOUtilManager diskIOUtilManager;
 
   private final ExecutorService xferService;
 
@@ -490,6 +491,11 @@ public class DataNode extends ReconfigurableBase
     volumeChecker = new DatasetVolumeChecker(conf, new Timer());
     this.xferService =
         HadoopExecutors.newCachedThreadPool(new Daemon.DaemonFactory());
+    if (Shell.LINUX) {
+      this.diskIOUtilManager = new DiskIOUtilManager(conf);
+    } else {
+      LOG.info("Disk io util manager does not start, only Linux OS release support!");
+    }
   }
 
   /**
@@ -1190,6 +1196,9 @@ public class DataNode extends ReconfigurableBase
         conf.set(DFS_DATANODE_DATA_DIR_KEY,
             Joiner.on(",").join(effectiveVolumes));
         dataDirs = getStorageLocations(conf);
+        if (diskIOUtilManager != null) {
+          diskIOUtilManager.setStorageLocations(dataDirs);
+        }
       }
     }
   }
@@ -1708,6 +1717,10 @@ public class DataNode extends ReconfigurableBase
     this.secureResources = resources;
     synchronized (this) {
       this.dataDirs = dataDirectories;
+    }
+    if (diskIOUtilManager != null) {
+      this.diskIOUtilManager.setStorageLocations(dataDirectories);
+      this.diskIOUtilManager.start();
     }
     this.dnConf = new DNConf(this);
     checkSecureConfig(dnConf, getConf(), resources);
@@ -2505,6 +2518,10 @@ public class DataNode extends ReconfigurableBase
       dataNodeInfoBeanName = null;
     }
     if (shortCircuitRegistry != null) shortCircuitRegistry.shutdown();
+    if (diskIOUtilManager != null) {
+      diskIOUtilManager.stop();
+      diskIOUtilManager = null;
+    }
     LOG.info("Shutdown complete.");
     synchronized(this) {
       // it is already false, but setting it again to avoid a findbug warning.
@@ -4157,5 +4174,10 @@ public class DataNode extends ReconfigurableBase
   @VisibleForTesting
   public BlockPoolManager getBlockPoolManager() {
     return blockPoolManager;
+  }
+
+  public int getStorageLocationDiskUtil(StorageLocation location) {
+    return diskIOUtilManager != null ?
+        diskIOUtilManager.getStorageLocationDiskIOUtil(location) : 0;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskIOUtilManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskIOUtilManager.java
@@ -1,0 +1,278 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
+import org.apache.hadoop.io.nativeio.NativeIO;
+import org.apache.hadoop.util.NativeCodeLoader;
+import org.apache.hadoop.util.Shell;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_KEY;
+
+public class DiskIOUtilManager implements Runnable {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(DiskIOUtilManager.class);
+  private volatile long intervalMs;
+  private volatile boolean shouldStop = false;
+  private Thread diskStatThread;
+  private Map<StorageLocation, DiskLocation> locationToDisks = new HashMap<>();
+  private Map<DiskLocation, IOStat> ioStats = new HashMap<>();
+
+  private static class DiskLocation {
+    private final String diskName;
+    private final StorageLocation location;
+    DiskLocation(StorageLocation location) throws IOException {
+      this.location = location;
+      FileStore fs = Files.getFileStore(Paths.get(location.getUri().getPath()));
+      Path path = Paths.get(fs.name());
+      if (path == null) {
+        throw new IOException("Storage location is invalid, path is null");
+      }
+      Path diskName = path.getFileName();
+      if (diskName == null) {
+        throw new IOException("Storage location is invalid, diskName is null");
+      }
+      String diskNamePlace = null;
+      if (NativeCodeLoader.isNativeCodeLoaded() && Shell.LINUX) {
+        try {
+          diskNamePlace = NativeIO.getDiskName(location.getUri().getPath());
+          LOG.info("location is {}, disk name is {}", location.getUri().getPath(), diskNamePlace);
+        } catch (IOException e) {
+          LOG.error("Get disk name by NativeIO failed.", e);
+          diskNamePlace = diskName.toString();
+        } finally {
+          this.diskName = diskNamePlace;
+        }
+      } else {
+        this.diskName = diskName.toString();
+      }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof DiskLocation)) {
+        return false;
+      }
+      DiskLocation o = (DiskLocation) other;
+      return diskName.equals(o.diskName) && location.equals(o.location);
+    }
+
+    @Override
+    public int hashCode() {
+      return location.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return location.toString() + " disk: " + diskName;
+    }
+  }
+
+  private static class IOStat {
+    private long lastTotalTicks;
+    private int util;
+    IOStat(long lastTotalTicks) {
+      this.lastTotalTicks = lastTotalTicks;
+    }
+
+    public int getUtil() {
+      return util;
+    }
+
+    public void setUtil(int util) {
+      if (util <= 100 && util >= 0) {
+        this.util = util;
+      } else if (util < 0) {
+        this.util = 0;
+      } else {
+        this.util = 100;
+      }
+    }
+
+    public long getLastTotalTicks() {
+      return lastTotalTicks;
+    }
+
+    public void setLastTotalTicks(long lastTotalTicks) {
+      this.lastTotalTicks = lastTotalTicks;
+    }
+  }
+
+  DiskIOUtilManager(Configuration conf) {
+    this.intervalMs = TimeUnit.SECONDS.toMillis(conf.getLong(
+        DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_KEY,
+        DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_DEFAULT));
+    if (this.intervalMs < DFS_DATANODE_DISK_STAT_INTERVAL_SECONDS_DEFAULT) {
+      this.intervalMs = 1;
+    }
+  }
+
+  @Override
+  public void run() {
+    FsVolumeImpl.LOG.info(this + " starting disk util stat.");
+    while (true) {
+      try {
+        if (shouldStop) {
+          FsVolumeImpl.LOG.info(this + " stopping disk util stat.");
+          break;
+        }
+        if (!Shell.LINUX) {
+          FsVolumeImpl.LOG.debug("Not support disk util stat on this os release.");
+          continue;
+        }
+        Map<String, IOStat> allIOStats = getDiskIoUtils();
+        synchronized (this) {
+          for (Map.Entry<DiskLocation, IOStat> entry : ioStats.entrySet()) {
+            String disk = entry.getKey().diskName;
+            IOStat oldStat = entry.getValue();
+            int util = 0;
+            if (allIOStats.containsKey(disk)) {
+              long oldTotalTicks = oldStat.getLastTotalTicks();
+              long newTotalTicks = allIOStats.get(disk).getLastTotalTicks();
+              if (oldTotalTicks != 0) {
+                util = (int) ((double) (newTotalTicks - oldTotalTicks) * 100 / intervalMs);
+              }
+              oldStat.setLastTotalTicks(newTotalTicks);
+              oldStat.setUtil(util);
+              LOG.debug(disk + " disk io util:" + util);
+            } else {
+              //Maybe this disk has been umounted.
+              oldStat.setUtil(100);
+            }
+          }
+        }
+        try {
+          Thread.sleep(intervalMs);
+        } catch (InterruptedException e) {
+          LOG.debug("Thread interrupted while sleep in DiskIOUtilManager", e);
+        }
+      } catch (Throwable e) {
+        LOG.error("DiskIOUtilManager encountered an exception.", e);
+      }
+    }
+  }
+
+  void start() {
+    if (diskStatThread != null) {
+      return;
+    }
+    shouldStop = false;
+    diskStatThread = new Thread(this, threadName());
+    diskStatThread.setDaemon(true);
+    diskStatThread.start();
+  }
+
+  void stop() {
+    shouldStop = true;
+    if (diskStatThread != null) {
+      diskStatThread.interrupt();
+      try {
+        diskStatThread.join();
+      } catch (InterruptedException e) {
+        LOG.debug("Thread interrupted while stop DiskIOUtilManager", e);
+      }
+    }
+  }
+
+  private String threadName() {
+    return "DataNode disk io util manager";
+  }
+
+  private static final String PROC_DISKSSTATS = "/proc/diskstats";
+  private static final Pattern DISK_STAT_FORMAT =
+      Pattern.compile("[ \t]*[0-9]*[ \t]*[0-9]*[ \t]*(\\S*)" +
+          "[ \t]*[0-9]*[ \t]*[0-9]*[ \t]*[0-9]*" +
+          "[ \t]*[0-9]*[ \t]*[0-9]*[ \t]*[0-9]*" +
+          "[ \t]*[0-9]*[ \t]*[0-9]*[ \t]*[0-9]*" +
+          "[ \t]*([0-9]*)[ \t].*");
+
+  private Map<String, IOStat> getDiskIoUtils() {
+    Map<String, IOStat> rets = new HashMap<>();
+    try(InputStreamReader fReader = new InputStreamReader(
+        new FileInputStream(PROC_DISKSSTATS), Charset.forName("UTF-8"));
+        BufferedReader in = new BufferedReader(fReader)) {
+      Matcher mat = null;
+      String str = in.readLine();
+      while (str != null) {
+        mat = DISK_STAT_FORMAT.matcher(str);
+        if (mat.find()) {
+          String disk = mat.group(1);
+          long totalTicks = Long.parseLong(mat.group(2));
+          LOG.debug(str + " totalTicks:" + totalTicks);
+          IOStat stat = new IOStat(totalTicks);
+          rets.put(disk, stat);
+        }
+        str = in.readLine();
+      }
+    } catch (FileNotFoundException f) {
+      // Shouldn't happen.
+      return rets;
+    } catch (IOException e) {
+      LOG.warn("Get disk ioUtils failed.", e);
+    }
+    return rets;
+  }
+
+  public synchronized void setStorageLocations(List<StorageLocation> locations) throws IOException {
+    if (locations == null) {
+      return;
+    }
+    locationToDisks.clear();
+    ioStats.clear();
+    for (StorageLocation location : locations) {
+      DiskLocation diskLocation = new DiskLocation(location);
+      locationToDisks.put(location, diskLocation);
+      IOStat stat = new IOStat(0);
+      ioStats.put(diskLocation, stat);
+    }
+  }
+
+  public synchronized int getStorageLocationDiskIOUtil(StorageLocation location) {
+    DiskLocation diskLocation = locationToDisks.get(location);
+    if (diskLocation == null) {
+      return 0;
+    }
+    if (ioStats.containsKey(diskLocation)) {
+      return ioStats.get(diskLocation).getUtil();
+    } else {
+      return 0;
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
@@ -685,4 +685,12 @@ public interface FsDatasetSpi<V extends FsVolumeSpi> extends FSDatasetMBean {
    * Get the volume list.
    */
   List<FsVolumeImpl> getVolumeList();
+
+  /**
+   * Get the utility of storage location.
+   *
+   * @param location
+   * @return The utility of storage location.
+   */
+  int getStorageLocationDiskUtil(StorageLocation location);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsVolumeSpi.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsVolumeSpi.java
@@ -448,4 +448,12 @@ public interface FsVolumeSpi
   FileIoProvider getFileIoProvider();
 
   DataNodeVolumeMetrics getMetrics();
+
+  /**
+   * Get the utility of disk. The value is between 0 and 100,
+   * 0 means the volume is idle, 100 means the volume is very busy.
+   *
+   * @return The utility of disk.
+   */
+  int getVolumeIOUtil();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -223,6 +223,11 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     }
   }
 
+  @Override
+  public int getStorageLocationDiskUtil(StorageLocation location) {
+    return datanode.getStorageLocationDiskUtil(location);
+  }
+
   /**
    * This should be primarily used for testing.
    * @return clone of replica store in datanode memory

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsVolumeImpl.java
@@ -1409,6 +1409,11 @@ public class FsVolumeImpl implements FsVolumeSpi {
     return metrics;
   }
 
+  @Override
+  public int getVolumeIOUtil() {
+    return dataset.getStorageLocationDiskUtil(storageLocation);
+  }
+
   /**
    * Filter for block file names stored on the file system volumes.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2705,6 +2705,25 @@
 </property>
 
 <property>
+  <name>dfs.datanode.available-space-volume-choosing-policy.io.util.preference.enable</name>
+  <value>false</value>
+  <description>
+    Only used when the dfs.datanode.fsdataset.volume.choosing.policy is set to
+    org.apache.hadoop.hdfs.server.datanode.fsdataset.AvailableSpaceVolumeChoosingPolicy.
+    If set to true, busy disks will be filtered as much as possible when data is written.
+    The default is false.
+  </description>
+</property>
+
+<property>
+  <name>dfs.datanode.disk.stat.interval.seconds</name>
+  <value>1</value>
+  <description>
+    How often does DiskIOUtilManager collect ioutil metrics.
+  </description>
+</property>
+
+<property>
   <name>dfs.datanode.round-robin-volume-choosing-policy.additional-available-space</name>
   <value>1073741824</value> <!-- 1 GB -->
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -689,6 +689,11 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
     }
 
     @Override
+    public int getVolumeIOUtil() {
+      return 0;
+    }
+
+    @Override
     public VolumeCheckResult check(VolumeCheckContext context)
         throws Exception {
       return VolumeCheckResult.HEALTHY;
@@ -1610,6 +1615,11 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   @Override
   public List<FsVolumeImpl> getVolumeList() {
     return null;
+  }
+
+  @Override
+  public int getStorageLocationDiskUtil(StorageLocation location) {
+    return 0;
   }
 }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -1088,6 +1088,11 @@ public class TestDirectoryScanner {
     }
 
     @Override
+    public int getVolumeIOUtil() {
+      return 0;
+    }
+
+    @Override
     public VolumeCheckResult check(VolumeCheckContext context)
         throws Exception {
       return VolumeCheckResult.HEALTHY;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -473,4 +473,9 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   public List<FsVolumeImpl> getVolumeList() {
     return null;
   }
+
+  @Override
+  public int getStorageLocationDiskUtil(StorageLocation location) {
+    return 0;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalVolumeImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalVolumeImpl.java
@@ -137,6 +137,11 @@ public class ExternalVolumeImpl implements FsVolumeSpi {
   }
 
   @Override
+  public int getVolumeIOUtil() {
+    return 0;
+  }
+
+  @Override
   public VolumeCheckResult check(VolumeCheckContext context)
       throws Exception {
     return VolumeCheckResult.HEALTHY;


### PR DESCRIPTION
JIRA: [HDFS-16446](https://issues.apache.org/jira/browse/HDFS-16446).

Consider ioutils of disk when choosing volume to avoid busy disks.

Document: https://docs.google.com/document/d/1Ko1J7shz8hVLnNACT6PKVQ_leIHf_YaIFA2s3yJMZHQ/edit?usp=sharing

Architecture is as follows:
![image](https://user-images.githubusercontent.com/55134131/159827737-f4ca4d66-c2f2-4bef-901b-6d2bc7bdda9a.png)

