### PR TITLE
HADOOP-18104: S3A: Add configs to configure minSeekForVectorReads and maxReadSizeForVectorReads

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md
@@ -474,6 +474,7 @@ end of first and start of next range is more than this value.
 
 Maximum number of bytes which can be read in one go after merging the ranges.
 Two ranges won't be merged if the combined data to be read is more than this value.
+Essentially setting this to 0 will disable the merging of ranges.
 
 ## Consistency
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
@@ -18,15 +18,6 @@
 
 package org.apache.hadoop.fs.contract;
 
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileRange;
-import org.apache.hadoop.fs.FileRangeImpl;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.impl.FutureIOSupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -42,6 +33,15 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileRange;
+import org.apache.hadoop.fs.FileRangeImpl;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.impl.FutureIOSupport;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractContractVectoredReadTest extends AbstractFSContrac
 
   public static final int DATASET_LEN = 64 * 1024;
   private static final byte[] DATASET = ContractTestUtils.dataset(DATASET_LEN, 'a', 32);
-  private static final String VECTORED_READ_FILE_NAME = "vectored_file.txt";
+  protected static final String VECTORED_READ_FILE_NAME = "vectored_file.txt";
   private static final String VECTORED_READ_FILE_1MB_NAME = "vectored_file_1M.txt";
   private static final byte[] DATASET_MB = ContractTestUtils.dataset(1024 * 1024, 'a', 256);
 
@@ -172,6 +172,7 @@ public abstract class AbstractContractVectoredReadTest extends AbstractFSContrac
     }
   }
 
+  @Test
   public void testSameRanges() throws Exception {
     FileSystem fs = getFileSystem();
     List<FileRange> fileRanges = new ArrayList<>();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
@@ -207,6 +207,32 @@ public class TestVectoredReadUtils extends HadoopTestBase {
             VectoredReadUtils.isOrderedDisjoint(outputList, 1, 800));
 
   }
+
+  @Test
+  public void testMaxSizeZeroDisablesMering() throws Exception {
+    List<FileRange> randomRanges = Arrays.asList(
+            new FileRangeImpl(3000, 110),
+            new FileRangeImpl(3000, 100),
+            new FileRangeImpl(2100, 100)
+    );
+
+    List<CombinedFileRange> combinedFileRanges = VectoredReadUtils
+            .sortAndMergeRanges(randomRanges, 1, 1, 0);
+    assertEquals("Mismatch in number of ranges post merging",
+            randomRanges.size(), combinedFileRanges.size());
+
+    List<CombinedFileRange> combinedFileRanges1 = VectoredReadUtils
+            .sortAndMergeRanges(randomRanges, 1, 0, 0);
+    assertEquals("Mismatch in number of ranges post merging",
+            randomRanges.size(), combinedFileRanges1.size());
+
+    List<CombinedFileRange> combinedFileRanges2 = VectoredReadUtils
+            .sortAndMergeRanges(randomRanges, 1, 100, 0);
+    assertEquals("Mismatch in number of ranges post merging",
+            randomRanges.size(), combinedFileRanges2.size());
+
+  }
+
   interface Stream extends PositionedReadable, ByteBufferPositionedReadable {
     // nothing
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
@@ -215,25 +215,20 @@ public class TestVectoredReadUtils extends HadoopTestBase {
             new FileRangeImpl(3000, 100),
             new FileRangeImpl(2100, 100)
     );
+    assertEqualRangeCountsAfterMerging(randomRanges, 1, 1, 0);
+    assertEqualRangeCountsAfterMerging(randomRanges, 1, 0, 0);
+    assertEqualRangeCountsAfterMerging(randomRanges, 1, 100, 0);
+  }
 
+  private void assertEqualRangeCountsAfterMerging(List<FileRange> inputRanges,
+                                                  int chunkSize,
+                                                  int minimumSeek,
+                                                  int maxSize) {
     List<CombinedFileRange> combinedFileRanges = VectoredReadUtils
-            .sortAndMergeRanges(randomRanges, 1, 1, 0);
+            .sortAndMergeRanges(inputRanges, chunkSize, minimumSeek, maxSize);
     Assertions.assertThat(combinedFileRanges)
             .describedAs("Mismatch in number of ranges post merging")
-            .hasSize(randomRanges.size());
-
-    List<CombinedFileRange> combinedFileRanges1 = VectoredReadUtils
-            .sortAndMergeRanges(randomRanges, 1, 0, 0);
-    Assertions.assertThat(combinedFileRanges1)
-            .describedAs("Mismatch in number of ranges post merging")
-            .hasSize(randomRanges.size());
-
-    List<CombinedFileRange> combinedFileRanges2 = VectoredReadUtils
-            .sortAndMergeRanges(randomRanges, 1, 100, 0);
-    Assertions.assertThat(combinedFileRanges2)
-            .describedAs("Mismatch in number of ranges post merging")
-            .hasSize(randomRanges.size());
-
+            .hasSize(inputRanges.size());
   }
 
   interface Stream extends PositionedReadable, ByteBufferPositionedReadable {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/impl/TestVectoredReadUtils.java
@@ -218,18 +218,21 @@ public class TestVectoredReadUtils extends HadoopTestBase {
 
     List<CombinedFileRange> combinedFileRanges = VectoredReadUtils
             .sortAndMergeRanges(randomRanges, 1, 1, 0);
-    assertEquals("Mismatch in number of ranges post merging",
-            randomRanges.size(), combinedFileRanges.size());
+    Assertions.assertThat(combinedFileRanges)
+            .describedAs("Mismatch in number of ranges post merging")
+            .hasSize(randomRanges.size());
 
     List<CombinedFileRange> combinedFileRanges1 = VectoredReadUtils
             .sortAndMergeRanges(randomRanges, 1, 0, 0);
-    assertEquals("Mismatch in number of ranges post merging",
-            randomRanges.size(), combinedFileRanges1.size());
+    Assertions.assertThat(combinedFileRanges1)
+            .describedAs("Mismatch in number of ranges post merging")
+            .hasSize(randomRanges.size());
 
     List<CombinedFileRange> combinedFileRanges2 = VectoredReadUtils
             .sortAndMergeRanges(randomRanges, 1, 100, 0);
-    assertEquals("Mismatch in number of ranges post merging",
-            randomRanges.size(), combinedFileRanges2.size());
+    Assertions.assertThat(combinedFileRanges2)
+            .describedAs("Mismatch in number of ranges post merging")
+            .hasSize(randomRanges.size());
 
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MoreAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MoreAsserts.java
@@ -95,7 +95,7 @@ public class MoreAsserts {
    */
   public static <T> void assertEqual(T actual, T expected, String message) {
     Assertions.assertThat(actual)
-            .describedAs("Mismatch in "+ message)
+            .describedAs("Mismatch in " + message)
             .isEqualTo(expected);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MoreAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MoreAsserts.java
@@ -86,4 +86,16 @@ public class MoreAsserts {
                     "completed exceptionally")
             .isTrue();
   }
+
+  /**
+   * Assert two same type of values.
+   * @param actual actual value.
+   * @param expected expected value.
+   * @param message error message to print in case of mismatch.
+   */
+  public static <T> void assertEqual(T actual, T expected, String message) {
+    Assertions.assertThat(actual)
+            .describedAs("Mismatch in "+ message)
+            .isEqualTo(expected);
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MoreAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MoreAsserts.java
@@ -95,7 +95,7 @@ public class MoreAsserts {
    */
   public static <T> void assertEqual(T actual, T expected, String message) {
     Assertions.assertThat(actual)
-            .describedAs("Mismatch in " + message)
+            .describedAs("Mismatch in %s", message)
             .isEqualTo(expected);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1066,4 +1066,29 @@ public final class Constants {
    * Require that all S3 access is made through Access Points.
    */
   public static final String AWS_S3_ACCESSPOINT_REQUIRED = "fs.s3a.accesspoint.required";
+
+  /**
+   * What is the smallest reasonable seek that we should group ranges
+   * together during vectored read operation.
+   * Value : {@value}.
+   */
+  public static final String AWS_S3_MIN_SEEK_VECTOR_READS = "fs.s3a.min.seek.vectored.read";
+
+  /**
+   * What is the largest size that we should group ranges
+   * together during vectored read?
+   * Setting this value 0 will disable merging of ranges.
+   * Value : {@value}.
+   */
+  public static final String AWS_S3_MAX_READSIZE_VECTOR_READS = "fs.s3a.max.readsize.vectored.read";
+
+  /**
+   * Default minimum seek during vectored reads : {@value}.
+   */
+  public static final int DEFAULT_AWS_S3_MIN_SEEK_VECTOR_READS = 4 * 1024;
+
+  /**
+   * Default maximum read size during vectored reads : {@value}.
+   */
+  public static final int DEFAULT_AWS_S3_MAX_READSIZE_VECTOR_READS = 1024 * 1024;
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1068,27 +1068,27 @@ public final class Constants {
   public static final String AWS_S3_ACCESSPOINT_REQUIRED = "fs.s3a.accesspoint.required";
 
   /**
-   * What is the smallest reasonable seek that we should group ranges
-   * together during vectored read operation.
+   * What is the smallest reasonable seek such that we group
+   * ranges together during vectored read operation.
    * Value : {@value}.
    */
-  public static final String AWS_S3_MIN_SEEK_VECTOR_READS = "fs.s3a.min.seek.vectored.read";
+  public static final String AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = "fs.s3a.vectored.read.min.seek.size";
 
   /**
-   * What is the largest size that we should group ranges
-   * together during vectored read?
-   * Setting this value 0 will disable merging of ranges.
+   * What is the largest merged read size such that we group
+   * ranges together during vectored read.
+   * Setting this value to 0 will disable merging of ranges.
    * Value : {@value}.
    */
-  public static final String AWS_S3_MAX_READSIZE_VECTOR_READS = "fs.s3a.max.readsize.vectored.read";
+  public static final String AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = "fs.s3a.vectored.read.max.merged.size";
 
   /**
    * Default minimum seek during vectored reads : {@value}.
    */
-  public static final int DEFAULT_AWS_S3_MIN_SEEK_VECTOR_READS = 4 * 1024;
+  public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4 * 1024;
 
   /**
    * Default maximum read size during vectored reads : {@value}.
    */
-  public static final int DEFAULT_AWS_S3_MAX_READSIZE_VECTOR_READS = 1024 * 1024;
+  public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1024 * 1024;
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1072,7 +1072,8 @@ public final class Constants {
    * ranges together during vectored read operation.
    * Value : {@value}.
    */
-  public static final String AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = "fs.s3a.vectored.read.min.seek.size";
+  public static final String AWS_S3_VECTOR_READS_MIN_SEEK_SIZE =
+          "fs.s3a.vectored.read.min.seek.size";
 
   /**
    * What is the largest merged read size such that we group
@@ -1080,7 +1081,8 @@ public final class Constants {
    * Setting this value to 0 will disable merging of ranges.
    * Value : {@value}.
    */
-  public static final String AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = "fs.s3a.vectored.read.max.merged.size";
+  public static final String AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE =
+          "fs.s3a.vectored.read.max.merged.size";
 
   /**
    * Default minimum seek during vectored reads : {@value}.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1068,16 +1068,16 @@ public final class Constants {
   public static final String AWS_S3_ACCESSPOINT_REQUIRED = "fs.s3a.accesspoint.required";
 
   /**
-   * What is the smallest reasonable seek such that we group
-   * ranges together during vectored read operation.
+   * What is the smallest reasonable seek in bytes such
+   * that we group ranges together during vectored read operation.
    * Value : {@value}.
    */
   public static final String AWS_S3_VECTOR_READS_MIN_SEEK_SIZE =
           "fs.s3a.vectored.read.min.seek.size";
 
   /**
-   * What is the largest merged read size such that we group
-   * ranges together during vectored read.
+   * What is the largest merged read size in bytes such
+   * that we group ranges together during vectored read.
    * Setting this value to 0 will disable merging of ranges.
    * Value : {@value}.
    */
@@ -1085,12 +1085,12 @@ public final class Constants {
           "fs.s3a.vectored.read.max.merged.size";
 
   /**
-   * Default minimum seek during vectored reads : {@value}.
+   * Default minimum seek in bytes during vectored reads : {@value}.
    */
-  public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4 * 1024;
+  public static final int DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE = 4896; // 4K
 
   /**
-   * Default maximum read size during vectored reads : {@value}.
+   * Default maximum read size in bytes during vectored reads : {@value}.
    */
-  public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1024 * 1024;
+  public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1253376; //1M
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -575,10 +575,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @return VectoredIOContext.
    */
   private VectoredIOContext populateVectoredIOContext(Configuration conf) {
-    final int minSeekVectored = conf.getInt(AWS_S3_MIN_SEEK_VECTOR_READS,
-            DEFAULT_AWS_S3_MIN_SEEK_VECTOR_READS);
-    final int maxReadSizeVectored = conf.getInt(AWS_S3_MAX_READSIZE_VECTOR_READS,
-            DEFAULT_AWS_S3_MAX_READSIZE_VECTOR_READS);
+    final int minSeekVectored = conf.getInt(AWS_S3_VECTOR_READS_MIN_SEEK_SIZE,
+            DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE);
+    final int maxReadSizeVectored = conf.getInt(AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE,
+            DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE);
     return new VectoredIOContext()
             .setMinSeekForVectoredReads(minSeekVectored)
             .setMaxReadSizeForVectoredReads(maxReadSizeVectored)

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -575,10 +575,10 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @return VectoredIOContext.
    */
   private VectoredIOContext populateVectoredIOContext(Configuration conf) {
-    final int minSeekVectored = conf.getInt(AWS_S3_VECTOR_READS_MIN_SEEK_SIZE,
-            DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE);
-    final int maxReadSizeVectored = conf.getInt(AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE,
-            DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE);
+    final int minSeekVectored = (int) longBytesOption(conf, AWS_S3_VECTOR_READS_MIN_SEEK_SIZE,
+            DEFAULT_AWS_S3_VECTOR_READS_MIN_SEEK_SIZE, 0);
+    final int maxReadSizeVectored = (int) longBytesOption(conf, AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE,
+            DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE, 0);
     return new VectoredIOContext()
             .setMinSeekForVectoredReads(minSeekVectored)
             .setMaxReadSizeForVectoredReads(maxReadSizeVectored)

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -817,7 +817,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
 
   /**
    * To override this value set property defined by
-   * {@link Constants#AWS_S3_MIN_SEEK_VECTOR_READS} in configuration.
+   * {@link Constants#AWS_S3_VECTOR_READS_MIN_SEEK_SIZE} in configuration.
    *
    * {@inheritDoc}.
    */
@@ -828,7 +828,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
 
   /**
    * To override this value set property defined by
-   * {@link Constants#AWS_S3_MAX_READSIZE_VECTOR_READS} in configuration.
+   * {@link Constants#AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE} in configuration.
    *
    * {@inheritDoc}.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -137,6 +137,9 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   private S3AInputPolicy inputPolicy;
   private long readahead = Constants.DEFAULT_READAHEAD_RANGE;
 
+  /** Vectored IO context. */
+  private VectoredIOContext vectoredIOContext;
+
   /**
    * This is the actual position within the object, used by
    * lazy seek to decide whether to seek on the next read or not.
@@ -197,6 +200,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
     setInputPolicy(ctx.getInputPolicy());
     setReadahead(ctx.getReadahead());
     this.unboundedThreadPool = unboundedThreadPool;
+    this.vectoredIOContext = context.getVectoredIOContext();
   }
 
   /**
@@ -808,6 +812,28 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
         seekQuietly(oldPos);
       }
     }
+  }
+
+  /**
+   * To override this value set property defined by
+   * {@link Constants#AWS_S3_MIN_SEEK_VECTOR_READS} in configuration.
+   *
+   * {@inheritDoc}.
+   */
+  @Override
+  public int minSeekForVectorReads() {
+    return vectoredIOContext.getMinSeekForVectorReads();
+  }
+
+  /**
+   * To override this value set property defined by
+   * {@link Constants#AWS_S3_MAX_READSIZE_VECTOR_READS} in configuration.
+   *
+   * {@inheritDoc}.
+   */
+  @Override
+  public int maxReadSizeForVectorReads() {
+    return vectoredIOContext.getMaxReadSizeForVectorReads();
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -768,6 +768,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
       sb.append(" remainingInCurrentRequest=")
           .append(remainingInCurrentRequest());
       sb.append(" ").append(changeTracker);
+      sb.append(" ").append(vectoredIOContext);
       sb.append('\n').append(s);
       sb.append('}');
       return sb.toString();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -138,7 +138,7 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   private long readahead = Constants.DEFAULT_READAHEAD_RANGE;
 
   /** Vectored IO context. */
-  private VectoredIOContext vectoredIOContext;
+  private final VectoredIOContext vectoredIOContext;
 
   /**
    * This is the actual position within the object, used by
@@ -816,9 +816,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   }
 
   /**
-   * To override this value set property defined by
-   * {@link Constants#AWS_S3_VECTOR_READS_MIN_SEEK_SIZE} in configuration.
-   *
    * {@inheritDoc}.
    */
   @Override
@@ -827,9 +824,6 @@ public class S3AInputStream extends FSInputStream implements  CanSetReadahead,
   }
 
   /**
-   * To override this value set property defined by
-   * {@link Constants#AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE} in configuration.
-   *
    * {@inheritDoc}.
    */
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -98,7 +98,7 @@ public class S3AReadOpContext extends S3AOpContext {
     this.inputPolicy = checkNotNull(inputPolicy);
     this.changeDetectionPolicy = checkNotNull(changeDetectionPolicy);
     this.readahead = readahead;
-    this.vectoredIOContext = vectoredIOContext;
+    this.vectoredIOContext = checkNotNull(vectoredIOContext);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -27,9 +27,6 @@ import org.apache.hadoop.fs.store.audit.AuditSpan;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
-import java.util.function.IntFunction;
-
 import org.apache.hadoop.util.Preconditions;
 
 import static org.apache.hadoop.util.Preconditions.checkNotNull;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -75,19 +75,19 @@ public class S3AReadOpContext extends S3AOpContext {
    * @param changeDetectionPolicy change detection policy.
    * @param readahead readahead for GET operations/skip, etc.
    * @param auditSpan active audit
-   * @param vectoredIOContext
+   * @param vectoredIOContext context for vectored read operation.
    */
   public S3AReadOpContext(
-          final Path path,
-          Invoker invoker,
-          @Nullable FileSystem.Statistics stats,
-          S3AStatisticsContext instrumentation,
-          FileStatus dstFileStatus,
-          S3AInputPolicy inputPolicy,
-          ChangeDetectionPolicy changeDetectionPolicy,
-          final long readahead,
-          final AuditSpan auditSpan,
-          VectoredIOContext vectoredIOContext) {
+        final Path path,
+        Invoker invoker,
+        @Nullable FileSystem.Statistics stats,
+        S3AStatisticsContext instrumentation,
+        FileStatus dstFileStatus,
+        S3AInputPolicy inputPolicy,
+        ChangeDetectionPolicy changeDetectionPolicy,
+        final long readahead,
+        final AuditSpan auditSpan,
+        VectoredIOContext vectoredIOContext) {
 
     super(invoker, stats, instrumentation,
         dstFileStatus);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -27,6 +27,9 @@ import org.apache.hadoop.fs.store.audit.AuditSpan;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
+import java.util.function.IntFunction;
+
 import org.apache.hadoop.util.Preconditions;
 
 import static org.apache.hadoop.util.Preconditions.checkNotNull;
@@ -59,6 +62,12 @@ public class S3AReadOpContext extends S3AOpContext {
   private final AuditSpan auditSpan;
 
   /**
+   * Vectored IO context for vectored read api
+   * in {@code S3AInputStream#readVectored(List, IntFunction)}.
+   */
+  private final VectoredIOContext vectoredIOContext;
+
+  /**
    * Instantiate.
    * @param path path of read
    * @param invoker invoker for normal retries.
@@ -69,17 +78,19 @@ public class S3AReadOpContext extends S3AOpContext {
    * @param changeDetectionPolicy change detection policy.
    * @param readahead readahead for GET operations/skip, etc.
    * @param auditSpan active audit
+   * @param vectoredIOContext
    */
   public S3AReadOpContext(
-      final Path path,
-      Invoker invoker,
-      @Nullable FileSystem.Statistics stats,
-      S3AStatisticsContext instrumentation,
-      FileStatus dstFileStatus,
-      S3AInputPolicy inputPolicy,
-      ChangeDetectionPolicy changeDetectionPolicy,
-      final long readahead,
-      final AuditSpan auditSpan) {
+          final Path path,
+          Invoker invoker,
+          @Nullable FileSystem.Statistics stats,
+          S3AStatisticsContext instrumentation,
+          FileStatus dstFileStatus,
+          S3AInputPolicy inputPolicy,
+          ChangeDetectionPolicy changeDetectionPolicy,
+          final long readahead,
+          final AuditSpan auditSpan,
+          VectoredIOContext vectoredIOContext) {
 
     super(invoker, stats, instrumentation,
         dstFileStatus);
@@ -90,6 +101,7 @@ public class S3AReadOpContext extends S3AOpContext {
     this.inputPolicy = checkNotNull(inputPolicy);
     this.changeDetectionPolicy = checkNotNull(changeDetectionPolicy);
     this.readahead = readahead;
+    this.vectoredIOContext = vectoredIOContext;
   }
 
   /**
@@ -134,6 +146,14 @@ public class S3AReadOpContext extends S3AOpContext {
    */
   public AuditSpan getAuditSpan() {
     return auditSpan;
+  }
+
+  /**
+   * Get Vectored IO context for this this read op.
+   * @return vectored IO context.
+   */
+  public VectoredIOContext getVectoredIOContext() {
+    return vectoredIOContext;
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/VectoredIOContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/VectoredIOContext.java
@@ -67,4 +67,12 @@ public class VectoredIOContext {
   public int getMaxReadSizeForVectorReads() {
     return maxReadSizeForVectorReads;
   }
+
+  @Override
+  public String toString() {
+    return "VectoredIOContext{" +
+            "minSeekForVectorReads=" + minSeekForVectorReads +
+            ", maxReadSizeForVectorReads=" + maxReadSizeForVectorReads +
+            '}';
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/VectoredIOContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/VectoredIOContext.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.util.List;
+import java.util.function.IntFunction;
+
+/**
+ * Context related to vectored IO operation.
+ * See {@link S3AInputStream#readVectored(List, IntFunction)}.
+ */
+public class VectoredIOContext {
+
+  /**
+   * What is the smallest reasonable seek that we should group
+   * ranges together during vectored read operation.
+   */
+  private int minSeekForVectorReads;
+
+  /**
+   * What is the largest size that we should group ranges
+   * together during vectored read operation.
+   * Setting this value 0 will disable merging of ranges.
+   */
+  private int maxReadSizeForVectorReads;
+
+  /**
+   * Default no arg constructor.
+   */
+  public VectoredIOContext() {
+  }
+
+  public VectoredIOContext setMinSeekForVectoredReads(int minSeek) {
+    this.minSeekForVectorReads = minSeek;
+    return this;
+  }
+
+  public VectoredIOContext setMaxReadSizeForVectoredReads(int maxSize) {
+    this.maxReadSizeForVectorReads = maxSize;
+    return this;
+  }
+
+  public VectoredIOContext build() {
+    return this;
+  }
+
+  public int getMinSeekForVectorReads() {
+    return minSeekForVectorReads;
+  }
+
+  public int getMaxReadSizeForVectorReads() {
+    return maxReadSizeForVectorReads;
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -59,7 +59,7 @@ To make most efficient use of S3, care is needed.
 The S3A FileSystem supports implementation of vectored read api using which
 a client can provide a list of file ranges to read returning a future read
 object associated with each range. For full api specification please see
-[FSDataInputStream](hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md).
+[FSDataInputStream](../../hadoop-common-project/hadoop-common/filesystem/fsdatainputstream.html).
 
 The following properties can be configured to optimise vectored reads based
 on the client requirements.
@@ -67,18 +67,19 @@ on the client requirements.
 ```xml
 <property>
   <name>fs.s3a.vectored.read.min.seek.size</name>
-  <value>4 * 1024</value>
+  <value>4K</value>
   <description>
-     What is the smallest reasonable seek such that we group
-     ranges together during vectored read operation.
+     What is the smallest reasonable seek in bytes such
+     that we group ranges together during vectored
+     read operation.
    </description>
 </property>
 <property>
 <name>fs.s3a.vectored.read.max.merged.size</name>
-<value>1024 * 1024</value>
+<value>1M</value>
 <description>
-   What is the largest merged read size such that we group
-   ranges together during vectored read.
+   What is the largest merged read size in bytes such
+   that we group ranges together during vectored read.
    Setting this value to 0 will disable merging of ranges.
 </description>
 </property>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -55,6 +55,35 @@ it isn't, and some attempts to preserve the metaphor are "aggressively suboptima
 
 To make most efficient use of S3, care is needed.
 
+## <a name="vectoredIO"></a> Improving read performance using Vectored IO
+The S3A FileSystem supports implementation of vectored read api using which
+a client can provide a list of file ranges to read returning a future read
+object associated with each range. For full api specification please see
+[FSDataInputStream](hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md).
+
+The following properties can be configured to optimise vectored reads based
+on the client requirements.
+
+```xml
+<property>
+  <name>fs.s3a.vectored.read.min.seek.size</name>
+  <value>4 * 1024</value>
+  <description>
+     What is the smallest reasonable seek such that we group
+     ranges together during vectored read operation.
+   </description>
+</property>
+<property>
+<name>fs.s3a.vectored.read.max.merged.size</name>
+<value>1024 * 1024</value>
+<description>
+   What is the largest merged read size such that we group
+   ranges together during vectored read.
+   Setting this value to 0 will disable merging of ranges.
+</description>
+</property>
+```
+
 ## <a name="fadvise"></a> Improving data input performance through fadvise
 
 The S3A Filesystem client supports the notion of input policies, similar

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java
@@ -66,10 +66,10 @@ public class ITestS3AContractVectoredRead extends AbstractContractVectoredReadTe
             Constants.AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE,
             Constants.AWS_S3_VECTOR_READS_MIN_SEEK_SIZE);
     S3ATestUtils.disableFilesystemCaching(conf);
-    final int configuredMinSeek = 1024;
-    final int configuredMaxSize = 2 * 1024;
-    conf.setInt(Constants.AWS_S3_VECTOR_READS_MIN_SEEK_SIZE, configuredMinSeek);
-    conf.setInt(Constants.AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE, configuredMaxSize);
+    final int configuredMinSeek = 2 * 1024;
+    final int configuredMaxSize = 10 * 1024 * 1024;
+    conf.set(Constants.AWS_S3_VECTOR_READS_MIN_SEEK_SIZE, "2K");
+    conf.set(Constants.AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE, "10M");
     try (S3AFileSystem fs = S3ATestUtils.createTestFileSystem(conf)) {
       try (FSDataInputStream fis = fs.open(path(VECTORED_READ_FILE_NAME))) {
         int newMinSeek = fis.minSeekForVectorReads();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java
@@ -69,6 +69,7 @@ public class ITestS3AContractVectoredRead extends AbstractContractVectoredReadTe
     conf.setInt(Constants.AWS_S3_MAX_READSIZE_VECTOR_READS, configuredMaxSize);
     try (S3AFileSystem fs = S3ATestUtils.createTestFileSystem(conf)) {
       try (FSDataInputStream fis = fs.open(path(VECTORED_READ_FILE_NAME))) {
+        System.out.println(fis.toString());
         int newMinSeek = fis.minSeekForVectorReads();
         int newMaxSize = fis.maxReadSizeForVectorReads();
         assertEqual(newMinSeek, configuredMinSeek,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractVectoredRead.java
@@ -88,7 +88,6 @@ public class ITestS3AContractVectoredRead extends AbstractContractVectoredReadTe
     S3ATestUtils.removeBaseAndBucketOverrides(conf,
             Constants.AWS_S3_VECTOR_READS_MIN_SEEK_SIZE,
             Constants.AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE);
-    S3ATestUtils.disableFilesystemCaching(conf);
     try (S3AFileSystem fs = S3ATestUtils.createTestFileSystem(conf)) {
       try (FSDataInputStream fis = fs.open(path(VECTORED_READ_FILE_NAME))) {
         int minSeek = fis.minSeekForVectorReads();


### PR DESCRIPTION

### Description of PR
Part of HADOOP-18103.
Introducing fs.s3a.min.seek.vectored.read and fs.s3a.max.readsize.vectored.read
to configure min seek and max read during a vectored IO operation in S3A connector.
These propeties actually define how the ranges will be merged. To completely
disable merging set fs.s3a.max.readsize.vectored.read to 0.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

