### PR TITLE
HDFS-16447. RBF: Registry HDFS Router's RPCServer & RPCClient metrics for PrometheusSink

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
@@ -189,41 +189,49 @@ public class FederationRPCMetrics implements FederationRPCMBean {
   }
 
   @Override
+  @Metric({"RpcServerCallQueue", "Length of the rpc server call queue"})
   public int getRpcServerCallQueue() {
     return rpcServer.getServer().getCallQueueLen();
   }
 
   @Override
+  @Metric({"RpcServerNumOpenConnections", "Number of the rpc server open connections"})
   public int getRpcServerNumOpenConnections() {
     return rpcServer.getServer().getNumOpenConnections();
   }
 
   @Override
+  @Metric({"RpcClientNumConnections", "Number of the rpc client open connections"})
   public int getRpcClientNumConnections() {
     return rpcServer.getRPCClient().getNumConnections();
   }
 
   @Override
+  @Metric({"RpcClientNumActiveConnections", "Number of the rpc client active connections"})
   public int getRpcClientNumActiveConnections() {
     return rpcServer.getRPCClient().getNumActiveConnections();
   }
 
   @Override
+  @Metric({"RpcClientNumIdleConnections", "Number of the rpc client idle connections"})
   public int getRpcClientNumIdleConnections() {
     return rpcServer.getRPCClient().getNumIdleConnections();
   }
 
   @Override
+  @Metric({"RpcClientNumActiveConnectionsRecently", "Number of the rpc client active connections recently"})
   public int getRpcClientNumActiveConnectionsRecently() {
     return rpcServer.getRPCClient().getNumActiveConnectionsRecently();
   }
 
   @Override
+  @Metric({"RpcClientNumCreatingConnections", "Number of the rpc client creating connections"})
   public int getRpcClientNumCreatingConnections() {
     return rpcServer.getRPCClient().getNumCreatingConnections();
   }
 
   @Override
+  @Metric({"RpcClientNumConnectionPools", "Number of the rpc client connection pools"})
   public int getRpcClientNumConnectionPools() {
     return rpcServer.getRPCClient().getNumConnectionPools();
   }


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-16447
When we enable PrometheusSink for HDFS Router,  Router' prometheus sink miss some metrics, for example `RpcClientNumActiveConnections` and so on.

We need  registry some  Router's rpcserver & rpcclient metrics for PrometheusSink.

### How was this patch tested?

no new test

### For code changes:
use `@Metric` to registry metrics. 

