### PR TITLE
HDFS-16451. RBF: Add search box for Router's tab-mounttable web page

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
@@ -458,7 +458,7 @@ No nodes are decommissioning.
   </ul>
 </div>
 <small>
-<table class="table">
+<table class="table" id="table-mounttable">
   <thead>
     <tr>
       <th>Global path</th>
@@ -478,9 +478,9 @@ No nodes are decommissioning.
   <tbody>
     {#MountTable}
     <tr>
-      <td>{sourcePath}</td>
-      <td>{nameserviceId}</td>
-      <td>{path}</td>
+      <td ng-value="{sourcePath}">{sourcePath}</td>
+      <td ng-value="{nameserviceId}">{nameserviceId}</td>
+      <td ng-value="{path}">{path}</td>
       <td>{order}</td>
       <td align="center" class="federationhealth-mounttable-icon federationhealth-mounttable-{readonly}" title="{status}"/>
       <td align="center" class="mount-table-icon mount-table-fault-tolerant-{faulttolerant}" title="{ftStatus}"></td>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.js
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.js
@@ -475,6 +475,22 @@
         var base = dust.makeBase(HELPERS);
         dust.render('mounttable', base.push(data), function(err, out) {
           $('#tab-mounttable').html(out);
+          $('#table-mounttable').dataTable( {
+            'lengthMenu': [ [25, 50, 100, -1], [25, 50, 100, "All"] ],
+            'columns': [
+              { 'orderDataType': 'ng-value', 'searchable': true },
+              { 'orderDataType': 'ng-value', 'searchable': true },
+              { 'orderDataType': 'ng-value', 'searchable': true },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" },
+              { 'type': 'string' , "defaultContent": "" }
+            ]});
           $('#ui-tabs a[href="#tab-mounttable"]').tab('show');
         });
       })).fail(ajax_error_handler);


### PR DESCRIPTION


### Description of PR
https://issues.apache.org/jira/browse/HDFS-16451
In our cluster, we have mount many paths in HDFS Router and it may lead to take some time to load the mount-table page of Router when we open it  in the browser.

In order to use the mount-table page more conveniently, maybe we should add a search box style, just like the screenshot below
![image](https://user-images.githubusercontent.com/10757009/153178234-dbf59390-6a6b-4be7-a5b9-5d0d33b59057.png)
![image](https://user-images.githubusercontent.com/10757009/153178258-21220620-291c-4bdb-b09f-5e57ddc0b125.png)


### How was this patch tested?
no new test

### For code changes:
none

