### PR TITLE
HDFS-16440. RBF: Support router get HAServiceStatus with Lifeline RPC address

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -48,6 +48,8 @@ import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.classification.VisibleForTesting;
+
 /**
  * The {@link Router} periodically checks the state of a Namenode (usually on
  * the same server) and reports their high availability (HA) state and
@@ -346,7 +348,8 @@ public class NamenodeHeartbeatService extends PeriodicService {
           // Determine if NN is active
           // TODO: dynamic timeout
           if (localTargetHAProtocol == null) {
-            localTargetHAProtocol = localTarget.getProxy(conf, 30*1000);
+            localTargetHAProtocol = localTarget.getHealthMonitorProxy(conf, 30*1000);
+            LOG.debug("Get HA status with address {}", lifelineAddress);
           }
           HAServiceStatus status = localTargetHAProtocol.getServiceStatus();
           report.setHAServiceState(status.getState());
@@ -371,6 +374,11 @@ public class NamenodeHeartbeatService extends PeriodicService {
           getNamenodeDesc(), e.getMessage(), e);
     }
     return report;
+  }
+
+  @VisibleForTesting
+  NNHAServiceTarget getLocalTarget(){
+    return this.localTarget;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -50,17 +50,12 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test the service that heartbeats the state of the namenodes to the State
  * Store.
  */
 public class TestRouterNamenodeHeartbeat {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestRouterNamenodeHeartbeat.class);
 
   private static MiniRouterDFSCluster cluster;
   private static ActiveNamenodeResolver namenodeResolver;
@@ -236,7 +231,7 @@ public class TestRouterNamenodeHeartbeat {
       String nsId, String nnId,
       int rpcPort, int servicePort,
       int lifelinePort, int webAddressPort,
-      String expected1, String expected2) {
+      String expected0, String expected1) {
     Configuration conf = generateNamenodeConfiguration(nsId, nnId,
         rpcPort, servicePort, lifelinePort, webAddressPort);
 
@@ -249,19 +244,15 @@ public class TestRouterNamenodeHeartbeat {
     assertEquals(2, heartbeatServices.size());
 
     Iterator<NamenodeHeartbeatService> iterator = heartbeatServices.iterator();
-    NamenodeHeartbeatService service = iterator.next();
-    service.init(conf);
-    assertNotNull(service.getLocalTarget());
-    LOG.info("NamenodeHeartbeatService HealthMonitorAddress {}",
-        service.getLocalTarget().getHealthMonitorAddress().toString());
-    assertEquals(expected1, service.getLocalTarget().getHealthMonitorAddress().toString());
+    NamenodeHeartbeatService service0 = iterator.next();
+    service0.init(conf);
+    assertNotNull(service0.getLocalTarget());
+    assertEquals(expected0, service0.getLocalTarget().getHealthMonitorAddress().toString());
 
-    service = iterator.next();
-    service.init(conf);
-    assertNotNull(service.getLocalTarget());
-    LOG.info("NamenodeHeartbeatService HealthMonitorAddress {}",
-        service.getLocalTarget().getHealthMonitorAddress().toString());
-    assertEquals(expected2, service.getLocalTarget().getHealthMonitorAddress().toString());
+    NamenodeHeartbeatService service1 = iterator.next();
+    service1.init(conf);
+    assertNotNull(service1.getLocalTarget());
+    assertEquals(expected1, service1.getLocalTarget().getHealthMonitorAddress().toString());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 public class TestRouterNamenodeHeartbeat {
 
   private static final Logger LOG =
-          LoggerFactory.getLogger(TestRouterNamenodeHeartbeat.class);
+      LoggerFactory.getLogger(TestRouterNamenodeHeartbeat.class);
 
   private static MiniRouterDFSCluster cluster;
   private static ActiveNamenodeResolver namenodeResolver;
@@ -219,32 +219,32 @@ public class TestRouterNamenodeHeartbeat {
   @Test
   public void testNamenodeHeartbeatServiceHAServiceProtocolProxy(){
     testNamenodeHeartbeatServiceHAServiceProtocol(
-            "test-ns", "nn", 1000, -1, -1, 1003,
-            "host01.test:1000", "host02.test:1000");
+        "test-ns", "nn", 1000, -1, -1, 1003,
+        "host01.test:1000", "host02.test:1000");
     testNamenodeHeartbeatServiceHAServiceProtocol(
-            "test-ns", "nn", 1000, 1001, -1, 1003,
-            "host01.test:1001", "host02.test:1001");
+        "test-ns", "nn", 1000, 1001, -1, 1003,
+        "host01.test:1001", "host02.test:1001");
     testNamenodeHeartbeatServiceHAServiceProtocol(
-            "test-ns", "nn", 1000, -1, 1002, 1003,
-            "host01.test:1002", "host02.test:1002");
+        "test-ns", "nn", 1000, -1, 1002, 1003,
+        "host01.test:1002", "host02.test:1002");
     testNamenodeHeartbeatServiceHAServiceProtocol(
-            "test-ns", "nn", 1000, 1001, 1002, 1003,
-            "host01.test:1002", "host02.test:1002");
+        "test-ns", "nn", 1000, 1001, 1002, 1003,
+        "host01.test:1002", "host02.test:1002");
   }
 
   private void testNamenodeHeartbeatServiceHAServiceProtocol(
-          String nsId, String nnId,
-          int rpcPort, int servicePort,
-          int lifelinePort, int webAddressPort,
-          String expected1, String expected2) {
+      String nsId, String nnId,
+      int rpcPort, int servicePort,
+      int lifelinePort, int webAddressPort,
+      String expected1, String expected2) {
     Configuration conf = generateNamenodeConfiguration(nsId, nnId,
-            rpcPort, servicePort, lifelinePort, webAddressPort);
+        rpcPort, servicePort, lifelinePort, webAddressPort);
 
     Router testRouter = new Router();
     testRouter.setConf(conf);
 
     Collection<NamenodeHeartbeatService> heartbeatServices =
-            testRouter.createNamenodeHeartbeatServices();
+        testRouter.createNamenodeHeartbeatServices();
 
     assertEquals(2, heartbeatServices.size());
 
@@ -253,14 +253,14 @@ public class TestRouterNamenodeHeartbeat {
     service.init(conf);
     assertNotNull(service.getLocalTarget());
     LOG.info("NamenodeHeartbeatService HealthMonitorAddress {}",
-            service.getLocalTarget().getHealthMonitorAddress().toString());
+        service.getLocalTarget().getHealthMonitorAddress().toString());
     assertEquals(expected1, service.getLocalTarget().getHealthMonitorAddress().toString());
 
     service = iterator.next();
     service.init(conf);
     assertNotNull(service.getLocalTarget());
     LOG.info("NamenodeHeartbeatService HealthMonitorAddress {}",
-            service.getLocalTarget().getHealthMonitorAddress().toString());
+        service.getLocalTarget().getHealthMonitorAddress().toString());
     assertEquals(expected2, service.getLocalTarget().getHealthMonitorAddress().toString());
   }
 


### PR DESCRIPTION
JIRA: [HDFS-16440](https://issues.apache.org/jira/browse/HDFS-16440)

NamenodeHeartbeatService gets HAServiceStatus using NNHAServiceTarget.getProxy. When we set a special dfs.namenode.lifeline.rpc-address , NamenodeHeartbeatService may get HAServiceStatus using NNHAServiceTarget.getHealthMonitorProxy.