### PR TITLE
HDFS-16452. msync RPC should send to acitve namenode directly

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -79,6 +79,7 @@ public interface HdfsClientConfigKeys {
   String  DFS_NAMENODE_HTTPS_ADDRESS_KEY = "dfs.namenode.https-address";
   String DFS_HA_NAMENODES_KEY_PREFIX = "dfs.ha.namenodes";
   int DFS_NAMENODE_RPC_PORT_DEFAULT = 8020;
+  String DFS_HA_OBSERVER_NAMENODES_KEY_SUFFIX = "observers";
   String DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY =
       "dfs.namenode.kerberos.principal";
   String  DFS_CLIENT_WRITE_PACKET_SIZE_KEY = "dfs.client-write-packet-size";

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/AbstractNNFailoverProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/AbstractNNFailoverProxyProvider.java
@@ -167,10 +167,15 @@ public abstract class AbstractNNFailoverProxyProvider<T> implements
    * Get list of configured NameNode proxy addresses.
    * Randomize the list if requested.
    */
-  protected List<NNProxyInfo<T>> getProxyAddresses(URI uri, String addressKey) {
+  protected List<NNProxyInfo<T>> getProxyAddresses(URI uri, String addressKey,
+      boolean forOnnFailover2Ann) {
     final List<NNProxyInfo<T>> proxies = new ArrayList<NNProxyInfo<T>>();
-    Map<String, Map<String, InetSocketAddress>> map =
-        DFSUtilClient.getAddresses(conf, null, addressKey);
+    Map<String, Map<String, InetSocketAddress>> map;
+    if (forOnnFailover2Ann) {
+      map = DFSUtilClient.getAddresses(conf, null, true, addressKey);
+    } else {
+      map = DFSUtilClient.getAddresses(conf, null, addressKey);
+    }
     Map<String, InetSocketAddress> addressesInNN = map.get(uri.getHost());
 
     if (addressesInNN == null || addressesInNN.size() == 0) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ConfiguredFailoverProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ConfiguredFailoverProxyProvider.java
@@ -48,7 +48,18 @@ public class ConfiguredFailoverProxyProvider<T> extends
   public ConfiguredFailoverProxyProvider(Configuration conf, URI uri,
       Class<T> xface, HAProxyFactory<T> factory, String addressKey) {
     super(conf, uri, xface, factory);
-    this.proxies = getProxyAddresses(uri, addressKey);
+    this.proxies = getProxyAddresses(uri, addressKey, false);
+  }
+
+  public ConfiguredFailoverProxyProvider(Configuration conf, URI uri,
+      Class<T> xface, HAProxyFactory<T> factory, boolean forOnnFailover2Ann) {
+    this(conf, uri, xface, factory, DFS_NAMENODE_RPC_ADDRESS_KEY, forOnnFailover2Ann);
+  }
+
+  public ConfiguredFailoverProxyProvider(Configuration conf, URI uri,
+      Class<T> xface, HAProxyFactory<T> factory, String addressKey, boolean forOnnFailover2Ann) {
+    super(conf, uri, xface, factory);
+    this.proxies = getProxyAddresses(uri, addressKey, forOnnFailover2Ann);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/ObserverReadProxyProvider.java
@@ -168,7 +168,7 @@ public class ObserverReadProxyProvider<T>
   public ObserverReadProxyProvider(
       Configuration conf, URI uri, Class<T> xface, HAProxyFactory<T> factory) {
     this(conf, uri, xface, factory,
-        new ConfiguredFailoverProxyProvider<>(conf, uri, xface, factory));
+        new ConfiguredFailoverProxyProvider<>(conf, uri, xface, factory, true));
   }
 
   @SuppressWarnings("unchecked")
@@ -189,7 +189,7 @@ public class ObserverReadProxyProvider<T>
 
     // Get all NameNode proxies
     nameNodeProxies = getProxyAddresses(uri,
-        HdfsClientConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY);
+        HdfsClientConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY, false);
 
     // Create a wrapped proxy containing all the proxies. Since this combined
     // proxy is just redirecting to other proxies, all invocations can share it.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -117,9 +117,9 @@ public class TestObserverReadProxyProvider {
         })  {
       @Override
       protected List<NNProxyInfo<ClientProtocol>> getProxyAddresses(
-          URI uri, String addressKey) {
+          URI uri, String addressKey, boolean forOnnFailover2Ann) {
         List<NNProxyInfo<ClientProtocol>> nnProxies =
-            super.getProxyAddresses(uri, addressKey);
+            super.getProxyAddresses(uri, addressKey, forOnnFailover2Ann);
         return nnProxies;
       }
     };


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In current ObserverReadProxyProvider implementation,   we use the following code to  invoke msync RPC.

```java
getProxyAsClientProtocol(failoverProxy.getProxy().proxy).msync(); 
```
But msync RPC maybe send to Observer NameNode in this way, and then failover to Active NameNode.   This can be avoid by applying this patch. 

