### PR TITLE
HADOOP-13704. Optimised getContentSummary()

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -463,7 +463,7 @@ Given a path return it's content summary.
 
     exists(FS, path) else raise FileNotFoundException
 
-### Postconditions
+#### Postconditions
 
 Returns a `ContentSummary` object with information such as directory count
 and file count for a given path.

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -459,7 +459,7 @@ The atomicity and consistency constraints are as for
 Given a path return it's content summary.
 
 GetContentSummary first checks if the given path is a file and if yes, it returns 0 for directory count 
- and 1 for file count.
+and 1 for file count.
 
 #### Preconditions
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -453,6 +453,24 @@ The function `getLocatedFileStatus(FS, d)` is as defined in
 The atomicity and consistency constraints are as for
 `listStatus(Path, PathFilter)`.
 
+
+### `ContentSummary getContentSummary(Path path)`
+
+Given a path return it's content summary.
+
+ 
+#### Preconditions
+
+    exists(FS, path) else raise FileNotFoundException
+
+### Postconditions
+
+Returns a `ContentSummary` object with information such as directory count
+and file count for a given path.
+
+The atomicity and consistency constraints are as for
+`listStatus(Path, PathFilter)`.
+
 ### `BlockLocation[] getFileBlockLocations(FileStatus f, int s, int l)`
 
 #### Preconditions

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -456,11 +456,11 @@ The atomicity and consistency constraints are as for
 
 ### `ContentSummary getContentSummary(Path path)`
 
-Given a path return it's content summary. 
+Given a path return it's content summary.
 
- GetContentSummary first checks if the given path is a file and if yes, it returns 0 for directory count 
+GetContentSummary first checks if the given path is a file and if yes, it returns 0 for directory count 
  and 1 for file count.
- 
+
 #### Preconditions
 
     exists(FS, path) else raise FileNotFoundException

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -456,8 +456,10 @@ The atomicity and consistency constraints are as for
 
 ### `ContentSummary getContentSummary(Path path)`
 
-Given a path return it's content summary.
+Given a path return it's content summary. 
 
+ GetContentSummary first checks if the given path is a file and if yes, it returns 0 for directory count 
+ and 1 for file count.
  
 #### Preconditions
 

--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/filesystem.md
@@ -458,7 +458,7 @@ The atomicity and consistency constraints are as for
 
 Given a path return it's content summary.
 
-GetContentSummary first checks if the given path is a file and if yes, it returns 0 for directory count 
+GetContentSummary first checks if the given path is a file and if yes, it returns 0 for directory count
 and 1 for file count.
 
 #### Preconditions

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
@@ -21,13 +21,14 @@ package org.apache.hadoop.fs.contract;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 public abstract class AbstractContractContentSummaryTest extends AbstractFSContractTestBase  {
 
@@ -63,11 +64,7 @@ public abstract class AbstractContractContentSummaryTest extends AbstractFSContr
 
         fs.mkdirs(parent);
 
-        try {
-            fs.getContentSummary(nested);
-            Assert.fail("Should throw FileNotFoundException");
-        }  catch (FileNotFoundException e) {
-          // expected
-        }
+        intercept(FileNotFoundException.class,
+            () -> fs.getContentSummary(nested));
     }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.fs.contract;
 
 import org.apache.hadoop.fs.ContentSummary;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
@@ -30,41 +30,36 @@ import java.io.FileNotFoundException;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
-public abstract class AbstractContractContentSummaryTest extends AbstractFSContractTestBase  {
+public abstract class AbstractContractContentSummaryTest extends AbstractFSContractTestBase {
 
-    @Test
-    public void testGetContentSummary() throws Throwable {
-        FileSystem fs = getFileSystem();
+  @Test
+  public void testGetContentSummary() throws Throwable {
+    FileSystem fs = getFileSystem();
 
-        Path parent = path("parent");
-        Path nested = path(parent + "/a/b/c");
-        Path filePath = path(nested + "file.txt");
+    Path parent = path("parent");
+    Path nested = path(parent + "/a/b/c");
+    Path filePath = path(nested + "file.txt");
 
-        fs.mkdirs(parent);
-        fs.mkdirs(nested);
-        touch(getFileSystem(), filePath);
+    fs.mkdirs(parent);
+    fs.mkdirs(nested);
+    touch(getFileSystem(), filePath);
 
-        ContentSummary summary = fs.getContentSummary(parent);
+    ContentSummary summary = fs.getContentSummary(parent);
 
-        Assertions.assertThat(summary.getDirectoryCount())
-                .as("Summary " + summary)
-                .isEqualTo(4);
+    Assertions.assertThat(summary.getDirectoryCount()).as("Summary " + summary).isEqualTo(4);
 
-        Assertions.assertThat(summary.getFileCount())
-                .as("Summary " + summary)
-                .isEqualTo(1);
-    }
+    Assertions.assertThat(summary.getFileCount()).as("Summary " + summary).isEqualTo(1);
+  }
 
-    @Test
-    public void testGetContentSummaryIncorrectPath() throws Throwable {
-        FileSystem fs = getFileSystem();
+  @Test
+  public void testGetContentSummaryIncorrectPath() throws Throwable {
+    FileSystem fs = getFileSystem();
 
-        Path parent = path("parent");
-        Path nested = path(parent + "/a");
+    Path parent = path("parent");
+    Path nested = path(parent + "/a");
 
-        fs.mkdirs(parent);
+    fs.mkdirs(parent);
 
-        intercept(FileNotFoundException.class,
-            () -> fs.getContentSummary(nested));
-    }
+    intercept(FileNotFoundException.class, () -> fs.getContentSummary(nested));
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractContentSummaryTest.java
@@ -1,0 +1,55 @@
+package org.apache.hadoop.fs.contract;
+
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+
+public abstract class AbstractContractContentSummaryTest extends AbstractFSContractTestBase  {
+
+    @Test
+    public void testGetContentSummary() throws Throwable {
+        FileSystem fs = getFileSystem();
+
+        Path parent = path("parent");
+        Path nested = path(parent + "/a/b/c");
+        Path filePath = path(nested + "file.txt");
+
+        fs.mkdirs(parent);
+        fs.mkdirs(nested);
+        touch(getFileSystem(), filePath);
+
+        ContentSummary summary = fs.getContentSummary(parent);
+
+        Assertions.assertThat(summary.getDirectoryCount())
+                .as("Summary " + summary)
+                .isEqualTo(4);
+
+        Assertions.assertThat(summary.getFileCount())
+                .as("Summary " + summary)
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void testGetContentSummaryIncorrectPath() throws Throwable {
+        FileSystem fs = getFileSystem();
+
+        Path parent = path("parent");
+        Path nested = path(parent + "/a");
+
+        fs.mkdirs(parent);
+
+        try {
+            fs.getContentSummary(nested);
+            Assert.fail("Should throw FileNotFoundException");
+        }  catch (FileNotFoundException e) {
+          // expected
+        }
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractContentSummary.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractContentSummary.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 
 public class TestLocalFSContractContentSummary extends AbstractContractContentSummaryTest {
 
-    @Override
-    protected AbstractFSContract createContract(Configuration conf) {
-        return new LocalFSContract(conf);
-    }
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new LocalFSContract(conf);
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractContentSummary.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractContentSummary.java
@@ -1,0 +1,13 @@
+package org.apache.hadoop.fs.contract.localfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractContentSummaryTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+
+public class TestLocalFSContractContentSummary extends AbstractContractContentSummaryTest {
+
+    @Override
+    protected AbstractFSContract createContract(Configuration conf) {
+        return new LocalFSContract(conf);
+    }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractContentSummary.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractContentSummary.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.fs.contract.localfs;
 
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3284,8 +3284,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
 
     @Override
-    public RemoteIterator<S3ALocatedFileStatus> listFilesIterator(final Path path, final boolean recursive)
-            throws IOException {
+    public RemoteIterator<S3ALocatedFileStatus> listFilesIterator(final Path path,
+        final boolean recursive) throws IOException {
       return S3AFileSystem.this.innerListFiles(path, recursive, Listing.ACCEPT_ALL_BUT_S3N, null);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3284,12 +3284,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     }
 
     @Override
-    public RemoteIterator<S3AFileStatus> listStatusIterator(final Path path)
-        throws IOException {
-      return S3AFileSystem.this.innerListStatus(path);
-    }
-
-    @Override
     public RemoteIterator<S3ALocatedFileStatus> listFilesIterator(final Path path, final boolean recursive)
             throws IOException {
       return S3AFileSystem.this.innerListFiles(path, recursive, Listing.ACCEPT_ALL_BUT_S3N, null);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -3288,6 +3288,12 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         throws IOException {
       return S3AFileSystem.this.innerListStatus(path);
     }
+
+    @Override
+    public RemoteIterator<S3ALocatedFileStatus> listFilesIterator(final Path path, final boolean recursive)
+            throws IOException {
+      return S3AFileSystem.this.innerListFiles(path, recursive, Listing.ACCEPT_ALL_BUT_S3N, null);
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ObjectAttributes.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ObjectAttributes.java
@@ -66,7 +66,7 @@ public class S3ObjectAttributes {
   /**
    * Construct from the result of a copy and those parameters
    * which aren't included in an AWS SDK response.
-   * @param path
+   * @param path path
    * @param copyResult copy result.
    * @param serverSideEncryptionAlgorithm current encryption algorithm
    * @param serverSideEncryptionKey any server side encryption key?

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
@@ -167,19 +167,21 @@ public class GetContentSummaryOperation extends
   }
 
   /***
-   * This method builds the set of all directories found under the base path. We need to do this because if the
-   * directory structure /a/b/c was created with a single mkdirs() call, it is stored as 1 object in S3 and the list
-   * files iterator will only return a single entry /a/b/c.
+   * This method builds the set of all directories found under the base path. We need to do this
+   * because if the directory structure /a/b/c was created with a single mkdirs() call, it is
+   * stored as 1 object in S3 and the list files iterator will only return a single entry /a/b/c.
    *
-   * We keep track of paths traversed so far to prevent duplication of work. For eg, if we had a/b/c/file-1.txt and
-   * /a/b/c/file-2.txt, we will only recurse over the complete path once and won't have to do anything for file-2.txt.
+   * We keep track of paths traversed so far to prevent duplication of work. For eg, if we had
+   * a/b/c/file-1.txt and /a/b/c/file-2.txt, we will only recurse over the complete path once
+   * and won't have to do anything for file-2.txt.
    *
    * @param dirSet Set of all directories found in the path
    * @param pathsTraversed Set of all paths traversed so far
    * @param basePath Path of directory to scan
    * @param parentPath Parent path of the current file/directory in the iterator
    */
-  private void buildDirectorySet(Set<Path> dirSet, Set<Path> pathsTraversed, Path basePath, Path parentPath) {
+  private void buildDirectorySet(Set<Path> dirSet, Set<Path> pathsTraversed, Path basePath,
+      Path parentPath) {
 
     if (parentPath == null || pathsTraversed.contains(parentPath) || parentPath.equals(basePath)) {
       return;
@@ -225,7 +227,7 @@ public class GetContentSummaryOperation extends
     S3AFileStatus probePathStatus(Path path, Set<StatusProbeEnum> probes) throws IOException;
 
     /***
-     * List all entries under a path
+     * List all entries under a path.
      *
      * @param path
      * @param recursive if the subdirectories need to be traversed recursively

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
@@ -230,7 +230,7 @@ public class GetContentSummaryOperation extends
      * @param path
      * @param recursive if the subdirectories need to be traversed recursively
      * @return an iterator over the listing.
-     * @throws IOException
+     * @throws IOException failure
      */
     RemoteIterator<S3ALocatedFileStatus> listFilesIterator(Path path, boolean recursive)
         throws IOException;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +35,7 @@ import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSnapshot;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
+import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
 
 import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.retrieveIOStatistics;
 
@@ -215,24 +215,24 @@ public class GetContentSummaryOperation extends
 
     /**
      * Get the status of a path.
-     * @param path path to probe.
+     *
+     * @param path   path to probe.
      * @param probes probes to exec
      * @return the status
      * @throws IOException failure
      */
     @Retries.RetryTranslated
-    S3AFileStatus probePathStatus(Path path,
-        Set<StatusProbeEnum> probes) throws IOException;
+    S3AFileStatus probePathStatus(Path path, Set<StatusProbeEnum> probes) throws IOException;
 
-    /**
-     * Incremental list of all entries in a directory.
-     * @param path path of dir
-     * @return an iterator
-     * @throws IOException failure
+    /***
+     * List all entries under a path
+     *
+     * @param path
+     * @param recursive if the subdirectories need to be traversed recursively
+     * @return an iterator over the listing.
+     * @throws IOException
      */
-    RemoteIterator<S3AFileStatus> listStatusIterator(Path path)
+    RemoteIterator<S3ALocatedFileStatus> listFilesIterator(Path path, boolean recursive)
         throws IOException;
-
-    RemoteIterator<S3ALocatedFileStatus> listFilesIterator(Path path, boolean recursive) throws IOException;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/GetContentSummaryOperation.java
@@ -23,11 +23,14 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.statistics.IOStatistics;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.fs.contract.s3a;
 
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
@@ -18,57 +18,53 @@
 
 package org.apache.hadoop.fs.contract.s3a;
 
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractContentSummaryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 
-
 public class ITestS3AContractContentSummary extends AbstractContractContentSummaryTest {
 
-    @Test
-    public void testGetContentSummaryDir() throws Throwable {
-        describe("getContentSummary on test dir with children");
-        S3AFileSystem fs = getFileSystem();
-        Path baseDir = methodPath();
+  @Test
+  public void testGetContentSummaryDir() throws Throwable {
+    describe("getContentSummary on test dir with children");
+    S3AFileSystem fs = getFileSystem();
+    Path baseDir = methodPath();
 
-        // Nested folders created separately will return as separate objects in listFiles()
-        fs.mkdirs(new Path(baseDir + "/a"));
-        fs.mkdirs(new Path(baseDir + "/a/b"));
-        fs.mkdirs(new Path(baseDir + "/a/b/a"));
+    // Nested folders created separately will return as separate objects in listFiles()
+    fs.mkdirs(new Path(baseDir, "a"));
+    fs.mkdirs(new Path(baseDir, "a/b"));
+    fs.mkdirs(new Path(baseDir, "a/b/a"));
 
-        // Will return as one object
-        fs.mkdirs(new Path(baseDir + "/d/e/f"));
+    // Will return as one object
+    fs.mkdirs(new Path(baseDir, "d/e/f"));
 
-        Path filePath = new Path(baseDir, "a/b/file");
-        touch(fs, filePath);
+    Path filePath = new Path(baseDir, "a/b/file");
+    touch(fs, filePath);
 
-        // look at path to see if it is a file
-        // it is not: so LIST
-        final ContentSummary summary = fs.getContentSummary(baseDir);
+    // look at path to see if it is a file
+    // it is not: so LIST
+    final ContentSummary summary = fs.getContentSummary(baseDir);
 
-        Assertions.assertThat(summary.getDirectoryCount())
-                .as("Summary " + summary)
-                .isEqualTo(7);
-        Assertions.assertThat(summary.getFileCount())
-                .as("Summary " + summary)
-                .isEqualTo(1);
-    }
+    Assertions.assertThat(summary.getDirectoryCount()).as("Summary " + summary).isEqualTo(7);
+    Assertions.assertThat(summary.getFileCount()).as("Summary " + summary).isEqualTo(1);
+  }
 
-    @Override
-    protected AbstractFSContract createContract(Configuration conf) {
-        return new S3AContract(conf);
-    }
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new S3AContract(conf);
+  }
 
-    @Override
-    public S3AFileSystem getFileSystem() {
-        return (S3AFileSystem) super.getFileSystem();
-    }
+  @Override
+  public S3AFileSystem getFileSystem() {
+    return (S3AFileSystem) super.getFileSystem();
+  }
 
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
@@ -1,0 +1,56 @@
+package org.apache.hadoop.fs.contract.s3a;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractContentSummaryTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+
+
+public class ITestS3AContractContentSummary extends AbstractContractContentSummaryTest {
+
+    @Test
+    public void testGetContentSummaryDir() throws Throwable {
+        describe("getContentSummary on test dir with children");
+        S3AFileSystem fs = getFileSystem();
+        Path baseDir = methodPath();
+
+        // Nested folders created separately will return as separate objects in listFiles()
+        fs.mkdirs(new Path(baseDir + "/a"));
+        fs.mkdirs(new Path(baseDir + "/a/b"));
+        fs.mkdirs(new Path(baseDir + "/a/b/a"));
+
+        // Will return as one object
+        fs.mkdirs(new Path(baseDir + "/d/e/f"));
+
+        Path filePath = new Path(baseDir, "a/b/file");
+        touch(fs, filePath);
+
+        // look at path to see if it is a file
+        // it is not: so LIST
+        final ContentSummary summary = fs.getContentSummary(baseDir);
+
+        Assertions.assertThat(summary.getDirectoryCount())
+                .as("Summary " + summary)
+                .isEqualTo(7);
+        Assertions.assertThat(summary.getFileCount())
+                .as("Summary " + summary)
+                .isEqualTo(1);
+    }
+
+    @Override
+    protected AbstractFSContract createContract(Configuration conf) {
+        return new S3AContract(conf);
+    }
+
+    @Override
+    public S3AFileSystem getFileSystem() {
+        return (S3AFileSystem) super.getFileSystem();
+    }
+
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
@@ -155,41 +155,6 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
   }
 
   @Test
-  public void testGetContentSummaryNestedDirs() throws Throwable {
-    describe("getContentSummary on test dir with children");
-    S3AFileSystem fs = getFileSystem();
-    Path baseDir = methodPath();
-
-    // Nested folders created separately will return as separate objects in listFiles()
-    fs.mkdirs(new Path(baseDir + "/a"));
-    fs.mkdirs(new Path(baseDir + "/a/b"));
-    fs.mkdirs(new Path(baseDir + "/a/b/a"));
-
-    // Will return as one object
-    fs.mkdirs(new Path(baseDir + "/d/e/f"));
-
-    Path filePath = new Path(baseDir, "a/b/file");
-    touch(fs, filePath);
-
-    // look at path to see if it is a file
-    // it is not: so LIST
-    final ContentSummary summary = verifyMetrics(
-            () -> getContentSummary(baseDir),
-            with(INVOCATION_GET_CONTENT_SUMMARY, 1),
-            withAuditCount(1),
-            always(FILE_STATUS_FILE_PROBE    // look at path to see if it is a file
-                    .plus(LIST_OPERATION))); // it is not: so LIST
-
-    Assertions.assertThat(summary.getDirectoryCount())
-            .as("Summary " + summary)
-            .isEqualTo(7);
-    Assertions.assertThat(summary.getFileCount())
-            .as("Summary " + summary)
-            .isEqualTo(1);
-  }
-
-
-  @Test
   public void testGetContentMissingPath() throws Throwable {
     describe("getContentSummary on a missing path");
     Path baseDir = methodPath();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.amazonaws.services.servermigration.model.SSMOutput;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
@@ -141,7 +141,7 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
     // look at path to see if it is a file
     // it is not: so LIST
     final ContentSummary summary = verifyMetrics(
-        () -> getContentSummary(childDir),
+        () -> getContentSummary(baseDir),
         with(INVOCATION_GET_CONTENT_SUMMARY, 1),
         withAuditCount(1),
         always(FILE_STATUS_FILE_PROBE    // look at path to see if it is a file
@@ -149,7 +149,7 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
 
     Assertions.assertThat(summary.getDirectoryCount())
         .as("Summary " + summary)
-        .isEqualTo(1);
+        .isEqualTo(2);
     Assertions.assertThat(summary.getFileCount())
         .as("Summary " + summary)
         .isEqualTo(1);


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-13704

This PR implements an optimised version of getContentSummary which uses the result from the listFiles iterator.

Explanation of new `buildDirectorySet` method added:

Since the listFiles operation can return the directory `a/b/c` as a single object, we need to recurse over the path `a/b/c` to ensure we have counted all directories. We do this by keeping two sets, dirSet (Set of all directories under the base path) and pathTraversed (Set of paths we have recursed over so far).

Iterating over directory structure `basePath/a/b/c`, `basePath/a/b/d`, we will first find all the directories in `basePath/a/b/c`. Once this is completed, the pathTraversed set will have `{basePath/a/b}` and dirSet will have `{basePath/a, basePath/a/b, basePath/a/b/c}`.

Then for `basePath/a/b/d`, just add `basePath/a/b/d` to the dirSet and don't do any additional work as path `basePath/a/b` has already been traversed.

The Jira ticket mentions that we should add in some instrumentation to measure usage. T's already code that does this 
 [here](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L3256) and usage is tested in an integration test [here](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java#L144) .

### How was this patch tested?

Tested in eu-west-1 by running

`mvn -Dparallel-tests -DtestsThreadCount=16 clean verify`
