### PR TITLE
HADOOP-18119. ViewFileSystem#getUri should return a URI with an empty path component

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -314,7 +314,9 @@ public class ViewFileSystem extends FileSystem {
       tableName = theUri.getHost();
     }
     try {
-      myUri = new URI(getScheme(), authority, "/", null, null);
+      myUri = (authority != null) ?
+          new URI(getScheme(), authority, null, null, null) :
+          new URI(getScheme(), null, "/", null, null);
       boolean initingUriAsFallbackOnNoMounts =
           supportAutoAddingFallbackOnNoMounts();
       fsState = new InodeTree<FileSystem>(conf, tableName, myUri,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemWithAuthorityLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemWithAuthorityLocalFileSystem.java
@@ -52,7 +52,7 @@ public class TestViewFileSystemWithAuthorityLocalFileSystem extends ViewFileSyst
     // Now create a viewfs using a mount table called "default"
     // hence viewfs://default/
     schemeWithAuthority = 
-      new URI(FsConstants.VIEWFS_SCHEME, "default", "/", null, null);
+      new URI(FsConstants.VIEWFS_SCHEME, "default", null, null, null);
     fsView = FileSystem.get(schemeWithAuthority, conf);
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1515,4 +1515,17 @@ abstract public class ViewFileSystemBaseTest {
     // viewfs inner cache is disabled
     assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
   }
+
+  @Test
+  public void testGetURI() throws Exception {
+    // test that URIs without authority return the path component.
+    URI viewFsWithoutAuthority = URI.create("viewfs:///");
+    FileSystem fs = FileSystem.get(viewFsWithoutAuthority, conf);
+    assertEquals(viewFsWithoutAuthority, fs.getUri());
+
+    // test that URIs with authority do not return the path component.
+    URI viewFsWithAuthority = URI.create("viewfs://default");
+    fs = FileSystem.get(viewFsWithAuthority, conf);
+    assertEquals(viewFsWithAuthority, fs.getUri());
+  }
 }


### PR DESCRIPTION
### Description of PR
The goal here is that the semantics of FileSystem#getURI() remains the same as before when using ViewFileSystem. 

We should assume that the URI returned by FileSystem#getURI() doesn't have a Path component (i.e., path component is null). DistributedFileSystem follows this pattern. However, ViewFileSystem add "/" as the path component in the URI returned.

### How was this patch tested?
mvn test -Dtest=TestViewFileSystem*

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

