### PR TITLE
HADOOP-18121: Change scope of fixFileStatus and Fix path in fileStatus for internal directories

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -517,8 +517,8 @@ public class ViewFileSystem extends FileSystem {
     return res.targetFileSystem.getFileChecksum(res.remainingPath, length);
   }
 
-  private static FileStatus fixFileStatus(FileStatus orig,
-      Path qualified) throws IOException {
+  private static FileStatus fixFileStatus(FileStatus orig, Path qualifiedPath,
+      Path originalPath, boolean isInternalDir) throws IOException {
     // FileStatus#getPath is a fully qualified path relative to the root of
     // target file system.
     // We need to change it to viewfs URI - relative to root of mount table.
@@ -530,10 +530,10 @@ public class ViewFileSystem extends FileSystem {
     // Hence we need to interpose a new ViewFileSystemFileStatus that
     // works around.
     if ("file".equals(orig.getPath().toUri().getScheme())) {
-      orig = wrapLocalFileStatus(orig, qualified);
+      orig = wrapLocalFileStatus(orig, qualifiedPath);
     }
 
-    orig.setPath(qualified);
+    orig.setPath(qualifiedPath);
     return orig;
   }
 
@@ -558,7 +558,7 @@ public class ViewFileSystem extends FileSystem {
     InodeTree.ResolveResult<FileSystem> res =
       fsState.resolve(getUriPath(f), true);
     FileStatus status =  res.targetFileSystem.getFileStatus(res.remainingPath);
-    return fixFileStatus(status, this.makeQualified(f));
+    return fixFileStatus(status, this.makeQualified(f), f, res.isInternalDir());
   }
   
   @Override
@@ -603,14 +603,12 @@ public class ViewFileSystem extends FileSystem {
       fsState.resolve(getUriPath(f), true);
     
     FileStatus[] statusLst = res.targetFileSystem.listStatus(res.remainingPath);
-    if (!res.isInternalDir()) {
-      // We need to change the name in the FileStatus as described in
-      // {@link #getFileStatus }
-      int i = 0;
-      for (FileStatus status : statusLst) {
-          statusLst[i++] = fixFileStatus(status,
-              getChrootedPath(res, status, f));
-      }
+    // We need to change the name in the FileStatus as described in
+    // {@link #getFileStatus }
+    int i = 0;
+    for (FileStatus status : statusLst) {
+      statusLst[i++] = fixFileStatus(status,
+          getChrootedPath(res, status, f), f, res.isInternalDir());
     }
     return statusLst;
   }
@@ -623,10 +621,6 @@ public class ViewFileSystem extends FileSystem {
     final RemoteIterator<LocatedFileStatus> statusIter =
         res.targetFileSystem.listLocatedStatus(res.remainingPath);
 
-    if (res.isInternalDir()) {
-      return statusIter;
-    }
-
     return new RemoteIterator<LocatedFileStatus>() {
       @Override
       public boolean hasNext() throws IOException {
@@ -636,8 +630,8 @@ public class ViewFileSystem extends FileSystem {
       @Override
       public LocatedFileStatus next() throws IOException {
         final LocatedFileStatus status = statusIter.next();
-        return (LocatedFileStatus)fixFileStatus(status,
-            getChrootedPath(res, status, f));
+        return (LocatedFileStatus) fixFileStatus(status,
+              getChrootedPath(res, status, f), f, res.isInternalDir());
       }
     };
   }
@@ -645,6 +639,10 @@ public class ViewFileSystem extends FileSystem {
   private Path getChrootedPath(InodeTree.ResolveResult<FileSystem> res,
       FileStatus status, Path f) throws IOException {
     final String suffix;
+    // For internal directories return the qualified path of status
+    if (res.isInternalDir()) {
+      return this.makeQualified(status.getPath());
+    }
     if (res.targetFileSystem instanceof ChRootedFileSystem) {
       suffix = ((ChRootedFileSystem)res.targetFileSystem)
           .stripOutRoot(status.getPath());


### PR DESCRIPTION
### Description of PR

- Change scope of fixFileStatus
- Fix path in fileStatus for internal directories

### How was this patch tested?
mvn test -Dtest=TestViewFileSystem*

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

