### PR TITLE
HADOOP-18122. ViewFileSystem fails on determining owning group when primary group doesn't exist for user

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -139,4 +139,16 @@ public interface Constants {
   String CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT =
       "fs.viewfs.trash.force-inside-mount-point";
   boolean CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT = false;
+
+  /**
+   * Configuration for specifying user name for mount links.
+   */
+  String CONFIG_VIEWFS_MOUNT_LINKS_USER_NAME =
+      "fs.viewfs.mount.links.user.name";
+
+  /**
+   * Configuration for specifying group name for mount links.
+   */
+  String CONFIG_VIEWFS_MOUNT_LINKS_GROUP_NAME =
+      "fs.viewfs.mount.links.group.name";
 }


### PR DESCRIPTION
### Description of PR
ViewFileSystem should not fail on determining owning group when primary group doesn't exist for user

### How was this patch tested?
new unit test; run existing unit tests `mvn test -Dtest=TestViewFileSystem*`

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

