### PR TITLE
YARN-10788. TestCsiClient fails

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -20,13 +20,14 @@ package org.apache.hadoop.yarn.csi.client;
 
 import csi.v0.Csi;
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,19 +37,21 @@ import java.nio.file.Files;
  * Test class for CSI client.
  */
 public class TestCsiClient {
-
+  private static final Logger LOG = LoggerFactory.getLogger(TestCsiClient.class);
   private static File testRoot = null;
   private static String domainSocket = null;
   private static FakeCsiDriver driver = null;
 
   @BeforeClass
   public static void setUp() throws IOException {
-    File testDir = GenericTestUtils.getTestDir();
+    // Use /tmp to fix bind failure caused by the long file name
+    File tmpDir = new File(System.getProperty("java.io.tmpdir"));
     testRoot = Files
-        .createTempDirectory(testDir.toPath(), "test").toFile();
+        .createTempDirectory(tmpDir.toPath(), "test").toFile();
     File socketPath = new File(testRoot, "csi.sock");
     FileUtils.forceMkdirParent(socketPath);
     domainSocket = "unix://" + socketPath.getAbsolutePath();
+    LOG.info("Create unix domain socket: {}", domainSocket);
     driver = new FakeCsiDriver(domainSocket);
   }
 


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Create unix domain socket in java.io.tmpdir instead of
test.build.dir to avoid 'File name too long' error.

### How was this patch tested?

Locally ran the test and it passed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- n/a Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

