### PR TITLE
HDFS-16459. RBF: register RBFMetrics in MetricsSystem for promethuessink

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -105,8 +105,7 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
   private static final Logger LOG =
       LoggerFactory.getLogger(RBFMetrics.class);
 
-  private final MetricsRegistry registry =
-      new MetricsRegistry("RBFMetrics");
+  private final MetricsRegistry registry = new MetricsRegistry("RBFMetrics");
 
   /** Format for a date. */
   private static final String DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.metrics;
 
+import static org.apache.hadoop.metrics2.impl.MsInfo.ProcessName;
 import static org.apache.hadoop.util.Time.now;
 
 import java.io.IOException;
@@ -79,7 +80,11 @@ import org.apache.hadoop.hdfs.server.federation.store.records.MembershipStats;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.hdfs.server.federation.store.records.RouterState;
 import org.apache.hadoop.hdfs.server.federation.store.records.StateStoreVersion;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
@@ -99,6 +104,9 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(RBFMetrics.class);
+
+  private final MetricsRegistry registry =
+      new MetricsRegistry("RBFMetrics");
 
   /** Format for a date. */
   private static final String DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";
@@ -171,6 +179,10 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
     this.topTokenRealOwners = conf.getInt(
         RBFConfigKeys.DFS_ROUTER_METRICS_TOP_NUM_TOKEN_OWNERS_KEY,
         RBFConfigKeys.DFS_ROUTER_METRICS_TOP_NUM_TOKEN_OWNERS_KEY_DEFAULT);
+
+    registry.tag(ProcessName, "Router");
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.register(RBFMetrics.class.getName(), "RBFActivity Metrics", this);
   }
 
   /**
@@ -183,6 +195,8 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
     if (this.federationBeanName != null) {
       MBeans.unregister(federationBeanName);
     }
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(RBFMetrics.class.getName());
   }
 
   @Override
@@ -458,53 +472,65 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
   }
 
   @Override
+  @Metric({"NumLiveNodes", "Number of live data nodes"})
   public int getNumLiveNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfActiveDatanodes);
   }
 
   @Override
+  @Metric({"NumDeadNodes", "Number of dead data nodes"})
   public int getNumDeadNodes() {
     return getNameserviceAggregatedInt(MembershipStats::getNumOfDeadDatanodes);
   }
 
   @Override
+  @Metric({"NumStaleNodes", "Number of stale data nodes"})
   public int getNumStaleNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfStaleDatanodes);
   }
 
   @Override
+  @Metric({"NumDecommissioningNodes", "Number of Decommissioning data nodes"})
   public int getNumDecommissioningNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfDecommissioningDatanodes);
   }
 
   @Override
+  @Metric({"NumDecomLiveNodes", "Number of decommissioned Live data nodes"})
   public int getNumDecomLiveNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfDecomActiveDatanodes);
   }
 
   @Override
+  @Metric({"NumDecomDeadNodes", "Number of decommissioned dead data nodes"})
   public int getNumDecomDeadNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfDecomDeadDatanodes);
   }
 
   @Override
+  @Metric({"NumInMaintenanceLiveDataNodes",
+      "Number of IN_MAINTENANCE live data nodes"})
   public int getNumInMaintenanceLiveDataNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfInMaintenanceLiveDataNodes);
   }
 
   @Override
+  @Metric({"NumInMaintenanceDeadDataNodes",
+      "Number of IN_MAINTENANCE dead data nodes"})
   public int getNumInMaintenanceDeadDataNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfInMaintenanceDeadDataNodes);
   }
 
   @Override
+  @Metric({"NumEnteringMaintenanceDataNodes",
+      "Number of ENTERING_MAINTENANCE data nodes"})
   public int getNumEnteringMaintenanceDataNodes() {
     return getNameserviceAggregatedInt(
         MembershipStats::getNumOfEnteringMaintenanceDataNodes);
@@ -557,34 +583,41 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
   }
 
   @Override
+  @Metric({"NumBlocks", "Total number of blocks"})
   public long getNumBlocks() {
     return getNameserviceAggregatedLong(MembershipStats::getNumOfBlocks);
   }
 
   @Override
+  @Metric({"NumOfMissingBlocks", "Number of missing blocks"})
   public long getNumOfMissingBlocks() {
     return getNameserviceAggregatedLong(MembershipStats::getNumOfBlocksMissing);
   }
 
   @Override
+  @Metric({"NumOfBlocksPendingReplication",
+      "Number of blocks pending replication"})
   public long getNumOfBlocksPendingReplication() {
     return getNameserviceAggregatedLong(
         MembershipStats::getNumOfBlocksPendingReplication);
   }
 
   @Override
+  @Metric({"NumOfBlocksUnderReplicated", "Number of blocks under replication"})
   public long getNumOfBlocksUnderReplicated() {
     return getNameserviceAggregatedLong(
         MembershipStats::getNumOfBlocksUnderReplicated);
   }
 
   @Override
+  @Metric({"NumOfBlocksPendingDeletion", "Number of blocks pending deletion"})
   public long getNumOfBlocksPendingDeletion() {
     return getNameserviceAggregatedLong(
         MembershipStats::getNumOfBlocksPendingDeletion);
   }
 
   @Override
+  @Metric({"NumFiles", "Number of files"})
   public long getNumFiles() {
     return getNameserviceAggregatedLong(MembershipStats::getNumOfFiles);
   }
@@ -659,6 +692,7 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
   }
 
   @Override
+  @Metric({"CurrentTokensCount", "Number of router's current tokens"})
   public long getCurrentTokensCount() {
     RouterSecurityManager mgr =
         this.router.getRpcServer().getRouterSecurityManager();
@@ -714,11 +748,13 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
   }
 
   @Override
+  @Metric({"RouterFederationRenameCount", "Number of federation rename"})
   public int getRouterFederationRenameCount() {
     return this.router.getRpcServer().getRouterFederationRenameCount();
   }
 
   @Override
+  @Metric({"SchedulerJobCount", "Number of scheduler job"})
   public int getSchedulerJobCount() {
     return this.router.getRpcServer().getSchedulerJobCount();
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/HDFS-16459
Router' RBFMetrics was not register  in MetricsSystem. We can't find these metrics from PrometheusSink. Maybe we should fix it. 

 

After fix it ,  some  RBFMetrics will export like this 
```
# HELP rbf_metrics_current_tokens_count Number of router's current tokens
# TYPE rbf_metrics_current_tokens_count gauge
rbf_metrics_current_tokens_count{processname="Router",context="dfs",hostname="xxxx"} 2 
```

### How was this patch tested?
no new test

### For code changes:
1. DefaultMetricsSystem.instance().register 
2. use `@Metric` to export metrics
