### PR TITLE
HDFS-16461. Expose JournalNode storage info in the jmx metrics

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
@@ -427,7 +427,7 @@ public class JournalNode implements Tool, Configurable, JournalNodeMXBean {
   // JournalNodeMXBean
   public List<String> getStorageInfos() {
     return journalsById.values().stream()
-        .map(journal -> journal.getStorage().toString())
+        .map(journal -> journal.getStorage().toMapString())
         .collect(Collectors.toList());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNode.java
@@ -423,6 +423,14 @@ public class JournalNode implements Tool, Configurable, JournalNodeMXBean {
     return this.startTime;
   }
 
+  @Override
+  // JournalNodeMXBean
+  public List<String> getStorageInfos() {
+    return journalsById.values().stream()
+        .map(journal -> journal.getStorage().toString())
+        .collect(Collectors.toList());
+  }
+
   /**
    * Register JournalNodeMXBean
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalNodeMXBean.java
@@ -64,4 +64,13 @@ public interface JournalNodeMXBean {
    * @return the start time of the JournalNode.
    */
   long getJNStartedTimeInMillis();
+
+  /**
+   * Get the list of the storage infos of JournalNode's journals. Storage infos
+   * include layout version, namespace id, cluster id and creation time of the
+   * File system state.
+   *
+   * @return the list of storage infos associated with journals.
+   */
+  List<String> getStorageInfos();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/StorageInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/StorageInfo.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.SortedSet;
@@ -111,6 +112,20 @@ public class StorageInfo {
     sb.append("lv=").append(layoutVersion).append(";cid=").append(clusterID)
     .append(";nsid=").append(namespaceID).append(";c=").append(cTime);
     return sb.toString();
+  }
+
+  /**
+   * Returns string representation of Storage info attributes stored in Map.
+   *
+   * @return string representation of storage info attributes.
+   */
+  public String toMapString() {
+    Map<String, Object> storageInfo = new HashMap<>();
+    storageInfo.put("LayoutVersion", layoutVersion);
+    storageInfo.put("ClusterId", clusterID);
+    storageInfo.put("NamespaceId", namespaceID);
+    storageInfo.put("CreationTime", cTime);
+    return storageInfo.toString();
   }
   
   public String toColonSeparatedString() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
@@ -81,9 +81,8 @@ public class TestJournalNodeMXBean {
     assertFalse(journalStatus.contains(NAMESERVICE));
 
     // format the journal ns1
-    final NamespaceInfo FAKE_NSINFO = new NamespaceInfo(NS_ID, "mycluster",
-        "my-bp", 0L);
-    jn.getOrCreateJournal(NAMESERVICE).format(FAKE_NSINFO, false);
+    final NamespaceInfo fakeNsInfo = new NamespaceInfo(NS_ID, "mycluster", "my-bp", 0L);
+    jn.getOrCreateJournal(NAMESERVICE).format(fakeNsInfo, false);
 
     // check again after format
     // getJournalsStatus

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
@@ -111,9 +111,9 @@ public class TestJournalNodeMXBean {
     assertEquals(jn.getVersion(), version);
     String[] journalStorageInfos = (String[]) mbs.getAttribute(mxbeanName, "StorageInfos");
     assertEquals(jn.getStorageInfos().size(), journalStorageInfos.length);
-    assertTrue(journalStorageInfos[1].contains("cid=mycluster"));
-    assertTrue(journalStorageInfos[1].contains("c=0"));
-    assertTrue(journalStorageInfos[1].contains("nsid=" + NS_ID));
+    assertTrue(journalStorageInfos[1].contains("ClusterId=mycluster"));
+    assertTrue(journalStorageInfos[1].contains("CreationTime=0"));
+    assertTrue(journalStorageInfos[1].contains("NamespaceId=" + NS_ID));
 
     // restart journal node without formatting
     jCluster = new MiniJournalCluster.Builder(new Configuration()).format(false)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeMXBean.java
@@ -44,6 +44,7 @@ public class TestJournalNodeMXBean {
   
   private static final String NAMESERVICE = "ns1";
   private static final int NUM_JN = 1;
+  private static final int NS_ID = 12345;
   
   private MiniJournalCluster jCluster;
   private JournalNode jn;
@@ -80,7 +81,7 @@ public class TestJournalNodeMXBean {
     assertFalse(journalStatus.contains(NAMESERVICE));
 
     // format the journal ns1
-    final NamespaceInfo FAKE_NSINFO = new NamespaceInfo(12345, "mycluster",
+    final NamespaceInfo FAKE_NSINFO = new NamespaceInfo(NS_ID, "mycluster",
         "my-bp", 0L);
     jn.getOrCreateJournal(NAMESERVICE).format(FAKE_NSINFO, false);
 
@@ -109,6 +110,11 @@ public class TestJournalNodeMXBean {
     assertEquals(jn.getJNStartedTimeInMillis(), startTime);
     String version = (String) mbs.getAttribute(mxbeanName, "Version");
     assertEquals(jn.getVersion(), version);
+    String[] journalStorageInfos = (String[]) mbs.getAttribute(mxbeanName, "StorageInfos");
+    assertEquals(jn.getStorageInfos().size(), journalStorageInfos.length);
+    assertTrue(journalStorageInfos[1].contains("cid=mycluster"));
+    assertTrue(journalStorageInfos[1].contains("c=0"));
+    assertTrue(journalStorageInfos[1].contains("nsid=" + NS_ID));
 
     // restart journal node without formatting
     jCluster = new MiniJournalCluster.Builder(new Configuration()).format(false)


### PR DESCRIPTION
### Description of PR
We should expose the list of storage info of JournalNode's journals (including layout version, namespace id, cluster id and creation time of the FS state) in the jmx metrics.

### How was this patch tested?
Local dev cluster and UT.

<img width="944" alt="Screenshot 2022-02-20 at 12 10 12 AM" src="https://user-images.githubusercontent.com/34790606/154830587-c009a870-f1d2-48fb-a90f-e6bbecadf8f1.png">

Updated screenshot:

<img width="1611" alt="Screenshot 2022-02-21 at 12 32 04 PM" src="https://user-images.githubusercontent.com/34790606/154905364-73cc3d3b-16d8-4661-ab5f-00d66bb564cc.png">


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
