### PR TITLE
HADOOP-18138. UserGroupInformation shouldn't log exception unnecessarily

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -1871,8 +1871,7 @@ public class UserGroupInformation {
   @InterfaceStability.Evolving
   public <T> T doAs(PrivilegedAction<T> action) {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
-          new Exception());
+      LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action);
     }
     return Subject.doAs(subject, action);
   }
@@ -1894,8 +1893,7 @@ public class UserGroupInformation {
                     ) throws IOException, InterruptedException {
     try {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
-            new Exception());
+        LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action);
       }
       return Subject.doAs(subject, action);
     } catch (PrivilegedActionException pae) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

In UserGroupInformation.doAs, we currently create a new Exception and log it in LOG.debug. This doesn't look necessary:

```
      if (LOG.isDebugEnabled()) {
        LOG.debug("PrivilegedAction [as: {}][action: {}]", this, action,
            new Exception());
      }
```

### How was this patch tested?

Existing tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

