### PR TITLE
HDFS-16475. Cleanup code in the write path

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -275,10 +275,8 @@ public class DFSOutputStream extends FSOutputSummer
 
       // Retry the create if we get a RetryStartFileException up to a maximum
       // number of times
-      boolean shouldRetry = true;
       int retryCount = CREATE_RETRY_COUNT;
-      while (shouldRetry) {
-        shouldRetry = false;
+      while (true) {
         try {
           stat = dfsClient.namenode.create(src, masked, dfsClient.clientName,
               new EnumSetWritable<>(flag), createParent, replication,
@@ -301,7 +299,6 @@ public class DFSOutputStream extends FSOutputSummer
               UnknownCryptoProtocolVersionException.class);
           if (e instanceof RetryStartFileException) {
             if (retryCount > 0) {
-              shouldRetry = true;
               retryCount--;
             } else {
               throw new IOException("Too many retries because of encryption" +

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -97,7 +96,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
     MultipleBlockingQueue(int numQueue, int queueSize) {
       queues = new ArrayList<>(numQueue);
       for (int i = 0; i < numQueue; i++) {
-        queues.add(new LinkedBlockingQueue<T>(queueSize));
+        queues.add(new LinkedBlockingQueue<>(queueSize));
       }
     }
 
@@ -480,7 +479,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
         }
       }
     }
-    return excluded.toArray(new DatanodeInfo[excluded.size()]);
+    return excluded.toArray(DatanodeInfo.EMPTY_ARRAY);
   }
 
   private void allocateNewBlock() throws IOException {
@@ -1316,12 +1315,9 @@ public class DFSStripedOutputStream extends DFSOutputStream
           // flush all data to Datanode
           final long toWaitFor = flushInternalWithoutWaitingAck();
           future = flushAllExecutorCompletionService.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  s.waitForAckedSeqno(toWaitFor);
-                  return null;
-                }
+              () -> {
+                s.waitForAckedSeqno(toWaitFor);
+                return null;
               });
           flushAllFuturesMap.put(future, i);
         } catch (Exception e) {


### PR DESCRIPTION
### Description of PR

1. In DFSOutputStream#newStreamForCreate(), `shouldRetry` is always true at the while loop. Remove this unnecessary varible.
2. Cleanup code in the write path.

### How was this patch tested?

No code logic was changed, CI should be enough.