### PR TITLE
HDFS-16476.Increase the number of metrics used to record PendingRecoveryBlocks.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Metrics.md
@@ -264,6 +264,7 @@ Each metrics record contains tags such as HAState and Hostname as additional inf
 | `CorruptBlocks` | Current number of blocks with corrupt replicas. |
 | `ScheduledReplicationBlocks` | Current number of blocks scheduled for replications |
 | `PendingDeletionBlocks` | Current number of blocks pending deletion |
+| `PendingRecoveryBlocks` | Current number of blocks currently undergoing or about to recover |
 | `ExcessBlocks` | Current number of excess blocks |
 | `PostponedMisreplicatedBlocks` | (HA-only) Current number of blocks postponed to replicate |
 | `PendingDataNodeMessageCount` | (HA-only) Current number of pending block-related messages for later processing in the standby NameNode |
@@ -534,6 +535,7 @@ RBFMetrics shows the metrics which are the aggregated values of sub-clusters' in
 | `NumOfBlocksPendingReplication` | Current number of blocks pending to be replicated |
 | `NumOfBlocksUnderReplicated` | Current number of blocks under replicated |
 | `NumOfBlocksPendingDeletion` | Current number of blocks pending deletion |
+| `NumOfBlocksPendingRecovery` | Current number of blocks currently undergoing or about to recover |
 | `ProvidedSpace` | The total remote storage capacity mounted in the federated cluster |
 | `NumInMaintenanceLiveDataNodes` | Number of live Datanodes which are in maintenance state |
 | `NumInMaintenanceDeadDataNodes` | Number of dead Datanodes which are in maintenance state |

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationMBean.java
@@ -211,6 +211,12 @@ public interface FederationMBean {
   long getNumOfBlocksPendingDeletion();
 
   /**
+   * Number of blocks currently undergoing or about to recover.
+   * @return number of blocks currently undergoing or about to recover
+   */
+  int getNumOfBlocksPendingRecovery();
+
+  /**
    * Get the number of files in the federation.
    * @return Number of files in the federation.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NamenodeBeanMetrics.java
@@ -363,6 +363,16 @@ public class NamenodeBeanMetrics
   }
 
   @Override
+  public int getPendingRecoveryBlocks() {
+    try {
+      return getRBFMetrics().getNumOfBlocksPendingRecovery();
+    } catch (IOException e) {
+      LOG.debug("Failed to get number of blocks pending recovery", e);
+    }
+    return 0;
+  }
+
+  @Override
   public long getScheduledReplicationBlocks() {
     try {
       return getRBFMetrics().getScheduledReplicationBlocks();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -616,6 +616,13 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
   }
 
   @Override
+  @Metric({"NumOfBlocksPendingRecovery", "Number of blocks pending recovery"})
+  public int getNumOfBlocksPendingRecovery() {
+    return getNameserviceAggregatedInt(
+        MembershipStats::getNumOfBlocksPendingRecovery);
+  }
+
+  @Override
   @Metric({"NumFiles", "Number of files"})
   public long getNumFiles() {
     return getNameserviceAggregatedLong(MembershipStats::getNumOfFiles);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -281,6 +281,8 @@ public class MembershipNamenodeResolver
           report.getNumOfBlocksUnderReplicated());
       stats.setNumOfBlocksPendingDeletion(
           report.getNumOfBlocksPendingDeletion());
+      stats.setNumOfBlocksPendingRecovery(
+          report.getNumOfBlocksPendingRecovery());
       stats.setAvailableSpace(report.getAvailableSpace());
       stats.setTotalSpace(report.getTotalSpace());
       stats.setProvidedSpace(report.getProvidedSpace());

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/NamenodeStatusReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/NamenodeStatusReport.java
@@ -68,6 +68,7 @@ public class NamenodeStatusReport {
   private long numOfBlocksPendingReplication = -1;
   private long numOfBlocksUnderReplicated = -1;
   private long numOfBlocksPendingDeletion = -1;
+  private int numOfBlocksPendingRecovery = -1;
   private long totalSpace = -1;
   private long providedSpace = -1;
   private int corruptFilesCount = -1;
@@ -368,11 +369,13 @@ public class NamenodeStatusReport {
    * @param numBlocksUnderReplicated Number of blocks under replication.
    * @param numBlocksPendingDeletion Number of blocks pending deletion.
    * @param providedSpace Space in provided storage.
+   * @param numBlocksPendingRecovery Number of blocks pending recovery.
    */
   public void setNamesystemInfo(long available, long total,
       long numFiles, long numBlocks, long numBlocksMissing,
       long numBlocksPendingReplication, long numBlocksUnderReplicated,
-      long numBlocksPendingDeletion, long providedSpace) {
+      long numBlocksPendingDeletion, long providedSpace,
+      int numBlocksPendingRecovery) {
     this.totalSpace = total;
     this.availableSpace = available;
     this.numOfBlocks = numBlocks;
@@ -383,6 +386,7 @@ public class NamenodeStatusReport {
     this.numOfFiles = numFiles;
     this.statsValid = true;
     this.providedSpace = providedSpace;
+    this.numOfBlocksPendingRecovery = numBlocksPendingRecovery;
   }
 
   /**
@@ -538,6 +542,10 @@ public class NamenodeStatusReport {
    */
   public long getNumOfBlocksPendingDeletion() {
     return this.numOfBlocksPendingDeletion;
+  }
+
+  public int getNumOfBlocksPendingRecovery() {
+    return this.numOfBlocksPendingRecovery;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/NamenodeHeartbeatService.java
@@ -478,7 +478,8 @@ public class NamenodeHeartbeatService extends PeriodicService {
               jsonObject.getLong("PendingReplicationBlocks"),
               jsonObject.getLong("UnderReplicatedBlocks"),
               jsonObject.getLong("PendingDeletionBlocks"),
-              jsonObject.optLong("ProvidedCapacityTotal"));
+              jsonObject.optLong("ProvidedCapacityTotal"),
+              jsonObject.optInt("PendingRecoveryBlocks"));
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MembershipStats.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MembershipStats.java
@@ -73,6 +73,10 @@ public abstract class MembershipStats extends BaseRecord {
 
   public abstract long getNumOfBlocksPendingDeletion();
 
+  public abstract void setNumOfBlocksPendingRecovery(int blocks);
+
+  public abstract int getNumOfBlocksPendingRecovery();
+
   public abstract void setNumOfActiveDatanodes(int nodes);
 
   public abstract int getNumOfActiveDatanodes();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/impl/pb/MembershipStatsPBImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/impl/pb/MembershipStatsPBImpl.java
@@ -149,6 +149,16 @@ public class MembershipStatsPBImpl extends MembershipStats
   }
 
   @Override
+  public void setNumOfBlocksPendingRecovery(int blocks) {
+    this.translator.getBuilder().setNumOfBlocksPendingRecovery(blocks);
+  }
+
+  @Override
+  public int getNumOfBlocksPendingRecovery() {
+    return this.translator.getProtoOrBuilder().getNumOfBlocksPendingRecovery();
+  }
+
+  @Override
   public void setNumOfActiveDatanodes(int nodes) {
     this.translator.getBuilder().setNumOfActiveDatanodes(nodes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/FederationProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/proto/FederationProtocol.proto
@@ -39,6 +39,7 @@ message NamenodeMembershipStatsRecordProto {
   optional uint64 numOfBlocksPendingReplication = 13;
   optional uint64 numOfBlocksUnderReplicated = 14;
   optional uint64 numOfBlocksPendingDeletion = 15;
+  optional uint32 numOfBlocksPendingRecovery = 16;
 
   optional uint32 numOfActiveDatanodes = 20;
   optional uint32 numOfDeadDatanodes = 21;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/webapps/router/federationhealth.html
@@ -128,6 +128,7 @@
   <tr><th><a href="#tab-datanode">Decommissioning Nodes</a></th><td>{NumDecommissioningNodes}</td></tr>
   <tr><th title="Excludes missing blocks.">Number of Under-Replicated Blocks</th><td>{NumOfBlocksUnderReplicated}</td></tr>
   <tr><th>Number of Blocks Pending Deletion</th><td>{NumOfBlocksPendingDeletion}</td></tr>
+  <tr><th>Number of Blocks Pending Recovery</th><td>{NumOfBlocksPendingRecovery}</td></tr>
 </table>
 {/federation}
 </script>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRBFMetrics.java
@@ -293,6 +293,7 @@ public class TestRBFMetrics extends TestMetricsBase {
     int numCorruptsFilesCount = 0;
     long scheduledReplicationBlocks = 0;
     long numberOfMissingBlocksWithReplicationFactorOne = 0;
+    long numOfBlocksPendingRecovery = 0;
     long highestPriorityLowRedundancyReplicatedBlocks = 0;
     long highestPriorityLowRedundancyECBlocks = 0;
     long numFiles = 0;
@@ -316,6 +317,7 @@ public class TestRBFMetrics extends TestMetricsBase {
           stats.getHighestPriorityLowRedundancyReplicatedBlocks();
       highestPriorityLowRedundancyECBlocks +=
           stats.getHighestPriorityLowRedundancyECBlocks();
+      numOfBlocksPendingRecovery += stats.getNumOfBlocksPendingRecovery();
     }
 
     assertEquals(numBlocks, bean.getNumBlocks());
@@ -342,6 +344,7 @@ public class TestRBFMetrics extends TestMetricsBase {
         bean.getHighestPriorityLowRedundancyReplicatedBlocks());
     assertEquals(highestPriorityLowRedundancyECBlocks,
         bean.getHighestPriorityLowRedundancyECBlocks());
+    assertEquals(numOfBlocksPendingRecovery, bean.getNumOfBlocksPendingRecovery());
   }
 
   private void validateClusterStatsRouterBean(RouterMBean bean) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestMembershipState.java
@@ -62,6 +62,7 @@ public class TestMembershipState {
   private static final long MISSING_BLOCK_WITH_REPLICATION_ONE = 221;
   private static final long HIGHEST_PRIORITY_LOW_REDUNDANCY_REPL_BLOCK = 212;
   private static final long HIGHEST_PRIORITY_LOW_REDUNDANCY_EC_BLOCK = 122;
+  private static final int RECOVERY_BLOCK = 123;
 
   private static final long TOTAL_SPACE = 1100;
   private static final long AVAILABLE_SPACE = 1200;
@@ -101,6 +102,7 @@ public class TestMembershipState {
         HIGHEST_PRIORITY_LOW_REDUNDANCY_REPL_BLOCK);
     stats.setHighestPriorityLowRedundancyECBlocks(
         HIGHEST_PRIORITY_LOW_REDUNDANCY_EC_BLOCK);
+    stats.setNumOfBlocksPendingRecovery(RECOVERY_BLOCK);
     record.setStats(stats);
     return record;
   }
@@ -142,6 +144,7 @@ public class TestMembershipState {
         stats.getHighestPriorityLowRedundancyReplicatedBlocks());
     assertEquals(HIGHEST_PRIORITY_LOW_REDUNDANCY_EC_BLOCK,
         stats.getHighestPriorityLowRedundancyECBlocks());
+    assertEquals(RECOVERY_BLOCK, stats.getNumOfBlocksPendingRecovery());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -244,6 +244,11 @@ public class BlockManager implements BlockStatsMXBean {
   }
 
   /** Used by metrics. */
+  public int getPendingRecoveryBlocksCount() {
+    return pendingRecoveryBlocks.size();
+  }
+
+  /** Used by metrics. */
   public long getLowRedundancyBlocks() {
     return neededReconstruction.getLowRedundancyBlocks();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingRecoveryBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingRecoveryBlocks.java
@@ -54,6 +54,14 @@ class PendingRecoveryBlocks {
   }
 
   /**
+   * Get how many blocks are currently undergoing or about to recover.
+   * @return number of blocks currently undergoing or about to recover
+   */
+  public int size() {
+    return recoveryTimeouts.size();
+  }
+
+  /**
    * Checks whether a recovery attempt has been made for the given block.
    * If so, checks whether that attempt has timed out.
    * @param block block for which recovery is being attempted

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5366,6 +5366,12 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return blockManager.getPendingDeletionBlocksCount();
   }
 
+  @Override
+  @Metric
+  public int getPendingRecoveryBlocks() {
+    return blockManager.getPendingRecoveryBlocksCount();
+  }
+
   @Override // ReplicatedBlocksMBean
   @Metric({"LowRedundancyReplicatedBlocks",
       "Number of low redundancy replicated blocks"})

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/FSNamesystemMBean.java
@@ -191,6 +191,12 @@ public interface FSNamesystemMBean {
   long getPendingDeletionBlocks();
 
   /**
+   * Number of blocks currently undergoing or about to recover.
+   * @return number of blocks currently undergoing or about to recover
+   */
+  int getPendingRecoveryBlocks();
+
+  /**
    * Time when block deletions will begin
    * @return time when block deletions will begin
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
@@ -48,6 +48,10 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
+
+import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoContiguous;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
@@ -949,6 +953,19 @@ public class TestNameNodeMetrics {
     MetricsRecordBuilder rbNew = getMetrics(NN_METRICS);
     assertTrue(MetricsAsserts.getLongCounter("TransactionsNumOps", rbNew) >
         startWriteCounter);
+  }
+
+  @Test
+  public void testPendingRecoveryBlocksMetric() throws Exception {
+    BlockInfo blk1 = new BlockInfoContiguous(new Block(1), (short) 0);
+    BlockInfo blk2 = new BlockInfoContiguous(new Block(2), (short) 0);
+    bm.addBlockRecoveryAttempt(blk1);
+    bm.addBlockRecoveryAttempt(blk2);
+    assertGauge("PendingRecoveryBlocks", 2, getMetrics(NS_METRICS));
+
+    bm.successfulBlockRecovery(blk1);
+    bm.successfulBlockRecovery(blk2);
+    assertGauge("PendingRecoveryBlocks", 0, getMetrics(NS_METRICS));
   }
 
   /**


### PR DESCRIPTION
### Description of PR
Now we don't know how many blocks are happening or are about to recover, the purpose of this pr is to record them through metrics.
Details: HDFS-16476

### How was this patch tested?
When some blocks are recovering or are about to recover, you can view the number through metrics.
