### PR TITLE
HDFS-16478 Add thread id to command processor name

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1378,7 +1378,7 @@ class BPServiceActor implements Runnable {
     private final BlockingQueue<Runnable> queue;
 
     CommandProcessingThread(BPServiceActor actor) {
-      setName("Command processor-" + getId());
+      setName("Command processor (id=" + getId() + ") for " + dn.getDisplayName());
       this.actor = actor;
       this.queue = new LinkedBlockingQueue<>();
       setDaemon(true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1378,7 +1378,7 @@ class BPServiceActor implements Runnable {
     private final BlockingQueue<Runnable> queue;
 
     CommandProcessingThread(BPServiceActor actor) {
-      super("Command processor");
+      setName("Command processor-" + getId());
       this.actor = actor;
       this.queue = new LinkedBlockingQueue<>();
       setDaemon(true);


### PR DESCRIPTION
### Description of PR

Provides additional clarity in logs when debugging MiniDFSCluster with
multiple in-process DataNodes.

### How was this patch tested?

Visual inspection of log output.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
