### PR TITLE
YARN-11080. Improve debug log in ContainerTokenIdentifier when writin…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/ContainerTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/ContainerTokenIdentifier.java
@@ -326,7 +326,9 @@ public class ContainerTokenIdentifier extends TokenIdentifier {
 
   @Override
   public void write(DataOutput out) throws IOException {
-    LOG.debug("Writing ContainerTokenIdentifier to RPC layer: {}", this);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Writing ContainerTokenIdentifier to RPC layer: {}", this);
+    }
     out.write(proto.toByteArray());
   }
 


### PR DESCRIPTION
ContainerTokenIdentifier  debug information takes up too much CPU time, Just add debug level check.


