### PR TITLE
YARN-10894. Follow up YARN-10237: fix the new test case in TestRMWebServicesCapacitySched.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -130,7 +130,7 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
 
     // Define top-level queues
     config.setQueues(CapacitySchedulerConfiguration.ROOT,
-        new String[] {"a", "b"});
+        new String[] {"a", "b", "c"});
 
     final String A = CapacitySchedulerConfiguration.ROOT + ".a";
     config.setCapacity(A, 10.5f);
@@ -391,7 +391,7 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     assertEquals("utilization", info.getString("orderingPolicyInfo"));
 
     JSONArray arr = info.getJSONObject("queues").getJSONArray("queue");
-    assertEquals("incorrect number of elements in: " + arr, 2, arr.length());
+    assertEquals("incorrect number of elements in: " + arr, 3, arr.length());
 
     // test subqueues
     for (int i = 0; i < arr.length(); i++) {
@@ -433,6 +433,7 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     qi.numApplications = info.getInt("numApplications");
     qi.queueName = info.getString("queueName");
     qi.state = info.getString("state");
+    qi.isAbsoluteResource = info.getBoolean("isAbsoluteResource");
 
     verifySubQueueGeneric(q, qi, parentAbsCapacity, parentAbsMaxCapacity);
 
@@ -506,7 +507,8 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
         + " expected: " + q, qshortName.matches(info.queueName));
     assertTrue("state doesn't match",
         (csConf.getState(q).toString()).matches(info.state));
-    if (q.equals("c")) {
+
+    if (q.equals("root.c")) {
       assertTrue("c queue is not configured in Absolute resource",
           info.isAbsoluteResource);
     } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesSchedulerActivities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesSchedulerActivities.java
@@ -154,7 +154,7 @@ public class TestRMWebServicesSchedulerActivities
       verifyStateOfAllocations(allocation,
           FN_ACT_FINAL_ALLOCATION_STATE, "ALLOCATED");
       verifyQueueOrder(allocation,
-          "root-root.a-root.b-root.b.b2-root.b.b3-root.b.b1");
+          "root-root.a-root.c-root.b-root.b.b2-root.b.b3-root.b.b1");
     } finally {
       rm.stop();
     }
@@ -378,7 +378,7 @@ public class TestRMWebServicesSchedulerActivities
       JSONObject allocations = getFirstSubNodeFromJson(json,
           FN_SCHEDULER_ACT_ROOT, FN_ACT_ALLOCATIONS);
       verifyQueueOrder(allocations,
-          "root-root.a-root.b-root.b.b3-root.b.b1");
+          "root-root.c-root.a-root.b-root.b.b3-root.b.b1");
       verifyStateOfAllocations(allocations, FN_ACT_FINAL_ALLOCATION_STATE,
           "RESERVED");
 


### PR DESCRIPTION
Depends on: https://github.com/apache/hadoop/pull/3808  YARN-11033

