### PR TITLE
HDFS-16481. Provide support to set Http and Rpc ports in MiniJournalCluster

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -1054,6 +1054,25 @@ public class NetUtils {
   }
 
   /**
+   * Return free ports. There is no guarantee they will remain free, so
+   * ports should be used immediately. The number of free ports returned by
+   * this method should match argument {@code numOfPorts}.
+   *
+   * @param numOfPorts Number of free ports to acquire.
+   * @return Free ports for binding a local socket.
+   */
+  public static Set<Integer> getFreeSocketPorts(int numOfPorts) {
+    final Set<Integer> freePorts = new HashSet<>(numOfPorts);
+    for (int i = 0; i < numOfPorts * 5; i++) {
+      freePorts.add(getFreeSocketPort());
+      if (freePorts.size() == numOfPorts) {
+        return freePorts;
+      }
+    }
+    throw new IllegalStateException(numOfPorts + " free ports could not be acquired.");
+  }
+
+  /**
    * Return an @{@link InetAddress} to bind to. If bindWildCardAddress is true
    * than returns null.
    *

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -1056,15 +1056,22 @@ public class NetUtils {
   /**
    * Return free ports. There is no guarantee they will remain free, so
    * ports should be used immediately. The number of free ports returned by
-   * this method should match argument {@code numOfPorts}.
+   * this method should match argument {@code numOfPorts}. Num of ports
+   * provided in the argument should not exceed 25.
    *
    * @param numOfPorts Number of free ports to acquire.
    * @return Free ports for binding a local socket.
    */
   public static Set<Integer> getFreeSocketPorts(int numOfPorts) {
+    Preconditions.checkArgument(numOfPorts > 0 && numOfPorts <= 25,
+        "Valid range for num of ports is between 0 and 26");
     final Set<Integer> freePorts = new HashSet<>(numOfPorts);
     for (int i = 0; i < numOfPorts * 5; i++) {
-      freePorts.add(getFreeSocketPort());
+      int port = getFreeSocketPort();
+      if (port == 0) {
+        continue;
+      }
+      freePorts.add(port);
       if (freePorts.size() == numOfPorts) {
         return freePorts;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
@@ -52,6 +52,8 @@ public class MiniJournalCluster {
     private int numJournalNodes = 3;
     private boolean format = true;
     private final Configuration conf;
+    private int[] httpPorts = null;
+    private int[] rpcPorts = null;
 
     static {
       DefaultMetricsSystem.setMiniClusterMode(true);
@@ -73,6 +75,16 @@ public class MiniJournalCluster {
 
     public Builder format(boolean f) {
       this.format = f;
+      return this;
+    }
+
+    public Builder setHttpPorts(int... httpPorts) {
+      this.httpPorts = httpPorts;
+      return this;
+    }
+
+    public Builder setRpcPorts(int... rpcPorts) {
+      this.rpcPorts = rpcPorts;
       return this;
     }
 
@@ -99,6 +111,19 @@ public class MiniJournalCluster {
   private final JNInfo[] nodes;
   
   private MiniJournalCluster(Builder b) throws IOException {
+
+    if (b.httpPorts != null && b.httpPorts.length != b.numJournalNodes) {
+      throw new IllegalArgumentException(
+          "Num of http ports (" + b.httpPorts.length + ") should match num of JournalNodes ("
+              + b.numJournalNodes + ")");
+    }
+
+    if (b.rpcPorts != null && b.rpcPorts.length != b.numJournalNodes) {
+      throw new IllegalArgumentException(
+          "Num of rpc ports (" + b.rpcPorts.length + ") should match num of JournalNodes ("
+              + b.numJournalNodes + ")");
+    }
+
     LOG.info("Starting MiniJournalCluster with " +
         b.numJournalNodes + " journal nodes");
     
@@ -173,8 +198,10 @@ public class MiniJournalCluster {
     Configuration conf = new Configuration(b.conf);
     File logDir = getStorageDir(idx);
     conf.set(DFSConfigKeys.DFS_JOURNALNODE_EDITS_DIR_KEY, logDir.toString());
-    conf.set(DFSConfigKeys.DFS_JOURNALNODE_RPC_ADDRESS_KEY, "localhost:0");
-    conf.set(DFSConfigKeys.DFS_JOURNALNODE_HTTP_ADDRESS_KEY, "localhost:0");
+    int httpPort = b.httpPorts != null ? b.httpPorts[idx] : 0;
+    int rpcPort = b.rpcPorts != null ? b.rpcPorts[idx] : 0;
+    conf.set(DFSConfigKeys.DFS_JOURNALNODE_RPC_ADDRESS_KEY, "localhost:" + rpcPort);
+    conf.set(DFSConfigKeys.DFS_JOURNALNODE_HTTP_ADDRESS_KEY, "localhost:" + httpPort);
     return conf;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
@@ -46,7 +46,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.test.GenericTestUtils;
 
-public class MiniJournalCluster implements Closeable {
+public final class MiniJournalCluster implements Closeable {
 
   public static final String CLUSTER_WAITACTIVE_URI = "waitactive";
   public static class Builder {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
@@ -78,13 +78,13 @@ public class MiniJournalCluster {
       return this;
     }
 
-    public Builder setHttpPorts(int... httpPorts) {
-      this.httpPorts = httpPorts;
+    public Builder setHttpPorts(int... ports) {
+      this.httpPorts = ports;
       return this;
     }
 
-    public Builder setRpcPorts(int... rpcPorts) {
-      this.rpcPorts = rpcPorts;
+    public Builder setRpcPorts(int... ports) {
+      this.rpcPorts = ports;
       return this;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniJournalCluster.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.qjournal;
 import static org.apache.hadoop.hdfs.qjournal.QJMTestUtil.FAKE_NSINFO;
 import static org.junit.Assert.fail;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -45,7 +46,8 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.test.GenericTestUtils;
 
-public class MiniJournalCluster {
+public class MiniJournalCluster implements Closeable {
+
   public static final String CLUSTER_WAITACTIVE_URI = "waitactive";
   public static class Builder {
     private String baseDir;
@@ -301,4 +303,10 @@ public class MiniJournalCluster {
           .DFS_NAMENODE_SHARED_EDITS_DIR_KEY, quorumJournalURI.toString());
     }
   }
+
+  @Override
+  public void close() throws IOException {
+    this.shutdown();
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
@@ -102,6 +102,11 @@ public class TestMiniJournalCluster {
     final Set<Integer> httpAndRpcPorts = NetUtils.getFreeSocketPorts(6);
     LOG.info("Free socket ports: {}", httpAndRpcPorts);
 
+    for (Integer httpAndRpcPort : httpAndRpcPorts) {
+      assertNotEquals("None of the acquired socket port should not be zero", 0,
+          httpAndRpcPort.intValue());
+    }
+
     final int[] httpPorts = new int[3];
     final int[] rpcPorts = new int[3];
     int httpPortIdx = 0;
@@ -116,11 +121,6 @@ public class TestMiniJournalCluster {
 
     LOG.info("Http ports selected: {}", httpPorts);
     LOG.info("Rpc ports selected: {}", rpcPorts);
-
-    for (int i = 0; i < 3; i++) {
-      assertNotEquals(0, rpcPorts[i]);
-      assertNotEquals(0, httpPorts[i]);
-    }
 
     try (MiniJournalCluster miniJournalCluster = new MiniJournalCluster.Builder(conf)
         .setHttpPorts(httpPorts)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 
 public class TestMiniJournalCluster {
+
   @Test
   public void testStartStop() throws IOException {
     Configuration conf = new Configuration();
@@ -52,4 +53,70 @@ public class TestMiniJournalCluster {
       c.shutdown();
     }
   }
+
+  @Test
+  public void testStartStopWithPorts() throws IOException {
+    Configuration conf = new Configuration();
+
+    try {
+      new MiniJournalCluster.Builder(conf).setHttpPorts(8481).build();
+      fail("Should not reach here");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Num of http ports (1) should match num of JournalNodes (3)", e.getMessage());
+    }
+
+    try {
+      new MiniJournalCluster.Builder(conf).setRpcPorts(8481, 8482)
+          .build();
+      fail("Should not reach here");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Num of rpc ports (2) should match num of JournalNodes (3)", e.getMessage());
+    }
+
+    try {
+      new MiniJournalCluster.Builder(conf).setHttpPorts(800, 9000, 10000).setRpcPorts(8481)
+          .build();
+      fail("Should not reach here");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Num of rpc ports (1) should match num of JournalNodes (3)", e.getMessage());
+    }
+
+    try {
+      new MiniJournalCluster.Builder(conf).setHttpPorts(800, 9000, 1000, 2000)
+          .setRpcPorts(8481, 8482, 8483)
+          .build();
+      fail("Should not reach here");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Num of http ports (4) should match num of JournalNodes (3)", e.getMessage());
+    }
+
+    MiniJournalCluster miniJournalCluster =
+        new MiniJournalCluster.Builder(conf).setHttpPorts(8481, 8482, 8483)
+            .setRpcPorts(8491, 8492, 8493).build();
+    try {
+      miniJournalCluster.waitActive();
+      URI uri = miniJournalCluster.getQuorumJournalURI("myjournal");
+      String[] addrs = uri.getAuthority().split(";");
+      assertEquals(3, addrs.length);
+
+      assertEquals(8481, miniJournalCluster.getJournalNode(0).getHttpAddress().getPort());
+      assertEquals(8482, miniJournalCluster.getJournalNode(1).getHttpAddress().getPort());
+      assertEquals(8483, miniJournalCluster.getJournalNode(2).getHttpAddress().getPort());
+
+      assertEquals(8491,
+          miniJournalCluster.getJournalNode(0).getRpcServer().getAddress().getPort());
+      assertEquals(8492,
+          miniJournalCluster.getJournalNode(1).getRpcServer().getAddress().getPort());
+      assertEquals(8493,
+          miniJournalCluster.getJournalNode(2).getRpcServer().getAddress().getPort());
+
+      JournalNode node = miniJournalCluster.getJournalNode(0);
+      String dir = node.getConf().get(DFSConfigKeys.DFS_JOURNALNODE_EDITS_DIR_KEY);
+      assertEquals(new File(MiniDFSCluster.getBaseDirectory() + "journalnode-0").getAbsolutePath(),
+          dir);
+    } finally {
+      miniJournalCluster.shutdown();
+    }
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -98,10 +99,20 @@ public class TestMiniJournalCluster {
               .setRpcPorts(8481, 8482, 8483).build();
         });
 
-    final int[] httpPorts = new int[] { NetUtils.getFreeSocketPort(), NetUtils.getFreeSocketPort(),
-        NetUtils.getFreeSocketPort() };
-    final int[] rpcPorts = new int[] { NetUtils.getFreeSocketPort(), NetUtils.getFreeSocketPort(),
-        NetUtils.getFreeSocketPort() };
+    final Set<Integer> httpAndRpcPorts = NetUtils.getFreeSocketPorts(6);
+    LOG.info("Free socket ports: {}", httpAndRpcPorts);
+
+    final int[] httpPorts = new int[3];
+    final int[] rpcPorts = new int[3];
+    int httpPortIdx = 0;
+    int rpcPortIdx = 0;
+    for (Integer httpAndRpcPort : httpAndRpcPorts) {
+      if (httpPortIdx < 3) {
+        httpPorts[httpPortIdx++] = httpAndRpcPort;
+      } else {
+        rpcPorts[rpcPortIdx++] = httpAndRpcPort;
+      }
+    }
 
     LOG.info("Http ports selected: {}", httpPorts);
     LOG.info("Rpc ports selected: {}", rpcPorts);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/TestMiniJournalCluster.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.qjournal.server.JournalNode;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 
 import org.junit.Test;
@@ -97,22 +98,18 @@ public class TestMiniJournalCluster {
               .setRpcPorts(8481, 8482, 8483).build();
         });
 
-    final int[] httpPorts = new int[3];
-    final int[] rpcPorts = new int[3];
-    try (MiniJournalCluster miniJournalCluster = new MiniJournalCluster.Builder(conf).build()) {
-      miniJournalCluster.waitActive();
-
-      for (int i = 0; i < 3; i++) {
-        httpPorts[i] = miniJournalCluster.getJournalNode(i).getHttpAddress().getPort();
-      }
-
-      for (int i = 0; i < 3; i++) {
-        rpcPorts[i] = miniJournalCluster.getJournalNode(i).getRpcServer().getAddress().getPort();
-      }
-    }
+    final int[] httpPorts = new int[] { NetUtils.getFreeSocketPort(), NetUtils.getFreeSocketPort(),
+        NetUtils.getFreeSocketPort() };
+    final int[] rpcPorts = new int[] { NetUtils.getFreeSocketPort(), NetUtils.getFreeSocketPort(),
+        NetUtils.getFreeSocketPort() };
 
     LOG.info("Http ports selected: {}", httpPorts);
     LOG.info("Rpc ports selected: {}", rpcPorts);
+
+    for (int i = 0; i < 3; i++) {
+      assertNotEquals(0, rpcPorts[i]);
+      assertNotEquals(0, httpPorts[i]);
+    }
 
     try (MiniJournalCluster miniJournalCluster = new MiniJournalCluster.Builder(conf)
         .setHttpPorts(httpPorts)


### PR DESCRIPTION
### Description of PR
We should provide support for clients to set Http and Rpc ports of JournalNodes in MiniJournalCluster.

### How was this patch tested?
Using a downstreamer application as well as using UT.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
