### PR TITLE
HADOOP-18143. toString method of RpcCall throws IllegalArgumentException

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
@@ -658,8 +658,9 @@ public class ProtobufRpcEngine2 implements RpcEngine {
     public void writeTo(ResponseBuffer out) throws IOException {
       lock.lock();
       try {
-        requestHeader.writeDelimitedTo(out);
-        if (payload != null) {
+        RequestHeaderProto request = getRequestHeader();
+        if (payload != null && request != null) {
+          request.writeDelimitedTo(out);
           payload.writeDelimitedTo(out);
         }
       } finally {
@@ -672,6 +673,9 @@ public class ProtobufRpcEngine2 implements RpcEngine {
     public String toString() {
       try {
         RequestHeaderProto header = getRequestHeader();
+        if (header == null) {
+          throw new IllegalArgumentException("No request header is found");
+        }
         return header.getDeclaringClassProtocolName() + "." +
                header.getMethodName();
       } catch (IOException e) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

