### PR TITLE
HDFS-16484. [SPS]: Fix an infinite loop bug in SPSPathIdProcessor thread

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/sps/BlockStorageMovementNeeded.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/sps/BlockStorageMovementNeeded.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.sps;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -227,15 +228,18 @@ public class BlockStorageMovementNeeded {
    * ID's to process for satisfy the policy.
    */
   private class SPSPathIdProcessor implements Runnable {
+    private static final int MAX_RETRY_COUNT = 3;
 
     @Override
     public void run() {
       LOG.info("Starting SPSPathIdProcessor!.");
       Long startINode = null;
+      int retryCount = 0;
       while (ctxt.isRunning()) {
         try {
           if (!ctxt.isInSafeMode()) {
             if (startINode == null) {
+              retryCount = 0;
               startINode = ctxt.getNextSPSPath();
             } // else same id will be retried
             if (startINode == null) {
@@ -248,7 +252,12 @@ public class BlockStorageMovementNeeded {
                   pendingWorkForDirectory.get(startINode);
               if (dirPendingWorkInfo != null
                   && dirPendingWorkInfo.isDirWorkDone()) {
-                ctxt.removeSPSHint(startINode);
+                try {
+                  ctxt.removeSPSHint(startINode);
+                } catch (FileNotFoundException e) {
+                  // ignore if the file doesn't already exist
+                  startINode = null;
+                }
                 pendingWorkForDirectory.remove(startINode);
               }
             }
@@ -267,6 +276,11 @@ public class BlockStorageMovementNeeded {
           } catch (InterruptedException e) {
             LOG.info("Interrupted while waiting in SPSPathIdProcessor", t);
             break;
+          }
+          retryCount++;
+          if (retryCount >= MAX_RETRY_COUNT) {
+            LOG.warn("Skipping this inode {} due to too many retries.", startINode);
+            startINode = null;
           }
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
@@ -189,6 +189,20 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
+  private void stopExternalSps() {
+    if (externalSps != null) {
+      externalSps.stopGracefully();
+    }
+  }
+
+  private void startExternalSps() {
+    externalSps = new StoragePolicySatisfier(getConf());
+    externalCtxt = new ExternalSPSContext(externalSps, nnc);
+
+    externalSps.init(externalCtxt);
+    externalSps.start(StoragePolicySatisfierMode.EXTERNAL);
+  }
+
   private void createCluster() throws IOException {
     getConf().setLong("dfs.block.size", DEFAULT_BLOCK_SIZE);
     setCluster(startCluster(getConf(), allDiskTypes, NUM_OF_DATANODES,
@@ -1369,6 +1383,45 @@ public class TestExternalStoragePolicySatisfier {
       shutdownCluster();
     }
   }
+
+  /**
+   * Test SPS that satisfy the files and then delete the files before start SPS.
+   */
+  @Test(timeout = 300000)
+  public void testSPSSatisfyAndThenDeleteFileBeforeStartSPS() throws Exception {
+    try {
+      createCluster();
+      HdfsAdmin hdfsAdmin =
+          new HdfsAdmin(FileSystem.getDefaultUri(config), config);
+
+      StorageType[][] newtypes =
+          new StorageType[][]{{StorageType.DISK, StorageType.ARCHIVE},
+              {StorageType.DISK, StorageType.ARCHIVE},
+              {StorageType.DISK, StorageType.ARCHIVE}};
+      startAdditionalDNs(config, 3, NUM_OF_DATANODES, newtypes,
+          STORAGES_PER_DATANODE, CAPACITY, hdfsCluster);
+
+      stopExternalSps();
+
+      dfs.setStoragePolicy(new Path(FILE), COLD);
+      hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
+      dfs.delete(new Path(FILE), true);
+
+      startExternalSps();
+
+      String file1 = "/testMoveToSatisfyStoragePolicy_1";
+      writeContent(file1);
+      dfs.setStoragePolicy(new Path(file1), COLD);
+      hdfsAdmin.satisfyStoragePolicy(new Path(file1));
+
+      hdfsCluster.triggerHeartbeats();
+      DFSTestUtil.waitExpectedStorageType(file1, StorageType.ARCHIVE, 3, 30000,
+          dfs);
+    } finally {
+      shutdownCluster();
+    }
+  }
+
 
   /**
    * Test SPS for directory which has multilevel directories.


### PR DESCRIPTION
JIRA: [HDFS-16484](https://issues.apache.org/jira/browse/HDFS-16484)

Currently, we ran SPS in our cluster and found this log. The SPSPathIdProcessor thread enters an infinite loop and prints the same log all the time.
![image](https://user-images.githubusercontent.com/2844826/159828355-7bad2cb5-4b11-40a3-8854-666262c2ab32.png)

The reason is that #ctxt.getNextSPSPath() get a inodeId which path does not exist. The inodeId will not be set to null, causing the thread hold this inodeId forever.
```java
public void run() {
  LOG.info("Starting SPSPathIdProcessor!.");
  Long startINode = null;
  while (ctxt.isRunning()) {
    try {
      if (!ctxt.isInSafeMode()) {
        if (startINode == null) {
          startINode = ctxt.getNextSPSPath();
        } // else same id will be retried
        if (startINode == null) {
          // Waiting for SPS path
          Thread.sleep(3000);
        } else {
          ctxt.scanAndCollectFiles(startINode);
          // check if directory was empty and no child added to queue
          DirPendingWorkInfo dirPendingWorkInfo =
              pendingWorkForDirectory.get(startINode);
          if (dirPendingWorkInfo != null
              && dirPendingWorkInfo.isDirWorkDone()) {
            ctxt.removeSPSHint(startINode);
            pendingWorkForDirectory.remove(startINode);
          }
        }
        startINode = null; // Current inode successfully scanned.
      }
    } catch (Throwable t) {
      String reClass = t.getClass().getName();
      if (InterruptedException.class.getName().equals(reClass)) {
        LOG.info("SPSPathIdProcessor thread is interrupted. Stopping..");
        break;
      }
      LOG.warn("Exception while scanning file inodes to satisfy the policy",
          t);
      try {
        Thread.sleep(3000);
      } catch (InterruptedException e) {
        LOG.info("Interrupted while waiting in SPSPathIdProcessor", t);
        break;
      }
    }
  }
} 
```





