### PR TITLE
HDFS-16485. [SPS]: allow re-satisfy path after restarting sps process

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirSatisfyStoragePolicyOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirSatisfyStoragePolicyOp.java
@@ -85,10 +85,16 @@ final class FSDirSatisfyStoragePolicyOp {
         }
       } else if (inodeHasSatisfyXAttr(inode)) {
         NameNode.LOG
-            .warn("Cannot request to call satisfy storage policy on path: "
+            .info("Call satisfy storage policy on path: "
                 + inode.getFullPathName()
                 + ", as this file/dir was already called for satisfying "
                 + "storage policy.");
+        // Adding pathId in the pending queue if we re-satisfy path
+        StoragePolicySatisfyManager spsManager =
+            fsd.getBlockManager().getSPSManager();
+        if (spsManager != null) {
+          spsManager.addPathId(inode.getId());
+        }
       } else {
         XAttr satisfyXAttr = XAttrHelper
             .buildXAttr(XATTR_SATISFY_STORAGE_POLICY);
@@ -131,7 +137,7 @@ final class FSDirSatisfyStoragePolicyOp {
 
   private static boolean inodeHasSatisfyXAttr(INode inode) {
     final XAttrFeature f = inode.getXAttrFeature();
-    if (inode.isFile() && f != null
+    if (f != null
         && f.getXAttr(XATTR_SATISFY_STORAGE_POLICY) != null) {
       return true;
     }


### PR DESCRIPTION
When SPSPathIdProcessor thread call getNextSPSPath(), it get the pathId from namenode and namenode will also remove this pathId from pathsToBeTraveresed queue.
```java
public Long getNextPathId() {
  synchronized (pathsToBeTraveresed) {
    return pathsToBeTraveresed.poll();
  }
} 
```
If SPS process restart, this path will not continue the move operation until namenode restart.

So we want to provide a way for the SPS to continue performing the move operation after SPS restart.

First solution: 

1) When SPSPathIdProcessor thread call getNextSPSPath(), namenode return pathId and then move this pathId to a pathsBeingTraveresed queue;

2) After SPS finish a path movement operation, it call a rpc to namenode to remove this pathId from pathsBeingTraveresed queue;

3) If SPS restart, SPSPathIdProcessor thread should call a rpc to namenode to get all pathId from pathsBeingTraveresed queue;

Second solution:

We added timeout detection in the application layer, if a path does not complete the movement within the specified time, we can re-satisfy this path even though it has "hdfs.sps" xattr already.

We choose the second solution because the first solution will add more rpc operation and may affect namenode performance.