### PR TITLE
HADOOP-18144. getTrashRoot/s in ViewFileSystem return a viewFS path

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
@@ -192,7 +192,7 @@ public class TrashPolicyDefault extends TrashPolicy {
       }
     }
     throw (IOException) new IOException(
-        "Failed to move " + path + " to trash " + trashPath).initCause(cause);
+        "Failed to move " + path + " to trash " + trashPath, cause);
   }
 
   @SuppressWarnings("deprecation")

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
@@ -132,7 +132,6 @@ public class TrashPolicyDefault extends TrashPolicy {
     String qpath = fs.makeQualified(path).toString();
 
     Path trashRoot = fs.getTrashRoot(path);
-    LOG.info("trashRoot: " + trashRoot);
     Path trashCurrent = new Path(trashRoot, CURRENT);
     if (qpath.startsWith(trashRoot.toString())) {
       return false;                               // already in trash

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
@@ -191,8 +191,8 @@ public class TrashPolicyDefault extends TrashPolicy {
         cause = e;
       }
     }
-    throw (IOException) new IOException(
-        "Failed to move " + path + " to trash " + trashPath, cause);
+    throw new IOException("Failed to move " + path + " to trash " + trashPath,
+        cause);
   }
 
   @SuppressWarnings("deprecation")

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/TrashPolicyDefault.java
@@ -132,6 +132,7 @@ public class TrashPolicyDefault extends TrashPolicy {
     String qpath = fs.makeQualified(path).toString();
 
     Path trashRoot = fs.getTrashRoot(path);
+    LOG.info("trashRoot: " + trashRoot);
     Path trashCurrent = new Path(trashRoot, CURRENT);
     if (qpath.startsWith(trashRoot.toString())) {
       return false;                               // already in trash
@@ -191,8 +192,8 @@ public class TrashPolicyDefault extends TrashPolicy {
         cause = e;
       }
     }
-    throw (IOException)
-      new IOException("Failed to move to trash: " + path).initCause(cause);
+    throw (IOException) new IOException(
+        "Failed to move " + path + " to trash " + trashPath).initCause(cause);
   }
 
   @SuppressWarnings("deprecation")

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -137,7 +137,7 @@ public interface Constants {
    * Enable ViewFileSystem to return a trashRoot which is in the root dir of a
    * mount point.
    */
-  String CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT =
-      "fs.viewfs.trash.root.under.mount.point.root";
-  boolean CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT = false;
+  String CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT =
+      "fs.viewfs.trash.force-inside-mount-point";
+  boolean CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT = true;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -134,10 +134,9 @@ public interface Constants {
       HCFSMountTableConfigLoader.class;
 
   /**
-   * Enable ViewFileSystem to return a trashRoot which is in the root dir of a
-   * mount point.
+   * Enable ViewFileSystem to return the viewFS path for the trashRoot
    */
-  String CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT =
-      "fs.viewfs.trash.force-inside-mount-point";
-  boolean CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT = true;
+  String CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH =
+      "fs.viewfs.trash.use-viewfs-path";
+  boolean CONFIG_VIEWFS_TRASH_VIEWFS_PATH_DEFAULT = true;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -134,7 +134,7 @@ public interface Constants {
       HCFSMountTableConfigLoader.class;
 
   /**
-   * Enable ViewFileSystem to return a trashRoot which in the root dir of a
+   * Enable ViewFileSystem to return a trashRoot which is in the root dir of a
    * mount point.
    */
   String CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT =

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -134,9 +134,9 @@ public interface Constants {
       HCFSMountTableConfigLoader.class;
 
   /**
-   * Enable ViewFileSystem to return the viewFS path for the trashRoot
+   * Force ViewFileSystem to return a trashRoot that is inside a mount point.
    */
-  String CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH =
-      "fs.viewfs.trash.use-viewfs-path";
-  boolean CONFIG_VIEWFS_TRASH_VIEWFS_PATH_DEFAULT = true;
+  String CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT =
+      "fs.viewfs.trash.force-inside-mount-point";
+  boolean CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT = true;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -134,8 +134,10 @@ public interface Constants {
       HCFSMountTableConfigLoader.class;
 
   /**
-   * Enable ViewFileSystem to return a trashRoot which is local to mount point.
+   * Enable ViewFileSystem to return a trashRoot which in the root dir of a
+   * mount point.
    */
-  String CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH = "fs.viewfs.mount.point.local.trash";
-  boolean CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH_DEFAULT = false;
+  String CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT =
+      "fs.viewfs.trash.root.under.mount.point.root";
+  boolean CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT = false;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -138,5 +138,5 @@ public interface Constants {
    */
   String CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT =
       "fs.viewfs.trash.force-inside-mount-point";
-  boolean CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT = true;
+  boolean CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT = false;
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1235,9 +1235,19 @@ public class ViewFileSystem extends FileSystem {
       return trashRoots.values();
     }
 
-    // Get trash roots in TRASH_PREFIX dir inside mount points.
+    // Get trash roots in TRASH_PREFIX dir inside mount points and fallback FS.
+    List<InodeTree.MountPoint<FileSystem>> mountPoints =
+        fsState.getMountPoints();
+    // If we have a fallback FS, add a mount point for it as <"", fallback FS>.
+    // The source path of a mount point shall not end with '/', thus for
+    // fallback fs, we set its mount point src as "".
+    if (fsState.getRootFallbackLink() != null) {
+      mountPoints.add(new InodeTree.MountPoint<>("",
+          fsState.getRootFallbackLink()));
+    }
+
     try {
-      for (InodeTree.MountPoint<FileSystem> mountPoint : fsState.getMountPoints()) {
+      for (InodeTree.MountPoint<FileSystem> mountPoint : mountPoints) {
 
         Path trashRoot =
             makeQualified(new Path(mountPoint.src + "/" + TRASH_PREFIX));
@@ -1270,7 +1280,7 @@ public class ViewFileSystem extends FileSystem {
         }
       }
     } catch (IOException e) {
-      LOG.warn("Exception in get all trash roots", e);
+      LOG.warn("Exception in get all trash roots for mount points", e);
     }
 
     return trashRoots.values();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1190,9 +1190,10 @@ public class ViewFileSystem extends FileSystem {
         // targetFSTrashRootPath is the default trash root based on user home
         // dir.
         Path defaultUserHome = res.targetFileSystem.getHomeDirectory();
-        if ((mountTargetPath == null || ROOT_PATH.equals(mountTargetPath))
-            && defaultUserHome != null && targetFSTrashRootPath.equals(
-            new Path(defaultUserHome, TRASH_PREFIX))) {
+        if ((mountTargetPath == null || mountTargetPath.isEmpty()
+            || ROOT_PATH.equals(mountTargetPath)) && defaultUserHome != null
+            && targetFSTrashRootPath.equals(
+            defaultUserHome.toUri().getPath() + "/" + TRASH_PREFIX)) {
           return makeQualified(new Path(res.resolvedPath,
               TRASH_PREFIX + "/" + ugi.getShortUserName()));
         } else {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -25,8 +25,8 @@ import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_IGNORE_PORT_IN
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS_DEFAULT;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH_DEFAULT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT;
 
 import java.util.function.Function;
 import java.io.FileNotFoundException;
@@ -1158,8 +1158,8 @@ public class ViewFileSystem extends FileSystem {
   @Override
   public Path getTrashRoot(Path path) {
     boolean useMountPointLocalTrash =
-        config.getBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH,
-            CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH_DEFAULT);
+        config.getBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT,
+            CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT);
 
     try {
       InodeTree.ResolveResult<FileSystem> res =
@@ -1204,8 +1204,8 @@ public class ViewFileSystem extends FileSystem {
 
     // Add trash dirs for each mount point
     boolean useMountPointLocalTrash =
-        config.getBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH,
-            CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH_DEFAULT);
+        config.getBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT,
+            CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT);
     if (useMountPointLocalTrash) {
 
       Set<Path> currentTrashPaths = new HashSet<>();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1164,6 +1164,8 @@ public class ViewFileSystem extends FileSystem {
       }
 
       // New trash root policy
+      // Uri.getPath() will return an empty string if path is not defined in
+      // the URI.
       String targetFSTrashRootPath = targetFSTrashRoot.toUri().getPath();
       String mountTargetPath = res.targetFileSystem.getUri().getPath();
       if (ROOT_PATH.equals(new Path(res.resolvedPath))) {
@@ -1190,9 +1192,9 @@ public class ViewFileSystem extends FileSystem {
         // targetFSTrashRootPath is the default trash root based on user home
         // dir.
         Path defaultUserHome = res.targetFileSystem.getHomeDirectory();
-        if ((mountTargetPath == null || mountTargetPath.isEmpty()
-            || ROOT_PATH.equals(mountTargetPath)) && defaultUserHome != null
-            && targetFSTrashRootPath.equals(
+        if ((mountTargetPath.isEmpty() ||
+            ROOT_PATH.equals(new Path(mountTargetPath)))
+            && defaultUserHome != null && targetFSTrashRootPath.equals(
             defaultUserHome.toUri().getPath() + "/" + TRASH_PREFIX)) {
           return makeQualified(new Path(res.resolvedPath,
               TRASH_PREFIX + "/" + ugi.getShortUserName()));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -25,8 +25,8 @@ import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_IGNORE_PORT_IN
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS_DEFAULT;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT;
 
 import java.util.function.Function;
 import java.io.FileNotFoundException;
@@ -1149,8 +1149,8 @@ public class ViewFileSystem extends FileSystem {
   @Override
   public Path getTrashRoot(Path path) {
     boolean trashRootUnderMountPointRoot =
-        config.getBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT,
-            CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT);
+        config.getBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT,
+            CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT);
 
     try {
       InodeTree.ResolveResult<FileSystem> res =
@@ -1220,8 +1220,8 @@ public class ViewFileSystem extends FileSystem {
     }
 
     boolean trashRootUnderMountPointRoot =
-        config.getBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT,
-            CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT_DEFAULT);
+        config.getBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT,
+            CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT);
     // Return trashRoots if CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is
     // disabled.
     if (!trashRootUnderMountPointRoot) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -25,8 +25,8 @@ import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_IGNORE_PORT_IN
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS_DEFAULT;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_VIEWFS_PATH_DEFAULT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT;
 
 import java.util.function.Function;
 import java.io.FileNotFoundException;
@@ -1149,9 +1149,9 @@ public class ViewFileSystem extends FileSystem {
    */
   @Override
   public Path getTrashRoot(Path path) {
-    boolean trashRootUnderMountPointRoot =
-        config.getBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH,
-            CONFIG_VIEWFS_TRASH_VIEWFS_PATH_DEFAULT);
+    boolean trashForceInsideMountPoint =
+        config.getBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT,
+            CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT);
 
     try {
       InodeTree.ResolveResult<FileSystem> res =
@@ -1162,7 +1162,7 @@ public class ViewFileSystem extends FileSystem {
       String targetFSTrashRootPath = targetFSTrashRoot.toUri().getPath();
       String mountTargetPath = res.targetFileSystem.getUri().getPath();
 
-      if (!trashRootUnderMountPointRoot) {
+      if (!trashForceInsideMountPoint) {
         return targetFSTrashRoot;
       }
 
@@ -1206,7 +1206,7 @@ public class ViewFileSystem extends FileSystem {
   /**
    * Get all the trash roots for current user or all users.
    *
-   * When TRASH_USE_VIEWFS_PATH is set to true, we also return trash roots
+   * When FORCE_INSIDE_MOUNT_POINT is set to true, we also return trash roots
    * under the root of each mount point, with their viewFS paths.
    *
    * @param allUsers return trash roots for all users if true.
@@ -1219,12 +1219,11 @@ public class ViewFileSystem extends FileSystem {
       trashRoots.addAll(fs.getTrashRoots(allUsers));
     }
 
-    boolean trashRootUnderMountPointRoot =
-        config.getBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH,
-            CONFIG_VIEWFS_TRASH_VIEWFS_PATH_DEFAULT);
-    // Return trashRoots if CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is
-    // disabled.
-    if (!trashRootUnderMountPointRoot) {
+    boolean trashForceInsideMountPoint =
+        config.getBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT,
+            CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT);
+    // Return trashRoots if FORCE_INSIDE_MOUNT_POINT is disabled.
+    if (!trashForceInsideMountPoint) {
       return trashRoots;
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1274,9 +1274,9 @@ public class ViewFileSystem extends FileSystem {
         } else {
           FileStatus[] mountPointTrashRoots = listStatus(trashRoot);
           for (FileStatus trash : mountPointTrashRoots) {
-            // Remove the mountPoint to get the targetFS path and use
+            // Remove the mountPoint to get the targetFsTrash path
             String targetFsTrash = trash.getPath().toUri().getPath()
-                .substring(mountPoint.src.length());
+                                        .substring(mountPoint.src.length());
 
             // Use getFileStatus to get the full path.
             // Do not use targetFS.makeQualified(new Path(targetFsTrash)).

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1177,9 +1177,9 @@ public class ViewFileSystem extends FileSystem {
             fsState.resolve(targetFSTrashRootPath, true);
         if (!ROOT_PATH.equals(new Path(res2.resolvedPath))) {
           LOG.warn(String.format("A mount point %s exists for trash root %s "
-              + "returned by fallback FS for path %s. Rename between %s and "
-                  + "trash root %s will fail, as the trash root is in a mount"
-                  + " point while %s is in the fallback FS",
+              + "returned by fallback FS for path %s. Rename between path %s "
+                  + "and trash root %s will fail, as the trash root is in a "
+                  + "mount point while path %s is in the fallback FS",
               res2.resolvedPath, targetFSTrashRootPath, path, path,
               targetFSTrashRootPath, path));
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1191,10 +1191,10 @@ public class ViewFileSystem extends FileSystem {
       }
 
       Path targetFsUserHome = res.targetFileSystem.getHomeDirectory();
-      if (targetFSTrashRootPath.startsWith(mountTargetPath) && !(
-          mountTargetPath.equals(ROOT_PATH.toString())
-              && !res.resolvedPath.equals(ROOT_PATH.toString()) && (
-              targetFsUserHome != null && targetFSTrashRootPath.startsWith(
+      if (targetFSTrashRootPath.startsWith(mountTargetPath) &&
+          !(mountTargetPath.equals(ROOT_PATH.toString()) &&
+              !res.resolvedPath.equals(ROOT_PATH.toString()) &&
+              (targetFsUserHome != null && targetFSTrashRootPath.startsWith(
                   targetFsUserHome.toUri().getPath())))) {
         String relativeTrashRoot =
             targetFSTrashRootPath.substring(mountTargetPath.length());

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1222,7 +1222,6 @@ public class ViewFileSystem extends FileSystem {
   public Collection<FileStatus> getTrashRoots(boolean allUsers) {
     // A map from targetFSPath -> FileStatus.
     // FileStatus can be from targetFS or viewFS.
-
     HashMap<Path, FileStatus> trashRoots = new HashMap<>();
     for (FileSystem fs : getChildFileSystems()) {
       for (FileStatus trash : fs.getTrashRoots(allUsers)) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1189,6 +1189,10 @@ public class ViewFileSystem extends FileSystem {
   /**
    * Get all the trash roots for current user or all users.
    *
+   * When CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is set to true, we
+   * also return trash roots under the root of each mount point, with their
+   * viewFS paths.
+   *
    * @param allUsers return trash roots for all users if true.
    * @return all Trash root directories.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1132,10 +1132,10 @@ public class ViewFileSystem extends FileSystem {
    * Get the trash root directory for current user when the path
    * specified is deleted.
    *
-   * If TRASH_USE_VIEWFS_PATH flag is not set, return the default trash root
+   * If FORCE_INSIDE_MOUNT_POINT flag is not set, return the default trash root
    * from targetFS.
    *
-   * When TRASH_USE_VIEWFS_PATH is set to true,
+   * When FORCE_INSIDE_MOUNT_POINT is set to true,
    * 1) If path p in fallback FS, return trash root from fallback FS. Print a
    *    warning if there is a mount point for the trash root.
    * 2) If the trash root for path p is in the same mount point as path p,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFileSystem.java
@@ -1143,14 +1143,14 @@ public class ViewFileSystem extends FileSystem {
    * Get the trash root directory for current user when the path
    * specified is deleted.
    *
-   * If CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH is not set, return
-   * a trash root based on the trash root returned by targetFS.
+   * If CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is not set, return
+   * the default trash root from targetFS.
    *
-   * When CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH is set to true,
+   * When CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is set to true,
    * 1) If path p is in a snapshot or encryption zone, or when it is in the
-   *    fallback FS, return a trash root based on the trash root returned
-   *    by targetFS (/mntpoint/trashRootInTargetFS).
-   * 2) else, return a trash root in the mount point (/mntpoint/.Trash/{user}).
+   *    fallback FS, return the default trash root from targetFS.
+   * 2) else, return a viewFS path for the trash root under the root of the
+   *    mount point (/mntpoint/.Trash/{user}).
    *
    * @param path the trash root of the path to be determined.
    * @return the trash root path.
@@ -1173,8 +1173,8 @@ public class ViewFileSystem extends FileSystem {
       }
 
       // New trash root policy
-      if (isSnapshotEnabledOrEncrypted(path) || ROOT_PATH.equals(
-          new Path(res.resolvedPath))) {
+      if (isSnapshotEnabledOrEncrypted(path) ||
+          ROOT_PATH.equals(new Path(res.resolvedPath))) {
         return targetFSTrashRoot;
       } else {
         // Return the trash root for the mount point.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemLocalFileSystem.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
+import org.apache.hadoop.security.UserGroupInformation;
 
 import org.junit.After;
 import org.junit.Before;
@@ -59,6 +61,13 @@ public class TestViewFileSystemLocalFileSystem extends ViewFileSystemBaseTest {
     fsTarget = FileSystem.getLocal(new Configuration());
     super.setUp();
     
+  }
+
+  @Override
+  Path getTrashRootInFallBackFS() throws IOException {
+    return new Path(
+        "/" + TRASH_PREFIX + "/" + UserGroupInformation.getCurrentUser()
+            .getShortUserName());
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemWithAuthorityLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemWithAuthorityLocalFileSystem.java
@@ -25,6 +25,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.fs.FsConstants;
 import org.apache.hadoop.fs.Path;
+import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
+import org.apache.hadoop.security.UserGroupInformation;
+import java.io.IOException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -63,6 +66,13 @@ public class TestViewFileSystemWithAuthorityLocalFileSystem extends ViewFileSyst
     super.tearDown();
   }
  
+  @Override
+  Path getTrashRootInFallBackFS() throws IOException {
+    return new Path(
+        "/" + TRASH_PREFIX + "/" + UserGroupInformation.getCurrentUser()
+            .getShortUserName());
+  }
+
   @Override
   @Test
   public void testBasicPaths() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1062,6 +1062,7 @@ abstract public class ViewFileSystemBaseTest {
     assertEquals(mountDataRootTrashPath.toUri().getPath(),
         mountDataFileTrashPath.toUri().getPath());
 
+
     // Verify trash root for an non-existing file but on a valid mountpoint.
     Path trashRoot = fsView.getTrashRoot(mountDataNonExistingFilePath);
     assertEquals(mountDataRootTrashPath.toUri().getPath(),

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1118,8 +1118,8 @@ abstract public class ViewFileSystemBaseTest {
     // Case 1: path p in the /data mount point.
     // Return a trash root within the mount point.
     Path dataTestPath = new Path("/data/dir/file");
-    Path dataTrashRoot =
-        new Path("/data/" + TRASH_PREFIX + "/" + ugi.getShortUserName());
+    Path dataTrashRoot = fsView2.makeQualified(
+        new Path("/data/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
     Assert.assertEquals(dataTrashRoot, fsView2.getTrashRoot(dataTestPath));
 
     // Case 2: path p not found in mount table, fall back to the default FS
@@ -1127,7 +1127,8 @@ abstract public class ViewFileSystemBaseTest {
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
     Path userHomeTrashRoot =
         new Path(fsTarget.getHomeDirectory().toUri().getPath(), TRASH_PREFIX);
-    Assert.assertEquals(userHomeTrashRoot,
+    Path viewFSUserHomeTrashRoot = fsView2.makeQualified(userHomeTrashRoot);
+    Assert.assertEquals(viewFSUserHomeTrashRoot,
         fsView2.getTrashRoot(nonExistentPath));
 
     // Case 3: turn off the CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT flag.
@@ -1174,8 +1175,8 @@ abstract public class ViewFileSystemBaseTest {
         URI.create("mocktrashfs://localhost/vol"));
     Path testPath = new Path("/mnt/datavol1/projs/proj");
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
-    Path expectedTrash =
-        new Path("/mnt/datavol1/very/deep/deep/trash/dir/.Trash");
+    Path expectedTrash = fsView2.makeQualified(
+        new Path("/mnt/datavol1/very/deep/deep/trash/dir/.Trash"));
     Assert.assertEquals(expectedTrash, fsView2.getTrashRoot(testPath));
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1116,18 +1116,18 @@ abstract public class ViewFileSystemBaseTest {
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     // Case 1: path p in the /data mount point.
-    // Return a trash root within the mount point.
+    // Return a trash root within the /data mount point.
     Path dataTestPath = new Path("/data/dir/file");
     Path dataTrashRoot = fsView2.makeQualified(
         new Path("/data/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
     Assert.assertEquals(dataTrashRoot, fsView2.getTrashRoot(dataTestPath));
 
     // Case 2: path p not found in mount table, fall back to the default FS
-    // Return a trash root in user home dir
+    // Return a trash root in mount point "/"
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
-    Path userHomeTrashRoot =
-        new Path(fsTarget.getHomeDirectory().toUri().getPath(), TRASH_PREFIX);
-    Path viewFSUserHomeTrashRoot = fsView2.makeQualified(userHomeTrashRoot);
+    Path rootTrashRoot = fsView2.makeQualified(
+        new Path("/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
+    Path viewFSUserHomeTrashRoot = fsView2.makeQualified(rootTrashRoot);
     Assert.assertEquals(viewFSUserHomeTrashRoot,
         fsView2.getTrashRoot(nonExistentPath));
 
@@ -1135,7 +1135,8 @@ abstract public class ViewFileSystemBaseTest {
     // Return a trash root in user home dir.
     conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
-    Path targetFSUserHomeTrashRoot = fsTarget.makeQualified(userHomeTrashRoot);
+    Path targetFSUserHomeTrashRoot = fsTarget.makeQualified(
+        new Path(fsTarget.getHomeDirectory(), TRASH_PREFIX));
     Assert.assertEquals(targetFSUserHomeTrashRoot,
         fsView2.getTrashRoot(dataTestPath));
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 
 import org.junit.After;
@@ -1105,13 +1105,13 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
-   * Test trash root at the root of mount points
+   * Test TRASH_USE_VIEWFS_PATH feature for getTrashRoot
    */
   @Test
   public void testTrashRootRootOfMountPoint() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
     ConfigUtil.addLinkFallback(conf2, targetTestRoot.toUri());
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
@@ -1130,9 +1130,9 @@ abstract public class ViewFileSystemBaseTest {
     Assert.assertEquals(userHomeTrashRoot,
         fsView2.getTrashRoot(nonExistentPath));
 
-    // Case 3: turn off the CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH flag.
+    // Case 3: turn off the CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH flag.
     // Return a trash root in user home dir.
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, false);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
     Path targetFSUserHomeTrashRoot = fsTarget.makeQualified(userHomeTrashRoot);
     Assert.assertEquals(targetFSUserHomeTrashRoot,
@@ -1167,7 +1167,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testTrashRootDeepTrashDir() throws IOException {
 
     Configuration conf2 = ViewFileSystemTestSetup.createConfig();
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
     conf2.setClass("fs.mocktrashfs.impl", DeepTrashRootMockFS.class,
         FileSystem.class);
     ConfigUtil.addLink(conf2, "/mnt/datavol1",
@@ -1185,7 +1185,7 @@ abstract public class ViewFileSystemBaseTest {
   @Test
   public void testTrashRootsAllUsers() throws IOException {
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     // Case 1: verify correct trash roots from fsView and fsView2
@@ -1231,7 +1231,7 @@ abstract public class ViewFileSystemBaseTest {
     String currentUser =
         UserGroupInformation.getCurrentUser().getShortUserName();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     int beforeTrashRootNum = fsView.getTrashRoots(false).size();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1161,7 +1161,7 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
-   * Test a trash root that is inside a mount point for getTrashRoot
+   * Test getTrashRoot that is very deep inside a mount point.
    */
   @Test
   public void testTrashRootDeepTrashDir() throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 
 import org.junit.After;
@@ -1105,13 +1105,13 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
-   * Test TRASH_USE_VIEWFS_PATH feature for getTrashRoot
+   * Test TRASH_FORCE_INSIDE_MOUNT_POINT feature for getTrashRoot
    */
   @Test
   public void testTrashRootRootOfMountPoint() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     ConfigUtil.addLinkFallback(conf2, targetTestRoot.toUri());
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
@@ -1130,9 +1130,9 @@ abstract public class ViewFileSystemBaseTest {
     Assert.assertEquals(userHomeTrashRoot,
         fsView2.getTrashRoot(nonExistentPath));
 
-    // Case 3: turn off the CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH flag.
+    // Case 3: turn off the CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT flag.
     // Return a trash root in user home dir.
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, false);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
     Path targetFSUserHomeTrashRoot = fsTarget.makeQualified(userHomeTrashRoot);
     Assert.assertEquals(targetFSUserHomeTrashRoot,
@@ -1167,7 +1167,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testTrashRootDeepTrashDir() throws IOException {
 
     Configuration conf2 = ViewFileSystemTestSetup.createConfig();
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     conf2.setClass("fs.mocktrashfs.impl", DeepTrashRootMockFS.class,
         FileSystem.class);
     ConfigUtil.addLink(conf2, "/mnt/datavol1",
@@ -1185,7 +1185,7 @@ abstract public class ViewFileSystemBaseTest {
   @Test
   public void testTrashRootsAllUsers() throws IOException {
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     // Case 1: verify correct trash roots from fsView and fsView2
@@ -1231,7 +1231,7 @@ abstract public class ViewFileSystemBaseTest {
     String currentUser =
         UserGroupInformation.getCurrentUser().getShortUserName();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_USE_VIEWFS_PATH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     int beforeTrashRootNum = fsView.getTrashRoots(false).size();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1129,12 +1129,11 @@ abstract public class ViewFileSystemBaseTest {
         new Path("/data/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
     Assert.assertEquals(dataTrashRoot, fsView2.getTrashRoot(dataTestPath));
 
-    // Case 2: path p not found in mount table, fall back to the default FS
-    // Return a trash root in mount point "/"
+    // Case 2: path p not found in mount table.
+    // Return a trash root in fallback FS.
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
     Path expectedTrash =
         fsView2.makeQualified(getTrashRootInFallBackFS());
-
     Assert.assertEquals(expectedTrash, fsView2.getTrashRoot(nonExistentPath));
 
     // Case 3: turn off the CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT flag.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1108,7 +1108,7 @@ abstract public class ViewFileSystemBaseTest {
    * Test TRASH_FORCE_INSIDE_MOUNT_POINT feature for getTrashRoot
    */
   @Test
-  public void testTrashRootRootOfMountPoint() throws IOException {
+  public void testTrashRootForceInsideMountPoint() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     Configuration conf2 = new Configuration(conf);
     conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1228,6 +1228,16 @@ abstract public class ViewFileSystemBaseTest {
     FileSystem fsView4 = FileSystem.get(FsConstants.VIEWFS_URI, conf4);
     int trashRootsNum4 = fsView4.getTrashRoots(true).size();
     Assert.assertEquals(afterTrashRootsNum2 + 2, trashRootsNum4);
+
+    // Case 4: test trash roots in fallback FS
+    fsTarget.mkdirs(new Path(targetTestRoot, ".Trash/user10"));
+    fsTarget.mkdirs(new Path(targetTestRoot, ".Trash/user11"));
+    fsTarget.mkdirs(new Path(targetTestRoot, ".Trash/user12"));
+    Configuration conf5 = new Configuration(conf2);
+    ConfigUtil.addLinkFallback(conf5, targetTestRoot.toUri());
+    FileSystem fsView5 = FileSystem.get(FsConstants.VIEWFS_URI, conf5);
+    int trashRootsNum5 = fsView5.getTrashRoots(true).size();
+    Assert.assertEquals(afterTrashRootsNum2 + 3, trashRootsNum5);
   }
 
   /**
@@ -1254,6 +1264,14 @@ abstract public class ViewFileSystemBaseTest {
     int afterTrashRootsNum2 = fsView2.getTrashRoots(false).size();
     Assert.assertEquals(beforeTrashRootNum, afterTrashRootsNum);
     Assert.assertEquals(beforeTrashRootNum2 + 2, afterTrashRootsNum2);
+
+    // Test trash roots in fallback FS
+    Configuration conf3 = new Configuration(conf2);
+    fsTarget.mkdirs(new Path(targetTestRoot, TRASH_PREFIX + "/" + currentUser));
+    ConfigUtil.addLinkFallback(conf3, targetTestRoot.toUri());
+    FileSystem fsView3 = FileSystem.get(FsConstants.VIEWFS_URI, conf3);
+    int trashRootsNum3 = fsView3.getTrashRoots(false).size();
+    Assert.assertEquals(afterTrashRootsNum2 + 1, trashRootsNum3);
   }
 
   @Test(expected = NotInMountpointException.class)

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1056,12 +1056,11 @@ abstract public class ViewFileSystemBaseTest {
     // Verify if Trash roots from ViewFileSystem matches that of the ones
     // from the target mounted FileSystem.
     assertEquals(mountDataRootTrashPath.toUri().getPath(),
-        "/data" + fsTargetRootTrashRoot.toUri().getPath());
+        fsTargetRootTrashRoot.toUri().getPath());
     assertEquals(mountDataFileTrashPath.toUri().getPath(),
-        "/data" + fsTargetFileTrashPath.toUri().getPath());
+        fsTargetFileTrashPath.toUri().getPath());
     assertEquals(mountDataRootTrashPath.toUri().getPath(),
         mountDataFileTrashPath.toUri().getPath());
-
 
     // Verify trash root for an non-existing file but on a valid mountpoint.
     Path trashRoot = fsView.getTrashRoot(mountDataNonExistingFilePath);
@@ -1125,18 +1124,16 @@ abstract public class ViewFileSystemBaseTest {
     // Case 2: path p not found in mount table, fall back to the default FS
     // Return a trash root in user home dir
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
-    Path userTrashRoot =
-        new Path(fsTarget.getHomeDirectory().toUri().getPath(), TRASH_PREFIX);
-    Assert.assertEquals(userTrashRoot, fsView2.getTrashRoot(nonExistentPath));
+    Path targetFsTrashRoot = fsTarget.makeQualified(
+        new Path(fsTarget.getHomeDirectory().toUri().getPath(), TRASH_PREFIX));
+    Assert.assertEquals(targetFsTrashRoot,
+        fsView2.getTrashRoot(nonExistentPath));
 
     // Case 3: turn off the CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH flag.
-    // Return a trash root in user home dir in the mount point.
+    // Return a trash root in user home dir.
     conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
-    Path dataUserTrashRoot = new Path(
-        "/data" + fsTarget.getHomeDirectory().toUri().getPath() + "/"
-            + TRASH_PREFIX);
-    Assert.assertEquals(dataUserTrashRoot, fsView2.getTrashRoot(dataTestPath));
+    Assert.assertEquals(targetFsTrashRoot, fsView2.getTrashRoot(dataTestPath));
 
     // Case 4: viewFS without fallback. Expect exception for a nonExistent path
     conf2 = new Configuration(conf);
@@ -1181,8 +1178,7 @@ abstract public class ViewFileSystemBaseTest {
     ConfigUtil.addLink(conf2, "/mnt", URI.create("mocktrashfs://mnt/path"));
     Path testPath = new Path("/mnt/projs/proj");
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
-    Assert.assertEquals("/mnt" + MockTrashRootFS.TRASH,
-        fsView2.getTrashRoot(testPath).toUri().getPath());
+    Assert.assertEquals(MockTrashRootFS.TRASH, fsView2.getTrashRoot(testPath));
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1105,7 +1105,7 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
-   * Test TRASH_FORCE_INSIDE_MOUNT_POINT feature for getTrashRoot
+   * Test TRASH_FORCE_INSIDE_MOUNT_POINT feature for getTrashRoot.
    */
   @Test
   public void testTrashRootForceInsideMountPoint() throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 
 import org.junit.After;
@@ -1111,7 +1111,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testTrashRootRootOfMountPoint() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
     ConfigUtil.addLinkFallback(conf2, targetTestRoot.toUri());
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
@@ -1131,7 +1131,7 @@ abstract public class ViewFileSystemBaseTest {
 
     // Case 3: turn off the CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH flag.
     // Return a trash root in user home dir in the mount point.
-    conf2.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, false);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
     Path dataUserTrashRoot = new Path(
         "/data" + fsTarget.getHomeDirectory().toUri().getPath() + "/"
@@ -1175,7 +1175,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testTrashRootEncryptedTrashDir() throws IOException {
 
     Configuration conf2 = ViewFileSystemTestSetup.createConfig();
-    conf2.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
     conf2.setClass("fs.mocktrashfs.impl", MockTrashRootFS.class,
         FileSystem.class);
     ConfigUtil.addLink(conf2, "/mnt", URI.create("mocktrashfs://mnt/path"));
@@ -1191,7 +1191,7 @@ abstract public class ViewFileSystemBaseTest {
   @Test
   public void testTrashRootsAllUsers() throws IOException {
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     // Case 1: verify correct trash roots from fsView and fsView2
@@ -1237,7 +1237,7 @@ abstract public class ViewFileSystemBaseTest {
     String currentUser =
         UserGroupInformation.getCurrentUser().getShortUserName();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     int beforeTrashRootNum = fsView.getTrashRoots(false).size();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_ENABLE_INNER_CACHE;
 import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
-import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT;
+import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 
 import org.junit.After;
@@ -1111,7 +1111,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testTrashRootRootOfMountPoint() throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     ConfigUtil.addLinkFallback(conf2, targetTestRoot.toUri());
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
@@ -1132,7 +1132,7 @@ abstract public class ViewFileSystemBaseTest {
 
     // Case 3: turn off the CONFIG_VIEWFS_MOUNT_POINT_LOCAL_TRASH flag.
     // Return a trash root in user home dir.
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, false);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, false);
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
     Path targetFSUserHomeTrashRoot = fsTarget.makeQualified(userHomeTrashRoot);
     Assert.assertEquals(targetFSUserHomeTrashRoot,
@@ -1150,7 +1150,7 @@ abstract public class ViewFileSystemBaseTest {
   /**
    * A mocked FileSystem which returns a deep trash dir.
    */
-  static class MockTrashRootFS extends MockFileSystem {
+  static class DeepTrashRootMockFS extends MockFileSystem {
     public static final Path TRASH =
         new Path("/vol/very/deep/deep/trash/dir/.Trash");
 
@@ -1167,8 +1167,8 @@ abstract public class ViewFileSystemBaseTest {
   public void testTrashRootDeepTrashDir() throws IOException {
 
     Configuration conf2 = ViewFileSystemTestSetup.createConfig();
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
-    conf2.setClass("fs.mocktrashfs.impl", MockTrashRootFS.class,
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
+    conf2.setClass("fs.mocktrashfs.impl", DeepTrashRootMockFS.class,
         FileSystem.class);
     ConfigUtil.addLink(conf2, "/mnt/datavol1",
         URI.create("mocktrashfs://localhost/vol"));
@@ -1185,7 +1185,7 @@ abstract public class ViewFileSystemBaseTest {
   @Test
   public void testTrashRootsAllUsers() throws IOException {
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     // Case 1: verify correct trash roots from fsView and fsView2
@@ -1231,7 +1231,7 @@ abstract public class ViewFileSystemBaseTest {
     String currentUser =
         UserGroupInformation.getCurrentUser().getShortUserName();
     Configuration conf2 = new Configuration(conf);
-    conf2.setBoolean(CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT, true);
+    conf2.setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
 
     int beforeTrashRootNum = fsView.getTrashRoots(false).size();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1104,9 +1104,13 @@ abstract public class ViewFileSystemBaseTest {
     Assert.assertTrue("", fsView.getTrashRoots(true).size() > 0);
   }
 
-  private String getTrashRootForPathInFallBackFS() {
-    return fsTarget.getHomeDirectory().toUri().getPath() + "/" + TRASH_PREFIX;
+  // Default implementation of getTrashRoot for a fallback FS mounted at root:
+  // e.g., fallbackFS.uri.getPath = '/'
+  Path getTrashRootInFallBackFS() throws IOException {
+    return new Path(fsTarget.getHomeDirectory().toUri().getPath(),
+        TRASH_PREFIX);
   }
+
   /**
    * Test TRASH_FORCE_INSIDE_MOUNT_POINT feature for getTrashRoot.
    */
@@ -1128,15 +1132,8 @@ abstract public class ViewFileSystemBaseTest {
     // Case 2: path p not found in mount table, fall back to the default FS
     // Return a trash root in mount point "/"
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
-    Path expectedTrash;
-    if (targetTestRoot.toUri().getPath().equals("/")) {
-      expectedTrash =
-          fsView2.makeQualified(new Path(fsTarget.getHomeDirectory().toUri().getPath(),
-              TRASH_PREFIX));
-    } else {
-      expectedTrash =
-          fsView2.makeQualified(new Path("/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
-    }
+    Path expectedTrash =
+        fsView2.makeQualified(getTrashRootInFallBackFS());
 
     Assert.assertEquals(expectedTrash, fsView2.getTrashRoot(nonExistentPath));
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1104,6 +1104,9 @@ abstract public class ViewFileSystemBaseTest {
     Assert.assertTrue("", fsView.getTrashRoots(true).size() > 0);
   }
 
+  private String getTrashRootForPathInFallBackFS() {
+    return fsTarget.getHomeDirectory().toUri().getPath() + "/" + TRASH_PREFIX;
+  }
   /**
    * Test TRASH_FORCE_INSIDE_MOUNT_POINT feature for getTrashRoot.
    */
@@ -1125,11 +1128,17 @@ abstract public class ViewFileSystemBaseTest {
     // Case 2: path p not found in mount table, fall back to the default FS
     // Return a trash root in mount point "/"
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
-    Path rootTrashRoot = fsView2.makeQualified(
-        new Path("/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
-    Path viewFSUserHomeTrashRoot = fsView2.makeQualified(rootTrashRoot);
-    Assert.assertEquals(viewFSUserHomeTrashRoot,
-        fsView2.getTrashRoot(nonExistentPath));
+    Path expectedTrash;
+    if (targetTestRoot.toUri().getPath().equals("/")) {
+      expectedTrash =
+          fsView2.makeQualified(new Path(fsTarget.getHomeDirectory().toUri().getPath(),
+              TRASH_PREFIX));
+    } else {
+      expectedTrash =
+          fsView2.makeQualified(new Path("/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
+    }
+
+    Assert.assertEquals(expectedTrash, fsView2.getTrashRoot(nonExistentPath));
 
     // Case 3: turn off the CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT flag.
     // Return a trash root in user home dir.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -1183,7 +1183,7 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
-   * Test localized trash roots in getTrashRoots() for all users.
+   * Test getTrashRoots() for all users.
    */
   @Test
   public void testTrashRootsAllUsers() throws IOException {
@@ -1227,7 +1227,7 @@ abstract public class ViewFileSystemBaseTest {
   }
 
   /**
-   * Test localized trash roots in getTrashRoots() for current user.
+   * Test getTrashRoots() for current user.
    */
   @Test
   public void testTrashRootsCurrentUser() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemHdfs.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
+import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -179,6 +180,13 @@ public class TestViewFileSystemHdfs extends ViewFileSystemBaseTest {
   @Override
   int getExpectedDelegationTokenCountWithCredentials() {
     return 2;
+  }
+
+  @Override
+  Path getTrashRootInFallBackFS() throws IOException {
+    return new Path(
+        "/" + TRASH_PREFIX + "/" + UserGroupInformation.getCurrentUser()
+            .getShortUserName());
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Modified getTrashRoot/s to return viewFS path for the new trash location. 

 If CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is not set, return the default trash root (a targetFS path) from targetFS.
  
When CONFIG_VIEWFS_TRASH_ROOT_UNDER_MOUNT_POINT_ROOT is set to true,
   1) If path p is in a snapshot or encryption zone, or when it is in the
       fallback FS, return the default trash root (a targetFS path) from targetFS.
  2) else, return a viewFS path for the trash root under the root of the
       mount point (/mntpoint/.Trash/{user}).

### How was this patch tested?

Run unit tests manually from intellij. 



