### PR TITLE
HDFS-16458. [SPS]: Fix bug for unit test of reconfiguring SPS mode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeReconfigure.java
@@ -307,6 +307,8 @@ public class TestNameNodeReconfigure {
         StoragePolicySatisfierMode.EXTERNAL.toString(),
         nameNode.getConf().get(DFS_STORAGE_POLICY_SATISFIER_MODE_KEY,
             DFS_STORAGE_POLICY_SATISFIER_MODE_DEFAULT));
+    assertNotNull("SPS Manager should be created",
+        nameNode.getNamesystem().getBlockManager().getSPSManager());
   }
 
   /**
@@ -322,6 +324,8 @@ public class TestNameNodeReconfigure {
         StoragePolicySatisfierMode.NONE.toString());
     verifySPSEnabled(nameNode, DFS_STORAGE_POLICY_SATISFIER_MODE_KEY,
         StoragePolicySatisfierMode.NONE, false);
+    assertNull("SPS Manager should be null",
+        nameNode.getNamesystem().getBlockManager().getSPSManager());
 
     Path filePath = new Path("/testSPS");
     DistributedFileSystem fileSystem = cluster.getFileSystem();
@@ -345,7 +349,7 @@ public class TestNameNodeReconfigure {
             .getNamesystem().getBlockManager().getSPSManager();
     boolean isSPSRunning = spsMgr != null ? spsMgr.isSatisfierRunning()
         : false;
-    assertEquals(property + " has wrong value", isSPSRunning, isSPSRunning);
+    assertEquals(property + " has wrong value", isSatisfierRunning, isSPSRunning);
     String actual = nameNode.getConf().get(property,
         DFS_STORAGE_POLICY_SATISFIER_MODE_DEFAULT);
     assertEquals(property + " has wrong value", expected,


### PR DESCRIPTION
JIRA: [HDFS-16458](https://issues.apache.org/jira/browse/HDFS-16458).

**_I resubmitted a PR, because the previous PR [#3998](https://github.com/apache/hadoop/pull/3998) forgot to set the `issue ID`._**

TestNameNodeReconfigure#verifySPSEnabled was compared with itself(`isSPSRunning`) at assertEquals.

In addition, after an `internal SPS `has been removed, `spsService daemon` will not start within StoragePolicySatisfyManager. I think the relevant code can be removed to simplify the code.

IMO, after reconfig SPS mode, we just need to confirm whether the mode is correct and whether spsManager is NULL.