### PR TITLE
HADOOP-18149 Allow S3 and other potential fs implementations to bypass verifyAndDownload IO Exception

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1363,6 +1363,10 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_LOCAL_DIRS = NM_PREFIX + "local-dirs";
   public static final String DEFAULT_NM_LOCAL_DIRS = "/tmp/nm-local-dir";
 
+  /**Should modification time be used to verify localized files.*/
+  public static final String NM_DL_VERIFICATION_DISABLED = NM_PREFIX + "download.verification.disabled";
+  public static final boolean DEFAULT_NM_DL_VERIFICATION_DISABLED = false;
+
   /**
    * Number of files in each localized directories
    * Avoid tuning this too low. 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1355,6 +1355,14 @@
   </property>
 
   <property>
+    <description>Whether or not to ignore distributed file modification time for verification
+      before downloading.
+    </description>
+    <name>yarn.nodemanager.download.verification.disabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
     <description>It limits the maximum number of files which will be localized
       in a single local directory. If the limit is reached then sub-directories
       will be created and new files will be localized in them. If it is set to


### PR DESCRIPTION
… time behaviors that would cause verifyAndCopy to throw an IO exception

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

