### PR TITLE
HADOOP-18150. Fix ITestAuditManagerDisabled test in S3A.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/ITestAuditManagerDisabled.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/ITestAuditManagerDisabled.java
@@ -28,9 +28,10 @@ import org.apache.hadoop.fs.s3a.performance.AbstractS3ACostTest;
 
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.NOOP_SPAN;
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.resetAuditOptions;
+import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_ENABLED;
 
 /**
- * Verify that by default audit managers are disabled.
+ * Verify that audit managers are disabled if set to false.
  */
 public class ITestAuditManagerDisabled extends AbstractS3ACostTest {
 
@@ -42,11 +43,12 @@ public class ITestAuditManagerDisabled extends AbstractS3ACostTest {
   public Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     resetAuditOptions(conf);
+    conf.set(AUDIT_ENABLED, "false");
     return conf;
   }
 
   /**
-   * The default auditor is the no-op auditor.
+   * Verify that the auditor is the no-op auditor if auditing is disabled.
    */
   @Test
   public void testAuditorDisabled() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/ITestAuditManagerDisabled.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/ITestAuditManagerDisabled.java
@@ -43,7 +43,7 @@ public class ITestAuditManagerDisabled extends AbstractS3ACostTest {
   public Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     resetAuditOptions(conf);
-    conf.set(AUDIT_ENABLED, "false");
+    conf.setBoolean(AUDIT_ENABLED, false);
     return conf;
   }
 


### PR DESCRIPTION
### Description of PR

Fix ITestAuditManagerDisabled test which verifies that auditing is disabled by default. In [HADOOP-18091](https://issues.apache.org/jira/browse/HADOOP-18091) we made it enabled by default.

### How was this patch tested?
Region: ap-south-1.
Command: `mvn clean verify -Dparallel-tests -DtestsThreadCount=4 -Dscale`

```
[INFO] Running org.apache.hadoop.fs.s3a.audit.ITestAuditManagerDisabled
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.275 s - in org.apache.hadoop.fs.s3a.audit.ITestAuditManagerDisabled
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

