### PR TITLE
HDFS-16494.Removed reuse of AvailableSpaceVolumeChoosingPolicy#initLocks().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/AvailableSpaceVolumeChoosingPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/AvailableSpaceVolumeChoosingPolicy.java
@@ -63,7 +63,6 @@ public class AvailableSpaceVolumeChoosingPolicy<V extends FsVolumeSpi>
 
   public AvailableSpaceVolumeChoosingPolicy() {
     this(new Random());
-    initLocks();
   }
 
   private void initLocks() {


### PR DESCRIPTION

### Description of PR
When using the default constructor to build the AvailableSpaceVolumeChoosingPolicy, initLocks() is used twice, which is actually unnecessary, the purpose of this pr is to avoid this from happening.
Details: HDFS-16494

### How was this patch tested?
Not too stressful for testing. Because this class is relatively mature.
