### PR TITLE
Hadoop 18154 branch 2.10.1

### DIFF
--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -417,6 +417,8 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-bundle</artifactId>
+      <!-- AWS WebIdentityTokenProvider class name changed since 1.11 -->
+      <version>1.12.167</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -36,10 +36,8 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
 
     public OIDCTokenCredentialsProvider(Configuration conf) {
         try {
-            LOG.info("conf {}", conf.toString());
             Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
                     conf, S3AFileSystem.class);
-            LOG.info("c {}", c.toString());
             this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
             this.roleARN = S3AUtils.lookupPassword(c, ROLE_ARN, null);
             this.sessionName = S3AUtils.lookupPassword(c, SESSION_NAME, null);
@@ -55,7 +53,7 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
                     lookupIOE);
         }
 
-        LOG.info("jwtPath {} roleARN {}", jwtPath, roleARN);
+        LOG.debug("jwtPath {} roleARN {}", jwtPath, roleARN);
 
         if (!StringUtils.isEmpty(jwtPath) && !StringUtils.isEmpty(roleARN)) {
             final AWSCredentialsProvider credentialsProvider =
@@ -64,9 +62,9 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
                     .roleArn(roleARN)
                     .roleSessionName(sessionName)
                     .build();
-            credentialsProvider.getCredentials();
+            return credentialsProvider.getCredentials();
         }
-        throw new CredentialInitializationException(
+        else throw new CredentialInitializationException(
                 "OIDC token path or role ARN is null");
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -1,0 +1,80 @@
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.commons.lang.StringUtils;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.ProviderUtils;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * WebIdentityTokenCredentialsProvider supports static configuration
+ * of OIDC token path, role ARN and role session name.
+ *
+ */
+//@InterfaceAudience.Public
+//@InterfaceStability.Stable
+public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
+    public static final String NAME
+            = "org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider";
+
+    //usually from import static org.apache.hadoop.fs.s3a.Constants.*;
+    public static final String JWT_PATH = "fs.s3a.jwt.path";
+    public static final String ROLE_ARN = "fs.s3a.role.arn";
+    public static final String SESSION_NAME = "fs.s3a.session.name";
+
+    /** Reuse the S3AFileSystem log. */
+    private static final Logger LOG = S3AFileSystem.LOG;
+
+    private String jwtPath;
+    private String roleARN;
+    private String sessionName;
+    private IOException lookupIOE;
+
+    public OIDCTokenCredentialsProvider(Configuration conf) {
+        try {
+            LOG.info("conf {}", conf.toString());
+            Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
+                    conf, S3AFileSystem.class);
+            LOG.info("c {}", c.toString());
+            this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
+            this.roleARN = S3AUtils.lookupPassword(c, ROLE_ARN, null);
+            this.sessionName = S3AUtils.lookupPassword(c, SESSION_NAME, null);
+        } catch (IOException e) {
+            lookupIOE = e;
+        }
+    }
+
+    public AWSCredentials getCredentials() {
+        if (lookupIOE != null) {
+            // propagate any initialization problem
+            throw new CredentialInitializationException(lookupIOE.toString(),
+                    lookupIOE);
+        }
+
+        LOG.info("jwtPath {} roleARN {}", jwtPath, roleARN);
+
+        if (!StringUtils.isEmpty(jwtPath) && !StringUtils.isEmpty(roleARN)) {
+            final AWSCredentialsProvider credentialsProvider =
+                WebIdentityTokenCredentialsProvider.builder()
+                    .webIdentityTokenFile(jwtPath)
+                    .roleArn(roleARN)
+                    .roleSessionName(sessionName)
+                    .build();
+            credentialsProvider.getCredentials();
+        }
+        throw new CredentialInitializationException(
+                "OIDC token path or role ARN is null");
+    }
+
+    public void refresh() {}
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}


### PR DESCRIPTION
### Description of PR
The PR addresses a requirement to comply with AWS security concept [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) while operating [Delta sharing](https://github.com/delta-io/delta-sharing) in Amazon Elastic Kubernetes Service (EKS).
The code change consists in adding a new credentials provider class `org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider` to the module [hadoop-aws](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) in [Hadoop release 2.10.1](https://github.com/apache/hadoop/tree/rel/release-2.10.1). In addition, the dependency aws-java-sdk-bundle-1.11.271 was upgraded to its latest version 1.12.167 as [AWS WebIdentityTokenCredentialsProvider class](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.html%E2%80%A6) was not yet available in original version.

### How was this patch tested?
No new unit-test or integration-test was created on-purpose. The patch was "only" tested as part of our specific use-case, using Delta sharing server 0.4.0 with the following Hadoop configuration (core-site.xml):
```
<?xml version="1.0"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
<configuration>
  <property>
    <name>fs.s3a.aws.credentials.provider</name>
    <value>org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider</value>
  </property>
  <property>
    <name>fs.s3a.jwt.path</name>
    <value>/var/run/secrets/eks.amazonaws.com/serviceaccount/token</value>
  </property>
  <property>
    <name>fs.s3a.role.arn</name>
    <value>my_iam_role_arn</value>
  </property>
  <property>
    <name>fs.s3a.session.name</name>
    <value>my_iam_session_name</value>
  </property>
  <property>
      <name>fs.s3a.server-side-encryption-algorithm</name>
      <value>SSE-KMS</value>
  </property>
  <property>
      <name>fs.s3a.server-side-encryption.key</name>
      <value>my_kms_key_id</value>
  </property>      
</configuration>
```

### For code changes:
- [X] The title or this PR starts with the corresponding JIRA issue 'HADOOP-18154'
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] No new dependency was added to the code, however one dependency was upgraded.