### PR TITLE
HADOOP-18155. Refactor tests in TestFileUtil

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -993,7 +993,7 @@ public class FileUtil {
           + " would create entry outside of " + outputDir);
     }
 
-    if (Shell.WINDOWS && (entry.isSymbolicLink() || entry.isLink())) {
+    if (entry.isSymbolicLink() || entry.isLink()) {
       String canonicalTargetPath = getCanonicalPath(entry.getLinkName(), outputDir);
       if (!canonicalTargetPath.startsWith(targetDirPath)) {
         throw new IOException(

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -39,6 +39,7 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -992,6 +993,14 @@ public class FileUtil {
           + " would create entry outside of " + outputDir);
     }
 
+    if (Shell.WINDOWS && (entry.isSymbolicLink() || entry.isLink())) {
+      String canonicalTargetPath = getCanonicalPath(entry.getLinkName(), outputDir);
+      if (!canonicalTargetPath.startsWith(targetDirPath)) {
+        throw new IOException(
+            "expanding " + entry.getName() + " would create entry outside of " + outputDir);
+      }
+    }
+
     if (entry.isDirectory()) {
       File subDir = new File(outputDir, entry.getName());
       if (!subDir.mkdirs() && !subDir.isDirectory()) {
@@ -1007,10 +1016,12 @@ public class FileUtil {
     }
 
     if (entry.isSymbolicLink()) {
-      // Create symbolic link relative to tar parent dir
-      Files.createSymbolicLink(FileSystems.getDefault()
-              .getPath(outputDir.getPath(), entry.getName()),
-          FileSystems.getDefault().getPath(entry.getLinkName()));
+      // Create symlink with canonical target path to ensure that we don't extract
+      // outside targetDirPath
+      String canonicalTargetPath = getCanonicalPath(entry.getLinkName(), outputDir);
+      Files.createSymbolicLink(
+          FileSystems.getDefault().getPath(outputDir.getPath(), entry.getName()),
+          FileSystems.getDefault().getPath(canonicalTargetPath));
       return;
     }
 
@@ -1022,12 +1033,27 @@ public class FileUtil {
     }
 
     if (entry.isLink()) {
-      File src = new File(outputDir, entry.getLinkName());
+      String canonicalTargetPath = getCanonicalPath(entry.getLinkName(), outputDir);
+      File src = new File(canonicalTargetPath);
       HardLink.createHardLink(src, outputFile);
       return;
     }
 
     org.apache.commons.io.FileUtils.copyToFile(tis, outputFile);
+  }
+
+  /**
+   * Gets the canonical path for the given path.
+   *
+   * @param path      The path for which the canonical path needs to be computed.
+   * @param parentDir The parent directory to use if the path is a relative path.
+   * @return The canonical path of the given path.
+   */
+  private static String getCanonicalPath(String path, File parentDir) throws IOException {
+    java.nio.file.Path targetPath = Paths.get(path);
+    return (targetPath.isAbsolute() ?
+        new File(path) :
+        new File(parentDir, path)).getCanonicalPath();
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -558,7 +558,7 @@ public class TestFileUtil {
       return file;
     }
   }
-  
+
   /**
    * Extend {@link File}. Same as {@link File} except for two things: (1) This
    * treats file1Name as a very special file which is not delete-able

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -1401,6 +1401,8 @@ public class TestFileUtil {
 
     File rootDir = new File("tmp");
     try (TarArchiveOutputStream tos = new TarArchiveOutputStream(os)) {
+      tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+
       // Create arbitrary dir
       File arbitraryDir = new File(rootDir, "arbitrary-dir/");
       assertTrue(arbitraryDir.mkdirs());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -62,6 +62,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarOutputStream;
@@ -607,9 +608,9 @@ public class TestFileUtil {
       FileUtil.chmod(partitioned.getAbsolutePath(), "0777", true/*recursive*/);
     }
   }
-  
+
   @Test (timeout = 30000)
-  public void testUnTar() throws IOException {
+  public void testUnTar() throws Exception {
     // make a simple tar:
     final File simpleTar = new File(del, FILE);
     OutputStream os = new FileOutputStream(simpleTar);
@@ -629,16 +630,11 @@ public class TestFileUtil {
     // check result:
     assertTrue(new File(tmp, "/bar/foo").exists());
     assertEquals(12, new File(tmp, "/bar/foo").length());
-    
+
     final File regularFile = new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog");
     regularFile.createNewFile();
     assertTrue(regularFile.exists());
-    try {
-      FileUtil.unTar(simpleTar, regularFile);
-      fail("An IOException expected.");
-    } catch (IOException ioe) {
-      // okay
-    }
+    LambdaTestUtils.intercept(IOException.class, () -> FileUtil.unTar(simpleTar, regularFile));
   }
   
   @Test (timeout = 30000)
@@ -698,7 +694,7 @@ public class TestFileUtil {
   }
   
   @Test (timeout = 30000)
-  public void testUnZip() throws IOException {
+  public void testUnZip() throws Exception {
     // make sa simple zip
     final File simpleZip = new File(del, FILE);
     OutputStream os = new FileOutputStream(simpleZip); 
@@ -725,12 +721,7 @@ public class TestFileUtil {
     final File regularFile = new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog");
     regularFile.createNewFile();
     assertTrue(regularFile.exists());
-    try {
-      FileUtil.unZip(simpleZip, regularFile);
-      assertTrue("An IOException expected.", false);
-    } catch (IOException ioe) {
-      // okay
-    }
+    LambdaTestUtils.intercept(IOException.class, () -> FileUtil.unZip(simpleZip, regularFile));
   }
 
   @Test (timeout = 30000)

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -66,6 +66,8 @@ import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarOutputStream;
+
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -278,13 +280,13 @@ public class TestFileUtil {
   @Test (timeout = 30000)
   public void testFullyDeleteSymlinks() throws IOException {
     File link = new File(del, LINK);
-    Assert.assertEquals(5, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(5);
     // Since tmpDir is symlink to tmp, fullyDelete(tmpDir) should not
     // delete contents of tmp. See setupDirs for details.
     boolean ret = FileUtil.fullyDelete(link);
     Assert.assertTrue(ret);
     Assert.assertFalse(link.exists());
-    Assert.assertEquals(4, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(4);
     validateTmpDir();
 
     File linkDir = new File(del, "tmpDir");
@@ -293,7 +295,7 @@ public class TestFileUtil {
     ret = FileUtil.fullyDelete(linkDir);
     Assert.assertTrue(ret);
     Assert.assertFalse(linkDir.exists());
-    Assert.assertEquals(3, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(3);
     validateTmpDir();
   }
 
@@ -313,12 +315,12 @@ public class TestFileUtil {
 
     // dangling symlink to file
     File link = new File(del, LINK);
-    Assert.assertEquals(5, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(5);
     // Even though 'y' is dangling symlink to file tmp/x, fullyDelete(y)
     // should delete 'y' properly.
     ret = FileUtil.fullyDelete(link);
     Assert.assertTrue(ret);
-    Assert.assertEquals(4, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(4);
 
     // dangling symlink to directory
     File linkDir = new File(del, "tmpDir");
@@ -326,7 +328,7 @@ public class TestFileUtil {
     // delete tmpDir properly.
     ret = FileUtil.fullyDelete(linkDir);
     Assert.assertTrue(ret);
-    Assert.assertEquals(3, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(3);
   }
 
   @Test (timeout = 30000)
@@ -462,7 +464,7 @@ public class TestFileUtil {
     // fail symlink deletion
     Assert.assertFalse(ret);
     Assert.assertTrue(linkDir.exists());
-    Assert.assertEquals(5, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(5);
     // tmp dir should exist
     validateTmpDir();
     // simulate disk recovers and turns good
@@ -471,9 +473,18 @@ public class TestFileUtil {
     // success symlink deletion
     Assert.assertTrue(ret);
     Assert.assertFalse(linkDir.exists());
-    Assert.assertEquals(4, Objects.requireNonNull(del.list()).length);
+    assertDelListLength(4);
     // tmp dir should exist
     validateTmpDir();
+  }
+
+  /**
+   * Asserts if the {@link TestFileUtil#del} meets the given expected length.
+   *
+   * @param expectedLength The expected length of the {@link TestFileUtil#del}.
+   */
+  private void assertDelListLength(int expectedLength) {
+    Assertions.assertThat(del.list()).describedAs("del list").isNotNull().hasSize(expectedLength);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -163,12 +163,12 @@ public class TestFileUtil {
     FileUtils.forceMkdir(dir1);
     FileUtils.forceMkdir(dir2);
 
-    createNewFileAndVerify(new File(del, FILE));
-    File tmpFile = createNewFileAndVerify(new File(tmp, FILE));
+    Verify.createNewFile(new File(del, FILE));
+    File tmpFile = Verify.createNewFile(new File(tmp, FILE));
 
     // create files
-    createNewFileAndVerify(new File(dir1, FILE));
-    createNewFileAndVerify(new File(dir2, FILE));
+    Verify.createNewFile(new File(dir1, FILE));
+    Verify.createNewFile(new File(dir2, FILE));
 
     // create a symlink to file
     File link = new File(del, LINK);
@@ -366,15 +366,15 @@ public class TestFileUtil {
    * @throws IOException
    */
   private void setupDirsAndNonWritablePermissions() throws IOException {
-    createNewFileAndVerify(new MyFile(del, FILE_1_NAME));
+    Verify.createNewFile(new MyFile(del, FILE_1_NAME));
 
     // "file1" is non-deletable by default, see MyFile.delete().
 
     xSubDir.mkdirs();
-    createNewFileAndVerify(file2);
+    Verify.createNewFile(file2);
 
     xSubSubDir.mkdirs();
-    createNewFileAndVerify(file22);
+    Verify.createNewFile(file22);
 
     revokePermissions(file22);
     revokePermissions(xSubSubDir);
@@ -383,9 +383,9 @@ public class TestFileUtil {
     revokePermissions(xSubDir);
 
     ySubDir.mkdirs();
-    createNewFileAndVerify(file3);
+    Verify.createNewFile(file3);
 
-    File tmpFile = createNewFileAndVerify(new File(tmp, FILE));
+    File tmpFile = Verify.createNewFile(new File(tmp, FILE));
     FileUtil.symLink(tmpFile.toString(), zlink.toString());
   }
 
@@ -486,17 +486,22 @@ public class TestFileUtil {
   }
 
   /**
-   * Creates a new file and verifies the result of the operation.
-   *
-   * @param file The {@link File} to create.
-   * @return The {@link File} instance that was passed.
-   * @throws IOException As per {@link File#createNewFile()}.
+   * Helper class to perform {@link File} operation and also verify them.
    */
-  private File createNewFileAndVerify(File file) throws IOException {
-    assertTrue("Unable to create new file " + file, file.createNewFile());
-    return file;
+  public static class Verify {
+    /**
+     * Creates a new file and verifies the result of the operation.
+     *
+     * @param file The {@link File} to create.
+     * @return The {@link File} instance that was passed.
+     * @throws IOException As per {@link File#createNewFile()}.
+     */
+    public static File createNewFile(File file) throws IOException {
+      assertTrue("Unable to create new file " + file, file.createNewFile());
+      return file;
+    }
   }
-
+  
   /**
    * Extend {@link File}. Same as {@link File} except for two things: (1) This
    * treats file1Name as a very special file which is not delete-able
@@ -653,14 +658,14 @@ public class TestFileUtil {
     assertEquals(12, new File(tmp, "/bar/foo").length());
 
     final File regularFile =
-        createNewFileAndVerify(new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog"));
+        Verify.createNewFile(new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog"));
     LambdaTestUtils.intercept(IOException.class, () -> FileUtil.unTar(simpleTar, regularFile));
   }
   
   @Test (timeout = 30000)
   public void testReplaceFile() throws IOException {
     // src exists, and target does not exist:
-    final File srcFile = createNewFileAndVerify(new File(tmp, "src"));
+    final File srcFile = Verify.createNewFile(new File(tmp, "src"));
     final File targetFile = new File(tmp, "target");
     assertTrue(!targetFile.exists());
     FileUtil.replaceFile(srcFile, targetFile);
@@ -668,18 +673,18 @@ public class TestFileUtil {
     assertTrue(targetFile.exists());
 
     // src exists and target is a regular file: 
-    createNewFileAndVerify(srcFile);
+    Verify.createNewFile(srcFile);
     assertTrue(srcFile.exists());
     FileUtil.replaceFile(srcFile, targetFile);
     assertTrue(!srcFile.exists());
     assertTrue(targetFile.exists());
     
     // src exists, and target is a non-empty directory: 
-    createNewFileAndVerify(srcFile);
+    Verify.createNewFile(srcFile);
     assertTrue(srcFile.exists());
     targetFile.delete();
     targetFile.mkdirs();
-    File obstacle = createNewFileAndVerify(new File(targetFile, "obstacle"));
+    File obstacle = Verify.createNewFile(new File(targetFile, "obstacle"));
     assertTrue(targetFile.exists() && targetFile.isDirectory());
     try {
       FileUtil.replaceFile(srcFile, targetFile);
@@ -734,7 +739,7 @@ public class TestFileUtil {
     assertEquals(12, new File(tmp, "foo").length());
 
     final File regularFile =
-        createNewFileAndVerify(new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog"));
+        Verify.createNewFile(new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog"));
     LambdaTestUtils.intercept(IOException.class, () -> FileUtil.unZip(simpleZip, regularFile));
   }
 
@@ -891,7 +896,7 @@ public class TestFileUtil {
    */
   @Test (timeout = 30000)
   public void testSymlinkRenameTo() throws Exception {
-    File file = createNewFileAndVerify(new File(del, FILE));
+    File file = Verify.createNewFile(new File(del, FILE));
     File link = new File(del, "_link");
 
     // create the symlink
@@ -919,7 +924,7 @@ public class TestFileUtil {
    */
   @Test (timeout = 30000)
   public void testSymlinkDelete() throws Exception {
-    File file = createNewFileAndVerify(new File(del, FILE));
+    File file = Verify.createNewFile(new File(del, FILE));
     File link = new File(del, "_link");
 
     // create the symlink
@@ -1178,9 +1183,9 @@ public class TestFileUtil {
     }
 
     // create non-jar files, which we expect to not be included in the classpath
-    createNewFileAndVerify(new File(tmp, "text.txt"));
-    createNewFileAndVerify(new File(tmp, "executable.exe"));
-    createNewFileAndVerify(new File(tmp, "README"));
+    Verify.createNewFile(new File(tmp, "text.txt"));
+    Verify.createNewFile(new File(tmp, "executable.exe"));
+    Verify.createNewFile(new File(tmp, "README"));
 
     // create classpath jar
     String wildcardPath = tmp.getCanonicalPath() + File.separator + "*";
@@ -1266,9 +1271,9 @@ public class TestFileUtil {
     }
 
     // create non-jar files, which we expect to not be included in the result
-    createNewFileAndVerify(new File(tmp, "text.txt"));
-    createNewFileAndVerify(new File(tmp, "executable.exe"));
-    createNewFileAndVerify(new File(tmp, "README"));
+    Verify.createNewFile(new File(tmp, "text.txt"));
+    Verify.createNewFile(new File(tmp, "executable.exe"));
+    Verify.createNewFile(new File(tmp, "README"));
 
     // pass in the directory
     String directory = tmp.getCanonicalPath();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -42,7 +42,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -1472,11 +1471,11 @@ public class TestFileUtil {
 
       // We will tar from the tar-root lineage
       File tarRoot = new File(rootDir, "tar-root/");
-      File dir1 = new File(tarRoot, "dir1/");
-      Verify.mkdirs(dir1);
+      File symlinkRoot = new File(tarRoot, "dir1/");
+      Verify.mkdirs(symlinkRoot);
 
       // Create Symbolic Link to an arbitrary dir
-      java.nio.file.Path symLink = Paths.get(dir1.getPath(), "sl");
+      java.nio.file.Path symLink = Paths.get(symlinkRoot.getPath(), "sl");
       Files.createSymbolicLink(symLink, arbitraryDir.toPath().toAbsolutePath());
 
       // Put entries in tar file

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -485,6 +485,13 @@ public class TestFileUtil {
     Assertions.assertThat(del.list()).describedAs("del list").isNotNull().hasSize(expectedLength);
   }
 
+  /**
+   * Creates a new file and verifies the result of the operation.
+   *
+   * @param file The {@link File} to create.
+   * @return The {@link File} instance that was passed.
+   * @throws IOException As per {@link File#createNewFile()}.
+   */
   private File createNewFileAndVerify(File file) throws IOException {
     assertTrue("Unable to create new file " + file, file.createNewFile());
     return file;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -490,10 +490,10 @@ public class TestFileUtil {
    */
   public static class Verify {
     /**
-     * Creates a new file and verifies the result of the operation.
+     * Invokes {@link File#createNewFile()} on the given {@link File} instance.
      *
-     * @param file The {@link File} to create.
-     * @return The {@link File} instance that was passed.
+     * @param file The file to call {@link File#createNewFile()} on.
+     * @return The result of {@link File#createNewFile()}.
      * @throws IOException As per {@link File#createNewFile()}.
      */
     public static File createNewFile(File file) throws IOException {
@@ -520,6 +520,17 @@ public class TestFileUtil {
      */
     public static File mkdirs(File file) {
       assertTrue("Unable to mkdirs for " + file, file.mkdirs());
+      return file;
+    }
+
+    /**
+     * Invokes {@link File#delete()} on the given {@link File} instance.
+     *
+     * @param file The file to call {@link File#delete()} on.
+     * @return The result of {@link File#delete()}.
+     */
+    public static File delete(File file) {
+      assertTrue("Unable to delete " + file, file.delete());
       return file;
     }
   }
@@ -704,7 +715,7 @@ public class TestFileUtil {
     // src exists, and target is a non-empty directory: 
     Verify.createNewFile(srcFile);
     assertTrue(srcFile.exists());
-    targetFile.delete();
+    Verify.delete(targetFile);
     Verify.mkdirs(targetFile);
     File obstacle = Verify.createNewFile(new File(targetFile, "obstacle"));
     assertTrue(targetFile.exists() && targetFile.isDirectory());
@@ -730,8 +741,8 @@ public class TestFileUtil {
     assertTrue(tmp1.exists() && tmp2.exists());
     assertTrue(tmp1.canWrite() && tmp2.canWrite());
     assertTrue(tmp1.canRead() && tmp2.canRead());
-    tmp1.delete();
-    tmp2.delete();
+    Verify.delete(tmp1);
+    Verify.delete(tmp2);
     assertTrue(!tmp1.exists() && !tmp2.exists());
   }
   
@@ -814,7 +825,7 @@ public class TestFileUtil {
     assertTrue(srcFile.exists()); // should not be deleted
     
     // copy regular file, delete src:
-    dest.delete();
+    Verify.delete(dest);
     assertTrue(!dest.exists());
     result = FileUtil.copy(fs, srcPath, dest, true, conf);
     assertTrue(result);
@@ -824,7 +835,7 @@ public class TestFileUtil {
     assertTrue(!srcFile.exists()); // should be deleted
     
     // copy a dir:
-    dest.delete();
+    Verify.delete(dest);
     assertTrue(!dest.exists());
     srcPath = new Path(partitioned.toURI());
     result = FileUtil.copy(fs, srcPath, dest, true, conf);
@@ -985,12 +996,12 @@ public class TestFileUtil {
     Assert.assertEquals(data.length, file.length());
     Assert.assertEquals(data.length, link.length());
 
-    file.delete();
+    Verify.delete(file);
     Assert.assertFalse(file.exists());
 
     Assert.assertEquals(0, link.length());
 
-    link.delete();
+    Verify.delete(link);
     Assert.assertFalse(link.exists());
   }
 
@@ -1057,7 +1068,7 @@ public class TestFileUtil {
   public void testSymlinkSameFile() throws IOException {
     File file = new File(del, FILE);
 
-    file.delete();
+    Verify.delete(file);
 
     // Create a symbolic link
     // The operation should succeed
@@ -1546,7 +1557,7 @@ public class TestFileUtil {
     String result = FileUtil.readLink(file);
     Assert.assertEquals("", result);
 
-    file.delete();
+    Verify.delete(file);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -1434,7 +1434,7 @@ public class TestFileUtil {
     if (f.isDirectory()) {
       tos.putArchiveEntry(new TarArchiveEntry(f));
       tos.closeArchiveEntry();
-      for (File child : Objects.requireNonNull(f.listFiles())) {
+      for (File child : f.listFiles()) {
         putEntriesInTar(tos, child);
       }
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -218,7 +218,7 @@ public class TestFileUtil {
 
     //Test existing directory with no files case 
     File newDir = new File(tmp.getPath(),"test");
-    assertTrue(newDir.mkdir());
+    Verify.mkdir(newDir);
     Assert.assertTrue("Failed to create test dir", newDir.exists());
     files = FileUtil.listFiles(newDir);
     Assert.assertEquals(0, files.length);
@@ -244,7 +244,7 @@ public class TestFileUtil {
 
     //Test existing directory with no files case 
     File newDir = new File(tmp.getPath(),"test");
-    assertTrue(newDir.mkdir());
+    Verify.mkdir(newDir);
     Assert.assertTrue("Failed to create test dir", newDir.exists());
     files = FileUtil.list(newDir);
     Assert.assertEquals("New directory unexpectedly contains files", 0, files.length);
@@ -498,6 +498,17 @@ public class TestFileUtil {
      */
     public static File createNewFile(File file) throws IOException {
       assertTrue("Unable to create new file " + file, file.createNewFile());
+      return file;
+    }
+
+    /**
+     * Invokes {@link File#mkdir()} on the given {@link File} instance.
+     *
+     * @param file The file to call {@link File#mkdir()} on.
+     * @return The result of {@link File#mkdir()}.
+     */
+    public static File mkdir(File file) {
+      assertTrue("Unable to mkdir for " + file, file.mkdir());
       return file;
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -370,10 +370,10 @@ public class TestFileUtil {
 
     // "file1" is non-deletable by default, see MyFile.delete().
 
-    xSubDir.mkdirs();
+    Verify.mkdirs(xSubDir);
     Verify.createNewFile(file2);
 
-    xSubSubDir.mkdirs();
+    Verify.mkdirs(xSubSubDir);
     Verify.createNewFile(file22);
 
     revokePermissions(file22);
@@ -382,7 +382,7 @@ public class TestFileUtil {
     revokePermissions(file2);
     revokePermissions(xSubDir);
 
-    ySubDir.mkdirs();
+    Verify.mkdirs(ySubDir);
     Verify.createNewFile(file3);
 
     File tmpFile = Verify.createNewFile(new File(tmp, FILE));
@@ -498,6 +498,17 @@ public class TestFileUtil {
      */
     public static File createNewFile(File file) throws IOException {
       assertTrue("Unable to create new file " + file, file.createNewFile());
+      return file;
+    }
+
+    /**
+     * Invokes {@link File#mkdirs()} on the given {@link File} instance.
+     *
+     * @param file The file to call {@link File#mkdirs()} on.
+     * @return The result of {@link File#mkdirs()}.
+     */
+    public static File mkdirs(File file) {
+      assertTrue("Unable to mkdirs for " + file, file.mkdirs());
       return file;
     }
   }
@@ -683,7 +694,7 @@ public class TestFileUtil {
     Verify.createNewFile(srcFile);
     assertTrue(srcFile.exists());
     targetFile.delete();
-    targetFile.mkdirs();
+    Verify.mkdirs(targetFile);
     File obstacle = Verify.createNewFile(new File(targetFile, "obstacle"));
     assertTrue(targetFile.exists() && targetFile.isDirectory());
     try {
@@ -1373,12 +1384,8 @@ public class TestFileUtil {
       final String tmpDir = "tmp/test";
       File tmpDir1 = new File(tmpDir, "dir1/");
       File tmpDir2 = new File(tmpDir, "dir2/");
-      if (!tmpDir1.mkdirs()) {
-        throw new IOException(String.format("Unable to create directory %s", tmpDir1));
-      }
-      if (!tmpDir2.mkdirs()) {
-        throw new IOException(String.format("Unable to create directory %s", tmpDir2));
-      }
+      Verify.mkdirs(tmpDir1);
+      Verify.mkdirs(tmpDir2);
 
       java.nio.file.Path symLink = Paths.get(tmpDir1.getPath(), "sl");
 
@@ -1413,12 +1420,12 @@ public class TestFileUtil {
 
       // Create arbitrary dir
       File arbitraryDir = new File(rootDir, "arbitrary-dir/");
-      assertTrue(arbitraryDir.mkdirs());
+      Verify.mkdirs(arbitraryDir);
 
       // We will tar from the tar-root lineage
       File tarRoot = new File(rootDir, "tar-root/");
       File dir1 = new File(tarRoot, "dir1/");
-      assertTrue(dir1.mkdirs());
+      Verify.mkdirs(dir1);
 
       // Create Symbolic Link to an arbitrary dir
       java.nio.file.Path symLink = Paths.get(dir1.getPath(), "sl");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFileUtil.java
@@ -163,13 +163,12 @@ public class TestFileUtil {
     FileUtils.forceMkdir(dir1);
     FileUtils.forceMkdir(dir2);
 
-    new File(del, FILE).createNewFile();
-    File tmpFile = new File(tmp, FILE);
-    assertTrue(tmpFile.createNewFile());
+    createNewFileAndVerify(new File(del, FILE));
+    File tmpFile = createNewFileAndVerify(new File(tmp, FILE));
 
     // create files
-    new File(dir1, FILE).createNewFile();
-    new File(dir2, FILE).createNewFile();
+    createNewFileAndVerify(new File(dir1, FILE));
+    createNewFileAndVerify(new File(dir2, FILE));
 
     // create a symlink to file
     File link = new File(del, LINK);
@@ -367,15 +366,15 @@ public class TestFileUtil {
    * @throws IOException
    */
   private void setupDirsAndNonWritablePermissions() throws IOException {
-    new MyFile(del, FILE_1_NAME).createNewFile();
+    createNewFileAndVerify(new MyFile(del, FILE_1_NAME));
 
     // "file1" is non-deletable by default, see MyFile.delete().
 
     xSubDir.mkdirs();
-    file2.createNewFile();
+    createNewFileAndVerify(file2);
 
     xSubSubDir.mkdirs();
-    file22.createNewFile();
+    createNewFileAndVerify(file22);
 
     revokePermissions(file22);
     revokePermissions(xSubSubDir);
@@ -384,10 +383,9 @@ public class TestFileUtil {
     revokePermissions(xSubDir);
 
     ySubDir.mkdirs();
-    file3.createNewFile();
+    createNewFileAndVerify(file3);
 
-    File tmpFile = new File(tmp, FILE);
-    tmpFile.createNewFile();
+    File tmpFile = createNewFileAndVerify(new File(tmp, FILE));
     FileUtil.symLink(tmpFile.toString(), zlink.toString());
   }
 
@@ -485,6 +483,11 @@ public class TestFileUtil {
    */
   private void assertDelListLength(int expectedLength) {
     Assertions.assertThat(del.list()).describedAs("del list").isNotNull().hasSize(expectedLength);
+  }
+
+  private File createNewFileAndVerify(File file) throws IOException {
+    assertTrue("Unable to create new file " + file, file.createNewFile());
+    return file;
   }
 
   /**
@@ -642,19 +645,15 @@ public class TestFileUtil {
     assertTrue(new File(tmp, "/bar/foo").exists());
     assertEquals(12, new File(tmp, "/bar/foo").length());
 
-    final File regularFile = new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog");
-    regularFile.createNewFile();
-    assertTrue(regularFile.exists());
+    final File regularFile =
+        createNewFileAndVerify(new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog"));
     LambdaTestUtils.intercept(IOException.class, () -> FileUtil.unTar(simpleTar, regularFile));
   }
   
   @Test (timeout = 30000)
   public void testReplaceFile() throws IOException {
-    final File srcFile = new File(tmp, "src");
-    
     // src exists, and target does not exist:
-    srcFile.createNewFile();
-    assertTrue(srcFile.exists());
+    final File srcFile = createNewFileAndVerify(new File(tmp, "src"));
     final File targetFile = new File(tmp, "target");
     assertTrue(!targetFile.exists());
     FileUtil.replaceFile(srcFile, targetFile);
@@ -662,20 +661,18 @@ public class TestFileUtil {
     assertTrue(targetFile.exists());
 
     // src exists and target is a regular file: 
-    srcFile.createNewFile();
+    createNewFileAndVerify(srcFile);
     assertTrue(srcFile.exists());
     FileUtil.replaceFile(srcFile, targetFile);
     assertTrue(!srcFile.exists());
     assertTrue(targetFile.exists());
     
     // src exists, and target is a non-empty directory: 
-    srcFile.createNewFile();
+    createNewFileAndVerify(srcFile);
     assertTrue(srcFile.exists());
     targetFile.delete();
     targetFile.mkdirs();
-    File obstacle = new File(targetFile, "obstacle");
-    obstacle.createNewFile();
-    assertTrue(obstacle.exists());
+    File obstacle = createNewFileAndVerify(new File(targetFile, "obstacle"));
     assertTrue(targetFile.exists() && targetFile.isDirectory());
     try {
       FileUtil.replaceFile(srcFile, targetFile);
@@ -728,10 +725,9 @@ public class TestFileUtil {
     // check result:
     assertTrue(new File(tmp, "foo").exists());
     assertEquals(12, new File(tmp, "foo").length());
-    
-    final File regularFile = new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog");
-    regularFile.createNewFile();
-    assertTrue(regularFile.exists());
+
+    final File regularFile =
+        createNewFileAndVerify(new File(tmp, "QuickBrownFoxJumpsOverTheLazyDog"));
     LambdaTestUtils.intercept(IOException.class, () -> FileUtil.unZip(simpleZip, regularFile));
   }
 
@@ -888,8 +884,7 @@ public class TestFileUtil {
    */
   @Test (timeout = 30000)
   public void testSymlinkRenameTo() throws Exception {
-    File file = new File(del, FILE);
-    file.createNewFile();
+    File file = createNewFileAndVerify(new File(del, FILE));
     File link = new File(del, "_link");
 
     // create the symlink
@@ -917,8 +912,7 @@ public class TestFileUtil {
    */
   @Test (timeout = 30000)
   public void testSymlinkDelete() throws Exception {
-    File file = new File(del, FILE);
-    file.createNewFile();
+    File file = createNewFileAndVerify(new File(del, FILE));
     File link = new File(del, "_link");
 
     // create the symlink
@@ -1177,9 +1171,9 @@ public class TestFileUtil {
     }
 
     // create non-jar files, which we expect to not be included in the classpath
-    Assert.assertTrue(new File(tmp, "text.txt").createNewFile());
-    Assert.assertTrue(new File(tmp, "executable.exe").createNewFile());
-    Assert.assertTrue(new File(tmp, "README").createNewFile());
+    createNewFileAndVerify(new File(tmp, "text.txt"));
+    createNewFileAndVerify(new File(tmp, "executable.exe"));
+    createNewFileAndVerify(new File(tmp, "README"));
 
     // create classpath jar
     String wildcardPath = tmp.getCanonicalPath() + File.separator + "*";
@@ -1265,9 +1259,9 @@ public class TestFileUtil {
     }
 
     // create non-jar files, which we expect to not be included in the result
-    assertTrue(new File(tmp, "text.txt").createNewFile());
-    assertTrue(new File(tmp, "executable.exe").createNewFile());
-    assertTrue(new File(tmp, "README").createNewFile());
+    createNewFileAndVerify(new File(tmp, "text.txt"));
+    createNewFileAndVerify(new File(tmp, "executable.exe"));
+    createNewFileAndVerify(new File(tmp, "README"));
 
     // pass in the directory
     String directory = tmp.getCanonicalPath();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
We need to ensure that we check the results of file operations whenever we invoke mkdir, deleteFile etc. and assert them right there before proceeding on. Also, we need to ensure that some of the relevant FileSystem APIs don't return null.

### How was this patch tested?
Unit tests on CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

