### PR TITLE
HADOOP-18158. Fix failure of create-release script due to releasedocmaker changes in branch-2.10

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -557,8 +557,8 @@ function makearelease
   #shellcheck disable=SC2038
   find . -name rat.txt | xargs -I% cat % > "${ARTIFACTS_DIR}/hadoop-${HADOOP_VERSION}${RC_LABEL}-rat.txt"
 
-  # Stage CHANGES and RELEASENOTES files
-  for i in CHANGES RELEASENOTES; do
+  # Stage CHANGELOG and RELEASENOTES files
+  for i in CHANGELOG RELEASENOTES; do
     run cp -p \
         "${BASEDIR}/hadoop-common-project/hadoop-common/src/site/markdown/release/${HADOOP_VERSION}"/${i}*.md \
         "${ARTIFACTS_DIR}/${i}.md"

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -856,6 +856,8 @@
                             <argument>--projecttitle</argument>
                             <argument>"Apache Hadoop"</argument>
                             <argument>--usetoday</argument>
+                            <argument>--fileversions</argument>
+                            <argument>--dirversions</argument>
                             <argument>--version</argument>
                             <argument>${project.version}</argument>
                         </arguments>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18158

The file name generated by releasedocmaker of Yetus was changed from CHANGES.md to CHANGELOG.md. dev-support scripts should be updated along with the change.