### PR TITLE
HADOOP-18142. Increase precommit job timeout from 24 hr to 30 hr

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout (time: 24, unit: 'HOURS')
+        timeout (time: 30, unit: 'HOURS')
         timestamps()
         checkoutToSubdirectory('src')
     }


### PR DESCRIPTION
### Description of PR
As per some recent precommit build results, full build QA is not getting completed in 24 hr (recent example [here](https://github.com/apache/hadoop/pull/4000) where more than 5 builds timed out after 24 hr). We should increase it to 30 hr.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
