### PR TITLE
HADOOP-16298. Manage/Renew delegation tokens for externally scheduled jobs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Credentials.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Credentials.java
@@ -213,9 +213,8 @@ public class Credentials implements Writable {
    * @param conf
    * @throws IOException
    */
-  public static Credentials readTokenStorageFile(Path filename,
-                                                 Configuration conf)
-  throws IOException {
+  public static Credentials readTokenStorageFile(Path filename, Configuration conf)
+        throws IOException {
     FSDataInputStream in = null;
     Credentials credentials = new Credentials();
     try {
@@ -459,6 +458,23 @@ public class Credentials implements Writable {
       if (!tokenMap.containsKey(key) || overwrite) {
         addToken(key, token.getValue());
       }
+    }
+  }
+
+  /**
+   * Update the token map to synchronize between HA pair servers
+   */
+  public void synchTokens(Token<? extends TokenIdentifier> token) {
+    for(Map.Entry<Text, Token<?>> entry: tokenMap.entrySet()){
+      LOG.debug("synching token.to_s");
+      tokenMap.forEach((key, value) -> LOG.debug("Before: " + key + ":" + value));
+      if (entry.getValue().getKind().equals(token.getKind())){
+        LOG.debug("matched " + entry.getValue().getKind());
+        Token<? extends TokenIdentifier> clone = new Token<>(token.getIdentifier(),
+            token.getPassword(), token.getKind(), entry.getValue().getService());
+        tokenMap.put(entry.getKey(), clone);
+      }
+      tokenMap.forEach((key, value) -> LOG.debug("After: " + key + ":" + value));
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/DelegationTokenUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/DelegationTokenUtil.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.security;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DelegationTokenUtil {
+  public static final String HADOOP_TOKEN_FILE_LOCATION =
+          "HADOOP_TOKEN_FILE_LOCATION";
+
+  static final Logger LOG = LoggerFactory.getLogger(
+      DelegationTokenUtil.class);
+
+  private DelegationTokenUtil() {
+  }
+
+  public static synchronized Credentials readDelegationTokens(Configuration conf)
+        throws IOException {
+    String fileLocation = System.getenv(HADOOP_TOKEN_FILE_LOCATION);
+    if (fileLocation != null) {
+      // Load the token storage file and put all of the tokens into the
+      // user. Don't use the FileSystem API for reading since it has a lock
+      // cycle (HADOOP-9212).
+      File source = new File(fileLocation);
+      Credentials creds = Credentials.readTokenStorageFile(
+          source, conf);
+      LOG.info("Loaded {} tokens", creds.numberOfTokens());
+      return creds;
+    }
+    return null;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -87,6 +87,7 @@ import org.apache.hadoop.security.SaslRpcServer.AuthMethod;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Time;
 
@@ -186,12 +187,25 @@ public class UserGroupInformation {
       return null;
     }
 
+    private void addDelegationTokensToSubject() throws LoginException {
+      try {
+        Credentials creds = DelegationTokenUtil.readDelegationTokens(conf);
+        if (creds != null) {
+          subject.getPrivateCredentials().add(creds);
+        }
+      } catch (IOException e) {
+        throw new LoginException("Failed to load token file from " +
+                HADOOP_TOKEN_FILE_LOCATION);
+      }
+    }
+
     @Override
     public boolean commit() throws LoginException {
       LOG.debug("hadoop login commit");
       // if we already have a user, we are done.
       if (!subject.getPrincipals(User.class).isEmpty()) {
         LOG.debug("Using existing subject: {}", subject.getPrincipals());
+        addDelegationTokensToSubject();
         return true;
       }
       Principal user = getCanonicalUser(KerberosPrincipal.class);
@@ -229,6 +243,7 @@ public class UserGroupInformation {
         LOG.debug("User entry: \"{}\"", userEntry);
 
         subject.getPrincipals().add(userEntry);
+        addDelegationTokensToSubject();
         return true;
       }
       throw new LoginException("Failed to find user in name " + subject);
@@ -740,11 +755,12 @@ public class UserGroupInformation {
           LOG.debug("Reading credentials from location {}",
               tokenFile.getCanonicalPath());
           if (tokenFile.exists() && tokenFile.isFile()) {
-            Credentials cred = Credentials.readTokenStorageFile(
-                tokenFile, conf);
-            LOG.debug("Loaded {} tokens from {}", cred.numberOfTokens(),
-                tokenFile.getCanonicalPath());
-            loginUser.addCredentials(cred);
+            Credentials cred = DelegationTokenUtil.readDelegationTokens(conf);
+            if (cred != null ) {
+              LOG.debug("Loaded {} tokens from {}", cred.numberOfTokens(),
+                  tokenFile.getCanonicalPath());
+              loginUser.addCredentials(cred);
+            }
           } else {
             LOG.info("Token file {} does not exist",
                 tokenFile.getCanonicalPath());
@@ -850,6 +866,59 @@ public class UserGroupInformation {
     long end = tgt.getEndTime().getTime();
     return start + (long) ((end - start) * TICKET_RENEW_WINDOW);
   }
+
+  /**
+   * Re-Login a user in from delegation tokens
+   * method assumes that login had happened already.
+   * The Subject field of this UserGroupInformation object is updated to have
+   * the new credentials.
+   * @throws IOException
+   * @throws IOException on a failure
+   */
+  @InterfaceAudience.Public
+  @InterfaceStability.Evolving
+  public synchronized void reloginFromDelegationTokens() throws IOException {
+
+    if (!isFromDelegationToken()) {
+      throw new IOException("User has not logged on using delegation token");
+    }
+
+    synchronized(UserGroupInformation.class){
+      Credentials cred = DelegationTokenUtil.readDelegationTokens(conf);
+      if (cred != null ) {
+        addCredentials(cred);
+      }
+
+      for (Token<? extends TokenIdentifier> token: cred.getAllTokens()) {
+        for ( Credentials currentCreds : subject.getPrivateCredentials(Credentials.class)) {
+          currentCreds.synchTokens(token);
+        }
+      }
+    }
+  }
+
+  public boolean isFromDelegationToken () {
+    return !isFromKeytab() && getTGT() == null && !subject.getPrivateCredentials(Credentials.class).isEmpty();
+  }
+
+  public Collection<AbstractDelegationTokenIdentifier> getAllDelegationTokens(Credentials cred) {
+    cred.getAllTokens();
+    List<AbstractDelegationTokenIdentifier> delegToks = new ArrayList<>();
+
+    for(Token<? extends TokenIdentifier> t: getCredentials().getAllTokens()) {
+      try {
+        TokenIdentifier identifier = t.decodeIdentifier();
+        if (identifier == null || !AbstractDelegationTokenIdentifier.class.isAssignableFrom(identifier.getClass())) {
+          continue;
+        }
+        delegToks.add((AbstractDelegationTokenIdentifier) identifier);
+      } catch (IOException e) {
+        LOG.warn("Error decoding token identifier of kind  " + t.getKind(), e);
+      }
+    }
+    return delegToks;
+  }
+
 
   @InterfaceAudience.Private
   @InterfaceStability.Unstable


### PR DESCRIPTION
### Description of PR
This PR provides a means to reload authentication credentials from updated Hadoop delegation tokens similar to how one would reload credentials from an updated kerberos ticket.

### How was this patch tested?
This patch has been tested via:
* The unit tests
* Via long-running (modified to use the refresh) HBase 1.x clients. Long-running means through many delegation token refresh cycles
* Further it has been used in non-long running Spark workloads which were delegation token based
* TODO: I would like to figure out how I can write a unit-test to validate [the reload for an HA HDFS|https://github.com/apache/hadoop/compare/trunk...cbaenziger:HADOOP-16298?expand=1#diff-e160685d647b1420f6c56264302c0e1c82ead52e75a31d91fb2a12f0ce9261c4R465-R481] but I can not find what seems like the correct layer to put such a test. I do not expect HDFS should be used in a `hadoop-common` layer test; is it okay to test UGI's behavior in `hadoop-hdfs-project`?

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [N/A] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [N/A] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?