### PR TITLE
HDFS-16501. Print the exception when reporting a bad block

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/VolumeScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/VolumeScanner.java
@@ -293,7 +293,7 @@ public class VolumeScanner extends Thread {
             volume, block);
         return;
       }
-      LOG.warn("Reporting bad {} on {}", block, volume);
+      LOG.warn("Reporting bad {} on {}", block, volume, e);
       scanner.datanode.handleBadBlock(block, e, true);
     }
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2844826/157654307-18cec889-2b59-40c4-b40c-a7e0aacf73ef.png)

Currently, volumeScanner will find bad blocks and report them to namenode without printing the reason why they are bad blocks. I think we should be better print the exception in log file.