### PR TITLE
HADOOP-18154. S3A Authentication to support WebIdentity

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -142,6 +142,10 @@ public final class Constants {
   public static final String ASSUMED_ROLE_CREDENTIALS_DEFAULT =
       SimpleAWSCredentialsProvider.NAME;
 
+  /**
+   * Absolute path to the web identity token file
+   */
+  public static final String JWT_PATH = "fs.s3a.jwt.path";
 
   // the maximum number of tasks cached if all threads are already uploading
   public static final String MAX_TOTAL_TASKS = "fs.s3a.max.total.tasks";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -22,28 +22,32 @@ import org.apache.commons.lang3.StringUtils;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.ProviderUtils;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.fs.s3a.Constants.*;
+
 /**
- * WebIdentityTokenCredentialsProvider supports static configuration
- * of OIDC token path, role ARN and role session name.
+ * Support OpenID Connect (OIDC) token for authenticating with AWS.
  *
+ * Please note that users may reference this class name from configuration
+ * property fs.s3a.aws.credentials.provider.  Therefore, changing the class name
+ * would be a backward-incompatible change.
+ *
+ * This credential provider must not fail in creation because that will
+ * break a chain of credential providers.
  */
-//@InterfaceAudience.Public
-//@InterfaceStability.Stable
+@InterfaceAudience.Public
+@InterfaceStability.Stable
 public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
   public static final String NAME
           = "org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider";
-
-  //these are the parameters to document and to pass along with the class
-  //usually from import static org.apache.hadoop.fs.s3a.Constants.*;
-  public static final String JWT_PATH = "fs.s3a.jwt.path";
-  public static final String ROLE_ARN = "fs.s3a.role.arn";
-  public static final String SESSION_NAME = "fs.s3a.session.name";
 
   /** Reuse the S3AFileSystem log. */
   private static final Logger LOG = S3AFileSystem.LOG;
@@ -58,8 +62,8 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
           Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
                   conf, S3AFileSystem.class);
           this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
-          this.roleARN = S3AUtils.lookupPassword(c, ROLE_ARN, null);
-          this.sessionName = S3AUtils.lookupPassword(c, SESSION_NAME, null);
+          this.roleARN = S3AUtils.lookupPassword(c, ASSUMED_ROLE_ARN, null);
+          this.sessionName = S3AUtils.lookupPassword(c, ASSUMED_ROLE_SESSION_NAME, null);
       } catch (IOException e) {
           lookupIOE = e;
       }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -21,6 +21,7 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
     public static final String NAME
             = "org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider";
 
+    //these are the parameters to document and to pass along with the class
     //usually from import static org.apache.hadoop.fs.s3a.Constants.*;
     public static final String JWT_PATH = "fs.s3a.jwt.path";
     public static final String ROLE_ARN = "fs.s3a.role.arn";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -1,0 +1,78 @@
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.commons.lang3.StringUtils;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.ProviderUtils;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * WebIdentityTokenCredentialsProvider supports static configuration
+ * of OIDC token path, role ARN and role session name.
+ *
+ */
+//@InterfaceAudience.Public
+//@InterfaceStability.Stable
+public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
+    public static final String NAME
+            = "org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider";
+
+    //usually from import static org.apache.hadoop.fs.s3a.Constants.*;
+    public static final String JWT_PATH = "fs.s3a.jwt.path";
+    public static final String ROLE_ARN = "fs.s3a.role.arn";
+    public static final String SESSION_NAME = "fs.s3a.session.name";
+
+    /** Reuse the S3AFileSystem log. */
+    private static final Logger LOG = S3AFileSystem.LOG;
+
+    private String jwtPath;
+    private String roleARN;
+    private String sessionName;
+    private IOException lookupIOE;
+
+    public OIDCTokenCredentialsProvider(Configuration conf) {
+        try {
+            Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
+                    conf, S3AFileSystem.class);
+            this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
+            this.roleARN = S3AUtils.lookupPassword(c, ROLE_ARN, null);
+            this.sessionName = S3AUtils.lookupPassword(c, SESSION_NAME, null);
+        } catch (IOException e) {
+            lookupIOE = e;
+        }
+    }
+
+    public AWSCredentials getCredentials() {
+        if (lookupIOE != null) {
+            // propagate any initialization problem
+            throw new CredentialInitializationException(lookupIOE.toString(),
+                    lookupIOE);
+        }
+
+        LOG.debug("jwtPath {} roleARN {}", jwtPath, roleARN);
+
+        if (!StringUtils.isEmpty(jwtPath) && !StringUtils.isEmpty(roleARN)) {
+            final AWSCredentialsProvider credentialsProvider =
+                WebIdentityTokenCredentialsProvider.builder()
+                    .webIdentityTokenFile(jwtPath)
+                    .roleArn(roleARN)
+                    .roleSessionName(sessionName)
+                    .build();
+            return credentialsProvider.getCredentials();
+        }
+        else throw new CredentialInitializationException(
+                "OIDC token path or role ARN is null");
+    }
+
+    public void refresh() {}
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -18,15 +18,17 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import org.apache.commons.lang3.StringUtils;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.ProviderUtils;
+
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -58,15 +60,15 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
   private IOException lookupIOE;
 
   public OIDCTokenCredentialsProvider(Configuration conf) {
-      try {
-          Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
+    try {
+      Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
                   conf, S3AFileSystem.class);
-          this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
-          this.roleARN = S3AUtils.lookupPassword(c, ASSUMED_ROLE_ARN, null);
-          this.sessionName = S3AUtils.lookupPassword(c, ASSUMED_ROLE_SESSION_NAME, null);
-      } catch (IOException e) {
-          lookupIOE = e;
-      }
+      this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
+      this.roleARN = S3AUtils.lookupPassword(c, ASSUMED_ROLE_ARN, null);
+      this.sessionName = S3AUtils.lookupPassword(c, ASSUMED_ROLE_SESSION_NAME, null);
+    } catch (IOException e) {
+      lookupIOE = e;
+    }
   }
 
   public AWSCredentials getCredentials() {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -76,7 +76,7 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
                   lookupIOE);
       }
 
-      LOG.debug("jwtPath {} roleARN {}", jwtPath, roleARN);
+      LOG.debug("jwtPath {} roleARN {} sessionName {}", jwtPath, roleARN, sessionName);
 
       if (!StringUtils.isEmpty(jwtPath) && !StringUtils.isEmpty(roleARN)) {
           final AWSCredentialsProvider credentialsProvider =
@@ -95,6 +95,9 @@ public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
 
   @Override
   public String toString() {
-        return getClass().getSimpleName();
-    }
+      return String.format("%s " +
+                  "jwtPath {%s} roleARN {%s} sessionName {%s}",
+              getClass().getSimpleName(),
+              jwtPath, roleARN, sessionName);
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.s3a;
 
 import org.apache.commons.lang3.StringUtils;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/OIDCTokenCredentialsProvider.java
@@ -18,62 +18,61 @@ import java.io.IOException;
 //@InterfaceAudience.Public
 //@InterfaceStability.Stable
 public class OIDCTokenCredentialsProvider implements AWSCredentialsProvider {
-    public static final String NAME
-            = "org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider";
+  public static final String NAME
+          = "org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider";
 
-    //these are the parameters to document and to pass along with the class
-    //usually from import static org.apache.hadoop.fs.s3a.Constants.*;
-    public static final String JWT_PATH = "fs.s3a.jwt.path";
-    public static final String ROLE_ARN = "fs.s3a.role.arn";
-    public static final String SESSION_NAME = "fs.s3a.session.name";
+  //these are the parameters to document and to pass along with the class
+  //usually from import static org.apache.hadoop.fs.s3a.Constants.*;
+  public static final String JWT_PATH = "fs.s3a.jwt.path";
+  public static final String ROLE_ARN = "fs.s3a.role.arn";
+  public static final String SESSION_NAME = "fs.s3a.session.name";
 
-    /** Reuse the S3AFileSystem log. */
-    private static final Logger LOG = S3AFileSystem.LOG;
+  /** Reuse the S3AFileSystem log. */
+  private static final Logger LOG = S3AFileSystem.LOG;
 
-    private String jwtPath;
-    private String roleARN;
-    private String sessionName;
-    private IOException lookupIOE;
+  private String jwtPath;
+  private String roleARN;
+  private String sessionName;
+  private IOException lookupIOE;
 
-    public OIDCTokenCredentialsProvider(Configuration conf) {
-        try {
-            Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
-                    conf, S3AFileSystem.class);
-            this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
-            this.roleARN = S3AUtils.lookupPassword(c, ROLE_ARN, null);
-            this.sessionName = S3AUtils.lookupPassword(c, SESSION_NAME, null);
-        } catch (IOException e) {
-            lookupIOE = e;
-        }
-    }
+  public OIDCTokenCredentialsProvider(Configuration conf) {
+      try {
+          Configuration c = ProviderUtils.excludeIncompatibleCredentialProviders(
+                  conf, S3AFileSystem.class);
+          this.jwtPath = S3AUtils.lookupPassword(c, JWT_PATH, null);
+          this.roleARN = S3AUtils.lookupPassword(c, ROLE_ARN, null);
+          this.sessionName = S3AUtils.lookupPassword(c, SESSION_NAME, null);
+      } catch (IOException e) {
+          lookupIOE = e;
+      }
+  }
 
-    public AWSCredentials getCredentials() {
-        if (lookupIOE != null) {
-            // propagate any initialization problem
-            throw new CredentialInitializationException(lookupIOE.toString(),
-                    lookupIOE);
-        }
+  public AWSCredentials getCredentials() {
+      if (lookupIOE != null) {
+          // propagate any initialization problem
+          throw new CredentialInitializationException(lookupIOE.toString(),
+                  lookupIOE);
+      }
 
-        LOG.debug("jwtPath {} roleARN {}", jwtPath, roleARN);
+      LOG.debug("jwtPath {} roleARN {}", jwtPath, roleARN);
 
-        if (!StringUtils.isEmpty(jwtPath) && !StringUtils.isEmpty(roleARN)) {
-            final AWSCredentialsProvider credentialsProvider =
-                WebIdentityTokenCredentialsProvider.builder()
-                    .webIdentityTokenFile(jwtPath)
-                    .roleArn(roleARN)
-                    .roleSessionName(sessionName)
-                    .build();
-            return credentialsProvider.getCredentials();
-        }
-        else throw new CredentialInitializationException(
-                "OIDC token path or role ARN is null");
-    }
+      if (!StringUtils.isEmpty(jwtPath) && !StringUtils.isEmpty(roleARN)) {
+          final AWSCredentialsProvider credentialsProvider =
+              WebIdentityTokenCredentialsProvider.builder()
+                  .webIdentityTokenFile(jwtPath)
+                  .roleArn(roleARN)
+                  .roleSessionName(sessionName)
+                  .build();
+          return credentialsProvider.getCredentials();
+      }
+      else throw new CredentialInitializationException(
+              "OIDC token path or role ARN is null");
+  }
 
-    public void refresh() {}
+  public void refresh() {}
 
-    @Override
-    public String toString() {
+  @Override
+  public String toString() {
         return getClass().getSimpleName();
     }
-
 }


### PR DESCRIPTION
### Description of PR
The PR addresses a requirement to comply with AWS security concept [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) while operating a service that isn't based on Apache Spark and that runs inside Amazon Elastic Kubernetes Service (EKS).

The code change consists in adding a new credentials provider class `org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider` to the module [hadoop-aws](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html).

### How was this patch tested?
No new unit-test or integration-test was created on-purpose. The patch was "only" tested based on [Hadoop release 2.10.1](https://github.com/apache/hadoop/tree/rel/release-2.10.1), as part of our specific use-case based on [Delta sharing service](https://github.com/delta-io/delta-sharing) v0.4.0 along with the following Hadoop configuration (core-site.xml):
```
<?xml version="1.0"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
<configuration>
  <property>
    <name>fs.s3a.aws.credentials.provider</name>
    <value>org.apache.hadoop.fs.s3a.OIDCTokenCredentialsProvider</value>
  </property>
  <property>
    <name>fs.s3a.jwt.path</name>
    <value>/var/run/secrets/eks.amazonaws.com/serviceaccount/token</value>
  </property>
  <property>
    <name>fs.s3a.assumed.role.arn</name>
    <value>my_iam_role_arn</value>
  </property>
  <property>
    <name>fs.s3a.assumed.role.session.name</name>
    <value>my_iam_session_name</value>
  </property>
  <property>
      <name>fs.s3a.server-side-encryption-algorithm</name>
      <value>SSE-KMS</value>
  </property>
  <property>
      <name>fs.s3a.server-side-encryption.key</name>
      <value>my_kms_key_id</value>
  </property>      
</configuration>
```

### For code changes:
- [X] The title or this PR starts with the corresponding JIRA issue 'HADOOP-18154'
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] No new dependency was added to the code.