### PR TITLE
HDFS-16505. Setting safemode should not be interrupted by abnormal nodes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -674,13 +674,18 @@ public class DFSAdmin extends FsShell {
           HAUtil.getProxiesForAllNameNodesInNameservice(
           dfsConf, nsId, ClientProtocol.class);
       for (ProxyAndInfo<ClientProtocol> proxy : proxies) {
-        ClientProtocol haNn = proxy.getProxy();
-        boolean inSafeMode = haNn.setSafeMode(action, false);
-        if (waitExitSafe) {
-          inSafeMode = waitExitSafeMode(haNn, inSafeMode);
+        try {
+          ClientProtocol haNn = proxy.getProxy();
+          boolean inSafeMode = haNn.setSafeMode(action, false);
+          if (waitExitSafe) {
+            inSafeMode = waitExitSafeMode(haNn, inSafeMode);
+          }
+          System.out.println("Safe mode is " + (inSafeMode ? "ON" : "OFF")
+              + " in " + proxy.getAddress());
+        } catch (Throwable e) {
+          System.err.println("Set safe mode failed in " + proxy.getAddress() + ", error message: "
+              + e.getMessage());
         }
-        System.out.println("Safe mode is " + (inSafeMode ? "ON" : "OFF")
-            + " in " + proxy.getAddress());
       }
     } else {
       boolean inSafeMode = dfs.setSafeMode(action);


### PR DESCRIPTION
JIRA: [HDFS-16505](https://issues.apache.org/jira/browse/HDFS-16505).

Setting safemode should not be interrupted by abnormal nodes. 

For example, we have four namenodes configured in the following order:
NS1 -> active
NS2 -> standby
NS3 -> observer
NS4 -> observer.

When the `NS1` process exits, setting the states of safemode, `NS2`, `NS3`, and `NS4` fails. Similarly, when the `NS2` process exits, only the safemode state of `NS1` can be set successfully.

When the `NS1` process exits:
Before the change:
![image](https://user-images.githubusercontent.com/55134131/158288412-b0915dba-aa69-4e71-a47d-1d7728ba673d.png)

After the change:
![image](https://user-images.githubusercontent.com/55134131/158288423-f7de2689-ad0b-455e-9717-1b5ff877f20f.png)

