### PR TITLE
HADOOP-18160 Avoid shading wildfly.openssl runtime dependency

### DIFF
--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -160,9 +160,9 @@
                         <exclude>org/bouncycastle/**/*</exclude>
                         <!-- Exclude snappy-java -->
                         <exclude>org/xerial/snappy/*</exclude>
-			<exclude>org/xerial/snappy/**/*</exclude>
-			<!-- Exclude org.widlfly.openssl -->
-			<exclude>org/wildfly/openssl/*</exclude>
+                        <exclude>org/xerial/snappy/**/*</exclude>
+                        <!-- Exclude org.widlfly.openssl -->
+                        <exclude>org/wildfly/openssl/*</exclude>
                       </excludes>
                     </relocation>
                     <relocation>

--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -160,7 +160,9 @@
                         <exclude>org/bouncycastle/**/*</exclude>
                         <!-- Exclude snappy-java -->
                         <exclude>org/xerial/snappy/*</exclude>
-                        <exclude>org/xerial/snappy/**/*</exclude>
+			<exclude>org/xerial/snappy/**/*</exclude>
+			<!-- Exclude org.widlfly.openssl -->
+			<exclude>org/wildfly/openssl/*</exclude>
                       </excludes>
                     </relocation>
                     <relocation>

--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -163,6 +163,7 @@
                         <exclude>org/xerial/snappy/**/*</exclude>
                         <!-- Exclude org.widlfly.openssl -->
                         <exclude>org/wildfly/openssl/*</exclude>
+                        <exclude>org/wildfly/openssl/**/*</exclude>
                       </excludes>
                     </relocation>
                     <relocation>


### PR DESCRIPTION
### Description of PR

`org.wildfly.openssl` is a runtime library and its references are being shaded on Hadoop, breaking the integration with other frameworks like Spark, whenever the "fs.s3a.ssl.channel.mode" is set to "openssl". The error produced in this situation is:

```
Suppressed: java.lang.NoClassDefFoundError: org/apache/hadoop/shaded/org/wildfly/openssl/OpenSSLProvider
```

This PR aims to exclude `org.wildfly.openssl` from the shade, keeping the original namespace to be referenced whenever this runtime dependency is added to the classpath. 

### How was this patch tested?

Used the patched jar on a Spark 3.2.1 application which now correctly references the `org.wildfly.openssl` dependency added to the classpath.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

