### PR TITLE
HDFS-16509. Fix decommission UnsupportedOperationException

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -390,8 +390,10 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
       // Remove the block from the list if it's no longer in the block map,
       // e.g. the containing file has been deleted
       if (blockManager.blocksMap.getStoredBlock(block) == null) {
-        LOG.trace("Removing unknown block {}", block);
-        it.remove();
+        if (pruneReliableBlocks) {
+          LOG.trace("Removing unknown block {}", block);
+          it.remove();
+        }
         continue;
       }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
@@ -687,22 +687,7 @@ public class TestDecommission extends AdminStatesBaseTest {
     dn.getStorageInfos()[0].addBlock(blk, blk);
 
     datanodeManager.getDatanodeAdminManager().startDecommission(dn);
-    waitNodeDecommissioned(dn);
-  }
-
-  private void waitNodeDecommissioned(DatanodeInfo node) {
-    DatanodeInfo.AdminStates state = DatanodeInfo.AdminStates.DECOMMISSIONED;
-    boolean done = (state == node.getAdminState());
-    while (!done) {
-      LOG.info("Waiting for node " + node + " to change state to "
-          + state + " current state: " + node.getAdminState());
-      try {
-        Thread.sleep(500);
-      } catch (InterruptedException e) {
-        // nothing
-      }
-      done = (state == node.getAdminState());
-    }
+    waitNodeState(dn, DatanodeInfo.AdminStates.DECOMMISSIONED);
   }
 
   private static String scanIntoString(final ByteArrayOutputStream baos) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDecommission.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.BatchedRemoteIterator.BatchedEntries;
 import org.apache.hadoop.hdfs.client.HdfsDataInputStream;
 import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo.AdminStates;
@@ -64,6 +65,7 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.protocol.OpenFileEntry;
 import org.apache.hadoop.hdfs.protocol.OpenFilesIterator;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoContiguous;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManagerTestUtil;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
@@ -671,6 +673,36 @@ public class TestDecommission extends AdminStatesBaseTest {
     }
 
     fdos.close();
+  }
+
+  @Test(timeout = 20000)
+  public void testDecommissionWithUnknownBlock() throws IOException {
+    startCluster(1, 3);
+
+    FSNamesystem ns = getCluster().getNamesystem(0);
+    DatanodeManager datanodeManager = ns.getBlockManager().getDatanodeManager();
+
+    BlockInfo blk = new BlockInfoContiguous(new Block(1L), (short) 1);
+    DatanodeDescriptor dn = datanodeManager.getDatanodes().iterator().next();
+    dn.getStorageInfos()[0].addBlock(blk, blk);
+
+    datanodeManager.getDatanodeAdminManager().startDecommission(dn);
+    waitNodeDecommissioned(dn);
+  }
+
+  private void waitNodeDecommissioned(DatanodeInfo node) {
+    DatanodeInfo.AdminStates state = DatanodeInfo.AdminStates.DECOMMISSIONED;
+    boolean done = (state == node.getAdminState());
+    while (!done) {
+      LOG.info("Waiting for node " + node + " to change state to "
+          + state + " current state: " + node.getAdminState());
+      try {
+        Thread.sleep(500);
+      } catch (InterruptedException e) {
+        // nothing
+      }
+      done = (state == node.getAdminState());
+    }
   }
 
   private static String scanIntoString(final ByteArrayOutputStream baos) {


### PR DESCRIPTION
We encountered an `UnsupportedOperationException: Remove unsupported` error when some datanodes were in decommission. The reason of the exception is that `datanode.getBlockIterator()` returns an Iterator does not support remove, however `DatanodeAdminDefaultMonitor#processBlocksInternal` invokes `it.remove()` when a block not found, e.g, the file containing the block is deleted.