### PR TITLE
HDFS-16507. [SBN read] Avoid purging edit log which is in progress

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -1509,22 +1509,18 @@ public class FSEditLog implements LogsPurgeable {
    * effect.
    */
   @Override
-  public synchronized void purgeLogsOlderThan(long minTxIdToKeep) {
+  public synchronized void purgeLogsOlderThan(final long minTxIdToKeep) {
     // Should not purge logs unless they are open for write.
     // This prevents the SBN from purging logs on shared storage, for example.
     if (!isOpenForWrite()) {
       return;
     }
 
-    // Reset purgeLogsFrom to avoid purging edit log which is in progress.
-    if (isSegmentOpen()) {
-      minTxIdToKeep = minTxIdToKeep > curSegmentTxId ? curSegmentTxId : minTxIdToKeep;
-    }
-
-    assert curSegmentTxId == HdfsServerConstants.INVALID_TXID || // on format this is no-op
-      minTxIdToKeep <= curSegmentTxId :
-      "cannot purge logs older than txid " + minTxIdToKeep +
-      " when current segment starts at " + curSegmentTxId;
+    Preconditions.checkArgument(
+        curSegmentTxId == HdfsServerConstants.INVALID_TXID || // on format this is no-op
+        minTxIdToKeep <= curSegmentTxId,
+        "cannot purge logs older than txid " + minTxIdToKeep +
+        " when current segment starts at " + curSegmentTxId);
     if (minTxIdToKeep == 0) {
       return;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -1509,13 +1509,18 @@ public class FSEditLog implements LogsPurgeable {
    * effect.
    */
   @Override
-  public synchronized void purgeLogsOlderThan(final long minTxIdToKeep) {
+  public synchronized void purgeLogsOlderThan(long minTxIdToKeep) {
     // Should not purge logs unless they are open for write.
     // This prevents the SBN from purging logs on shared storage, for example.
     if (!isOpenForWrite()) {
       return;
     }
-    
+
+    // Reset purgeLogsFrom to avoid purging edit log which is in progress.
+    if (isSegmentOpen()) {
+      minTxIdToKeep = minTxIdToKeep > curSegmentTxId ? curSegmentTxId : minTxIdToKeep;
+    }
+
     assert curSegmentTxId == HdfsServerConstants.INVALID_TXID || // on format this is no-op
       minTxIdToKeep <= curSegmentTxId :
       "cannot purge logs older than txid " + minTxIdToKeep +


### PR DESCRIPTION
JIRA: [HDFS-16507](https://issues.apache.org/jira/browse/HDFS-16507).

Avoid purging edit log which is in progress. This is described in detail in JIRA.

The stack:
```
java.lang.Thread.getStackTrace(Thread.java:1552)
    org.apache.hadoop.util.StringUtils.getStackTrace(StringUtils.java:1032)
    org.apache.hadoop.hdfs.server.namenode.FileJournalManager.purgeLogsOlderThan(FileJournalManager.java:185)
    org.apache.hadoop.hdfs.server.namenode.JournalSet$5.apply(JournalSet.java:623)
    org.apache.hadoop.hdfs.server.namenode.JournalSet.mapJournalsAndReportErrors(JournalSet.java:388)
    org.apache.hadoop.hdfs.server.namenode.JournalSet.purgeLogsOlderThan(JournalSet.java:620)
    org.apache.hadoop.hdfs.server.namenode.FSEditLog.purgeLogsOlderThan(FSEditLog.java:1512)
org.apache.hadoop.hdfs.server.namenode.NNStorageRetentionManager.purgeOldStorage(NNStorageRetentionManager.java:177)
    org.apache.hadoop.hdfs.server.namenode.FSImage.purgeOldStorage(FSImage.java:1249)
    org.apache.hadoop.hdfs.server.namenode.ImageServlet$2.run(ImageServlet.java:617)
    org.apache.hadoop.hdfs.server.namenode.ImageServlet$2.run(ImageServlet.java:516)
    java.security.AccessController.doPrivileged(Native Method)
    javax.security.auth.Subject.doAs(Subject.java:422)
    org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1730)
    org.apache.hadoop.hdfs.server.namenode.ImageServlet.doPut(ImageServlet.java:515)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:710)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
    org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:848)
    org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1772)
    org.apache.hadoop.http.HttpServer2$QuotingInputFilter.doFilter(HttpServer2.java:1604)
    org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1759)
    org.apache.hadoop.http.NoCacheFilter.doFilter(NoCacheFilter.java:45)
    org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1759)
    org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:582)
    org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
    org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
    org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:226)
    org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1180)
    org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:512)
    org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
    org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1112)
    org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:119)
    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:134)
    org.eclipse.jetty.server.Server.handle(Server.java:539)
    org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:333)
    org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:251)
    org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:283)
    org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:108)
    org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:93)
    org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.executeProduceConsume(ExecuteProduceConsume.java:303)
    org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceConsume(ExecuteProduceConsume.java:148)
    org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:136)
    org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:671)
    org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:589)
    java.lang.Thread.run(Thread.java:745)
```