### PR TITLE
HDFS-16513. [SBN read] Observer Namenode should not trigger the edits rolling of active Namenode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1940,7 +1940,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
   public boolean isInObserverState() {
     if (haContext == null || haContext.getState() == null) {
-      return haEnabled;
+      return false;
     }
 
     return HAServiceState.OBSERVER == haContext.getState().getServiceState();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1938,6 +1938,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         HAServiceState.OBSERVER == haContext.getState().getServiceState();
   }
 
+  public boolean isInObserverState() {
+    if (haContext == null || haContext.getState() == null) {
+      return haEnabled;
+    }
+
+    return HAServiceState.OBSERVER == haContext.getState().getServiceState();
+  }
+
   /**
    * return a list of blocks &amp; their locations on {@code datanode} whose
    * total size is {@code size}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/EditLogTailer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/EditLogTailer.java
@@ -505,7 +505,7 @@ public class EditLogTailer {
           // read any more transactions since the last time a roll was
           // triggered.
           boolean triggeredLogRoll = false;
-          if (tooLongSinceLastLoad() &&
+          if (!namesystem.isInObserverState() && tooLongSinceLastLoad() &&
               lastRollTriggerTxId < lastLoadedTxnId) {
             triggerActiveLogRoll();
             triggeredLogRoll = true;


### PR DESCRIPTION
JIRA: [HDFS-16513](https://issues.apache.org/jira/browse/HDFS-16513).

To avoid frequent edtis rolling, we should disable OBN from triggering the edits rolling of active Namenode. 

It is sufficient to retain only the `triggering of SNN` and the `auto rolling of ANN`. 