### PR TITLE
HDFS-16514. Reduce the failover sleep time if multiple namenode are c…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -316,13 +316,16 @@ public class NameNodeProxiesClient {
       Configuration conf, URI nameNodeUri, Class<T> xface,
       AbstractNNFailoverProxyProvider<T> failoverProxyProvider) {
     Preconditions.checkNotNull(failoverProxyProvider);
+    Map<String, Map<String, InetSocketAddress>> map =
+        DFSUtilClient.getAddresses(conf, null, HdfsClientConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY);
+    Map<String, InetSocketAddress> nnMap = map.get(nameNodeUri.getHost());
     // HA case
     DfsClientConf config = new DfsClientConf(conf);
     T proxy = (T) RetryProxy.create(xface, failoverProxyProvider,
         RetryPolicies.failoverOnNetworkException(
             RetryPolicies.TRY_ONCE_THEN_FAIL, config.getMaxFailoverAttempts(),
             config.getMaxRetryAttempts(), config.getFailoverSleepBaseMillis(),
-            config.getFailoverSleepMaxMillis()));
+            config.getFailoverSleepMaxMillis(), nnMap.size()));
 
     Text dtService;
     if (failoverProxyProvider.useLogicalURI()) {


### PR DESCRIPTION
JIRA: [HDFS-16514](https://issues.apache.org/jira/browse/HDFS-16514)
Recently, we used the [Standby Read] feature in our test cluster, and deployed 4 namenode as follow:
node1 -> active nn
node2 -> standby nn
node3 -> observer nn
node3 -> observer nn

If we set ’dfs.client.failover.random.order=true‘, the client may failover twice and wait a long time to send msync to active namenode. 

![image](https://user-images.githubusercontent.com/2844826/159257471-4398ae11-fad3-4aee-8f56-1b89bef2f611.png)


I think we can reduce the sleep time of the first several failover based on the number of namenode.
For example, if 4 namenode are configured, the sleep time of first three failover operations is set to zero.