### PR TITLE
HADOOP-18169. getDelegationTokens in ViewFs should also fetch the token from fallback FS

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -749,9 +749,9 @@ public class ViewFs extends AbstractFileSystem {
 
     // Add tokens from fallback FS
     if (this.fsState.getRootFallbackLink() != null) {
-      AbstractFileSystem linkFallbackFs =
+      AbstractFileSystem rootFallbackFs =
           this.fsState.getRootFallbackLink().getTargetFileSystem();
-      List<Token<?>> tokens = linkFallbackFs.getDelegationTokens(renewer);
+      List<Token<?>> tokens = rootFallbackFs.getDelegationTokens(renewer);
       if (tokens != null) {
         result.addAll(tokens);
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -746,6 +746,17 @@ public class ViewFs extends AbstractFileSystem {
         result.addAll(tokens);
       }
     }
+
+    // Add tokens from fallback FS
+    if (this.fsState.getRootFallbackLink() != null) {
+      AbstractFileSystem linkedFallbackFs =
+          this.fsState.getRootFallbackLink().getTargetFileSystem();
+      List<Token<?>> tokens = linkedFallbackFs.getDelegationTokens(renewer);
+      if (tokens != null) {
+        result.addAll(tokens);
+      }
+    }
+
     return result;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -749,9 +749,9 @@ public class ViewFs extends AbstractFileSystem {
 
     // Add tokens from fallback FS
     if (this.fsState.getRootFallbackLink() != null) {
-      AbstractFileSystem linkedFallbackFs =
+      AbstractFileSystem linkFallbackFs =
           this.fsState.getRootFallbackLink().getTargetFileSystem();
-      List<Token<?>> tokens = linkedFallbackFs.getDelegationTokens(renewer);
+      List<Token<?>> tokens = linkFallbackFs.getDelegationTokens(renewer);
       if (tokens != null) {
         result.addAll(tokens);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsLinkFallback.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsLinkFallback.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.EnumSet;
 
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.AbstractFileSystem;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -45,6 +46,7 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
+import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -180,6 +182,26 @@ public class TestViewFsLinkFallback {
     assertFalse(fsTarget.exists(test));
     vfs.mkdir(p, null, true);
     assertTrue(fsTarget.exists(test));
+  }
+
+  /**
+   * Test getDelegationToken when fallback is configured
+   */
+  @Test
+  public void testGetDelegationToken() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(Constants.CONFIG_VIEWFS_MOUNT_LINKS_AS_SYMLINKS, false);
+    ConfigUtil.addLink(conf, "/user",
+        new Path(targetTestRoot.toString(), "user").toUri());
+    ConfigUtil.addLink(conf, "/data",
+        new Path(targetTestRoot.toString(), "data").toUri());
+    ConfigUtil.addLinkFallback(conf, targetTestRoot.toUri());
+
+    FileContext fcView =
+        FileContext.getFileContext(FsConstants.VIEWFS_URI, conf);
+    List<Token<?>> tokens = fcView.getDelegationTokens(new Path("/"), "tester");
+    // Two tokens from the two mount points and one token from fallback
+    assertEquals(3, tokens.size());
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsLinkFallback.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFsLinkFallback.java
@@ -185,7 +185,7 @@ public class TestViewFsLinkFallback {
   }
 
   /**
-   * Test getDelegationToken when fallback is configured
+   * Test getDelegationToken when fallback is configured.
    */
   @Test
   public void testGetDelegationToken() throws IOException {


### PR DESCRIPTION

### Description of PR


### How was this patch tested?
mvn test -Dtest="TestViewFs*" in both hadoop-common-project and hadoop-hdfs-project.



