### PR TITLE
HADOOP-18180. Replace use of twitter util-core with java futures

### DIFF
--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -436,12 +436,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.twitter</groupId>
-      <artifactId>util-core_2.11</artifactId>
-      <version>21.2.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/BufferData.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/BufferData.java
@@ -22,10 +22,9 @@ package org.apache.hadoop.fs.common;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.zip.CRC32;
 
-import com.twitter.util.Awaitable.CanAwait;
-import com.twitter.util.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -263,8 +262,6 @@ public class BufferData {
     return false;
   }
 
-  private static final CanAwait CAN_AWAIT = () -> false;
-
   public String toString() {
 
     return String.format(
@@ -281,7 +278,7 @@ public class BufferData {
     if (f == null) {
       return "--";
     } else {
-      return this.action.isReady(CAN_AWAIT) ? "done" : "not done";
+      return this.action.isDone() ? "done" : "not done";
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/BufferPool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/BufferPool.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 
 import org.slf4j.Logger;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/BufferPool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/BufferPool.java
@@ -27,8 +27,8 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
 
-import com.twitter.util.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,7 +233,7 @@ public class BufferPool implements Closeable {
     for (BufferData data : this.getAll()) {
       Future<Void> actionFuture = data.getActionFuture();
       if (actionFuture != null) {
-        actionFuture.raise(new CancellationException("BufferPool is closing."));
+        actionFuture.cancel(true);
       }
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/CachingBlockManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/CachingBlockManager.java
@@ -440,8 +440,7 @@ public abstract class CachingBlockManager extends BlockManager {
         return;
       }
     } catch (Exception e) {
-      String message = String.format("error waiting on blockFuture: %s", data);
-      LOG.error(message, e);
+      LOG.error("error waiting on blockFuture: {}", data, e);
       data.setDone();
       return;
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/CachingBlockManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/CachingBlockManager.java
@@ -248,7 +248,7 @@ public abstract class CachingBlockManager extends BlockManager {
 
       BlockOperations.Operation op = this.ops.requestPrefetch(blockNumber);
       PrefetchTask prefetchTask = new PrefetchTask(data, this);
-      Future<Void> prefetchFuture = this.futurePool.apply(prefetchTask);
+      Future<Void> prefetchFuture = this.futurePool.executeFunction(prefetchTask);
       data.setPrefetch(prefetchFuture);
       this.ops.end(op);
     }
@@ -419,7 +419,7 @@ public abstract class CachingBlockManager extends BlockManager {
       }
 
       CachePutTask task = new CachePutTask(data, blockFuture, this);
-      Future<Void> actionFuture = this.futurePool.apply(task);
+      Future<Void> actionFuture = this.futurePool.executeFunction(task);
       data.setCaching(actionFuture);
       this.ops.end(op);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/CachingBlockManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/CachingBlockManager.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class CachingBlockManager extends BlockManager {
   private static final Logger LOG = LoggerFactory.getLogger(CachingBlockManager.class);
+  private static final int TIMEOUT_MINUTES = 60;
 
   // Asynchronous tasks are performed in this pool.
   private final ExecutorServiceFuturePool futurePool;
@@ -434,7 +436,7 @@ public abstract class CachingBlockManager extends BlockManager {
     }
 
     try {
-      blockFuture.get(); //TODO consider calling get(long timeout, TimeUnit unit) instead
+      blockFuture.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
       if (data.stateEqualsOneOf(BufferData.State.DONE)) {
         // There was an error during prefetch.
         return;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -24,6 +24,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
+/**
+ * A FuturePool implementation backed by a java.util.concurrent.ExecutorService.
+ *
+ * If a piece of work has started, it cannot (currently) be cancelled.
+ *
+ * This class is a simplified version of <code>com.twitter:util-core_2.11</code> ExecutorServiceFuturePool
+ * designed to avoid depending on that Scala library. One problem with using a Scala library is that many
+ * downstream projects (eg Apache Spark) use Scala and they might want to use a different version of Scala
+ * from the version that Hadoop chooses to use.
+ *
+ */
 public class ExecutorServiceFuturePool {
     private ExecutorService executor;
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hadoop.fs.common;
+
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+public class ExecutorServiceFuturePool {
+    private ExecutorService executor;
+
+    public ExecutorServiceFuturePool(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * @param f function to run in future on executor pool
+     * @return future
+     * @throws java.util.concurrent.RejectedExecutionException can be thrown
+     * @throws NullPointerException if f param is null
+     */
+    public Future<Void> apply(final Supplier<Void> f) {
+        return executor.submit(f::get);
+    }
+
+    public String toString() {
+        return String.format(Locale.ROOT,"ExecutorServiceFuturePool(executor=%s)", executor);
+    }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -29,9 +29,10 @@ import java.util.function.Supplier;
  *
  * If a piece of work has started, it cannot (currently) be cancelled.
  *
- * This class is a simplified version of <code>com.twitter:util-core_2.11</code> ExecutorServiceFuturePool
- * designed to avoid depending on that Scala library. One problem with using a Scala library is that many
- * downstream projects (eg Apache Spark) use Scala and they might want to use a different version of Scala
+ * This class is a simplified version of <code>com.twitter:util-core_2.11</code>
+ * ExecutorServiceFuturePool designed to avoid depending on that Scala library.
+ * One problem with using a Scala library is that many downstream projects
+ * (eg Apache Spark) use Scala, and they might want to use a different version of Scala
  * from the version that Hadoop chooses to use.
  *
  */
@@ -64,6 +65,6 @@ public class ExecutorServiceFuturePool {
   }
 
   public String toString() {
-    return String.format(Locale.ROOT,"ExecutorServiceFuturePool(executor=%s)", executor);
+    return String.format(Locale.ROOT, "ExecutorServiceFuturePool(executor=%s)", executor);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -48,7 +48,7 @@ public class ExecutorServiceFuturePool {
      * @throws java.util.concurrent.RejectedExecutionException can be thrown
      * @throws NullPointerException if f param is null
      */
-    public Future<Void> apply(final Supplier<Void> f) {
+    public Future<Void> executeFunction(final Supplier<Void> f) {
         return executor.submit(f::get);
     }
 
@@ -58,7 +58,7 @@ public class ExecutorServiceFuturePool {
      * @throws java.util.concurrent.RejectedExecutionException can be thrown
      * @throws NullPointerException if f param is null
      */
-    public Future<Void> apply(final Runnable r) {
+    public Future<Void> executeRunnable(final Runnable r) {
         return (Future<Void>) executor.submit(() -> r.run());
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -58,6 +58,7 @@ public class ExecutorServiceFuturePool {
      * @throws java.util.concurrent.RejectedExecutionException can be thrown
      * @throws NullPointerException if r param is null
      */
+    @SuppressWarnings("unchecked")
     public Future<Void> executeRunnable(final Runnable r) {
         return (Future<Void>) executor.submit(() -> r.run());
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -36,34 +36,34 @@ import java.util.function.Supplier;
  *
  */
 public class ExecutorServiceFuturePool {
-    private ExecutorService executor;
+  private ExecutorService executor;
 
-    public ExecutorServiceFuturePool(ExecutorService executor) {
-        this.executor = executor;
-    }
+  public ExecutorServiceFuturePool(ExecutorService executor) {
+    this.executor = executor;
+  }
 
-    /**
-     * @param f function to run in future on executor pool
-     * @return future
-     * @throws java.util.concurrent.RejectedExecutionException can be thrown
-     * @throws NullPointerException if f param is null
-     */
-    public Future<Void> executeFunction(final Supplier<Void> f) {
-        return executor.submit(f::get);
-    }
+  /**
+   * @param f function to run in future on executor pool
+   * @return future
+   * @throws java.util.concurrent.RejectedExecutionException can be thrown
+   * @throws NullPointerException if f param is null
+   */
+  public Future<Void> executeFunction(final Supplier<Void> f) {
+    return executor.submit(f::get);
+  }
 
-    /**
-     * @param r runnable to run in future on executor pool
-     * @return future
-     * @throws java.util.concurrent.RejectedExecutionException can be thrown
-     * @throws NullPointerException if r param is null
-     */
-    @SuppressWarnings("unchecked")
-    public Future<Void> executeRunnable(final Runnable r) {
-        return (Future<Void>) executor.submit(() -> r.run());
-    }
+  /**
+   * @param r runnable to run in future on executor pool
+   * @return future
+   * @throws java.util.concurrent.RejectedExecutionException can be thrown
+   * @throws NullPointerException if r param is null
+   */
+  @SuppressWarnings("unchecked")
+  public Future<Void> executeRunnable(final Runnable r) {
+    return (Future<Void>) executor.submit(() -> r.run());
+  }
 
-    public String toString() {
-        return String.format(Locale.ROOT,"ExecutorServiceFuturePool(executor=%s)", executor);
-    }
+  public String toString() {
+    return String.format(Locale.ROOT,"ExecutorServiceFuturePool(executor=%s)", executor);
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -52,6 +52,16 @@ public class ExecutorServiceFuturePool {
         return executor.submit(f::get);
     }
 
+    /**
+     * @param r runnable to run in future on executor pool
+     * @return future
+     * @throws java.util.concurrent.RejectedExecutionException can be thrown
+     * @throws NullPointerException if f param is null
+     */
+    public Future<Void> apply(final Runnable r) {
+        return (Future<Void>) executor.submit(() -> r.run());
+    }
+
     public String toString() {
         return String.format(Locale.ROOT,"ExecutorServiceFuturePool(executor=%s)", executor);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -61,7 +61,7 @@ public class ExecutorServiceFuturePool {
    */
   @SuppressWarnings("unchecked")
   public Future<Void> executeRunnable(final Runnable r) {
-    return (Future<Void>) executor.submit(() -> r.run());
+    return (Future<Void>) executor.submit(r::run);
   }
 
   public String toString() {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/common/ExecutorServiceFuturePool.java
@@ -56,7 +56,7 @@ public class ExecutorServiceFuturePool {
      * @param r runnable to run in future on executor pool
      * @return future
      * @throws java.util.concurrent.RejectedExecutionException can be thrown
-     * @throws NullPointerException if f param is null
+     * @throws NullPointerException if r param is null
      */
     public Future<Void> executeRunnable(final Runnable r) {
         return (Future<Void>) executor.submit(() -> r.run());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -76,8 +76,7 @@ import com.amazonaws.services.s3.transfer.model.CopyResult;
 import com.amazonaws.services.s3.transfer.model.UploadResult;
 import com.amazonaws.event.ProgressListener;
 
-import com.twitter.util.ExecutorServiceFuturePool;
-import com.twitter.util.FuturePool;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -283,7 +282,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   private ThreadPoolExecutor unboundedThreadPool;
 
   // S3 reads are prefetched asynchronously using this future pool.
-  private FuturePool futurePool;
+  private ExecutorServiceFuturePool futurePool;
 
   // If true, the prefetching input stream is used for reads.
   private boolean prefetchEnabled;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AReadOpContext.java
@@ -18,11 +18,10 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import com.twitter.util.FuturePool;
-
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.statistics.S3AStatisticsContext;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
@@ -61,7 +60,7 @@ public class S3AReadOpContext extends S3AOpContext {
   private final AuditSpan auditSpan;
 
   // S3 reads are prefetched asynchronously using this future pool.
-  private FuturePool futurePool;
+  private ExecutorServiceFuturePool futurePool;
 
   // Size in bytes of a single prefetch block.
   private final int prefetchBlockSize;
@@ -80,7 +79,7 @@ public class S3AReadOpContext extends S3AOpContext {
    * @param changeDetectionPolicy change detection policy.
    * @param readahead readahead for GET operations/skip, etc.
    * @param auditSpan active audit
-   * @param futurePool the FuturePool instance used by async prefetches.
+   * @param futurePool the ExecutorServiceFuturePool instance used by async prefetches.
    * @param prefetchBlockSize the size (in number of bytes) of each prefetched block.
    * @param prefetchBlockCount maximum number of prefetched blocks.
    */
@@ -94,7 +93,7 @@ public class S3AReadOpContext extends S3AOpContext {
       ChangeDetectionPolicy changeDetectionPolicy,
       final long readahead,
       final AuditSpan auditSpan,
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       int prefetchBlockSize,
       int prefetchBlockCount) {
 
@@ -161,11 +160,11 @@ public class S3AReadOpContext extends S3AOpContext {
   }
 
   /**
-   * Gets the {@code FuturePool} used for asynchronous prefetches.
+   * Gets the {@code ExecutorServiceFuturePool} used for asynchronous prefetches.
    *
-   * @return the {@code FuturePool} used for asynchronous prefetches.
+   * @return the {@code ExecutorServiceFuturePool} used for asynchronous prefetches.
    */
-  public FuturePool getFuturePool() {
+  public ExecutorServiceFuturePool getFuturePool() {
     return this.futurePool;
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/read/S3CachingBlockManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/read/S3CachingBlockManager.java
@@ -22,7 +22,7 @@ package org.apache.hadoop.fs.s3a.read;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import com.twitter.util.FuturePool;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class S3CachingBlockManager extends CachingBlockManager {
    * @throws IllegalArgumentException if reader is null.
    */
   public S3CachingBlockManager(
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       S3Reader reader,
       BlockData blockData,
       int bufferPoolSize) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/read/S3CachingBlockManager.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/read/S3CachingBlockManager.java
@@ -22,12 +22,12 @@ package org.apache.hadoop.fs.s3a.read;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.common.BlockData;
 import org.apache.hadoop.fs.common.CachingBlockManager;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.fs.common.Validate;
 
 /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/read/S3CachingInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/read/S3CachingInputStream.java
@@ -21,13 +21,13 @@ package org.apache.hadoop.fs.s3a.read;
 
 import java.io.IOException;
 
-import com.twitter.util.FuturePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.fs.common.BlockData;
 import org.apache.hadoop.fs.common.BlockManager;
 import org.apache.hadoop.fs.common.BufferData;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.fs.s3a.S3AInputStream;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
@@ -186,7 +186,7 @@ public class S3CachingInputStream extends S3InputStream {
   }
 
   protected BlockManager createBlockManager(
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       S3Reader reader,
       BlockData blockData,
       int bufferPoolSize) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestBufferData.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestBufferData.java
@@ -24,8 +24,8 @@ import java.nio.ReadOnlyBufferException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
-import com.twitter.util.Future;
 import org.junit.Test;
 
 import org.apache.hadoop.test.AbstractHadoopTestBase;
@@ -83,13 +83,14 @@ public class TestBufferData extends AbstractHadoopTestBase {
 
     assertEquals(BufferData.State.BLANK, data.getState());
 
-    Future<Void> actionFuture = Future.value(null);
+    CompletableFuture<Void> actionFuture = new CompletableFuture<>();
+    actionFuture.complete(null);
     data.setPrefetch(actionFuture);
     assertEquals(BufferData.State.PREFETCHING, data.getState());
     assertNotNull(data.getActionFuture());
     assertSame(actionFuture, data.getActionFuture());
 
-    Future<Void> actionFuture2 = Future.value(null);
+    CompletableFuture<Void> actionFuture2 = new CompletableFuture<>();
     data.setCaching(actionFuture2);
     assertEquals(BufferData.State.CACHING, data.getState());
     assertNotNull(data.getActionFuture());
@@ -117,7 +118,8 @@ public class TestBufferData extends AbstractHadoopTestBase {
 
   @Test
   public void testInvalidStateUpdates() throws Exception {
-    Future<Void> actionFuture = Future.value(null);
+    CompletableFuture<Void> actionFuture = new CompletableFuture<>();
+    actionFuture.complete(null);
     testInvalidStateUpdatesHelper(
         (d) -> d.setPrefetch(actionFuture),
         BufferData.State.BLANK,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
@@ -19,18 +19,19 @@
 
 package org.apache.hadoop.fs.common;
 
-import org.apache.hadoop.test.AbstractHadoopTestBase;
-import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.apache.hadoop.test.LambdaTestUtils;
 
 import static org.junit.Assert.assertTrue;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.fs.common;
 
 import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +32,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TestExecutorServiceFuturePool extends AbstractHadoopTestBase {
@@ -72,22 +72,20 @@ public class TestExecutorServiceFuturePool extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testRunnableFails() {
+  public void testRunnableFails() throws Exception {
     ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
     Future<Void> future = futurePool.executeRunnable(() -> {
       throw new IllegalStateException("deliberate");
     });
-    assertThrows("future failed with ExecutionException?",
-        ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+    LambdaTestUtils.intercept(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
   }
 
   @Test
-  public void testSupplierFails() {
+  public void testSupplierFails() throws Exception {
     ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
     Future<Void> future = futurePool.executeFunction(() -> {
       throw new IllegalStateException("deliberate");
     });
-    assertThrows("future failed with ExecutionException?",
-        ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+    LambdaTestUtils.intercept(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -39,7 +38,7 @@ public class TestExecutorServiceFuturePool {
         try {
             ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
             final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
-            Future<Void> future = futurePool.apply(() -> atomicBoolean.set(true));
+            Future<Void> future = futurePool.executeRunnable(() -> atomicBoolean.set(true));
             future.get(30, TimeUnit.SECONDS);
             assertTrue(atomicBoolean.get());
         } finally {
@@ -53,7 +52,7 @@ public class TestExecutorServiceFuturePool {
         try {
             ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
             final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
-            Future<Void> future = futurePool.apply(() -> {
+            Future<Void> future = futurePool.executeFunction(() -> {
                 atomicBoolean.set(true);
                 return null;
             });
@@ -69,7 +68,7 @@ public class TestExecutorServiceFuturePool {
         ExecutorService executorService = Executors.newFixedThreadPool(3);
         try {
             ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
-            Future<Void> future = futurePool.apply((Runnable) () -> {
+            Future<Void> future = futurePool.executeRunnable(() -> {
                 throw new IllegalStateException("deliberate");
             });
             assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
@@ -83,11 +82,8 @@ public class TestExecutorServiceFuturePool {
         ExecutorService executorService = Executors.newFixedThreadPool(3);
         try {
             ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
-            Future<Void> future = futurePool.apply(new Supplier<Void>() {
-                @Override
-                public Void get() {
-                    throw new IllegalStateException("deliberate");
-                }
+            Future<Void> future = futurePool.executeFunction(() -> {
+                throw new IllegalStateException("deliberate");
             });
             assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
         } finally {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.hadoop.fs.common;
 
 import org.junit.Test;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
@@ -32,62 +32,62 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TestExecutorServiceFuturePool {
-    @Test
-    public void testRunnableSucceeds() throws Exception {
-        ExecutorService executorService = Executors.newFixedThreadPool(3);
-        try {
-            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
-            final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
-            Future<Void> future = futurePool.executeRunnable(() -> atomicBoolean.set(true));
-            future.get(30, TimeUnit.SECONDS);
-            assertTrue(atomicBoolean.get());
-        } finally {
-            executorService.shutdownNow();
-        }
+  @Test
+  public void testRunnableSucceeds() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+    try {
+      ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+      final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+      Future<Void> future = futurePool.executeRunnable(() -> atomicBoolean.set(true));
+      future.get(30, TimeUnit.SECONDS);
+      assertTrue(atomicBoolean.get());
+    } finally {
+      executorService.shutdownNow();
     }
+  }
 
-    @Test
-    public void testSupplierSucceeds() throws Exception {
-        ExecutorService executorService = Executors.newFixedThreadPool(3);
-        try {
-            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
-            final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
-            Future<Void> future = futurePool.executeFunction(() -> {
-                atomicBoolean.set(true);
-                return null;
-            });
-            future.get(30, TimeUnit.SECONDS);
-            assertTrue(atomicBoolean.get());
-        } finally {
-            executorService.shutdownNow();
-        }
+  @Test
+  public void testSupplierSucceeds() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+    try {
+      ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+      final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+      Future<Void> future = futurePool.executeFunction(() -> {
+        atomicBoolean.set(true);
+        return null;
+      });
+      future.get(30, TimeUnit.SECONDS);
+      assertTrue(atomicBoolean.get());
+    } finally {
+      executorService.shutdownNow();
     }
+  }
 
-    @Test
-    public void testRunnableFails() throws Exception {
-        ExecutorService executorService = Executors.newFixedThreadPool(3);
-        try {
-            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
-            Future<Void> future = futurePool.executeRunnable(() -> {
-                throw new IllegalStateException("deliberate");
-            });
-            assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
-        } finally {
-            executorService.shutdownNow();
-        }
+  @Test
+  public void testRunnableFails() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+    try {
+      ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+      Future<Void> future = futurePool.executeRunnable(() -> {
+        throw new IllegalStateException("deliberate");
+      });
+      assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+    } finally {
+      executorService.shutdownNow();
     }
+  }
 
-    @Test
-    public void testSupplierFails() throws Exception {
-        ExecutorService executorService = Executors.newFixedThreadPool(3);
-        try {
-            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
-            Future<Void> future = futurePool.executeFunction(() -> {
-                throw new IllegalStateException("deliberate");
-            });
-            assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
-        } finally {
-            executorService.shutdownNow();
-        }
+  @Test
+  public void testSupplierFails() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+    try {
+      ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+      Future<Void> future = futurePool.executeFunction(() -> {
+        throw new IllegalStateException("deliberate");
+      });
+      assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+    } finally {
+      executorService.shutdownNow();
     }
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/common/TestExecutorServiceFuturePool.java
@@ -1,0 +1,78 @@
+package org.apache.hadoop.fs.common;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class TestExecutorServiceFuturePool {
+    @Test
+    public void testRunnableSucceeds() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        try {
+            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+            final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+            Future<Void> future = futurePool.apply(() -> atomicBoolean.set(true));
+            future.get(30, TimeUnit.SECONDS);
+            assertTrue(atomicBoolean.get());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testSupplierSucceeds() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        try {
+            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+            final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+            Future<Void> future = futurePool.apply(() -> {
+                atomicBoolean.set(true);
+                return null;
+            });
+            future.get(30, TimeUnit.SECONDS);
+            assertTrue(atomicBoolean.get());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testRunnableFails() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        try {
+            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+            Future<Void> future = futurePool.apply((Runnable) () -> {
+                throw new IllegalStateException("deliberate");
+            });
+            assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testSupplierFails() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        try {
+            ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(executorService);
+            Future<Void> future = futurePool.apply(new Supplier<Void>() {
+                @Override
+                public Void get() {
+                    throw new IllegalStateException("deliberate");
+                }
+            });
+            assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/Fakes.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/Fakes.java
@@ -34,11 +34,11 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.twitter.util.FuturePool;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.common.BlockCache;
 import org.apache.hadoop.fs.common.BlockData;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.fs.common.SingleFilePerBlockCache;
 import org.apache.hadoop.fs.common.Validate;
 import org.apache.hadoop.fs.s3a.Invoker;
@@ -109,7 +109,7 @@ public final class Fakes {
   }
 
   public static S3AReadOpContext createReadContext(
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       String key,
       int fileSize,
       int prefetchBlockSize,
@@ -195,7 +195,7 @@ public final class Fakes {
 
   public static S3InputStream createInputStream(
       Class<? extends S3InputStream> clazz,
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       String bucket,
       String key,
       int fileSize,
@@ -225,7 +225,7 @@ public final class Fakes {
   }
 
   public static TestS3InMemoryInputStream createS3InMemoryInputStream(
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       String bucket,
       String key,
       int fileSize) {
@@ -235,7 +235,7 @@ public final class Fakes {
   }
 
   public static TestS3CachingInputStream createS3CachingInputStream(
-      FuturePool futurePool,
+      ExecutorServiceFuturePool futurePool,
       String bucket,
       String key,
       int fileSize,
@@ -322,7 +322,7 @@ public final class Fakes {
 
   public static class TestS3CachingBlockManager extends S3CachingBlockManager {
     public TestS3CachingBlockManager(
-        FuturePool futurePool,
+        ExecutorServiceFuturePool futurePool,
         S3Reader reader,
         BlockData blockData,
         int bufferPoolSize) {
@@ -359,7 +359,7 @@ public final class Fakes {
 
     @Override
     protected S3CachingBlockManager createBlockManager(
-        FuturePool futurePool,
+        ExecutorServiceFuturePool futurePool,
         S3Reader reader,
         BlockData blockData,
         int bufferPoolSize) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3CachingBlockManager.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3CachingBlockManager.java
@@ -24,13 +24,12 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.twitter.util.ExecutorServiceFuturePool;
-import com.twitter.util.FuturePool;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.common.BlockData;
 import org.apache.hadoop.fs.common.BufferData;
 import org.apache.hadoop.fs.common.ExceptionAsserts;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.junit.Assert.assertEquals;
@@ -41,7 +40,7 @@ public class TestS3CachingBlockManager extends AbstractHadoopTestBase {
   static final int POOL_SIZE = 3;
 
   private final ExecutorService threadPool = Executors.newFixedThreadPool(4);
-  private final FuturePool futurePool = new ExecutorServiceFuturePool(threadPool);
+  private final ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(threadPool);
 
   private final BlockData blockData = new BlockData(FILE_SIZE, BLOCK_SIZE);
 
@@ -106,7 +105,7 @@ public class TestS3CachingBlockManager extends AbstractHadoopTestBase {
    */
   static class TestBlockManager extends S3CachingBlockManager {
     TestBlockManager(
-        FuturePool futurePool,
+        ExecutorServiceFuturePool futurePool,
         S3Reader reader,
         BlockData blockData,
         int bufferPoolSize) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3File.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3File.java
@@ -22,11 +22,10 @@ package org.apache.hadoop.fs.s3a.read;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.twitter.util.ExecutorServiceFuturePool;
-import com.twitter.util.FuturePool;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.common.ExceptionAsserts;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.fs.s3a.S3AInputStream;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
@@ -36,7 +35,7 @@ import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 public class TestS3File extends AbstractHadoopTestBase {
   private final ExecutorService threadPool = Executors.newFixedThreadPool(1);
-  private final FuturePool futurePool = new ExecutorServiceFuturePool(threadPool);
+  private final ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(threadPool);
   private final S3AInputStream.InputStreamCallbacks client = MockS3File.createClient("bucket");
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3InputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3InputStream.java
@@ -24,11 +24,11 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.common.ExceptionAsserts;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.apache.hadoop.fs.s3a.S3AInputStream;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3InputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/read/TestS3InputStream.java
@@ -24,8 +24,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.twitter.util.ExecutorServiceFuturePool;
-import com.twitter.util.FuturePool;
+import org.apache.hadoop.fs.common.ExecutorServiceFuturePool;
 import org.junit.Test;
 
 import org.apache.hadoop.fs.FSExceptionMessages;
@@ -45,7 +44,7 @@ public class TestS3InputStream extends AbstractHadoopTestBase {
   private static final int FILE_SIZE = 10;
 
   private final ExecutorService threadPool = Executors.newFixedThreadPool(4);
-  private final FuturePool futurePool = new ExecutorServiceFuturePool(threadPool);
+  private final ExecutorServiceFuturePool futurePool = new ExecutorServiceFuturePool(threadPool);
   private final S3AInputStream.InputStreamCallbacks client = MockS3File.createClient("bucket");
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-18180 replace use of twitter util-core - it uses scala 2.11 and will cause issue for Spark and other scala based tools that use different versions of scala

### How was this patch tested?

* CI build
* local build

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

