### PR TITLE
HDFS-16529. Remove unnecessary setObserverRead in TestConsistentReadsObserver

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestConsistentReadsObserver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestConsistentReadsObserver.java
@@ -108,8 +108,6 @@ public class TestConsistentReadsObserver {
 
   @Test
   public void testRequeueCall() throws Exception {
-    setObserverRead(true);
-
     // Update the configuration just for the observer, by enabling
     // IPC backoff and using the test scheduler class, which starts to backoff
     // after certain number of calls.


### PR DESCRIPTION
Remove unnecessary setObserverRead in TestConsistentReadsObserver
JIRA: https://issues.apache.org/jira/browse/HDFS-16529


### Description of PR


### How was this patch tested?


### For code changes:


