### PR TITLE
HADOOP-16104. Wasb tests to downgrade to skip when test a/c is namesp…

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azure.metrics.AzureFileSystemInstrumentation;
 import org.apache.hadoop.fs.azure.metrics.AzureFileSystemMetricsSystem;
+import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.MetricsSink;
@@ -525,6 +526,8 @@ public final class AzureBlobStorageTestAccount implements AutoCloseable,
 
   static CloudStorageAccount createTestAccount(Configuration conf)
       throws URISyntaxException, KeyProviderException {
+    AzureTestUtils.assumeNamespaceDisabled(conf);
+
     String testAccountName = verifyWasbAccountNameInConfig(conf);
     if (testAccountName == null) {
       LOG.warn("Skipping live Azure test because of missing test account");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/contract/NativeAzureFileSystemContract.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/contract/NativeAzureFileSystemContract.java
@@ -34,6 +34,7 @@ public class NativeAzureFileSystemContract extends AbstractBondedFSContract {
   public NativeAzureFileSystemContract(Configuration conf) {
     super(conf); //insert the base features
     addConfResource(CONTRACT_XML);
+    AzureTestUtils.assumeNamespaceDisabled(conf);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
@@ -47,6 +47,7 @@ import static org.junit.Assume.assumeTrue;
 import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX;
 import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.WASB_TEST_ACCOUNT_NAME_WITH_DOMAIN;
 import static org.apache.hadoop.fs.azure.integration.AzureTestConstants.*;
+import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
@@ -544,5 +545,13 @@ public final class AzureTestUtils extends Assert {
     }
     inputStream.close();
     return new String(buffer, 0, count);
+  }
+
+  /**
+   * Assume hierarchical namespace is disabled for test account.
+   */
+  public static void assumeNamespaceDisabled(Configuration conf) {
+    Assume.assumeFalse("Hierarchical namespace is enabled for test account.",
+        conf.getBoolean(FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT, false));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/resources/azure-test.xml
+++ b/hadoop-tools/hadoop-azure/src/test/resources/azure-test.xml
@@ -28,6 +28,11 @@
     <value>false</value>
   </property>
 
+  <property>
+    <name>fs.azure.test.namespace.enabled</name>
+    <value>false</value>
+  </property>
+
   <!--====================  ABFS CONFIGURATION ====================-->
   <!-- SEE relevant section in "site/markdown/testing_azure.md"-->
 

--- a/hadoop-tools/hadoop-azure/src/test/resources/wasb.xml
+++ b/hadoop-tools/hadoop-azure/src/test/resources/wasb.xml
@@ -161,4 +161,9 @@
     <value>true</value>
   </property>
 
+  <property>
+    <name>fs.azure.test.namespace.enabled</name>
+    <value>false</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
…ace enabled. Contributed by Masatake Iwasaki.

(cherry picked from commit aa3ad3660506382884324c4b8997973f5a68e29a)

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
cherry-pick of aa3ad3660506382884324c4b8997973f5a68e29a from trunk to branch-2.10
The unit tests that fail in this PR are also failing in the vanilla branch-2.10

@omalley  can you please review it?

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

