### PR TITLE
HDFS-16530. setReplication debug log creates a new string even if debug is disabled

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirAttrOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirAttrOp.java
@@ -415,7 +415,7 @@ public class FSDirAttrOp {
       bm.setReplication(oldBR, targetReplication, b);
     }
 
-    if (oldBR != -1) {
+    if (oldBR != -1 && FSDirectory.LOG.isDebugEnabled()) {
       if (oldBR > targetReplication) {
         FSDirectory.LOG.debug("Decreasing replication from {} to {} for {}",
                              oldBR, targetReplication, iip.getPath());


### PR DESCRIPTION
### Description of PR

In FSDirAttrOp, [HDFS-14521](https://issues.apache.org/jira/browse/HDFS-14521) made a good change to move a noisy logger to debug:

```
      if (oldBR > targetReplication) {
        FSDirectory.LOG.debug("Decreasing replication from {} to {} for {}",
                             oldBR, targetReplication, iip.getPath());
      } else if (oldBR < targetReplication) {
        FSDirectory.LOG.debug("Increasing replication from {} to {} for {}",
                             oldBR, targetReplication, iip.getPath());
      } else {
        FSDirectory.LOG.debug("Replication remains unchanged at {} for {}",
                             oldBR, iip.getPath());
      }
    }
```
However the `iip.getPath()` method must be evaluated to pass the resulting string into the LOG.debug method, even if debug is not enabled:

This code may form a new string where it does not need to:
```
  public String getPath() {
    if (pathname == null) {
      pathname = DFSUtil.byteArray2PathString(path);
    }
    return pathname;
  }
```
We should wrap the entire logging block in `if LOG.debugEnabled()` to avoid any overhead when the logger is not enabled.

### How was this patch tested?

No new tests - simple change.

