### PR TITLE
HADOOP-18172: Change scope of InodeTree and its member methods to make them accessible from outside package.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -73,7 +73,7 @@ public abstract class InodeTree<T> {
   private final String homedirPrefix;
   private List<MountPoint<T>> mountPoints = new ArrayList<MountPoint<T>>();
 
-  static class MountPoint<T> {
+  public static class MountPoint<T> {
     String src;
     INodeLink<T> target;
 
@@ -229,7 +229,7 @@ public abstract class InodeTree<T> {
    * For a merge, each target is checked to be dir when created but if target
    * is changed later it is then ignored (a dir with null entries)
    */
-  static class INodeLink<T> extends INode<T> {
+  public static class INodeLink<T> extends INode<T> {
     final String[] targetDirLinkList;
     private T targetFileSystem;   // file system object created from the link.
     // Function to initialize file system. Only applicable for simple links
@@ -636,7 +636,7 @@ public abstract class InodeTree<T> {
    * If the input pathname leads to an internal mount-table entry then
    * the target file system is one that represents the internal inode.
    */
-  static class ResolveResult<T> {
+  public static class ResolveResult<T> {
     final ResultKind kind;
     final T targetFileSystem;
     final String resolvedPath;
@@ -663,7 +663,7 @@ public abstract class InodeTree<T> {
    * @return ResolveResult which allows further resolution of the remaining path
    * @throws FileNotFoundException
    */
-  ResolveResult<T> resolve(final String p, final boolean resolveLastComponent)
+  public ResolveResult<T> resolve(final String p, final boolean resolveLastComponent)
       throws IOException {
     // TO DO: - more efficient to not split the path, but simply compare
     String[] path = breakIntoPathComponents(p); 
@@ -756,7 +756,7 @@ public abstract class InodeTree<T> {
     return res;
   }
 
-  List<MountPoint<T>> getMountPoints() {
+  public List<MountPoint<T>> getMountPoints() {
     return mountPoints;
   }
 
@@ -765,7 +765,7 @@ public abstract class InodeTree<T> {
    * @return home dir value from mount table; null if no config value
    * was found.
    */
-  String getHomeDirPrefixValue() {
+  public String getHomeDirPrefixValue() {
     return homedirPrefix;
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.util.StringUtils;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-abstract class InodeTree<T> {
+public abstract class InodeTree<T> {
   enum ResultKind {
     INTERNAL_DIR,
     EXTERNAL_DIR
@@ -410,7 +410,16 @@ abstract class InodeTree<T> {
     return rootFallbackLink != null;
   }
 
-  protected INodeLink<T> getRootFallbackLink() {
+  /**
+   * @return true if the root represented as internalDir. In LinkMergeSlash,
+   * there will be root to root mapping. So, root does not represent as
+   * internalDir.
+   */
+  public boolean isRootInternalDir() {
+    return root.isInternalDir();
+  }
+
+  public INodeLink<T> getRootFallbackLink() {
     Preconditions.checkState(root.isInternalDir());
     return rootFallbackLink;
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -73,7 +73,7 @@ public abstract class InodeTree<T> {
   private final String homedirPrefix;
   private List<MountPoint<T>> mountPoints = new ArrayList<MountPoint<T>>();
 
-  public static class MountPoint<T> {
+  static class MountPoint<T> {
     String src;
     INodeLink<T> target;
 
@@ -229,7 +229,7 @@ public abstract class InodeTree<T> {
    * For a merge, each target is checked to be dir when created but if target
    * is changed later it is then ignored (a dir with null entries)
    */
-  public static class INodeLink<T> extends INode<T> {
+  static class INodeLink<T> extends INode<T> {
     final String[] targetDirLinkList;
     private T targetFileSystem;   // file system object created from the link.
     // Function to initialize file system. Only applicable for simple links
@@ -408,15 +408,6 @@ public abstract class InodeTree<T> {
 
   private boolean hasFallbackLink() {
     return rootFallbackLink != null;
-  }
-
-  /**
-   * @return true if the root represented as internalDir. In LinkMergeSlash,
-   * there will be root to root mapping. So, root does not represent as
-   * internalDir.
-   */
-  public boolean isRootInternalDir() {
-    return root.isInternalDir();
   }
 
   public INodeLink<T> getRootFallbackLink() {
@@ -756,7 +747,7 @@ public abstract class InodeTree<T> {
     return res;
   }
 
-  public List<MountPoint<T>> getMountPoints() {
+  List<MountPoint<T>> getMountPoints() {
     return mountPoints;
   }
 


### PR DESCRIPTION
### Description of PR
backport of HADOOP-18172 for branch-2.10

### How was this patch tested?

mvn install -DskipTests


