### PR TITLE
HADOOP-18201. Remove endpoint config overrides for ITestS3ARequesterPays

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARequesterPays.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ARequesterPays.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.statistics.IOStatisticAssertions;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
 import static org.apache.hadoop.fs.s3a.Constants.ALLOW_REQUESTER_PAYS;
+import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.S3A_BUCKET_PROBE;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
@@ -43,6 +44,7 @@ public class ITestS3ARequesterPays extends AbstractS3ATestBase {
     Configuration conf = super.createConfiguration();
     S3ATestUtils.removeBaseAndBucketOverrides(conf,
         ALLOW_REQUESTER_PAYS,
+        ENDPOINT,
         S3A_BUCKET_PROBE);
     return conf;
   }


### PR DESCRIPTION
### Description of PR

Requester pays was added in #3962. The new tests remove overrides for requester pays enablement but do not account for developers changing the S3 endpoint.

To address this, we remove the override for endpoint.

Addresses HADOOP-18201.

### How was this patch tested?

Patch will be tested against `eu-west-1` - specifically against its regional endpoint.

