### PR TITLE
HDFS-16542. Fix failed unit tests in branch branch-3.2

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
@@ -175,8 +175,9 @@ public class OfflineImageViewerPB {
     String tempPath = cmd.getOptionValue("t", "");
 
     Configuration conf = new Configuration();
-    try (PrintStream out = outputFile.equals("-") ?
-        System.out : new PrintStream(outputFile, "UTF-8")) {
+    PrintStream out = null;
+    try {
+      out = outputFile.equals("-") ? System.out : new PrintStream(outputFile, "UTF-8");
       switch (StringUtils.toUpperCase(processor)) {
       case "FILEDISTRIBUTION":
         long maxSize = Long.parseLong(cmd.getOptionValue("maxSize", "0"));
@@ -223,6 +224,10 @@ public class OfflineImageViewerPB {
     } catch (IOException e) {
       System.err.println("Encountered exception.  Exiting: " + e.getMessage());
       e.printStackTrace(System.err);
+    } finally {
+      if (out != null && out != System.out) {
+        out.close();
+      }
     }
     return -1;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CreateFlag;
@@ -889,6 +890,7 @@ public class TestBlockManager {
 
   @Test
   public void testSkipReconstructionWithManyBusyNodes2() {
+    NameNode.initMetrics(new Configuration(), HdfsServerConstants.NamenodeRole.NAMENODE);
     long blockId = -9223372036854775776L; // real ec block id
     // RS-3-2 EC policy
     ErasureCodingPolicy ecPolicy =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 
 
 public class TestUnderReplicatedBlocks {
-  @Test(timeout=120000) // 1 min timeout
+  @Test(timeout=180000) // 3 minutes timeout
   public void testSetRepIncWithUnderReplicatedBlocks() throws Exception {
     Configuration conf = new HdfsConfiguration();
     final short REPLICATION_FACTOR = 2;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -670,7 +670,7 @@ public class TestDirectoryScanner {
     // We need lots of blocks so the report compiler threads have enough to
     // keep them busy while we watch them.
     int blocks = 20000;
-    int maxRetries = 3;
+    int maxRetries = 5;
 
     cluster = new MiniDFSCluster.Builder(conf).build();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFsck.java
@@ -201,6 +201,7 @@ public class TestFsck {
   private void shutdownCluster() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
+      cluster = null;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -838,7 +838,7 @@ public class TestOfflineImageViewer {
       writer.println("<?xml version=\"1.0\"?>");
       writer.println("<fsimage>");
       writer.println("<version>");
-      writer.println("<layoutVersion>-67</layoutVersion>");
+      writer.println("<layoutVersion>-65</layoutVersion>");
       writer.println("<onDiskVersion>1</onDiskVersion>");
       writer.println("<oivRevision>545bbef596c06af1c3c8dca1ce29096a64608478</oivRevision>");
       writer.println("</version>");


### PR DESCRIPTION
Tests fail in branch branch-3.2:
```
hadoop.hdfs.tools.offlineImageViewer.TestOfflineImageViewer
hadoop.hdfs.TestReconstructStripedFileWithValidator
hadoop.hdfs.server.namenode.TestFsck
hadoop.hdfs.server.blockmanagement.TestBlockManager
```