### PR TITLE
HDFS-16543. Keep default value of dfs.datanode.directoryscan.throttle.limit.ms.pe…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -885,7 +885,7 @@
 
 <property>
   <name>dfs.datanode.directoryscan.throttle.limit.ms.per.sec</name>
-  <value>1000</value>
+  <value>-1</value>
   <description>The report compilation threads are limited to only running for
   a given number of milliseconds per second, as configured by the
   property. The limit is taken per thread, not in aggregate, e.g. setting
@@ -896,9 +896,9 @@
   actual running time of the threads per second will typically be somewhat
   higher than the throttle limit, usually by no more than 20%.
 
-  Setting this limit to 1000 disables compiler thread throttling. Only
+  Setting this limit to -1 disables compiler thread throttling. Only
   values between 1 and 1000 are valid. Setting an invalid value will result
-  in the throttle being disabled and an error message being logged. 1000 is
+  in the throttle being disabled and an error message being logged. -1 is
   the default setting.
   </description>
 </property>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeConfig.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeConfig.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.io.nativeio.NativeIO;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -165,4 +166,14 @@ public class TestDatanodeConfig {
           prevLimit);
     }
   }
+
+  @Test(timeout = 10000)
+  public void testValue() throws Exception {
+    Configuration conf = cluster.getConfiguration(0);
+    int throttle = conf.getInt(
+        DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_KEY,
+        DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_DEFAULT);
+    Assert.assertEquals(-1, throttle);
+  }
+
 }


### PR DESCRIPTION
`WARN datanode.DirectoryScanner (DirectoryScanner.java:<init>(300)) - dfs.datanode.directoryscan.throttle.limit.ms.per.sec set to value above 1000 ms/sec. Assuming default value of -1`
A warning log like above will be printed when datanode is starting. The reason of that is the default value of `dfs.datanode.directoryscan.throttle.limit.ms.per.sec` is 1000 in hdfs-site.xml, and is -1 in `DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_DEFAULT`. We should try to keep it consistent, and value -1 looks is better to 1000.

The code segment that print the warning log:
```
if (throttle >= TimeUnit.SECONDS.toMillis(1)) {
  LOG.warn(
      "{} set to value above 1000 ms/sec. Assuming default value of {}",
      DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_KEY,
      DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_DEFAULT);
  throttle =
      DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THROTTLE_LIMIT_MS_PER_SEC_DEFAULT;
}
```