### PR TITLE
HDFS-16632. modify block reader finish condition

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/reader/block_reader.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/reader/block_reader.cc
@@ -395,7 +395,7 @@ struct BlockReaderImpl::AckRead : continuation::Continuation
   virtual void Run(const Next &next) override {
     LOG_TRACE(kBlockReader, << "BlockReaderImpl::AckRead::Run(" << FMT_CONT_AND_PARENT_ADDR << ") called");
 
-    if (parent_->bytes_to_read_ > 0) {
+    if (parent_->bytes_to_read_ >= 0) {
       next(Status::OK());
       return;
     }


### PR DESCRIPTION


Description of PR
bytes_to_read_ is used to calculate all the data that client had received（include DATA and META length）. while currently we initialize it to data length，so the stop condition should be:
 bytes_to_read_  < 0

JIRA: [HADOOP-18204](https://issues.apache.org/jira/browse/HADOOP-18204)

