### PR TITLE
HDFS-16546. Fix UT TestOfflineImageViewer#testReverseXmlWithoutSnapshotDiffSection to branch branch-3.2

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewer.java
@@ -838,7 +838,7 @@ public class TestOfflineImageViewer {
       writer.println("<?xml version=\"1.0\"?>");
       writer.println("<fsimage>");
       writer.println("<version>");
-      writer.println("<layoutVersion>-67</layoutVersion>");
+      writer.println("<layoutVersion>-65</layoutVersion>");
       writer.println("<onDiskVersion>1</onDiskVersion>");
       writer.println("<oivRevision>545bbef596c06af1c3c8dca1ce29096a64608478</oivRevision>");
       writer.println("</version>");


### PR DESCRIPTION
The test fails due to incorrect layoutVersion.