### PR TITLE
HDFS-14750. RBF: Support dynamic handler allocation in routers

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
@@ -44,6 +44,7 @@ public class AbstractRouterRpcFairnessPolicyController
 
   /** Hash table to hold semaphore for each configured name service. */
   private Map<String, AdjustableSemaphore> permits;
+  private final Map<String, Integer> permitSizes = new HashMap<>();
   private Map<String, LongAdder> rejectedPermitsPerNs;
   private Map<String, LongAdder> acceptedPermitsPerNs;
 
@@ -99,6 +100,19 @@ public class AbstractRouterRpcFairnessPolicyController
   }
 
   @Override
+  public String getPermitCapacityPerNs() {
+    JSONObject json = new JSONObject();
+    for (Map.Entry<String, Integer> entry : permitSizes.entrySet()) {
+      try {
+        json.put(entry.getKey(), entry.getValue());
+      } catch (JSONException e) {
+        LOG.warn("Cannot put {} into JSONObject", entry.getKey(), e);
+      }
+    }
+    return json.toString();
+  }
+
+  @Override
   public void setMetrics(Map<String, LongAdder> rejectedPermits,
       Map<String, LongAdder> acceptedPermits) {
     this.rejectedPermitsPerNs = rejectedPermits;
@@ -114,5 +128,9 @@ public class AbstractRouterRpcFairnessPolicyController
   }
   public Map<String, LongAdder> getAcceptedPermitsPerNs() {
     return acceptedPermitsPerNs;
+  }
+
+  protected Map<String, Integer> getPermitSizes() {
+    return permitSizes;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
@@ -43,9 +43,9 @@ public class AbstractRouterRpcFairnessPolicyController
       LoggerFactory.getLogger(AbstractRouterRpcFairnessPolicyController.class);
 
   /** Hash table to hold semaphore for each configured name service. */
-  protected Map<String, AdjustableSemaphore> permits;
-  protected Map<String, LongAdder> rejectedPermitsPerNs;
-  protected Map<String, LongAdder> acceptedPermitsPerNs;
+  private Map<String, AdjustableSemaphore> permits;
+  private Map<String, LongAdder> rejectedPermitsPerNs;
+  private Map<String, LongAdder> acceptedPermitsPerNs;
 
   public void init(Configuration conf) {
     this.permits = new HashMap<>();
@@ -99,9 +99,20 @@ public class AbstractRouterRpcFairnessPolicyController
   }
 
   @Override
-  public void setMetrics(Map<String, LongAdder> rejectedPermitsPerNs,
-      Map<String, LongAdder> acceptedPermitsPerNs) {
-    this.rejectedPermitsPerNs = rejectedPermitsPerNs;
-    this.acceptedPermitsPerNs = acceptedPermitsPerNs;
+  public void setMetrics(Map<String, LongAdder> rejectedPermits,
+      Map<String, LongAdder> acceptedPermits) {
+    this.rejectedPermitsPerNs = rejectedPermits;
+    this.acceptedPermitsPerNs = acceptedPermits;
+  }
+
+  protected Map<String, AdjustableSemaphore> getPermits() {
+    return permits;
+  }
+
+  public Map<String, LongAdder> getRejectedPermitsPerNs() {
+    return rejectedPermitsPerNs;
+  }
+  public Map<String, LongAdder> getAcceptedPermitsPerNs() {
+    return acceptedPermitsPerNs;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/DynamicRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/DynamicRouterRpcFairnessPolicyController.java
@@ -33,8 +33,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.utils.AdjustableSemaphore;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_DEFAULT;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
 
@@ -42,7 +42,8 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
  * Dynamic fairness policy extending {@link StaticRouterRpcFairnessPolicyController}
  * and fetching handlers from configuration for all available name services.
  * The handlers count changes according to traffic to namespaces.
- * Total handlers might NOT strictly add up to the value defined by DFS_ROUTER_HANDLER_COUNT_KEY.
+ * Total handlers might NOT strictly add up to the value defined by DFS_ROUTER_HANDLER_COUNT_KEY
+ * but will not exceed initial handler count + number of nameservices.
  */
 public class DynamicRouterRpcFairnessPolicyController
     extends StaticRouterRpcFairnessPolicyController {
@@ -67,8 +68,9 @@ public class DynamicRouterRpcFairnessPolicyController
     super(conf);
     handlerCount = conf.getInt(DFS_ROUTER_HANDLER_COUNT_KEY, DFS_ROUTER_HANDLER_COUNT_DEFAULT);
     long refreshInterval =
-        conf.getTimeDuration(DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_KEY,
-            DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
+        conf.getTimeDuration(DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_KEY,
+            DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_DEFAULT,
+            TimeUnit.SECONDS);
     permitsResizerService = new PermitsResizerService();
     refreshTask = scheduledExecutor
         .scheduleWithFixedDelay(permitsResizerService, refreshInterval, refreshInterval,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/DynamicRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/DynamicRouterRpcFairnessPolicyController.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.server.federation.utils.AdjustableSemaphore;
+import org.apache.hadoop.util.concurrent.HadoopExecutors;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
+
+/**
+ * Dynamic fairness policy extending {@link StaticRouterRpcFairnessPolicyController}
+ * and fetching handlers from configuration for all available name services.
+ * The handlers count changes according to traffic to namespaces.
+ * Total handlers might NOT strictly add up to the value defined by DFS_ROUTER_HANDLER_COUNT_KEY.
+ */
+public class DynamicRouterRpcFairnessPolicyController
+    extends StaticRouterRpcFairnessPolicyController {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DynamicRouterRpcFairnessPolicyController.class);
+
+  private static final ScheduledExecutorService scheduledExecutor = HadoopExecutors
+      .newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setDaemon(true)
+          .setNameFormat("DynamicRouterRpcFairnessPolicyControllerPermitsResizer").build());
+  private PermitsResizerService permitsResizerService;
+  private ScheduledFuture<?> refreshTask;
+  private int handlerCount;
+
+  /**
+   * Initializes using the same logic as {@link StaticRouterRpcFairnessPolicyController}
+   * and starts a periodic semaphore resizer thread
+   *
+   * @param conf configuration
+   */
+  public DynamicRouterRpcFairnessPolicyController(Configuration conf) {
+    super(conf);
+    handlerCount = conf.getInt(DFS_ROUTER_HANDLER_COUNT_KEY, DFS_ROUTER_HANDLER_COUNT_DEFAULT);
+    long refreshInterval =
+        conf.getTimeDuration(DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_KEY,
+            DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
+    permitsResizerService = new PermitsResizerService();
+    refreshTask = scheduledExecutor
+        .scheduleWithFixedDelay(permitsResizerService, refreshInterval, refreshInterval,
+            TimeUnit.MILLISECONDS);
+  }
+
+  @VisibleForTesting
+  public DynamicRouterRpcFairnessPolicyController(Configuration conf, long refreshInterval) {
+    super(conf);
+    handlerCount = conf.getInt(DFS_ROUTER_HANDLER_COUNT_KEY, DFS_ROUTER_HANDLER_COUNT_DEFAULT);
+    permitsResizerService = new PermitsResizerService();
+    refreshTask = scheduledExecutor
+        .scheduleWithFixedDelay(permitsResizerService, refreshInterval, refreshInterval,
+            TimeUnit.MILLISECONDS);
+  }
+
+  @VisibleForTesting
+  public void refreshPermitsCap() {
+    permitsResizerService.run();
+  }
+
+  @Override
+  public void shutdown() {
+    super.shutdown();
+    if (refreshTask != null) {
+      refreshTask.cancel(true);
+    }
+    if (scheduledExecutor != null) {
+      scheduledExecutor.shutdown();
+    }
+  }
+
+  class PermitsResizerService implements Runnable {
+
+    @Override
+    public synchronized void run() {
+      long totalOps = 0;
+      Map<String, Long> nsOps = new HashMap<>();
+      for (Map.Entry<String, AdjustableSemaphore> entry : permits.entrySet()) {
+        long ops = (rejectedPermitsPerNs.containsKey(entry.getKey()) ?
+            rejectedPermitsPerNs.get(entry.getKey()).longValue() :
+            0) + (acceptedPermitsPerNs.containsKey(entry.getKey()) ?
+            acceptedPermitsPerNs.get(entry.getKey()).longValue() :
+            0);
+        nsOps.put(entry.getKey(), ops);
+        totalOps += ops;
+      }
+
+      for (Map.Entry<String, AdjustableSemaphore> entry : permits.entrySet()) {
+        String ns = entry.getKey();
+        AdjustableSemaphore semaphore = entry.getValue();
+        int oldPermitCap = permitSizes.get(ns);
+        int newPermitCap = (int) Math.ceil((float) nsOps.get(ns) / totalOps * handlerCount);
+        // Leave at least 1 handler even if there's no traffic
+        if (newPermitCap == 0) {
+          newPermitCap = 1;
+        }
+        permitSizes.put(ns, newPermitCap);
+        if (newPermitCap > oldPermitCap) {
+          semaphore.release(newPermitCap - oldPermitCap);
+        } else if (newPermitCap < oldPermitCap) {
+          semaphore.reducePermits(oldPermitCap - newPermitCap);
+        }
+        LOG.info("Resized handlers for nsId {} from {} to {}", ns, oldPermitCap, newPermitCap);
+      }
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
@@ -56,6 +56,11 @@ public class NoRouterRpcFairnessPolicyController implements
   }
 
   @Override
+  public String getPermitCapacityPerNs() {
+    return "N/A";
+  }
+
+  @Override
   public void setMetrics(Map<String, LongAdder> rejectedPermitsPerNs,
       Map<String, LongAdder> acceptedPermitsPerNs) {
     // Nothing

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.hdfs.server.federation.fairness;
 
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -50,5 +53,11 @@ public class NoRouterRpcFairnessPolicyController implements
   @Override
   public String getAvailableHandlerOnPerNs(){
     return "N/A";
+  }
+
+  @Override
+  public void setMetrics(Map<String, LongAdder> rejectedPermitsPerNs,
+      Map<String, LongAdder> acceptedPermitsPerNs) {
+    // Nothing
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.hdfs.server.federation.fairness;
 
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -67,4 +70,10 @@ public interface RouterRpcFairnessPolicyController {
    * Returns the JSON string of the available handler for each Ns.
    */
   String getAvailableHandlerOnPerNs();
+
+  /**
+   * Attaches permits access metrics to the controller
+   */
+  void setMetrics(Map<String, LongAdder> rejectedPermitsPerNs,
+      Map<String, LongAdder> acceptedPermitsPerNs);
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
@@ -72,7 +72,7 @@ public interface RouterRpcFairnessPolicyController {
   String getAvailableHandlerOnPerNs();
 
   /**
-   * Attaches permits access metrics to the controller
+   * Attaches permits access metrics to the controller.
    */
   void setMetrics(Map<String, LongAdder> rejectedPermitsPerNs,
       Map<String, LongAdder> acceptedPermitsPerNs);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
@@ -72,6 +72,11 @@ public interface RouterRpcFairnessPolicyController {
   String getAvailableHandlerOnPerNs();
 
   /**
+   * Returns the JSON string of the max handler count for each ns.
+   */
+  String getPermitCapacityPerNs();
+
+  /**
    * Attaches permits access metrics to the controller.
    */
   void setMetrics(Map<String, LongAdder> rejectedPermitsPerNs,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
@@ -48,7 +48,7 @@ public class StaticRouterRpcFairnessPolicyController extends
       + DFS_ROUTER_HANDLER_COUNT_KEY + '='
       + " %d is less than the minimum required handlers %d";
 
-  protected Map<String, Integer> permitSizes = new HashMap<>();
+  private Map<String, Integer> permitSizes = new HashMap<>();
 
   public StaticRouterRpcFairnessPolicyController(Configuration conf) {
     init(conf);
@@ -142,4 +142,7 @@ public class StaticRouterRpcFairnessPolicyController extends
     }
   }
 
+  protected Map<String, Integer> getPermitSizes() {
+    return permitSizes;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 
@@ -45,6 +47,8 @@ public class StaticRouterRpcFairnessPolicyController extends
   public static final String ERROR_MSG = "Configured handlers "
       + DFS_ROUTER_HANDLER_COUNT_KEY + '='
       + " %d is less than the minimum required handlers %d";
+
+  protected Map<String, Integer> permitSizes = new HashMap<>();
 
   public StaticRouterRpcFairnessPolicyController(Configuration conf) {
     init(conf);
@@ -78,6 +82,7 @@ public class StaticRouterRpcFairnessPolicyController extends
         handlerCount -= dedicatedHandlers;
         insertNameServiceWithPermits(nsId, dedicatedHandlers);
         logAssignment(nsId, dedicatedHandlers);
+        permitSizes.put(nsId, dedicatedHandlers);
       } else {
         unassignedNS.add(nsId);
       }
@@ -92,6 +97,7 @@ public class StaticRouterRpcFairnessPolicyController extends
       for (String nsId : unassignedNS) {
         insertNameServiceWithPermits(nsId, handlersPerNS);
         logAssignment(nsId, handlersPerNS);
+        permitSizes.put(nsId, handlersPerNS);
       }
     }
 
@@ -103,6 +109,7 @@ public class StaticRouterRpcFairnessPolicyController extends
       LOG.info("Assigned extra {} handlers to commons pool", leftOverHandlers);
       insertNameServiceWithPermits(CONCURRENT_NS,
           existingPermits + leftOverHandlers);
+      permitSizes.put(CONCURRENT_NS, existingPermits + leftOverHandlers);
     }
     LOG.info("Final permit allocation for concurrent ns: {}",
         getAvailablePermits(CONCURRENT_NS));

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import java.util.HashSet;
 
 import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX;
@@ -45,6 +47,9 @@ public class StaticRouterRpcFairnessPolicyController extends
   public static final String ERROR_MSG = "Configured handlers "
       + DFS_ROUTER_HANDLER_COUNT_KEY + '='
       + " %d is less than the minimum required handlers %d";
+  public static final String ERROR_NS_MSG =
+      "Configured handlers %s=%d is less than the minimum required handlers %d";
+
 
   public StaticRouterRpcFairnessPolicyController(Configuration conf) {
     init(conf);
@@ -119,15 +124,23 @@ public class StaticRouterRpcFairnessPolicyController extends
   private void validateHandlersCount(Configuration conf, int handlerCount,
                                      Set<String> allConfiguredNS) {
     int totalDedicatedHandlers = 0;
+    int minimumHandlerPerNs = conf.getInt(DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_KEY,
+        DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_DEFAULT);
     for (String nsId : allConfiguredNS) {
       int dedicatedHandlers =
               conf.getInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + nsId, 0);
       if (dedicatedHandlers > 0) {
+        if (dedicatedHandlers < minimumHandlerPerNs) {
+          String msg = String.format(ERROR_NS_MSG, DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + nsId,
+              handlerCount, minimumHandlerPerNs);
+          LOG.error(msg);
+          throw new IllegalArgumentException(msg);
+        }
         // Total handlers should not be less than sum of dedicated handlers.
         totalDedicatedHandlers += dedicatedHandlers;
       } else {
-        // Each NS should have at least one handler assigned.
-        totalDedicatedHandlers++;
+        // Each NS has to have a minimum number of handlers assigned.
+        totalDedicatedHandlers += minimumHandlerPerNs;
       }
     }
     if (totalDedicatedHandlers > handlerCount) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticRouterRpcFairnessPolicyController.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 
@@ -47,8 +45,6 @@ public class StaticRouterRpcFairnessPolicyController extends
   public static final String ERROR_MSG = "Configured handlers "
       + DFS_ROUTER_HANDLER_COUNT_KEY + '='
       + " %d is less than the minimum required handlers %d";
-
-  private Map<String, Integer> permitSizes = new HashMap<>();
 
   public StaticRouterRpcFairnessPolicyController(Configuration conf) {
     init(conf);
@@ -82,7 +78,7 @@ public class StaticRouterRpcFairnessPolicyController extends
         handlerCount -= dedicatedHandlers;
         insertNameServiceWithPermits(nsId, dedicatedHandlers);
         logAssignment(nsId, dedicatedHandlers);
-        permitSizes.put(nsId, dedicatedHandlers);
+        getPermitSizes().put(nsId, dedicatedHandlers);
       } else {
         unassignedNS.add(nsId);
       }
@@ -97,7 +93,7 @@ public class StaticRouterRpcFairnessPolicyController extends
       for (String nsId : unassignedNS) {
         insertNameServiceWithPermits(nsId, handlersPerNS);
         logAssignment(nsId, handlersPerNS);
-        permitSizes.put(nsId, handlersPerNS);
+        getPermitSizes().put(nsId, handlersPerNS);
       }
     }
 
@@ -109,7 +105,7 @@ public class StaticRouterRpcFairnessPolicyController extends
       LOG.info("Assigned extra {} handlers to commons pool", leftOverHandlers);
       insertNameServiceWithPermits(CONCURRENT_NS,
           existingPermits + leftOverHandlers);
-      permitSizes.put(CONCURRENT_NS, existingPermits + leftOverHandlers);
+      getPermitSizes().put(CONCURRENT_NS, existingPermits + leftOverHandlers);
     }
     LOG.info("Final permit allocation for concurrent ns: {}",
         getAvailablePermits(CONCURRENT_NS));
@@ -140,9 +136,5 @@ public class StaticRouterRpcFairnessPolicyController extends
       LOG.error(msg);
       throw new IllegalArgumentException(msg);
     }
-  }
-
-  protected Map<String, Integer> getPermitSizes() {
-    return permitSizes;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMBean.java
@@ -116,6 +116,12 @@ public interface FederationRPCMBean {
   String getAvailableHandlerOnPerNs();
 
   /**
+   * JSON representation of max handler count per ns.
+   * @return JSON string representation.
+   */
+  String getPermitCapacityPerNs();
+
+  /**
    * Get the JSON representation of the async caller thread pool.
    * @return JSON string representation of the async caller thread pool.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMetrics.java
@@ -248,6 +248,11 @@ public class FederationRPCMetrics implements FederationRPCMBean {
   }
 
   @Override
+  public String getPermitCapacityPerNs() {
+    return rpcServer.getRPCClient().getRouterRpcFairnessPolicyController().getPermitCapacityPerNs();
+  }
+
+  @Override
   public String getAsyncCallerPool() {
     return rpcServer.getRPCClient().getAsyncCallerPoolJson();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/FederationUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/FederationUtil.java
@@ -278,8 +278,8 @@ public final class FederationUtil {
    * from the configuration and attaches permits access metrics to the controller.
    *
    * @param conf Configuration that defines the fairness controller class.
-   * @param rejectedPermitsPerNs Metrics map ns -> rejected permits
-   * @param acceptedPermitsPerNs Metrics map ns -> accepted permits
+   * @param rejectedPermitsPerNs Metrics map ns:rejected permits
+   * @param acceptedPermitsPerNs Metrics map ns:accepted permits
    * @return Fairness policy controller.
    */
   public static RouterRpcFairnessPolicyController newFairnessPolicyController(Configuration conf,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/FederationUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/FederationUtil.java
@@ -29,7 +29,9 @@ import java.net.URLConnection;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSUtil;
@@ -269,6 +271,22 @@ public final class FederationUtil {
         RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS_DEFAULT,
         RouterRpcFairnessPolicyController.class);
     return newInstance(conf, null, null, clazz);
+  }
+
+  /**
+   * Creates an instance of an RouterRpcFairnessPolicyController
+   * from the configuration and attaches permits access metrics to the controller.
+   *
+   * @param conf Configuration that defines the fairness controller class.
+   * @param rejectedPermitsPerNs Metrics map ns -> rejected permits
+   * @param acceptedPermitsPerNs Metrics map ns -> accepted permits
+   * @return Fairness policy controller.
+   */
+  public static RouterRpcFairnessPolicyController newFairnessPolicyController(Configuration conf,
+      Map<String, LongAdder> rejectedPermitsPerNs, Map<String, LongAdder> acceptedPermitsPerNs) {
+    RouterRpcFairnessPolicyController instance = newFairnessPolicyController(conf);
+    instance.setMetrics(rejectedPermitsPerNs, acceptedPermitsPerNs);
+    return instance;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hdfs.server.federation.router;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdfs.server.federation.fairness.NoRouterRpcFairnessPolicyController;
@@ -27,13 +29,11 @@ import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FileSubclusterResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.MembershipNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.MountTableResolver;
+import org.apache.hadoop.hdfs.server.federation.router.security.token.ZKDelegationTokenSecretManagerImpl;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreDriver;
 import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreSerializerPBImpl;
 import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreZooKeeperImpl;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager;
-import org.apache.hadoop.hdfs.server.federation.router.security.token.ZKDelegationTokenSecretManagerImpl;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Config fields for router-based hdfs federation.
@@ -354,10 +354,10 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       NoRouterRpcFairnessPolicyController.class;
   public static final String DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX =
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "handler.count.";
-  public static final long DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_DEFAULT =
-      600000;
-  public static final String DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_KEY =
-      FEDERATION_ROUTER_FAIRNESS_PREFIX + "policy.controller.dynamic.refresh.interval";
+  public static final long DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_DEFAULT =
+      600;
+  public static final String DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_KEY =
+      FEDERATION_ROUTER_FAIRNESS_PREFIX + "policy.controller.dynamic.refresh.interval.seconds";
 
   // HDFS Router Federation Rename.
   public static final String DFS_ROUTER_FEDERATION_RENAME_PREFIX =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -354,6 +354,10 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       NoRouterRpcFairnessPolicyController.class;
   public static final String DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX =
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "handler.count.";
+  public static final long DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_DEFAULT =
+      600000;
+  public static final String DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_KEY =
+      FEDERATION_ROUTER_FAIRNESS_PREFIX + "policy.controller.dynamic.refresh.interval";
 
   // HDFS Router Federation Rename.
   public static final String DFS_ROUTER_FEDERATION_RENAME_PREFIX =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -354,6 +354,9 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       NoRouterRpcFairnessPolicyController.class;
   public static final String DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX =
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "handler.count.";
+  public static final String DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_KEY =
+      FEDERATION_ROUTER_FAIRNESS_PREFIX + "minimum.handler.count";
+  public static int DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_DEFAULT = 1;
   public static final long DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_DEFAULT =
       600;
   public static final String DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -356,7 +356,7 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "handler.count.";
   public static final String DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_KEY =
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "minimum.handler.count";
-  public static int DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_DEFAULT = 1;
+  public static final int DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_DEFAULT = 1;
   public static final long DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_DEFAULT =
       600;
   public static final String DFS_ROUTER_DYNAMIC_FAIRNESS_CONTROLLER_REFRESH_INTERVAL_SECONDS_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -156,8 +156,8 @@ public class RouterRpcClient {
             HADOOP_CALLER_CONTEXT_SEPARATOR_DEFAULT);
     this.connectionManager = new ConnectionManager(clientConf);
     this.connectionManager.start();
-    this.routerRpcFairnessPolicyController =
-        FederationUtil.newFairnessPolicyController(conf);
+    this.routerRpcFairnessPolicyController = FederationUtil
+        .newFairnessPolicyController(conf, rejectedPermitsPerNs, acceptedPermitsPerNs);
 
     int numThreads = conf.getInt(
         RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/utils/AdjustableSemaphore.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/utils/AdjustableSemaphore.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.utils;
+
+import java.util.concurrent.Semaphore;
+
+public class AdjustableSemaphore extends Semaphore {
+
+  public AdjustableSemaphore(int permits) {
+    super(permits);
+  }
+
+  public AdjustableSemaphore(int permits, boolean fair) {
+    super(permits, fair);
+  }
+
+  public void reducePermits(int reduction) {
+    super.reducePermits(reduction);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -707,6 +707,14 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.fairness.policy.controller.dynamic.refresh.interval.seconds</name>
+    <value>600</value>
+    <description>
+      Interval (in seconds) between each handler count resize by DynamicFairnessPolicyController
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.fairness.handler.count.EXAMPLENAMESERVICE</name>
     <value></value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -707,6 +707,16 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.fairness.minimum.handler.count</name>
+    <value>1</value>
+    <description>
+      Minimum number of handlers assigned per nameservice.
+      If any dedicated handler count is smaller than this number,
+      router initialization will fail.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.fairness.policy.controller.dynamic.refresh.interval.seconds</name>
     <value>600</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestDynamicRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestDynamicRouterRpcFairnessPolicyController.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
+
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
+
+/**
+ * Test functionality of {@link DynamicRouterRpcFairnessPolicyController).
+ */
+public class TestDynamicRouterRpcFairnessPolicyController {
+
+  private static String nameServices = "ns1.nn1, ns1.nn2, ns2.nn1, ns2.nn2";
+
+  @Test
+  public void testDynamicControllerSimple() throws InterruptedException {
+    verifyDynamicControllerSimple(true);
+    verifyDynamicControllerSimple(false);
+  }
+
+  @Test
+  public void testDynamicControllerAllPermitsAcquired() throws InterruptedException {
+    verifyDynamicControllerAllPermitsAcquired(true);
+    verifyDynamicControllerAllPermitsAcquired(false);
+  }
+
+  private void verifyDynamicControllerSimple(boolean manualRefresh)
+      throws InterruptedException {
+    // 3 permits each ns
+    DynamicRouterRpcFairnessPolicyController controller;
+    if (manualRefresh) {
+      controller = getFairnessPolicyController(9);
+    } else {
+      controller = getFairnessPolicyController(9, 4000);
+    }
+    for (int i = 0; i < 3; i++) {
+      Assert.assertTrue(controller.acquirePermit("ns1"));
+      Assert.assertTrue(controller.acquirePermit("ns2"));
+      Assert.assertTrue(controller.acquirePermit(CONCURRENT_NS));
+    }
+    Assert.assertFalse(controller.acquirePermit("ns1"));
+    Assert.assertFalse(controller.acquirePermit("ns2"));
+    Assert.assertFalse(controller.acquirePermit(CONCURRENT_NS));
+
+    // Release all permits
+    for (int i = 0; i < 3; i++) {
+      controller.releasePermit("ns1");
+      controller.releasePermit("ns2");
+      controller.releasePermit(CONCURRENT_NS);
+    }
+
+    // Inject dummy metrics
+    // Split half half for ns1 and concurrent
+    Map<String, LongAdder> rejectedPermitsPerNs = new HashMap<>();
+    Map<String, LongAdder> acceptedPermitsPerNs = new HashMap<>();
+    injectDummyMetrics(rejectedPermitsPerNs, "ns1", 10);
+    injectDummyMetrics(rejectedPermitsPerNs, "ns2", 0);
+    injectDummyMetrics(rejectedPermitsPerNs, CONCURRENT_NS, 10);
+    controller.setMetrics(rejectedPermitsPerNs, acceptedPermitsPerNs);
+
+    if (manualRefresh) {
+      controller.refreshPermitsCap();
+    } else {
+      Thread.sleep(5000);
+    }
+
+    // Current permits count should be 5:1:5
+    for (int i = 0; i < 5; i++) {
+      Assert.assertTrue(controller.acquirePermit("ns1"));
+      Assert.assertTrue(controller.acquirePermit(CONCURRENT_NS));
+    }
+    Assert.assertTrue(controller.acquirePermit("ns2"));
+
+    Assert.assertFalse(controller.acquirePermit("ns1"));
+    Assert.assertFalse(controller.acquirePermit("ns2"));
+    Assert.assertFalse(controller.acquirePermit(CONCURRENT_NS));
+  }
+
+  public void verifyDynamicControllerAllPermitsAcquired(boolean manualRefresh)
+      throws InterruptedException {
+    // 10 permits each ns
+    DynamicRouterRpcFairnessPolicyController controller;
+    if (manualRefresh) {
+      controller = getFairnessPolicyController(30);
+    } else {
+      controller = getFairnessPolicyController(30, 4000);
+    }
+    for (int i = 0; i < 10; i++) {
+      Assert.assertTrue(controller.acquirePermit("ns1"));
+      Assert.assertTrue(controller.acquirePermit("ns2"));
+      Assert.assertTrue(controller.acquirePermit(CONCURRENT_NS));
+    }
+
+    // Inject dummy metrics
+    Map<String, LongAdder> rejectedPermitsPerNs = new HashMap<>();
+    Map<String, LongAdder> acceptedPermitsPerNs = new HashMap<>();
+    injectDummyMetrics(rejectedPermitsPerNs, "ns1", 14);
+    injectDummyMetrics(rejectedPermitsPerNs, "ns2", 14);
+    injectDummyMetrics(rejectedPermitsPerNs, CONCURRENT_NS, 2);
+    controller.setMetrics(rejectedPermitsPerNs, acceptedPermitsPerNs);
+    if (manualRefresh) {
+      controller.refreshPermitsCap();
+    } else {
+      Thread.sleep(5000);
+    }
+    Assert.assertEquals("{\"concurrent\":-8,\"ns2\":4,\"ns1\":4}",
+        controller.getAvailableHandlerOnPerNs());
+
+    // Current permits count should be 14:14:2
+    // Can acquire 4 more permits for ns1 and ns2
+    for (int i = 0; i < 4; i++) {
+      Assert.assertTrue(controller.acquirePermit("ns1"));
+      Assert.assertTrue(controller.acquirePermit("ns2"));
+    }
+    Assert.assertFalse(controller.acquirePermit("ns1"));
+    Assert.assertFalse(controller.acquirePermit("ns2"));
+    // Need to release at least 9 permits for concurrent before it has any free permits
+    Assert.assertFalse(controller.acquirePermit(CONCURRENT_NS));
+    for (int i = 0; i < 8; i++) {
+      controller.releasePermit(CONCURRENT_NS);
+    }
+    Assert.assertFalse(controller.acquirePermit(CONCURRENT_NS));
+    controller.releasePermit(CONCURRENT_NS);
+    Assert.assertTrue(controller.acquirePermit(CONCURRENT_NS));
+  }
+
+
+  private void injectDummyMetrics(Map<String, LongAdder> metrics, String ns, long value) {
+    metrics.computeIfAbsent(ns, k -> new LongAdder()).add(value);
+  }
+
+  private DynamicRouterRpcFairnessPolicyController getFairnessPolicyController(int handlers,
+      long refreshInterval) {
+    return new DynamicRouterRpcFairnessPolicyController(createConf(handlers), refreshInterval);
+  }
+
+  private DynamicRouterRpcFairnessPolicyController getFairnessPolicyController(int handlers) {
+    return new DynamicRouterRpcFairnessPolicyController(createConf(handlers), Long.MAX_VALUE);
+  }
+
+  private Configuration createConf(int handlers) {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFS_ROUTER_HANDLER_COUNT_KEY, handlers);
+    conf.set(DFS_ROUTER_MONITOR_NAMENODE, nameServices);
+    conf.setClass(RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
+        DynamicRouterRpcFairnessPolicyController.class, RouterRpcFairnessPolicyController.class);
+    return conf;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestDynamicRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestDynamicRouterRpcFairnessPolicyController.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
-import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_MINIMUM_HANDLER_COUNT_KEY;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
@@ -114,6 +114,18 @@ public class TestRouterRpcFairnessPolicyController {
   }
 
   @Test
+  public void testGetPermitCapacityPerNs() {
+    RouterRpcFairnessPolicyController routerRpcFairnessPolicyController
+        = getFairnessPolicyController(30);
+    assertEquals("{\"concurrent\":10,\"ns2\":10,\"ns1\":10}",
+        routerRpcFairnessPolicyController.getPermitCapacityPerNs());
+    routerRpcFairnessPolicyController.acquirePermit("ns1");
+    routerRpcFairnessPolicyController.acquirePermit("ns2");
+    assertEquals("{\"concurrent\":10,\"ns2\":10,\"ns1\":10}",
+        routerRpcFairnessPolicyController.getPermitCapacityPerNs());
+  }
+
+  @Test
   public void testGetAvailableHandlerOnPerNsForNoFairness() {
     Configuration conf = new Configuration();
     RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =


### PR DESCRIPTION
### Description of PR
Add a `DynamicRouterRpcFairnessPolicyController` class that resizes permit capacity periodically based on traffic to namespaces.

### How was this patch tested?
Unit tests and local deployment.

### For code changes:
- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?