### PR TITLE
YARN-11111. Recovery failure when node-label configure-type transit f…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/op/NodeLabelMirrorOp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/op/NodeLabelMirrorOp.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb
     .AddToClusterNodeLabelsRequestPBImpl;
 import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb
     .ReplaceLabelsOnNodeRequestPBImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +42,8 @@ import java.util.Set;
  */
 public class NodeLabelMirrorOp
     extends FSNodeStoreLogOp<CommonNodeLabelsManager> {
+  private static final Logger LOG = LoggerFactory.getLogger(
+          NodeLabelMirrorOp.class);
 
   public NodeLabelMirrorOp() {
     super();
@@ -66,15 +70,20 @@ public class NodeLabelMirrorOp
             .parseDelimitedFrom(is)).getNodeLabels();
     mgr.addToCluserNodeLabels(labels);
 
-    if (mgr.isCentralizedConfiguration()) {
-      // Only load node to labels mapping while using centralized
-      // configuration
-      Map<NodeId, Set<String>> nodeToLabels =
-          new ReplaceLabelsOnNodeRequestPBImpl(
-              YarnServerResourceManagerServiceProtos
-                  .ReplaceLabelsOnNodeRequestProto
-                  .parseDelimitedFrom(is)).getNodeToLabels();
-      mgr.replaceLabelsOnNode(nodeToLabels);
+    try {
+      if (mgr.isCentralizedConfiguration() && is.available() != 0) {
+        // Only load node to labels mapping while using centralized
+        // configuration
+        Map<NodeId, Set<String>> nodeToLabels =
+                new ReplaceLabelsOnNodeRequestPBImpl(
+                        YarnServerResourceManagerServiceProtos
+                                .ReplaceLabelsOnNodeRequestProto
+                                .parseDelimitedFrom(is)).getNodeToLabels();
+        mgr.replaceLabelsOnNode(nodeToLabels);
+      }
+    } catch (Exception e) {
+      LOG.error("Errors on loading node to labels mapping while using "
+              + "centralized configuration", e);
     }
   }
 


### PR DESCRIPTION
…rom delegated-centralized to centralized

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

