### PR TITLE
HADOOP-17650. Bump solr to unblock build failure with Maven 3.8.1 (#2939)

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -208,7 +208,7 @@
     <assertj.version>3.12.2</assertj.version>
     <jline.version>3.9.0</jline.version>
     <powermock.version>1.5.6</powermock.version>
-    <solr.version>7.7.0</solr.version>
+    <solr.version>8.8.2</solr.version>
     <openssl-wildfly.version>1.0.7.Final</openssl-wildfly.version>
     <woodstox.version>5.3.0</woodstox.version>
     <json-smart.version>2.4.7</json-smart.version>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -110,6 +110,18 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -133,6 +145,10 @@
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-client</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>
@@ -158,6 +174,10 @@
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-client</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/application/EmbeddedSolrServerFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/application/EmbeddedSolrServerFactory.java
@@ -82,12 +82,10 @@ public final class EmbeddedSolrServerFactory {
       solrHomeDir.mkdirs();
     }
 
-    final SolrResourceLoader loader = new SolrResourceLoader(
-        solrHomeDir.toPath());
     final Path configSetPath = Paths.get(configSetHome).toAbsolutePath();
 
     final NodeConfig config = new NodeConfig.NodeConfigBuilder(
-        "embeddedSolrServerNode", loader)
+        "embeddedSolrServerNode", solrHomeDir.toPath())
             .setConfigSetBaseDirectory(configSetPath.toString()).build();
 
     final EmbeddedSolrServer embeddedSolrServer = new EmbeddedSolrServer(config,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/application/TestAppCatalogSolrClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/application/TestAppCatalogSolrClient.java
@@ -47,7 +47,7 @@ public class TestAppCatalogSolrClient {
     String targetLocation = EmbeddedSolrServerFactory.class
         .getProtectionDomain().getCodeSource().getLocation().getFile() + "/..";
 
-    String solrHome = targetLocation + "/solr";
+    String solrHome = targetLocation.split("/test-classes")[0] + "/solr";
     solrClient = EmbeddedSolrServerFactory.create(solrHome, CONFIGSET_DIR,
         "exampleCollection");
     spy = PowerMockito.spy(new AppCatalogSolrClient());


### PR DESCRIPTION

Reviewed-by: Siyao Meng <siyao@apache.org>


### Description of PR

patch 538ce9c / #2939 on branch-3.3; if good will add to 3.3.3

without this you can only build hadoop with a proxy nexus server

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

