### PR TITLE
HDFS-16550. Improper cache-size for journal node may cause cluster crash

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1424,7 +1424,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_JOURNALNODE_SYNC_INTERVAL_DEFAULT = 2*60*1000L;
   public static final String DFS_JOURNALNODE_EDIT_CACHE_SIZE_KEY =
       "dfs.journalnode.edit-cache-size.bytes";
-  public static final int DFS_JOURNALNODE_EDIT_CACHE_SIZE_DEFAULT = 1024 * 1024;
+
+  public static final String DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_KEY =
+          "dfs.journalnode.edit-cache-size.fraction";
+  public static final float DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_DEFAULT = 0.5f;
 
   // Journal-node related configs for the client side.
   public static final String  DFS_QJOURNAL_QUEUE_SIZE_LIMIT_KEY = "dfs.qjournal.queued-edits.limit.mb";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournaledEditsCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournaledEditsCache.java
@@ -40,8 +40,7 @@ import org.apache.hadoop.hdfs.server.namenode.EditLogFileOutputStream;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogLoader;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp;
 import org.apache.hadoop.util.AutoCloseableLock;
-
-import static org.apache.hadoop.util.ExitUtil.terminate;
+import org.apache.hadoop.util.Preconditions;
 
 /**
  * An in-memory cache of edits in their serialized form. This is used to serve
@@ -125,12 +124,10 @@ class JournaledEditsCache {
   JournaledEditsCache(Configuration conf) {
     float fraction = conf.getFloat(DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_KEY,
         DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_DEFAULT);
-    if (fraction <= 0 || fraction >= 1.0f) {
-      terminate(1, new IllegalArgumentException(String.format(
-          "Cache config %s is set at %f. It should be a positive float value, " +
-          "not greater than 1.0. The recommended value is less than 0.9.",
-          DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_KEY, fraction)));
-    }
+    Preconditions.checkArgument((fraction > 0 && fraction < 1.0f),
+        String.format("Cache config %s is set at %f, it should be a positive float value, " +
+            "less than 1.0. The recommended value is less than 0.9.",
+            DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_KEY, fraction));
     capacity = conf.getInt(DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_KEY,
         (int) (Runtime.getRuntime().maxMemory() * fraction));
     if (capacity > 0.9 * Runtime.getRuntime().maxMemory()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4956,6 +4956,19 @@
 </property>
 
 <property>
+  <name>dfs.journalnode.edit-cache-size.fraction</name>
+  <value>0.5f</value>
+  <description>
+    This ratio refers to the proportion of the maximum memory of the JVM.
+    Used to calculate the size of the edits cache that is kept in the JournalNode's memory.
+    The recommended value is less than 0.9. We recommend using
+    dfs.journalnode.edit-cache-size.fraction instead of
+    dfs.journalnode.edit-cache-size.bytes. If we set
+    dfs.journalnode.edit-cache-size.bytes, this parameter will not take effect.
+  </description>
+</property>
+
+<property>
   <name>dfs.journalnode.kerberos.internal.spnego.principal</name>
   <value></value>
   <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4945,7 +4945,7 @@
 
 <property>
   <name>dfs.journalnode.edit-cache-size.bytes</name>
-  <value>1048576</value>
+  <value></value>
   <description>
     The size, in bytes, of the in-memory cache of edits to keep on the
     JournalNode. This cache is used to serve edits for tailing via the RPC-based
@@ -4961,10 +4961,13 @@
   <description>
     This ratio refers to the proportion of the maximum memory of the JVM.
     Used to calculate the size of the edits cache that is kept in the JournalNode's memory.
-    The recommended value is less than 0.9. We recommend using
-    dfs.journalnode.edit-cache-size.fraction instead of
-    dfs.journalnode.edit-cache-size.bytes. If we set
-    dfs.journalnode.edit-cache-size.bytes, this parameter will not take effect.
+    This config is an alternative to the dfs.journalnode.edit-cache-size.bytes.
+    And it is used to serve edits for tailing via the RPC-based mechanism, and is only
+    enabled when dfs.ha.tail-edits.in-progress is true. Transactions range in size but
+    are around 200 bytes on average, so the default of 1MB can store around 5000 transactions.
+    So we can configure a reasonable value based on the maximum memory. The recommended value
+    is less than 0.9. If we set dfs.journalnode.edit-cache-size.bytes, this parameter will
+    not take effect.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
@@ -502,6 +502,12 @@ lag time will be much longer. The relevant configurations are:
     the oldest data in the cache was at transaction ID 20, a value of 10 would be added to the
     average.
 
+*   **dfs.journalnode.edit-cache-size.fraction** - This ratio refers to the proportion of the maximum memory
+    of the JVM. Used to calculate the size of the edits cache that is kept in the JournalNode's memory.
+    The recommended value is less than 0.9. We recommend using dfs.journalnode.edit-cache-size.fraction 
+    instead of dfs.journalnode.edit-cache-size.bytes. If we set dfs.journalnode.edit-cache-size.bytes, 
+    this parameter will not take effect.
+
 This feature is primarily useful in conjunction with the Standby/Observer Read feature. Using this
 feature, read requests can be serviced from non-active NameNodes; thus tailing in-progress edits
 provides these nodes with the ability to serve requests with data which is much more fresh. See the

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
@@ -502,11 +502,15 @@ lag time will be much longer. The relevant configurations are:
     the oldest data in the cache was at transaction ID 20, a value of 10 would be added to the
     average.
 
-*   **dfs.journalnode.edit-cache-size.fraction** - This ratio refers to the proportion of the maximum memory
-    of the JVM. Used to calculate the size of the edits cache that is kept in the JournalNode's memory.
-    The recommended value is less than 0.9. We recommend using dfs.journalnode.edit-cache-size.fraction
-    instead of dfs.journalnode.edit-cache-size.bytes. If we set dfs.journalnode.edit-cache-size.bytes,
-    this parameter will not take effect.
+*   **dfs.journalnode.edit-cache-size.fraction** - This fraction refers to the proportion of
+    the maximum memory of the JVM. Used to calculate the size of the edits cache that is
+    kept in the JournalNode's memory. This config is an alternative to the
+    dfs.journalnode.edit-cache-size.bytes. And it is used to serve edits for tailing via
+    the RPC-based mechanism, and is only enabled when dfs.ha.tail-edits.in-progress is true.
+    Transactions range in size but are around 200 bytes on average, so the default of 1MB
+    can store around 5000 transactions. So we can configure a reasonable value based on
+    the maximum memory. The recommended value is less than 0.9. If we set
+    dfs.journalnode.edit-cache-size.bytes, this parameter will not take effect.
 
 This feature is primarily useful in conjunction with the Standby/Observer Read feature. Using this
 feature, read requests can be serviced from non-active NameNodes; thus tailing in-progress edits

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
@@ -504,8 +504,8 @@ lag time will be much longer. The relevant configurations are:
 
 *   **dfs.journalnode.edit-cache-size.fraction** - This ratio refers to the proportion of the maximum memory
     of the JVM. Used to calculate the size of the edits cache that is kept in the JournalNode's memory.
-    The recommended value is less than 0.9. We recommend using dfs.journalnode.edit-cache-size.fraction 
-    instead of dfs.journalnode.edit-cache-size.bytes. If we set dfs.journalnode.edit-cache-size.bytes, 
+    The recommended value is less than 0.9. We recommend using dfs.journalnode.edit-cache-size.fraction
+    instead of dfs.journalnode.edit-cache-size.bytes. If we set dfs.journalnode.edit-cache-size.bytes,
     this parameter will not take effect.
 
 This feature is primarily useful in conjunction with the Standby/Observer Read feature. Using this

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ObserverNameNode.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ObserverNameNode.md
@@ -194,6 +194,25 @@ few configurations to your **hdfs-site.xml**:
           <value>1048576</value>
         </property>
 
+*  **dfs.journalnode.edit-cache-size.fraction** - the ratio refers to
+   the proportion of the maximum memory of the JVM.
+
+   Used to calculate the size of the edits cache that
+   is kept in the JournalNode's memory.
+   The recommended value is less than 0.9.
+   The cache is used for serving edits via
+   RPC-based tailing. This is only effective when
+   dfs.ha.tail-edits.in-progress is turned on. 
+   We recommend using dfs.journalnode.edit-cache-size.fraction 
+   instead of dfs.journalnode.edit-cache-size.bytes.
+   If we set dfs.journalnode.edit-cache-size.bytes, 
+   this parameter will not take effect. 
+
+        <property>
+          <name>dfs.journalnode.edit-cache-size.fraction</name>
+          <value>0.5f</value>
+        </property>
+
 *  **dfs.namenode.accesstime.precision** -- whether to enable access
    time for HDFS file.
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ObserverNameNode.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ObserverNameNode.md
@@ -194,19 +194,18 @@ few configurations to your **hdfs-site.xml**:
           <value>1048576</value>
         </property>
 
-*  **dfs.journalnode.edit-cache-size.fraction** - the ratio refers to
+*  **dfs.journalnode.edit-cache-size.fraction** - the fraction refers to
    the proportion of the maximum memory of the JVM.
 
    Used to calculate the size of the edits cache that
    is kept in the JournalNode's memory.
-   The recommended value is less than 0.9.
-   The cache is used for serving edits via
-   RPC-based tailing. This is only effective when
-   dfs.ha.tail-edits.in-progress is turned on.
-   We recommend using dfs.journalnode.edit-cache-size.fraction
-   instead of dfs.journalnode.edit-cache-size.bytes.
-   If we set dfs.journalnode.edit-cache-size.bytes,
-   this parameter will not take effect.
+   This config is an alternative to the dfs.journalnode.edit-cache-size.bytes.
+   And it is used to serve edits for tailing via the RPC-based mechanism, and is only
+   enabled when dfs.ha.tail-edits.in-progress is true. Transactions range in size but
+   are around 200 bytes on average, so the default of 1MB can store around 5000 transactions.
+   So we can configure a reasonable value based on the maximum memory. The recommended value
+   is less than 0.9. If we set dfs.journalnode.edit-cache-size.bytes, this parameter will
+   not take effect.
 
         <property>
           <name>dfs.journalnode.edit-cache-size.fraction</name>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ObserverNameNode.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/ObserverNameNode.md
@@ -202,11 +202,11 @@ few configurations to your **hdfs-site.xml**:
    The recommended value is less than 0.9.
    The cache is used for serving edits via
    RPC-based tailing. This is only effective when
-   dfs.ha.tail-edits.in-progress is turned on. 
-   We recommend using dfs.journalnode.edit-cache-size.fraction 
+   dfs.ha.tail-edits.in-progress is turned on.
+   We recommend using dfs.journalnode.edit-cache-size.fraction
    instead of dfs.journalnode.edit-cache-size.bytes.
-   If we set dfs.journalnode.edit-cache-size.bytes, 
-   this parameter will not take effect. 
+   If we set dfs.journalnode.edit-cache-size.bytes,
+   this parameter will not take effect.
 
         <property>
           <name>dfs.journalnode.edit-cache-size.fraction</name>


### PR DESCRIPTION
JIRA: HDFS-16550.

For details, please refer to the JIRA.