### PR TITLE
HDFS-16552. Fix NPE for TestBlockManager

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -854,6 +854,7 @@ public class TestBlockManager {
 
   @Test
   public void testSkipReconstructionWithManyBusyNodes() {
+    NameNode.initMetrics(new Configuration(), HdfsServerConstants.NamenodeRole.NAMENODE);
     long blockId = -9223372036854775776L; // real ec block id
     // RS-3-2 EC policy
     ErasureCodingPolicy ecPolicy =
@@ -899,6 +900,7 @@ public class TestBlockManager {
 
   @Test
   public void testSkipReconstructionWithManyBusyNodes2() {
+    NameNode.initMetrics(new Configuration(), HdfsServerConstants.NamenodeRole.NAMENODE);
     long blockId = -9223372036854775776L; // real ec block id
     // RS-3-2 EC policy
     ErasureCodingPolicy ecPolicy =


### PR DESCRIPTION
JIRA: HDFS-16552.

Fix NPE for BlockManager#scheduleReconstruction.

There is a NPE in BlockManager when run TestBlockManager#testSkipReconstructionWithManyBusyNodes2. Because NameNodeMetrics is not initialized in this unit test.

Related ci link, see [this](https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-4209/1/artifact/out/patch-unit-hadoop-hdfs-project_hadoop-hdfs.txt).