### PR TITLE
HADOOP-18215. Enhance WritableName to be able to return aliases for classes that use serializers

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -2196,7 +2196,7 @@ public class SequenceFile {
     public synchronized Class<?> getKeyClass() {
       if (null == keyClass) {
         try {
-          keyClass = WritableName.getClass(getKeyClassName(), conf, false);
+          keyClass = WritableName.getClass(getKeyClassName(), conf);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
@@ -2213,7 +2213,7 @@ public class SequenceFile {
     public synchronized Class<?> getValueClass() {
       if (null == valClass) {
         try {
-          valClass = WritableName.getClass(getValueClassName(), conf, false);
+          valClass = WritableName.getClass(getValueClassName(), conf);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/SequenceFile.java
@@ -2196,7 +2196,7 @@ public class SequenceFile {
     public synchronized Class<?> getKeyClass() {
       if (null == keyClass) {
         try {
-          keyClass = WritableName.getClass(getKeyClassName(), conf);
+          keyClass = WritableName.getClass(getKeyClassName(), conf, false);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
@@ -2213,7 +2213,7 @@ public class SequenceFile {
     public synchronized Class<?> getValueClass() {
       if (null == valClass) {
         try {
-          valClass = WritableName.getClass(getValueClassName(), conf);
+          valClass = WritableName.getClass(getValueClassName(), conf, false);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableName.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableName.java
@@ -92,7 +92,7 @@ public class WritableName {
                                             ) throws IOException {
     Class<?> writableClass = NAME_TO_CLASS.get(name);
     if (writableClass != null)
-      return writableClass.asSubclass(Writable.class);
+      return writableClass;
     try {
       return conf.getClassByName(name);
     } catch (ClassNotFoundException e) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableName.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableName.java
@@ -80,41 +80,19 @@ public class WritableName {
   }
 
   /**
-   * Return the class for a name. Requires the class for name to extend Writable.
-   * See {@link #getClass(String, Configuration, boolean)} if class doesn't extend Writable.
-   * Default is {@link Class#forName(String)}.
-   *
-   * @param name input name.
-   * @param conf input configuration.
-   * @return class for a name.
-   * @throws IOException raised on errors performing I/O.
-   */
-  public static synchronized Class<?> getClass(String name, Configuration conf)
-      throws IOException {
-    return getClass(name, conf, true);
-  }
-
-  /**
    * Return the class for a name.
    * Default is {@link Class#forName(String)}.
    *
    * @param name input name.
    * @param conf input configuration.
-   * @param requireWritable if true, require the class for name to extend Writable
    * @return class for a name.
    * @throws IOException raised on errors performing I/O.
    */
-  public static synchronized Class<?> getClass(String name, Configuration conf,
-      boolean requireWritable) throws IOException {
+  public static synchronized Class<?> getClass(String name, Configuration conf
+                                            ) throws IOException {
     Class<?> writableClass = NAME_TO_CLASS.get(name);
-    if (writableClass != null) {
-      if (requireWritable) {
-        return writableClass.asSubclass(Writable.class);
-      } else {
-        return writableClass;
-      }
-    }
-
+    if (writableClass != null)
+      return writableClass;
     try {
       return conf.getClassByName(name);
     } catch (ClassNotFoundException e) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableName.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableName.java
@@ -80,7 +80,8 @@ public class WritableName {
   }
 
   /**
-   * Return the class for a name.
+   * Return the class for a name. Requires the class for name to extend Writable.
+   * See {@link #getClass(String, Configuration, boolean)} if class doesn't extend Writable.
    * Default is {@link Class#forName(String)}.
    *
    * @param name input name.
@@ -88,11 +89,32 @@ public class WritableName {
    * @return class for a name.
    * @throws IOException raised on errors performing I/O.
    */
-  public static synchronized Class<?> getClass(String name, Configuration conf
-                                            ) throws IOException {
+  public static synchronized Class<?> getClass(String name, Configuration conf)
+      throws IOException {
+    return getClass(name, conf, true);
+  }
+
+  /**
+   * Return the class for a name.
+   * Default is {@link Class#forName(String)}.
+   *
+   * @param name input name.
+   * @param conf input configuration.
+   * @param requireWritable if true, require the class for name to extend Writable
+   * @return class for a name.
+   * @throws IOException raised on errors performing I/O.
+   */
+  public static synchronized Class<?> getClass(String name, Configuration conf,
+      boolean requireWritable) throws IOException {
     Class<?> writableClass = NAME_TO_CLASS.get(name);
-    if (writableClass != null)
-      return writableClass;
+    if (writableClass != null) {
+      if (requireWritable) {
+        return writableClass.asSubclass(Writable.class);
+      } else {
+        return writableClass;
+      }
+    }
+
     try {
       return conf.getClassByName(name);
     } catch (ClassNotFoundException e) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestWritableName.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestWritableName.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.io.serializer.Serializer;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /** Unit tests for WritableName. */
@@ -137,11 +136,7 @@ public class TestWritableName {
 
     WritableName.addName(SimpleSerializable.class, altName);
 
-    // test that old behavior works as expected if requireWritable not set to false
-    assertThrows(ClassCastException.class, () -> WritableName.getClass(altName, conf));
-
-    // test that it succeeds with requireWritable = false
-    Class<?> test = WritableName.getClass(altName, conf, false);
+    Class<?> test = WritableName.getClass(altName, conf);
     assertEquals(test, SimpleSerializable.class);
     assertNotNull(serializationFactory.getSerialization(test));
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestWritableName.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestWritableName.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.io.serializer.Serializer;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /** Unit tests for WritableName. */
@@ -136,7 +137,11 @@ public class TestWritableName {
 
     WritableName.addName(SimpleSerializable.class, altName);
 
-    Class<?> test = WritableName.getClass(altName, conf);
+    // test that old behavior works as expected if requireWritable not set to false
+    assertThrows(ClassCastException.class, () -> WritableName.getClass(altName, conf));
+
+    // test that it succeeds with requireWritable = false
+    Class<?> test = WritableName.getClass(altName, conf, false);
     assertEquals(test, SimpleSerializable.class);
     assertNotNull(serializationFactory.getSerialization(test));
 


### PR DESCRIPTION
### Description of PR
Very simple one-line change that allows users to optionally call addName for key/value classes that may not inherit Writable (instead relying on serialization). 

### How was this patch tested?
Added two tests:
1. Simple unit test in TestWritableName
2. More of an integration test in TestSequenceFile which verifies that it works to read and write with shimmed serializable classes.

This patch has also been deployed in our environment for 2 months.


