### PR TITLE
HADOOP-15783. [JDK10] TestSFTPFileSystem.testGetModifyTime fails.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/sftp/TestSFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/sftp/TestSFTPFileSystem.java
@@ -316,6 +316,7 @@ public class TestSFTPFileSystem {
     java.nio.file.Path path = (local).pathToFile(file).toPath();
     long accessTime1 = Files.readAttributes(path, BasicFileAttributes.class)
         .lastAccessTime().toMillis();
+    // SFTPFileSystem doesn't have milliseconds. Excluding it.
     accessTime1 = (accessTime1 / 1000) * 1000;
     long accessTime2 = sftpFs.getFileStatus(file).getAccessTime();
     assertEquals(accessTime1, accessTime2);
@@ -326,6 +327,8 @@ public class TestSFTPFileSystem {
     Path file = touch(localFs, name.getMethodName().toLowerCase() + "1");
     java.io.File localFile = ((LocalFileSystem) localFs).pathToFile(file);
     long modifyTime1 = localFile.lastModified();
+    // SFTPFileSystem doesn't have milliseconds. Excluding it.
+    modifyTime1 = (modifyTime1 / 1000) * 1000;
     long modifyTime2 = sftpFs.getFileStatus(file).getModificationTime();
     assertEquals(modifyTime1, modifyTime2);
   }


### PR DESCRIPTION
(cherry picked from commit 93b0f540ed52f31c53fe4afc6d423e64c57c0af2)


### Description of PR

trivial clean cherry-pick

### How was this patch tested?

mvn test -Dtest="TestSFTPFileSystem"

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.sftp.TestSFTPFileSystem
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.105 s - in org.apache.hadoop.fs.sftp.TestSFTPFileSystem
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
```


