### PR TITLE
HDFS-16557. BootstrapStandby failed because of checking gap for inprogress EditLogInputStream

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -1792,7 +1792,7 @@ public class FSEditLog implements LogsPurgeable {
       EditLogInputStream elis = iter.next();
       if (elis.getFirstTxId() > txId) break;
       long next = elis.getLastTxId();
-      if (next == HdfsServerConstants.INVALID_TXID) {
+      if (next == HdfsServerConstants.INVALID_TXID || elis.isInProgress()) {
         if (!inProgressOk) {
           throw new RuntimeException("inProgressOk = false, but " +
               "selectInputStreams returned an in-progress edit " +


### PR DESCRIPTION
JIRA: HDFS-16557.

The lastTxId of an inprogress EditLogInputStream lastTxId isn't necessarily HdfsServerConstants.INVALID_TXID. We can determine its status directly by EditLogInputStream#isInProgress.

We introduced [SBN READ], and set `dfs.ha.tail-edits.in-progress=true`. Then bootstrapStandby a new Namenode, the EditLogInputStream of inProgress is misjudged, resulting in a gap check failure, which causes bootstrapStandby to fail.

`hdfs namenode -bootstrapStandby`
![image](https://user-images.githubusercontent.com/55134131/164676951-686f46ae-9b89-4be8-8d3c-41a08bb432ae.png)
![image](https://user-images.githubusercontent.com/55134131/164676977-bd3ece9d-3ffc-406f-8c06-aacdeac0dee8.png)
