### PR TITLE
HADOOP-18216. io.file.buffer.size must be greater than zero

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -793,7 +793,8 @@
   <description>The size of buffer for use in sequence files.
   The size of this buffer should probably be a multiple of hardware
   page size (4096 on Intel x86), and it determines how much data is
-  buffered during read and write operations.</description>
+  buffered during read and write operations. Must be greater than zero.
+  </description>
 </property>
 
 <property>


### PR DESCRIPTION
### Description of PR
[HADOOP-18216](https://issues.apache.org/jira/browse/HADOOP-18216)
Modify the description of "io.file.buffer.size" in the default configuration file to prevent io operations from failing or blocking due to incorrect settings of this configuration item.
