### PR TITLE
HDFS-16559 Seperate IBR thread waiting time from heart beat waiting t…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeReport.java
@@ -171,7 +171,8 @@ public class TestDatanodeReport {
       } catch (IOException e) {
         // all bad datanodes
       }
-      cluster.triggerHeartbeats(); // IBR delete ack
+      // ibr thread is seperated from heart beat thread, use BlockReports to trigger deletion ibr
+      cluster.triggerBlockReports();
       int retries = 0;
       while (true) {
         lb = fs.getClient().getLocatedBlocks(p.toString(), 0).get(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -166,8 +166,8 @@ public class TestIncrementalBlockReports {
           anyString(),
           any(StorageReceivedDeletedBlocks[].class));
 
-      // Trigger a heartbeat, this also triggers an IBR.
-      DataNodeTestUtils.triggerHeartbeat(singletonDn);
+      // Trigger a block report, this also triggers an IBR.
+      DataNodeTestUtils.triggerBlockReport(singletonDn);
 
       // Ensure that the deleted block is reported.
       int retries = 0;


### PR DESCRIPTION
…ime.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

IBR opeeration is seperated from heartbeat thread since [HDFS-16016](https://issues.apache.org/jira/browse/HDFS-16016), which is great. 

But IBR thread is using the expireTime of heart beat to deside whether wait or not. In a high load DataNode, IBR thread becomes an infinit loop without sleeping and consuming 100% cpu because of the latency of heartbeat reporting.