### PR TITLE
MAPREDUCE-7375 set permission for JobSubmissionFiles

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmissionFiles.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmissionFiles.java
@@ -160,6 +160,7 @@ public class JobSubmissionFiles {
       }
     } catch (FileNotFoundException e) {
       fs.mkdirs(stagingArea, new FsPermission(JOB_DIR_PERMISSION));
+      fs.setPermission(stagingArea, JOB_DIR_PERMISSION);
     }
     return stagingArea;
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobSubmissionFiles.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobSubmissionFiles.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 /**
  * Tests for JobSubmissionFiles Utility class.
  */
@@ -138,5 +140,21 @@ public class TestJobSubmissionFiles {
     when(cluster.getStagingAreaDir()).thenReturn(stagingPath);
     assertEquals(stagingPath,
         JobSubmissionFiles.getStagingDir(cluster, conf, user));
+  }
+
+  @Test
+  public void testDirPermission() throws Exception {
+      Cluster cluster = mock(Cluster.class);
+      HdfsConfiguration CONF = new HdfsConfiguration();
+      MiniDFSCluster cluster1 = new MiniDFSCluster.Builder(CONF).numDataNodes(2).build();
+      FileSystem fs = cluster1.getFileSystem();
+      UserGroupInformation user = UserGroupInformation
+        .createUserForTesting(USER_1_SHORT_NAME, GROUP_NAMES);
+      Path stagingPath = new Path(fs.getUri().toString() + "/testDirPermission");
+
+      fs.create(stagingPath);
+      when(cluster.getStagingAreaDir()).thenReturn(stagingPath);
+      Path res = JobSubmissionFiles.getStagingDir(cluster, CONF, user);
+      assertEquals(new FsPermission(0700),fs.getFileStatus(res).getPermission());
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->
MAPREDUCE-7375 set permission for JobSubmissionFiles
### Description of PR
JobSubmissionFiles provide getStagingDir to get Staging Directory.If stagingArea missing, method will create new directory with this.
fs.mkdirs(stagingArea, new FsPermission(JOB_DIR_PERMISSION));
It seems create new directory with JOB_DIR_PERMISSION,but this permission will be apply by umask.If umask too strict , this permission may be 000(if umask is 700).So we should change permission after create.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

