### PR TITLE
HADOOP-18198. add -mvnargs option to create-release command line

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -293,6 +293,7 @@ function usage
   echo "--security              Emergency security release"
   echo "--sign                  Use .gnupg dir to sign the artifacts and jars"
   echo "--version=[version]     Use an alternative version string"
+  echo "--mvnargs=[args]        Extra Maven args to be provided when running mvn commands"
 }
 
 function option_parse
@@ -346,6 +347,9 @@ function option_parse
       ;;
       --version=*)
         HADOOP_VERSION=${i#*=}
+      ;;
+      --mvnargs=*)
+        MVNEXTRAARGS=${i#*=}
       ;;
     esac
   done
@@ -412,6 +416,9 @@ function option_parse
     if [[ -d "${MVNCACHE}" ]]; then
       MVN_ARGS=("-Dmaven.repo.local=${MVNCACHE}")
     fi
+  fi
+  if [ -n "$MVNEXTRAARGS" ]; then
+    MVN_ARGS+=("$MVNEXTRAARGS")
   fi
 
   if [[ "${SECURITYRELEASE}" = true ]]; then


### PR DESCRIPTION

This allows for release builds to be run with options like
--mvnargs="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false"

Contributed by Ayush Saxena.

