### PR TITLE
YARN-11116. Migrate Times util from SimpleDateFormat to thread-safe D…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Times.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Times.java
@@ -19,8 +19,9 @@
 package org.apache.hadoop.yarn.util;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,23 +32,16 @@ public class Times {
   private static final Logger LOG =
       LoggerFactory.getLogger(Times.class);
 
-  static final String ISO8601DATEFORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+  static final String ISO8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
   // This format should match the one used in yarn.dt.plugins.js
-  static final ThreadLocal<SimpleDateFormat> dateFormat =
-      new ThreadLocal<SimpleDateFormat>() {
-        @Override protected SimpleDateFormat initialValue() {
-          return new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy");
-        }
-      };
+  static final DateTimeFormatter DATE_FORMAT =
+      DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss Z yyyy").withZone(
+          ZoneId.systemDefault());
 
-  static final ThreadLocal<SimpleDateFormat> isoFormat =
-      new ThreadLocal<SimpleDateFormat>() {
-        @Override
-        protected SimpleDateFormat initialValue() {
-          return new SimpleDateFormat(ISO8601DATEFORMAT);
-        }
-      };
+  static final DateTimeFormatter ISO_OFFSET_DATE_TIME =
+      DateTimeFormatter.ofPattern(ISO8601_DATE_FORMAT).withZone(
+          ZoneId.systemDefault());
 
   public static long elapsed(long started, long finished) {
     return Times.elapsed(started, finished, true);
@@ -83,8 +77,7 @@ public class Times {
   }
 
   public static String format(long ts) {
-    return ts > 0 ? String.valueOf(dateFormat.get().format(new Date(ts)))
-                  : "N/A";
+    return ts > 0 ? DATE_FORMAT.format(Instant.ofEpochMilli(ts)) : "N/A";
   }
 
   /**
@@ -94,7 +87,7 @@ public class Times {
    * @return ISO 8601 formatted string.
    */
   public static String formatISO8601(long ts) {
-    return isoFormat.get().format(new Date(ts));
+    return ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(ts));
   }
 
   /**
@@ -109,6 +102,6 @@ public class Times {
     if (isoString == null) {
       throw new ParseException("Invalid input.", -1);
     }
-    return isoFormat.get().parse(isoString).getTime();
+    return Instant.from(ISO_OFFSET_DATE_TIME.parse(isoString)).toEpochMilli();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestTimes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestTimes.java
@@ -21,6 +21,12 @@ package org.apache.hadoop.yarn.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.apache.hadoop.yarn.util.Times.ISO8601_DATE_FORMAT;
+
 public class TestTimes {
 
   @Test
@@ -60,5 +66,16 @@ public class TestTimes {
     // use Long.MAX_VALUE to ensure started time is after the current one
     elapsed = Times.elapsed(Long.MAX_VALUE, 0, true);
     Assert.assertEquals("Elapsed time is not -1", -1, elapsed);
+  }
+
+  @Test
+  public void validateISO() throws IOException {
+    SimpleDateFormat isoFormat = new SimpleDateFormat(ISO8601_DATE_FORMAT);
+    for (int i = 0; i < 1000; i++) {
+      long now = System.currentTimeMillis();
+      String instant =  Times.formatISO8601(now);
+      String date = isoFormat.format(new Date(now));
+      Assert.assertEquals(date, instant);
+    }
   }
 }


### PR DESCRIPTION
…ateTimeFormatter class

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Upgrading to the recommended thread safe java.time libraries for formatting and parsing with a little better performance

### How was this patch tested?
Attached a performance test patch to the jira and added unit test to ensure compatible behavior

### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

