### PR TITLE
YARN-11117 check permission for LeveldbRMStateStore

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/LeveldbRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/LeveldbRMStateStore.java
@@ -155,7 +155,7 @@ public class LeveldbRMStateStore extends RMStateStore {
     FileSystem fs = FileSystem.getLocal(getConfig());
     FsPermission perm = new FsPermission((short)0700);
     fs.mkdirs(root, perm);
-    if (!perms.equals(perms.applyUMask(fs.getUMask()))) {
+    if (!perm.equals(perm.applyUMask(FsPermission.getUMask(getConfig())))) {
       fs.setPermission(root, perm);
     }
     return root;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/LeveldbRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/LeveldbRMStateStore.java
@@ -153,7 +153,11 @@ public class LeveldbRMStateStore extends RMStateStore {
   private Path createStorageDir() throws IOException {
     Path root = getStorageDir();
     FileSystem fs = FileSystem.getLocal(getConfig());
-    fs.mkdirs(root, new FsPermission((short)0700));
+    FsPermission perm = new FsPermission((short)0700);
+    fs.mkdirs(root, perm);
+    if (!perms.equals(perms.applyUMask(fs.getUMask()))) {
+      fs.setPermission(root, perm);
+    }
     return root;
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->
YARN-11117 check permission for LeveldbRMStateStore
### Description of PR
LeveldbRMStateStore use fs.mkdirs(root,new FsPermission((short)0700));  to create root directory with permission 700.BUT if umask is too strict such as 0777, this directory will have wrong permission with 000. So it should check if umask can affect permission, if true , use setPermission to fix it

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

