### PR TITLE
HDFS-16564. Use uint32_t for hdfs_find

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfspp_mini_dfs_smoke.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfspp_mini_dfs_smoke.cc
@@ -34,7 +34,6 @@ TEST_F(HdfsMiniDfsSmokeTest, SmokeTest) {
   EXPECT_NE(nullptr, connection.handle());
 }
 
-
 }
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfspp_mini_dfs_smoke.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfspp_mini_dfs_smoke.cc
@@ -34,6 +34,7 @@ TEST_F(HdfsMiniDfsSmokeTest, SmokeTest) {
   EXPECT_NE(nullptr, connection.handle());
 }
 
+
 }
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-find/hdfs-find.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-find/hdfs-find.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <cstdint>
 #include <future>
 #include <iostream>
 #include <memory>
@@ -40,7 +41,7 @@ bool Find::Initialize() {
       "If provided, all results will be matching the NAME pattern otherwise, "
       "the implicit '*' will be used NAME allows wild-cards");
   add_options(
-      "max-depth,m", po::value<u_int32_t>(),
+      "max-depth,m", po::value<uint32_t>(),
       "If provided, the maximum depth to recurse after the end of the path is "
       "reached will be limited by MAX_DEPTH otherwise, the maximum depth to "
       "recurse is unbound MAX_DEPTH can be set to 0 for pure globbing and "


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
`hdfs_find` uses `u_int32_t` type for storing the value for the `max-depth` command line argument - https://github.com/apache/hadoop/blob/a631f45a99c7abf8c9a2dcfb10afb668c8ff6b09/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/hdfs-find/hdfs-find.cc#L43.
The type `u_int32_t` isn't standard, isn't available on Windows and thus breaks cross-platform compatibility. We need to replace this with `uint32_t` which is available on all platforms since it's part of the C++ standard.

### How was this patch tested?
The existing unit tests exercise this PR sufficiently.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

