### PR TITLE
YARN-11120-Metrics for Federation getClusterMetrics

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterMetrics.java
@@ -51,6 +51,8 @@ public final class RouterMetrics {
   private MutableGaugeInt numAppsFailedRetrieved;
   @Metric("# of multiple applications reports failed to be retrieved")
   private MutableGaugeInt numMultipleAppsFailedRetrieved;
+  @Metric("# of cluster metrics failed to be retrieved")
+  private MutableGaugeInt numClusteMetricsFailedRetrieved;
 
   // Aggregate metrics are shared, and don't have to be looked up per call
   @Metric("Total number of successful Submitted apps and latency(ms)")
@@ -64,6 +66,9 @@ public final class RouterMetrics {
   @Metric("Total number of successful Retrieved multiple apps reports and "
       + "latency(ms)")
   private MutableRate totalSucceededMultipleAppsRetrieved;
+  @Metric("Total number of successful Retrieved cluster metrics and "
+          + "latency(ms)")
+  private MutableRate totalSucceededClusterMetricsRetrieved;
 
   /**
    * Provide quantile counters for all latencies.
@@ -73,6 +78,7 @@ public final class RouterMetrics {
   private MutableQuantiles killApplicationLatency;
   private MutableQuantiles getApplicationReportLatency;
   private MutableQuantiles getApplicationsReportLatency;
+  private MutableQuantiles getClusterMetricsLatency;
 
   private static volatile RouterMetrics INSTANCE = null;
   private static MetricsRegistry registry;
@@ -92,6 +98,8 @@ public final class RouterMetrics {
     getApplicationsReportLatency =
         registry.newQuantiles("getApplicationsReportLatency",
             "latency of get applications report", "ops", "latency", 10);
+    getClusterMetricsLatency = registry.newQuantiles("getClusterMetricsLatency",
+            "latency of get cluster metrics", "ops", "latency", 10);
   }
 
   public static RouterMetrics getMetrics() {
@@ -213,6 +221,11 @@ public final class RouterMetrics {
     getApplicationsReportLatency.add(duration);
   }
 
+  public void successedClusterMetricsRetrieved(long duration) {
+    totalSucceededClusterMetricsRetrieved.add(duration);
+    getClusterMetricsLatency.add(duration);
+  }
+
   public void incrAppsFailedCreated() {
     numAppsFailedCreated.incr();
   }
@@ -231,6 +244,10 @@ public final class RouterMetrics {
 
   public void incrMultipleAppsFailedRetrieved() {
     numMultipleAppsFailedRetrieved.incr();
+  }
+
+  public void incrClusterNodesFailedRetrieved() {
+    numClusteMetricsFailedRetrieved.incr();
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -609,6 +609,7 @@ public class FederationClientInterceptor
   public GetClusterMetricsResponse getClusterMetrics(
       GetClusterMetricsRequest request) throws YarnException, IOException {
     if (request == null) {
+      routerMetrics.incrClusterNodesFailedRetrieved();
       RouterServerUtil.logAndThrowException("Missing getClusterMetrics request.", null);
     }
     GetClusterMetricsResponse response = null;


### PR DESCRIPTION
YARN-11120-Metrics for Federation getClusterMetrics

### Description of PR
Recently, I studied and researched Yarn's federation-related functions. I found that many methods have not been implemented. I chose the getClusterMetrics method, but found that this method has been merged into Trunk.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

