### PR TITLE
HADOOP-18217. ExitUtil synchronized blocks reduced to avoid exit bloc…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.util;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.slf4j.Logger;
@@ -36,8 +38,10 @@ public final class ExitUtil {
       LOG = LoggerFactory.getLogger(ExitUtil.class.getName());
   private static volatile boolean systemExitDisabled = false;
   private static volatile boolean systemHaltDisabled = false;
-  private static volatile ExitException firstExitException;
-  private static volatile HaltException firstHaltException;
+  private static final AtomicReference<ExitException> FIRST_EXIT_EXCEPTION =
+      new AtomicReference<>();
+  private static final AtomicReference<HaltException> FIRST_HALT_EXCEPTION =
+      new AtomicReference<>();
   /** Message raised from an exit exception if none were provided: {@value}. */
   public static final String EXIT_EXCEPTION_MESSAGE = "ExitException";
   /** Message raised from a halt exception if none were provided: {@value}. */
@@ -159,28 +163,29 @@ public final class ExitUtil {
    */
   public static boolean terminateCalled() {
     // Either we set this member or we actually called System#exit
-    return firstExitException != null;
+    return FIRST_EXIT_EXCEPTION.get()!=null;
   }
 
   /**
    * @return true if halt has been called.
    */
   public static boolean haltCalled() {
-    return firstHaltException != null;
+    // Either we set this member or we actually called Runtime#halt
+    return FIRST_HALT_EXCEPTION.get()!=null;
   }
 
   /**
-   * @return the first ExitException thrown, null if none thrown yet.
+   * @return the first {@code ExitException} thrown, null if none thrown yet.
    */
   public static ExitException getFirstExitException() {
-    return firstExitException;
+    return FIRST_EXIT_EXCEPTION.get();
   }
 
   /**
    * @return the first {@code HaltException} thrown, null if none thrown yet.
    */
   public static HaltException getFirstHaltException() {
-    return firstHaltException;
+    return FIRST_HALT_EXCEPTION.get();
   }
 
   /**
@@ -188,32 +193,42 @@ public final class ExitUtil {
    * where one test in the suite expects an exit but others do not.
    */
   public static void resetFirstExitException() {
-    firstExitException = null;
-  }
-
-  public static void resetFirstHaltException() {
-    firstHaltException = null;
+    FIRST_EXIT_EXCEPTION.set(null);
   }
 
   /**
+   * Reset the tracking of process termination. This is for use in unit tests
+   * where one test in the suite expects a halt but others do not.
+   */
+  public static void resetFirstHaltException() {
+    FIRST_HALT_EXCEPTION.set(null);
+  }
+
+  /**
+   * Exits the JVM if exit is enabled, rethrow provided exception or any raised error otherwise.
    * Inner termination: either exit with the exception's exit code,
    * or, if system exits are disabled, rethrow the exception.
    * @param ee exit exception
+   * @throws ExitException if {@link System#exit(int)} is disabled and not suppressed by an Error
+   * @throws Error if {@link System#exit(int)} is disabled and one Error arise, suppressing
+   * anything else, even <code>ee</code>
    */
   public static void terminate(ExitException ee)
       throws ExitException {
     final int status = ee.getExitCode();
-    Error catched = null;
+    Error caught = null;
     if (status != 0) {
       try {
-        //exit indicates a problem, log it
+        // exit indicates a problem, log it
         String msg = ee.getMessage();
         LOG.debug("Exiting with status {}: {}",  status, msg, ee);
         LOG.info("Exiting with status {}: {}", status, msg);
       } catch (Error e) {
-        catched = e; // errors have higher priority than HaltException, it may be re-thrown. OOM and ThreadDeath are 2 examples of Errors to re-throw
+        // errors have higher priority than HaltException, it may be re-thrown.
+        // OOM and ThreadDeath are 2 examples of Errors to re-throw
+        caught = e;
       } catch (Throwable t) {
-        // all other kind of throwables are supressed
+        // all other kind of throwables are suppressed
         ee.addSuppressed(t);
       }
     }
@@ -221,76 +236,82 @@ public final class ExitUtil {
       try {
         LOG.error("Terminate called", ee);
       } catch (Error e) {
-        if (catched == null) {
-          catched = e; // errors will be re-thrown
+        // errors have higher priority again, if it's a 2nd error, the 1st one suprpesses it
+        if (caught == null) {
+          caught = e;
         } else {
-          catched.addSuppressed(e); // 1st raised error has priority and will be re-thrown, so the 1st error supresses the 2nd
+          caught.addSuppressed(e);
         }
       } catch (Throwable t) {
-        ee.addSuppressed(t); // all other kind of throwables are supressed
+        // all other kind of throwables are suppressed
+        ee.addSuppressed(t);
       }
-      synchronized (ExitUtil.class) {
-        if (!terminateCalled()) {
-          firstExitException = ee;
-        }
-      }
-      if (catched != null) {
-        catched.addSuppressed(ee);
-        throw catched;
+      FIRST_EXIT_EXCEPTION.compareAndSet(null, ee);
+      if (caught != null) {
+        caught.addSuppressed(ee);
+        throw caught;
       }
       throw ee;
     } else {
-      System.exit(status); // System.exit has higher priority than any catched error
+      // when exit is enabled, whatever Throwable happened, we exit the VM
+      System.exit(status);
     }
   }
 
   /**
-   * Forcibly terminates the currently running Java virtual machine.
-   * The exception argument is rethrown if JVM halting is disabled.
-   * @param ee the exception containing the status code, message and any stack
+   * Halts the JVM if halt is enabled, rethrow provided exception or any raised error otherwise.
+   * If halt is disabled, this method throws either the exception argument if no
+   * error arise, the first error if at least one arise, suppressing <code>he</code>.
+   * If halt is enabled, all throwables are caught, even errors.
+   *
+   * @param he the exception containing the status code, message and any stack
    * trace.
-   * @throws HaltException if {@link Runtime#halt(int)} is disabled.
+   * @throws HaltException if {@link Runtime#halt(int)} is disabled and not suppressed by an Error
+   * @throws Error if {@link Runtime#halt(int)} is disabled and one Error arise, suppressing
+   * anyuthing else, even <code>he</code>
    */
-  public static void halt(HaltException ee) throws HaltException {
-    final int status = ee.getExitCode();
-    Error catched = null;
+  public static void halt(HaltException he) throws HaltException {
+    final int status = he.getExitCode();
+    Error caught = null;
     if (status != 0) {
       try {
-        //exit indicates a problem, log it
-        String msg = ee.getMessage();
-        LOG.info("Halt with status {}: {}", status, msg, ee);
+        // exit indicates a problem, log it
+        String msg = he.getMessage();
+        LOG.info("Halt with status {}: {}", status, msg, he);
       } catch (Error e) {
-        catched = e; // errors have higher priority than HaltException, it may be re-thrown. OOM and ThreadDeath are 2 examples of Errors to re-throw
+        // errors have higher priority than HaltException, it may be re-thrown.
+        // OOM and ThreadDeath are 2 examples of Errors to re-throw
+        caught = e;
       } catch (Throwable t) {
-        // all other kind of throwables are supressed
-        ee.addSuppressed(t);
+        // all other kind of throwables are suppressed
+        he.addSuppressed(t);
       }
     }
-    if (systemHaltDisabled) { // this is a volatile so reading it does not need a synchronized block
+    // systemHaltDisabled is volatile and not used in scenario nheding atomicty,
+    // thus it does not nhed a synchronized access nor a atomic access
+    if (systemHaltDisabled) {
       try {
-        LOG.error("Halt called", ee);
+        LOG.error("Halt called", he);
       } catch (Error e) {
-        if (catched == null) {
-          catched = e; // errors will be re-thrown
+        // errors have higher priority again, if it's a 2nd error, the 1st one suprpesses it
+        if (caught == null) {
+          caught = e;
         } else {
-          catched.addSuppressed(e);
+          caught.addSuppressed(e);
         }
       } catch (Throwable t) {
-        // all other kind of throwables are supressed
-        ee.addSuppressed(t);
+        // all other kind of throwables are suppressed
+        he.addSuppressed(t);
       }
-      synchronized (ExitUtil.class) {
-        if (!haltCalled()) {
-          firstHaltException = ee;
-        }
+      FIRST_HALT_EXCEPTION.compareAndSet(null, he);
+      if (caught != null) {
+        caught.addSuppressed(he);
+        throw caught;
       }
-      if (catched != null) {
-        catched.addSuppressed(ee);
-        throw catched;
-      }
-      throw ee; // not supressed by a higher prority error
+      // not suppressed by a higher prority error
+      throw he;
     } else {
-      // when halt is not disabled, whatever Throwable happened, we halt the VM
+      // when halt is enabled, whatever Throwable happened, we halt the VM
       Runtime.getRuntime().halt(status);
     }
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
@@ -207,6 +207,9 @@ public final class ExitUtil {
   /**
    * Suppresses if legit and returns the first non-null of the two. Legit means
    * <code>suppressor</code> if neither <code>null</code> nor <code>suppressed</code>.
+   * @param suppressor <code>Throwable</code> that suppresses <code>suppressed</code>
+   * @param suppressed <code>Throwable</code> that is suppressed by <code>suppressor</code>
+   * @return <code>suppressor</code> if not <code>null</code>, <code>suppressed</code> otherwise
    */
   private static <T extends Throwable> T addSuppressed(T suppressor, T suppressed) {
     if (suppressor == null) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
@@ -163,7 +163,7 @@ public final class ExitUtil {
    */
   public static boolean terminateCalled() {
     // Either we set this member or we actually called System#exit
-    return FIRST_EXIT_EXCEPTION.get()!=null;
+    return FIRST_EXIT_EXCEPTION.get() != null;
   }
 
   /**
@@ -171,7 +171,7 @@ public final class ExitUtil {
    */
   public static boolean haltCalled() {
     // Either we set this member or we actually called Runtime#halt
-    return FIRST_HALT_EXCEPTION.get()!=null;
+    return FIRST_HALT_EXCEPTION.get() != null;
   }
 
   /**
@@ -229,7 +229,9 @@ public final class ExitUtil {
         caught = e;
       } catch (Throwable t) {
         // all other kind of throwables are suppressed
-        ee.addSuppressed(t);
+        if (ee != t) {
+          ee.addSuppressed(t);
+        }
       }
     }
     if (systemExitDisabled) {
@@ -239,12 +241,14 @@ public final class ExitUtil {
         // errors have higher priority again, if it's a 2nd error, the 1st one suprpesses it
         if (caught == null) {
           caught = e;
-        } else {
+        } else if (caught != e) {
           caught.addSuppressed(e);
         }
       } catch (Throwable t) {
         // all other kind of throwables are suppressed
-        ee.addSuppressed(t);
+        if (ee != t) {
+          ee.addSuppressed(t);
+        }
       }
       FIRST_EXIT_EXCEPTION.compareAndSet(null, ee);
       if (caught != null) {
@@ -284,7 +288,9 @@ public final class ExitUtil {
         caught = e;
       } catch (Throwable t) {
         // all other kind of throwables are suppressed
-        he.addSuppressed(t);
+        if (he != t) {
+          he.addSuppressed(t);
+        }
       }
     }
     // systemHaltDisabled is volatile and not used in scenario nheding atomicty,
@@ -296,12 +302,14 @@ public final class ExitUtil {
         // errors have higher priority again, if it's a 2nd error, the 1st one suprpesses it
         if (caught == null) {
           caught = e;
-        } else {
+        } else if (caught != e) {
           caught.addSuppressed(e);
         }
       } catch (Throwable t) {
         // all other kind of throwables are suppressed
-        he.addSuppressed(t);
+        if (he != t) {
+          he.addSuppressed(t);
+        }
       }
       FIRST_HALT_EXCEPTION.compareAndSet(null, he);
       if (caught != null) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestExitUtil.java
@@ -23,57 +23,66 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.hadoop.util.ExitUtil.ExitException;
 import org.apache.hadoop.util.ExitUtil.HaltException;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 
+public class TestExitUtil extends AbstractHadoopTestBase {
 
-public class TestExitUtil {
+  @Before
+  public void before() {
+    ExitUtil.disableSystemExit();
+    ExitUtil.disableSystemHalt();
+    ExitUtil.resetFirstExitException();
+    ExitUtil.resetFirstHaltException();
+  }
+
+  @After
+  public void after() {
+    ExitUtil.resetFirstExitException();
+    ExitUtil.resetFirstHaltException();
+  }
 
   @Test
   public void testGetSetExitExceptions() throws Throwable {
     // prepare states and exceptions
-    ExitUtil.disableSystemExit();
-    ExitUtil.resetFirstExitException();
     ExitException ee1 = new ExitException(1, "TestExitUtil forged 1st ExitException");
     ExitException ee2 = new ExitException(2, "TestExitUtil forged 2nd ExitException");
-    try {
-      // check proper initial settings
-      assertFalse("ExitUtil.terminateCalled initial value should be false",
-          ExitUtil.terminateCalled());
-      assertNull("ExitUtil.getFirstExitException initial value should be null",
-          ExitUtil.getFirstExitException());
+    // check proper initial settings
+    assertFalse("ExitUtil.terminateCalled initial value should be false",
+        ExitUtil.terminateCalled());
+    assertNull("ExitUtil.getFirstExitException initial value should be null",
+        ExitUtil.getFirstExitException());
 
-      // simulate/check 1st call
-      ExitException ee = intercept(ExitException.class, ()->ExitUtil.terminate(ee1));
-      assertSame("ExitUtil.terminate should have rethrown its ExitException argument but it "
-          + "had thrown something else", ee1, ee);
-      assertTrue("ExitUtil.terminateCalled should be true after 1st ExitUtil.terminate call",
-          ExitUtil.terminateCalled());
-      assertSame("ExitUtil.terminate should store its 1st call's ExitException",
-          ee1, ExitUtil.getFirstExitException());
+    // simulate/check 1st call
+    ExitException ee = intercept(ExitException.class, ()->ExitUtil.terminate(ee1));
+    assertSame("ExitUtil.terminate should have rethrown its ExitException argument but it "
+        + "had thrown something else", ee1, ee);
+    assertTrue("ExitUtil.terminateCalled should be true after 1st ExitUtil.terminate call",
+        ExitUtil.terminateCalled());
+    assertSame("ExitUtil.terminate should store its 1st call's ExitException",
+        ee1, ExitUtil.getFirstExitException());
 
-      // simulate/check 2nd call not overwritting 1st one
-      ee = intercept(ExitException.class, ()->ExitUtil.terminate(ee2));
-      assertSame("ExitUtil.terminate should have rethrown its HaltException argument but it "
-          + "had thrown something else", ee2, ee);
-      assertTrue("ExitUtil.terminateCalled should still be true after 2nd ExitUtil.terminate call",
-          ExitUtil.terminateCalled());
-      // 2nd call rethrown the 2nd ExitException yet only the 1st only should have been stored
-      assertSame("ExitUtil.terminate when called twice should only remember 1st call's "
-          + "ExitException", ee1, ExitUtil.getFirstExitException());
+    // simulate/check 2nd call not overwritting 1st one
+    ee = intercept(ExitException.class, ()->ExitUtil.terminate(ee2));
+    assertSame("ExitUtil.terminate should have rethrown its HaltException argument but it "
+        + "had thrown something else", ee2, ee);
+    assertTrue("ExitUtil.terminateCalled should still be true after 2nd ExitUtil.terminate call",
+        ExitUtil.terminateCalled());
+    // 2nd call rethrown the 2nd ExitException yet only the 1st only should have been stored
+    assertSame("ExitUtil.terminate when called twice should only remember 1st call's "
+        + "ExitException", ee1, ExitUtil.getFirstExitException());
 
-      // simulate cleanup, also tries to make sure state is ok for all junit still has to do
-      ExitUtil.resetFirstExitException();
-      assertFalse("ExitUtil.terminateCalled should be false after "
-          + "ExitUtil.resetFirstExitException call", ExitUtil.terminateCalled());
-      assertNull("ExitUtil.getFirstExitException should be null after "
-          + "ExitUtil.resetFirstExitException call", ExitUtil.getFirstExitException());
-    } finally {
-      // cleanup
-      ExitUtil.resetFirstExitException();
-    }
+    // simulate cleanup, also tries to make sure state is ok for all junit still has to do
+    ExitUtil.resetFirstExitException();
+    assertFalse("ExitUtil.terminateCalled should be false after "
+        + "ExitUtil.resetFirstExitException call", ExitUtil.terminateCalled());
+    assertNull("ExitUtil.getFirstExitException should be null after "
+        + "ExitUtil.resetFirstExitException call", ExitUtil.getFirstExitException());
   }
 
   @Test
@@ -83,40 +92,36 @@ public class TestExitUtil {
     ExitUtil.resetFirstHaltException();
     HaltException he1 = new HaltException(1, "TestExitUtil forged 1st HaltException");
     HaltException he2 = new HaltException(2, "TestExitUtil forged 2nd HaltException");
-    try {
-      // check proper initial settings
-      assertFalse("ExitUtil.haltCalled initial value should be false",
-          ExitUtil.haltCalled());
-      assertNull("ExitUtil.getFirstHaltException initial value should be null",
-          ExitUtil.getFirstHaltException());
 
-      // simulate/check 1st call
-      HaltException he = intercept(HaltException.class, ()->ExitUtil.halt(he1));
-      assertSame("ExitUtil.halt should have rethrown its HaltException argument but it had "
-          +"thrown something else", he1, he);
-      assertTrue("ExitUtil.haltCalled should be true after 1st ExitUtil.halt call",
-          ExitUtil.haltCalled());
-      assertSame("ExitUtil.halt should store its 1st call's HaltException",
-          he1, ExitUtil.getFirstHaltException());
+    // check proper initial settings
+    assertFalse("ExitUtil.haltCalled initial value should be false",
+        ExitUtil.haltCalled());
+    assertNull("ExitUtil.getFirstHaltException initial value should be null",
+        ExitUtil.getFirstHaltException());
 
-      // simulate/check 2nd call not overwritting 1st one
-      he = intercept(HaltException.class, ()->ExitUtil.halt(he2));
-      assertSame("ExitUtil.halt should have rethrown its HaltException argument but it had "
-          +"thrown something else", he2, he);
-      assertTrue("ExitUtil.haltCalled should still be true after 2nd ExitUtil.halt call",
-          ExitUtil.haltCalled());
-      assertSame("ExitUtil.halt when called twice should only remember 1st call's HaltException",
-          he1, ExitUtil.getFirstHaltException());
+    // simulate/check 1st call
+    HaltException he = intercept(HaltException.class, ()->ExitUtil.halt(he1));
+    assertSame("ExitUtil.halt should have rethrown its HaltException argument but it had "
+        +"thrown something else", he1, he);
+    assertTrue("ExitUtil.haltCalled should be true after 1st ExitUtil.halt call",
+        ExitUtil.haltCalled());
+    assertSame("ExitUtil.halt should store its 1st call's HaltException",
+        he1, ExitUtil.getFirstHaltException());
 
-      // simulate cleanup, also tries to make sure state is ok for all junit still has to do
-      ExitUtil.resetFirstHaltException();
-      assertFalse("ExitUtil.haltCalled should be false after "
-          + "ExitUtil.resetFirstHaltException call", ExitUtil.haltCalled());
-      assertNull("ExitUtil.getFirstHaltException should be null after "
-          + "ExitUtil.resetFirstHaltException call", ExitUtil.getFirstHaltException());
-    } finally {
-      // cleanup, useless if last test succeed, useful if not
-      ExitUtil.resetFirstHaltException();
-    }
+    // simulate/check 2nd call not overwritting 1st one
+    he = intercept(HaltException.class, ()->ExitUtil.halt(he2));
+    assertSame("ExitUtil.halt should have rethrown its HaltException argument but it had "
+        +"thrown something else", he2, he);
+    assertTrue("ExitUtil.haltCalled should still be true after 2nd ExitUtil.halt call",
+        ExitUtil.haltCalled());
+    assertSame("ExitUtil.halt when called twice should only remember 1st call's HaltException",
+        he1, ExitUtil.getFirstHaltException());
+
+    // simulate cleanup, also tries to make sure state is ok for all junit still has to do
+    ExitUtil.resetFirstHaltException();
+    assertFalse("ExitUtil.haltCalled should be false after "
+        + "ExitUtil.resetFirstHaltException call", ExitUtil.haltCalled());
+    assertNull("ExitUtil.getFirstHaltException should be null after "
+        + "ExitUtil.resetFirstHaltException call", ExitUtil.getFirstHaltException());
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestExitUtil.java
@@ -17,17 +17,22 @@
  */
 package org.apache.hadoop.util;
 
-import static org.junit.Assert.*;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 import org.apache.hadoop.util.ExitUtil.ExitException;
 import org.apache.hadoop.util.ExitUtil.HaltException;
 
-import org.junit.Test;
 
 public class TestExitUtil {
 
   @Test
-  public void testGetSetExitExceptions() {
+  public void testGetSetExitExceptions() throws Throwable {
     // prepare states and exceptions
     ExitUtil.disableSystemExit();
     ExitUtil.resetFirstExitException();
@@ -35,38 +40,36 @@ public class TestExitUtil {
     ExitException ee2 = new ExitException(2, "TestExitUtil forged 2nd ExitException");
     try {
       // check proper initial settings
-      assertFalse(ExitUtil.terminateCalled());
-      assertNull(ExitUtil.getFirstExitException());
+      assertFalse("ExitUtil.terminateCalled initial value should be false",
+          ExitUtil.terminateCalled());
+      assertNull("ExitUtil.getFirstExitException initial value should be null",
+          ExitUtil.getFirstExitException());
 
       // simulate/check 1st call
-      try {
-        ExitUtil.terminate(ee1);
-        fail("ExitUtil.terminate should have rethrown its ExitException argument but it returned");
-      } catch (ExitException ee) {
-        assertEquals("ExitUtil.terminate should have rethrown its ExitException argument but it "
-            +"had thrown something else", ee1, ee);
-      }
-      assertTrue(ExitUtil.terminateCalled());
-      assertEquals("ExitUtil.terminate should store its 1st call's ExitException",
+      ExitException ee = intercept(ExitException.class, ()->ExitUtil.terminate(ee1));
+      assertSame("ExitUtil.terminate should have rethrown its ExitException argument but it "
+          + "had thrown something else", ee1, ee);
+      assertTrue("ExitUtil.terminateCalled should be true after 1st ExitUtil.terminate call",
+          ExitUtil.terminateCalled());
+      assertSame("ExitUtil.terminate should store its 1st call's ExitException",
           ee1, ExitUtil.getFirstExitException());
 
       // simulate/check 2nd call not overwritting 1st one
-      try {
-        ExitUtil.terminate(ee2);
-        fail("ExitUtil.terminate should have rethrown its ExitException argument but it returned");
-      } catch (ExitException ee) {
-        assertEquals("ExitUtil.terminate should have rethrown its HaltException argument but it "
-            +"had thrown something else", ee2, ee);
-      }
-      assertTrue(ExitUtil.terminateCalled());
+      ee = intercept(ExitException.class, ()->ExitUtil.terminate(ee2));
+      assertSame("ExitUtil.terminate should have rethrown its HaltException argument but it "
+          + "had thrown something else", ee2, ee);
+      assertTrue("ExitUtil.terminateCalled should still be true after 2nd ExitUtil.terminate call",
+          ExitUtil.terminateCalled());
       // 2nd call rethrown the 2nd ExitException yet only the 1st only should have been stored
-      assertEquals("ExitUtil.terminate when called twice should only remember 1st call's "
-          +"ExitException", ee1, ExitUtil.getFirstExitException());
+      assertSame("ExitUtil.terminate when called twice should only remember 1st call's "
+          + "ExitException", ee1, ExitUtil.getFirstExitException());
 
       // simulate cleanup, also tries to make sure state is ok for all junit still has to do
       ExitUtil.resetFirstExitException();
-      assertFalse(ExitUtil.terminateCalled());
-      assertNull(ExitUtil.getFirstExitException());
+      assertFalse("ExitUtil.terminateCalled should be false after "
+          + "ExitUtil.resetFirstExitException call", ExitUtil.terminateCalled());
+      assertNull("ExitUtil.getFirstExitException should be null after "
+          + "ExitUtil.resetFirstExitException call", ExitUtil.getFirstExitException());
     } finally {
       // cleanup
       ExitUtil.resetFirstExitException();
@@ -74,7 +77,7 @@ public class TestExitUtil {
   }
 
   @Test
-  public void testGetSetHaltExceptions() {
+  public void testGetSetHaltExceptions() throws Throwable {
     // prepare states and exceptions
     ExitUtil.disableSystemHalt();
     ExitUtil.resetFirstHaltException();
@@ -82,38 +85,35 @@ public class TestExitUtil {
     HaltException he2 = new HaltException(2, "TestExitUtil forged 2nd HaltException");
     try {
       // check proper initial settings
-      assertFalse(ExitUtil.haltCalled());
-      assertNull(ExitUtil.getFirstHaltException());
+      assertFalse("ExitUtil.haltCalled initial value should be false",
+          ExitUtil.haltCalled());
+      assertNull("ExitUtil.getFirstHaltException initial value should be null",
+          ExitUtil.getFirstHaltException());
 
       // simulate/check 1st call
-      try {
-        ExitUtil.halt(he1);
-        fail("ExitUtil.halt should have rethrown its HaltException argument but it returned");
-      } catch (HaltException he) {
-        assertEquals("ExitUtil.halt should have rethrown its HaltException argument but it had "
-            +"thrown something else", he1, he);
-      }
-      assertTrue("ExitUtil.halt/haltCalled should remember halt has been called",
+      HaltException he = intercept(HaltException.class, ()->ExitUtil.halt(he1));
+      assertSame("ExitUtil.halt should have rethrown its HaltException argument but it had "
+          +"thrown something else", he1, he);
+      assertTrue("ExitUtil.haltCalled should be true after 1st ExitUtil.halt call",
           ExitUtil.haltCalled());
-      assertEquals("ExitUtil.halt should store its 1st call's HaltException",
+      assertSame("ExitUtil.halt should store its 1st call's HaltException",
           he1, ExitUtil.getFirstHaltException());
 
       // simulate/check 2nd call not overwritting 1st one
-      try {
-        ExitUtil.halt(he2);
-        fail("ExitUtil.halt should have rethrown its HaltException argument but it returned");
-      } catch (HaltException he) {
-        assertEquals("ExitUtil.halt should have rethrown its HaltException argument but it had "
-            +"thrown something else", he2, he);
-      }
-      assertTrue(ExitUtil.haltCalled());
-      assertEquals("ExitUtil.halt when called twice should only remember 1st call's HaltException",
+      he = intercept(HaltException.class, ()->ExitUtil.halt(he2));
+      assertSame("ExitUtil.halt should have rethrown its HaltException argument but it had "
+          +"thrown something else", he2, he);
+      assertTrue("ExitUtil.haltCalled should still be true after 2nd ExitUtil.halt call",
+          ExitUtil.haltCalled());
+      assertSame("ExitUtil.halt when called twice should only remember 1st call's HaltException",
           he1, ExitUtil.getFirstHaltException());
 
       // simulate cleanup, also tries to make sure state is ok for all junit still has to do
       ExitUtil.resetFirstHaltException();
-      assertFalse(ExitUtil.haltCalled());
-      assertNull(ExitUtil.getFirstHaltException());
+      assertFalse("ExitUtil.haltCalled should be false after "
+          + "ExitUtil.resetFirstHaltException call", ExitUtil.haltCalled());
+      assertNull("ExitUtil.getFirstHaltException should be null after "
+          + "ExitUtil.resetFirstHaltException call", ExitUtil.getFirstHaltException());
     } finally {
       // cleanup, useless if last test succeed, useful if not
       ExitUtil.resetFirstHaltException();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestExitUtil.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+import static org.junit.Assert.*;
+
+import org.apache.hadoop.util.ExitUtil.ExitException;
+import org.apache.hadoop.util.ExitUtil.HaltException;
+
+import org.junit.Test;
+
+public class TestExitUtil {
+
+  @Test
+  public void testGetSetExitExceptions() {
+    // prepare states and exceptions
+    ExitUtil.disableSystemExit();
+    ExitUtil.resetFirstExitException();
+    ExitException ee1 = new ExitException(1, "TestExitUtil forged 1st ExitException");
+    ExitException ee2 = new ExitException(2, "TestExitUtil forged 2nd ExitException");
+    try {
+      // check proper initial settings
+      assertFalse(ExitUtil.terminateCalled());
+      assertNull(ExitUtil.getFirstExitException());
+
+      // simulate/check 1st call
+      try {
+        ExitUtil.terminate(ee1);
+        fail("ExitUtil.terminate should have rethrown its ExitException argument but it returned");
+      } catch (ExitException ee) {
+        assertEquals("ExitUtil.terminate should have rethrown its ExitException argument but it "
+            +"had thrown something else", ee1, ee);
+      }
+      assertTrue(ExitUtil.terminateCalled());
+      assertEquals("ExitUtil.terminate should store its 1st call's ExitException",
+          ee1, ExitUtil.getFirstExitException());
+
+      // simulate/check 2nd call not overwritting 1st one
+      try {
+        ExitUtil.terminate(ee2);
+        fail("ExitUtil.terminate should have rethrown its ExitException argument but it returned");
+      } catch (ExitException ee) {
+        assertEquals("ExitUtil.terminate should have rethrown its HaltException argument but it "
+            +"had thrown something else", ee2, ee);
+      }
+      assertTrue(ExitUtil.terminateCalled());
+      // 2nd call rethrown the 2nd ExitException yet only the 1st only should have been stored
+      assertEquals("ExitUtil.terminate when called twice should only remember 1st call's "
+          +"ExitException", ee1, ExitUtil.getFirstExitException());
+
+      // simulate cleanup, also tries to make sure state is ok for all junit still has to do
+      ExitUtil.resetFirstExitException();
+      assertFalse(ExitUtil.terminateCalled());
+      assertNull(ExitUtil.getFirstExitException());
+    } finally {
+      // cleanup
+      ExitUtil.resetFirstExitException();
+    }
+  }
+
+  @Test
+  public void testGetSetHaltExceptions() {
+    // prepare states and exceptions
+    ExitUtil.disableSystemHalt();
+    ExitUtil.resetFirstHaltException();
+    HaltException he1 = new HaltException(1, "TestExitUtil forged 1st HaltException");
+    HaltException he2 = new HaltException(2, "TestExitUtil forged 2nd HaltException");
+    try {
+      // check proper initial settings
+      assertFalse(ExitUtil.haltCalled());
+      assertNull(ExitUtil.getFirstHaltException());
+
+      // simulate/check 1st call
+      try {
+        ExitUtil.halt(he1);
+        fail("ExitUtil.halt should have rethrown its HaltException argument but it returned");
+      } catch (HaltException he) {
+        assertEquals("ExitUtil.halt should have rethrown its HaltException argument but it had "
+            +"thrown something else", he1, he);
+      }
+      assertTrue("ExitUtil.halt/haltCalled should remember halt has been called",
+          ExitUtil.haltCalled());
+      assertEquals("ExitUtil.halt should store its 1st call's HaltException",
+          he1, ExitUtil.getFirstHaltException());
+
+      // simulate/check 2nd call not overwritting 1st one
+      try {
+        ExitUtil.halt(he2);
+        fail("ExitUtil.halt should have rethrown its HaltException argument but it returned");
+      } catch (HaltException he) {
+        assertEquals("ExitUtil.halt should have rethrown its HaltException argument but it had "
+            +"thrown something else", he2, he);
+      }
+      assertTrue(ExitUtil.haltCalled());
+      assertEquals("ExitUtil.halt when called twice should only remember 1st call's HaltException",
+          he1, ExitUtil.getFirstHaltException());
+
+      // simulate cleanup, also tries to make sure state is ok for all junit still has to do
+      ExitUtil.resetFirstHaltException();
+      assertFalse(ExitUtil.haltCalled());
+      assertNull(ExitUtil.getFirstHaltException());
+    } finally {
+      // cleanup, useless if last test succeed, useful if not
+      ExitUtil.resetFirstHaltException();
+    }
+  }
+}


### PR DESCRIPTION
…king halt + enlarged catches (robustness) to all Throwables (not just Exceptions)

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
I've reduced the synchronized blocks scope so System.exit and Runtime.halt calls aren't within their boundaries, so ExitUtil wrappers do not block each others (System.exit never returns if called and no SecurityException is raised, so ExitUtil.terminate was never releasing the acquired lock, thus forbidding ExitUtil.halt to be able to halt the JVM even when in the middle of a graceful shutdown, thus it was not behaving like the 2 wrapped java's methods System.exit/Runtime.halt which do not block each other)
I've altered throwable handling:
  - what is catched: was nothing or only Exception, now all Throwables are catched (even ThreadDeath)
  - what is rethrown: when exit/halt has been disabled, if what was catched is an Error it will be rethrown rather than the initial ExitException/HaltException. Other Throwables will be added as suppressed to the Exit/HaltException
  - what wasn't catched: if not disabled, even is something was raised that wasn't catched before, it is now catched and System.exit/Runtime.halt is always called
  - what is suppressed: if the what needs to be rethrown is changed on the way, the newly to-be-thrown will have the old one as a suppressed Throwable. I've also done this for the Exit/Halt Exception that can supress Throwables that are not Error (might not be a so good idea)

### How was this patch tested?
No more tests than the existing ones (if any). This case is not really hard to reproduce but the test would need to exit a JVM. I've not added such tests because if unit does not fork, it would kills the test suite (thus impacting all tests). I think developing a robust test for this specific case is way more hard and  dangerous to offset the cost of a review, the risk of what could be missed by this review.

Easiest way can be reproduced the initial bug: having a shutdown hook call ExitUtil.terminate, have another thread that will call ExitUtil.halt after (use pauses to ensure it calls it after the hook), witness the JVM not stopping and needing either an external kill or a internal Runtime.halt call, maybe check the JVM threads' stacks too to view the ExitUtil.terminate call stuck on System.exit, and ExitUtil.halt call stuck on ExitUtil.terminate.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

