### PR TITLE
MAPREDUCE-7376. AggregateWordCount fetches wrong results.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/aggregate/ValueAggregatorJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/aggregate/ValueAggregatorJob.java
@@ -200,7 +200,7 @@ public class ValueAggregatorJob {
     conf.setInt(ValueAggregatorJobBase.DESCRIPTOR_NUM, descriptors.length);
     //specify the aggregator descriptors
     for(int i=0; i< descriptors.length; i++) {
-      conf.set(ValueAggregatorJobBase.DESCRIPTOR + i, 
+      conf.set(ValueAggregatorJobBase.DESCRIPTOR + "." + i,
                "UserDefined," + descriptors[i].getName());
     }
     return conf;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/AggregateWordCount.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/AggregateWordCount.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.aggregate.ValueAggregatorBaseDescriptor;
 import org.apache.hadoop.mapreduce.lib.aggregate.ValueAggregatorJob;
+import org.apache.hadoop.util.ExitUtil;
 
 /**
  * This is an example Aggregated Hadoop Map/Reduce application. It reads the
@@ -72,7 +73,7 @@ public class AggregateWordCount {
         , new Class[] {WordCountPlugInClass.class});
     job.setJarByClass(AggregateWordCount.class);
     int ret = job.waitForCompletion(true) ? 0 : 1;
-    System.exit(ret);
+    ExitUtil.terminate(ret);
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestAggregateWordCount.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestAggregateWordCount.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.HadoopTestCase;
-import org.apache.hadoop.util.ExitUtil;
+import org.apache.hadoop.util.ExitUtil.ExitException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -68,13 +68,13 @@ public class TestAggregateWordCount extends HadoopTestCase {
       FileUtil.write(fs, file2, "Hello Hadoop");
 
       String[] args =
-          new String[] { INPUT_PATH.toString(), OUTPUT_PATH.toString(), "1",
-              "textinputformat" };
+          new String[] {INPUT_PATH.toString(), OUTPUT_PATH.toString(), "1",
+              "textinputformat"};
 
       // Run AggregateWordCount Job.
       try {
         AggregateWordCount.main(args);
-      } catch (ExitUtil.ExitException e) {
+      } catch (ExitException e) {
         // Ignore
       }
 
@@ -106,7 +106,7 @@ public class TestAggregateWordCount extends HadoopTestCase {
     @Override
     public void checkExit(int status) {
       super.checkExit(status);
-      throw new ExitUtil.ExitException(status, "Dummy");
+      throw new ExitException(status, "Dummy");
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestAggregateWordCount.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/test/java/org/apache/hadoop/examples/TestAggregateWordCount.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.examples;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.security.Permission;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.HadoopTestCase;
+import org.apache.hadoop.util.ExitUtil;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestAggregateWordCount extends HadoopTestCase {
+  public TestAggregateWordCount() throws IOException {
+    super(LOCAL_MR, LOCAL_FS, 1, 1);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    getFileSystem().delete(TEST_DIR, true);
+    super.tearDown();
+  }
+
+  // Input/Output paths for sort
+  private static final Path TEST_DIR = new Path(
+      new File(System.getProperty("test.build.data", "/tmp"),
+          "aggregatewordcount").getAbsoluteFile().toURI().toString());
+
+  private static final Path INPUT_PATH = new Path(TEST_DIR, "inPath");
+  private static final Path OUTPUT_PATH = new Path(TEST_DIR, "outPath");
+
+  @Test
+  public void testAggregateTestCount()
+      throws IOException, ClassNotFoundException, InterruptedException {
+    SecurityManager securityManager = System.getSecurityManager();
+    System.setSecurityManager(new NoExitSecurityManager());
+    try {
+      FileSystem fs = getFileSystem();
+      fs.mkdirs(INPUT_PATH);
+      Path file1 = new Path(INPUT_PATH, "file1");
+      Path file2 = new Path(INPUT_PATH, "file2");
+      FileUtil.write(fs, file1, "Hello World");
+      FileUtil.write(fs, file2, "Hello Hadoop");
+
+      String[] args =
+          new String[] { INPUT_PATH.toString(), OUTPUT_PATH.toString(), "1",
+              "textinputformat" };
+
+      // Run AggregateWordCount Job.
+      try {
+        AggregateWordCount.main(args);
+      } catch (ExitUtil.ExitException e) {
+        // Ignore
+      }
+
+      String allEntries;
+      try (FSDataInputStream stream = fs
+          .open(new Path(OUTPUT_PATH, "part-r-00000"));) {
+        allEntries = IOUtils.toString(stream, Charset.defaultCharset());
+      }
+
+      assertEquals("Hadoop\t1\n" + "Hello\t2\n" + "World\t1\n", allEntries);
+
+    } finally {
+      System.setSecurityManager(securityManager);
+    }
+  }
+
+  /**
+   * Created to avoid System.exit called in the main method to kill the JVM.
+   */
+  private static class NoExitSecurityManager extends SecurityManager {
+    @Override
+    public void checkPermission(Permission perm) {
+    }
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+    }
+
+    @Override
+    public void checkExit(int status) {
+      super.checkExit(status);
+      throw new ExitUtil.ExitException(status, "Dummy");
+    }
+  }
+}


### PR DESCRIPTION
### Description of PR

Fixes AggregateWordCount

### How was this patch tested?
```
hadoop-3.4.0-SNAPSHOT % bin/hadoop jar share/hadoop/mapreduce/hadoop-mapreduce-examples-3.4.0-SNAPSHOT.jar  aggregatewordcount /testData /testOut 1 textinputformat

hadoop-3.4.0-SNAPSHOT % bin/hdfs dfs -cat /testOut/part-r-00000                                                                                                   
Bye	1
Goodbye	1
Hadoop	2
Hello	2
World	2
```
``/testData`` had two files:
`wc01.txt:`
Hello World Bye World

`wc02.txt:`
Hello Hadoop Goodbye Hadoop

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?