### PR TITLE
HADOOP-18542. Keep MSI tenant ID and client ID optional

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -963,9 +963,9 @@ public class AbfsConfiguration{
               FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT,
               AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT);
           String tenantGuid =
-              getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT);
+              getPasswordString(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT);
           String clientId =
-              getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
+              getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
           String authority = getTrimmedPasswordString(
               FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY,
               AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
@@ -460,7 +460,7 @@ public class TestAccountConfiguration {
       // Test that we managed to instantiate an MsiTokenProvider without having to define the tenant and client ID.
       // Those 2 fields are optional as they can automatically be determined by the Azure Metadata service when
       // running on an Azure VM.
-      Assertions.assertThat(tokenProviderTypeName).isInstanceOf(MsiTokenProvider.class);
+      Assertions.assertThat(tokenProviderTypeName).describedAs("Token Provider Should be MsiTokenProvider").isInstanceOf(MsiTokenProvider.class);
   }
 
   public void testGlobalAndAccountOAuthPrecedence(AbfsConfiguration abfsConf,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.ConfigurationPropertyNotFoundException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationValueException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TokenAccessProviderException;
+import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.CustomTokenProviderAdapter;
 import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
@@ -65,7 +66,7 @@ import static org.junit.Assert.assertNull;
  * that do allow default values (all others) follow another form.
  */
 public class TestAccountConfiguration {
-  private static final String TEST_OAUTH_PROVIDER_CLASS_CONFIG = "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider";
+  private static final String TEST_OAUTH_MSI_TOKEN_PROVIDER_CLASS_CONFIG = "org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider";
   private static final String TEST_CUSTOM_PROVIDER_CLASS_CONFIG = "org.apache.hadoop.fs.azurebfs.oauth2.RetryTestTokenProvider";
   private static final String TEST_SAS_PROVIDER_CLASS_CONFIG_1 = "org.apache.hadoop.fs.azurebfs.extensions.MockErrorSASTokenProvider";
   private static final String TEST_SAS_PROVIDER_CLASS_CONFIG_2 = "org.apache.hadoop.fs.azurebfs.extensions.MockSASTokenProvider";
@@ -442,6 +443,30 @@ public class TestAccountConfiguration {
             ConfigurationPropertyNotFoundException.class,
             LambdaTestUtils.intercept(TokenAccessProviderException.class,
                 () -> abfsConf.getTokenProvider().getClass().getTypeName())));
+  }
+
+  @Test
+  public void testClientAndTenantIdOptionalWhenUsingMsiTokenProvider() throws Throwable {
+      final String accountName = "account";
+      final Configuration conf = new Configuration();
+      final AbfsConfiguration abfsConf = new AbfsConfiguration(conf, accountName);
+
+      final String accountNameSuffix = "." + abfsConf.getAccountName();
+      String authKey = FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix;
+      String providerClassKey = "";
+      String providerClassValue = "";
+
+      providerClassKey = FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix;
+      providerClassValue = TEST_OAUTH_MSI_TOKEN_PROVIDER_CLASS_CONFIG;
+
+      abfsConf.set(authKey, AuthType.OAuth.toString());
+      abfsConf.set(providerClassKey, providerClassValue);
+
+      AccessTokenProvider tokenProviderTypeName = abfsConf.getTokenProvider();
+      // Test that we managed to instantiate an MsiTokenProvider without having to define the tenant and client ID.
+      // Those 2 fields are optional as they can automatically be determined by the Azure Metadata service when
+      // running on an Azure VM.
+      Assertions.assertThat(tokenProviderTypeName).isInstanceOf(MsiTokenProvider.class);
   }
 
   public void testGlobalAndAccountOAuthPrecedence(AbfsConfiguration abfsConf,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
@@ -66,6 +66,7 @@ import static org.junit.Assert.assertNull;
  * that do allow default values (all others) follow another form.
  */
 public class TestAccountConfiguration {
+  private static final String TEST_OAUTH_PROVIDER_CLASS_CONFIG = "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider";
   private static final String TEST_OAUTH_MSI_TOKEN_PROVIDER_CLASS_CONFIG = "org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider";
   private static final String TEST_CUSTOM_PROVIDER_CLASS_CONFIG = "org.apache.hadoop.fs.azurebfs.oauth2.RetryTestTokenProvider";
   private static final String TEST_SAS_PROVIDER_CLASS_CONFIG_1 = "org.apache.hadoop.fs.azurebfs.extensions.MockErrorSASTokenProvider";
@@ -90,11 +91,6 @@ public class TestAccountConfiguration {
           FS_AZURE_ACCOUNT_OAUTH_CLIENT_ENDPOINT,
           FS_AZURE_ACCOUNT_OAUTH_USER_NAME,
           FS_AZURE_ACCOUNT_OAUTH_USER_PASSWORD));
-
-  private static final List<String> MSI_TOKEN_OAUTH_CONFIG_KEYS =
-      Collections.unmodifiableList(Arrays.asList(
-          FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT,
-          FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID));
 
   private static final List<String> REFRESH_TOKEN_OAUTH_CONFIG_KEYS =
       Collections.unmodifiableList(Arrays.asList(
@@ -411,10 +407,8 @@ public class TestAccountConfiguration {
   public void testOAuthConfigPropNotFound() throws Throwable {
     testConfigPropNotFound(CLIENT_CREDENTIAL_OAUTH_CONFIG_KEYS, ClientCredsTokenProvider.class.getName());
     testConfigPropNotFound(USER_PASSWORD_OAUTH_CONFIG_KEYS, UserPasswordTokenProvider.class.getName());
-    testConfigPropNotFound(MSI_TOKEN_OAUTH_CONFIG_KEYS, MsiTokenProvider.class.getName());
     testConfigPropNotFound(REFRESH_TOKEN_OAUTH_CONFIG_KEYS, RefreshTokenBasedTokenProvider.class.getName());
     testConfigPropNotFound(WORKLOAD_IDENTITY_OAUTH_CONFIG_KEYS, WorkloadIdentityTokenProvider.class.getName());
-
   }
 
   private void testConfigPropNotFound(List<String> configKeys,


### PR DESCRIPTION
### Description of PR
This PR is the same as https://github.com/apache/hadoop/pull/3788 but rebased onto a more recent version of the trunk branch.

This make tenant and client ID optional when getting an Azure token from the Azure Metadata Service since they can be inferred from the VM the calls is made from. 

For some reason the integration tests were failing in @virajjasani 's version (couldn't get a useful error message) but once I rebased onto `trunk` it worked.
I ran the integration tests from an azure VM so that Azure's metadata service can infer the tenant and client ID (which is why they are optional in `MsiTokenProvider`)

### How was this patch tested?

I ran the integration tests:

```
/hadoop/hadoop-tools/hadoop-azure# mvn -T 1C clean verify -Dtest=none -Dit.test=ITest*
[...]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1559, Failures: 0, Errors: 0, Skipped: 1542
[INFO]
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (depcheck) @ hadoop-azure ---
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M1:verify (default) @ hadoop-azure ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.325 s
[INFO] Finished at: 2022-05-06T15:23:32Z
[INFO] ------------------------------------------------------------------------
```

Let me know if something's missing, this is the first PR I do in this repo.