### PR TITLE
HADOOP-18222. Prevent DelegationTokenSecretManagerMetrics from registering multiple times

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -70,6 +70,12 @@ extends AbstractDelegationTokenIdentifier>
   private static final Logger LOG = LoggerFactory
       .getLogger(AbstractDelegationTokenSecretManager.class);
 
+  /**
+   * Metrics to track token management operations.
+   */
+  private static final DelegationTokenSecretManagerMetrics METRICS
+      = DelegationTokenSecretManagerMetrics.create();
+
   private String formatTokenId(TokenIdent id) {
     return "(" + id + ")";
   }
@@ -107,10 +113,6 @@ extends AbstractDelegationTokenIdentifier>
    * Access to currentKey is protected by this object lock
    */
   private DelegationKey currentKey;
-  /**
-   * Metrics to track token management operations.
-   */
-  private DelegationTokenSecretManagerMetrics metrics;
   
   private long keyUpdateInterval;
   private long tokenMaxLifetime;
@@ -149,7 +151,6 @@ extends AbstractDelegationTokenIdentifier>
     this.tokenRenewInterval = delegationTokenRenewInterval;
     this.tokenRemoverScanInterval = delegationTokenRemoverScanInterval;
     this.storeTokenTrackingId = false;
-    this.metrics = DelegationTokenSecretManagerMetrics.create();
   }
 
   /** should be called before this object is used */
@@ -446,7 +447,7 @@ extends AbstractDelegationTokenIdentifier>
     DelegationTokenInformation tokenInfo = new DelegationTokenInformation(now
         + tokenRenewInterval, password, getTrackingIdIfEnabled(identifier));
     try {
-      metrics.trackStoreToken(() -> storeToken(identifier, tokenInfo));
+      METRICS.trackStoreToken(() -> storeToken(identifier, tokenInfo));
     } catch (IOException ioe) {
       LOG.error("Could not store token " + formatTokenId(identifier) + "!!",
           ioe);
@@ -571,7 +572,7 @@ extends AbstractDelegationTokenIdentifier>
       throw new InvalidToken("Renewal request for unknown token "
           + formatTokenId(id));
     }
-    metrics.trackUpdateToken(() -> updateToken(id, info));
+    METRICS.trackUpdateToken(() -> updateToken(id, info));
     return renewTime;
   }
   
@@ -607,7 +608,7 @@ extends AbstractDelegationTokenIdentifier>
     if (info == null) {
       throw new InvalidToken("Token not found " + formatTokenId(id));
     }
-    metrics.trackRemoveToken(() -> {
+    METRICS.trackRemoveToken(() -> {
       removeTokenForOwnerStats(id);
       removeStoredToken(id);
     });
@@ -845,7 +846,7 @@ extends AbstractDelegationTokenIdentifier>
   }
 
   protected DelegationTokenSecretManagerMetrics getMetrics() {
-    return metrics;
+    return METRICS;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -647,7 +647,7 @@ public class TestDelegationToken {
     assertNotNull(dtSecretManager2.getMetrics());
 
     DefaultMetricsSystem.instance().init("test");
-    
+
     TestDelegationTokenSecretManager dtSecretManager3 =
         new TestDelegationTokenSecretManager(0, 0, 0, 0);
     assertNotNull(dtSecretManager3.getMetrics());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -652,7 +652,7 @@ public class TestDelegationToken {
         new TestDelegationTokenSecretManager(0, 0, 0, 0);
     assertNotNull(dtSecretManager3.getMetrics());
   }
-  
+
   @Test
   public void testDelegationTokenSecretManagerMetrics() throws Exception {
     TestDelegationTokenSecretManager dtSecretManager =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.fs.statistics.IOStatisticAssertions;
 import org.apache.hadoop.fs.statistics.MeanStatistic;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -635,6 +636,23 @@ public class TestDelegationToken {
     assertEquals(token1.encodeToUrlString(), token2.encodeToUrlString());
   }
 
+  @Test
+  public void testMultipleDelegationTokenSecretManagerMetrics() {
+    TestDelegationTokenSecretManager dtSecretManager1 =
+        new TestDelegationTokenSecretManager(0, 0, 0, 0);
+    assertNotNull(dtSecretManager1.getMetrics());
+
+    TestDelegationTokenSecretManager dtSecretManager2 =
+        new TestDelegationTokenSecretManager(0, 0, 0, 0);
+    assertNotNull(dtSecretManager2.getMetrics());
+
+    DefaultMetricsSystem.instance().init("test");
+    
+    TestDelegationTokenSecretManager dtSecretManager3 =
+        new TestDelegationTokenSecretManager(0, 0, 0, 0);
+    assertNotNull(dtSecretManager3.getMetrics());
+  }
+  
   @Test
   public void testDelegationTokenSecretManagerMetrics() throws Exception {
     TestDelegationTokenSecretManager dtSecretManager =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -663,13 +663,13 @@ public class TestDelegationToken {
 
       final Token<TestDelegationTokenIdentifier> token = callAndValidateMetrics(
           dtSecretManager, dtSecretManager.getMetrics().getStoreToken(), "storeToken",
-          () -> generateDelegationToken(dtSecretManager, "SomeUser", "JobTracker"), 1);
+          () -> generateDelegationToken(dtSecretManager, "SomeUser", "JobTracker"));
 
       callAndValidateMetrics(dtSecretManager, dtSecretManager.getMetrics().getUpdateToken(),
-          "updateToken", () -> dtSecretManager.renewToken(token, "JobTracker"), 1);
+          "updateToken", () -> dtSecretManager.renewToken(token, "JobTracker"));
 
       callAndValidateMetrics(dtSecretManager, dtSecretManager.getMetrics().getRemoveToken(),
-          "removeToken", () -> dtSecretManager.cancelToken(token, "JobTracker"), 1);
+          "removeToken", () -> dtSecretManager.cancelToken(token, "JobTracker"));
     } finally {
       dtSecretManager.stopThreads();
     }
@@ -689,14 +689,14 @@ public class TestDelegationToken {
 
       dtSecretManager.setThrowError(true);
 
-      callAndValidateFailureMetrics(dtSecretManager, "storeToken", 1, 1, false,
+      callAndValidateFailureMetrics(dtSecretManager, "storeToken", false,
           errorSleepMillis,
           () -> generateDelegationToken(dtSecretManager, "SomeUser", "JobTracker"));
 
-      callAndValidateFailureMetrics(dtSecretManager, "updateToken", 1, 2, true,
+      callAndValidateFailureMetrics(dtSecretManager, "updateToken", true,
           errorSleepMillis, () -> dtSecretManager.renewToken(token, "JobTracker"));
 
-      callAndValidateFailureMetrics(dtSecretManager, "removeToken", 1, 3, true,
+      callAndValidateFailureMetrics(dtSecretManager, "removeToken", true,
           errorSleepMillis, () -> dtSecretManager.cancelToken(token, "JobTracker"));
     } finally {
       dtSecretManager.stopThreads();
@@ -704,33 +704,33 @@ public class TestDelegationToken {
   }
 
   private <T> T callAndValidateMetrics(TestDelegationTokenSecretManager dtSecretManager,
-      MutableRate metric, String statName,  Callable<T> callable, int expectedCount)
+      MutableRate metric, String statName,  Callable<T> callable)
       throws Exception {
     MeanStatistic stat = IOStatisticAssertions.lookupMeanStatistic(
         dtSecretManager.getMetrics().getIoStatistics(), statName + ".mean");
-    assertEquals(expectedCount - 1, metric.lastStat().numSamples());
-    assertEquals(expectedCount - 1, stat.getSamples());
+    long metricBefore = metric.lastStat().numSamples();
+    long statBefore = stat.getSamples();
     T returnedObject = callable.call();
-    assertEquals(expectedCount, metric.lastStat().numSamples());
-    assertEquals(expectedCount, stat.getSamples());
+    assertEquals(metricBefore + 1, metric.lastStat().numSamples());
+    assertEquals(statBefore + 1, stat.getSamples());
     return returnedObject;
   }
 
   private <T> void callAndValidateFailureMetrics(TestDelegationTokenSecretManager dtSecretManager,
-      String statName, int expectedStatCount, int expectedMetricCount, boolean expectError,
-      int errorSleepMillis, Callable<T> callable) throws Exception {
+      String statName, boolean expectError, int errorSleepMillis, Callable<T> callable)
+      throws Exception {
     MutableCounterLong counter = dtSecretManager.getMetrics().getTokenFailure();
     MeanStatistic failureStat = IOStatisticAssertions.lookupMeanStatistic(
         dtSecretManager.getMetrics().getIoStatistics(), statName + ".failures.mean");
-    assertEquals(expectedMetricCount - 1, counter.value());
-    assertEquals(expectedStatCount - 1, failureStat.getSamples());
+    long counterBefore = counter.value();
+    long statBefore = failureStat.getSamples();
     if (expectError) {
       LambdaTestUtils.intercept(IOException.class, callable);
     } else {
       callable.call();
     }
-    assertEquals(expectedMetricCount, counter.value());
-    assertEquals(expectedStatCount, failureStat.getSamples());
+    assertEquals(counterBefore + 1, counter.value());
+    assertEquals(statBefore + 1, failureStat.getSamples());
     assertTrue(failureStat.getSum() >= errorSleepMillis);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

