### PR TITLE
YARN-11127. Potential deadlock in AsyncDispatcher caused by RMNodeImp…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailoverProxyProvider.java
@@ -78,6 +78,7 @@ public class TestRMFailoverProxyProvider {
    * gets called.
    */
   @Test
+  @SuppressWarnings("unchecked")
   public void testFailoverChange() throws Exception {
     //Adjusting the YARN Conf
     conf.set(YarnConfiguration.RM_HA_IDS, "rm0, rm1");
@@ -190,6 +191,7 @@ public class TestRMFailoverProxyProvider {
    * gets called.
    */
   @Test
+  @SuppressWarnings("unchecked")
   public void testAutoRefreshFailoverChange() throws Exception {
     conf.setClass(YarnConfiguration.CLIENT_FAILOVER_NO_HA_PROXY_PROVIDER,
         AutoRefreshRMFailoverProxyProvider.class,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestRMDeadLockTriggerByApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestRMDeadLockTriggerByApp.java
@@ -1,0 +1,356 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.client.api.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.service.Service.STATE;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationRequest;
+import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
+import org.apache.hadoop.yarn.api.records.ExecutionType;
+import org.apache.hadoop.yarn.api.records.ExecutionTypeRequest;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LogAggregationStatus;
+import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.client.ClientRMProxy;
+import org.apache.hadoop.yarn.client.api.AMRMClient;
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.event.AsyncDispatcher;
+import org.apache.hadoop.yarn.event.Event;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.MiniYARNCluster;
+import org.apache.hadoop.yarn.server.api.protocolrecords.LogAggregationReport;
+import org.apache.hadoop.yarn.server.nodemanager.NodeManager;
+import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttemptState;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
+import org.apache.hadoop.yarn.server.utils.BuilderUtils;
+import org.apache.hadoop.yarn.util.Records;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestRMDeadLockTriggerByApp {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(TestRMDeadLockTriggerByApp.class);
+
+  private static final int INTERVAL = 1;
+  private static final int LOOP = 5000;
+  private static final float CHECK_DEAD_LOCK_RATIO = 2.0f;
+  private static final int NODE_COUNT = 1;
+
+  private boolean deadLock = false;
+  private String errString = null;
+
+  private Configuration conf = null;
+  private MiniYARNCluster yarnCluster = null;
+
+  private List<NodeReport> nodeReports = null;
+  private ApplicationId appId = null;
+  private ApplicationAttemptId attemptId = null;
+
+  private YarnClient yarnClient = null;
+  private AMRMClient<ContainerRequest> amClient = null;
+
+  private ResourceManager rm;
+  private NodeManager nm;
+
+  // thread for allocate container
+  private Thread allocateThread = new AllocateTread();
+
+  // thread for add log aggregation report
+  private Thread addLogAggReportThread = new AddLogAggregationReportThread();
+
+  // thread for get application report
+  private Thread getAppReportThread = new GetApplicationReportThread();
+
+  @Before
+  public void setup() throws Exception {
+    createClusterAndStartApplication();
+  }
+
+  void createClusterAndStartApplication()
+      throws Exception {
+    this.conf = new YarnConfiguration();
+    conf.set(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class.getName());
+    conf.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 512);
+    conf.setLong(YarnConfiguration.NM_LOG_RETAIN_SECONDS, 1);
+    conf.setInt(
+        YarnConfiguration.NM_OPPORTUNISTIC_CONTAINERS_MAX_QUEUE_LENGTH, 10);
+    conf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
+    conf.setInt(YarnConfiguration.NM_VCORES, LOOP);
+    conf.setInt(YarnConfiguration.YARN_MINICLUSTER_NM_PMEM_MB, 512 * LOOP);
+    conf.setInt(YarnConfiguration.RM_NM_HEARTBEAT_INTERVAL_MS, this.INTERVAL);
+
+    this.yarnCluster = new MiniYARNCluster(
+        TestAMRMClient.class.getName(), NODE_COUNT, 1, 1);
+    yarnCluster.init(conf);
+    yarnCluster.start();
+
+    // start rm client
+    this.yarnClient = YarnClient.createYarnClient();
+    yarnClient.init(conf);
+    yarnClient.start();
+
+    // get node info
+    assertTrue("All node managers did not connect to the RM within the "
+            + "allotted 5-second timeout",
+        yarnCluster.waitForNodeManagersToConnect(5000L));
+    this.nodeReports = yarnClient.getNodeReports(NodeState.RUNNING);
+    assertEquals("Not all node managers were reported running",
+        NODE_COUNT, nodeReports.size());
+
+    // get rm and nm info
+    this.rm = yarnCluster.getResourceManager(0);
+    this.nm = yarnCluster.getNodeManager(0);
+
+    // submit new app
+    ApplicationSubmissionContext appContext =
+        yarnClient.createApplication().getApplicationSubmissionContext();
+    this.appId = appContext.getApplicationId();
+    // set the application name
+    appContext.setApplicationName("Test");
+    // Set the priority for the application master
+    Priority pri = Records.newRecord(Priority.class);
+    pri.setPriority(0);
+    appContext.setPriority(pri);
+    // Set the queue to which this application is to be submitted in the RM
+    appContext.setQueue("default");
+    // Set up the container launch context for the application master
+    ContainerLaunchContext amContainer =
+        BuilderUtils.newContainerLaunchContext(
+            Collections.<String, LocalResource>emptyMap(),
+            new HashMap<String, String>(), Arrays.asList("sleep", "100"),
+            new HashMap<String, ByteBuffer>(), null,
+            new HashMap<ApplicationAccessType, String>());
+    appContext.setAMContainerSpec(amContainer);
+    appContext.setResource(Resource.newInstance(1024, 1));
+    // Create the request to send to the applications manager
+    SubmitApplicationRequest appRequest = Records
+        .newRecord(SubmitApplicationRequest.class);
+    appRequest.setApplicationSubmissionContext(appContext);
+    // Submit the application to the applications manager
+    yarnClient.submitApplication(appContext);
+
+    // wait for app to start
+    GenericTestUtils.waitFor(() -> {
+      try {
+        ApplicationReport appReport = yarnClient.getApplicationReport(appId);
+        if (appReport.getYarnApplicationState()
+            == YarnApplicationState.ACCEPTED) {
+          this.attemptId = appReport.getCurrentApplicationAttemptId();
+          RMAppAttempt appAttempt = rm.getRMContext().getRMApps()
+              .get(attemptId.getApplicationId()).getCurrentAppAttempt();
+          if (appAttempt.getAppAttemptState() == RMAppAttemptState.LAUNCHED) {
+            return true;
+          }
+        }
+      } catch (Exception e) {
+        fail("Application launch failed.");
+      }
+      return false;
+    }, 1000, 10000);
+
+    // Just dig into the ResourceManager and get the AMRMToken just for the sake
+    // of testing.
+    UserGroupInformation.setLoginUser(UserGroupInformation
+        .createRemoteUser(UserGroupInformation.getCurrentUser().getUserName()));
+
+    // emulate RM setup of AMRM token in credentials by adding the token
+    // *before* setting the token service
+    RMAppAttempt appAttempt = rm.getRMContext().getRMApps()
+        .get(attemptId.getApplicationId()).getCurrentAppAttempt();
+    UserGroupInformation.getCurrentUser().addToken(appAttempt.getAMRMToken());
+    appAttempt.getAMRMToken().setService(
+        ClientRMProxy.getAMRMTokenService(conf));
+
+    // create AMRMClient
+    this.amClient = AMRMClient.createAMRMClient();
+    amClient.init(conf);
+    amClient.start();
+    amClient.registerApplicationMaster("Host", 10000, "");
+  }
+
+  @After
+  public void teardown() throws YarnException, IOException {
+    if (allocateThread != null) {
+      allocateThread.interrupt();
+      allocateThread = null;
+    }
+    if (addLogAggReportThread != null) {
+      addLogAggReportThread.interrupt();
+      addLogAggReportThread = null;
+    }
+    if (getAppReportThread != null) {
+      getAppReportThread.interrupt();
+      getAppReportThread = null;
+    }
+
+    if (yarnClient != null && yarnClient.getServiceState() == STATE.STARTED) {
+      yarnClient.stop();
+    }
+    this.yarnClient = null;
+
+    if (amClient != null && amClient.getServiceState() == STATE.STARTED) {
+      amClient.stop();
+    }
+    this.amClient = null;
+
+    // Avoid the EventHandlingThread stuck forever
+    if (deadLock) {
+      LOG.info("Found dead lock, stop EventHandlingThread manually!");
+      ((AsyncDispatcher) rm.getRMContext().getDispatcher())
+          .forceEventHandlingThreadStop();
+    }
+    if (yarnCluster != null && yarnCluster.getServiceState() == STATE.STARTED) {
+      yarnCluster.stop();
+    }
+    this.yarnCluster = null;
+  }
+
+  @Test(timeout = 60000)
+  public void TestRMDeadLockTriggerByApp() throws InterruptedException {
+    // start all thread
+    allocateThread.start();
+    addLogAggReportThread.start();
+    getAppReportThread.start();
+
+    this.deadLock = checkAsyncDispatcherDeadLock();
+    Assert.assertFalse("There is dead lock!", deadLock);
+    Assert.assertNull(errString);
+  }
+
+  private boolean checkAsyncDispatcherDeadLock() throws InterruptedException {
+    Event lastEvent = null;
+    Event currentEvent;
+    int counter = 0;
+    for (int i = 0; i < LOOP * CHECK_DEAD_LOCK_RATIO; i++) {
+      currentEvent = ((AsyncDispatcher) rm.getRmDispatcher()).getHeadEvent();
+      if (currentEvent != null && (currentEvent == lastEvent)) {
+        if (counter++ > LOOP * CHECK_DEAD_LOCK_RATIO / 2) {
+          return true;
+        }
+      } else {
+        counter = 0;
+        lastEvent = currentEvent;
+      }
+      Thread.sleep(INTERVAL);
+    }
+    return false;
+  }
+
+  class AllocateTread extends Thread {
+
+    @Override
+    public void run() {
+      ContainerId amContainerId = rm.getRMContext().getRMApps().get(appId)
+          .getAppAttempts().get(attemptId).getMasterContainer().getId();
+      ContainerRequest request = setupContainerAskForRM();
+      try {
+        for (int i = 0; i < LOOP; i++) {
+          amClient.addContainerRequest(request);
+          for (ContainerId containerId : nm.getNMContext().getContainers()
+              .keySet()) {
+            // release all container except am container
+            if (!amContainerId.equals(containerId)) {
+              amClient.releaseAssignedContainer(containerId);
+            }
+          }
+          amClient.allocate(0.1f);
+          Thread.sleep(INTERVAL);
+        }
+      } catch (Throwable t) {
+        errString = t.getMessage();
+        return;
+      }
+    }
+  }
+
+  class AddLogAggregationReportThread extends Thread {
+
+    @Override
+    public void run() {
+      LogAggregationReport report = LogAggregationReport
+          .newInstance(appId, LogAggregationStatus.RUNNING, "");
+      try {
+        for (int i = 0; i < LOOP; i++) {
+          if (nm.getNMContext().getLogAggregationStatusForApps().size() == 0) {
+            nm.getNMContext().getLogAggregationStatusForApps().add(report);
+          }
+          Thread.sleep(INTERVAL);
+        }
+      } catch (Throwable t) {
+        errString = t.getMessage();
+        return;
+      }
+    }
+  }
+
+  class GetApplicationReportThread extends Thread {
+
+    @Override
+    public void run() {
+      try {
+        for (int i = 0; i < LOOP; i++) {
+          yarnClient.getApplicationReport(appId);
+          Thread.sleep(INTERVAL);
+        }
+      } catch (Throwable t) {
+        errString = t.getMessage();
+        return;
+      }
+    }
+  }
+
+  private ContainerRequest setupContainerAskForRM() {
+    Priority pri = Priority.newInstance(1);
+    ContainerRequest request = new ContainerRequest(
+        Resource.newInstance(512, 1), null, null, pri, 0, true, null,
+        ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED, true), "");
+    return request;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestRMDeadLockTriggerByApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestRMDeadLockTriggerByApp.java
@@ -75,9 +75,6 @@ import org.slf4j.LoggerFactory;
 
 public class TestRMDeadLockTriggerByApp {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(TestRMDeadLockTriggerByApp.class);
-
   private static final int INTERVAL = 1;
   private static final int LOOP = 5000;
   private static final float CHECK_DEAD_LOCK_RATIO = 2.0f;
@@ -240,12 +237,6 @@ public class TestRMDeadLockTriggerByApp {
     }
     this.amClient = null;
 
-    // Avoid the EventHandlingThread stuck forever
-    if (deadLock) {
-      LOG.info("Found dead lock, stop EventHandlingThread manually!");
-      ((AsyncDispatcher) rm.getRMContext().getDispatcher())
-          .forceEventHandlingThreadStop();
-    }
     if (yarnCluster != null && yarnCluster.getServiceState() == STATE.STARTED) {
       yarnCluster.stop();
     }
@@ -253,7 +244,7 @@ public class TestRMDeadLockTriggerByApp {
   }
 
   @Test(timeout = 60000)
-  public void TestRMDeadLockTriggerByApp() throws InterruptedException {
+  public void testRMDeadLockTriggerByApp() throws InterruptedException {
     // start all thread
     allocateThread.start();
     addLogAggReportThread.start();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestRMDeadLockTriggerByApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestRMDeadLockTriggerByApp.java
@@ -116,8 +116,7 @@ public class TestRMDeadLockTriggerByApp {
     conf.set(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class.getName());
     conf.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 512);
     conf.setLong(YarnConfiguration.NM_LOG_RETAIN_SECONDS, 1);
-    conf.setInt(
-        YarnConfiguration.NM_OPPORTUNISTIC_CONTAINERS_MAX_QUEUE_LENGTH, 10);
+    conf.setInt(YarnConfiguration.NM_OPPORTUNISTIC_CONTAINERS_MAX_QUEUE_LENGTH, 10);
     conf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
     conf.setInt(YarnConfiguration.NM_VCORES, LOOP);
     conf.setInt(YarnConfiguration.YARN_MINICLUSTER_NM_PMEM_MB, 512 * LOOP);
@@ -134,12 +133,10 @@ public class TestRMDeadLockTriggerByApp {
     yarnClient.start();
 
     // get node info
-    assertTrue("All node managers did not connect to the RM within the "
-            + "allotted 5-second timeout",
+    assertTrue("All node managers did not connect to the RM within the allotted 5-second timeout",
         yarnCluster.waitForNodeManagersToConnect(5000L));
     this.nodeReports = yarnClient.getNodeReports(NodeState.RUNNING);
-    assertEquals("Not all node managers were reported running",
-        NODE_COUNT, nodeReports.size());
+    assertEquals("Not all node managers were reported running", NODE_COUNT, nodeReports.size());
 
     // get rm and nm info
     this.rm = yarnCluster.getResourceManager(0);
@@ -177,8 +174,7 @@ public class TestRMDeadLockTriggerByApp {
     GenericTestUtils.waitFor(() -> {
       try {
         ApplicationReport appReport = yarnClient.getApplicationReport(appId);
-        if (appReport.getYarnApplicationState()
-            == YarnApplicationState.ACCEPTED) {
+        if (appReport.getYarnApplicationState() == YarnApplicationState.ACCEPTED) {
           this.attemptId = appReport.getCurrentApplicationAttemptId();
           RMAppAttempt appAttempt = rm.getRMContext().getRMApps()
               .get(attemptId.getApplicationId()).getCurrentAppAttempt();
@@ -194,16 +190,15 @@ public class TestRMDeadLockTriggerByApp {
 
     // Just dig into the ResourceManager and get the AMRMToken just for the sake
     // of testing.
-    UserGroupInformation.setLoginUser(UserGroupInformation
-        .createRemoteUser(UserGroupInformation.getCurrentUser().getUserName()));
+    UserGroupInformation.setLoginUser(
+        UserGroupInformation.createRemoteUser(UserGroupInformation.getCurrentUser().getUserName()));
 
     // emulate RM setup of AMRM token in credentials by adding the token
     // *before* setting the token service
     RMAppAttempt appAttempt = rm.getRMContext().getRMApps()
         .get(attemptId.getApplicationId()).getCurrentAppAttempt();
     UserGroupInformation.getCurrentUser().addToken(appAttempt.getAMRMToken());
-    appAttempt.getAMRMToken().setService(
-        ClientRMProxy.getAMRMTokenService(conf));
+    appAttempt.getAMRMToken().setService(ClientRMProxy.getAMRMTokenService(conf));
 
     // create AMRMClient
     this.amClient = AMRMClient.createAMRMClient();
@@ -284,8 +279,7 @@ public class TestRMDeadLockTriggerByApp {
       try {
         for (int i = 0; i < LOOP; i++) {
           amClient.addContainerRequest(request);
-          for (ContainerId containerId : nm.getNMContext().getContainers()
-              .keySet()) {
+          for (ContainerId containerId : nm.getNMContext().getContainers().keySet()) {
             // release all container except am container
             if (!amContainerId.equals(containerId)) {
               amClient.releaseAssignedContainer(containerId);
@@ -339,9 +333,9 @@ public class TestRMDeadLockTriggerByApp {
 
   private ContainerRequest setupContainerAskForRM() {
     Priority pri = Priority.newInstance(1);
-    ContainerRequest request = new ContainerRequest(
-        Resource.newInstance(512, 1), null, null, pri, 0, true, null,
-        ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED, true), "");
+    ContainerRequest request =
+        new ContainerRequest(Resource.newInstance(512, 1), null, null, pri, 0, true, null,
+            ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED, true), "");
     return request;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -418,9 +418,4 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
   public Event getHeadEvent() {
     return eventQueue.peek();
   }
-
-  @VisibleForTesting
-  public void forceEventHandlingThreadStop() {
-    eventHandlingThread.stop();
-  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -413,4 +413,14 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
   public int getEventQueueSize() {
     return eventQueue.size();
   }
+
+  @VisibleForTesting
+  public Event getHeadEvent() {
+    return eventQueue.peek();
+  }
+
+  @VisibleForTesting
+  public void forceEventHandlingThreadStop() {
+    eventHandlingThread.stop();
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -262,7 +262,7 @@ public class ResourceManager extends CompositeService
   }
 
   @VisibleForTesting
-  Dispatcher getRmDispatcher() {
+  public Dispatcher getRmDispatcher() {
     return rmDispatcher;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -1122,8 +1122,7 @@ public class RMAppImpl implements RMApp, Recoverable {
 
     @Override
     public void transition(RMAppImpl app, RMAppEvent event) {
-      RMAppLogAggregationStatusEvent logEvent =
-          (RMAppLogAggregationStatusEvent) event;
+      RMAppLogAggregationStatusEvent logEvent = (RMAppLogAggregationStatusEvent) event;
       app.aggregateLogReport(logEvent.getNodeId(), logEvent.getReport());
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -279,6 +279,9 @@ public class RMAppImpl implements RMApp, Recoverable {
     .addTransition(RMAppState.ACCEPTED, RMAppState.ACCEPTED, 
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
+    .addTransition(RMAppState.ACCEPTED, RMAppState.ACCEPTED,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
       // Handle AppAttemptLaunch to update the launchTime and publish to ATS
       .addTransition(RMAppState.ACCEPTED, RMAppState.ACCEPTED,
         RMAppEventType.ATTEMPT_LAUNCHED,
@@ -298,6 +301,9 @@ public class RMAppImpl implements RMApp, Recoverable {
     .addTransition(RMAppState.RUNNING, RMAppState.RUNNING, 
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
+    .addTransition(RMAppState.RUNNING, RMAppState.RUNNING,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
     .addTransition(RMAppState.RUNNING,
         EnumSet.of(RMAppState.ACCEPTED, RMAppState.FINAL_SAVING),
         RMAppEventType.ATTEMPT_FAILED,
@@ -316,6 +322,9 @@ public class RMAppImpl implements RMApp, Recoverable {
     .addTransition(RMAppState.FINAL_SAVING, RMAppState.FINAL_SAVING, 
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
+    .addTransition(RMAppState.FINAL_SAVING, RMAppState.FINAL_SAVING,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
     // ignorable transitions
     .addTransition(RMAppState.FINAL_SAVING, RMAppState.FINAL_SAVING,
         EnumSet.of(RMAppEventType.NODE_UPDATE, RMAppEventType.KILL,
@@ -327,6 +336,9 @@ public class RMAppImpl implements RMApp, Recoverable {
     .addTransition(RMAppState.FINISHING, RMAppState.FINISHING, 
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
+    .addTransition(RMAppState.FINISHING, RMAppState.FINISHING,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
     // ignorable transitions
     .addTransition(RMAppState.FINISHING, RMAppState.FINISHING,
       EnumSet.of(RMAppEventType.NODE_UPDATE,
@@ -338,6 +350,9 @@ public class RMAppImpl implements RMApp, Recoverable {
     .addTransition(RMAppState.KILLING, RMAppState.KILLING, 
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
+    .addTransition(RMAppState.KILLING, RMAppState.KILLING,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
     .addTransition(RMAppState.KILLING, RMAppState.FINAL_SAVING,
         RMAppEventType.ATTEMPT_KILLED,
         new FinalSavingTransition(
@@ -368,6 +383,9 @@ public class RMAppImpl implements RMApp, Recoverable {
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
     .addTransition(RMAppState.FINISHED, RMAppState.FINISHED,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
+    .addTransition(RMAppState.FINISHED, RMAppState.FINISHED,
         EnumSet.of(
             RMAppEventType.NODE_UPDATE,
             RMAppEventType.ATTEMPT_UNREGISTERED,
@@ -380,6 +398,9 @@ public class RMAppImpl implements RMApp, Recoverable {
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
     .addTransition(RMAppState.FAILED, RMAppState.FAILED,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
+    .addTransition(RMAppState.FAILED, RMAppState.FAILED,
         EnumSet.of(RMAppEventType.KILL, RMAppEventType.NODE_UPDATE))
 
      // Transitions from KILLED state
@@ -387,6 +408,9 @@ public class RMAppImpl implements RMApp, Recoverable {
     .addTransition(RMAppState.KILLED, RMAppState.KILLED, 
         RMAppEventType.APP_RUNNING_ON_NODE,
         new AppRunningOnNodeTransition())
+    .addTransition(RMAppState.KILLED, RMAppState.KILLED,
+        RMAppEventType.APP_LOG_AGG_STATUS_UPDATE,
+        new AppLogAggregationStatusTransition())
     .addTransition(
         RMAppState.KILLED,
         RMAppState.KILLED,
@@ -1090,6 +1114,17 @@ public class RMAppImpl implements RMApp, Recoverable {
 
       app.logAggregation.addReportIfNecessary(
           nodeAddedEvent.getNodeId(), app.getApplicationId());
+    }
+  }
+
+  private static final class AppLogAggregationStatusTransition extends
+      RMAppTransition {
+
+    @Override
+    public void transition(RMAppImpl app, RMAppEvent event) {
+      RMAppLogAggregationStatusEvent logEvent =
+          (RMAppLogAggregationStatusEvent) event;
+      app.aggregateLogReport(logEvent.getNodeId(), logEvent.getReport());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppLogAggregationStatusEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppLogAggregationStatusEvent.java
@@ -18,33 +18,27 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.rmapp;
 
-public enum RMAppEventType {
-  // Source: ClientRMService
-  START,
-  RECOVER,
-  KILL,
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.server.api.protocolrecords.LogAggregationReport;
 
-  // Source: Scheduler and RMAppManager
-  APP_REJECTED,
+public class RMAppLogAggregationStatusEvent extends RMAppEvent {
 
-  // Source: Scheduler
-  APP_ACCEPTED,
+  private final NodeId node;
+  private final LogAggregationReport report;
 
-  // Source: RMAppAttempt
-  ATTEMPT_REGISTERED,
-  ATTEMPT_UNREGISTERED,
-  ATTEMPT_FINISHED, // Will send the final state
-  ATTEMPT_FAILED,
-  ATTEMPT_KILLED,
-  NODE_UPDATE,
-  ATTEMPT_LAUNCHED,
-  
-  // Source: Container and ResourceTracker
-  APP_RUNNING_ON_NODE,
-  APP_LOG_AGG_STATUS_UPDATE,
+  public RMAppLogAggregationStatusEvent(ApplicationId appId, NodeId node,
+      LogAggregationReport report) {
+    super(appId, RMAppEventType.APP_LOG_AGG_STATUS_UPDATE);
+    this.node = node;
+    this.report = report;
+  }
 
-  // Source: RMStateStore
-  APP_NEW_SAVED,
-  APP_UPDATE_SAVED,
-  APP_SAVE_FAILED,
+  public NodeId getNodeId() {
+    return node;
+  }
+
+  public LogAggregationReport getReport() {
+    return report;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.apache.commons.collections.keyvalue.DefaultMapEntry;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppLogAggregationStatusEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1703,7 +1704,9 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
     for (LogAggregationReport report : logAggregationReportsForApps) {
       RMApp rmApp = this.context.getRMApps().get(report.getApplicationId());
       if (rmApp != null) {
-        ((RMAppImpl)rmApp).aggregateLogReport(this.nodeId, report);
+        this.context.getDispatcher().getEventHandler().handle(
+            new RMAppLogAggregationStatusEvent(rmApp.getApplicationId(),
+                this.nodeId, report));
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -1704,8 +1704,7 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       RMApp rmApp = this.context.getRMApps().get(report.getApplicationId());
       if (rmApp != null) {
         this.context.getDispatcher().getEventHandler().handle(
-            new RMAppLogAggregationStatusEvent(rmApp.getApplicationId(),
-                this.nodeId, report));
+            new RMAppLogAggregationStatusEvent(rmApp.getApplicationId(), this.nodeId, report));
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -78,7 +78,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.NodesListManager;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
-import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppImpl;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppRunningOnNodeEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.ContainerAllocationExpirer;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.AllocationExpirationInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
@@ -110,8 +110,8 @@ public class SchedulerApplicationAttempt implements SchedulableEntity {
       FastDateFormat.getInstance("EEE MMM dd HH:mm:ss Z yyyy");
 
   private static final long MEM_AGGREGATE_ALLOCATION_CACHE_MSECS = 3000;
-  protected long lastMemoryAggregateAllocationUpdateTime = 0;
-  private Map<String, Long> lastResourceSecondsMap = new HashMap<>();
+  protected volatile long lastMemoryAggregateAllocationUpdateTime = 0;
+  private volatile Map<String, Long> lastResourceSecondsMap = new HashMap<>();
   protected final AppSchedulingInfo appSchedulingInfo;
   protected ApplicationAttemptId attemptId;
   protected Map<ContainerId, RMContainer> liveContainers =
@@ -1130,7 +1130,7 @@ public class SchedulerApplicationAttempt implements SchedulableEntity {
   }
 
   public ApplicationResourceUsageReport getResourceUsageReport() {
-    writeLock.lock();
+    readLock.lock();
     try {
       AggregateAppResourceUsage runningResourceUsage =
           getRunningAggregateAppResourceUsage();
@@ -1166,7 +1166,7 @@ public class SchedulerApplicationAttempt implements SchedulableEntity {
               runningResourceUsage.getResourceUsageSecondsMap(), queueUsagePerc,
               clusterUsagePerc, preemptedResourceSecondsMaps);
     } finally {
-      writeLock.unlock();
+      readLock.unlock();
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/common/fica/FiCaSchedulerApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/common/fica/FiCaSchedulerApp.java
@@ -1105,11 +1105,8 @@ public class FiCaSchedulerApp extends SchedulerApplicationAttempt {
    */
   @Override
   public ApplicationResourceUsageReport getResourceUsageReport() {
-    writeLock.lock();
+    readLock.lock();
     try {
-      // Use write lock here because
-      // SchedulerApplicationAttempt#getResourceUsageReport updated fields
-      // TODO: improve this
       ApplicationResourceUsageReport report = super.getResourceUsageReport();
       Resource cluster = rmContext.getScheduler().getClusterResource();
       Resource totalPartitionRes =
@@ -1129,7 +1126,7 @@ public class FiCaSchedulerApp extends SchedulerApplicationAttempt {
       }
       return report;
     } finally {
-      writeLock.unlock();
+      readLock.unlock();
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/logaggregationstatus/TestRMAppLogAggregationStatus.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/logaggregationstatus/TestRMAppLogAggregationStatus.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppEventType;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppImpl;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppLogAggregationStatusEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppRunningOnNodeEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl;
@@ -177,6 +178,7 @@ public class TestRMAppLogAggregationStatus {
         NodeHealthStatus.newInstance(true, null, 0), null, null, null);
     node1.handle(new RMNodeStatusEvent(node1.getNodeID(), nodeStatus1,
         node1ReportForApp));
+    rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId1, report1));
 
     List<LogAggregationReport> node2ReportForApp =
         new ArrayList<LogAggregationReport>();
@@ -191,6 +193,7 @@ public class TestRMAppLogAggregationStatus {
         NodeHealthStatus.newInstance(true, null, 0), null, null, null);
     node2.handle(new RMNodeStatusEvent(node2.getNodeID(), nodeStatus2,
         node2ReportForApp));
+    rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId2, report2));
     // node1 and node2 has updated its log aggregation status
     // verify that the log aggregation status for node1, node2
     // has been changed
@@ -228,6 +231,7 @@ public class TestRMAppLogAggregationStatus {
     node1ReportForApp2.add(report1_2);
     node1.handle(new RMNodeStatusEvent(node1.getNodeID(), nodeStatus1,
         node1ReportForApp2));
+    rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_2));
 
     // verify that the log aggregation status for node1
     // has been changed
@@ -283,19 +287,26 @@ public class TestRMAppLogAggregationStatus {
     // be changed from TIME_OUT to SUCCEEDED
     List<LogAggregationReport> node1ReportForApp3 =
         new ArrayList<LogAggregationReport>();
-    LogAggregationReport report1_3;
+    LogAggregationReport[] report1_3 = new LogAggregationReport[10];
     for (int i = 0; i < 10 ; i ++) {
-      report1_3 =
-          LogAggregationReport.newInstance(appId,
-            LogAggregationStatus.RUNNING, "test_message_" + i);
-      node1ReportForApp3.add(report1_3);
+      report1_3[i] = LogAggregationReport
+          .newInstance(appId, LogAggregationStatus.RUNNING,
+              "test_message_" + i);
+      node1ReportForApp3.add(report1_3[i]);
     }
-    node1ReportForApp3.add(LogAggregationReport.newInstance(appId,
-      LogAggregationStatus.SUCCEEDED, ""));
+    LogAggregationReport report1_3_s = LogAggregationReport.newInstance(appId,
+        LogAggregationStatus.SUCCEEDED, "");
+    node1ReportForApp3.add(report1_3_s);
     // For every logAggregationReport cached in memory, we can only save at most
     // 10 diagnostic messages/failure messages
     node1.handle(new RMNodeStatusEvent(node1.getNodeID(), nodeStatus1,
         node1ReportForApp3));
+    for (int i = 0; i < 10; i++) {
+      rmApp.handle(
+          new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_3[i]));
+    }
+    rmApp.handle(
+        new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_3_s));
 
     logAggregationStatus = rmApp.getLogAggregationReportsForApp();
     Assert.assertEquals(2, logAggregationStatus.size());
@@ -340,6 +351,8 @@ public class TestRMAppLogAggregationStatus {
     node2ReportForApp2.add(report2_3);
     node2.handle(new RMNodeStatusEvent(node2.getNodeID(), nodeStatus2,
         node2ReportForApp2));
+    rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId2, report2_2));
+    rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId2, report2_3));
     Assert.assertEquals(LogAggregationStatus.FAILED,
       rmApp.getLogAggregationStatusForAppReport());
     logAggregationStatus = rmApp.getLogAggregationReportsForApp();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/logaggregationstatus/TestRMAppLogAggregationStatus.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/logaggregationstatus/TestRMAppLogAggregationStatus.java
@@ -290,8 +290,7 @@ public class TestRMAppLogAggregationStatus {
     LogAggregationReport[] report1_3 = new LogAggregationReport[10];
     for (int i = 0; i < 10 ; i ++) {
       report1_3[i] = LogAggregationReport
-          .newInstance(appId, LogAggregationStatus.RUNNING,
-              "test_message_" + i);
+          .newInstance(appId, LogAggregationStatus.RUNNING, "test_message_" + i);
       node1ReportForApp3.add(report1_3[i]);
     }
     LogAggregationReport report1_3_s = LogAggregationReport.newInstance(appId,
@@ -302,11 +301,9 @@ public class TestRMAppLogAggregationStatus {
     node1.handle(new RMNodeStatusEvent(node1.getNodeID(), nodeStatus1,
         node1ReportForApp3));
     for (int i = 0; i < 10; i++) {
-      rmApp.handle(
-          new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_3[i]));
+      rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_3[i]));
     }
-    rmApp.handle(
-        new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_3_s));
+    rmApp.handle(new RMAppLogAggregationStatusEvent(appId, nodeId1, report1_3_s));
 
     logAggregationStatus = rmApp.getLogAggregationReportsForApp();
     Assert.assertEquals(2, logAggregationStatus.size());


### PR DESCRIPTION
### Description of PR

detail message see:    https://issues.apache.org/jira/browse/YARN-11127


### How was this patch tested?

uni-test in PR

### For code changes:

* For thread "RM Event dispatcher", we have lock writelock twice. We could update aggregateLogReport async, then only lock writelock one time.
* For thread "IPC Server handler 264 on default port 8032", I think getResourceUsageReport could use readLock.

