### PR TITLE
HADOOP-18228. Update hadoop-vote to use HADOOP_RC_VERSION dir

### DIFF
--- a/dev-support/hadoop-vote.sh
+++ b/dev-support/hadoop-vote.sh
@@ -189,6 +189,8 @@ pushd "${OUTPUT_DIR}"
 download_and_import_keys
 download_release_candidate
 
+pushd "${HADOOP_RC_VERSION}"
+
 execute verify_signatures
 execute verify_checksums
 execute unzip_from_source
@@ -196,6 +198,7 @@ execute rat_test
 execute build_from_source
 execute build_tar_from_source
 
+popd
 popd
 
 print_when_exit


### PR DESCRIPTION
### Description of PR
The recent changes in release script requires a minor change in hadoop-vote to use Hadoop RC version dir before verifying signature and checksum of .tar.gz files.

### How was this patch tested?
Tested locally against Hadoop 3.3.3 RC0.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
