### PR TITLE
YARN-11130:Rmove RouterClientRMService Has Unused import

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.yarn.server.router.clientrm;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;


### PR DESCRIPTION
### Description of PR
[YARN-11130:org.apache.hadoop.yarn.server.router.clientrm#RouterClientRMService Has Unused import](https://issues.apache.org/jira/browse/YARN-11130)
During code debugging, it was found that RouterClientRMService has unreferenced import, java.io.InputStream, remove it

### How was this patch tested?
Not  Need Test

### For code changes:
remove unused import

