### PR TITLE
YARN-11131:use readAllVersions replace setMaxVersions

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/flow/FlowRunCoprocessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/src/main/java/org/apache/hadoop/yarn/server/timelineservice/storage/flow/FlowRunCoprocessor.java
@@ -173,7 +173,7 @@ public class FlowRunCoprocessor implements RegionCoprocessor, RegionObserver {
   public void preGetOp(ObserverContext<RegionCoprocessorEnvironment> e,
                        Get get, List<Cell> results) throws IOException {
     Scan scan = new Scan(get);
-    scan.setMaxVersions();
+    scan.readAllVersions();
     RegionScanner scanner = null;
     try {
       scanner = new FlowScanner(e.getEnvironment(), scan,
@@ -204,7 +204,7 @@ public class FlowRunCoprocessor implements RegionCoprocessor, RegionObserver {
       throws IOException {
     // set max versions for scan to see all
     // versions to aggregate for metrics
-    scan.setMaxVersions();
+    scan.readAllVersions();
   }
 
   /*


### PR DESCRIPTION
JIRA:[YARN-11131:FlowRunCoprocessor Scan Used Deprecated Method](https://issues.apache.org/jira/browse/YARN-11131)
I Found Some deprecated methods are used in [Atsv2] module, try to replace related methods