### PR TITLE
Yarn 11134. Support getNodeToLabels API in FederationClientInterceptor

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -429,7 +429,6 @@ public abstract class InodeTree<T> {
   /**
    * The user of this class must subclass and implement the following
    * 3 abstract methods.
-   * @throws IOException
    */
   protected abstract Function<URI, T> initAndGetTargetFs();
 
@@ -882,7 +881,7 @@ public abstract class InodeTree<T> {
   /**
    * Walk through all regex mount points to see
    * whether the path match any regex expressions.
-   *  E.g. link: ^/user/(?<username>\\w+) => s3://$user.apache.com/_${user}
+   *  E.g. link: ^/user/(?&lt;username&gt;\\w+) =&gt; s3://$user.apache.com/_${user}
    *  srcPath: is /user/hadoop/dir1
    *  resolveLastComponent: true
    *  then return value is s3://hadoop.apache.com/_hadoop
@@ -907,7 +906,7 @@ public abstract class InodeTree<T> {
    * Build resolve result.
    * Here's an example
    * Mountpoint: fs.viewfs.mounttable.mt
-   *     .linkRegex.replaceresolveddstpath:_:-#.^/user/(?<username>\w+)
+   *     .linkRegex.replaceresolveddstpath:_:-#.^/user/(?&lt;username&gt;\w+)
    * Value: /targetTestRoot/$username
    * Dir path to test:
    * viewfs://mt/user/hadoop_user1/hadoop_dir1

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -110,7 +110,8 @@ extends AbstractDelegationTokenIdentifier>
   /**
    * Metrics to track token management operations.
    */
-  private DelegationTokenSecretManagerMetrics metrics;
+  private static final DelegationTokenSecretManagerMetrics METRICS
+          = DelegationTokenSecretManagerMetrics.create();
   
   private long keyUpdateInterval;
   private long tokenMaxLifetime;
@@ -149,7 +150,6 @@ extends AbstractDelegationTokenIdentifier>
     this.tokenRenewInterval = delegationTokenRenewInterval;
     this.tokenRemoverScanInterval = delegationTokenRemoverScanInterval;
     this.storeTokenTrackingId = false;
-    this.metrics = DelegationTokenSecretManagerMetrics.create();
   }
 
   /** should be called before this object is used */
@@ -446,7 +446,7 @@ extends AbstractDelegationTokenIdentifier>
     DelegationTokenInformation tokenInfo = new DelegationTokenInformation(now
         + tokenRenewInterval, password, getTrackingIdIfEnabled(identifier));
     try {
-      metrics.trackStoreToken(() -> storeToken(identifier, tokenInfo));
+      METRICS.trackStoreToken(() -> storeToken(identifier, tokenInfo));
     } catch (IOException ioe) {
       LOG.error("Could not store token " + formatTokenId(identifier) + "!!",
           ioe);
@@ -571,7 +571,7 @@ extends AbstractDelegationTokenIdentifier>
       throw new InvalidToken("Renewal request for unknown token "
           + formatTokenId(id));
     }
-    metrics.trackUpdateToken(() -> updateToken(id, info));
+    METRICS.trackUpdateToken(() -> updateToken(id, info));
     return renewTime;
   }
   
@@ -607,7 +607,7 @@ extends AbstractDelegationTokenIdentifier>
     if (info == null) {
       throw new InvalidToken("Token not found " + formatTokenId(id));
     }
-    metrics.trackRemoveToken(() -> {
+    METRICS.trackRemoveToken(() -> {
       removeTokenForOwnerStats(id);
       removeStoredToken(id);
     });
@@ -845,7 +845,7 @@ extends AbstractDelegationTokenIdentifier>
   }
 
   protected DelegationTokenSecretManagerMetrics getMetrics() {
-    return metrics;
+    return METRICS;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestDelegationToken.java
@@ -645,13 +645,13 @@ public class TestDelegationToken {
 
       final Token<TestDelegationTokenIdentifier> token = callAndValidateMetrics(
           dtSecretManager, dtSecretManager.getMetrics().getStoreToken(), "storeToken",
-          () -> generateDelegationToken(dtSecretManager, "SomeUser", "JobTracker"), 1);
+          () -> generateDelegationToken(dtSecretManager, "SomeUser", "JobTracker"));
 
       callAndValidateMetrics(dtSecretManager, dtSecretManager.getMetrics().getUpdateToken(),
-          "updateToken", () -> dtSecretManager.renewToken(token, "JobTracker"), 1);
+          "updateToken", () -> dtSecretManager.renewToken(token, "JobTracker"));
 
       callAndValidateMetrics(dtSecretManager, dtSecretManager.getMetrics().getRemoveToken(),
-          "removeToken", () -> dtSecretManager.cancelToken(token, "JobTracker"), 1);
+          "removeToken", () -> dtSecretManager.cancelToken(token, "JobTracker"));
     } finally {
       dtSecretManager.stopThreads();
     }
@@ -671,14 +671,14 @@ public class TestDelegationToken {
 
       dtSecretManager.setThrowError(true);
 
-      callAndValidateFailureMetrics(dtSecretManager, "storeToken", 1, 1, false,
+      callAndValidateFailureMetrics(dtSecretManager, "storeToken", false,
           errorSleepMillis,
           () -> generateDelegationToken(dtSecretManager, "SomeUser", "JobTracker"));
 
-      callAndValidateFailureMetrics(dtSecretManager, "updateToken", 1, 2, true,
+      callAndValidateFailureMetrics(dtSecretManager, "updateToken", true,
           errorSleepMillis, () -> dtSecretManager.renewToken(token, "JobTracker"));
 
-      callAndValidateFailureMetrics(dtSecretManager, "removeToken", 1, 3, true,
+      callAndValidateFailureMetrics(dtSecretManager, "removeToken", true,
           errorSleepMillis, () -> dtSecretManager.cancelToken(token, "JobTracker"));
     } finally {
       dtSecretManager.stopThreads();
@@ -686,33 +686,32 @@ public class TestDelegationToken {
   }
 
   private <T> T callAndValidateMetrics(TestDelegationTokenSecretManager dtSecretManager,
-      MutableRate metric, String statName,  Callable<T> callable, int expectedCount)
+      MutableRate metric, String statName,  Callable<T> callable)
       throws Exception {
     MeanStatistic stat = IOStatisticAssertions.lookupMeanStatistic(
         dtSecretManager.getMetrics().getIoStatistics(), statName + ".mean");
-    assertEquals(expectedCount - 1, metric.lastStat().numSamples());
-    assertEquals(expectedCount - 1, stat.getSamples());
+    long metricBefore = metric.lastStat().numSamples();
+    long statBefore = stat.getSamples();
     T returnedObject = callable.call();
-    assertEquals(expectedCount, metric.lastStat().numSamples());
-    assertEquals(expectedCount, stat.getSamples());
+    assertEquals(metricBefore + 1, metric.lastStat().numSamples());
+    assertEquals(statBefore + 1, stat.getSamples());
     return returnedObject;
   }
 
   private <T> void callAndValidateFailureMetrics(TestDelegationTokenSecretManager dtSecretManager,
-      String statName, int expectedStatCount, int expectedMetricCount, boolean expectError,
-      int errorSleepMillis, Callable<T> callable) throws Exception {
+      String statName, boolean expectError, int errorSleepMillis, Callable<T> callable) throws Exception {
     MutableCounterLong counter = dtSecretManager.getMetrics().getTokenFailure();
     MeanStatistic failureStat = IOStatisticAssertions.lookupMeanStatistic(
         dtSecretManager.getMetrics().getIoStatistics(), statName + ".failures.mean");
-    assertEquals(expectedMetricCount - 1, counter.value());
-    assertEquals(expectedStatCount - 1, failureStat.getSamples());
+    long counterBefore = counter.value();
+    long statBefore = failureStat.getSamples();
     if (expectError) {
       LambdaTestUtils.intercept(IOException.class, callable);
     } else {
       callable.call();
     }
-    assertEquals(expectedMetricCount, counter.value());
-    assertEquals(expectedStatCount, failureStat.getSamples());
+    assertEquals(counterBefore + 1, counter.value());
+    assertEquals(statBefore + 1, failureStat.getSamples());
     assertTrue(failureStat.getSum() >= errorSleepMillis);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/RouterMetrics.java
@@ -56,6 +56,9 @@ public final class RouterMetrics {
   @Metric("# of getClusterMetrics failed to be retrieved")
   private MutableGaugeInt numGetClusterMetricsFailedRetrieved;
 
+  @Metric("# of getClusterNodes failed to be retrieved")
+  private MutableGaugeInt numGetNodeToLabelsFailedRetrieved;
+
   // Aggregate metrics are shared, and don't have to be looked up per call
   @Metric("Total number of successful Submitted apps and latency(ms)")
   private MutableRate totalSucceededAppsSubmitted;
@@ -75,6 +78,10 @@ public final class RouterMetrics {
       + "latency(ms)")
   private MutableRate totalSucceededGetClusterMetricsRetrieved;
 
+  @Metric("Total number of successful Retrieved GetNodeToLabels and "
+          + "latency(ms)")
+  private MutableRate totalSucceededGetNodeToLabelsRetrieved;
+
 
   /**
    * Provide quantile counters for all latencies.
@@ -86,6 +93,8 @@ public final class RouterMetrics {
   private MutableQuantiles getApplicationsReportLatency;
   private MutableQuantiles getApplicationAttemptReportLatency;
   private MutableQuantiles getClusterMetricsLatency;
+
+  private MutableQuantiles getNodeToLabelsLatency;
 
   private static volatile RouterMetrics INSTANCE = null;
   private static MetricsRegistry registry;
@@ -112,6 +121,10 @@ public final class RouterMetrics {
     getClusterMetricsLatency =
         registry.newQuantiles("getClusterMetricsLatency",
             "latency of get cluster metrics", "ops", "latency", 10);
+
+    getNodeToLabelsLatency =
+            registry.newQuantiles("getNodeToLabelsLatency",
+                    "latency of get node labels", "ops", "latency", 10);
   }
 
   public static RouterMetrics getMetrics() {
@@ -169,6 +182,11 @@ public final class RouterMetrics {
   }
 
   @VisibleForTesting
+  public long getNumSucceededGetNodeToLabelsRetrieved(){
+    return totalSucceededGetNodeToLabelsRetrieved.lastStat().numSamples();
+  }
+
+  @VisibleForTesting
   public double getLatencySucceededAppsCreated() {
     return totalSucceededAppsCreated.lastStat().mean();
   }
@@ -201,6 +219,11 @@ public final class RouterMetrics {
   @VisibleForTesting
   public double getLatencySucceededGetClusterMetricsRetrieved() {
     return totalSucceededGetClusterMetricsRetrieved.lastStat().mean();
+  }
+
+  @VisibleForTesting
+  public double getLatencySucceededGetNodeToLabelsRetrieved() {
+    return totalSucceededGetNodeToLabelsRetrieved.lastStat().mean();
   }
 
   @VisibleForTesting
@@ -238,6 +261,11 @@ public final class RouterMetrics {
     return numGetClusterMetricsFailedRetrieved.value();
   }
 
+  @VisibleForTesting
+  public int getNodeToLabelsFailedRetrieved() {
+    return numGetNodeToLabelsFailedRetrieved.value();
+  }
+
   public void succeededAppsCreated(long duration) {
     totalSucceededAppsCreated.add(duration);
     getNewApplicationLatency.add(duration);
@@ -273,6 +301,11 @@ public final class RouterMetrics {
     getClusterMetricsLatency.add(duration);
   }
 
+  public void succeededGetNodeToLabelsRetrieved(long duration) {
+    totalSucceededGetNodeToLabelsRetrieved.add(duration);
+    getNodeToLabelsLatency.add(duration);
+  }
+
   public void incrAppsFailedCreated() {
     numAppsFailedCreated.incr();
   }
@@ -299,6 +332,10 @@ public final class RouterMetrics {
 
   public void incrGetClusterMetricsFailedRetrieved() {
     numGetClusterMetricsFailedRetrieved.incr();
+  }
+
+  public void incrGetNodeToLabelsFailedRetrieved() {
+    numGetNodeToLabelsFailedRetrieved.incr();
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterYarnClientUtils.java
@@ -20,14 +20,14 @@ package org.apache.hadoop.yarn.server.router.clientrm;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsResponse;
-import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.apache.hadoop.yarn.api.records.ApplicationReport;
-import org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport;
-import org.apache.hadoop.yarn.api.records.YarnClusterMetrics;
+import org.apache.hadoop.yarn.api.protocolrecords.GetNodesToLabelsResponse;
+import org.apache.hadoop.yarn.api.records.*;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
+import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 /**
@@ -193,5 +193,25 @@ public final class RouterYarnClientUtils {
     }
     return !(appName.startsWith(UnmanagedApplicationManager.APP_NAME) ||
         appName.startsWith(PARTIAL_REPORT));
+  }
+
+  /**
+   * Merges a list of GetNodesToLabelsResponse grouping by SubClusterId.
+   *
+   * @param responses a list of GetNodesToLabelsResponse to merge
+   * @return the merged GetNodesToLabelsResponse
+   */
+  public static GetNodesToLabelsResponse mergeNodesToLabelsResponse(
+          Collection<GetNodesToLabelsResponse> responses) {
+    GetNodesToLabelsResponse nodesToLabelsResponse = Records.newRecord(
+            GetNodesToLabelsResponse.class);
+    Map<NodeId, Set<String>> nodesToLabelMap = new HashMap<>();
+    for (GetNodesToLabelsResponse response : responses) {
+      if (response != null && response.getNodeToLabels() != null) {
+        nodesToLabelMap.putAll(response.getNodeToLabels());
+      }
+    }
+    nodesToLabelsResponse.setNodeToLabels(nodesToLabelMap);
+    return nodesToLabelsResponse;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -30,20 +30,7 @@ import java.util.Set;
 
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.MockApps;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportResponse;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportResponse;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsResponse;
-import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsResponse;
-import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
-import org.apache.hadoop.yarn.api.protocolrecords.KillApplicationRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.KillApplicationResponse;
-import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationRequest;
-import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.*;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -640,5 +627,18 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     Assert.assertNotNull(responseGet);
     Assert.assertTrue(responseGet.getApplicationList().isEmpty());
+  }
+
+  @Test
+  public void testGetNodeToLabelsRequest() throws Exception {
+    LOG.info("Test FederationClientInterceptor : GetNodeToLabels request");
+    // null request
+    LambdaTestUtils.intercept(YarnException.class,
+            "Missing getNodeToLabels request.", () -> interceptor.getNodeToLabels(null));
+
+    // normal request.
+    GetNodesToLabelsResponse response =
+            interceptor.getNodeToLabels(GetNodesToLabelsRequest.newInstance());
+    Assert.assertEquals(0, response.getNodeToLabels().size());
   }
 }


### PR DESCRIPTION
JIRA：
[YARN-11134 . Support getNodeToLabels API in FederationClientInterceptor](https://issues.apache.org/jira/browse/YARN-11134)
YARN Federation is a very useful architecture, the getNodeToLabels method is not implemented, implement this method。