### PR TITLE
HDFS-16575. [SPS]Should use real replication num instead getReplicati…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/sps/StoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/sps/StoragePolicySatisfier.java
@@ -402,7 +402,7 @@ public class StoragePolicySatisfier implements SPSService, Runnable {
         }
       } else {
         expectedStorageTypes = existingStoragePolicy
-            .chooseStorageTypes(fileInfo.getReplication());
+            .chooseStorageTypes((short) blockInfo.getLocations().length);
       }
 
       List<StorageType> existing = new LinkedList<StorageType>(


### PR DESCRIPTION
The SPS may have misjudged in the following scenario:
1. Create a file with one block and this block have 3 replication with **DISK** type [DISK, DISK, DISK].
2. Set this file with **ALL_SSD** storage policy.
3. The replication of this file may become [DISK, DISK, **SSD**, DISK] with **decommission**.
4. Set this file with **HOT** storage policy and satisfy storage policy on this file.
5. The replication finally look like [DISK, DISK, SSD] not  [DISK, DISK, DISK] after decommissioned node offline.
6. The reason is that SPS get the block replications by 

FileStatus.getReplication() which is not the real num of the block.
![image](https://user-images.githubusercontent.com/2844826/167540656-7191cf54-22f0-47c4-a1d3-2e648672224b.png)



So this block will be ignored, because it have 3 replications with DISK type already ( one replication in a decommissioning node) 

![image](https://user-images.githubusercontent.com/2844826/167540674-6a926ba0-f4ad-4e4c-910f-6dacb2e9a955.png)


I think we can use blockInfo.getLocations().length to count the replication of block instead of FileStatus.getReplication().