### PR TITLE
HDFS-16573. Fix TestDFSStripedInputStreamWithRandomECPolicy in branch-3.3

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStream.java
@@ -669,7 +669,12 @@ public class TestDFSStripedInputStream {
 
   @Test
   public void testBlockReader() throws Exception {
-    ecPolicy = StripedFileTestUtil.getDefaultECPolicy(); // RS-6-3-1024k
+    ErasureCodingPolicy targetPolicy = StripedFileTestUtil.getDefaultECPolicy(); // RS-6-3-1024k
+    if (!ecPolicy.equals(targetPolicy)) {
+      // Be sure not affected by random EC policy from
+      // TestDFSStripedInputStreamWithRandomECPolicy.
+      return;
+    }
     int fileSize = 19 * cellSize + 100;
     long stripeSize = (long) dataBlocks * cellSize;
     byte[] bytes = StripedFileTestUtil.generateBytes(fileSize);


### PR DESCRIPTION
TestDFSStripedInputStreamWithRandomECPolicy fails due to test from [HDFS-16520](https://issues.apache.org/jira/browse/HDFS-16520)