### PR TITLE
MAPREDUCE-7378. Change job temporary dir name to avoid delete by other jobs

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -139,7 +139,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
     super(outputPath, context);
     Configuration conf = context.getConfiguration();
 
-    JOB_PENDING_DIR_NAME = "_temporary_" + context.getJobID();
+    setJobPendingDirName(context);
 
     algorithmVersion =
         conf.getInt(FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
@@ -168,7 +168,11 @@ public class FileOutputCommitter extends PathOutputCommitter {
       this.outputPath = fs.makeQualified(outputPath);
     }
   }
-  
+
+  private static void setJobPendingDirName(JobContext context) {
+    JOB_PENDING_DIR_NAME = "_temporary_" + context.getJobID();
+  }
+
   /**
    * @return the path where final output of the job should be placed.  This
    * could also be considered the committed application attempt path.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -57,6 +57,8 @@ public class FileOutputCommitter extends PathOutputCommitter {
    * committed yet.
    */
   public static final String PENDING_DIR_NAME = "_temporary";
+
+  public static String JOB_PENDING_DIR_NAME = "_temporary";
   /**
    * Temporary directory name 
    *
@@ -136,6 +138,9 @@ public class FileOutputCommitter extends PathOutputCommitter {
                              JobContext context) throws IOException {
     super(outputPath, context);
     Configuration conf = context.getConfiguration();
+
+    JOB_PENDING_DIR_NAME = "_temporary_" + context.getJobID();
+
     algorithmVersion =
         conf.getInt(FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
                     FILEOUTPUTCOMMITTER_ALGORITHM_VERSION_DEFAULT);
@@ -187,7 +192,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
    * @return the location of pending job attempts.
    */
   private static Path getPendingJobAttemptsPath(Path out) {
-    return new Path(out, PENDING_DIR_NAME);
+    return new Path(out, JOB_PENDING_DIR_NAME);
   }
   
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -288,7 +288,7 @@ public class TestFileOutputCommitter {
 
     // check task and job temp directories exist
     File jobOutputDir = new File(
-        new Path(outDir, FileOutputCommitter.PENDING_DIR_NAME).toString());
+        new Path(outDir, FileOutputCommitter.JOB_PENDING_DIR_NAME).toString());
     File taskOutputDir = new File(Path.getPathWithoutSchemeAndAuthority(
         committer.getWorkPath()).toString());
     assertTrue("job temp dir does not exist", jobOutputDir.exists());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPreemptableFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPreemptableFileOutputCommitter.java
@@ -47,11 +47,17 @@ public class TestPreemptableFileOutputCommitter {
 
     Path p = spy(new Path("/user/hadoop/out"));
     Path a = new Path("hdfs://user/hadoop/out");
-    Path p0 = new Path(a, "_temporary/1/attempt_1363718006656_0001_r_000014_0");
-    Path p1 = new Path(a, "_temporary/1/attempt_1363718006656_0001_r_000014_1");
-    Path p2 = new Path(a, "_temporary/1/attempt_1363718006656_0001_r_000013_0");
+
+    final FileSystem fs = mock(FileSystem.class);
+    TaskAttemptContext context = mock(TaskAttemptContext.class);
+    PartialFileOutputCommitter foc = new TestPFOC(p, context, fs);
+    Path jobAttemptPath = foc.getJobAttemptPath(1);
+
+    Path p0 = new Path(jobAttemptPath, "attempt_1363718006656_0001_r_000014_0");
+    Path p1 = new Path(jobAttemptPath, "attempt_1363718006656_0001_r_000014_1");
+    Path p2 = new Path(jobAttemptPath, "attempt_1363718006656_0001_r_000013_0");
     // (p3 does not exist)
-    Path p3 = new Path(a, "_temporary/1/attempt_1363718006656_0001_r_000014_2");
+    Path p3 = new Path(jobAttemptPath, "attempt_1363718006656_0001_r_000014_2");
 
     FileStatus[] fsa = new FileStatus[3];
     fsa[0] = new FileStatus();
@@ -61,7 +67,6 @@ public class TestPreemptableFileOutputCommitter {
     fsa[2] = new FileStatus();
     fsa[2].setPath(p2);
 
-    final FileSystem fs = mock(FileSystem.class);
     when(fs.exists(eq(p0))).thenReturn(true);
     when(fs.exists(eq(p1))).thenReturn(true);
     when(fs.exists(eq(p2))).thenReturn(true);
@@ -71,11 +76,8 @@ public class TestPreemptableFileOutputCommitter {
     doReturn(fs).when(p).getFileSystem(any(Configuration.class));
     when(fs.makeQualified(eq(p))).thenReturn(a);
 
-    TaskAttemptContext context = mock(TaskAttemptContext.class);
     when(context.getTaskAttemptID()).thenReturn(tid0);
     when(context.getConfiguration()).thenReturn(conf);
-
-    PartialFileOutputCommitter foc = new TestPFOC(p, context, fs);
 
     foc.cleanUpPartialOutputForTask(context);
     verify(fs).delete(eq(p0), eq(true));


### PR DESCRIPTION
### Description of PR
when concurrent write data to a path , the finished job will delete the "_temporary" dir cause the others failed, so we need to make they have a separate dir to write datas to a path

JIRA: MAPREDUCE-7378

### How was this patch tested?
passed the all the hadoop tests

### For code changes:
add a new param as the job temporary dir with the job id
