### PR TITLE
YARN-10850. TimelineService v2 lists containers for all attempts when…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/AHSv2ClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/api/impl/AHSv2ClientImpl.java
@@ -129,9 +129,8 @@ public class AHSv2ClientImpl extends AHSClient {
       applicationAttemptId) throws  YarnException, IOException {
     ApplicationId appId = applicationAttemptId.getApplicationId();
     Map<String, String> filters = new HashMap<>();
-    filters.put("infofilters", "SYSTEM_INFO_PARENT_ENTITY eq {\"id\":\"" +
-        applicationAttemptId.toString() +
-        "\",\"type\":\"YARN_APPLICATION_ATTEMPT\"}");
+    filters.put("infofilters", "SYSTEM_INFO_PARENT_ENTITY eq "
+        + "{\"type\":\"YARN_APPLICATION_ATTEMPT\",\"id\":\"" + applicationAttemptId + "\"}");
     List<TimelineEntity> entities = readerClient.getContainerEntities(
         appId, "ALL", filters, 0, null);
     List<ContainerReport> containers =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineReaderClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/api/impl/TimelineReaderClientImpl.java
@@ -38,7 +38,10 @@ import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -208,12 +211,21 @@ public class TimelineReaderClientImpl extends TimelineReaderClient {
     return Arrays.asList(entity);
   }
 
+  @VisibleForTesting
+  protected String encodeValue(String value) throws UnsupportedEncodingException {
+    // Since URLEncoder doesn't use and doesn't have an option for percent-encoding
+    // (as specified in RFC 3986) the spaces are encoded to + signs, which need to be replaced
+    // manually
+    return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
+        .replaceAll("\\+", "%20");
+  }
+
   private void mergeFilters(MultivaluedMap<String, String> defaults,
-      Map<String, String> filters) {
+                            Map<String, String> filters) throws UnsupportedEncodingException {
     if (filters != null && !filters.isEmpty()) {
       for (Map.Entry<String, String> entry : filters.entrySet()) {
         if (!defaults.containsKey(entry.getKey())) {
-          defaults.add(entry.getKey(), filters.get(entry.getValue()));
+          defaults.add(entry.getKey(), encodeValue(entry.getValue()));
         }
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineReaderClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestTimelineReaderClientImpl.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.yarn.api.records.timelineservice.TimelineEntityT
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.sun.jersey.api.client.ClientResponse;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -47,6 +48,8 @@ import java.util.List;
  */
 public class TestTimelineReaderClientImpl {
 
+  private final String appAttemptInfoFilter = "{\"type\":\"YARN_APPLICATION_ATTEMPT\"," +
+      "\"id\":\"appattempt_1234_0001_000001\"}";
   private TimelineReaderClient client;
 
   @Before
@@ -107,6 +110,16 @@ public class TestTimelineReaderClientImpl {
     Assert.assertEquals("mockContainer2", entities.get(1).getId());
   }
 
+  @Test
+  public void testGetContainersForAppAttempt() throws Exception {
+    ApplicationId appId =
+        ApplicationId.fromString("application_1234_0001");
+    List<TimelineEntity> entities = client.getContainerEntities(appId,
+        null, ImmutableMap.of("infofilters", appAttemptInfoFilter), 0, null);
+    Assert.assertEquals(2, entities.size());
+    Assert.assertEquals("mockContainer4", entities.get(1).getId());
+  }
+
   @After
   public void tearDown() {
     if (client != null) {
@@ -135,11 +148,15 @@ public class TestTimelineReaderClientImpl {
     protected ClientResponse doGetUri(URI base, String path,
         MultivaluedMap<String, String> params) throws IOException {
       ClientResponse mockClientResponse = mock(ClientResponse.class);
-      if (path.contains(YARN_CONTAINER.toString())) {
+      if (path.contains(YARN_CONTAINER.toString()) && !params.containsKey("infofilters")) {
         when(mockClientResponse.getEntity(TimelineEntity.class)).thenReturn(
             createTimelineEntity("mockContainer1"));
         when(mockClientResponse.getEntity(TimelineEntity[].class)).thenReturn(
             createTimelineEntities("mockContainer1", "mockContainer2"));
+      } else if (path.contains(YARN_CONTAINER.toString()) && params.containsKey("infofilters")) {
+        Assert.assertEquals(encodeValue(appAttemptInfoFilter), params.get("infofilters").get(0));
+        when(mockClientResponse.getEntity(TimelineEntity[].class)).thenReturn(
+            createTimelineEntities("mockContainer3", "mockContainer4"));
       } else if (path.contains(YARN_APPLICATION_ATTEMPT.toString())) {
         when(mockClientResponse.getEntity(TimelineEntity.class)).thenReturn(
             createTimelineEntity("mockAppAttempt1"));
@@ -151,6 +168,7 @@ public class TestTimelineReaderClientImpl {
         when(mockClientResponse.getEntity(TimelineEntity[].class)).thenReturn(
             createTimelineEntities("mockApp1", "mockApp2"));
       }
+
       return mockClientResponse;
     }
   }


### PR DESCRIPTION
… filtering for one. Contributed by Benjamin Teke

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

