### PR TITLE
HADOOP-18237. Upgrade Apache Xerces Java to 2.12.2

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -48,7 +48,7 @@
     <!-- JDIFF generation from embedded ant in the antrun plugin -->
     <jdiff.version>1.0.9</jdiff.version>
     <!-- Version number for xerces used by JDiff -->
-    <xerces.jdiff.version>2.12.1</xerces.jdiff.version>
+    <xerces.jdiff.version>2.12.2</xerces.jdiff.version>
 
     <kafka.version>2.8.1</kafka.version>
 


### PR DESCRIPTION
### Description of PR
Upgraded Apache Xerces Java to 2.12.2 due to handle vulnerability [CVE-2022-23437](https://nvd.nist.gov/vuln/detail/CVE-2022-23437)
* JIRA: HADOOP-18237


- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
