### PR TITLE
HDFS-16583. DatanodeAdminDefaultMonitor can get stuck in an infinite loop holding the write lock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -32,8 +32,6 @@ import java.util.Map;
 import java.util.List;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.ArrayDeque;
-import java.util.Queue;
 import java.util.stream.Collectors;
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -72,12 +72,6 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
       outOfServiceNodeBlocks = new HashMap<>();
 
   /**
-   * Any nodes where decommission or maintenance has been cancelled are added
-   * to this queue for later processing.
-   */
-  private final Queue<DatanodeDescriptor> cancelledNodes = new ArrayDeque<>();
-
-  /**
    * The numbe of blocks to process when moving blocks to pendingReplication
    * before releasing and reclaiming the namenode lock.
    */
@@ -151,7 +145,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
   @Override
   public void stopTrackingNode(DatanodeDescriptor dn) {
     getPendingNodes().remove(dn);
-    cancelledNodes.add(dn);
+    getCancelledNodes().add(dn);
   }
 
   @Override
@@ -232,7 +226,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
           "in maintenance or transitioning state. {} nodes pending. {} " +
           "nodes waiting to be cancelled.",
           numBlocksChecked, outOfServiceNodeBlocks.size(), getPendingNodes().size(),
-          cancelledNodes.size());
+          getCancelledNodes().size());
     }
   }
 
@@ -259,8 +253,8 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
    * write lock to prevent the cancelledNodes list being modified externally.
    */
   private void processCancelledNodes() {
-    while(!cancelledNodes.isEmpty()) {
-      DatanodeDescriptor dn = cancelledNodes.poll();
+    while(!getCancelledNodes().isEmpty()) {
+      DatanodeDescriptor dn = getCancelledNodes().poll();
       outOfServiceNodeBlocks.remove(dn);
       pendingRep.remove(dn);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -198,7 +198,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         boolean fullScan = false;
         if (dn.isMaintenance() && dn.maintenanceExpired()) {
           // If maintenance expires, stop tracking it.
-          dnAdmin.stopMaintenance(dn);
+          dnAdmin.stopMaintenanceInternal(dn);
           toRemove.add(dn);
           continue;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -125,7 +125,6 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
   public void stopTrackingNode(DatanodeDescriptor dn) {
     getPendingNodes().remove(dn);
     getCancelledNodes().add(dn);
-    outOfServiceNodeBlocks.remove(dn);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -214,7 +214,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         boolean fullScan = false;
         if (dn.isMaintenance() && dn.maintenanceExpired()) {
           // If maintenance expires, stop tracking it.
-          dnAdmin.stopMaintenanceInternal(dn);
+          dnAdmin.stopMaintenance(dn);
           toRemove.add(dn);
           continue;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
@@ -255,6 +255,15 @@ public class DatanodeAdminManager {
    */
   @VisibleForTesting
   public void stopMaintenance(DatanodeDescriptor node) {
+    boolean shouldStopTracking = node.isMaintenance();
+    stopMaintenanceInternal(node);
+    if (shouldStopTracking) {
+      // Remove from tracking in DatanodeAdminManager
+      monitor.stopTrackingNode(node);
+    }
+  }
+
+  protected void stopMaintenanceInternal(DatanodeDescriptor node) {
     if (node.isMaintenance()) {
       // Update DN stats maintained by HeartbeatManager
       hbManager.stopMaintenance(node);
@@ -287,9 +296,6 @@ public class DatanodeAdminManager {
         // c. Take the node out of maintenance mode.
         blockManager.processExtraRedundancyBlocksOnInService(node);
       }
-
-      // Remove from tracking in DatanodeAdminManager
-      monitor.stopTrackingNode(node);
     } else {
       LOG.trace("stopMaintenance: Node {} in {}, nothing to do.",
           node, node.getAdminState());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
@@ -255,15 +255,6 @@ public class DatanodeAdminManager {
    */
   @VisibleForTesting
   public void stopMaintenance(DatanodeDescriptor node) {
-    boolean shouldStopTracking = node.isMaintenance();
-    stopMaintenanceInternal(node);
-    if (shouldStopTracking) {
-      // Remove from tracking in DatanodeAdminManager
-      monitor.stopTrackingNode(node);
-    }
-  }
-
-  protected void stopMaintenanceInternal(DatanodeDescriptor node) {
     if (node.isMaintenance()) {
       // Update DN stats maintained by HeartbeatManager
       hbManager.stopMaintenance(node);
@@ -296,6 +287,9 @@ public class DatanodeAdminManager {
         // c. Take the node out of maintenance mode.
         blockManager.processExtraRedundancyBlocksOnInService(node);
       }
+
+      // Remove from tracking in DatanodeAdminManager
+      monitor.stopTrackingNode(node);
     } else {
       LOG.trace("stopMaintenance: Node {} in {}, nothing to do.",
           node, node.getAdminState());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorBase.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdfs.server.namenode.Namesystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayDeque;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -52,6 +53,12 @@ public abstract class DatanodeAdminMonitorBase
 
   private final PriorityQueue<DatanodeDescriptor> pendingNodes = new PriorityQueue<>(
       PENDING_NODES_QUEUE_COMPARATOR);
+
+  /**
+   * Any nodes where decommission or maintenance has been cancelled are added
+   * to this queue for later processing.
+   */
+  private final Queue<DatanodeDescriptor> cancelledNodes = new ArrayDeque<>();
 
   /**
    * The maximum number of nodes to track in outOfServiceNodeBlocks.
@@ -161,6 +168,11 @@ public abstract class DatanodeAdminMonitorBase
   @Override
   public Queue<DatanodeDescriptor> getPendingNodes() {
     return pendingNodes;
+  }
+
+  @Override
+  public Queue<DatanodeDescriptor> getCancelledNodes() {
+    return cancelledNodes;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorInterface.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminMonitorInterface.java
@@ -32,6 +32,7 @@ public interface DatanodeAdminMonitorInterface extends Runnable {
   int getTrackedNodeCount();
   int getNumNodesChecked();
   Queue<DatanodeDescriptor> getPendingNodes();
+  Queue<DatanodeDescriptor> getCancelledNodes();
 
   void setBlockManager(BlockManager bm);
   void setDatanodeAdminManager(DatanodeAdminManager dnm);


### PR DESCRIPTION
### Description of PR

Avoid concurrently modifying the `outOfServiceNodeBlocks` map in the DatanodeAdminDefaultMonitor when ending maintenance. The concurrentModification can cause the monitor to get stuck in an infinite loop in some circumstances, while holding the NN write lock.

The issue does not affect the DatanodeAdminBackoffMonitor, as it is implemented slightly differently.

More details in the Jira  https://issues.apache.org/jira/browse/HDFS-16583

### How was this patch tested?

Existing tests should cover it.

