### PR TITLE
HDFS-16584.Record StandbyNameNode information when Balancer is running.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -202,15 +202,19 @@ public class TestBalancerWithHANameNodes {
     try {
       cluster.waitActive();
       cluster.transitionToActive(0);
+      String standbyNameNode = cluster.getNameNode(1).
+          getNameNodeAddress().getHostString();
       Thread.sleep(500);
       client = NameNodeProxies.createProxy(conf, FileSystem.getDefaultUri(conf),
           ClientProtocol.class).getProxy();
       doTest(conf);
       // Check getBlocks request to Standby NameNode.
       assertTrue(log.getOutput().contains(
-          "Request #getBlocks to Standby NameNode success."));
+          "Request #getBlocks to Standby NameNode success. remoteAddress: " +
+            standbyNameNode));
       assertTrue(log.getOutput().contains(
-          "Request #getLiveDatanodeStorageReport to Standby NameNode success"));
+          "Request #getLiveDatanodeStorageReport to Standby NameNode success. " +
+            "remoteAddress: " + standbyNameNode));
     } finally {
       cluster.shutdown();
     }


### PR DESCRIPTION
### Description of PR
When the Balancer is running, it is allowed to get block data from the StandbyNameNode, we should record more detailed information, such as the host related to the StandbyNameNode.
Details: HDFS-16584

### How was this patch tested?
When the Balancer is running, the Standby NameNode information should be checked.
