### PR TITLE
HADOOP-18251. Fix failure of extracting JIRA id from commit message in git_jira_fix_version_check.py.

### DIFF
--- a/dev-support/git-jira-validation/git_jira_fix_version_check.py
+++ b/dev-support/git-jira-validation/git_jira_fix_version_check.py
@@ -71,10 +71,9 @@ for commit in subprocess.check_output(['git', 'log', '--pretty=oneline']).decode
         print("Commit seems reverted. \t\t\t Commit: " + commit)
         continue
     ACTUAL_PROJECT_JIRA = None
-    for project_jira in project_jira_keys:
-        if project_jira in commit:
-            ACTUAL_PROJECT_JIRA = project_jira
-            break
+    matches = re.findall('|'.join(project_jira_keys), commit)
+    if matches:
+        ACTUAL_PROJECT_JIRA = matches[0]
     if not ACTUAL_PROJECT_JIRA:
         print("WARN: Jira not found. \t\t\t Commit: " + commit)
         continue


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18251

git_jira_fix_version_check.py is confused by commit message like `"YARN-1151. Ability to configure auxiliary services from HDFS-based JAR files."` which contains both `YARN-` and `HDFS-`. The latter `HDFS-` is unexpectedly picked as JIRA issue id then 404 is thrown on accessing invalid URL like "https://issues.apache.org/jira/rest/api/2/issue/HDFS-".

```
Traceback (most recent call last):
  File "/home/centos/srcs/hadoop/dev-support/git-jira-validation/git_jira_fix_version_check.py", line 87, in <module>
    issue = jira.issue(ACTUAL_PROJECT_JIRA + JIRA_NUM)
  File "/home/centos/venv/lib64/python3.6/site-packages/jira/client.py", line 1404, in issue
    issue.find(id, params=params)
  File "/home/centos/venv/lib64/python3.6/site-packages/jira/resources.py", line 288, in find
    self._load(url, params=params)
  File "/home/centos/venv/lib64/python3.6/site-packages/jira/resources.py", line 458, in _load
    r = self._session.get(url, headers=headers, params=params)
  File "/home/centos/venv/lib64/python3.6/site-packages/jira/resilientsession.py", line 195, in get
    return self.__verb("GET", str(url), **kwargs)
  File "/home/centos/venv/lib64/python3.6/site-packages/jira/resilientsession.py", line 189, in __verb
    raise_on_error(response, verb=verb, **kwargs)
  File "/home/centos/venv/lib64/python3.6/site-packages/jira/resilientsession.py", line 70, in raise_on_error
    **kwargs,
jira.exceptions.JIRAError: JiraError HTTP 404 url: https://issues.apache.org/jira/rest/api/2/issue/HDFS-
        text: Issue Does Not Exist
```

If commit message contains multiple match on 'HADOOP-|HDFS-|YARN-|MAPREDUCE-', choosing the first one should be the fix.
