### PR TITLE
YARN-6539. Create SecureLogin inside Router.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -3995,6 +3995,10 @@ public class YarnConfiguration extends Configuration {
 
   public static final String ROUTER_PREFIX = YARN_PREFIX + "router.";
 
+  public static final String ROUTER_KEYTAB = ROUTER_PREFIX + "keytab";
+
+  public static final String ROUTER_PRINCIPAL = ROUTER_PREFIX + "principal";
+
   public static final String ROUTER_BIND_HOST = ROUTER_PREFIX + "bind-host";
 
   public static final String ROUTER_CLIENTRM_PREFIX =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -4180,6 +4180,18 @@
   </property>
 
   <property>
+    <description>The keytab for the router.</description>
+    <name>yarn.router.keytab</name>
+    <value>/etc/krb5.keytab</value>
+  </property>
+
+  <property>
+    <description>The Kerberos principal for the resource manager.</description>
+    <name>yarn.router.principal</name>
+    <value></value>
+  </property>
+
+  <property>
     <description>
       The comma separated list of class names that implement the
       RequestInterceptor interface. This is used by the RouterClientRMService

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
@@ -382,8 +382,13 @@ public class UnmanagedApplicationManager {
   protected Token<AMRMTokenIdentifier> initializeUnmanagedAM(
       ApplicationId appId) throws IOException, YarnException {
     try {
-      UserGroupInformation appSubmitter =
-          UserGroupInformation.createRemoteUser(this.submitter);
+      UserGroupInformation appSubmitter;
+      if (UserGroupInformation.isSecurityEnabled()) {
+        appSubmitter = UserGroupInformation.createProxyUser(this.submitter,
+            UserGroupInformation.getLoginUser());
+      } else {
+        appSubmitter = UserGroupInformation.createRemoteUser(this.submitter);
+      }
       this.rmClient = createRMProxy(ApplicationClientProtocol.class, this.conf,
           appSubmitter, null);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
@@ -121,6 +121,19 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
+import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.ShutdownHookManager;
@@ -88,7 +89,8 @@ public class Router extends CompositeService {
   }
 
   protected void doSecureLogin() throws IOException {
-    // TODO YARN-6539 Create SecureLogin inside Router
+    SecurityUtil.login(this.conf, YarnConfiguration.ROUTER_KEYTAB,
+        YarnConfiguration.ROUTER_PRINCIPAL);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/AbstractClientRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/AbstractClientRequestInterceptor.java
@@ -106,7 +106,10 @@ public abstract class AbstractClientRequestInterceptor
     try {
       // Do not create a proxy user if user name matches the user name on
       // current UGI
-      if (userName.equalsIgnoreCase(
+      if (UserGroupInformation.isSecurityEnabled()) {
+        user = UserGroupInformation.createProxyUser(userName,
+            UserGroupInformation.getLoginUser());
+      } else if (userName.equalsIgnoreCase(
           UserGroupInformation.getCurrentUser().getUserName())) {
         user = UserGroupInformation.getCurrentUser();
       } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/TestSecureLogin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/TestSecureLogin.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.yarn.server.router.security;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.router.Router;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.junit.Test;
+import org.apache.hadoop.security.authentication.KerberosTestUtils;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TestSecureLogin {
+
+  private static final File TEST_ROOT_DIR = new File("target",
+      TestSecureLogin.class.getName() + "-root");
+  private static File routerKeytabFile = new File(
+      KerberosTestUtils.getKeytabFile());
+
+  private static MiniKdc testMiniKDC;
+
+  @BeforeClass
+  public static void setUp() {
+    try {
+      testMiniKDC = new MiniKdc(MiniKdc.createConf(), TEST_ROOT_DIR);
+      testMiniKDC.start();
+      testMiniKDC.createPrincipal(routerKeytabFile, "yarn/localhost");
+    } catch (Exception e) {
+      fail("Couldn't setup MiniKDC");
+    }
+  }
+
+  @Test
+  public void testRouterSecureLogin() {
+    Router router = null;
+    try {
+      Configuration conf = new YarnConfiguration();
+      conf.set(YarnConfiguration.ROUTER_BIND_HOST, "0.0.0.0");
+      conf.set(YarnConfiguration.ROUTER_CLIENTRM_INTERCEPTOR_CLASS_PIPELINE,
+          "org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor");
+      conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
+          "kerberos");
+      conf.set("yarn.router.principal", "yarn/localhost@EXAMPLE.COM");
+      conf.set("yarn.router.keytab", routerKeytabFile.getAbsolutePath());
+      assertEquals(AuthenticationMethod.SIMPLE,
+          UserGroupInformation.getLoginUser().getAuthenticationMethod());
+      UserGroupInformation.setConfiguration(conf);
+      router = new Router();
+      router.init(conf);
+      router.start();
+      assertEquals(AuthenticationMethod.KERBEROS,
+          UserGroupInformation.getLoginUser().getAuthenticationMethod());
+      assertEquals("yarn/localhost@EXAMPLE.COM",
+          UserGroupInformation.getLoginUser().getUserName());
+    } catch (Throwable t) {
+      fail("Can't start router!");
+    } finally {
+      if (router != null) {
+        router.stop();
+      }
+    }
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    if (testMiniKDC != null) {
+      testMiniKDC.stop();
+      testMiniKDC = null;
+    }
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/TestSecureLogin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/security/TestSecureLogin.java
@@ -52,19 +52,19 @@ public class TestSecureLogin {
   @Test
   public void testRouterSecureLogin() throws IOException {
     Router router = null;
+    Configuration conf = new YarnConfiguration();
+    conf.set(YarnConfiguration.ROUTER_BIND_HOST, "0.0.0.0");
+    conf.set(YarnConfiguration.ROUTER_CLIENTRM_INTERCEPTOR_CLASS_PIPELINE,
+        "org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor");
+    conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
+        "kerberos");
+    conf.set("yarn.router.principal", "yarn/localhost@EXAMPLE.COM");
+    conf.set("yarn.router.keytab", routerKeytabFile.getAbsolutePath());
+    assertEquals("Authentication Method should be simple before login!",
+        AuthenticationMethod.SIMPLE,
+        UserGroupInformation.getLoginUser().getAuthenticationMethod());
+    UserGroupInformation.setConfiguration(conf);
     try {
-      Configuration conf = new YarnConfiguration();
-      conf.set(YarnConfiguration.ROUTER_BIND_HOST, "0.0.0.0");
-      conf.set(YarnConfiguration.ROUTER_CLIENTRM_INTERCEPTOR_CLASS_PIPELINE,
-          "org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor");
-      conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
-          "kerberos");
-      conf.set("yarn.router.principal", "yarn/localhost@EXAMPLE.COM");
-      conf.set("yarn.router.keytab", routerKeytabFile.getAbsolutePath());
-      assertEquals("Authentication Method should be simple before login!",
-          AuthenticationMethod.SIMPLE,
-          UserGroupInformation.getLoginUser().getAuthenticationMethod());
-      UserGroupInformation.setConfiguration(conf);
       router = new Router();
       router.init(conf);
       router.start();


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/YARN-6539

This PR is contributed by Xie YiFan,  I transform from patch to PR, and fix some ut then add yarn-default.xml and license. 

It is precondition so that we could use yarn federation in security mode.

### How was this patch tested?

uni-test and test in our cluster manually.

### For code changes:

support security for router