### PR TITLE
YARN-11163. use relative path to fix reverse proxy image display

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/HeaderBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/HeaderBlock.java
@@ -33,7 +33,7 @@ public class HeaderBlock extends HtmlBlock {
         div("#user").
         __(loggedIn).__().
         div("#logo").
-          img("/static/hadoop-st.png").__().
+          img(root_url("static/hadoop-st.png")).__().
         h1($(TITLE)).__();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/HeaderBlockTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/view/HeaderBlockTest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.webapp.view;
+
+import com.google.inject.Injector;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.hadoop.yarn.webapp.test.WebAppTests;
+
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+
+public class HeaderBlockTest {
+
+  @SuppressWarnings("unchecked")
+  public void setEnv(Map<String, String> newEnv) throws Exception {
+    try {
+      Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
+      String fieldName = "Environment";
+      Field environmentField = processEnvironmentClass.getDeclaredField(fieldName);
+
+      // reset environment accessibility
+      environmentField.setAccessible(true);
+      if(environmentField.getType().equals(Map.class)) {
+        Map<String, String> env = (Map<String, String>) environmentField.get(null);
+        env.putAll(newEnv);
+      }
+      fieldName = "CaseInsensitiveEnvironment";
+      Field theCaseInsensitiveEnvField = processEnvironmentClass.getDeclaredField(fieldName);
+
+      // reset environment accessibility
+      theCaseInsensitiveEnvField.setAccessible(true);
+      if(theCaseInsensitiveEnvField.getType().equals(Map.class)) {
+        Map<String, String> ciEnv = (Map<String, String>) theCaseInsensitiveEnvField.get(null);
+        ciEnv.putAll(newEnv);
+      }
+
+    } catch (NoSuchFieldException e) {
+      Class[] classes = Collections.class.getDeclaredClasses();
+      Map<String, String> env = System.getenv();
+      for(Class cl : classes) {
+        if("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+          Field field = cl.getDeclaredField("m");
+          field.setAccessible(true);
+          if(field.getType().equals(Map.class)) {
+            Map<String, String> map = (Map<String, String>) field.get(env);
+            map.clear();
+            map.putAll(newEnv);
+          }
+        }
+      }
+    }
+  }
+
+  @Test public void testDefaultImgPath() throws Exception {
+    Injector injector = WebAppTests.testBlock(HeaderBlock.class);
+    PrintWriter out = injector.getInstance(PrintWriter.class);
+    String expectation = " src=\"/static/hadoop-st.png\"";
+    verify(out).print(expectation);
+  }
+
+  @Test public void testProxyBaseImgPath() throws Exception {
+    String key = "APPLICATION_WEB_PROXY_BASE";
+    String value = "/hadoop";
+    setEnv(Collections.singletonMap(key, value));
+    Injector injector = WebAppTests.testBlock(HeaderBlock.class);
+    PrintWriter out = injector.getInstance(PrintWriter.class);
+    String expectation = " src=\""+value+"/static/hadoop-st.png\"";
+    verify(out).print(expectation);
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
this pr corresponds to [YARN-11163](https://issues.apache.org/jira/browse/YARN-11163)

### How was this patch tested?
this patch has unit test added and tried in local docker environment

### For code changes:

- [x ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

