### PR TITLE
HDFS-16596. Improve the processing capability of FsDatasetAsyncDiskSe…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -151,6 +151,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long    DFS_DATANODE_MAX_LOCKED_MEMORY_DEFAULT = 0;
   public static final String  DFS_DATANODE_FSDATASETCACHE_MAX_THREADS_PER_VOLUME_KEY = "dfs.datanode.fsdatasetcache.max.threads.per.volume";
   public static final int     DFS_DATANODE_FSDATASETCACHE_MAX_THREADS_PER_VOLUME_DEFAULT = 4;
+  public static final String  DFS_DATANODE_FSDATASETASYNCDISK_CORE_THREADS_PER_VOLUME_KEY =
+      "dfs.datanode.fsdatasetasyncdisk.core.threads.per.volume";
+  public static final int     DFS_DATANODE_FSDATASETASYNCDISK_CORE_THREADS_PER_VOLUME_DEFAULT = 1;
   public static final String  DFS_DATANODE_FSDATASETASYNCDISK_MAX_THREADS_PER_VOLUME_KEY =
       "dfs.datanode.fsdatasetasyncdisk.max.threads.per.volume";
   public static final int     DFS_DATANODE_FSDATASETASYNCDISK_MAX_THREADS_PER_VOLUME_DEFAULT = 4;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -65,7 +65,7 @@ class FsDatasetAsyncDiskService {
       LoggerFactory.getLogger(FsDatasetAsyncDiskService.class);
   
   // ThreadPool core pool size
-  private static final int CORE_THREADS_PER_VOLUME = 1;
+  private final int coreNumThreadsPerVolume;
   // ThreadPool maximum pool size
   private final int maxNumThreadsPerVolume;
   // ThreadPool keep-alive time for threads over core pool size
@@ -90,6 +90,12 @@ class FsDatasetAsyncDiskService {
   FsDatasetAsyncDiskService(DataNode datanode, FsDatasetImpl fsdatasetImpl) {
     this.datanode = datanode;
     this.fsdatasetImpl = fsdatasetImpl;
+    this.coreNumThreadsPerVolume = datanode.getConf().getInt(
+      DFSConfigKeys.DFS_DATANODE_FSDATASETASYNCDISK_CORE_THREADS_PER_VOLUME_KEY,
+          DFSConfigKeys.DFS_DATANODE_FSDATASETASYNCDISK_CORE_THREADS_PER_VOLUME_DEFAULT);
+    Preconditions.checkArgument(coreNumThreadsPerVolume > 0,
+        DFSConfigKeys.DFS_DATANODE_FSDATASETASYNCDISK_CORE_THREADS_PER_VOLUME_KEY +
+          " must be a positive integer.");
     maxNumThreadsPerVolume = datanode.getConf().getInt(
       DFSConfigKeys.DFS_DATANODE_FSDATASETASYNCDISK_MAX_THREADS_PER_VOLUME_KEY,
           DFSConfigKeys.DFS_DATANODE_FSDATASETASYNCDISK_MAX_THREADS_PER_VOLUME_DEFAULT);
@@ -116,7 +122,7 @@ class FsDatasetAsyncDiskService {
     };
 
     ThreadPoolExecutor executor = new ThreadPoolExecutor(
-        CORE_THREADS_PER_VOLUME, maxNumThreadsPerVolume,
+        this.coreNumThreadsPerVolume, maxNumThreadsPerVolume,
         THREADS_KEEP_ALIVE_SECONDS, TimeUnit.SECONDS,
         new LinkedBlockingQueue<Runnable>(), threadFactory);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -3003,6 +3003,16 @@
 </property>
 
 <property>
+  <name>dfs.datanode.fsdatasetasyncdisk.core.threads.per.volume</name>
+  <value>1</value>
+  <description>
+    The number of core threads per volume used to process async disk
+    operations on the datanode. These threads consume I/O and CPU at the
+    same time. This will affect normal data node operations.
+  </description>
+</property>
+
+<property>
   <name>dfs.datanode.fsdatasetasyncdisk.max.threads.per.volume</name>
   <value>4</value>
   <description>


### PR DESCRIPTION
In our production environment, when DN needs to delete a large number blocks, we find that many deletion tasks are backlogged in the queue of threadPoolExecutor in FsDatasetAsyncDiskService. We can't improve its throughput because the number of core threads is hard coded.

So DN needs to support the number of core threads of FsDatasetAsyncDiskService can be configured.