### PR TITLE
YARN-11165. Use default java.policy when no group policy is set.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/JavaSandboxLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/JavaSandboxLinuxContainerRuntime.java
@@ -468,7 +468,7 @@ public class JavaSandboxLinuxContainerRuntime
         cacheDirs.add(path.getParent().toString());
       }
 
-      if (groupPolicyPaths != null) {
+      if (groupPolicyPaths != null && !groupPolicyPaths.isEmpty()) {
         for(String policyPath : groupPolicyPaths) {
           Files.copy(Paths.get(policyPath), policyOutStream);
         }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/YARN-11165

When JavaSandboxLinuxContainerRuntime is used, we can specify yarn.nodemanager.runtime.linux.sandbox-mode.policy to use self-provided java.policy file. When this setting is not specified, JavaSandboxLinuxContainerRuntime will use the default java.policy file.

However, when user belongs to a group (or more groups), and yarn.nodemanager.runtime.linux.sandbox-mode.policy.group.$groupName setting is not specified, JavaSandboxLinuxContainerRuntime still skips the default java.policy file, resulting in a final policy which looks like this:

```
grant codeBase "file:/usr/local/hadoop/-" {
  permission java.security.AllPermission;
};
grant {
   permission java.io.FilePermission "/tmp/hadoop-yarn/nm-local-dir/usercache/yarn/appcache/application_1653546011283_0006//-", "read";
   permission java.io.FilePermission "/tmp/hadoop-yarn/nm-local-dir/usercache/yarn/appcache/application_1653546011283_0006/filecache/13/-", "read";
   permission java.io.FilePermission "/tmp/hadoop-yarn/nm-local-dir/usercache/yarn/appcache/application_1653546011283_0006/filecache/11/-", "read";
   permission java.io.FilePermission "/tmp/hadoop-yarn/nm-local-dir/usercache/yarn/appcache/application_1653546011283_0006/filecache/12/-", "read";
   permission java.io.FilePermission "/tmp/hadoop-yarn/nm-local-dir/usercache/yarn/appcache/application_1653546011283_0006/filecache/10/-", "read";
}; 
```
which will cause problem running applications. 

This PR ensures that the default java.policy will still be used when no group policy is set.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

