### PR TITLE
HDFS-16597. RBF: Improve RouterRpcServer#reload With Lambda

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -2061,12 +2061,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
     public ListenableFuture<DatanodeInfo[]> reload(
         final DatanodeReportType type, DatanodeInfo[] oldValue)
         throws Exception {
-      return executorService.submit(new Callable<DatanodeInfo[]>() {
-        @Override
-        public DatanodeInfo[] call() throws Exception {
-          return load(type);
-        }
-      });
+      return executorService.submit(() -> load(type));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCClientRetries.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCClientRetries.java
@@ -68,7 +68,7 @@ public class TestRouterRPCClientRetries {
   private static ClientProtocol routerProtocol;
 
   @Rule
-  public final Timeout testTimeout = new Timeout(100000);
+  public final Timeout testTimeout = new Timeout(100000L, TimeUnit.MILLISECONDS);
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
JIRA: HDFS-16597 Improve RouterRpcServer#reload With Lambda

When reading the code, I found that RouterRpcServer#reload uses the following method to submit threads
RouterRpcServer#reload
```
public ListenableFuture<DatanodeInfo[]> reload(
        final DatanodeReportType type, DatanodeInfo[] oldValue)
        throws Exception {
      return executorService.submit(new Callable<DatanodeInfo[]>() {
        @Override
        public DatanodeInfo[] call() throws Exception {
          return load(type);
        }
      });
    } 
```

This place is better to use lambda .