### PR TITLE
HADOOP-18268. Install maven from Apache archives

### DIFF
--- a/dev-support/docker/pkg-resolver/install-maven.sh
+++ b/dev-support/docker/pkg-resolver/install-maven.sh
@@ -40,7 +40,7 @@ fi
 
 if [ "$version_to_install" == "3.6.3" ]; then
   mkdir -p /opt/maven /tmp/maven &&
-    curl -L -s -S https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+    curl -L -s -S https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
       -o /tmp/maven/apache-maven-3.6.3-bin.tar.gz &&
     tar xzf /tmp/maven/apache-maven-3.6.3-bin.tar.gz --strip-components 1 -C /opt/maven
 else

--- a/dev-support/docker/pkg-resolver/install-maven.sh
+++ b/dev-support/docker/pkg-resolver/install-maven.sh
@@ -40,7 +40,7 @@ fi
 
 if [ "$version_to_install" == "3.6.3" ]; then
   mkdir -p /opt/maven /tmp/maven &&
-    curl -L -s -S https://mirrors.estointernet.in/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+    curl -L -s -S https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
       -o /tmp/maven/apache-maven-3.6.3-bin.tar.gz &&
     tar xzf /tmp/maven/apache-maven-3.6.3-bin.tar.gz --strip-components 1 -C /opt/maven
 else

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
@@ -141,4 +141,3 @@ int main(int argc, char *argv[]) {
   google::protobuf::ShutdownProtobufLibrary();
   return exit_code;
 }
-

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
@@ -141,3 +141,4 @@ int main(int argc, char *argv[]) {
   google::protobuf::ShutdownProtobufLibrary();
   return exit_code;
 }
+


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The Jenkins CI for Hadoop is failing to build since it's unable to download and install maven -

```
22:38:13  #11 [ 7/16] RUN pkg-resolver/install-maven.sh centos:7
22:38:13  #11 sha256:8b1823a6197611693af5daa2888f195db76ae5e9d0765f799becc7e7d5f7b019
22:40:25  #11 131.5 curl: (7) Failed to connect to 2403:8940:3:1::f: Cannot assign requested address
22:40:25  #11 ERROR: executor failed running [/bin/bash --login -c pkg-resolver/install-maven.sh centos:7]: exit code: 7
```

Jenkins run - https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-4370/4/console
We need to switch to using Maven from Apache archives to prevent such issues.


### How was this patch tested?
CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

