### PR TITLE
HADOOP-18255. Fix fsdatainputstreambuilder.md reference to hadoop bra…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstreambuilder.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstreambuilder.md
@@ -230,7 +230,7 @@ Note: some operations on the input stream, such as `seek()` may not attempt any 
 at all. Such operations MAY NOT raise exceotions when interacting with
 nonexistent/unreadable files.
 
-## <a name="options"></a> Standard `openFile()` options since Hadoop 3.3.3
+## <a name="options"></a> Standard `openFile()` options since hadoop branch-3.3
 
 These are options which `FileSystem` and `FileContext` implementation
 MUST recognise and MAY support by changing the behavior of


### PR DESCRIPTION
### Description of PR
fsdatainputstreambuilder.md refers to hadoop 3.3.3, when it means whatever ships off hadoop branch-3.3
* JIRA: HADOOP-18255


- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
