### PR TITLE
HDFS-16610. Make fsck read timeout configurable

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -273,6 +273,14 @@ public interface HdfsClientConfigKeys {
   String DFS_LEASE_HARDLIMIT_KEY = "dfs.namenode.lease-hard-limit-sec";
   long DFS_LEASE_HARDLIMIT_DEFAULT = 20 * 60;
 
+  String DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS =
+      "dfs.client.fsck.connect.timeout.ms";
+  int DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS_DEFAULT = 60 * 1000;
+
+  String DFS_CLIENT_FSCK_READ_TIMEOUT_MS =
+      "dfs.client.fsck.read.timeout.ms";
+  int DFS_CLIENT_FSCK_READ_TIMEOUT_MS_DEFAULT = 60 * 1000;
+
   /**
    * These are deprecated config keys to client code.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -273,13 +273,13 @@ public interface HdfsClientConfigKeys {
   String DFS_LEASE_HARDLIMIT_KEY = "dfs.namenode.lease-hard-limit-sec";
   long DFS_LEASE_HARDLIMIT_DEFAULT = 20 * 60;
 
-  String DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS =
-      "dfs.client.fsck.connect.timeout.ms";
-  int DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS_DEFAULT = 60 * 1000;
+  String DFS_CLIENT_FSCK_CONNECT_TIMEOUT =
+      "dfs.client.fsck.connect.timeout";
+  int DFS_CLIENT_FSCK_CONNECT_TIMEOUT_DEFAULT = 60 * 1000;
 
-  String DFS_CLIENT_FSCK_READ_TIMEOUT_MS =
-      "dfs.client.fsck.read.timeout.ms";
-  int DFS_CLIENT_FSCK_READ_TIMEOUT_MS_DEFAULT = 60 * 1000;
+  String DFS_CLIENT_FSCK_READ_TIMEOUT =
+      "dfs.client.fsck.read.timeout";
+  int DFS_CLIENT_FSCK_READ_TIMEOUT_DEFAULT = 60 * 1000;
 
   /**
    * These are deprecated config keys to client code.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HAUtil;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.server.namenode.NamenodeFsck;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -137,8 +138,15 @@ public class DFSck extends Configured implements Tool {
     super(conf);
     this.ugi = UserGroupInformation.getCurrentUser();
     this.out = out;
+    int connectTimeout = conf.getInt(
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS,
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS_DEFAULT);
+    int readTimeout = conf.getInt(
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_READ_TIMEOUT_MS,
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_READ_TIMEOUT_MS_DEFAULT);
+
     this.connectionFactory = URLConnectionFactory
-        .newDefaultURLConnectionFactory(conf);
+        .newDefaultURLConnectionFactory(connectTimeout, readTimeout, conf);
     this.isSpnegoEnabled = UserGroupInformation.isSecurityEnabled();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
@@ -138,12 +139,14 @@ public class DFSck extends Configured implements Tool {
     super(conf);
     this.ugi = UserGroupInformation.getCurrentUser();
     this.out = out;
-    int connectTimeout = conf.getInt(
-        HdfsClientConfigKeys.DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS,
-        HdfsClientConfigKeys.DFS_CLIENT_FSCK_CONNECT_TIMEOUT_MS_DEFAULT);
-    int readTimeout = conf.getInt(
-        HdfsClientConfigKeys.DFS_CLIENT_FSCK_READ_TIMEOUT_MS,
-        HdfsClientConfigKeys.DFS_CLIENT_FSCK_READ_TIMEOUT_MS_DEFAULT);
+    int connectTimeout = (int) conf.getTimeDuration(
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_CONNECT_TIMEOUT,
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_CONNECT_TIMEOUT_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    int readTimeout = (int) conf.getTimeDuration(
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_READ_TIMEOUT,
+        HdfsClientConfigKeys.DFS_CLIENT_FSCK_READ_TIMEOUT_DEFAULT,
+        TimeUnit.MILLISECONDS);
 
     this.connectionFactory = URLConnectionFactory
         .newDefaultURLConnectionFactory(connectTimeout, readTimeout, conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6430,20 +6430,20 @@
     </description>
   </property>
   <property>
-    <name>dfs.client.fsck.connect.timeout.ms</name>
-    <value>60000</value>
+    <name>dfs.client.fsck.connect.timeout</name>
+    <value>60000ms</value>
     <description>
-      The amount of time in milliseconds the fsck client will wait to connect
-      to the namenode before timing out.
+      The amount of time the fsck client will wait to connect to the namenode
+      before timing out.
     </description>
   </property>
   <property>
-    <name>dfs.client.fsck.read.timeout.ms</name>
-    <value>60000</value>
+    <name>dfs.client.fsck.read.timeout</name>
+    <value>60000ms</value>
     <description>
-      The amount of time in milliseconds the fsck client will wait to read
-      from the namenode before timing out. If the namenode does not report
-      progress more frequently than this time, the client will give up waiting.
+      The amount of time the fsck client will wait to read from the namenode
+      before timing out. If the namenode does not report progress more
+      frequently than this time, the client will give up waiting.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6429,4 +6429,21 @@
       problem. In produce default set false, because it's have little performance loss.
     </description>
   </property>
+  <property>
+    <name>dfs.client.fsck.connect.timeout.ms</name>
+    <value>60000</value>
+    <description>
+      The amount of time in milliseconds the fsck client will wait to connect
+      to the namenode before timing out.
+    </description>
+  </property>
+  <property>
+    <name>dfs.client.fsck.read.timeout.ms</name>
+    <value>60000</value>
+    <description>
+      The amount of time in milliseconds the fsck client will wait to read
+      from the namenode before timing out. If the namenode does not report
+      progress more frequently than this time, the client will give up waiting.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
### Description of PR

In a cluster with a lot of small files, we encountered a case where fsck was very slow. I believe it is due to contention with many other threads reading / writing data on the cluster.

Sometimes fsck does not report any progress for more than 60 seconds and the client times out. Currently the connect and read timeout are hardcoded to 60 seconds. This change is to make them configurable.

### How was this patch tested?

Tested manually by inserting a sleep into the fsck logic in the NN. I then adjusted the read timeout to validate I got a timeout or not depending on the timeout setting.