### PR TITLE
HDFS-16611. impove TestSeveralNameNodes#testCircularLinkedListWrites Params

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestSeveralNameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestSeveralNameNodes.java
@@ -49,9 +49,9 @@ public class TestSeveralNameNodes {
   private static final int TIME_BETWEEN_FAILOVERS = 1000;
   private static final int NUM_NAMENODES = 3;
   private static final int NUM_THREADS = 3;
-  private static final int LIST_LENGTH = 50;
+  private static final int LIST_LENGTH = 40;
   /** ms for length of test */
-  private static final long RUNTIME = 100000;
+  private static final long RUNTIME = 120000;
 
   @Test
   public void testCircularLinkedListWrites() throws Exception {


### PR DESCRIPTION
JIRA:HDFS-16611. impove TestSeveralNameNodes#testCircularLinkedListWrites Params.

When I was dealing with [HDFS-16590](https://issues.apache.org/jira/browse/HDFS-16590) JIRA, Junit Tests often reported errors,  I found that the following error messages often appear

org.apache.hadoop.hdfs.server.namenode.ha.TestSeveralNameNodes#

testCircularLinkedListWrites

This method runs very close to success. It can be found that the current item is approximately equal to the target length in 3 runs. I think it can reduce the length of LIST_LENGTH and prolong the RUNTIME time, which can effectively increase the success rate of this Test.

Reducing LIST_LENGTH does not change the running purpose of Test, and it can also test Circular Writes in the case of NN failover.

- 1st run
```
[ERROR] testCircularLinkedListWrites(org.apache.hadoop.hdfs.server.namenode.ha.TestSeveralNameNodes)  Time elapsed: 114.252 s  <<< FAILURE!
java.lang.AssertionError: 
Some writers didn't complete in expected runtime! Current writer state:[Circular Writer:
	 directory: /test-0
	 target length: **50**
	 current item: **43**
	 done: false
, Circular Writer:
	 directory: /test-1
	 target length: **50**
	 current item: **47**
	 done: false
, Circular Writer:
	 directory: /test-2
	 target length: **50**
	 current item: **42**
	 done: false
] expected:<0> but was:<3>
```

- 2st run
```
[ERROR] testCircularLinkedListWrites(org.apache.hadoop.hdfs.server.namenode.ha.TestSeveralNameNodes)  Time elapsed: 110.349 s  <<< FAILURE!
java.lang.AssertionError: 
Some writers didn't complete in expected runtime! Current writer state:[Circular Writer:
	 directory: /test-0
	 target length: **50**
	 current item: **50**
	 done: false
, Circular Writer:
	 directory: /test-1
	 target length: **50**
	 current item: **49**
	 done: false
, Circular Writer:
	 directory: /test-2
	 target length: **50**
	 current item: **49**
	 done: false
] expected:<0> but was:<3>
```

- 3rd run
```
[ERROR] testCircularLinkedListWrites(org.apache.hadoop.hdfs.server.namenode.ha.TestSeveralNameNodes)  Time elapsed: 109.364 s  <<< FAILURE!
java.lang.AssertionError: 
Some writers didn't complete in expected runtime! Current writer state:[Circular Writer:
	 directory: /test-0
	 target length: **50**
	 current item: **47**
	 done: false
, Circular Writer:
	 directory: /test-1
	 target length: **50**
	 current item: **47**
	 done: false
, Circular Writer:
	 directory: /test-2
	 target length: **50**
	 current item: **46**
	 done: false
] expected:<0> but was:<3>
```