### PR TITLE
HADOOP-18274. Use CMake 3.19.0 in Debian 10

### DIFF
--- a/dev-support/docker/Dockerfile_debian_10
+++ b/dev-support/docker/Dockerfile_debian_10
@@ -82,6 +82,7 @@ ENV HADOOP_SKIP_YETUS_VERIFICATION true
 ####
 # Install packages
 ####
+RUN pkg-resolver/install-cmake.sh debian:10
 RUN pkg-resolver/install-spotbugs.sh debian:10
 RUN pkg-resolver/install-boost.sh debian:10
 RUN pkg-resolver/install-protobuf.sh debian:10

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -62,7 +62,6 @@
     "centos:8": "clang"
   },
   "cmake": {
-    "debian:10": "cmake",
     "ubuntu:focal": "cmake",
     "ubuntu:focal::arch64": "cmake"
   },


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
HDFS Native Client fails to build on Debian 10 due to the following error -

```
[WARNING] CMake Error at main/native/libhdfspp/CMakeLists.txt:68 (FetchContent_MakeAvailable):
[WARNING]   Unknown CMake command "FetchContent_MakeAvailable".
[WARNING] 
[WARNING] 
[WARNING] -- Configuring incomplete, errors occurred!
```
Jenkins run - https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-4371/2/artifact/out/branch-compile-hadoop-hdfs-project_hadoop-hdfs-native-client.txt

This cause for this issue is that the version of CMake on Debian 10 (which is installed through apt) is 3.13 and FetchContent_MakeAvailable was [introduced in CMake 3.14](https://cmake.org/cmake/help/v3.14/module/FetchContent.html)

Thus, we upgrade CMake by installing through the [install-cmake.sh](https://github.com/apache/hadoop/blob/34a973a90ef89b633c9b5c13a79aa1ac11c92eb5/dev-support/docker/pkg-resolver/install-cmake.sh) script from pkg-resolver which installs CMake 3.19.0, instead of installing CMake through apt on Debian 10.

### How was this patch tested?
Hadoop Jenkins CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

