### PR TITLE
HDFS-16618. sync_file_range error should include more volume/file info

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -223,11 +223,11 @@ class FsDatasetAsyncDiskService {
         streams.syncFileRangeIfPossible(offset, nbytes, flags);
       } catch (NativeIOException e) {
         try {
-          LOG.warn("sync_file_range error. Volume: {} , Capacity: {}, Available space: {}, "
+          LOG.warn("sync_file_range error. Volume: {}, Capacity: {}, Available space: {}, "
                   + "File range offset: {}, length: {}, flags: {}", volume, volume.getCapacity(),
               volume.getAvailable(), offset, nbytes, flags, e);
         } catch (IOException ioe) {
-          LOG.warn("sync_file_range error. Volume: {} , Capacity: {}, "
+          LOG.warn("sync_file_range error. Volume: {}, Capacity: {}, "
                   + "File range offset: {}, length: {}, flags: {}", volume, volume.getCapacity(),
               offset, nbytes, flags, e);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -216,16 +216,20 @@ class FsDatasetAsyncDiskService {
     }
   }
 
-  public void submitSyncFileRangeRequest(FsVolumeImpl volume,
-      final ReplicaOutputStreams streams, final long offset, final long nbytes,
-      final int flags) {
-    execute(volume, new Runnable() {
-      @Override
-      public void run() {
+  public void submitSyncFileRangeRequest(FsVolumeImpl volume, final ReplicaOutputStreams streams,
+      final long offset, final long nbytes, final int flags) {
+    execute(volume, () -> {
+      try {
+        streams.syncFileRangeIfPossible(offset, nbytes, flags);
+      } catch (NativeIOException e) {
         try {
-          streams.syncFileRangeIfPossible(offset, nbytes, flags);
-        } catch (NativeIOException e) {
-          LOG.warn("sync_file_range error", e);
+          LOG.warn("sync_file_range error. Volume: {} , Capacity: {}, Available space: {}, "
+                  + "File range offset: {}, length: {}, flags: {}", volume, volume.getCapacity(),
+              volume.getAvailable(), offset, nbytes, flags, e);
+        } catch (IOException ioe) {
+          LOG.warn("sync_file_range error. Volume: {} , Capacity: {}, "
+                  + "File range offset: {}, length: {}, flags: {}", volume, volume.getCapacity(),
+              offset, nbytes, flags, e);
         }
       }
     });


### PR DESCRIPTION
### Description of PR
Having seen multiple sync_file_range errors recently with Bad file descriptor, it would be good to include more volume stats as well as file offset/length info with the error log to get some more insights.