### PR TITLE
HDFS-16621.Remove unused JNStorage#getCurrentDir()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JNStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JNStorage.java
@@ -123,10 +123,6 @@ class JNStorage extends Storage {
     return new File(sd.getCurrentDir(), name);
   }
 
-  File getCurrentDir() {
-    return sd.getCurrentDir();
-  }
-
   /**
    * Directory {@code edits.sync} temporarily holds the log segments
    * downloaded through {@link JournalNodeSyncer} before they are moved to


### PR DESCRIPTION
### Description of PR
There is no use of getCurrentDir() anywhere in JNStorage, we should remove it.
Details: HDFS-16621

### How was this patch tested?
For testing, there is not much pressure.
