### PR TITLE
HDFS-16622. addRDBI in IncrementalBlockReportManager may remove the b…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/IncrementalBlockReportManager.java
@@ -251,12 +251,20 @@ class IncrementalBlockReportManager {
       DatanodeStorage storage) {
     // Make sure another entry for the same block is first removed.
     // There may only be one such entry.
+    ReceivedDeletedBlockInfo removedInfo = null;
     for (PerStorageIBR perStorage : pendingIBRs.values()) {
-      if (perStorage.remove(rdbi.getBlock()) != null) {
+      removedInfo = perStorage.remove(rdbi.getBlock());
+      if (removedInfo != null) {
         break;
       }
     }
-    getPerStorageIBR(storage).put(rdbi);
+    if (removedInfo != null &&
+        removedInfo.getBlock().getGenerationStamp()
+            > rdbi.getBlock().getGenerationStamp()) {
+      getPerStorageIBR(storage).put(removedInfo);
+    } else {
+      getPerStorageIBR(storage).put(rdbi);
+    }
   }
 
   synchronized void notifyNamenodeBlock(ReceivedDeletedBlockInfo rdbi,


### PR DESCRIPTION
JIRA: [HDFS-16622](https://issues.apache.org/jira/browse/HDFS-16622).  addRDBI in IncrementalBlockReportManager may remove the block with bigger GS.
I suspect there is a bug in function addRDBI(ReceivedDeletedBlockInfo rdbi,DatanodeStorage storage)(line 250).
Bug code in the for loop:
```
synchronized void addRDBI(ReceivedDeletedBlockInfo rdbi,
      DatanodeStorage storage) {
    // Make sure another entry for the same block is first removed.
    // There may only be one such entry.
    for (PerStorageIBR perStorage : pendingIBRs.values()) {
      if (perStorage.remove(rdbi.getBlock()) != null) {
        break;
      }
    }
    getPerStorageIBR(storage).put(rdbi);
  }
```
Removed the GS of the Block in ReceivedDeletedBlockInfo may be greater than the GS of the Block in rdbi. And NN will invalidate the Replicate will small GS when complete one block.