### PR TITLE
YARN-11172. Fix TestClientRMTokens#testDelegationToken introduced by HDFS-16563.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -518,9 +518,9 @@ extends AbstractDelegationTokenIdentifier>
     }
     long now = Time.now();
     if (info.getRenewDate() < now) {
-      err =
-          "Token has" + identifier.getRealUser() + "expired, current time: " + Time.formatTime(now)
-              + " expected renewal time: " + Time.formatTime(info.getRenewDate());
+      err = "Token " + identifier.getRealUser() + " has expired, current time: "
+          + Time.formatTime(now) + " expected renewal time: " + Time
+          .formatTime(info.getRenewDate());
       LOG.info("{}, Token={}", err, formatTokenId(identifier));
       throw new InvalidToken(err);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestClientRMTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestClientRMTokens.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.yarn.server.resourcemanager;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,6 +35,7 @@ import java.net.InetSocketAddress;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.thirdparty.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.net.NetUtils;
@@ -111,7 +111,7 @@ public class TestClientRMTokens {
   }
   
   @Test
-  public void testDelegationToken() throws IOException, InterruptedException {
+  public void testDelegationToken() throws Exception {
     
     final YarnConfiguration conf = new YarnConfiguration();
     conf.set(YarnConfiguration.RM_PRINCIPAL, "testuser/localhost@apache.org");
@@ -198,14 +198,11 @@ public class TestClientRMTokens {
       }
       Thread.sleep(50l);
       LOG.info("At time: " + System.currentTimeMillis() + ", token should be invalid");
-      // Token should have expired.      
-      try {
-        clientRMWithDT.getNewApplication(request);
-        fail("Should not have succeeded with an expired token");
-      } catch (Exception e) {
-        assertEquals(InvalidToken.class.getName(), e.getClass().getName());
-        assertTrue(e.getMessage().contains("is expired"));
-      } 
+      // Token should have expired.
+      final ApplicationClientProtocol finalClientRMWithDT = clientRMWithDT;
+      final GetNewApplicationRequest finalRequest = request;
+      LambdaTestUtils.intercept(InvalidToken.class, "Token  has expired",
+          () -> finalClientRMWithDT.getNewApplication(finalRequest));
 
       // Test cancellation
       // Stop the existing proxy, start another.


### PR DESCRIPTION
### Description of PR

UT fail after [HDFS-16563], other yarn PR is blocked.

```
[ERROR] testDelegationToken(org.apache.hadoop.yarn.server.resourcemanager.TestClientRMTokens)  Time elapsed: 17.379 s  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.hadoop.yarn.server.resourcemanager.TestClientRMTokens.testDelegationToken(TestClientRMTokens.java:207)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```