### PR TITLE
HDFS-16623. Avoid IllegalArgumentException in LifelineSender

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -1345,7 +1345,8 @@ class BPServiceActor implements Runnable {
     }
 
     long getLifelineWaitTime() {
-      return nextLifelineTime - monotonicNow();
+      long waitTime = nextLifelineTime - monotonicNow();
+      return waitTime > 0 ? waitTime : 0;
     }
 
     @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBpServiceActorScheduler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBpServiceActorScheduler.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdfs.server.datanode.BPServiceActor.Scheduler;
@@ -202,6 +203,18 @@ public class TestBpServiceActorScheduler {
       assertTrue(scheduler.isLifelineDue(now));
       assertThat(scheduler.getLifelineWaitTime(), is(0L));
     }
+  }
+
+  @Test
+  public void testScheduleLifelineScheduleTime() {
+    Scheduler mockScheduler = spy(new Scheduler(
+        HEARTBEAT_INTERVAL_MS, LIFELINE_INTERVAL_MS,
+        BLOCK_REPORT_INTERVAL_MS, OUTLIER_REPORT_INTERVAL_MS));
+    long now = Time.monotonicNow();
+    mockScheduler.scheduleNextLifeline(now);
+    long mockMonotonicNow = now + LIFELINE_INTERVAL_MS * 2;
+    doReturn(mockMonotonicNow).when(mockScheduler).monotonicNow();
+    assertTrue(mockScheduler.getLifelineWaitTime() >= 0);
   }
 
   @Test


### PR DESCRIPTION
Jira:  [HDFS-16623](https://issues.apache.org/jira/browse/HDFS-16623), fix bug to avoid IllegalArgumentException in LifelineSender.

In our production environment, an IllegalArgumentException occurred in the LifelineSender at one DataNode which was undergoing GC at that time.

