### PR TITLE
HADOOP-18272. Removing util.set from yarn project

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
@@ -167,7 +167,7 @@ class TestPlacementConstraintParser {
     assertEquals(0, single.getMinCardinality());
     assertEquals(1, single.getMaxCardinality());
     assertEquals(3, single.getTargetExpressions().size());
-    Set<TargetExpression> expectedTargetExpressions = new HashSet(Arrays.asList(
+    Set<TargetExpression> expectedTargetExpressions = new HashSet<>(Arrays.asList(
         PlacementTargets.allocationTag("foo"),
         PlacementTargets.allocationTag("bar"),
         PlacementTargets.allocationTag("moo")));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.yarn.api.resource;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -112,10 +114,10 @@ class TestPlacementConstraintParser {
     assertEquals(0, single.getMinCardinality());
     assertEquals(0, single.getMaxCardinality());
     assertEquals(3, single.getTargetExpressions().size());
-    Set<TargetExpression> expectedTargetExpressions = Sets.newHashSet(
+    Set<TargetExpression> expectedTargetExpressions = new HashSet<>(Arrays.asList(
         PlacementTargets.allocationTag("foo"),
         PlacementTargets.allocationTag("bar"),
-        PlacementTargets.allocationTag("exp"));
+        PlacementTargets.allocationTag("exp")));
     assertTrue(Sets.difference(expectedTargetExpressions,
         single.getTargetExpressions()).isEmpty());
     verifyConstraintToString(expressionStr, constraint);
@@ -165,10 +167,10 @@ class TestPlacementConstraintParser {
     assertEquals(0, single.getMinCardinality());
     assertEquals(1, single.getMaxCardinality());
     assertEquals(3, single.getTargetExpressions().size());
-    Set<TargetExpression> expectedTargetExpressions = Sets.newHashSet(
+    Set<TargetExpression> expectedTargetExpressions = new HashSet(Arrays.asList(
         PlacementTargets.allocationTag("foo"),
         PlacementTargets.allocationTag("bar"),
-        PlacementTargets.allocationTag("moo"));
+        PlacementTargets.allocationTag("moo")));
     assertTrue(Sets.difference(expectedTargetExpressions,
         single.getTargetExpressions()).isEmpty());
     verifyConstraintToString(expressionExpr, constraint);
@@ -579,9 +581,9 @@ class TestPlacementConstraintParser {
     result = PlacementConstraintParser
         .parsePlacementSpec("foo(2),notin,node,not-self/bar,all/moo");
     assertEquals(1, result.size());
-    Set<TargetExpression> expectedTargetExpressions = Sets.newHashSet(
+    Set<TargetExpression> expectedTargetExpressions = new HashSet<>(Arrays.asList(
         PlacementTargets.allocationTagWithNamespace("not-self", "bar"),
-        PlacementTargets.allocationTagWithNamespace("all", "moo"));
+        PlacementTargets.allocationTagWithNamespace("all", "moo")));
     AbstractConstraint constraint = result.values().iterator().next().
         getConstraintExpr();
     assertTrue(constraint instanceof SingleConstraint);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/main/java/org/apache/hadoop/yarn/service/webapp/ApiServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/main/java/org/apache/hadoop/yarn/service/webapp/ApiServer.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -372,7 +371,7 @@ public class ApiServer {
         LOG.info("PUT: upgrade component {} for service {} " +
             "user = {}", component.getName(), appName, ugi);
         return processComponentsUpgrade(ugi, appName,
-            Sets.newHashSet(componentName));
+            new HashSet<>(Collections.singleton(componentName)));
       }
 
       if (component.getNumberOfContainers() == null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestApiServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestApiServer.java
@@ -23,6 +23,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,7 +35,6 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.service.api.records.Artifact;
 import org.apache.hadoop.yarn.service.api.records.Artifact.TypeEnum;
 import org.apache.hadoop.yarn.service.api.records.Component;
@@ -530,8 +530,8 @@ public class TestApiServer {
     Container liveContainer = serviceStatus.getComponents().iterator().next()
         .getContainers().iterator().next();
     liveContainer.setState(ContainerState.NEEDS_UPGRADE);
-    mockServerClient.setExpectedInstances(Sets.newHashSet(
-        liveContainer.getComponentInstanceName()));
+    mockServerClient.setExpectedInstances(new HashSet<>(Collections.singleton(
+        liveContainer.getComponentInstanceName())));
 
     final Response actual = apiServer.updateComponentInstance(request,
         goodService.getName(), comp.getName(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/ServiceApiUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/ServiceApiUtil.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.registry.client.api.RegistryConstants;
 import org.apache.hadoop.registry.client.binding.RegistryUtils;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.service.api.records.ComponentContainers;
 import org.apache.hadoop.yarn.service.api.records.ComponentState;
@@ -622,7 +621,7 @@ public class ServiceApiUtil {
   public static List<Container> validateAndResolveCompsUpgrade(
       Service liveService, Collection<String> compNames) throws YarnException {
     Preconditions.checkNotNull(compNames);
-    HashSet<String> requestedComps = Sets.newHashSet(compNames);
+    HashSet<String> requestedComps = new HashSet<>(compNames);
     List<Container> containerNeedUpgrade = new ArrayList<>();
     for (Component liveComp : liveService.getComponents()) {
       if (requestedComps.contains(liveComp.getName())) {
@@ -648,7 +647,7 @@ public class ServiceApiUtil {
   public static List<Container> validateAndResolveCompsStable(
       Service liveService, Collection<String> compNames) throws YarnException {
     Preconditions.checkNotNull(compNames);
-    HashSet<String> requestedComps = Sets.newHashSet(compNames);
+    HashSet<String> requestedComps = new HashSet<>(compNames);
     List<Container> containerNeedUpgrade = new ArrayList<>();
     for (Component liveComp : liveService.getComponents()) {
       if (requestedComps.contains(liveComp.getName())) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestYarnCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestYarnCLI.java
@@ -39,6 +39,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -407,7 +408,7 @@ public class TestYarnCLI {
         "user", "queue", "appname", "host", 124, null,
         YarnApplicationState.RUNNING, "diagnostics", "url", 0, 0, 0,
         FinalApplicationStatus.SUCCEEDED, null, "N/A", 0.53789f, "YARN", null,
-        Sets.newHashSet("tag1", "tag3"), false, Priority.UNDEFINED, "", "");
+        new HashSet<>(Arrays.asList("tag1", "tag3")), false, Priority.UNDEFINED, "", "");
     List<ApplicationReport> applicationReports =
         new ArrayList<ApplicationReport>();
     applicationReports.add(newApplicationReport);
@@ -418,7 +419,7 @@ public class TestYarnCLI {
         "user2", "queue2", "appname2", "host2", 125, null,
         YarnApplicationState.FINISHED, "diagnostics2", "url2", 2, 2, 2,
         FinalApplicationStatus.SUCCEEDED, null, "N/A", 0.63789f, "NON-YARN", 
-        null, Sets.newHashSet("tag2", "tag3"), false, Priority.UNDEFINED,
+        null, new HashSet<>(Arrays.asList("tag2", "tag3")), false, Priority.UNDEFINED,
         "", "");
     applicationReports.add(newApplicationReport2);
 
@@ -428,7 +429,7 @@ public class TestYarnCLI {
         "user3", "queue3", "appname3", "host3", 126, null,
         YarnApplicationState.RUNNING, "diagnostics3", "url3", 3, 3, 3,
         FinalApplicationStatus.SUCCEEDED, null, "N/A", 0.73789f, "MAPREDUCE", 
-        null, Sets.newHashSet("tag1", "tag4"), false, Priority.UNDEFINED,
+        null, new HashSet<>(Arrays.asList("tag1", "tag4")), false, Priority.UNDEFINED,
         "", "");
     applicationReports.add(newApplicationReport3);
 
@@ -438,7 +439,8 @@ public class TestYarnCLI {
         "user4", "queue4", "appname4", "host4", 127, null,
         YarnApplicationState.FAILED, "diagnostics4", "url4", 4, 4, 4,
         FinalApplicationStatus.SUCCEEDED, null, "N/A", 0.83789f,
-        "NON-MAPREDUCE", null, Sets.newHashSet("tag1"), false,
+        "NON-MAPREDUCE", null,
+        new HashSet<>(Collections.singleton("tag1")), false,
         Priority.UNDEFINED, "", "");
     applicationReports.add(newApplicationReport4);
 
@@ -448,7 +450,7 @@ public class TestYarnCLI {
         "user5", "queue5", "appname5", "host5", 128, null,
         YarnApplicationState.ACCEPTED, "diagnostics5", "url5", 5, 5, 5,
         FinalApplicationStatus.KILLED, null, "N/A", 0.93789f, "HIVE", null,
-        Sets.newHashSet("tag2", "tag4"), false, Priority.UNDEFINED, "", "");
+        new HashSet<>(Arrays.asList("tag2", "tag4")), false, Priority.UNDEFINED, "", "");
     applicationReports.add(newApplicationReport5);
 
     ApplicationId applicationId6 = ApplicationId.newInstance(1234, 10);
@@ -753,7 +755,7 @@ public class TestYarnCLI {
 
     // Test command yarn application with tags.
     sysOutStream.reset();
-    Set<String> appTag1 = Sets.newHashSet("tag1");
+    Set<String> appTag1 = new HashSet<>(Collections.singleton("tag1"));
     when(client.getApplications(appType1, appState1, appTag1)).thenReturn(
         getApplicationReports(
             applicationReports, appType1, appState1, appTag1, false));
@@ -826,8 +828,8 @@ public class TestYarnCLI {
     verify(sysOut, times(8)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
-    Set<String> appType9 = Sets.newHashSet("YARN");
-    Set<String> appTag2 = Sets.newHashSet("tag3");
+    Set<String> appType9 = new HashSet<>(Collections.singleton("YARN"));
+    Set<String> appTag2 = new HashSet<>(Collections.singleton("tag3"));
     when(client.getApplications(appType9, appState1, appTag2)).thenReturn(
         getApplicationReports(
             applicationReports, appType9, appState1, appTag2, false));
@@ -855,8 +857,8 @@ public class TestYarnCLI {
     verify(sysOut, times(9)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
-    Set<String> appType10 = Sets.newHashSet("HIVE");
-    Set<String> appTag3 = Sets.newHashSet("tag4");
+    Set<String> appType10 = new HashSet<>(Collections.singleton("HIVE"));
+    Set<String> appTag3 = new HashSet<>(Collections.singleton("tag4"));
     EnumSet<YarnApplicationState> appState10 =
         EnumSet.of(YarnApplicationState.ACCEPTED);
     when(client.getApplications(appType10, appState10, appTag3)).thenReturn(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestYarnCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestYarnCLI.java
@@ -53,7 +53,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.UpdateApplicationTimeoutsRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.UpdateApplicationTimeoutsResponse;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/GetNodesToLabelsResponsePBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/GetNodesToLabelsResponsePBImpl.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.api.protocolrecords.impl.pb;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class GetNodesToLabelsResponsePBImpl extends
 
     for (NodeIdToLabelsProto c : list) {
       this.nodeToLabels.put(new NodeIdPBImpl(c.getNodeId()),
-          Sets.newHashSet(c.getNodeLabelsList()));
+          new HashSet<>(c.getNodeLabelsList()));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogFormat.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogFormat.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.math3.util.Pair;
@@ -66,7 +68,6 @@ import org.apache.hadoop.io.SecureIOUtils;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.file.tfile.TFile;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.LogAggregationContext;
@@ -76,7 +77,6 @@ import org.apache.hadoop.yarn.util.Times;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.thirdparty.com.google.common.collect.Iterables;
 
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_SEQUENTIAL;
@@ -360,10 +360,9 @@ public class AggregatedLogFormat {
               : this.logAggregationContext.getRolledLogsExcludePattern(),
           candidates, true);
 
-      Iterable<File> mask = Iterables.filter(candidates, (input) ->
-          !alreadyUploadedLogFiles
-              .contains(getLogFileMetaData(input)));
-      return Sets.newHashSet(mask);
+      return candidates.stream().filter(x -> x.isFile() &&
+          !alreadyUploadedLogFiles.contains(x)).collect(Collectors.toSet());
+
     }
 
     private void filterFiles(String pattern, Set<File> candidates,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/op/RemoveClusterLabelOp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/nodelabels/store/op/RemoveClusterLabelOp.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.yarn.nodelabels.store.op;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager;
 import org.apache.hadoop.yarn.proto.YarnServerResourceManagerServiceProtos;
 import org.apache.hadoop.yarn.server.api.protocolrecords
@@ -29,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * Remove label from cluster log store operation.
@@ -45,7 +45,7 @@ public class RemoveClusterLabelOp
       throws IOException {
     ((RemoveFromClusterNodeLabelsRequestPBImpl)
         RemoveFromClusterNodeLabelsRequest
-        .newInstance(Sets.newHashSet(labels.iterator()))).getProto()
+        .newInstance(new HashSet<>(labels))).getProto()
         .writeDelimitedTo(os);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/server/api/protocolrecords/impl/pb/ReplaceLabelsOnNodeRequestPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/server/api/protocolrecords/impl/pb/ReplaceLabelsOnNodeRequestPBImpl.java
@@ -19,13 +19,13 @@
 package org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.impl.pb.NodeIdPBImpl;
 import org.apache.hadoop.yarn.proto.YarnProtos.NodeIdProto;
@@ -62,7 +62,7 @@ public class ReplaceLabelsOnNodeRequestPBImpl extends
 
     for (NodeIdToLabelsProto c : list) {
       this.nodeIdToLabels.put(new NodeIdPBImpl(c.getNodeId()),
-          Sets.newHashSet(c.getNodeLabelsList()));
+          new HashSet<>(c.getNodeLabelsList()));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet2/HamletGen.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet2/HamletGen.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -61,8 +62,8 @@ public class HamletGen {
 
   int bytes = 0;
   PrintWriter out;
-  final Set<String> endTagOptional = Sets.newHashSet();
-  final Set<String> inlineElements = Sets.newHashSet();
+  final Set<String> endTagOptional = new HashSet<>();
+  final Set<String> inlineElements = new HashSet<>();
   Class<?> top; // html top-level interface
   String hamlet; // output class simple name;
   boolean topMode;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet2/HamletGen.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet2/HamletGen.java
@@ -33,7 +33,6 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.webapp.WebAppException;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/BasePBImplRecordsTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/BasePBImplRecordsTest.java
@@ -116,7 +116,7 @@ public class BasePBImplRecordsTest {
       } if (rawType.equals(List.class)) {
         ret = Lists.newArrayList(genTypeValue(params[0]));
       } else if (rawType.equals(Set.class)) {
-        ret = Sets.newHashSet(genTypeValue(params[0]));
+        ret = new HashSet<>(Collections.singleton(genTypeValue(params[0])));
       } else if (rawType.equals(Map.class)) {
         Map<Object, Object> map = Maps.newHashMap();
         map.put(genTypeValue(params[0]), genTypeValue(params[1]));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/BasePBImplRecordsTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/BasePBImplRecordsTest.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.yarn.api;
 
 import org.apache.commons.lang3.Range;
 import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraints;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/TestGetApplicationsRequestPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/TestGetApplicationsRequestPBImpl.java
@@ -22,10 +22,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.proto.YarnServiceProtos.GetApplicationsRequestProto;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +42,7 @@ public class TestGetApplicationsRequestPBImpl {
 
   @Test
   public void testAppTagsLowerCaseConversionDefault() {
-    impl.setApplicationTags(Sets.newHashSet("ABcd", "efgH"));
+    impl.setApplicationTags(new HashSet<>(Arrays.asList("ABcd", "efgH")));
     impl.getApplicationTags().forEach(s ->
         assertEquals(s, s.toLowerCase()));
   }
@@ -49,7 +50,7 @@ public class TestGetApplicationsRequestPBImpl {
   @Test
   public void testAppTagsLowerCaseConversionDisabled() {
     GetApplicationsRequestPBImpl.setForceLowerCaseTags(false);
-    impl.setApplicationTags(Sets.newHashSet("ABcd", "efgH"));
+    impl.setApplicationTags(new HashSet<>(Arrays.asList("ABcd", "efgH")));
     impl.getApplicationTags().forEach(s ->
         assertNotEquals(s, s.toLowerCase()));
   }
@@ -57,7 +58,7 @@ public class TestGetApplicationsRequestPBImpl {
   @Test
   public void testAppTagsLowerCaseConversionEnabled() {
     GetApplicationsRequestPBImpl.setForceLowerCaseTags(true);
-    impl.setApplicationTags(Sets.newHashSet("ABcd", "efgH"));
+    impl.setApplicationTags(new HashSet<>(Arrays.asList("ABcd", "efgH")));
     impl.getApplicationTags().forEach(s ->
         assertEquals(s, s.toLowerCase()));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/records/impl/pb/TestApplicationSubmissionContextPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/api/records/impl/pb/TestApplicationSubmissionContextPBImpl.java
@@ -22,10 +22,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.proto.YarnProtos.ApplicationSubmissionContextProto;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +42,7 @@ public class TestApplicationSubmissionContextPBImpl {
 
   @Test
   public void testAppTagsLowerCaseConversionDefault() {
-    impl.setApplicationTags(Sets.newHashSet("ABcd", "efgH"));
+    impl.setApplicationTags(new HashSet<>(Arrays.asList("ABcd", "efgH")));
     impl.getApplicationTags().forEach(s ->
         assertEquals(s, s.toLowerCase()));
   }
@@ -49,7 +50,7 @@ public class TestApplicationSubmissionContextPBImpl {
   @Test
   public void testAppTagsLowerCaseConversionDisabled() {
     ApplicationSubmissionContextPBImpl.setForceLowerCaseTags(false);
-    impl.setApplicationTags(Sets.newHashSet("ABcd", "efgH"));
+    impl.setApplicationTags(new HashSet<>(Arrays.asList("ABcd", "efgH")));
     impl.getApplicationTags().forEach(s ->
         assertNotEquals(s, s.toLowerCase()));
   }
@@ -57,7 +58,7 @@ public class TestApplicationSubmissionContextPBImpl {
   @Test
   public void testAppTagsLowerCaseConversionEnabled() {
     ApplicationSubmissionContextPBImpl.setForceLowerCaseTags(true);
-    impl.setApplicationTags(Sets.newHashSet("ABcd", "efgH"));
+    impl.setApplicationTags(new HashSet<>(Arrays.asList("ABcd", "efgH")));
     impl.getApplicationTags().forEach(s ->
         assertEquals(s, s.toLowerCase()));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/NodeLabelTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/NodeLabelTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.nodelabels;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,7 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.junit.Assert;
@@ -120,8 +120,7 @@ public class NodeLabelTestBase {
 
   @SuppressWarnings("unchecked")
   public static <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
   
   public static Set<NodeLabel> toNodeLabelSet(String... nodeLabelsStr) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestCommonNodeLabelsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/nodelabels/TestCommonNodeLabelsManager.java
@@ -23,13 +23,13 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -62,14 +62,14 @@ public class TestCommonNodeLabelsManager extends NodeLabelTestBase {
   public void testAddRemovelabel() throws Exception {
     // Add some label
     mgr.addToCluserNodeLabelsWithDefaultExclusivity(ImmutableSet.of("hello"));
-    verifyNodeLabelAdded(Sets.newHashSet("hello"), mgr.lastAddedlabels);
+    verifyNodeLabelAdded(new HashSet<>(Collections.singleton("hello")), mgr.lastAddedlabels);
 
     mgr.addToCluserNodeLabelsWithDefaultExclusivity(ImmutableSet.of("world"));
     mgr.addToCluserNodeLabelsWithDefaultExclusivity(toSet("hello1", "world1"));
-    verifyNodeLabelAdded(Sets.newHashSet("hello1", "world1"), mgr.lastAddedlabels);
+    verifyNodeLabelAdded(new HashSet<>(Arrays.asList("hello1", "world1")), mgr.lastAddedlabels);
 
     Assert.assertTrue(mgr.getClusterNodeLabelNames().containsAll(
-        Sets.newHashSet("hello", "world", "hello1", "world1")));
+        new HashSet<>(Arrays.asList("hello", "world", "hello1", "world1"))));
     try {
       mgr.addToCluserNodeLabels(Arrays.asList(NodeLabel.newInstance("hello1",
           false)));
@@ -100,14 +100,14 @@ public class TestCommonNodeLabelsManager extends NodeLabelTestBase {
 
     // Remove some label
     mgr.removeFromClusterNodeLabels(Arrays.asList("hello"));
-    assertCollectionEquals(Sets.newHashSet("hello"), mgr.lastRemovedlabels);
+    assertCollectionEquals(new HashSet<>(Collections.singleton("hello")), mgr.lastRemovedlabels);
     Assert.assertTrue(mgr.getClusterNodeLabelNames().containsAll(
         Arrays.asList("world", "hello1", "world1")));
 
     mgr.removeFromClusterNodeLabels(Arrays
         .asList("hello1", "world1", "world"));
-    Assert.assertTrue(mgr.lastRemovedlabels.containsAll(Sets.newHashSet(
-        "hello1", "world1", "world")));
+    Assert.assertTrue(mgr.lastRemovedlabels.containsAll(new HashSet<>(Arrays.asList(
+        "hello1", "world1", "world"))));
     Assert.assertTrue(mgr.getClusterNodeLabelNames().isEmpty());
   }
 
@@ -115,7 +115,7 @@ public class TestCommonNodeLabelsManager extends NodeLabelTestBase {
   public void testAddlabelWithCase() throws Exception {
     // Add some label, case will not ignore here
     mgr.addToCluserNodeLabelsWithDefaultExclusivity(ImmutableSet.of("HeLlO"));
-    verifyNodeLabelAdded(Sets.newHashSet("HeLlO"), mgr.lastAddedlabels);
+    verifyNodeLabelAdded(new HashSet<>(Collections.singleton("HeLlO")), mgr.lastAddedlabels);
     Assert.assertFalse(mgr.getClusterNodeLabelNames().containsAll(
         Arrays.asList("hello")));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestProtocolRecords.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestProtocolRecords.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +32,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
@@ -181,10 +181,10 @@ public class TestProtocolRecords {
     record.setNodeStatus(nodeStatus);
 
     Set<NodeAttribute> attributeSet =
-        Sets.newHashSet(NodeAttribute.newInstance("attributeA",
+        new HashSet<>(Arrays.asList(NodeAttribute.newInstance("attributeA",
                 NodeAttributeType.STRING, "valueA"),
             NodeAttribute.newInstance("attributeB",
-                NodeAttributeType.STRING, "valueB"));
+                NodeAttributeType.STRING, "valueB")));
     record.setNodeAttributes(attributeSet);
 
     NodeHeartbeatRequestPBImpl pb = new

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/FpgaDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/FpgaDiscoverer.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugi
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -30,7 +32,6 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -120,7 +121,7 @@ public class FpgaDiscoverer extends Configured {
       currentFpgaInfo = ImmutableList.copyOf(list);
       return list;
     } else if (allowed.matches("(\\d,)*\\d")){
-      Set<String> minors = Sets.newHashSet(allowed.split(","));
+      Set<String> minors = new HashSet<>(Arrays.asList(allowed.split(",")));
 
       // Replace list with a filtered one
       list = list

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/GpuDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/GpuDiscoverer.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.GpuDeviceInformation;
@@ -42,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -328,7 +328,7 @@ public class GpuDiscoverer extends Configured {
   }
 
   private File lookupBinaryInDefaultDirsInternal() {
-    Set<String> triedBinaryPaths = Sets.newHashSet();
+    Set<String> triedBinaryPaths = new HashSet<>();
     for (String dir : DEFAULT_BINARY_SEARCH_DIRS) {
       File binaryPath = new File(dir, DEFAULT_BINARY_NAME);
       if (binaryPath.exists()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunchParameterized.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunchParameterized.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.launcher;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.Shell;
 import org.junit.Assert;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -146,6 +147,6 @@ public class TestContainerLaunchParameterized {
   }
 
   private static Set<String> asSet(String... str) {
-    return Sets.newHashSet(str);
+    return new HashSet<>(Arrays.asList(str));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
@@ -66,7 +66,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionMatcher;
 import org.apache.hadoop.yarn.server.nodemanager.executor.LocalizerStartContext;
@@ -1396,8 +1395,8 @@ public class TestResourceLocalizationService {
     verify(containerBus).handle(argThat(successContainerLoc));
 
     Set<Path> paths =
-        Sets.newHashSet(new Path(locPath1), new Path(locPath1 + "_tmp"),
-            new Path(locPath2), new Path(locPath2 + "_tmp"));
+        new HashSet<>(Arrays.asList(new Path(locPath1), new Path(locPath1 + "_tmp"),
+            new Path(locPath2), new Path(locPath2 + "_tmp")));
     // Wait for localizer runner thread for container c1 to finish.
     while (locC1.getState() != Thread.State.TERMINATED) {
       Thread.sleep(50);
@@ -1543,8 +1542,8 @@ public class TestResourceLocalizationService {
     verify(containerBus).handle(argThat(successContainerLoc));
 
     Set<Path> paths =
-        Sets.newHashSet(new Path(locPath1), new Path(locPath1 + "_tmp"),
-            new Path(locPath2), new Path(locPath2 + "_tmp"));
+        new HashSet<>(Arrays.asList(new Path(locPath1), new Path(locPath1 + "_tmp"),
+            new Path(locPath2), new Path(locPath2 + "_tmp")));
     // Wait for localizer runner thread for container c1 to finish.
     while (locC2.getState() != Thread.State.TERMINATED) {
       Thread.sleep(50);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
@@ -383,8 +383,8 @@ public class TestNECVEPlugin {
     VEDeviceDiscoverer veDeviceDiscoverer = mock(VEDeviceDiscoverer.class);
     when(mockEnvProvider.apply(eq("NEC_USE_UDEV"))).thenReturn("true");
     Device testDevice = getTestDevice(0);
-    when(veDeviceDiscoverer.getDevicesFromPath(anyString()))
-      .thenReturn(new HashSet<>(Collections.singleton(testDevice)));
+    when(veDeviceDiscoverer.getDevicesFromPath(anyString())).thenReturn(
+        new HashSet<>(Collections.singleton(testDevice)));
     plugin = new NECVEPlugin(mockEnvProvider, defaultSearchDirs, udevUtil);
     plugin.setVeDeviceDiscoverer(veDeviceDiscoverer);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.apache.commons.compress.utils.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Shell.CommandExecutor;
@@ -385,7 +384,7 @@ public class TestNECVEPlugin {
     when(mockEnvProvider.apply(eq("NEC_USE_UDEV"))).thenReturn("true");
     Device testDevice = getTestDevice(0);
     when(veDeviceDiscoverer.getDevicesFromPath(anyString()))
-      .thenReturn(Sets.newHashSet(testDevice));
+      .thenReturn(new HashSet<>(Collections.singleton(testDevice)));
     plugin = new NECVEPlugin(mockEnvProvider, defaultSearchDirs, udevUtil);
     plugin.setVeDeviceDiscoverer(veDeviceDiscoverer);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleValidationContextImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleValidationContextImpl.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerQueueManager;
@@ -36,12 +35,12 @@ public class MappingRuleValidationContextImpl
   /**
    * We store all known variables in this set.
    */
-  private Set<String> knownVariables = Sets.newHashSet();
+  private Set<String> knownVariables = new HashSet<>();
 
   /**
    * This set is to determine which variables are immutable.
    */
-  private Set<String> immutableVariables = Sets.newHashSet();
+  private Set<String> immutableVariables = new HashSet<>();
 
   /**
    * For queue path validations we need an instance of the queue manager

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -180,7 +181,7 @@ public class QueueMetrics implements MetricsSource {
     "AggregatePreemptedSeconds.";
   private static final String AGGREGATE_PREEMPTED_SECONDS_METRIC_DESC =
     "Aggregate Preempted Seconds for NAME";
-  protected Set<String> storedPartitionMetrics = Collections.newSetFromMap(new ConcurrentHashMap());
+  protected Set<String> storedPartitionMetrics = Sets.newConcurrentHashSet();
 
   public QueueMetrics(MetricsSystem ms, String queueName, Queue parent,
       boolean enableUserMetrics, Configuration conf) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -21,9 +21,11 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
 import static org.apache.hadoop.metrics2.lib.Interns.info;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -41,7 +43,6 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -179,7 +180,7 @@ public class QueueMetrics implements MetricsSource {
     "AggregatePreemptedSeconds.";
   private static final String AGGREGATE_PREEMPTED_SECONDS_METRIC_DESC =
     "Aggregate Preempted Seconds for NAME";
-  protected Set<String> storedPartitionMetrics = Sets.newConcurrentHashSet();
+  protected Set<String> storedPartitionMetrics = Collections.newSetFromMap(new ConcurrentHashMap());
 
   public QueueMetrics(MetricsSystem ms, String queueName, Queue parent,
       boolean enableUserMetrics, Configuration conf) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/allocation/AllocationFileParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/allocation/AllocationFileParser.java
@@ -17,7 +17,6 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocation;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.AllocationConfigurationException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.ConfigurableResource;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerConfiguration;
@@ -32,7 +31,9 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,13 +79,13 @@ public class AllocationFileParser {
       "defaultQueueSchedulingMode";
 
   private static final Set<String> VALID_TAG_NAMES =
-      Sets.newHashSet(QUEUE_MAX_RESOURCES_DEFAULT, USER_MAX_APPS_DEFAULT,
+      new HashSet<>(Arrays.asList(QUEUE_MAX_RESOURCES_DEFAULT, USER_MAX_APPS_DEFAULT,
           DEFAULT_FAIR_SHARE_PREEMPTION_TIMEOUT, FAIR_SHARE_PREEMPTION_TIMEOUT,
           DEFAULT_MIN_SHARE_PREEMPTION_TIMEOUT, QUEUE_MAX_APPS_DEFAULT,
           DEFAULT_FAIR_SHARE_PREEMPTION_THRESHOLD, QUEUE_MAX_AM_SHARE_DEFAULT,
           RESERVATION_PLANNER, RESERVATION_AGENT, RESERVATION_ADMISSION_POLICY,
           QUEUE_PLACEMENT_POLICY, QUEUE, POOL, USER,
-          DEFAULT_QUEUE_SCHEDULING_POLICY, DEFAULT_QUEUE_SCHEDULING_MODE);
+          DEFAULT_QUEUE_SCHEDULING_POLICY, DEFAULT_QUEUE_SCHEDULING_MODE));
 
   private final NodeList elements;
   private final Map<String, String> textValues = Maps.newHashMap();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/QueuePlacementConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/QueuePlacementConverter.java
@@ -16,10 +16,11 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.DefaultPlacementRule;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.FSPlacementRule;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.PlacementManager;
@@ -40,12 +41,12 @@ class QueuePlacementConverter {
   private static final FallbackResult SKIP_RESULT = FallbackResult.SKIP;
   private static final String DEFAULT_QUEUE = "root.default";
   private static final String MATCH_ALL_USER = "*";
-  private static final Set<Policy> NEED_ROOT_PARENT = Sets.newHashSet(
+  private static final Set<Policy> NEED_ROOT_PARENT = new HashSet<>(Arrays.asList(
       Policy.USER,
       Policy.PRIMARY_GROUP,
       Policy.PRIMARY_GROUP_USER,
       Policy.SECONDARY_GROUP,
-      Policy.SECONDARY_GROUP_USER);
+      Policy.SECONDARY_GROUP_USER));
 
   MappingRulesDescription convertPlacementPolicy(
       PlacementManager placementManager,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/ApplicationsRequestBuilder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/ApplicationsRequestBuilder.java
@@ -16,7 +16,6 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
@@ -25,15 +24,16 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity
 import org.apache.hadoop.yarn.webapp.BadRequestException;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.webapp.WebServices.parseQueries;
 
 public class ApplicationsRequestBuilder {
 
-  private Set<String> statesQuery = Sets.newHashSet();
-  private Set<String> users = Sets.newHashSetWithExpectedSize(1);
-  private Set<String> queues = Sets.newHashSetWithExpectedSize(1);
+  private Set<String> statesQuery = new HashSet<>();
+  private Set<String> users = new HashSet<>(1);
+  private Set<String> queues = new HashSet<>(1);
   private String limit = null;
   private Long limitNumber;
 
@@ -42,8 +42,8 @@ public class ApplicationsRequestBuilder {
   private long startedTimeEnd = Long.MAX_VALUE;
   private long finishTimeBegin = 0;
   private long finishTimeEnd = Long.MAX_VALUE;
-  private Set<String> appTypes = Sets.newHashSet();
-  private Set<String> appTags = Sets.newHashSet();
+  private Set<String> appTypes = new HashSet<>();
+  private Set<String> appTags = new HashSet<>();
   private String name = null;
   private ResourceManager rm;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
@@ -40,7 +40,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HtmlQuoting;
 import org.apache.hadoop.http.IsActiveServlet;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
@@ -25,6 +25,8 @@ import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
@@ -67,9 +69,9 @@ public class RMWebAppFilter extends GuiceContainer {
   private static final long serialVersionUID = 1L;
 
   // define a set of URIs which do not need to do redirection
-  private static final Set<String> NON_REDIRECTED_URIS = Sets.newHashSet(
+  private static final Set<String> NON_REDIRECTED_URIS = new HashSet<>(Arrays.asList(
       "/conf", "/stacks", "/logLevel", "/logs", IsActiveServlet.PATH_SPEC,
-      "/jmx", "/prom");
+      "/jmx", "/prom"));
   private String path;
   private boolean ahsEnabled;
   private String ahsPageURLPrefix;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -103,6 +103,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1644,7 +1645,7 @@ public class TestAppManager extends AppManagerTestBase{
     when(app.getApplicationType()).thenReturn("MAPREDUCE");
     when(app.getSubmitTime()).thenReturn(1000L);
     when(app.getLaunchTime()).thenReturn(2000L);
-    when(app.getApplicationTags()).thenReturn(Sets.newHashSet("tag2", "tag1"));
+    when(app.getApplicationTags()).thenReturn(new HashSet<>(Arrays.asList("tag2", "tag1")));
 
     RMAppAttempt mockRMAppAttempt = mock(RMAppAttempt.class);
     Container mockContainer = mock(Container.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestClientRMService.java
@@ -59,7 +59,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.MockApps;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.ApplicationsRequestScope;
@@ -1439,17 +1438,17 @@ public class TestClientRMService {
     assertEquals("Incorrect number of matching tags", 6,
         rmService.getApplications(request).getApplicationList().size());
 
-    tagSet = Sets.newHashSet(tags.get(0));
+    tagSet = new HashSet<>(Collections.singleton(tags.get(0)));
     request.setApplicationTags(tagSet);
     assertEquals("Incorrect number of matching tags", 3,
         rmService.getApplications(request).getApplicationList().size());
 
-    tagSet = Sets.newHashSet(tags.get(1));
+    tagSet = new HashSet<>(Collections.singleton(tags.get(1)));
     request.setApplicationTags(tagSet);
     assertEquals("Incorrect number of matching tags", 2,
         rmService.getApplications(request).getApplicationList().size());
 
-    tagSet = Sets.newHashSet(tags.get(2));
+    tagSet = new HashSet<>(Collections.singleton(tags.get(2)));
     request.setApplicationTags(tagSet);
     assertEquals("Incorrect number of matching tags", 1,
         rmService.getApplications(request).getApplicationList().size());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMRestart.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMRestart.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.service.Service.STATE;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.FinishApplicationMasterRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
@@ -2584,8 +2583,7 @@ public class TestRMRestart extends ParameterizedSchedulerTestBase {
   }
 
   private <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
 
   @Test(timeout = 20000)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
@@ -3161,7 +3161,7 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
     assertEquals(rmNode1.getState(), NodeState.DECOMMISSIONED);
     assertEquals(3, rm.getRMContext().getRMNodes().size());
     assertEquals(1, rm.getRMContext().getInactiveRMNodes().size());
-    assertEquals(Sets.newHashSet(nm1.getNodeId()),
+    assertEquals(new HashSet<>(Collections.singleton(nm1.getNodeId())),
         rm.getRMContext().getInactiveRMNodes().keySet());
 
     // remove nm1 from exclude hosts, so that it will be marked as untracked
@@ -3180,7 +3180,7 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
     assertEquals(rmNode2.getState(), NodeState.LOST);
     assertEquals(2, rm.getRMContext().getRMNodes().size());
     assertEquals(1, rm.getRMContext().getInactiveRMNodes().size());
-    assertEquals(Sets.newHashSet(nm2.getNodeId()),
+    assertEquals(new HashSet<>(Collections.singleton(nm2.getNodeId())),
         rm.getRMContext().getInactiveRMNodes().keySet());
     // confirmed that nm2 should be removed from inactive nodes in 1 second
     GenericTestUtils.waitFor(
@@ -3194,14 +3194,14 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
     assertEquals(rmNode3.getState(), NodeState.SHUTDOWN);
     assertEquals(1, rm.getRMContext().getRMNodes().size());
     assertEquals(1, rm.getRMContext().getInactiveRMNodes().size());
-    assertEquals(Sets.newHashSet(nm3.getNodeId()),
+    assertEquals(new HashSet<>(Collections.singleton(nm3.getNodeId())),
         rm.getRMContext().getInactiveRMNodes().keySet());
     // confirmed that nm3 should be removed from inactive nodes in 1 second
     GenericTestUtils.waitFor(
         () -> rm.getRMContext().getInactiveRMNodes().size() == 0, 100, 1000);
 
     // nm4 is still active node at last
-    assertEquals(Sets.newHashSet(nm4.getNodeId()),
+    assertEquals(new HashSet<>(Collections.singleton(nm4.getNodeId())),
         rm.getRMContext().getRMNodes().keySet());
 
     rm.close();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/TestNodeAttributesManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/TestNodeAttributesManager.java
@@ -35,6 +35,8 @@ import org.junit.After;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -129,13 +131,13 @@ public class TestNodeAttributesManager {
     //  yarn.test1.io/A2
     //  yarn.test1.io/A3
     Set<NodeAttribute> clusterAttributes = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(PREFIXES[0]));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(PREFIXES[0])));
     Assert.assertEquals(3, clusterAttributes.size());
 
     // Query for attributes under a non-exist prefix,
     // ensure it returns an empty set.
     clusterAttributes = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet("non_exist_prefix"));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton("non_exist_prefix")));
     Assert.assertEquals(0, clusterAttributes.size());
 
     // Not provide any prefix, ensure it returns all attributes.
@@ -216,13 +218,13 @@ public class TestNodeAttributesManager {
     Assert.assertEquals(4, nodeAttributes.size());
 
     allAttributesPerPrefix = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(PREFIXES[0]));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(PREFIXES[0])));
     Assert.assertEquals(3, allAttributesPerPrefix.size());
     allAttributesPerPrefix = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(PREFIXES[1]));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(PREFIXES[1])));
     Assert.assertEquals(5, allAttributesPerPrefix.size());
     allAttributesPerPrefix = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(PREFIXES[2]));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(PREFIXES[2])));
     Assert.assertEquals(2, allAttributesPerPrefix.size());
 
     // Remove "yarn.test1.io/A_2" from host1
@@ -260,7 +262,7 @@ public class TestNodeAttributesManager {
     // get all attributes under prefix "yarn.test1.io" should only return
     // us A_1 and A_3.
     allAttributesPerPrefix = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(PREFIXES[0]));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(PREFIXES[0])));
     Assert.assertEquals(2, allAttributesPerPrefix.size());
   }
 
@@ -296,7 +298,7 @@ public class TestNodeAttributesManager {
     nodeAttributes = attributesManager.getAttributesForNode(HOSTNAMES[0]);
     Assert.assertEquals(13, nodeAttributes.size());
     clusterAttributes = attributesManager.getClusterNodeAttributes(
-        Sets.newHashSet(NodeAttribute.PREFIX_DISTRIBUTED, PREFIXES[0]));
+        new HashSet<>(Arrays.asList(NodeAttribute.PREFIX_DISTRIBUTED, PREFIXES[0])));
     Assert.assertEquals(13, clusterAttributes.size());
 
     // Replace by prefix
@@ -310,7 +312,7 @@ public class TestNodeAttributesManager {
     nodeAttributes = attributesManager.getAttributesForNode(HOSTNAMES[0]);
     Assert.assertEquals(8, nodeAttributes.size());
     clusterAttributes = attributesManager.getClusterNodeAttributes(
-        Sets.newHashSet(NodeAttribute.PREFIX_DISTRIBUTED, PREFIXES[0]));
+        new HashSet<>(Arrays.asList(NodeAttribute.PREFIX_DISTRIBUTED, PREFIXES[0])));
     Assert.assertEquals(8, clusterAttributes.size());
 
     // Now we have 5 distributed attributes
@@ -337,7 +339,7 @@ public class TestNodeAttributesManager {
     nodeAttributes = attributesManager.getAttributesForNode(HOSTNAMES[0]);
     Assert.assertEquals(4, nodeAttributes.size());
     clusterAttributes = attributesManager.getClusterNodeAttributes(
-        Sets.newHashSet(NodeAttribute.PREFIX_DISTRIBUTED));
+        new HashSet<>(Collections.singleton(NodeAttribute.PREFIX_DISTRIBUTED)));
     Assert.assertEquals(1, clusterAttributes.size());
     NodeAttribute attr = clusterAttributes.iterator().next();
     Assert.assertEquals("dist-node-attribute-v2_0",
@@ -354,11 +356,11 @@ public class TestNodeAttributesManager {
     nodeAttributes = attributesManager.getAttributesForNode(HOSTNAMES[0]);
     Assert.assertEquals(2, nodeAttributes.size());
     clusterAttributes = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(PREFIXES[1]));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(PREFIXES[1])));
     Assert.assertEquals(2, clusterAttributes.size());
     clusterAttributes = attributesManager
-        .getClusterNodeAttributes(Sets.newHashSet(
-            NodeAttribute.PREFIX_DISTRIBUTED));
+        .getClusterNodeAttributes(new HashSet<>(Collections.singleton(
+            NodeAttribute.PREFIX_DISTRIBUTED)));
     Assert.assertEquals(0, clusterAttributes.size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/MockQueueHierarchyBuilder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/MockQueueHierarchyBuilder.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.ManagedP
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.ParentQueue;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ public class MockQueueHierarchyBuilder {
   private List<String> queuePaths = Lists.newArrayList();
   private List<String> managedParentQueues = Lists.newArrayList();
   private List<String> dynamicParentQueues = Lists.newArrayList();
-  private Set<String> ambiguous = Sets.newHashSet();
+  private Set<String> ambiguous = new HashSet<>();
   private Map<String, String> shortNameMapping = Maps.newHashMap();
   private CapacitySchedulerQueueManager queueManager;
   private Map<String, List<CSQueue>> childrenMap = Maps.newHashMap();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/MockQueueHierarchyBuilder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/MockQueueHierarchyBuilder.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server.resourcemanager.placement;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.apache.commons.compress.utils.Lists;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractCSQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CSQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerQueueManager;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRule.java
@@ -18,10 +18,12 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule;
 
+import java.util.Collections;
+import java.util.HashSet;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.VariableContext;
 import org.junit.Test;
@@ -109,7 +111,7 @@ public class TestMappingRule {
   public void testLegacyEvaluation() {
     VariableContext matching = setupVariables(
         "bob", "developer", "users", "MR");
-    matching.putExtraDataset("groups", Sets.newHashSet("developer"));
+    matching.putExtraDataset("groups", new HashSet<>(Collections.singleton("developer")));
     VariableContext mismatching = setupVariables(
         "joe", "tester", "admins", "Spark");
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
@@ -19,11 +19,13 @@
 package org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule;
 
 import junit.framework.TestCase;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.VariableContext;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 public class TestMappingRuleMatchers extends TestCase {
@@ -43,14 +45,15 @@ public class TestMappingRuleMatchers extends TestCase {
     matchingContext.put("%primary_group", "developers");
     matchingContext.put("%application", "TurboMR");
     matchingContext.put("%custom", "Matching string");
-    matchingContext.putExtraDataset("groups", Sets.newHashSet("developers"));
+    matchingContext.putExtraDataset("groups", new HashSet<>(Collections.singleton("developers")));
 
     VariableContext mismatchingContext = new VariableContext();
     mismatchingContext.put("%user", "dave");
     mismatchingContext.put("%primary_group", "testers");
     mismatchingContext.put("%application", "Tester APP");
     mismatchingContext.put("%custom", "Not matching string");
-    mismatchingContext.putExtraDataset("groups", Sets.newHashSet("testers"));
+    mismatchingContext.putExtraDataset("groups",
+        new HashSet<>(Collections.singleton("testers")));
 
     VariableContext emptyContext = new VariableContext();
 
@@ -188,17 +191,18 @@ public class TestMappingRuleMatchers extends TestCase {
     VariableContext developerBob = new VariableContext();
     developerBob.put("%user", "bob");
     developerBob.put("%primary_group", "developers");
-    developerBob.putExtraDataset("groups", Sets.newHashSet("developers"));
+    developerBob.putExtraDataset("groups",
+        new HashSet<>(Collections.singleton("developers")));
 
     VariableContext testerBob = new VariableContext();
     testerBob.put("%user", "bob");
     testerBob.put("%primary_group", "testers");
-    testerBob.putExtraDataset("groups", Sets.newHashSet("testers"));
+    testerBob.putExtraDataset("groups",new HashSet<>(Collections.singleton("testers")));
 
     VariableContext testerDave = new VariableContext();
     testerDave.put("%user", "dave");
     testerDave.put("%primary_group", "testers");
-    testerDave.putExtraDataset("groups", Sets.newHashSet("testers"));
+    testerDave.putExtraDataset("groups", new HashSet<>(Collections.singleton("testers")));
 
     VariableContext accountantDave = new VariableContext();
     accountantDave.put("%user", "dave");
@@ -260,10 +264,10 @@ public class TestMappingRuleMatchers extends TestCase {
   @Test
   public void testGroupMatching() {
     VariableContext letterGroups = new VariableContext();
-    letterGroups.putExtraDataset("groups", Sets.newHashSet("a", "b", "c"));
+    letterGroups.putExtraDataset("groups", new HashSet<>(Arrays.asList("a", "b", "c")));
 
     VariableContext numberGroups = new VariableContext();
-    numberGroups.putExtraDataset("groups", Sets.newHashSet("1", "2", "3"));
+    numberGroups.putExtraDataset("groups", new HashSet<>(Arrays.asList("1", "2", "3")));
 
     VariableContext noGroups = new VariableContext();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestMappingRuleMatchers.java
@@ -197,7 +197,7 @@ public class TestMappingRuleMatchers extends TestCase {
     VariableContext testerBob = new VariableContext();
     testerBob.put("%user", "bob");
     testerBob.put("%primary_group", "testers");
-    testerBob.putExtraDataset("groups",new HashSet<>(Collections.singleton("testers")));
+    testerBob.putExtraDataset("groups", new HashSet<>(Collections.singleton("testers")));
 
     VariableContext testerDave = new VariableContext();
     testerDave.put("%user", "dave");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,7 +38,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
@@ -468,7 +468,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
       SchedulingRequest sr = SchedulingRequest
           .newInstance(1l, Priority.newInstance(1),
               ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED),
-              Sets.newHashSet(testTag1),
+              new HashSet<>(Collections.singleton(testTag1)),
               ResourceSizing.newInstance(1, Resource.newInstance(1024, 1)),
               null);
 
@@ -476,7 +476,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
       SchedulingRequest sr1 = SchedulingRequest
           .newInstance(2l, Priority.newInstance(1),
               ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED),
-              Sets.newHashSet(testTag2),
+              new HashSet<>(Collections.singleton(testTag2)),
               ResourceSizing.newInstance(3, Resource.newInstance(1024, 1)),
               null);
 
@@ -577,7 +577,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
       SchedulingRequest sr = SchedulingRequest
           .newInstance(1L, Priority.newInstance(1),
               ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED),
-              Sets.newHashSet(testTag1),
+              new HashSet<>(Collections.singleton(testTag1)),
               ResourceSizing.newInstance(1, Resource.newInstance(1024, 1)),
               null);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerUtils.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterRequest;
@@ -243,7 +242,7 @@ public class TestSchedulerUtils {
           throws IOException {
     // mock queue and scheduler
     ResourceScheduler scheduler = mock(ResourceScheduler.class);
-    Set<String> queueAccessibleNodeLabels = Sets.newHashSet();
+    Set<String> queueAccessibleNodeLabels = new HashSet<>();
     QueueInfo queueInfo = mock(QueueInfo.class);
     when(queueInfo.getQueueName()).thenReturn("queue");
     when(queueInfo.getAccessibleNodeLabels())
@@ -792,7 +791,7 @@ public class TestSchedulerUtils {
           throws IOException {
     // mock queue and scheduler
     ResourceScheduler scheduler = mock(ResourceScheduler.class);
-    Set<String> queueAccessibleNodeLabels = Sets.newHashSet();
+    Set<String> queueAccessibleNodeLabels = new HashSet<>();
     QueueInfo queueInfo = mock(QueueInfo.class);
     when(queueInfo.getQueueName()).thenReturn("queue");
     when(queueInfo.getAccessibleNodeLabels()).thenReturn(queueAccessibleNodeLabels);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerTestUtilities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerTestUtilities.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.LocalConfigurationProvider;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -54,6 +53,8 @@ import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerQueueHelpers.setupQueueConfAmbiguousQueue;
@@ -69,7 +70,7 @@ public final class CapacitySchedulerTestUtilities {
 
   @SuppressWarnings("unchecked")
   public static <E> Set<E> toSet(E... elements) {
-    return Sets.newHashSet(elements);
+    return new HashSet<>(Arrays.asList(elements));
   }
 
   public static void checkPendingResource(MockRM rm, String queueName, int memory,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAMAllocatedToNonExclusivePartition.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAMAllocatedToNonExclusivePartition.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
@@ -64,8 +64,7 @@ public class TestAMAllocatedToNonExclusivePartition {
 
   @SuppressWarnings("unchecked")
   private <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
@@ -29,7 +29,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,7 +39,6 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -765,8 +766,7 @@ public class TestApplicationLimits {
   }
 
   private Set<String> toSet(String... elements) {
-    Set<String> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
 
   @Test(timeout = 120000)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacityScheduler.java
@@ -74,12 +74,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.service.ServiceStateException;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
@@ -642,7 +642,7 @@ public class TestCapacityScheduler {
     conf.setQueues("root", new String[] {childQueue});
     conf.setCapacity("root." + childQueue, "[memory=20480,vcores=200]");
     conf.setAccessibleNodeLabels("root." + childQueue,
-        Sets.newHashSet(labelName));
+        new HashSet<>(Collections.singleton(labelName)));
     conf.setCapacityByLabel("root", labelName, "[memory=10240,vcores=100]");
     conf.setCapacityByLabel("root." + childQueue, labelName,
         "[memory=4096,vcores=10]");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAutoQueueCreation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAutoQueueCreation.java
@@ -1029,7 +1029,7 @@ public class TestCapacitySchedulerAutoQueueCreation
           .withUser("hadoop")
           .withAcls(null)
           .withUnmanagedAM(false)
-          .withApplicationTags(Sets.newHashSet("userid=testuser"))
+          .withApplicationTags(new HashSet<>(Collections.singleton("userid=testuser")))
           .build();
       RMApp app = MockRMAppSubmitter.submit(mockRM, data);
       MockRM.launchAndRegisterAM(app, mockRM, nm);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAutoQueueCreation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAutoQueueCreation.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -18,10 +18,12 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.AccessControlList;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.QueueACL;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ROOT;
@@ -138,8 +140,8 @@ public class TestCapacitySchedulerConfiguration {
 
   @Test
   public void testSpecifiedSubmitACLForRoot() {
-    Set<String> expectedUsers = Sets.newHashSet(USER1);
-    Set<String> expectedGroups = Sets.newHashSet(GROUP1);
+    Set<String> expectedUsers = new HashSet<>(Collections.singleton(USER1));
+    Set<String> expectedGroups = new HashSet<>(Collections.singleton(GROUP1));
     testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, ONE_USER_ONE_GROUP_ACL, expectedUsers,
         expectedGroups);
   }
@@ -151,8 +153,8 @@ public class TestCapacitySchedulerConfiguration {
 
   @Test
   public void testSpecifiedSubmitACLTwoUsersTwoGroupsForRoot() {
-    Set<String> expectedUsers = Sets.newHashSet(USER1, USER2);
-    Set<String> expectedGroups = Sets.newHashSet(GROUP1, GROUP2);
+    Set<String> expectedUsers = new HashSet<>(Arrays.asList(USER1, USER2));
+    Set<String> expectedGroups = new HashSet<>(Arrays.asList(GROUP1, GROUP2));
     testWithGivenAclCorrectUserAndGroupHasAccess(ROOT, TWO_USERS_TWO_GROUPS_ACL, expectedUsers,
         expectedGroups);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerMaxParallelApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerMaxParallelApps.java
@@ -22,7 +22,9 @@ import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.C
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -195,10 +197,9 @@ public class TestCapacitySchedulerMaxParallelApps {
     // Check that app attempt #3 and #4 are non-runnable
     rootQueue = getRootQueue();
     defaultQueue = getDefaultQueue();
-    Set<ApplicationAttemptId> nonRunnables =
-        Sets.newHashSet(
+    Set<ApplicationAttemptId> nonRunnables = new HashSet<>(Arrays.asList(
             attempt3.getAppAttemptId(),
-            attempt4.getAppAttemptId());
+            attempt4.getAppAttemptId()));
     verifyRunnableAppsInParent(rootQueue, 2);
     verifyRunnableAppsInLeaf(defaultQueue, 2, nonRunnables);
     verifyRunningAndAcceptedApps(2, 2);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerMaxParallelApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerMaxParallelApps.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsResponse;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNodeLabelUpdate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerNodeLabelUpdate.java
@@ -21,12 +21,12 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -141,8 +141,7 @@ public class TestCapacitySchedulerNodeLabelUpdate {
   }
 
   private Set<String> toSet(String... elements) {
-    Set<String> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
   
   private void checkUsedResource(MockRM rm, String queueName, int memory) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWeightMode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWeightMode.java
@@ -49,6 +49,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 public class TestCapacitySchedulerWeightMode {
@@ -72,8 +74,7 @@ public class TestCapacitySchedulerWeightMode {
   }
 
   public static <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
 
   public static CapacitySchedulerConfiguration getConfigWithInheritedAccessibleNodeLabel(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWeightMode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerWeightMode.java
@@ -22,7 +22,6 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestLeafQueue.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -5286,7 +5287,7 @@ public class TestLeafQueue {
 
     ParentQueue rootQueue = (ParentQueue) cs.getRootQueue();
 
-    Assert.assertEquals(Sets.newHashSet("", "test", "test2"),
+    Assert.assertEquals(new HashSet<>(Arrays.asList("", "test", "test2")),
         rootQueue.queueNodeLabelsSettings.getConfiguredNodeLabels());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestNodeLabelContainerAllocation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestNodeLabelContainerAllocation.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.MetricsSystem;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -153,8 +152,7 @@ public class TestNodeLabelContainerAllocation {
   
   @SuppressWarnings("unchecked")
   private <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
   
   

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestUtils.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.*;
 import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.Event;
@@ -52,6 +51,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -259,8 +260,7 @@ public class TestUtils {
 
   @SuppressWarnings("unchecked")
   public static <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestWorkPreservingRMRestartForNodeLabel.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestWorkPreservingRMRestartForNodeLabel.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -74,8 +74,7 @@ public class TestWorkPreservingRMRestartForNodeLabel {
   
   @SuppressWarnings("unchecked")
   private <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
   
   private void checkRMContainerLabelExpression(ContainerId containerId,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/placement/TestMappingRuleCreator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/placement/TestMappingRuleCreator.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placeme
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule.MappingRule;
@@ -69,7 +71,8 @@ public class TestMappingRuleCreator {
     variableContext.put("%secondary_group", SECONDARY_GROUP);
     variableContext.put("%default", DEFAULT_QUEUE);
     variableContext.putExtraDataset("groups",
-        Sets.newLinkedHashSet(PRIMARY_GROUP, SECONDARY_GROUP));
+        new LinkedHashSet<>(Arrays.asList(PRIMARY_GROUP, SECONDARY_GROUP)));
+
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementConstraintManagerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementConstraintManagerService.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.Placement
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -34,7 +35,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.SchedulingRequest;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint;
@@ -206,7 +206,7 @@ public class TestPlacementConstraintManagerService {
     // if the source tag in the request is not mapped to any existing
     // registered constraint, we should get an empty AND constraint.
     constraint = pcm.getMultilevelConstraint(appId1,
-        Sets.newHashSet("not_exist_tag"), null);
+        new HashSet<>(Collections.singleton("not_exist_tag")), null);
     Assert.assertTrue(constraint.getConstraintExpr() instanceof And);
     mergedConstraint = (And) constraint.getConstraintExpr();
     // AND()
@@ -224,8 +224,7 @@ public class TestPlacementConstraintManagerService {
     // AC = null
     // GC = tag1->c1
     pcm.addGlobalConstraint(sourceTag1, c1, true);
-    constraint = pcm.getMultilevelConstraint(appId1,
-        Sets.newHashSet(sourceTag1), null);
+    constraint = pcm.getMultilevelConstraint(appId1, sourceTag1, null);
     Assert.assertTrue(constraint.getConstraintExpr() instanceof And);
     mergedConstraint = (And) constraint.getConstraintExpr();
     // AND(c1)
@@ -253,7 +252,7 @@ public class TestPlacementConstraintManagerService {
     pcm.addGlobalConstraint(sourceTag1, c2, true);
     pcm.registerApplication(appId1, constraintMap1);
     constraint = pcm.getMultilevelConstraint(appId1,
-        Sets.newHashSet(sourceTag1), c1);
+        sourceTag1, c1);
     Assert.assertTrue(constraint.getConstraintExpr() instanceof And);
     mergedConstraint = (And) constraint.getConstraintExpr();
     // AND(c1, c2)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairScheduler.java
@@ -121,6 +121,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -4469,7 +4470,7 @@ public class TestFairScheduler extends FairSchedulerTestBase {
     // apps in subqueues should be included
     apps = scheduler.getAppsInQueue("queue1");
     Assert.assertEquals(2, apps.size());
-    Set<ApplicationAttemptId> appAttIds = Sets.newHashSet(apps.get(0), apps.get(1));
+    Set<ApplicationAttemptId> appAttIds = new HashSet<>(Arrays.asList(apps.get(0), apps.get(1)));
     assertTrue(appAttIds.contains(appAttId1));
     assertTrue(appAttIds.contains(appAttId2));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.hadoop.util.Sets;
@@ -183,7 +185,7 @@ public class TestQueueManager {
     AllocationConfiguration allocConf =
         new AllocationConfiguration(scheduler);
     allocConf.configuredQueues.get(FSQueueType.LEAF)
-        .addAll(Sets.newHashSet(confLeafQueues));
+        .addAll(new HashSet<>(Arrays.asList(confLeafQueues)));
     queueMgr.updateAllocationConfiguration(allocConf);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSQueueConverter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/TestFSQueueConverter.java
@@ -26,6 +26,9 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
@@ -59,7 +62,7 @@ public class TestFSQueueConverter {
   private static final Resource CLUSTER_RESOURCE =
       Resource.newInstance(16384, 16);
   private final static Set<String> ALL_QUEUES =
-      Sets.newHashSet("root",
+      new HashSet<>(Arrays.asList("root",
           "root.default",
           "root.admins",
           "root.users",
@@ -69,7 +72,7 @@ public class TestFSQueueConverter {
           "root.users.john",
           "root.misc",
           "root.misc.a",
-          "root.misc.b");
+          "root.misc.b"));
 
   private static final String FILE_PREFIX = "file:";
   private static final String FAIR_SCHEDULER_XML =
@@ -165,11 +168,11 @@ public class TestFSQueueConverter {
         csConfig.get(PREFIX + "root.users.queues"));
 
     Set<String> leafs = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root",
+        new HashSet<>(Arrays.asList("root",
             "root.default",
             "root.admins",
             "root.users",
-            "root.misc"));
+            "root.misc")));
 
     assertNoValueForQueues(leafs, ".queues", csConfig);
   }
@@ -190,7 +193,7 @@ public class TestFSQueueConverter {
             "root.admins.alice.maximum-am-resource-percent"));
 
     Set<String> remaining = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root.admins.bob", "root.admins.alice"));
+        new HashSet<>(Arrays.asList("root.admins.bob", "root.admins.alice")));
     assertNoValueForQueues(remaining, ".maximum-am-resource-percent",
         csConfig);
   }
@@ -206,7 +209,7 @@ public class TestFSQueueConverter {
             -1));
 
     Set<String> remaining = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root.admins.alice"));
+        new HashSet<>(Collections.singleton("root.admins.alice")));
     assertNoValueForQueues(remaining, ".max-parallel-apps", csConfig);
   }
 
@@ -230,7 +233,7 @@ public class TestFSQueueConverter {
         csConfig.getInt(PREFIX + "root.users.john.maximum-allocation-mb", -1));
 
     Set<String> remaining = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root.admins", "root.users.john"));
+        new HashSet<>(Arrays.asList("root.admins", "root.users.john")));
     assertNoValueForQueues(remaining, ".maximum-allocation-vcores", csConfig);
     assertNoValueForQueues(remaining, ".maximum-allocation-mb", csConfig);
   }
@@ -249,7 +252,7 @@ public class TestFSQueueConverter {
             false));
 
     Set<String> remaining = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root.admins.alice", "root.users.joe"));
+        new HashSet<>(Arrays.asList("root.admins.alice", "root.users.joe")));
     assertNoValueForQueues(remaining, ".disable_preemption", csConfig);
   }
 
@@ -352,11 +355,11 @@ public class TestFSQueueConverter {
             PREFIX + "root.misc.auto-queue-creation-v2.enabled", false));
 
     Set<String> leafs = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root",
+        new HashSet<>(Arrays.asList("root",
             "root.default",
             "root.admins",
             "root.users",
-            "root.misc"));
+            "root.misc")));
     assertNoValueForQueues(leafs, "auto-queue-creation-v2.enabled",
         csConfig);
   }
@@ -368,7 +371,7 @@ public class TestFSQueueConverter {
     converter.convertQueueHierarchy(rootQueue);
 
     Set<String> noZeroSumAllowedQueues = Sets.difference(ALL_QUEUES,
-        Sets.newHashSet("root.misc"));
+        new HashSet<>(Collections.singleton("root.misc")));
     assertNoValueForQueues(noZeroSumAllowedQueues, ".allow-zero-capacity-sum",
         csConfig);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestApplicationsRequestBuilder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestApplicationsRequestBuilder.java
@@ -16,7 +16,6 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
@@ -25,6 +24,9 @@ import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.webapp.WebServices.parseQueries;
@@ -83,7 +85,7 @@ public class TestApplicationsRequestBuilder {
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
     Set<String> appStates =
-        Sets.newHashSet(YarnApplicationState.NEW_SAVING.toString());
+        new HashSet<>(Collections.singleton(YarnApplicationState.NEW_SAVING.toString()));
     Set<String> appStatesLowerCase = parseQueries(appStates, true);
     expectedRequest.setApplicationStates(appStatesLowerCase);
 
@@ -93,7 +95,7 @@ public class TestApplicationsRequestBuilder {
   @Test
   public void testRequestWithEmptyStateQueries() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStatesQuery(Sets.newHashSet()).build();
+        .withStatesQuery(new HashSet<>()).build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
 
@@ -103,7 +105,7 @@ public class TestApplicationsRequestBuilder {
   @Test(expected = BadRequestException.class)
   public void testRequestWithInvalidStateQueries() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStatesQuery(Sets.newHashSet("a1", "a2", "")).build();
+        .withStatesQuery(new HashSet<>(Arrays.asList("a1", "a2", ""))).build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
 
@@ -124,14 +126,14 @@ public class TestApplicationsRequestBuilder {
   public void testRequestWithValidStateQueries() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
         .withStatesQuery(
-            Sets.newHashSet(YarnApplicationState.NEW_SAVING.toString(),
-                YarnApplicationState.NEW.toString()))
+            new HashSet<>(Arrays.asList(YarnApplicationState.NEW_SAVING.toString(),
+                YarnApplicationState.NEW.toString())))
         .build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
     Set<String> appStates =
-        Sets.newHashSet(YarnApplicationState.NEW_SAVING.toString(),
-            YarnApplicationState.NEW.toString());
+        new HashSet<>(Arrays.asList(YarnApplicationState.NEW_SAVING.toString(),
+            YarnApplicationState.NEW.toString()));
     Set<String> appStatesLowerCase = parseQueries(appStates, true);
     expectedRequest.setApplicationStates(appStatesLowerCase);
 
@@ -162,7 +164,7 @@ public class TestApplicationsRequestBuilder {
         ApplicationsRequestBuilder.create().withUserQuery("user1").build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setUsers(Sets.newHashSet("user1"));
+    expectedRequest.setUsers(new HashSet<>(Collections.singleton("user1")));
     assertEquals(expectedRequest, request);
   }
 
@@ -193,7 +195,7 @@ public class TestApplicationsRequestBuilder {
         .withQueueQuery(rm, "queue1").build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setQueues(Sets.newHashSet("queue1"));
+    expectedRequest.setQueues(new HashSet<>(Collections.singleton("queue1")));
     assertEquals(expectedRequest, request);
   }
 
@@ -209,7 +211,7 @@ public class TestApplicationsRequestBuilder {
         .withQueueQuery(rm, "queue1").build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setQueues(Sets.newHashSet("queue1"));
+    expectedRequest.setQueues(new HashSet<>(Collections.singleton("queue1")));
     assertEquals(expectedRequest, request);
   }
 
@@ -484,20 +486,20 @@ public class TestApplicationsRequestBuilder {
   @Test
   public void testRequestWithEmptyApplicationTypesQuery() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withApplicationTypes(Sets.newHashSet()).build();
+        .withApplicationTypes(new HashSet<>()).build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setApplicationTypes(Sets.newHashSet());
+    expectedRequest.setApplicationTypes(new HashSet<>());
     assertEquals(expectedRequest, request);
   }
 
   @Test
   public void testRequestWithValidApplicationTypesQuery() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withApplicationTypes(Sets.newHashSet("type1")).build();
+        .withApplicationTypes(new HashSet<>(Collections.singleton("type1"))).build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setApplicationTypes(Sets.newHashSet("type1"));
+    expectedRequest.setApplicationTypes(new HashSet<>(Collections.singleton("type1")));
     assertEquals(expectedRequest, request);
   }
 
@@ -510,20 +512,20 @@ public class TestApplicationsRequestBuilder {
   @Test
   public void testRequestWithEmptyApplicationTagsQuery() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withApplicationTags(Sets.newHashSet()).build();
+        .withApplicationTags(new HashSet<>()).build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setApplicationTags(Sets.newHashSet());
+    expectedRequest.setApplicationTags(new HashSet<>());
     assertEquals(expectedRequest, request);
   }
 
   @Test
   public void testRequestWithValidApplicationTagsQuery() {
     GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withApplicationTags(Sets.newHashSet("tag1")).build();
+        .withApplicationTags(new HashSet<>(Collections.singleton("tag1"))).build();
 
     GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setApplicationTags(Sets.newHashSet("tag1"));
+    expectedRequest.setApplicationTags(new HashSet<>(Collections.singleton("tag1")));
     assertEquals(expectedRequest, request);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServiceAppsNodelabel.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServiceAppsNodelabel.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.ws.rs.core.MediaType;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
@@ -239,7 +239,6 @@ public class TestRMWebServiceAppsNodelabel extends JerseyTestBase {
 
   @SuppressWarnings("unchecked")
   private <E> Set<E> toSet(E... elements) {
-    Set<E> set = Sets.newHashSet(elements);
-    return set;
+    return new HashSet<>(Arrays.asList(elements));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
@@ -30,7 +30,6 @@ import com.sun.jersey.test.framework.WebAppDescriptor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ContainerState;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
@@ -68,6 +67,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
@@ -115,7 +115,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
   }
 
   private Set<String> getApplicationIds(JSONArray array) throws JSONException {
-    Set<String> ids = Sets.newHashSet();
+    Set<String> ids = new HashSet<>();
     for (int i = 0; i < array.length(); i++) {
       JSONObject app = array.getJSONObject(i);
       String appId = (String) app.get("id");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
@@ -28,7 +28,6 @@ import com.sun.jersey.test.framework.WebAppDescriptor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.QueueState;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
@@ -59,7 +59,9 @@ import javax.ws.rs.core.Response.Status;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ACCESSIBLE_NODE_LABELS;
@@ -838,9 +840,9 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
 
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
 
-    assertEquals(Sets.newHashSet("*"),
+    assertEquals(new HashSet<>(Collections.singleton("*")),
         cs.getConfiguration().getAccessibleNodeLabels(ROOT.getFullPath()));
-    assertEquals(Sets.newHashSet(LABEL_1),
+    assertEquals(new HashSet<>(Collections.singleton(LABEL_1)),
         cs.getConfiguration().getAccessibleNodeLabels(ROOT_A.getFullPath()));
 
     // 4. Set partition capacities to queues as below
@@ -937,7 +939,7 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
                 SchedConfUpdateInfo.class)), MediaType.APPLICATION_JSON)
             .put(ClientResponse.class);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    assertEquals(Sets.newHashSet("*"),
+    assertEquals(new HashSet<>(Collections.singleton("*")),
         cs.getConfiguration().getAccessibleNodeLabels(ROOT.getFullPath()));
     assertNull(cs.getConfiguration().getAccessibleNodeLabels(ROOT_A.getFullPath()));
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.StringReader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,7 +42,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.http.JettyUtils;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.api.records.Priority;
@@ -270,7 +270,8 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
   public void testPartitionInSchedulerActivities() throws Exception {
     rm.start();
     rm.getRMContext().getNodeLabelManager().addLabelsToNode(ImmutableMap
-        .of(NodeId.newInstance("127.0.0.1", 0), Sets.newHashSet(LABEL_LX)));
+        .of(NodeId.newInstance("127.0.0.1", 0),
+            new HashSet<>(Collections.singleton(LABEL_LX))));
 
     MockNM nm1 = new MockNM("127.0.0.1:1234", 2 * 1024,
         rm.getResourceTrackerService());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerJsonVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerJsonVerifications.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp.fairscheduler;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.ResourceTypes;
 import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -39,14 +40,14 @@ import static org.junit.Assert.assertTrue;
 public class FairSchedulerJsonVerifications {
 
   private static final Set<String> RESOURCE_FIELDS =
-      Sets.newHashSet("minResources", "amUsedResources", "amMaxResources",
+      new HashSet<>(Arrays.asList("minResources", "amUsedResources", "amMaxResources",
           "fairResources", "clusterResources", "reservedResources",
               "maxResources", "usedResources", "steadyFairResources",
-              "demandResources");
+              "demandResources"));
   private final Set<String> customResourceTypes;
 
   FairSchedulerJsonVerifications(List<String> customResourceTypes) {
-    this.customResourceTypes = Sets.newHashSet(customResourceTypes);
+    this.customResourceTypes = new HashSet<>(customResourceTypes);
   }
 
   public void verify(JSONObject jsonObject) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp.fairscheduler;
 
-
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.ResourceTypes;
 import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.w3c.dom.Document;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
@@ -27,6 +27,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -43,14 +45,14 @@ import static org.junit.Assert.assertTrue;
  */
 public class FairSchedulerXmlVerifications {
 
-  private static final Set<String> RESOURCE_FIELDS = Sets.newHashSet(
+  private static final Set<String> RESOURCE_FIELDS = new HashSet<>(Arrays.asList(
       "minResources", "amUsedResources", "amMaxResources", "fairResources",
       "clusterResources", "reservedResources", "maxResources", "usedResources",
-      "steadyFairResources", "demandResources");
+      "steadyFairResources", "demandResources"));
   private final Set<String> customResourceTypes;
 
   FairSchedulerXmlVerifications(List<String> customResourceTypes) {
-    this.customResourceTypes = Sets.newHashSet(customResourceTypes);
+    this.customResourceTypes = new HashSet<>(customResourceTypes);
   }
 
   public void verify(Element element) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/ResourceRequestsXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/ResourceRequestsXmlVerifications.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.yarn.server.resourcemanager.webapp.helper;
 
 import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.protocolrecords.ResourceTypes;
 import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
@@ -28,6 +27,7 @@ import org.w3c.dom.NodeList;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,7 +83,7 @@ public class ResourceRequestsXmlVerifications {
         (Element) requestInfo.getElementsByTagName("capability").item(0);
 
     return extractCustomResorceTypes(capability,
-        Sets.newHashSet(expectedResourceTypes));
+        new HashSet<>(expectedResourceTypes));
   }
 
   private static Map<String, Long> extractCustomResorceTypes(Element capability,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/EntityGroupPlugInForTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/EntityGroupPlugInForTest.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntityGroupId;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -35,7 +37,7 @@ class EntityGroupPlugInForTest extends TimelineEntityGroupPlugin {
       Collection<NameValuePair> secondaryFilters) {
     ApplicationId appId = ApplicationId.fromString(
         primaryFilter.getValue().toString());
-    return Sets.newHashSet(getStandardTimelineGroupId(appId));
+    return new HashSet<>(Collections.singleton(getStandardTimelineGroupId(appId)));
   }
 
   @Override
@@ -43,14 +45,14 @@ class EntityGroupPlugInForTest extends TimelineEntityGroupPlugin {
       String entityType) {
     ApplicationId appId = ApplicationId.fromString(
         entityId);
-    return Sets.newHashSet(getStandardTimelineGroupId(appId));
+    return new HashSet<>(Collections.singleton(getStandardTimelineGroupId(appId)));
   }
 
   @Override
   public Set<TimelineEntityGroupId> getTimelineEntityGroupId(String entityType,
       SortedSet<String> entityIds,
       Set<String> eventTypes) {
-    return Sets.newHashSet();
+    return new HashSet<>();
   }
 
   static TimelineEntityGroupId getStandardTimelineGroupId(ApplicationId appId) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/EntityGroupPlugInForTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/EntityGroupPlugInForTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntityGroupId;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/main/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/CosmosDBDocumentStoreReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/main/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/CosmosDBDocumentStoreReader.java
@@ -23,7 +23,6 @@ import com.microsoft.azure.cosmosdb.FeedOptions;
 import com.microsoft.azure.cosmosdb.FeedResponse;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.timelineservice.reader.TimelineReaderContext;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.DocumentStoreUtils;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.NoDocumentFoundException;
@@ -36,6 +35,7 @@ import rx.Observable;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -115,7 +115,7 @@ public class CosmosDBDocumentStoreReader<TimelineDoc extends TimelineDocument>
     LOG.debug("Querying Collection : {} , with query {}", collectionName,
         sqlQuery);
 
-    return Sets.newHashSet(client.queryDocuments(
+    return new HashSet<>(client.queryDocuments(
         String.format(COLLECTION_LINK, databaseName, collectionName),
         sqlQuery, new FeedOptions())
         .map(FeedResponse::getResults) // Map the page to the list of documents

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/collector/TestTimelineCollector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/collector/TestTimelineCollector.java
@@ -38,6 +38,7 @@ import org.mockito.internal.stubbing.answers.AnswersWithDelay;
 import org.mockito.internal.stubbing.answers.Returns;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -303,7 +304,7 @@ public class TestTimelineCollector {
     // Aggregate the entities.
     Map<String, AggregationStatusTable> aggregationGroups
         = collector.getAggregationGroups();
-    assertEquals(Sets.newHashSet("type"), aggregationGroups.keySet());
+    assertEquals(new HashSet<>(Collections.singleton("type")), aggregationGroups.keySet());
     TimelineEntity aggregatedEntity = TimelineCollector.
         aggregateWithoutGroupId(aggregationGroups, currContext.getAppId(),
             TimelineEntityType.YARN_APPLICATION.toString());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/collector/TestTimelineCollector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/collector/TestTimelineCollector.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server.timelineservice.collector;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineDomain;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetricOperation;
 import org.apache.hadoop.yarn.api.records.ApplicationId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/reader/TestTimelineReaderWebServicesUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/reader/TestTimelineReaderWebServicesUtils.java
@@ -18,12 +18,15 @@
 
 package org.apache.hadoop.yarn.server.timelineservice.reader;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.timelineservice.reader.filter.TimelineCompareFilter;
 import org.apache.hadoop.yarn.server.timelineservice.reader.filter.TimelineCompareOp;
 import org.apache.hadoop.yarn.server.timelineservice.reader.filter.TimelineExistsFilter;
@@ -717,9 +720,9 @@ public class TestTimelineReaderWebServicesUtils {
     String expr = "type1:entity11,type2:entity21:entity22";
     TimelineFilterList expectedList = new TimelineFilterList(
         new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-            "type1", Sets.newHashSet((Object)"entity11")),
+            "type1", new HashSet<>(Collections.singleton((Object)"entity11"))),
         new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-            "type2", Sets.newHashSet((Object)"entity21", "entity22"))
+            "type2", new HashSet<>(Arrays.asList((Object)"entity21", "entity22")))
     );
     verifyFilterList(expr, TimelineReaderWebServicesUtils.
         parseRelationFilters(expr), expectedList);
@@ -733,18 +736,18 @@ public class TestTimelineReaderWebServicesUtils {
     expectedList = new TimelineFilterList(Operator.OR,
         new TimelineFilterList(
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type1", Sets.newHashSet((Object)"entity11")),
+                "type1", new HashSet<>(Collections.singleton((Object)"entity11"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type2", Sets.newHashSet((Object)"entity21", "entity22"))
+                "type2", new HashSet<>(Arrays.asList((Object)"entity21", "entity22"))
         ),
         new TimelineFilterList(
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type3", Sets.newHashSet(
-                    (Object)"entity31", "entity32", "entity33")),
+                "type3", new HashSet<>(Arrays.asList(
+                    (Object)"entity31", "entity32", "entity33"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type1", Sets.newHashSet((Object)"entity11", "entity12"))
+                "type1", new HashSet<>(Arrays.asList((Object)"entity11", "entity12")))
         )
-    );
+    ));
     verifyFilterList(expr, TimelineReaderWebServicesUtils.
         parseRelationFilters(expr), expectedList);
 
@@ -754,20 +757,20 @@ public class TestTimelineReaderWebServicesUtils {
     expectedList = new TimelineFilterList(Operator.OR,
         new TimelineFilterList(
             new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                "type1", Sets.newHashSet((Object)"entity11")),
+                "type1",new HashSet<>(Collections.singleton((Object)"entity11"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                "type2", Sets.newHashSet((Object)"entity21", "entity22")),
+                "type2", new HashSet<>(Arrays.asList((Object)"entity21", "entity22"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                "type5", Sets.newHashSet((Object)"entity51"))
+                "type5", new HashSet<>(Collections.singleton((Object)"entity51")))
         ),
         new TimelineFilterList(
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type3", Sets.newHashSet(
-                    (Object)"entity31", "entity32", "entity33")),
+                "type3", new HashSet<>(Arrays.asList(
+                    (Object)"entity31", "entity32", "entity33"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type1", Sets.newHashSet((Object)"entity11", "entity12"))
+                "type1",new HashSet<>(Arrays.asList((Object)"entity11", "entity12"))
         )
-    );
+    ));
     verifyFilterList(expr, TimelineReaderWebServicesUtils.
         parseRelationFilters(expr), expectedList);
 
@@ -780,45 +783,45 @@ public class TestTimelineReaderWebServicesUtils {
             new TimelineFilterList(Operator.OR,
                 new TimelineFilterList(
                     new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                        "type1", Sets.newHashSet((Object)"entity11")),
+                        "type1", new HashSet<>(Collections.singleton((Object)"entity11"))),
                     new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                        "type2", Sets.newHashSet(
-                            (Object)"entity21", "entity22")),
+                        "type2", new HashSet<>(Arrays.asList(
+                            (Object)"entity21", "entity22"))),
                     new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                        "type5", Sets.newHashSet((Object)"entity51"))
+                        "type5", new HashSet<>(Collections.singleton((Object)"entity51")))
                 ),
                 new TimelineFilterList(
                     new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                        "type3", Sets.newHashSet(
-                            (Object)"entity31", "entity32", "entity33")),
+                        "type3", new HashSet<>(Arrays.asList(
+                            (Object)"entity31", "entity32", "entity33"))),
                     new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                        "type1", Sets.newHashSet(
-                            (Object)"entity11", "entity12"))
+                        "type1", new HashSet<>(Arrays.asList(
+                            (Object)"entity11", "entity12")))
                 )
             ),
             new TimelineFilterList(Operator.OR,
                 new TimelineFilterList(
                     new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                        "type11", Sets.newHashSet((Object)"entity111"))
+                        "type11", new HashSet<>(Collections.singleton((Object)"entity111")))
                 ),
                 new TimelineFilterList(
                     new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                        "type4", Sets.newHashSet((Object)"entity43", "entity44",
-                            "entity47", "entity49")),
+                        "type4", new HashSet<>(Arrays.asList((Object)"entity43", "entity44",
+                            "entity47", "entity49"))),
                     new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                        "type7", Sets.newHashSet((Object)"entity71"))
+                        "type7", new HashSet<>(Collections.singleton((Object)"entity71")))
                 )
             )
         ),
         new TimelineFilterList(
             new TimelineFilterList(
                 new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                    "type2", Sets.newHashSet((Object)"entity2")),
+                    "type2", new HashSet<>(Collections.singleton((Object)"entity2"))),
                 new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                    "type8", Sets.newHashSet((Object)"entity88"))
+                    "type8", new HashSet<>(Collections.singleton((Object)"entity88")))
             ),
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL, "t9",
-                Sets.newHashSet((Object)"e", "e1"))
+                new HashSet<>(Arrays.asList((Object)"e", "e1")))
         )
     );
     verifyFilterList(expr, TimelineReaderWebServicesUtils.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/reader/TestTimelineReaderWebServicesUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/src/test/java/org/apache/hadoop/yarn/server/timelineservice/reader/TestTimelineReaderWebServicesUtils.java
@@ -757,7 +757,7 @@ public class TestTimelineReaderWebServicesUtils {
     expectedList = new TimelineFilterList(Operator.OR,
         new TimelineFilterList(
             new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
-                "type1",new HashSet<>(Collections.singleton((Object)"entity11"))),
+                "type1", new HashSet<>(Collections.singleton((Object)"entity11"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
                 "type2", new HashSet<>(Arrays.asList((Object)"entity21", "entity22"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.NOT_EQUAL,
@@ -768,7 +768,7 @@ public class TestTimelineReaderWebServicesUtils {
                 "type3", new HashSet<>(Arrays.asList(
                     (Object)"entity31", "entity32", "entity33"))),
             new TimelineKeyValuesFilter(TimelineCompareOp.EQUAL,
-                "type1",new HashSet<>(Arrays.asList((Object)"entity11", "entity12"))
+                "type1", new HashSet<>(Arrays.asList((Object)"entity11", "entity12"))
         )
     ));
     verifyFilterList(expr, TimelineReaderWebServicesUtils.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HADOOP-18272](https://issues.apache.org/jira/browse/HADOOP-18272)

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

