### PR TITLE
HDFS-16624. Fix flaky unit test TestDFSAdmin#testAllDatanodesReconfig

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -2068,51 +2068,51 @@ public class DFSAdmin extends FsShell {
       errMsg = String.format("Node [%s] reloading configuration: %s.", address,
           e.toString());
     }
-    synchronized (this) {
-      if (errMsg != null) {
-        err.println(errMsg);
-        return 1;
-      } else {
-        out.print(outMsg);
-      }
 
-      if (status != null) {
-        if (!status.hasTask()) {
-          out.println("no task was found.");
-          return 0;
-        }
-        out.print("started at " + new Date(status.getStartTime()));
-        if (!status.stopped()) {
-          out.println(" and is still running.");
-          return 0;
-        }
-
-        out.println(" and finished at "
-                + new Date(status.getEndTime()).toString() + ".");
-        if (status.getStatus() == null) {
-          // Nothing to report.
-          return 0;
-        }
-        for (Map.Entry<PropertyChange, Optional<String>> result : status
-                .getStatus().entrySet()) {
-          if (!result.getValue().isPresent()) {
-            out.printf(
-                    "SUCCESS: Changed property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
-                    result.getKey().prop, result.getKey().oldVal,
-                    result.getKey().newVal);
-          } else {
-            final String errorMsg = result.getValue().get();
-            out.printf(
-                    "FAILED: Change property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
-                    result.getKey().prop, result.getKey().oldVal,
-                    result.getKey().newVal);
-            out.println("\tError: " + errorMsg + ".");
-          }
-        }
-      } else {
-        return 1;
-      }
+    if (errMsg != null) {
+      err.println(errMsg);
+      return 1;
+    } else {
+      out.print(outMsg);
     }
+
+    if (status != null) {
+      if (!status.hasTask()) {
+        out.println("no task was found.");
+        return 0;
+      }
+      out.print("started at " + new Date(status.getStartTime()));
+      if (!status.stopped()) {
+        out.println(" and is still running.");
+        return 0;
+      }
+
+      out.println(" and finished at "
+          + new Date(status.getEndTime()).toString() + ".");
+      if (status.getStatus() == null) {
+        // Nothing to report.
+        return 0;
+      }
+      for (Map.Entry<PropertyChange, Optional<String>> result : status
+          .getStatus().entrySet()) {
+        if (!result.getValue().isPresent()) {
+          out.printf(
+              "SUCCESS: Changed property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
+              result.getKey().prop, result.getKey().oldVal,
+              result.getKey().newVal);
+        } else {
+          final String errorMsg = result.getValue().get();
+          out.printf(
+              "FAILED: Change property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
+              result.getKey().prop, result.getKey().oldVal,
+              result.getKey().newVal);
+          out.println("\tError: " + errorMsg + ".");
+        }
+      }
+    } else {
+      return 1;
+    }
+
     return 0;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -2068,51 +2068,51 @@ public class DFSAdmin extends FsShell {
       errMsg = String.format("Node [%s] reloading configuration: %s.", address,
           e.toString());
     }
-
-    if (errMsg != null) {
-      err.println(errMsg);
-      return 1;
-    } else {
-      out.print(outMsg);
-    }
-
-    if (status != null) {
-      if (!status.hasTask()) {
-        out.println("no task was found.");
-        return 0;
-      }
-      out.print("started at " + new Date(status.getStartTime()));
-      if (!status.stopped()) {
-        out.println(" and is still running.");
-        return 0;
+    synchronized (this) {
+      if (errMsg != null) {
+        err.println(errMsg);
+        return 1;
+      } else {
+        out.print(outMsg);
       }
 
-      out.println(" and finished at "
-          + new Date(status.getEndTime()).toString() + ".");
-      if (status.getStatus() == null) {
-        // Nothing to report.
-        return 0;
-      }
-      for (Map.Entry<PropertyChange, Optional<String>> result : status
-          .getStatus().entrySet()) {
-        if (!result.getValue().isPresent()) {
-          out.printf(
-              "SUCCESS: Changed property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
-              result.getKey().prop, result.getKey().oldVal,
-              result.getKey().newVal);
-        } else {
-          final String errorMsg = result.getValue().get();
-          out.printf(
-              "FAILED: Change property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
-              result.getKey().prop, result.getKey().oldVal,
-              result.getKey().newVal);
-          out.println("\tError: " + errorMsg + ".");
+      if (status != null) {
+        if (!status.hasTask()) {
+          out.println("no task was found.");
+          return 0;
         }
-      }
-    } else {
-      return 1;
-    }
+        out.print("started at " + new Date(status.getStartTime()));
+        if (!status.stopped()) {
+          out.println(" and is still running.");
+          return 0;
+        }
 
+        out.println(" and finished at "
+                + new Date(status.getEndTime()).toString() + ".");
+        if (status.getStatus() == null) {
+          // Nothing to report.
+          return 0;
+        }
+        for (Map.Entry<PropertyChange, Optional<String>> result : status
+                .getStatus().entrySet()) {
+          if (!result.getValue().isPresent()) {
+            out.printf(
+                    "SUCCESS: Changed property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
+                    result.getKey().prop, result.getKey().oldVal,
+                    result.getKey().newVal);
+          } else {
+            final String errorMsg = result.getValue().get();
+            out.printf(
+                    "FAILED: Change property %s%n\tFrom: \"%s\"%n\tTo: \"%s\"%n",
+                    result.getKey().prop, result.getKey().oldVal,
+                    result.getKey().newVal);
+            out.println("\tError: " + errorMsg + ".");
+          }
+        }
+      } else {
+        return 1;
+      }
+    }
     return 0;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -1205,9 +1205,9 @@ public class TestDFSAdmin {
     LOG.info("dfsadmin -status -livenodes output:");
     outs.forEach(s -> LOG.info("{}", s));
     assertTrue(outs.get(0).startsWith("Reconfiguring status for node"));
-    assertEquals("SUCCESS: Changed property dfs.datanode.peer.stats.enabled", outs.get(2));
-    assertEquals("\tFrom: \"false\"", outs.get(3));
-    assertEquals("\tTo: \"true\"", outs.get(4));
+    assertEquals("SUCCESS: Changed property dfs.datanode.peer.stats.enabled", outs.get(1));
+    assertEquals("\tFrom: \"false\"", outs.get(2));
+    assertEquals("\tTo: \"true\"", outs.get(3));
     assertEquals("SUCCESS: Changed property dfs.datanode.peer.stats.enabled", outs.get(5));
     assertEquals("\tFrom: \"false\"", outs.get(6));
     assertEquals("\tTo: \"true\"", outs.get(7));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -1205,9 +1205,10 @@ public class TestDFSAdmin {
     LOG.info("dfsadmin -status -livenodes output:");
     outs.forEach(s -> LOG.info("{}", s));
     assertTrue(outs.get(0).startsWith("Reconfiguring status for node"));
-    assertEquals("SUCCESS: Changed property dfs.datanode.peer.stats.enabled", outs.get(1));
-    assertEquals("\tFrom: \"false\"", outs.get(2));
-    assertEquals("\tTo: \"true\"", outs.get(3));
+    assertTrue("SUCCESS: Changed property dfs.datanode.peer.stats.enabled".equals(outs.get(2))
+        || "SUCCESS: Changed property dfs.datanode.peer.stats.enabled".equals(outs.get(1)));
+    assertTrue("\tFrom: \"false\"".equals(outs.get(3)) || "\tFrom: \"false\"".equals(outs.get(2)));
+    assertTrue("\tTo: \"true\"".equals(outs.get(4)) || "\tTo: \"true\"".equals(outs.get(3)));
     assertEquals("SUCCESS: Changed property dfs.datanode.peer.stats.enabled", outs.get(5));
     assertEquals("\tFrom: \"false\"", outs.get(6));
     assertEquals("\tTo: \"true\"", outs.get(7));


### PR DESCRIPTION
JIRA:HDFS-16624. Fix org.apache.hadoop.hdfs.tools.TestDFSAdmin#testAllDatanodesReconfig ERROR.

(https://github.com/apache/hadoop/pull/4406) found an error message during Junit unit testing, as follows:

```
expected:<[SUCCESS: Changed property dfs.datanode.peer.stats.enabled]> but was:<[ From: "false"]>
```

After code debugging, it was found that there was an error in the selection outs.get(2) of the assertion(1208), index should be equal to 1.

Please see jira for details.

Introduce code in https://github.com/apache/hadoop/pull/4264