### PR TITLE
Under replicated blocks in dfsadmin report should contain pendingReconstruction‘s blocks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -244,8 +244,19 @@ public class BlockManager implements BlockStatsMXBean {
   }
 
   /** Used by metrics. */
+  public long getNumReplicatedPendingBlocks() {
+    return pendingReconstruction.getNumReplicatedPendingBlocks();
+  }
+
+  /** Used by metrics. */
+  public long getNumEcPendingBlocks() {
+    return pendingReconstruction.getNumEcPendingBlocks();
+  }
+
+  /** Used by metrics. */
   public long getLowRedundancyBlocks() {
-    return neededReconstruction.getLowRedundancyBlocks();
+    return neededReconstruction.getLowRedundancyBlocks() +
+        getNumReplicatedPendingBlocks();
   }
 
   /** Used by metrics. */
@@ -275,7 +286,8 @@ public class BlockManager implements BlockStatsMXBean {
 
   /** Used by metrics. */
   public long getLowRedundancyECBlockGroups() {
-    return neededReconstruction.getLowRedundancyECBlockGroups();
+    return neededReconstruction.getLowRedundancyECBlockGroups() +
+        getNumEcPendingBlocks();
   }
 
   /** Used by metrics. */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/PendingReconstructionBlocks.java
@@ -54,6 +54,10 @@ class PendingReconstructionBlocks {
   Daemon timerThread = null;
   private volatile boolean fsRunning = true;
   private long timedOutCount = 0L;
+  private long replicatedPendingNum = 0L;
+  private long ecPendingNum = 0L;
+  private long replicatedTimedOutNum = 0L;
+  private long ecTimedOutNum = 0L;
 
   //
   // It might take anywhere between 5 to 10 minutes before
@@ -86,6 +90,11 @@ class PendingReconstructionBlocks {
       PendingBlockInfo found = pendingReconstructions.get(block);
       if (found == null) {
         pendingReconstructions.put(block, new PendingBlockInfo(targets));
+        if (block.isStriped()) {
+          ecPendingNum++;
+        } else {
+          replicatedPendingNum++;
+        }
       } else {
         found.incrementReplicas(targets);
         found.setTimeStamp();
@@ -111,6 +120,11 @@ class PendingReconstructionBlocks {
         if (found.getNumReplicas() <= 0) {
           pendingReconstructions.remove(block);
           removed = true;
+          if (block.isStriped()) {
+            ecPendingNum--;
+          } else {
+            replicatedPendingNum--;
+          }
         }
       }
     }
@@ -126,6 +140,11 @@ class PendingReconstructionBlocks {
    */
   PendingBlockInfo remove(BlockInfo block) {
     synchronized (pendingReconstructions) {
+      if (block.isStriped()) {
+        ecPendingNum--;
+      } else {
+        replicatedPendingNum--;
+      }
       return pendingReconstructions.remove(block);
     }
   }
@@ -137,6 +156,8 @@ class PendingReconstructionBlocks {
         timedOutItems.clear();
       }
       timedOutCount = 0L;
+      ecPendingNum = 0L;
+      replicatedPendingNum = 0L;
     }
   }
 
@@ -173,6 +194,30 @@ class PendingReconstructionBlocks {
   }
 
   /**
+   * Used for metrics.
+   * @return The number of replicated pending blocks
+   */
+  long getNumReplicatedPendingBlocks() {
+    synchronized (pendingReconstructions) {
+      synchronized (timedOutItems) {
+        return replicatedPendingNum;
+      }
+    }
+  }
+
+  /**
+   * Used for metrics.
+   * @return The number of EC pending blocks
+   */
+  long getNumEcPendingBlocks() {
+    synchronized (pendingReconstructions) {
+      synchronized (timedOutItems) {
+        return ecPendingNum;
+      }
+    }
+  }
+
+  /**
    * Returns a list of blocks that have timed out their
    * reconstruction requests. Returns null if no blocks have
    * timed out.
@@ -187,6 +232,10 @@ class PendingReconstructionBlocks {
           new BlockInfo[size]);
       timedOutItems.clear();
       timedOutCount += size;
+      ecPendingNum -= ecTimedOutNum;
+      replicatedPendingNum -= replicatedTimedOutNum;
+      ecTimedOutNum = 0L;
+      replicatedTimedOutNum = 0L;
       return blockList;
     }
   }
@@ -279,6 +328,11 @@ class PendingReconstructionBlocks {
             BlockInfo block = entry.getKey();
             synchronized (timedOutItems) {
               timedOutItems.add(block);
+              if (block.isStriped()) {
+                ecTimedOutNum++;
+              } else {
+                replicatedTimedOutNum++;
+              }
             }
             LOG.warn("PendingReconstructionMonitor timed out " + block);
             NameNode.getNameNodeMetrics().incTimeoutReReplications();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
@@ -98,6 +98,7 @@ public class TestPendingReconstruction {
     }
     assertEquals("Size of pendingReconstruction ",
                  10, pendingReconstructions.size());
+    assertEquals(10L, pendingReconstructions.getNumReplicatedPendingBlocks());
 
 
     //
@@ -107,6 +108,7 @@ public class TestPendingReconstruction {
     pendingReconstructions.decrement(blk, storages[7]); // removes one replica
     assertEquals("pendingReconstructions.getNumReplicas ",
                  7, pendingReconstructions.getNumReplicas(blk));
+    assertEquals(10L, pendingReconstructions.getNumReplicatedPendingBlocks());
 
     //
     // insert the same item twice should be counted as once
@@ -114,15 +116,18 @@ public class TestPendingReconstruction {
     pendingReconstructions.increment(blk, storages[0]);
     assertEquals("pendingReconstructions.getNumReplicas ",
         7, pendingReconstructions.getNumReplicas(blk));
+    assertEquals(10L, pendingReconstructions.getNumReplicatedPendingBlocks());
 
     for (int i = 0; i < 7; i++) {
       // removes all replicas
       pendingReconstructions.decrement(blk, storages[i]);
     }
     assertTrue(pendingReconstructions.size() == 9);
+    assertEquals(9L, pendingReconstructions.getNumReplicatedPendingBlocks());
     pendingReconstructions.increment(blk,
         DFSTestUtil.createDatanodeStorageInfos(8));
     assertTrue(pendingReconstructions.size() == 10);
+    assertEquals(10L, pendingReconstructions.getNumReplicatedPendingBlocks());
 
     //
     // verify that the number of replicas returned
@@ -155,6 +160,7 @@ public class TestPendingReconstruction {
     }
     assertEquals(15, pendingReconstructions.size());
     assertEquals(0L, pendingReconstructions.getNumTimedOuts());
+    assertEquals(15L, pendingReconstructions.getNumReplicatedPendingBlocks());
 
     //
     // Wait for everything to timeout.
@@ -175,11 +181,13 @@ public class TestPendingReconstruction {
     //
     assertEquals("Size of pendingReconstructions ", 0, pendingReconstructions.size());
     assertEquals(15L, pendingReconstructions.getNumTimedOuts());
+    assertEquals(15L, pendingReconstructions.getNumReplicatedPendingBlocks());
     Block[] timedOut = pendingReconstructions.getTimedOutBlocks();
     assertNotNull(timedOut);
     assertEquals(15, timedOut.length);
     // Verify the number is not reset
     assertEquals(15L, pendingReconstructions.getNumTimedOuts());
+    assertEquals(0L, pendingReconstructions.getNumReplicatedPendingBlocks());
     for (Block block : timedOut) {
       assertTrue(block.getBlockId() < 15);
     }


### PR DESCRIPTION
[HDFS-16626](https://issues.apache.org/jira/browse/HDFS-16626)
In the output of command 'hdfs dfsadmin -report', the value of Under replicated blocks and ec Low redundancy block groups only contains the block number in BlockManager::neededReconstruction. It should also contain the block number in BlockManager::pendingReconstruction, include the timeout items. Specially, in some scenario, for example, decommission a dn with a lot of ec blocks, there would be a lot blocks in  pendingReconstruction at a long time but neededReconstruction's size may be 0. That will confuse user and they can't access the real decommissioning progress.

Configured Capacity: 1036741707829248 (942.91 TB)
Present Capacity: 983872491622400 (894.83 TB)
DFS Remaining: 974247450424426 (886.07 TB)
DFS Used: 9625041197974 (8.75 TB)
DFS Used%: 0.98%
Replicated Blocks:
    **Under replicated blocks: 0**
    Blocks with corrupt replicas: 0
    Missing blocks: 0
    Missing blocks (with replication factor 1): 0
    Low redundancy blocks with highest priority to recover: 0
    Pending deletion blocks: 0
Erasure Coded Block Groups:
    **Low redundancy block groups: 3481**
    Block groups with corrupt internal blocks: 0
    Missing block groups: 0
    Low redundancy blocks with highest priority to recover: 0
    Pending deletion blocks: 245 
