### PR TITLE
HDFS-16629. [JDK 11] Fix javadoc  warnings in hadoop-hdfs module.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DiskBalancer.java
@@ -62,12 +62,12 @@ import java.util.concurrent.locks.ReentrantLock;
  * Here is the high level logic executed by this class. Users can submit disk
  * balancing plans using submitPlan calls. After a set of sanity checks the plan
  * is admitted and put into workMap.
- * <p>
+ * </p>
  * The executePlan launches a thread that picks up work from workMap and hands
  * it over to the BlockMover#copyBlocks function.
  * <p>
  * Constraints :
- * <p>
+ * </p>
  * Only one plan can be executing in a datanode at any given time. This is
  * ensured by checking the future handle of the worker thread in submitPlan.
  */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/package-info.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/package-info.java
@@ -17,8 +17,9 @@
  */
 
 /**
- * This package provides a mechanism for tracking {@link NameNode} startup
- * progress.  The package models NameNode startup as a series of {@link Phase}s,
+ * This package provides a mechanism for tracking
+ * {@link org.apache.hadoop.hdfs.server.namenode.NameNode} startup progress.
+ * The package models NameNode startup as a series of {@link Phase}s,
  * with each phase further sub-divided into multiple {@link Step}s.  All phases
  * are coarse-grained and typically known in advance, implied by the structure of
  * the NameNode codebase (example: loading fsimage).  Steps are more granular and


### PR DESCRIPTION
JIRA: HDFS-16629. [JDK 11] Fix javadoc  warnings in hadoop-hdfs module.

During compilation of the most recently committed code, a java doc waring appeared and I will fix it.

the error in the compilation report([PR-4419](https://github.com/apache/hadoop/pull/4419)、[PR-4406](https://github.com/apache/hadoop/pull/4406))

```
1 error
100 warnings
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  37.132 s
[INFO] Finished at: 2022-06-09T17:07:12Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:javadoc-no-fork (default-cli) on project hadoop-hdfs: An error has occurred in Javadoc report generation: 
[ERROR] Exit code: 1 - javadoc: warning - You have specified the HTML version as HTML 4.01 by using the -html4 option.
[ERROR] The default is currently HTML5 and the support for HTML 4.01 will be removed
[ERROR] in a future release. To suppress this warning, please ensure that any HTML constructs 
```

this repair will take a long time.