### PR TITLE
MAPREDUCE-7387. Fix TestJHSSecurity#testDelegationToken AssertionError due to HDFS-16563

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
@@ -160,7 +160,7 @@ public class TestJHSSecurity {
         clientUsingDT.getJobReport(jobReportRequest);
         fail("Should not have succeeded with an expired token");
       } catch (IOException e) {
-        assertTrue(e.getCause().getMessage().contains("is expired"));
+        assertTrue(e.getCause().getMessage().contains("expired"));
       }
       
       // Test cancellation

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.mapreduce.security;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
@@ -159,7 +159,7 @@ public class TestJHSSecurity {
       LOG.info("At time: " + System.currentTimeMillis() + ", token should be invalid");
       // Token should have expired.
       final MRClientProtocol finalClientUsingDT = clientUsingDT;
-      LambdaTestUtils.intercept(SecretManager.InvalidToken.class, "expired",
+      LambdaTestUtils.intercept(SecretManager.InvalidToken.class, "has expired",
           () -> finalClientUsingDT.getJobReport(jobReportRequest));
 
       // Test cancellation


### PR DESCRIPTION
JIRA: MAPREDUCE-7387. Fix TestJHSSecurity#testDelegationToken AssertionError due to HDFS-16563.

During the processing of [HADOOP-18284](https://issues.apache.org/jira/browse/HADOOP-18284). Fix Repeated Semicolons., PR#4422 was submitted, and an error was reported in hadoop.mapreduce.security.TestJHSSecurity#testDelegationToken in the test report.

```
[ERROR] testDelegationToken(org.apache.hadoop.mapreduce.security.TestJHSSecurity)  Time elapsed: 16.344 s  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.hadoop.mapreduce.security.TestJHSSecurity.testDelegationToken(TestJHSSecurity.java:163)
```

It can be found that [HDFS-16563](https://issues.apache.org/jira/browse/HDFS-16563) is causing this problem.

The reason is because [HDFS-16563](https://issues.apache.org/jira/browse/HDFS-16563) changed error msg, which made MR's Jinit Test assertion fail.
