### PR TITLE
HADOOP-18289. Remove WhiteBox in hadoop-kms module.

### DIFF
--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -58,7 +58,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.FieldReader;
 import org.slf4j.event.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -948,12 +947,12 @@ public class TestKMS {
         KMSClientProvider kmscp = createKMSClientProvider(uri, conf);
 
         // get the reference to the internal cache, to test invalidation.
-        ValueQueue vq = (ValueQueue) new FieldReader(kmscp,
-            FieldUtils.getField(KMSClientProvider.class, "encKeyVersionQueue", true)).read();
+        ValueQueue vq = (ValueQueue) FieldUtils.getField(KMSClientProvider.class,
+            "encKeyVersionQueue", true).get(kmscp);
         LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq =
             (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
-                 new FieldReader(vq, FieldUtils.getField(ValueQueue.class,
-                     "keyQueues", true)).read();
+                 FieldUtils.getField(ValueQueue.class, "keyQueues", true).get(vq);
+
         EncryptedKeyVersion mockEKV = Mockito.mock(EncryptedKeyVersion.class);
         when(mockEKV.getEncryptionKeyName()).thenReturn(keyName);
         when(mockEKV.getEncryptionKeyVersionName()).thenReturn(mockVersionName);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -930,6 +930,7 @@ public class TestKMS {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testKMSProviderCaching() throws Exception {
     Configuration conf = new Configuration();
     File confDir = getTestDir();
@@ -949,10 +950,9 @@ public class TestKMS {
         // get the reference to the internal cache, to test invalidation.
         ValueQueue vq = (ValueQueue) new FieldReader(kmscp,
             FieldUtils.getField(KMSClientProvider.class, "encKeyVersionQueue", true)).read();
-        LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq;
-        Object keyQueues =
-            new FieldReader(vq, FieldUtils.getField(ValueQueue.class, "keyQueues", true)).read();
-        kq = (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>) keyQueues;
+        LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq =
+            (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
+                 new FieldReader(vq, FieldUtils.getField(ValueQueue.class, "keyQueues", true)).read();
         EncryptedKeyVersion mockEKV = Mockito.mock(EncryptedKeyVersion.class);
         when(mockEKV.getEncryptionKeyName()).thenReturn(keyName);
         when(mockEKV.getEncryptionKeyVersionName()).thenReturn(mockVersionName);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -952,7 +952,8 @@ public class TestKMS {
             FieldUtils.getField(KMSClientProvider.class, "encKeyVersionQueue", true)).read();
         LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq =
             (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
-                 new FieldReader(vq, FieldUtils.getField(ValueQueue.class, "keyQueues", true)).read();
+                 new FieldReader(vq, FieldUtils.getField(ValueQueue.class,
+                     "keyQueues", true)).read();
         EncryptedKeyVersion mockEKV = Mockito.mock(EncryptedKeyVersion.class);
         when(mockEKV.getEncryptionKeyName()).thenReturn(keyName);
         when(mockEKV.getEncryptionKeyVersionName()).thenReturn(mockVersionName);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.crypto.key.kms.server;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
@@ -48,7 +49,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.Time;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.After;
@@ -58,6 +58,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldReader;
 import org.slf4j.event.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -946,11 +947,11 @@ public class TestKMS {
         KMSClientProvider kmscp = createKMSClientProvider(uri, conf);
 
         // get the reference to the internal cache, to test invalidation.
-        ValueQueue vq =
-            (ValueQueue) Whitebox.getInternalState(kmscp, "encKeyVersionQueue");
+        ValueQueue vq = (ValueQueue) new FieldReader(kmscp,
+            FieldUtils.getField(KMSClientProvider.class,"encKeyVersionQueue",true)).read();
         LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq =
-            ((LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
-                Whitebox.getInternalState(vq, "keyQueues"));
+            (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
+                 new FieldReader(vq, FieldUtils.getField(ValueQueue.class,"keyQueues", true)).read();
         EncryptedKeyVersion mockEKV = Mockito.mock(EncryptedKeyVersion.class);
         when(mockEKV.getEncryptionKeyName()).thenReturn(keyName);
         when(mockEKV.getEncryptionKeyVersionName()).thenReturn(mockVersionName);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -948,10 +948,11 @@ public class TestKMS {
 
         // get the reference to the internal cache, to test invalidation.
         ValueQueue vq = (ValueQueue) new FieldReader(kmscp,
-            FieldUtils.getField(KMSClientProvider.class,"encKeyVersionQueue",true)).read();
-        LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq =
-            (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
-                 new FieldReader(vq, FieldUtils.getField(ValueQueue.class,"keyQueues", true)).read();
+            FieldUtils.getField(KMSClientProvider.class, "encKeyVersionQueue", true)).read();
+        LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>> kq;
+        Object keyQueues =
+            new FieldReader(vq, FieldUtils.getField(ValueQueue.class, "keyQueues", true)).read();
+        kq = (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>) keyQueues;
         EncryptedKeyVersion mockEKV = Mockito.mock(EncryptedKeyVersion.class);
         when(mockEKV.getEncryptionKeyName()).thenReturn(keyName);
         when(mockEKV.getEncryptionKeyVersionName()).thenReturn(mockVersionName);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -41,7 +41,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockito.internal.util.reflection.FieldReader;
 
 public class TestKMSAudit {
 

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -210,7 +210,7 @@ public class TestKMSAudit {
   public void testInitAuditLoggers() throws Exception {
     // Default should be the simple logger
     List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) new FieldReader(kmsAudit,
-        FieldUtils.getField(KMSAudit.class,"auditLoggers",true)).read();
+            FieldUtils.getField(KMSAudit.class, "auditLoggers", true)).read();
 
     Assert.assertEquals(1, loggers.size());
     Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
@@ -222,7 +222,7 @@ public class TestKMSAudit {
             + SimpleKMSAuditLogger.class.getName());
     final KMSAudit audit = new KMSAudit(conf);
     loggers = (List<KMSAuditLogger>) new FieldReader(audit,
-        FieldUtils.getField(KMSAudit.class,"auditLoggers",true)).read();
+        FieldUtils.getField(KMSAudit.class, "auditLoggers", true)).read();
     Assert.assertEquals(1, loggers.size());
     Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -209,8 +209,8 @@ public class TestKMSAudit {
   @Test
   public void testInitAuditLoggers() throws Exception {
     // Default should be the simple logger
-    List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) new FieldReader(kmsAudit,
-            FieldUtils.getField(KMSAudit.class, "auditLoggers", true)).read();
+    List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) FieldUtils.
+        getField(KMSAudit.class, "auditLoggers", true).get(kmsAudit);
 
     Assert.assertEquals(1, loggers.size());
     Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
@@ -221,8 +221,8 @@ public class TestKMSAudit {
         SimpleKMSAuditLogger.class.getName() + ", "
             + SimpleKMSAuditLogger.class.getName());
     final KMSAudit audit = new KMSAudit(conf);
-    loggers = (List<KMSAuditLogger>) new FieldReader(audit,
-        FieldUtils.getField(KMSAudit.class, "auditLoggers", true)).read();
+    loggers = (List<KMSAuditLogger>) FieldUtils.
+        getField(KMSAudit.class, "auditLoggers", true).get(kmsAudit);
     Assert.assertEquals(1, loggers.size());
     Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -24,13 +24,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.kms.server.KMS.KMSOp;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PropertyConfigurator;
@@ -40,6 +41,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.internal.util.reflection.FieldReader;
 
 public class TestKMSAudit {
 
@@ -63,7 +65,7 @@ public class TestKMSAudit {
   }
 
   @Rule
-  public final Timeout testTimeout = new Timeout(180000);
+  public final Timeout testTimeout = new Timeout(180000L, TimeUnit.MILLISECONDS);
 
   @Before
   public void setUp() throws IOException {
@@ -207,8 +209,9 @@ public class TestKMSAudit {
   @Test
   public void testInitAuditLoggers() throws Exception {
     // Default should be the simple logger
-    List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) Whitebox
-        .getInternalState(kmsAudit, "auditLoggers");
+    List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) new FieldReader(kmsAudit,
+        FieldUtils.getField(KMSAudit.class,"auditLoggers",true)).read();
+
     Assert.assertEquals(1, loggers.size());
     Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 
@@ -218,8 +221,8 @@ public class TestKMSAudit {
         SimpleKMSAuditLogger.class.getName() + ", "
             + SimpleKMSAuditLogger.class.getName());
     final KMSAudit audit = new KMSAudit(conf);
-    loggers =
-        (List<KMSAuditLogger>) Whitebox.getInternalState(audit, "auditLoggers");
+    loggers = (List<KMSAuditLogger>) new FieldReader(audit,
+        FieldUtils.getField(KMSAudit.class,"auditLoggers",true)).read();
     Assert.assertEquals(1, loggers.size());
     Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 


### PR DESCRIPTION
HADOOP-18289. Remove WhiteBox in hadoop-kms module.

WhiteBox is deprecated, try to remove this method in hadoop-kms.