### PR TITLE
HDFS-16469. Locate protoc-gen-hrpc across platforms

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/CMakeLists.txt
@@ -67,10 +67,10 @@ function(GEN_HRPC SRCS)
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.hrpc.inl"
       COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-      ARGS --plugin=protoc-gen-hrpc=${CMAKE_CURRENT_BINARY_DIR}/protoc-gen-hrpc --hrpc_out=${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
+      ARGS --plugin=protoc-gen-hrpc=$<TARGET_FILE:protoc-gen-hrpc> --hrpc_out=${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
       DEPENDS ${ABS_FIL} ${PROTOBUF_PROTOC_EXECUTABLE} protoc-gen-hrpc
       COMMENT "Running HRPC protocol buffer compiler on ${FIL}"
-      VERBATIM )
+      VERBATIM)
   endforeach()
 
   set_source_files_properties(${${SRCS}} PROPERTIES GENERATED TRUE)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -568,7 +568,6 @@ TEST(ConfigurationTest, TestUriConversions) {
 }
 
 
-
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -568,6 +568,7 @@ TEST(ConfigurationTest, TestUriConversions) {
 }
 
 
+
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The `protoc-gen-hrpc` executable is supposed to be found at `${CMAKE_CURRENT_BINARY_DIR}/protoc-gen-hrpc`.

https://github.com/apache/hadoop/blob/652b257478f723a9e119e5e9181f3c7450ac92b5/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/CMakeLists.txt#L70

This works so long as we're building the `Release` build. Since we can only build `RelWithDebInfo` on Windows, the protoc-gen-hrpc binary will be placed at ${CMAKE_CURRENT_BINARY_DIR}/RelWithDebInfo/protoc-gen-hrpc.exe. Hadoop would need to locate this binary in order to generate the Protobuf headers.

### Solution
We resolve this issue by using the `$<TARGET_FILE:...>` CMake generator expression to get the path to the `protoc-gen-hrpc` CMake target.

### How was this patch tested?
Hadoop Jenkins CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

