### PR TITLE
YARN-11178. Avoid CPU busy idling and resource wasting in DelegationTokenRenewerPoolTracker thread

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -819,6 +819,15 @@ public class YarnConfiguration extends Configuration {
   public static final int DEFAULT_RM_DT_RENEWER_THREAD_RETRY_MAX_ATTEMPTS =
       10;
 
+  /**
+   * The setting is used to control delegation token renewer thread perform backoff
+   * waiting when there are no renewer event futures to avoid CPU busy idling.
+   */
+  public static final String RM_DT_RENEWER_THREAD_IDLE_BACKOFF_MS =
+      RM_PREFIX + "delegation-token-renewer.thread-idle-backoff-ms";
+  public static final long DEFAULT_RM_DT_RENEWER_THREAD_IDLE_BACKOFF_MS =
+      TimeUnit.SECONDS.toMillis(3); // 3 Seconds
+
   public static final String RECOVERY_ENABLED = RM_PREFIX + "recovery.enabled";
   public static final boolean DEFAULT_RM_RECOVERY_ENABLED = false;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1150,6 +1150,16 @@
 
   <property>
     <description>
+      The setting is used to control each RM DelegationTokenRenewer thread perform backoff
+      waiting when there are no renewer event futures to avoid CPU busy idling.
+      the default value is 3 seconds.
+    </description>
+    <name>yarn.resourcemanager.delegation-token-renewer.thread-idle-backoff-ms</name>
+    <value>3s</value>
+  </property>
+
+  <property>
+    <description>
     Thread pool size for RMApplicationHistoryWriter.
     </description>
     <name>yarn.resourcemanager.history-writer.multi-threaded-dispatcher.pool-size</name>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -1047,10 +1047,10 @@ public class DelegationTokenRenewer extends AbstractService {
             try {
               futures.remove(evt);
               LOG.info("Removed done or cancelled renewer tasks of {}" +
-                      " in token renewer thread.", evt.getApplicationId());
+                  " in token renewer thread.", evt.getApplicationId());
             } catch (Exception e) {
               LOG.warn("Problem in removing done or cancelled renew" +
-                      " tasks in token renewer thread.", e);
+                  " tasks in token renewer thread.", e);
             }
           }
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -162,7 +162,7 @@ public class DelegationTokenRenewer extends AbstractService {
     tokenRenewerThreadIdleBackoffMs =
         conf.getTimeDuration(YarnConfiguration.RM_DT_RENEWER_THREAD_IDLE_BACKOFF_MS,
             YarnConfiguration.DEFAULT_RM_DT_RENEWER_THREAD_IDLE_BACKOFF_MS,
-            TimeUnit.MICROSECONDS);
+            TimeUnit.MILLISECONDS);
     tokenRenewerThreadRetryInterval = conf.getTimeDuration(
         YarnConfiguration.RM_DT_RENEWER_THREAD_RETRY_INTERVAL,
         YarnConfiguration.DEFAULT_RM_DT_RENEWER_THREAD_RETRY_INTERVAL,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -1042,9 +1042,11 @@ public class DelegationTokenRenewer extends AbstractService {
           if (future.isDone() || future.isCancelled()) {
             try {
               futures.remove(evt);
-              LOG.info("Removed done or cancelled renew tasks of {} in token renewer thread.", evt.getApplicationId());
+              LOG.info("Removed done or cancelled renewer tasks of {}" +
+                      " in token renewer thread.", evt.getApplicationId());
             } catch (Exception e) {
-              LOG.warn("Problem in removing done or cancelled renew tasks in token renewer thread.", e);
+              LOG.warn("Problem in removing done or cancelled renew" +
+                      " tasks in token renewer thread.", e);
             }
           }
         }


### PR DESCRIPTION
### Description of PR

The DelegationTokenRenewerPoolTracker thread is busy wasting CPU resource in empty poll iterate when there is no delegation token renewer event task in the futures map:

```java
// org.apache.hadoop.yarn.server.resourcemanager.security.DelegationTokenRenewer.DelegationTokenRenewerPoolTracker#run
@Override
public void run() {
  // this while true loop is busy when the `futures` is empty
  while (true) {
    for (Map.Entry<DelegationTokenRenewerEvent, Future<?>> entry : futures
        .entrySet()) {
      DelegationTokenRenewerEvent evt = entry.getKey();
      Future<?> future = entry.getValue();
      try {
        future.get(tokenRenewerThreadTimeout, TimeUnit.MILLISECONDS);
      } catch (TimeoutException e) {

        // Cancel thread and retry the same event in case of timeout
        if (future != null && !future.isDone() && !future.isCancelled()) {
          future.cancel(true);
          futures.remove(evt);
          if (evt.getAttempt() < tokenRenewerThreadRetryMaxAttempts) {
            renewalTimer.schedule(
                getTimerTask((AbstractDelegationTokenRenewerAppEvent) evt),
                tokenRenewerThreadRetryInterval);
          } else {
            LOG.info(
                "Exhausted max retry attempts {} in token renewer "
                    + "thread for {}",
                tokenRenewerThreadRetryMaxAttempts, evt.getApplicationId());
          }
        }
      } catch (Exception e) {
        LOG.info("Problem in submitting renew tasks in token renewer "
            + "thread.", e);
      }
    }
  }
}
```

A better way to avoid CPU idling is waiting for some time when the `futures` map is empty, and when the renewer task done or cancelled, we should remove the task future in `futures` map to avoid memory leak:

```java
@Override
public void run() {
  while (true) {
    // waiting for some time when futures map is empty
    if (futures.isEmpty()) {
      synchronized (this) {
        try {
          // waiting for tokenRenewerThreadTimeout milliseconds
          long waitingTimeMs = Math.min(10000, Math.max(500, tokenRenewerThreadTimeout));
          LOG.info("Delegation token renewer pool is empty, waiting for {} ms.", waitingTimeMs);
          wait(waitingTimeMs);
        } catch (InterruptedException e) {
          LOG.warn("Delegation token renewer pool tracker waiting interrupt occurred.");
          Thread.currentThread().interrupt();
        }
      }
      if (futures.isEmpty()) {
        continue;
      }
    }
    for (Map.Entry<DelegationTokenRenewerEvent, Future<?>> entry : futures
        .entrySet()) {
      DelegationTokenRenewerEvent evt = entry.getKey();
      Future<?> future = entry.getValue();
      try {
        future.get(tokenRenewerThreadTimeout, TimeUnit.MILLISECONDS);
      } catch (TimeoutException e) {

        // Cancel thread and retry the same event in case of timeout
        if (future != null && !future.isDone() && !future.isCancelled()) {
          future.cancel(true);
          futures.remove(evt);
          if (evt.getAttempt() < tokenRenewerThreadRetryMaxAttempts) {
            renewalTimer.schedule(
                getTimerTask((AbstractDelegationTokenRenewerAppEvent) evt),
                tokenRenewerThreadRetryInterval);
          } else {
            LOG.info(
                "Exhausted max retry attempts {} in token renewer "
                    + "thread for {}",
                tokenRenewerThreadRetryMaxAttempts, evt.getApplicationId());
          }
        }
      } catch (Exception e) {
        LOG.info("Problem in submitting renew tasks in token renewer "
            + "thread.", e);
      }
      // remove done and cancelled task
      if (future.isDone() || future.isCancelled()) {
        try {
          futures.remove(evt);
          LOG.info("Removed done or cancelled renew tasks of {} in token renewer thread.", evt.getApplicationId());
        } catch (Exception e) {
          LOG.warn("Problem in removing done or cancelled renew tasks in token renewer thread.", e);
        }
      }
    }
  }
} 
```

some screenshots and CPU profile as following:

> all screenshots images and CPU profile report HTML files were attached into issue: [YARN-11178](https://issues.apache.org/jira/browse/YARN-11178)

before optimized the **ACTIVE** ResourceManager process will occupy CPU core 100% continuous：

![YARN-11178.CPU idling busy 100% before optimized](https://issues.apache.org/jira/secure/attachment/13045187/YARN-11178.CPU%20idling%20busy%20100%25%20before%20optimized.png)

after optimized the code, CPU occupation decreased to normal：

![YARN-11178.CPU normal after optimized](https://issues.apache.org/jira/secure/attachment/13045189/YARN-11178.CPU%20normal%20after%20optimized.png)

for CPU profile, before optimized:

![YARN-11178.CPU profile for idling busy 100% before optimized](https://issues.apache.org/jira/secure/attachment/13045191/YARN-11178.CPU%20profile%20for%20idling%20busy%20100%25%20before%20optimized.png)

after optimized:

![YARN-11178.CPU profile for normal after optimized](https://issues.apache.org/jira/secure/attachment/13045192/YARN-11178.CPU%20profile%20for%20normal%20after%20optimized.png)