### PR TITLE
YARN-9971.YARN Native Service HttpProbe logs THIS_HOST in error messages

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/monitor/probe/HttpProbe.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/monitor/probe/HttpProbe.java
@@ -88,8 +88,9 @@ public class HttpProbe extends DefaultProbe {
     }
     String ip = instance.getContainerStatus().getIPs().get(0);
     HttpURLConnection connection = null;
+    String hostString = urlString.replace(HOST_TOKEN, ip);
     try {
-      URL url = new URL(urlString.replace(HOST_TOKEN, ip));
+      URL url = new URL(hostString);
       connection = getConnection(url, this.timeout);
       int rc = connection.getResponseCode();
       if (rc < min || rc > max) {
@@ -102,7 +103,7 @@ public class HttpProbe extends DefaultProbe {
       }
     } catch (Throwable e) {
       String error =
-          "Probe " + urlString.replace(HOST_TOKEN, ip) + " failed for IP " + ip + ": " + e;
+          "Probe " + hostString + " failed for IP " + ip + ": " + e;
       log.info(error, e);
       status.fail(this,
           new IOException(error, e));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/monitor/probe/HttpProbe.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/monitor/probe/HttpProbe.java
@@ -101,7 +101,8 @@ public class HttpProbe extends DefaultProbe {
         status.succeed(this);
       }
     } catch (Throwable e) {
-      String error = "Probe " + urlString + " failed for IP " + ip + ": " + e;
+      String error =
+          "Probe " + urlString.replace(HOST_TOKEN, ip) + " failed for IP " + ip + ": " + e;
       log.info(error, e);
       status.fail(this,
           new IOException(error, e));


### PR DESCRIPTION
### Description of PR
YARN Native Service HttpProbe logs THIS_HOST in error messages
* JIRA: YARN-9971


- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
