### PR TITLE
YARN-11179. Show more detailed info when container token is expired

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
@@ -906,9 +906,13 @@ public class ContainerManagerImpl extends CompositeService implements
       .currentTimeMillis()) {
       // Ensure the token is not expired.
       unauthorized = true;
-      messageBuilder.append("\nThis token is expired. current time is ")
-        .append(System.currentTimeMillis()).append(" found ")
-        .append(containerTokenIdentifier.getExpiryTimeStamp());
+      messageBuilder.append("\nThe container token of id ")
+              .append(containerIDStr)
+              .append(" is expired. Current system time is ")
+              .append(System.currentTimeMillis()).append(" ,token expiry time is ")
+              .append(containerTokenIdentifier.getExpiryTimeStamp())
+              .append(". And app id is ")
+              .append(nmTokenIdentifier.getApplicationAttemptId().getApplicationId());
       messageBuilder.append("\nNote: System times on machines may be out of sync.")
         .append(" Check system time and time zones.");
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
ISSUE: https://issues.apache.org/jira/browse/YARN-11179

I found in our nm logs, there is no appid in log about failing on starting containers when container token is expired. This will make hard to troubleshoot.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

