### PR TITLE
HADOOP-18297. Upgrade dependency-check-maven to 7.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
     <checkstyle.version>8.29</checkstyle.version>
-    <dependency-check-maven.version>1.4.3</dependency-check-maven.version>
+    <dependency-check-maven.version>7.1.1</dependency-check-maven.version>
     <spotbugs.version>4.2.2</spotbugs.version>
     <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>


### PR DESCRIPTION
### Description of PR
Upgrade dependency-check-maven to 7.1.1
The OWASP dependency-check-maven Plugin version has corrected various false positives in 7.1.1. We can upgrade to it.

https://github.com/jeremylong/DependencyCheck/milestone/45?closed=1

* JIRA: HADOOP-18297


- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
