### PR TITLE
HDFS-16635.Fixed javadoc error in Java 11

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/package-info.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/package-info.java
@@ -17,7 +17,7 @@
  */
 
 /**
- * This package provides a mechanism for tracking {@link NameNode} startup
+ * This package provides a mechanism for tracking NameNode startup
  * progress.  The package models NameNode startup as a series of {@link Phase}s,
  * with each phase further sub-divided into multiple {@link Step}s.  All phases
  * are coarse-grained and typically known in advance, implied by the structure of


### PR DESCRIPTION
### Description of PR
Fixed javadoc error in Java 11

* JIRA: HDFS-16635


- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
