### PR TITLE
HDFS-16633. Fixing when Reserved Space For Replicas is not released on some cases

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -368,7 +368,8 @@ class BlockReceiver implements Closeable {
     finally{
       streams.close();
     }
-    if (replicaInfo != null && replicaInfo instanceof ReplicaInPipeline) {
+    if (replicaInfo != null && replicaInfo instanceof ReplicaInPipeline
+        && replicaInfo.getBytesReserved() > 0) {
       replicaInfo.releaseAllBytesReserved();
     }
     if (replicaHandler != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -368,6 +368,9 @@ class BlockReceiver implements Closeable {
     finally{
       streams.close();
     }
+    if (replicaInfo != null && replicaInfo instanceof ReplicaInPipeline) {
+      replicaInfo.releaseAllBytesReserved();
+    }
     if (replicaHandler != null) {
       IOUtils.cleanupWithLogger(null, replicaHandler);
       replicaHandler = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java
@@ -307,6 +307,17 @@ class BlockReceiver implements Closeable {
     return replicaInfo;
   }
 
+  public void releaseAnyRemainingReservedSpace() {
+    if (replicaInfo != null) {
+      if (replicaInfo.getReplicaInfo().getBytesReserved() > 0) {
+        LOG.warn("Block {} has not released the reserved bytes. "
+                + "Releasing {} bytes as part of close.", replicaInfo.getBlockId(),
+            replicaInfo.getReplicaInfo().getBytesReserved());
+        replicaInfo.releaseAllBytesReserved();
+      }
+    }
+  }
+
   /**
    * close files and release volume reference.
    */
@@ -367,10 +378,6 @@ class BlockReceiver implements Closeable {
     }
     finally{
       streams.close();
-    }
-    if (replicaInfo != null && replicaInfo instanceof ReplicaInPipeline
-        && replicaInfo.getBytesReserved() > 0) {
-      replicaInfo.releaseAllBytesReserved();
     }
     if (replicaHandler != null) {
       IOUtils.cleanupWithLogger(null, replicaHandler);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -951,6 +951,9 @@ class DataXceiver extends Receiver implements Runnable {
       IOUtils.closeStream(mirrorIn);
       IOUtils.closeStream(replyOut);
       IOUtils.closeSocket(mirrorSock);
+      if (blockReceiver != null) {
+        blockReceiver.releaseAnyRemainingReservedSpace();
+      }
       IOUtils.closeStream(blockReceiver);
       setCurrentBlockReceiver(null);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplicaInPipeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/LocalReplicaInPipeline.java
@@ -174,6 +174,10 @@ public class LocalReplicaInPipeline extends LocalReplica
     getVolume().releaseLockedMemory(bytesReserved);
     bytesReserved = 0;
   }
+  @Override
+  public void releaseReplicaInfoBytesReserved() {
+    bytesReserved = 0;
+  }
 
   @Override
   public void setLastChecksumAndDataLen(long dataLength, byte[] checksum) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaInPipeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaInPipeline.java
@@ -52,6 +52,11 @@ public interface ReplicaInPipeline extends Replica {
   public void releaseAllBytesReserved();
 
   /**
+   * Release the reserved space from the ReplicaInfo.
+   */
+  void releaseReplicaInfoBytesReserved();
+
+  /**
    * store the checksum for the last chunk along with the data length
    * @param dataLength number of bytes on disk
    * @param lastChecksum - checksum bytes for the last chunk
@@ -118,10 +123,4 @@ public interface ReplicaInPipeline extends Replica {
    */
   void waitForMinLength(long minLength, long time, TimeUnit unit)
       throws IOException;
-
-  /**
-   * Get the bytes reserved
-   * @return the bytes reserved
-   */
-  long getBytesReserved();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaInPipeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ReplicaInPipeline.java
@@ -118,4 +118,10 @@ public interface ReplicaInPipeline extends Replica {
    */
   void waitForMinLength(long minLength, long time, TimeUnit unit)
       throws IOException;
+
+  /**
+   * Get the bytes reserved
+   * @return the bytes reserved
+   */
+  long getBytesReserved();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2022,6 +2022,9 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
         newReplicaInfo = v.addFinalizedBlock(
             bpid, replicaInfo, replicaInfo, replicaInfo.getBytesReserved());
+        if (replicaInfo instanceof ReplicaInPipeline) {
+          ((ReplicaInPipeline) replicaInfo).releaseReplicaInfoBytesReserved();
+        }
         if (v.isTransientStorage()) {
           releaseLockedMemory(
               replicaInfo.getOriginalBytesReserved()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -420,6 +420,11 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
     }
 
     @Override
+    public long getBytesReserved() {
+      return 0;
+    }
+
+    @Override
     public FsVolumeSpi getVolume() {
       return getStorage(theBlock).getVolume();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -357,6 +357,10 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
     }
 
     @Override
+    public void releaseReplicaInfoBytesReserved() {
+    }
+
+    @Override
     synchronized public long getBytesOnDisk() {
       if (finalized) {
         return theBlock.getNumBytes();
@@ -418,12 +422,6 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
       } while (deadLine > System.currentTimeMillis());
       throw new IOException("Minimum length was not achieved within timeout");
     }
-
-    @Override
-    public long getBytesReserved() {
-      return 0;
-    }
-
     @Override
     public FsVolumeSpi getVolume() {
       return getStorage(theBlock).getVolume();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalReplicaInPipeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalReplicaInPipeline.java
@@ -46,6 +46,10 @@ public class ExternalReplicaInPipeline implements ReplicaInPipeline {
   }
 
   @Override
+  public void releaseReplicaInfoBytesReserved() {
+  }
+
+  @Override
   public void releaseAllBytesReserved() {
   }
 
@@ -135,11 +139,6 @@ public class ExternalReplicaInPipeline implements ReplicaInPipeline {
   @Override
   public void waitForMinLength(long minLength, long time, TimeUnit unit)
       throws IOException {
-  }
-
-  @Override
-  public long getBytesReserved() {
-    return 0;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalReplicaInPipeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalReplicaInPipeline.java
@@ -138,6 +138,11 @@ public class ExternalReplicaInPipeline implements ReplicaInPipeline {
   }
 
   @Override
+  public long getBytesReserved() {
+    return 0;
+  }
+
+  @Override
   public FsVolumeSpi getVolume() {
     return null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestSpaceReservation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestSpaceReservation.java
@@ -18,8 +18,14 @@
 
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.function.Supplier;
 
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.server.datanode.ReplicaInfo;
 import org.apache.hadoop.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -745,5 +751,49 @@ public class TestSpaceReservation {
       }
     }, 500, 30000);
     checkReservedSpace(0);
+  }
+
+  /**
+   * Ensure that bytes reserved of ReplicaInfo gets cleared
+   * during finalize.
+   *
+   * @throws IOException
+   */
+  @Test(timeout = 300000)
+  public void testReplicaInfoBytesReservedReleasedOnFinalize() throws IOException {
+    short replication = 3;
+    int bufferLength = 4096;
+    startCluster(BLOCK_SIZE, replication, -1);
+
+    String methodName = GenericTestUtils.getMethodName();
+    Path path = new Path("/" + methodName + ".01.dat");
+
+    FSDataOutputStream fos =
+        fs.create(path, FsPermission.getFileDefault(), EnumSet.of(CreateFlag.CREATE), bufferLength,
+            replication, BLOCK_SIZE, null);
+    // Allocate a block.
+    fos.write(new byte[bufferLength]);
+    fos.hsync();
+
+    DataNode dataNode = cluster.getDataNodes().get(0);
+    FsDatasetImpl fsDataSetImpl = (FsDatasetImpl) dataNode.getFSDataset();
+    long expectedReservedSpace = BLOCK_SIZE - bufferLength;
+
+    String bpid = cluster.getNamesystem().getBlockPoolId();
+    Collection<ReplicaInfo> replicas = FsDatasetTestUtil.getReplicas(fsDataSetImpl, bpid);
+    ReplicaInfo r = replicas.iterator().next();
+
+    // Verify Initial Bytes Reserved for Replica and Volume are correct
+    assertThat(fsDataSetImpl.getVolumeList().get(0).getReservedForReplicas(),
+        is(expectedReservedSpace));
+    assertThat(r.getBytesReserved(), is(expectedReservedSpace));
+
+    // Verify Bytes Reserved for Replica and Volume are correct after finalize
+    fsDataSetImpl.finalizeNewReplica(r, new ExtendedBlock(bpid, r));
+
+    assertThat(fsDataSetImpl.getVolumeList().get(0).getReservedForReplicas(), is(0L));
+    assertThat(r.getBytesReserved(), is(0L));
+
+    fos.close();
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestSpaceReservation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestSpaceReservation.java
@@ -784,15 +784,15 @@ public class TestSpaceReservation {
     ReplicaInfo r = replicas.iterator().next();
 
     // Verify Initial Bytes Reserved for Replica and Volume are correct
-    assertThat(fsDataSetImpl.getVolumeList().get(0).getReservedForReplicas(),
-        is(expectedReservedSpace));
-    assertThat(r.getBytesReserved(), is(expectedReservedSpace));
+    assertEquals(fsDataSetImpl.getVolumeList().get(0).getReservedForReplicas(),
+        expectedReservedSpace);
+    assertEquals(r.getBytesReserved(), expectedReservedSpace);
 
     // Verify Bytes Reserved for Replica and Volume are correct after finalize
     fsDataSetImpl.finalizeNewReplica(r, new ExtendedBlock(bpid, r));
 
-    assertThat(fsDataSetImpl.getVolumeList().get(0).getReservedForReplicas(), is(0L));
-    assertThat(r.getBytesReserved(), is(0L));
+    assertEquals(fsDataSetImpl.getVolumeList().get(0).getReservedForReplicas(), 0L);
+    assertEquals(r.getBytesReserved(), 0L);
 
     fos.close();
   }


### PR DESCRIPTION
### Description of PR
Reserved Space For Replicas is not released on some cases

Have found the Reserved Space For Replicas is not released on some cases in a Cx Prod cluster. We can fix the issue completely by releasing any remaining reserved space from BlockReceiver#close which is initiated by DataXceiver#writeBlock finally.

* JIRA: HDFS-16633


- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
