### PR TITLE
HADOOP-18301.Upgrade commons-io to 2.11.0

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/HostRestrictingAuthorizationFilter.java
@@ -117,17 +117,12 @@ public class HostRestrictingAuthorizationFilter implements Filter {
       String rulePath = rule.getPath();
       LOG.trace("Evaluating rule, subnet: {}, path: {}",
           subnet != null ? subnet.getCidrSignature() : "*", rulePath);
-      try {
-        if ((subnet == null || subnet.isInRange(remoteIp))
-            && FilenameUtils.directoryContains(rulePath, path)) {
-          LOG.debug("Found matching rule, subnet: {}, path: {}; returned true",
-              rule.getSubnet() != null ? subnet.getCidrSignature() : null,
-              rulePath);
-          return true;
-        }
-      } catch (IOException e) {
-        LOG.warn("Got IOException {}; returned false", e);
-        return false;
+      if ((subnet == null || subnet.isInRange(remoteIp))
+          && FilenameUtils.directoryContains(rulePath, path)) {
+        LOG.debug("Found matching rule, subnet: {}, path: {}; returned true",
+            rule.getSubnet() != null ? subnet.getCidrSignature() : null,
+            rulePath);
+        return true;
       }
     }
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -121,7 +121,7 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-compress.version>1.21</commons-compress.version>
     <commons-csv.version>1.0</commons-csv.version>
-    <commons-io.version>2.8.0</commons-io.version>
+    <commons-io.version>2.11.0</commons-io.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>


### PR DESCRIPTION
### Description of PR

Upgrade commons-io to 2.11.0

Upgrading to new release to keep up for new features and bug fixes.

JIRA: HADOOP-18301


### How was this patch tested?
CI/Build Check


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

