### PR TITLE
HADOOP-18299. Fix unexpected contents in hadoop-client-check-test-invariants on aarch64.

### DIFF
--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -695,6 +695,7 @@
                       <!-- Leave snappy that includes native methods which cannot be relocated. -->
                       <exclude>org.xerial.snappy:*</exclude>
                       <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                      <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
                     </excludes>
                   </artifactSet>
                   <filters>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18299

Build on aarch64 failed due to banned classes. com.github.stephenc.findbugs:findbugs-annotations seems to be pulled somewhere.

```
[ERROR] Found artifact with unexpected contents: '/home/ubuntu/srcs/bigtop/output/hadoop/hadoop-3.3.3/hadoop-client-modules/hadoop-client-minicluster/target/hadoop-client-minicluster-3.3.3.jar'
    Please check the following and either correct the build or update
    the allowed list with reasoning.

    edu/
    edu/umd/
    edu/umd/cs/
    edu/umd/cs/findbugs/
    edu/umd/cs/findbugs/annotations/
    edu/umd/cs/findbugs/annotations/NonNull.class
    edu/umd/cs/findbugs/annotations/CheckForNull.class
    edu/umd/cs/findbugs/annotations/DefaultAnnotationForFields.class
```

I can reproduce this only in branch-3.3 by the following cmdline.

```
$ mvn -Pdist -Psrc -Dtar -Dzookeeper.version=3.5.9 -DskipTests -DskipTest -DskipITs install
```

Since the value of zookeeper.version in hadoop-project/pom.xml is 3.5.6, the issue looks only related to newer zookeeper 3.5.x. There is no issue in trunk in which the zookeeper.version is 3.6.3.

