### PR TITLE
YARN-11186: Upgrade frontend toolchains used by YARN application catalog webapp

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -189,7 +189,7 @@
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.132</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
-    <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
+    <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
     <jasmine-maven-plugin.version>2.1</jasmine-maven-plugin.version>
     <phantomjs-maven-plugin.version>0.7</phantomjs-maven-plugin.version>
     <yuicompressor-maven-plugin.version>1.5.1</yuicompressor-maven-plugin.version>
@@ -216,8 +216,8 @@
     <woodstox.version>5.3.0</woodstox.version>
     <json-smart.version>2.4.7</json-smart.version>
     <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
-    <nodejs.version>v12.22.1</nodejs.version>
-    <yarnpkg.version>v1.22.5</yarnpkg.version>
+    <nodejs.version>v16.15.1</nodejs.version>
+    <yarnpkg.version>v1.22.19</yarnpkg.version>
     <apache-ant.version>1.10.11</apache-ant.version>
   </properties>
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

NodeJS 12 is EOL, and starting from NodeJS 16, it supports Apple Sillion natively.

This PR proposes to 
- upgrade `frontend-maven-plugin` from 1.11.2 to 1.12.1, because of https://github.com/eirslett/frontend-maven-plugin/pull/970
- upgrade NodeJS from v12.22.1(EOL) to the latest LTS v16.15.1, see https://nodejs.org/en/about/releases/
- upgrade Yarn from v1.22.5 to the latest v1.22.19, see https://www.npmjs.com/package/yarn

### How was this patch tested?

Build on M1 chip machine.

```
[INFO] --- frontend-maven-plugin:1.12.1:install-node-and-yarn (install node and yarn) @ hadoop-yarn-applications-catalog-webapp ---
[INFO] testFailureIgnore property is ignored in non test phases
[INFO] Installing node version v16.15.1
[INFO] Downloading https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-arm64.tar.gz to /Users/chengpan/.m2/repository/com/github/eirslett/node/16.15.1/node-16.15.1-darwin-arm64.tar.gz
[INFO] No proxies configured
[INFO] No proxy was configured, downloading directly
[INFO] Unpacking /Users/chengpan/.m2/repository/com/github/eirslett/node/16.15.1/node-16.15.1-darwin-arm64.tar.gz into /Users/chengpan/Projects/apache-hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target/node/tmp
[INFO] Copying node binary from /Users/chengpan/Projects/apache-hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target/node/tmp/node-v16.15.1-darwin-arm64/bin/node to /Users/chengpan/Projects/apache-hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target/node/node
[INFO] Installed node locally.
[INFO] Installing Yarn version v1.22.19
[INFO] Unpacking /Users/chengpan/.m2/repository/com/github/eirslett/yarn/1.22.19/yarn-1.22.19.tar.gz into /Users/chengpan/Projects/apache-hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target/node/yarn
[INFO] Installed Yarn locally.
[INFO]
[INFO] --- frontend-maven-plugin:1.12.1:yarn (yarn install) @ hadoop-yarn-applications-catalog-webapp ---
[INFO] testFailureIgnore property is ignored in non test phases
[INFO] Running 'yarn ' in /Users/chengpan/Projects/apache-hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target
[INFO] yarn install v1.22.19
[INFO] [1/4] Resolving packages...
[INFO] [2/4] Fetching packages...
[INFO] [3/4] Linking dependencies...
[INFO] [4/4] Building fresh packages...
[INFO] Done in 0.44s.
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

