### PR TITLE
YARN-11139. Wait one millisecond in DelegationTokenRenewerPoolTracker

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -996,6 +996,7 @@ public class DelegationTokenRenewer extends AbstractService {
     @Override
     public void run() {
       while (true) {
+        waitOneMillisecond();
         for (Map.Entry<DelegationTokenRenewerEvent, Future<?>> entry : futures
             .entrySet()) {
           DelegationTokenRenewerEvent evt = entry.getKey();
@@ -1024,6 +1025,14 @@ public class DelegationTokenRenewer extends AbstractService {
                 + "thread.", e);
           }
         }
+      }
+    }
+
+    private void waitOneMillisecond() {
+      try {
+        Thread.sleep(1);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Added a wait statement to reduce the CPU usage

### How was this patch tested?
The issue owner already tested it. You can see the results over [there](https://issues.apache.org/jira/browse/YARN-11139)

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
