### PR TITLE
HDFS-16637. TestHDFSCLI#testAll consistently failing

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testHDFSConf.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/resources/testHDFSConf.xml
@@ -16723,19 +16723,19 @@
         <!-- miniDFS cluster started in CLITestHelper is set to match this output -->
         <comparator>
           <type>RegexpAcrossOutputComparator</type>
-          <expected-output>^Rack: \/rack1\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)</expected-output>
+          <expected-output>^Rack: \/rack1\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service</expected-output>
         </comparator>
         <comparator>
           <type>RegexpAcrossOutputComparator</type>
-          <expected-output>Rack: \/rack2\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)</expected-output>
+          <expected-output>Rack: \/rack2\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service</expected-output>
         </comparator>
         <comparator>
           <type>RegexpAcrossOutputComparator</type>
-          <expected-output>Rack: \/rack3\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)</expected-output>
+          <expected-output>Rack: \/rack3\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service</expected-output>
         </comparator>
         <comparator>
           <type>RegexpAcrossOutputComparator</type>
-          <expected-output>Rack: \/rack4\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)</expected-output>
+          <expected-output>Rack: \/rack4\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\sIn Service</expected-output>
         </comparator>
       </comparators>
     </test>


### PR DESCRIPTION
### Description of PR
```
2022-06-19 15:41:16,183 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(146)) - Detailed results:
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(147)) - ----------------------------------

2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(156)) - -------------------------------------------
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(157)) -                     Test ID: [629]
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(158)) -            Test Description: [printTopology: verifying that the topology map is what we expect]
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(159)) - 
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(163)) -               Test Commands: [-fs hdfs://localhost:51486 -printTopology]
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(167)) - 
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(174)) - 
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(178)) -                  Comparator: [RegexpAcrossOutputComparator]
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(180)) -          Comparision result:   [fail]
2022-06-19 15:41:16,184 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(182)) -             Expected output:   [^Rack: \/rack1\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)\s*127\.0\.0\.1:\d+\s\([-.a-zA-Z0-9]+\)]
2022-06-19 15:41:16,185 [Listener at localhost/51519] INFO  cli.CLITestHelper (CLITestHelper.java:displayResults(184)) -               Actual output:   [Rack: /rack1
   127.0.0.1:51487 (localhost) In Service
   127.0.0.1:51491 (localhost) In Service

Rack: /rack2
   127.0.0.1:51500 (localhost) In Service
   127.0.0.1:51496 (localhost) In Service
   127.0.0.1:51504 (localhost) In Service

Rack: /rack3
   127.0.0.1:51508 (localhost) In Service

Rack: /rack4
   127.0.0.1:51512 (localhost) In Service
   127.0.0.1:51516 (localhost) In Service

]
```

### How was this patch tested?
UT

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
