### PR TITLE
YARN-11190. CS Mapping rule bug: User matcher does not work correctly for usernames with dot

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/CSMappingPlacementRule.java
@@ -228,7 +228,11 @@ public class CSMappingPlacementRule extends PlacementRule {
       ApplicationSubmissionContext asc, String user) {
     VariableContext vctx = new VariableContext();
 
-    vctx.put("%user", cleanName(user));
+    String cleanedName = cleanName(user);
+    if (!user.equals(cleanedName)) {
+      vctx.putOriginal("%user", user);
+    }
+    vctx.put("%user", cleanedName);
     //If the specified matches the default it means NO queue have been specified
     //as per ClientRMService#submitApplication which sets the queue to default
     //when no queue is provided.
@@ -239,7 +243,7 @@ public class CSMappingPlacementRule extends PlacementRule {
       //Adding specified as empty will prevent it to be undefined and it won't
       //try to place the application to a queue named '%specified', queue path
       //validation will reject the empty path or the path with empty parts,
-      //so we sill still hit the fallback action of this rule if no queue
+      //so we still hit the fallback action of this rule if no queue
       //is specified
       vctx.put("%specified", "");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/VariableContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/VariableContext.java
@@ -156,8 +156,7 @@ public class VariableContext {
   }
   
   public String getOriginal(String name) {
-    String ret = originalVariables.get(name);
-    return ret;
+    return originalVariables.get(name);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/VariableContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/VariableContext.java
@@ -39,6 +39,7 @@ public class VariableContext {
    * This is our actual variable store.
    */
   private Map<String, String> variables = new HashMap<>();
+  private Map<String, String> originalVariables = new HashMap<>();
 
   /**
    * This is our conditional variable store.
@@ -124,6 +125,10 @@ public class VariableContext {
     return this;
   }
 
+  public void putOriginal(String name, String value) {
+    originalVariables.put(name, value);
+  }
+
   /**
    * This method is used to add a conditional variable to the variable context.
    * @param name Name of the variable
@@ -148,6 +153,11 @@ public class VariableContext {
   public String get(String name) {
     String ret = variables.get(name);
     return ret == null ? "" : ret;
+  }
+  
+  public String getOriginal(String name) {
+    String ret = originalVariables.get(name);
+    return ret;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/VariableContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/VariableContext.java
@@ -154,7 +154,7 @@ public class VariableContext {
     String ret = variables.get(name);
     return ret == null ? "" : ret;
   }
-  
+
   public String getOriginal(String name) {
     return originalVariables.get(name);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
@@ -87,6 +87,12 @@ public class MappingRuleMatchers {
       }
 
       String substituted = variables.replaceVariables(value);
+      
+      String originalVariableValue = variables.getOriginal(variable);
+      if (originalVariableValue != null) {
+        return substituted.equals(originalVariableValue);
+      }
+      
       return substituted.equals(variables.get(variable));
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/MappingRuleMatchers.java
@@ -87,12 +87,12 @@ public class MappingRuleMatchers {
       }
 
       String substituted = variables.replaceVariables(value);
-      
+
       String originalVariableValue = variables.getOriginal(variable);
       if (originalVariableValue != null) {
         return substituted.equals(originalVariableValue);
       }
-      
+
       return substituted.equals(variables.get(variable));
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
@@ -36,8 +36,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerQueueManager;
 import org.apache.hadoop.yarn.util.Records;
-import org.apache.log4j.Level;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -71,11 +69,6 @@ public class TestCSMappingPlacementRule {
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
   
-  @Before
-  public void setUp() {
-    setLoggerToDebug();
-  }
-
   private Map<String, Set<String>> userGroups =
       ImmutableMap.<String, Set<String>>builder()
       .put("alice", ImmutableSet.of("p_alice", "unique", "user"))
@@ -906,14 +899,6 @@ public class TestCSMappingPlacementRule {
     assertPlace(
         "test.user should be placed to root.user",
         engine, app, "test.user", "root.user.testuser");
-  }
-
-  private static void setLoggerToDebug() {
-    Log log = LogFactory.getLog("org.apache.hadoop.yarn.server.resourcemanager.placement");
-    if (log instanceof Log4JLogger) {
-      org.apache.log4j.Logger logger = ((Log4JLogger) log).getLogger();
-      logger.setLevel(Level.DEBUG);
-    }
   }
 
   private CSMappingPlacementRule initPlacementEngine(CapacityScheduler cs) throws IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/placement/csmappingrule/TestCSMappingPlacementRule.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.commons.logging.impl.Log4JLogger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.GroupMappingServiceProvider;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

