### PR TITLE
MAPREDUCE-7391. TestLocalDistributedCacheManager failing after HADOOP-16202

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/test/java/org/apache/hadoop/mapred/TestLocalDistributedCacheManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/test/java/org/apache/hadoop/mapred/TestLocalDistributedCacheManager.java
@@ -68,7 +68,7 @@ import org.mockito.stubbing.Answer;
 @SuppressWarnings("deprecation")
 public class TestLocalDistributedCacheManager {
 
-  public static final byte[] TEST_DATA = "This is a test file\n".getBytes();
+  private static final byte[] TEST_DATA = "This is a test file\n".getBytes();
 
   private static FileSystem mockfs;
 
@@ -84,7 +84,7 @@ public class TestLocalDistributedCacheManager {
    * Recursive delete of a path.
    * For safety, paths of length under 5 are rejected.
    * @param file path to delete.
-   * @throws IOException IO failure
+   * @throws IOException never, it is just "a dummy in the method signature"
    * @throws IllegalArgumentException path too short
    * @throws RuntimeException File.delete() failed.
    */


### PR DESCRIPTION

Mocking broke with the move to the builder.

Took the opportunity to clean up the test class with
* use of lambda expressions for answers where they were short enough
* constant for file contents
* return that data's length in the getFileStatus calls
* javadocs for the tests ca!ses which didn't have them.