### PR TITLE
HADOOP-18307. Remove hadoop-cos as a dependency of hadoop-cloud-storage.

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-cloud-storage/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-cloud-storage/pom.xml
@@ -128,10 +128,19 @@
       <artifactId>hadoop-openstack</artifactId>
       <scope>compile</scope>
     </dependency>
+<!--
+
+    This dependency has been cut from this release because
+    the cos library dependency broke the s3a client from interacting
+    with some AWS regions.
+    See HADOOP-18307.
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-cos</artifactId>
       <scope>compile</scope>
     </dependency>
+
+-->
   </dependencies>
 </project>


### PR DESCRIPTION
Workaround for HADOOP-18159; this ensures that projects declaring
a dependency on hadoop-cloud-storage do _not_ have their s3 http
connections broken by an out of date mozilla/public-suffix-list.txt
resource on the classpath.

Contributed by Steve Loughran



### Description of PR


### How was this patch tested?

mvn clean install; verified dependencies of the module, full dist build and verification it is not in tools/lib

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

