### PR TITLE
HADOOP-18310 Add option and make 400 bad request retryable

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1203,4 +1203,9 @@ public final class Constants {
    * Default maximum read size in bytes during vectored reads : {@value}.
    */
   public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1253376; //1M
+
+  public static final String FAIL_ON_AWS_BAD_REQUEST = "fs.s3a.retry.failOnAwsBadRequest";
+
+  public static final boolean DEFAULT_FAIL_ON_AWS_BAD_REQUEST = true;
+
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1204,8 +1204,17 @@ public final class Constants {
    */
   public static final int DEFAULT_AWS_S3_VECTOR_READS_MAX_MERGED_READ_SIZE = 1253376; //1M
 
-  public static final String FAIL_ON_AWS_BAD_REQUEST = "fs.s3a.retry.failOnAwsBadRequest";
+  /**
+   * Flag for immediate failure when observing a {@link AWSBadRequestException}.
+   * If it's disabled and set to false, the failure is treated as retryable.
+   * Value {@value}.
+   */
+  public static final String FAIL_ON_AWS_BAD_REQUEST = "fs.s3a.fail.on.aws.bad.request";
 
+  /**
+   * Default value for immediate failure when observing a
+   * {@link AWSBadRequestException}: {@value}.
+   */
   public static final boolean DEFAULT_FAIL_ON_AWS_BAD_REQUEST = true;
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ARetryPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ARetryPolicy.java
@@ -215,9 +215,8 @@ public class S3ARetryPolicy implements RetryPolicy {
     // policy on a 400/bad request still ambiguous.
     // Treated as an immediate failure
     RetryPolicy awsBadRequestExceptionRetryPolicy =
-      configuration.getBoolean(FAIL_ON_AWS_BAD_REQUEST, DEFAULT_FAIL_ON_AWS_BAD_REQUEST) ?
-        fail :
-        retryIdempotentCalls;
+        configuration.getBoolean(FAIL_ON_AWS_BAD_REQUEST, DEFAULT_FAIL_ON_AWS_BAD_REQUEST) ?
+            fail : retryIdempotentCalls;
     policyMap.put(AWSBadRequestException.class, awsBadRequestExceptionRetryPolicy);
 
     // Status 500 error code is also treated as a connectivity problem

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ARetryPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ARetryPolicy.java
@@ -214,7 +214,11 @@ public class S3ARetryPolicy implements RetryPolicy {
 
     // policy on a 400/bad request still ambiguous.
     // Treated as an immediate failure
-    policyMap.put(AWSBadRequestException.class, fail);
+    RetryPolicy awsBadRequestExceptionRetryPolicy =
+      configuration.getBoolean(FAIL_ON_AWS_BAD_REQUEST, DEFAULT_FAIL_ON_AWS_BAD_REQUEST) ?
+        fail :
+        retryIdempotentCalls;
+    policyMap.put(AWSBadRequestException.class, awsBadRequestExceptionRetryPolicy);
 
     // Status 500 error code is also treated as a connectivity problem
     policyMap.put(AWSStatus500Exception.class, connectivityFailure);

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1125,8 +1125,8 @@ is unrecoverable; it's the generic "No" response. Very rarely it
 does recover, which is why it is in this category, rather than that
 of unrecoverable failures. The default behavior fails immediately
 without retry. If your system is failure sensitive, you can
-configure `fs.s3a.fail.on.aws.bad.request` to `false` and allow 
-to retry when observing a Bad Request with status code 400. 
+configure `fs.s3a.fail.on.aws.bad.request` to `false` and allow
+to retry when observing a Bad Request with status code 400.
 
 These failures will be retried with an exponential sleep interval set in
 `fs.s3a.retry.interval`, up to the limit set in `fs.s3a.retry.limit`.

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -1118,12 +1118,15 @@ from them.
 
 * Connection timeout: `ConnectTimeoutException`. Timeout before
 setting up a connection to the S3 endpoint (or proxy).
-* HTTP response status code 400, "Bad Request"
+* HTTP response status code 400, "Bad Request" aka `AWSBadRequestException`
 
 The status code 400, Bad Request usually means that the request
 is unrecoverable; it's the generic "No" response. Very rarely it
 does recover, which is why it is in this category, rather than that
-of unrecoverable failures.
+of unrecoverable failures. The default behavior fails immediately
+without retry. If your system is failure sensitive, you can
+configure `fs.s3a.fail.on.aws.bad.request` to `false` and allow 
+to retry when observing a Bad Request with status code 400. 
 
 These failures will be retried with an exponential sleep interval set in
 `fs.s3a.retry.interval`, up to the limit set in `fs.s3a.retry.limit`.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInvoker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInvoker.java
@@ -311,10 +311,23 @@ public class TestInvoker extends Assert {
    */
   @Test(expected = AWSBadRequestException.class)
   public void testRetryBadRequestNotIdempotent() throws Throwable {
-    invoker.retry("test", null, false,
+
+    invoker.retry("test", null, true,
         () -> {
           throw BAD_REQUEST;
         });
+  }
+
+  @Test
+  public void testRetryBadRequestIdempotent() throws Throwable {
+    Configuration conf = new Configuration(FAST_RETRY_CONF);
+    conf.setBoolean(FAIL_ON_AWS_BAD_REQUEST, false);
+    S3ARetryPolicy retryPolicy = new S3ARetryPolicy(conf);
+
+    IOException ex = translateException("GET", "/", BAD_REQUEST);
+    assertRetryAction("Expected retry on aws bad request",
+      retryPolicy, RetryPolicy.RetryAction.RETRY,
+      ex, 1, true);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInvoker.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestInvoker.java
@@ -326,8 +326,8 @@ public class TestInvoker extends Assert {
 
     IOException ex = translateException("GET", "/", BAD_REQUEST);
     assertRetryAction("Expected retry on aws bad request",
-      retryPolicy, RetryPolicy.RetryAction.RETRY,
-      ex, 1, true);
+        retryPolicy, RetryPolicy.RetryAction.RETRY,
+        ex, 1, true);
   }
 
   @Test


### PR DESCRIPTION
### Description of PR

Add option and make 400 bad request retryable, added `fs.s3a.fail.on.aws.bad.request` and default to `true` such that it's acting the same behavior without turning it on.

### How was this patch tested?
Add a new unit test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?


### Integration Tests executed 

I configured auth-keys.xml with using `AssumedRoleCredentialProvider` with a `TemporaryAWSCredentialsProvider` in `auth-keys.xml`. the region is us-west-2 and the endpoint is s3.us-west-2.amazonaws.com.

```

% mvn -Dparallel-tests clean verify -DtestsThreadCount=12 | tee ~/s3-test.log
% grep "\[ERROR] Tests run" ~/s3-test.log

### default-integration-test
[ERROR] Tests run: 14, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 222.383 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.ITestS3ATemporaryCredentials
[ERROR] Tests run: 11, Failures: 0, Errors: 11, Skipped: 0, Time elapsed: 9.573 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.auth.delegation.ITestSessionDelegationInFileystem
[ERROR] Tests run: 11, Failures: 0, Errors: 11, Skipped: 0, Time elapsed: 10.08 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.auth.delegation.ITestRoleDelegationInFileystem
[ERROR] Tests run: 7, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 21.432 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.auth.delegation.ITestRoleDelegationTokens
[ERROR] Tests run: 20, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 40.107 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.ITestS3AConfiguration
[ERROR] Tests run: 6, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 70.07 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.auth.delegation.ITestDelegatedMRJob

### overall first set of tests for default-integration-test has 36 errors 
[ERROR] Tests run: 1088, Failures: 0, Errors: 36, Skipped: 96



# sequential-integration-tests

[ERROR] Tests run: 9, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 546.824 s <<< FAILURE! - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractRootDir
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 15.9 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.tools.ITestMarkerToolRootOperations

### second set of tests for the sequential-integration-tests has 4 errors 
[ERROR] Tests run: 117, Failures: 0, Errors: 4, Skipped: 77

```


The default-integration-test failed because the following reasons, they looks fine to me.
1. `com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException: Cannot call GetSessionToken with session credentials`
2. `ava.io.IOException: org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider instantiation exception: java.lang.IllegalArgumentException: Proxy error: fs.s3a.proxy.username or fs.s3a.proxy.password set without the other.`
3. `java.nio.file.AccessDeniedException: s3a://abc/fork-0006/test: getFileStatus on s3a://abc/fork-0006/test: com.amazonaws.services.s3.model.AmazonS3Exception: Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied;`
4.  `org.apache.hadoop.service.ServiceStateException: java.io.IOException: Unset property fs.s3a.assumed.role.arn`, this one is strange because I have set `fs.s3a.assumed.role.arn` in `auth-keys.xml`


For the sequential-integration-tests, the errors are. 
1. `org.junit.runners.model.TestTimedOutException: test timed out after 180000 milliseconds` 
 - this time mainly caused by a the `getFileStatus` cannot be done, `ERROR contract.ContractTestUtils (ContractTestUtils.java:cleanup(383)) - Error deleting in TEARDOWN - /test: java.io.InterruptedIOException: getFileStatus on s3a://taklwu-thunderhead-dev/test: com.amazonaws.AbortedException` 
2. `[ERROR] test_100_audit_root_noauth(org.apache.hadoop.fs.s3a.tools.ITestMarkerToolRootOperations)  Time elapsed: 7.774 s  <<< ERROR!
46: Marker count 2 out of range [0 - 0]` 

I'm wondered if I have a clean simple credential without using assumeRole setup, all above tests could passed and would not get into permission and the special `GetSessionToken` problem.