### PR TITLE
YARN-9874.Remove unnecessary LevelDb write call in LeveldbConfigurationStore#confirmMutation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/LeveldbConfigurationStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/conf/LeveldbConfigurationStore.java
@@ -204,8 +204,8 @@ public class LeveldbConfigurationStore extends YarnConfigurationStore {
   @Override
   public void confirmMutation(LogMutation pendingMutation,
       boolean isValid) {
-    WriteBatch updateBatch = db.createWriteBatch();
     if (isValid) {
+      WriteBatch updateBatch = db.createWriteBatch();
       for (Map.Entry<String, String> changes :
           pendingMutation.getUpdates().entrySet()) {
         if (changes.getValue() == null || changes.getValue().isEmpty()) {
@@ -215,8 +215,8 @@ public class LeveldbConfigurationStore extends YarnConfigurationStore {
         }
       }
       increaseConfigVersion();
+      db.write(updateBatch);
     }
-    db.write(updateBatch);
   }
 
   private byte[] serLogMutations(LinkedList<LogMutation> mutations) throws


### PR DESCRIPTION
### Description of PR

Remove unnecessary LevelDb write call in LeveldbConfigurationStore#confirmMutation

JIRA: YARN-9874

### How was this patch tested?
Current tests will suffice


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

