### PR TITLE
HADOOP-18292. Fix s3 select tests when running against unsupported storage class

### DIFF
--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3_select.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3_select.md
@@ -934,6 +934,21 @@ Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: GZIP is not applic
   ...
 ```
 
+
+### AWSBadRequestException  `UnsupportedStorageClass`
+
+S3 Select doesn't work with some storage classes like Glacier or Reduced Redundancy.
+Make sure you've set `fs.s3a.create.storage.class` to a supported storage class for S3 Select.
+
+```
+org.apache.hadoop.fs.s3a.AWSBadRequestException: 
+    Select on s3a://example/dataset.csv.gz: 
+    com.amazonaws.services.s3.model.AmazonS3Exception:
+     We do not support REDUCED_REDUNDANCY storage class.
+     Please check the service documentation and try again.
+     (Service: Amazon S3; Status Code: 400; Error Code: UnsupportedStorageClass
+```
+
 ### `PathIOException`: "seek() not supported"
 
 The input stream returned by the select call does not support seeking

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3_select.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/s3_select.md
@@ -941,8 +941,8 @@ S3 Select doesn't work with some storage classes like Glacier or Reduced Redunda
 Make sure you've set `fs.s3a.create.storage.class` to a supported storage class for S3 Select.
 
 ```
-org.apache.hadoop.fs.s3a.AWSBadRequestException: 
-    Select on s3a://example/dataset.csv.gz: 
+org.apache.hadoop.fs.s3a.AWSBadRequestException:
+    Select on s3a://example/dataset.csv.gz:
     com.amazonaws.services.s3.model.AmazonS3Exception:
      We do not support REDUCED_REDUNDANCY storage class.
      Please check the service documentation and try again.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/AbstractS3SelectTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/AbstractS3SelectTest.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.hadoop.util.DurationInfo;
 
 import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getLandsatCSVPath;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.select.CsvFile.ALL_QUOTES;
@@ -286,7 +285,6 @@ public abstract class AbstractS3SelectTest extends AbstractS3ATestBase {
   @Override
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
-    disableFilesystemCaching(conf);
     removeBaseAndBucketOverrides(conf, STORAGE_CLASS);
 
     return conf;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/AbstractS3SelectTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/AbstractS3SelectTest.java
@@ -60,7 +60,10 @@ import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.hadoop.util.DurationInfo;
 
+import static org.apache.hadoop.fs.s3a.Constants.STORAGE_CLASS;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getLandsatCSVPath;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.select.CsvFile.ALL_QUOTES;
 import static org.apache.hadoop.fs.s3a.select.SelectConstants.*;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -278,6 +281,15 @@ public abstract class AbstractS3SelectTest extends AbstractS3ATestBase {
     return filesystem instanceof StreamCapabilities
         && ((StreamCapabilities) filesystem)
         .hasCapability(S3_SELECT_CAPABILITY);
+  }
+
+  @Override
+  protected Configuration createConfiguration() {
+    Configuration conf = super.createConfiguration();
+    disableFilesystemCaching(conf);
+    removeBaseAndBucketOverrides(conf, STORAGE_CLASS);
+
+    return conf;
   }
 
   /**


### PR DESCRIPTION
### Description of PR
HADOOP-18292. when you set your fs client to work with unsupported storage classes, the s3 select tests fail.

Fix by removing storage class option before running S3 Select tests.

### How was this patch tested?
Tested with a bucket in `eu-west-1` with `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

