### PR TITLE
fix bug for MAPREDUCE-7392 bug for GzipCodec in native task

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/GzipCodec.cc
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/GzipCodec.cc
@@ -167,6 +167,12 @@ int32_t GzipDecompressStream::read(void * buff, uint32_t length) {
     }
     int ret = inflate(zstream, Z_NO_FLUSH);
     if (ret == Z_OK || ret == Z_STREAM_END) {
+      if (ret == Z_STREAM_END) {
+        int resetRet = inflateReset(zstream);
+        if (resetRet != Z_OK) {
+          return resetRet;
+        }
+      }
       if (zstream->avail_out == 0) {
         return length;
       }


### PR DESCRIPTION
I found that inflateReset is not called after inflate return Z_STREAM_END.When Z_STREAM_END is returned after an inflate() method is called,the next inflate() call does not consume any input data and dost not produce any output data,thus the loop cannot exit(This bug is trigged by some special compressed data).So I fix the problem. 

