### PR TITLE
HADOOP-18312. Yarn WebApps to support IPv6 address.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -1218,4 +1218,29 @@ public class NetUtils {
     }
     return null;
   }
+
+  /**
+   * Check the given address is IPv6 or not.
+   * @param address A String address to be verified.
+   * @return true if the given address is a valid IPv6 format, false otherwise.
+   */
+  public static boolean isIPv6Address(String address) {
+    return StringUtils.countMatches(address, ":") > 2;
+  }
+
+  /**
+   * Parse the given IPv6address into IP and port.
+   * @param bindAddress address to parse into IP/Port
+   * @return A String array contains Host and Port number.
+   */
+  public static String[] parseIPv6Address(String bindAddress) {
+    String target = bindAddress;
+    int i = target.lastIndexOf(':');
+    String port = target.substring(target.lastIndexOf(":") + 1);
+    String host = target.substring(0, i);
+    if (!host.startsWith("[")){
+      host = "[" + host + "]";
+    }
+    return new String[] {host, port};
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -854,4 +854,59 @@ public class TestNetUtils {
     assertEquals(ipv6Address, addr.getHostName());
     assertEquals(12345, addr.getPort());
   }
+
+  @Test public void testParseIPv6Address() throws Throwable {
+    String ipv6Address = "2a03:2880:2130:cf05:face:b00c:0:1";
+    String port = "12345";
+    String ipv6WithPort = ipv6Address + ':' + port;
+    String[] expectedIpPort = new String[] {'[' + ipv6Address + ']', port };
+
+    String[] ipPort = NetUtils.parseIPv6Address(ipv6WithPort);
+    assertTrue("Parse failed for IPv6 address ",
+        Arrays.equals(ipPort, expectedIpPort));
+
+    ipv6Address = "[2a03:2880:2130:cf05:face:b00c:0:1]";
+    ipv6WithPort = ipv6Address + ":12345";
+    ipPort = NetUtils.parseIPv6Address(ipv6WithPort);
+    assertTrue("Parse failed for IPv6 address ",
+        Arrays.equals(ipPort, expectedIpPort));
+
+    ipv6Address = "https://2a03:2880:2130:cf05:face:b00c:0:1:12345";
+    ipPort = NetUtils.parseIPv6Address(ipv6WithPort);
+    assertTrue("Parse failed for IPv6 address ",
+        Arrays.equals(ipPort, expectedIpPort));
+
+    ipv6Address = "https://[2a03:2880:2130:cf05:face:b00c:0:1]:12345";
+    ipPort = NetUtils.parseIPv6Address(ipv6WithPort);
+    assertTrue("Parse failed for IPv6 address ",
+        Arrays.equals(ipPort, expectedIpPort));
+  }
+
+  @Test public void testIsIPv6Address() throws Throwable {
+    String ipv6Address = "2a03:2880:2130:cf05:face:b00c:0:1:50000";
+    assertTrue("IPv6 address validation fails",
+        NetUtils.isIPv6Address(ipv6Address));
+
+    ipv6Address = "[2a03:2880:2130:cf05:face:b00c:0:1]:50000";
+    assertTrue("IPv6 address validation fails",
+        NetUtils.isIPv6Address(ipv6Address));
+
+    ipv6Address = "https://2a03:2880:2130:cf05:face:b00c:0:1:12345";
+    assertTrue("IPv6 address validation fails",
+        NetUtils.isIPv6Address(ipv6Address));
+
+    ipv6Address = "https://[2a03:2880:2130:cf05:face:b00c:0:1]:12345";
+    assertTrue("IPv6 address validation fails",
+        NetUtils.isIPv6Address(ipv6Address));
+
+    //IPv4 Address
+    ipv6Address = "0.0.0.0:50000";
+    assertFalse("IPv6 address validation fails",
+        NetUtils.isIPv6Address(ipv6Address));
+
+    //IPv4 without Port
+    ipv6Address = "0.0.0.0";
+    assertFalse("IPv6 address validation fails",
+        NetUtils.isIPv6Address(ipv6Address));
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/WebApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/WebApps.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configuration.IntegerRanges;
 import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.http.HttpServer2;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.security.http.RestCsrfPreventionFilter;
@@ -118,6 +119,11 @@ public class WebApps {
     }
 
     public Builder<T> at(String bindAddress) {
+      if(NetUtils.isIPv6Address(bindAddress)) {
+        String address[] = NetUtils.parseIPv6Address(bindAddress);
+        return at(address[0], Integer.parseInt(address[1]),
+            Integer.parseInt(address[1]) == 0);
+      }
       String[] parts = StringUtils.split(bindAddress, ':');
       if (parts.length == 2) {
         int port = Integer.parseInt(parts[1]);


### PR DESCRIPTION
org.apache.hadoop.yarn.webapp.WebApps.Builder#at(java.lang.String) 

This fails to parse an IPV6 address. Only IPv4 supported by the builder. 