### PR TITLE
HADOOP-18314. Add some description for PowerShellFencer.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/NodeFencer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/NodeFencer.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  * <li><code>shell(/path/to/some/script.sh args...)</code></li>
  * <li><code>sshfence(...)</code> (see {@link SshFenceByTcpPort})
+ * <li><code>powershell(...)</code> (see {@link PowerShellFencer})
  * </ul>
  */
 @InterfaceAudience.Private

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/PowerShellFencer.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/PowerShellFencer.java
@@ -34,6 +34,10 @@ import org.slf4j.LoggerFactory;
  * Fencer method that uses PowerShell to remotely connect to a machine and kill
  * the required process. This only works in Windows.
  *
+ * Fencing method uses PowerShell command. It should be specified
+ * in the fencing configuration like:<br>
+ * <code>powershell(NameNode)</code>
+ *
  * The argument passed to this fencer should be a unique string in the
  * "CommandLine" attribute for the "java.exe" process. For example, the full
  * path for the Namenode: "org.apache.hadoop.hdfs.server.namenode.NameNode".

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2930,7 +2930,7 @@ The switch to turn S3A auditing on or off.
   <value></value>
   <description>
     List of fencing methods to use for service fencing. May contain
-    builtin methods (eg shell and sshfence) or user-defined method.
+    builtin methods (eg shell, sshfence and powershell) or user-defined method.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithNFS.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithNFS.md
@@ -192,8 +192,8 @@ The order in which you set these configurations is unimportant, but the values y
     terminated, before transitioning another NameNode to the Active state. In
     order to do this, you must configure at least one **fencing method.** These are
     configured as a carriage-return-separated list, which will be attempted in order
-    until one indicates that fencing has succeeded. There are two methods which
-    ship with Hadoop: *shell* and *sshfence*. For information on implementing
+    until one indicates that fencing has succeeded. There are three methods which
+    ship with Hadoop: *shell*, *sshfence* and *powershell*. For information on implementing
     your own custom fencing method, see the *org.apache.hadoop.ha.NodeFencer* class.
 
     - - -
@@ -283,7 +283,27 @@ The order in which you set these configurations is unimportant, but the values y
     a subshell to kill its parent in some number of seconds).
 
     - - -
-  
+
+    **powershell** - use PowerShell to remotely connect to a machine and kill
+    the required process
+
+    The *powershell* fencing method uses PowerShell command. It may be
+    configured like so:
+
+            <property>
+              <name>dfs.ha.fencing.methods</name>
+              <value>powershell(NameNode)</value>
+            </property>
+
+    The argument passed to this fencer should be a unique string in the "CommandLine"
+    attribute for the "java.exe" process. For example, the full path for the Namenode:
+    "org.apache.hadoop.hdfs.server.namenode.NameNode".
+    The administrator can also shorten the name to "Namenode" if it's unique.
+
+    **Note:** This only works in Windows.
+
+    - - -
+
 *   **fs.defaultFS** - the default path prefix used by the Hadoop FS client when none is given
 
     Optionally, you may now configure the default path for Hadoop clients to use

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSHighAvailabilityWithQJM.md
@@ -239,8 +239,8 @@ The order in which you set these configurations is unimportant, but the values y
 
     The fencing methods used during a failover are configured as a
     carriage-return-separated list, which will be attempted in order until
-    one indicates that fencing has succeeded. There are two methods which ship with
-    Hadoop: *shell* and *sshfence*. For information on implementing your own custom
+    one indicates that fencing has succeeded. There are three methods which ship with
+    Hadoop: *shell*, *sshfence* and *powershell*. For information on implementing your own custom
     fencing method, see the *org.apache.hadoop.ha.NodeFencer* class.
 
     - - -
@@ -328,6 +328,26 @@ The order in which you set these configurations is unimportant, but the values y
     **Note:** This fencing method does not implement any timeout. If timeouts are
     necessary, they should be implemented in the shell script itself (eg by forking
     a subshell to kill its parent in some number of seconds).
+
+    - - -
+
+    **powershell** - use PowerShell to remotely connect to a machine and kill
+    the required process
+
+    The *powershell* fencing method uses PowerShell command. It may be
+    configured like so:
+
+            <property>
+              <name>dfs.ha.fencing.methods</name>
+              <value>powershell(NameNode)</value>
+            </property>
+
+    The argument passed to this fencer should be a unique string in the "CommandLine"
+    attribute for the "java.exe" process. For example, the full path for the Namenode:
+    "org.apache.hadoop.hdfs.server.namenode.NameNode".
+    The administrator can also shorten the name to "Namenode" if it's unique.
+
+    **Note:** This only works in Windows.
 
     - - -
 


### PR DESCRIPTION

### Description of PR
Some descriptions related to PowerShellFencer are missing here, such as: core-default.xml, HDFSHighAvailabilityWithQJM.md, HDFSHighAvailabilityWithNFS.md, NodeFencer.java.
The purpose of this PR is to perfect them.
Details: HADOOP-18314

### How was this patch tested?
Here is mainly to update some documents, for testing, there is not much pressure.

