### PR TITLE
YARN-11199. Replace htrace-core with hbase-noop-htrace

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -301,7 +301,7 @@ org.apache.hbase:hbase-annotations:1.7.1
 org.apache.hbase:hbase-client:1.7.1
 org.apache.hbase:hbase-common:1.7.1
 org.apache.hbase:hbase-protocol:1.7.1
-org.apache.htrace:htrace-core:3.1.0-incubating
+org.apache.hbase.thirdparty:hbase-noop-htrace:4.1.1
 org.apache.htrace:htrace-core4:4.1.0-incubating
 org.apache.httpcomponents:httpclient:4.5.6
 org.apache.httpcomponents:httpcore:4.4.10

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1668,6 +1668,11 @@
             <artifactId>jdk.tools</artifactId>
             <groupId>jdk.tools</groupId>
           </exclusion>
+          <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+          <exclusion>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1676,6 +1681,13 @@
         <version>${hbase.version}</version>
         <scope>test</scope>
         <classifier>tests</classifier>
+        <exclusions>
+          <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+          <exclusion>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
@@ -1687,7 +1699,18 @@
             <groupId>jdk.tools</groupId>
             <artifactId>jdk.tools</artifactId>
           </exclusion>
+          <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+          <exclusion>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+          </exclusion>
         </exclusions>
+      </dependency>
+      <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+      <dependency>
+        <groupId>org.apache.hbase.thirdparty</groupId>
+        <artifactId>hbase-noop-htrace</artifactId>
+        <version>4.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -245,6 +245,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-noop-htrace</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
@@ -205,6 +205,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-noop-htrace</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/pom.xml
@@ -115,6 +115,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-noop-htrace</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-1/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-1/pom.xml
@@ -144,6 +144,11 @@
             </exclusion>
           </exclusions>
         </dependency>
+        <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+        <dependency>
+          <groupId>org.apache.hbase.thirdparty</groupId>
+          <artifactId>hbase-noop-htrace</artifactId>
+        </dependency>
 
         <dependency>
           <groupId>org.apache.hbase</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/pom.xml
@@ -144,6 +144,11 @@
             </exclusion>
           </exclusions>
         </dependency>
+        <!-- replace htrace-core with hbase-noop-htrace for CVE-2018-7489 -->
+        <dependency>
+          <groupId>org.apache.hbase.thirdparty</groupId>
+          <artifactId>hbase-noop-htrace</artifactId>
+        </dependency>
 
         <!-- This is to work around the version divergence of
             org.jruby.jcodings:jcodings pulled in by hbase-client -->


### PR DESCRIPTION
Addresses the following CVEs:
- CVE-2018-7489
- CVE-2020-35491
- CVE-2020-35490
- CVE-2020-36518

### Description of PR

Distributions of Hadoop still contain `htrace-core`, which is associated with 4 CVEs concerning FasterXML `jackson-databind`.  This can be addressed by replacing `htrace-core` with `hbase-noop-htrace` in Hadoop builds.

### How was this patch tested?

The existence of `htrace-core` was verified in published distributions from the Apache Hadoop site, as well as by running a build against `trunk`.  Once the patch was applied `htrace-core` was replaced with `hbase-noop-htrace` in subsequent distribution builds, and all related tests passed as expected.

### For code changes:

- [] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?