### PR TITLE
remove duplicated conf.set() in TestScriptBasedMapping

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestScriptBasedMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestScriptBasedMapping.java
@@ -36,7 +36,6 @@ public class TestScriptBasedMapping {
     conf.setInt(ScriptBasedMapping.SCRIPT_ARG_COUNT_KEY,
                 ScriptBasedMapping.MIN_ALLOWABLE_ARGS - 1);
     conf.set(ScriptBasedMapping.SCRIPT_FILENAME_KEY, "any-filename");
-    conf.set(ScriptBasedMapping.SCRIPT_FILENAME_KEY, "any-filename");
     ScriptBasedMapping mapping = createMapping(conf);
     List<String> names = new ArrayList<String>();
     names.add("some.machine.name");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
There is a duplicated `conf.set()` in `TestScriptBasedMapping#testNoArgsMeansNoResult`.
This PR removes the duplicated line.

### How was this patch tested?
Rerun `TestScriptBasedMapping#testNoArgsMeansNoResult` and pass without any failure/error.