### PR TITLE
HDFS-16645. [JN] Bugfix: java.lang.IllegalStateException: Invalid log manifest

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/Journal.java
@@ -723,16 +723,20 @@ public class Journal implements Closeable {
     List<RemoteEditLog> logs = fjm.getRemoteEditLogs(sinceTxId, inProgressOk);
     
     if (inProgressOk) {
-      RemoteEditLog log = null;
+      RemoteEditLog maxInProgressLog = null;
       for (Iterator<RemoteEditLog> iter = logs.iterator(); iter.hasNext();) {
-        log = iter.next();
+        RemoteEditLog log = iter.next();
         if (log.isInProgress()) {
+          if (maxInProgressLog == null) {
+            maxInProgressLog = log;
+          } else if (maxInProgressLog.getStartTxId() < log.getStartTxId()) {
+            maxInProgressLog = log;
+          }
           iter.remove();
-          break;
         }
       }
-      if (log != null && log.isInProgress()) {
-        logs.add(new RemoteEditLog(log.getStartTxId(),
+      if (maxInProgressLog != null && maxInProgressLog.isInProgress()) {
+        logs.add(new RemoteEditLog(maxInProgressLog.getStartTxId(),
             getHighestWrittenTxId(), true));
       }
     }


### PR DESCRIPTION
### Description of PR

JournalNode will have a residual in-progress segment if it is shut down abnormally.  After this JournalNode restarted and Active NameNode try to open a new in-progress segment, this journalnode will contains two in-progress segment, one is the latest segment and another is the residual segment. 

At this moment, NameNode gets one IllegalStateException when trying to getEditLogManifest from this JournalNode, and the exception as bellow:
``` 
java.lang.IllegalStateException: Invalid log manifest (log [1-? (in-progress)] overlaps [6-? (in-progress)])[[6-? (in-progress)], [1-? (in-progress)]] CommittedTxId: 0 
    at org.apache.hadoop.hdfs.server.protocol.RemoteEditLogManifest.checkState(RemoteEditLogManifest.java:62)
    at org.apache.hadoop.hdfs.server.protocol.RemoteEditLogManifest.<init>(RemoteEditLogManifest.java:46)
    at org.apache.hadoop.hdfs.qjournal.server.Journal.getEditLogManifest(Journal.java:740)
```
