### PR TITLE
HDFS-16646. RBF: Support an elastic RouterRpcFairnessPolicyController

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractPermitManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractPermitManager.java
@@ -18,42 +18,21 @@
 
 package org.apache.hadoop.hdfs.server.federation.fairness;
 
-import org.apache.hadoop.conf.Configuration;
-
 /**
- * A pass through fairness policy that implements
- * {@link RouterRpcFairnessPolicyController} and allows any number
- * of handlers to connect to any specific downstream name service.
+ * A class to manage the issuance and recycling of Permits.
  */
-public class NoRouterRpcFairnessPolicyController implements
-    RouterRpcFairnessPolicyController {
+public interface AbstractPermitManager {
+  /**
+   * Request one Permit instance for the NS.
+   */
+  Permit acquirePermit();
 
-  public NoRouterRpcFairnessPolicyController(Configuration conf, int version) {
-      // Dummy constructor.
-  }
+  /**
+   * Release the permit instance for the NS.
+   */
+  void releasePermit(Permit permit);
 
-  @Override
-  public Permit acquirePermit(String nsId) {
-    return Permit.DONT_NEED_PERMIT;
-  }
+  void drainPermits();
 
-  @Override
-  public void releasePermit(String nsId, Permit permit) {
-    // Dummy, pass through.
-  }
-
-  @Override
-  public void shutdown() {
-    // Nothing for now.
-  }
-
-  @Override
-  public String getAvailableHandlerOnPerNs(){
-    return "N/A";
-  }
-
-  @Override
-  public int getVersion() {
-    return 0;
-  }
+  int availablePermits();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
@@ -77,7 +77,7 @@ public class AbstractRouterRpcFairnessPolicyController
     } else {
       // TODO Add one metric to monitor this abnormal case.
       LOG.warn("Can't find NSPermit for {}.", nsId, new Throwable());
-      return Permit.NO_PERMIT;
+      return Permit.getNoPermit();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/AbstractRouterRpcFairnessPolicyController.java
@@ -20,14 +20,16 @@ package org.apache.hadoop.hdfs.server.federation.fairness;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.Set;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
 
 /**
  * Base fairness policy that implements @RouterRpcFairnessPolicyController.
@@ -40,49 +42,70 @@ public class AbstractRouterRpcFairnessPolicyController
       LoggerFactory.getLogger(AbstractRouterRpcFairnessPolicyController.class);
 
   /** Hash table to hold semaphore for each configured name service. */
-  private Map<String, Semaphore> permits;
+  private Map<String, AbstractPermitManager> permits;
 
-  public void init(Configuration conf) {
-    this.permits = new HashMap<>();
+  /** Version to support dynamically change permits. **/
+  private final int version;
+
+  public static final String ERROR_MSG = "Configured handlers "
+      + DFS_ROUTER_HANDLER_COUNT_KEY + '='
+      + " %d is less than the minimum required handlers %d";
+
+  AbstractRouterRpcFairnessPolicyController(int version) {
+    permits = new HashMap<>();
+    this.version = version;
+  }
+
+  /**
+   * Init the permits.
+   */
+  public void initPermits(Map<String, AbstractPermitManager> newPermits) {
+    this.permits = newPermits;
   }
 
   @Override
-  public boolean acquirePermit(String nsId) {
-    try {
-      LOG.debug("Taking lock for nameservice {}", nsId);
-      return this.permits.get(nsId).tryAcquire(1, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      LOG.debug("Cannot get a permit for nameservice {}", nsId);
+  public int getVersion() {
+    return this.version;
+  }
+
+  @Override
+  public Permit acquirePermit(String nsId) {
+    LOG.debug("Taking lock for nameservice {}", nsId);
+    AbstractPermitManager permitManager = permits.get(nsId);
+    if (permitManager != null) {
+      return permitManager.acquirePermit();
+    } else {
+      // TODO Add one metric to monitor this abnormal case.
+      LOG.warn("Can't find NSPermit for {}.", nsId, new Throwable());
+      return Permit.NO_PERMIT;
     }
-    return false;
   }
 
   @Override
-  public void releasePermit(String nsId) {
-    this.permits.get(nsId).release();
+  public void releasePermit(String nsId, Permit permitInstance) {
+    if (permitInstance == null || permitInstance.isDontNeedPermit()) {
+      return;
+    }
+    AbstractPermitManager permitManager =
+        this.permits.get(nsId);
+    if (permitManager != null) {
+      permitManager.releasePermit(permitInstance);
+    }
   }
 
   @Override
   public void shutdown() {
     LOG.debug("Shutting down router fairness policy controller");
     // drain all semaphores
-    for (Semaphore sema: this.permits.values()) {
-      sema.drainPermits();
+    for (AbstractPermitManager permitManager: this.permits.values()) {
+      permitManager.drainPermits();
     }
-  }
-
-  protected void insertNameServiceWithPermits(String nsId, int maxPermits) {
-    this.permits.put(nsId, new Semaphore(maxPermits));
-  }
-
-  protected int getAvailablePermits(String nsId) {
-    return this.permits.get(nsId).availablePermits();
   }
 
   @Override
   public String getAvailableHandlerOnPerNs() {
     JSONObject json = new JSONObject();
-    for (Map.Entry<String, Semaphore> entry : permits.entrySet()) {
+    for (Map.Entry<String, AbstractPermitManager> entry : permits.entrySet()) {
       try {
         String nsId = entry.getKey();
         int availableHandler = entry.getValue().availablePermits();
@@ -92,5 +115,31 @@ public class AbstractRouterRpcFairnessPolicyController
       }
     }
     return json.toString();
+  }
+
+  protected int getDedicatedHandlers(Configuration conf, String nsId) {
+    return conf.getInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + nsId, 1);
+  }
+
+  /**
+   * Validate all configured dedicated handlers for the nameservices.
+   * @return sum of dedicated handlers of all nameservices
+   * @throws IllegalArgumentException
+   *         if total dedicated handlers more than handler count.
+   */
+  protected int validateHandlersCount(Configuration conf,
+      int handlerCount, Set<String> allConfiguredNS) {
+    int totalDedicatedHandlers = 0;
+    for (String nsId : allConfiguredNS) {
+      int dedicatedHandlers = getDedicatedHandlers(conf, nsId);
+      totalDedicatedHandlers += dedicatedHandlers;
+    }
+    if (totalDedicatedHandlers > handlerCount) {
+      String msg = String.format(ERROR_MSG, handlerCount,
+          totalDedicatedHandlers);
+      LOG.error(msg);
+      throw new IllegalArgumentException(msg);
+    }
+    return totalDedicatedHandlers;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ElasticPermitManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ElasticPermitManager.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hdfs.server.federation.fairness.Permit.PermitType;
+
+/**
+ * A class that manages permits in an exclusive and shared mode.
+ */
+public class ElasticPermitManager implements AbstractPermitManager {
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticPermitManager.class);
+  private final String nsId;
+  /** Dedicated Permit Numbers **/
+  private final int dedicatedCap;
+  private final Semaphore dedicatedPermits;
+  /** The maximum number of elastic permits that can be acquired **/
+  private final int maximumELNumberCanUse;
+  private final Semaphore maximumELPermitsCanUse;
+  /** Total elastic permits **/
+  private final Semaphore totalElasticPermits;
+  /** A version to ensure that permits can be correctly recycled
+   * after dynamically refreshing FairnessPolicyController **/
+  private final int version;
+  /** A cached permits Map **/
+  private final Map<PermitType, Permit> cachedPermits;
+
+  ElasticPermitManager(String nsId, int dedicatedCap,
+      int maximumELNumberCanUse, Semaphore totalElasticPermits, int version) {
+    this.nsId = nsId;
+    this.dedicatedCap = dedicatedCap;
+    this.dedicatedPermits = new Semaphore(dedicatedCap);
+    this.maximumELNumberCanUse = maximumELNumberCanUse;
+    this.maximumELPermitsCanUse = new Semaphore(maximumELNumberCanUse);
+    this.totalElasticPermits = totalElasticPermits;
+    this.version = version;
+    this.cachedPermits = Permit.getPermitBaseOnVersion(version);
+    LOG.info("New NSPermitManager " + this);
+  }
+
+  @Override
+  public String toString() {
+    return "NSPermitManager[nsId=" + nsId
+        + ", dedicatedPermitsNumber=" + dedicatedCap
+        + ", sharedPermitsNumber=" + maximumELNumberCanUse
+        + ", totalSharedPermits=" + totalElasticPermits
+        + ", version=" + version + "]";
+  }
+
+  @Override
+  public Permit acquirePermit() {
+    Permit permit = this.cachedPermits.get(PermitType.NO_PERMIT);
+    try {
+      if (acquireDedicatedPermit()) {
+        permit = this.cachedPermits.get(PermitType.DEDICATED);
+      } else if (acquireElasticPermit()) {
+        permit = this.cachedPermits.get(PermitType.SHARED);
+      }
+    } catch (InterruptedException e) {
+      // ignore
+    }
+    return permit;
+  }
+
+  /**
+   * Try to acquire one permit from Dedicated Semaphore.
+   * Tips: without timeout to ensure lower latency
+   */
+  private boolean acquireDedicatedPermit() throws InterruptedException {
+    return this.dedicatedPermits.tryAcquire();
+  }
+
+  /**
+   * Try to acquire one permit from Total Elastic Permits.
+   */
+  private boolean acquireElasticPermit() throws InterruptedException {
+    boolean result = false;
+    if (maximumELNumberCanUse > 0 && totalElasticPermits != null) {
+      if (this.maximumELPermitsCanUse.tryAcquire(1, TimeUnit.SECONDS)) {
+        if (this.totalElasticPermits.tryAcquire(1, TimeUnit.SECONDS)) {
+          result = true;
+        } else {
+          this.maximumELPermitsCanUse.release();
+        }
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public void releasePermit(Permit permit) {
+    if (permit.getPermitVersion() == version) {
+      switch (permit.getPermitType()) {
+      case DEDICATED:
+        this.dedicatedPermits.release();
+        break;
+      case SHARED:
+        this.maximumELPermitsCanUse.release();
+        this.totalElasticPermits.release();
+        break;
+      case DONT_NEED_PERMIT:
+        break;
+      default:
+        LOG.warn("Unexpected permitType {}", permit.getPermitType());
+        break;
+      }
+    } else {
+      LOG.warn("Wrong permit version fro {}, expect {}, actual {}.",
+          nsId, version, permit.getPermitVersion());
+    }
+  }
+
+  @Override
+  public void drainPermits() {
+    this.dedicatedPermits.drainPermits();
+  }
+
+  @Override
+  public int availablePermits() {
+    return this.dedicatedPermits.availablePermits()
+        + this.maximumELPermitsCanUse.availablePermits();
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ElasticPermitManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ElasticPermitManager.java
@@ -32,18 +32,18 @@ import org.apache.hadoop.hdfs.server.federation.fairness.Permit.PermitType;
 public class ElasticPermitManager implements AbstractPermitManager {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticPermitManager.class);
   private final String nsId;
-  /** Dedicated Permit Numbers **/
+  /** Dedicated Permit Numbers. **/
   private final int dedicatedCap;
   private final Semaphore dedicatedPermits;
-  /** The maximum number of elastic permits that can be acquired **/
+  /** The maximum number of elastic permits that can be acquired. **/
   private final int maximumELNumberCanUse;
   private final Semaphore maximumELPermitsCanUse;
-  /** Total elastic permits **/
+  /** Total elastic permits. **/
   private final Semaphore totalElasticPermits;
-  /** A version to ensure that permits can be correctly recycled
-   * after dynamically refreshing FairnessPolicyController **/
+  /** A version to ensure that permits can be correctly recycled,
+   * after dynamically refreshing FairnessPolicyController. **/
   private final int version;
-  /** A cached permits Map **/
+  /** A cached permits Map. **/
   private final Map<PermitType, Permit> cachedPermits;
 
   ElasticPermitManager(String nsId, int dedicatedCap,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ElasticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/ElasticRouterRpcFairnessPolicyController.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
+
+/**
+ * A subclass of RouterRpcFairnessPolicyController to flexible control
+ * the number of permits that each nameservice can use.
+ */
+public class ElasticRouterRpcFairnessPolicyController
+    extends AbstractRouterRpcFairnessPolicyController {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticRouterRpcFairnessPolicyController.class);
+  private Semaphore totalElasticPermits = null;
+
+  public ElasticRouterRpcFairnessPolicyController(Configuration conf, int version) {
+    super(version);
+    init(conf);
+  }
+
+  private void init(Configuration conf) {
+    if (conf == null) {
+      conf = new HdfsConfiguration();
+    }
+    int newVersion = getVersion();
+    Map<String, AbstractPermitManager> permitManagerMap = new HashMap<>();
+    int handlerCount = conf.getInt(DFS_ROUTER_HANDLER_COUNT_KEY,
+        DFS_ROUTER_HANDLER_COUNT_DEFAULT);
+
+    LOG.info("Handlers available for fairness assignment {} ", handlerCount);
+
+    Set<String> allConfiguredNS = FederationUtil.getAllConfiguredNS(conf);
+    allConfiguredNS.add(CONCURRENT_NS);
+    int totalDedicatedHandlers = validateHandlersCount(
+        conf, handlerCount, allConfiguredNS);
+    int totalElasticHandlers = handlerCount - totalDedicatedHandlers;
+
+    if (totalElasticHandlers > 0) {
+      this.totalElasticPermits = new Semaphore(totalElasticHandlers);
+    }
+
+    for (String nsId : allConfiguredNS) {
+      int maximumETPermitsCanUse = getMaximumETPermitCanUseForTheNS(
+          conf, nsId, totalElasticHandlers);
+      int dedicatedHandlers = getDedicatedHandlers(conf, nsId);
+
+      AbstractPermitManager permitManager = new ElasticPermitManager(
+          nsId, dedicatedHandlers, maximumETPermitsCanUse,
+          this.totalElasticPermits, newVersion);
+
+      permitManagerMap.put(nsId, permitManager);
+      LOG.info("Assigned {} dedicatedPermits and {} maximumETPermits for nsId {} ",
+          dedicatedHandlers, maximumETPermitsCanUse, nsId);
+    }
+    initPermits(permitManagerMap);
+  }
+
+  /**
+   * Get the maximum of elastic Permits that the ns can use.
+   * @param totalETPermits total number of elastic permits.
+   * @return long
+   */
+  private int getMaximumETPermitCanUseForTheNS(
+      Configuration conf, String nsId, int totalETPermits) {
+    int defaultElasticPermitPercent = conf.getInt(
+        DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT_KEY,
+        DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT);
+    int maxPercent = conf.getInt(
+        DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + nsId,
+        defaultElasticPermitPercent);
+    if (maxPercent < 0) {
+      maxPercent = 0;
+    }
+    return (int) Math.ceil(totalETPermits * (1.0 * Math.min(maxPercent, 100) / 100));
+  }
+
+  @Override
+  public void shutdown() {
+    super.shutdown();
+    if (this.totalElasticPermits != null) {
+      totalElasticPermits.drainPermits();
+    }
+  }
+
+  @VisibleForTesting
+  int getTotalElasticAvailableHandler() {
+    int available = 0;
+    if (this.totalElasticPermits != null) {
+      available = this.totalElasticPermits.availablePermits();
+    }
+    return available;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/NoRouterRpcFairnessPolicyController.java
@@ -34,7 +34,7 @@ public class NoRouterRpcFairnessPolicyController implements
 
   @Override
   public Permit acquirePermit(String nsId) {
-    return Permit.DONT_NEED_PERMIT;
+    return Permit.getDontNeedPermit();
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/Permit.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/Permit.java
@@ -27,10 +27,18 @@ import java.util.Map;
  * A permit object contains PermitType and PermitVersion.
  */
 public class Permit {
-  public static Permit DONT_NEED_PERMIT =
+  private static final Permit DONTNEEDPERMIT =
       new Permit(PermitType.DONT_NEED_PERMIT, 0);
-  public static Permit NO_PERMIT =
+  private static final Permit NOPERMIT =
       new Permit(PermitType.NO_PERMIT, 0);
+
+  public static Permit getDontNeedPermit() {
+    return DONTNEEDPERMIT;
+  }
+
+  public static Permit getNoPermit() {
+    return NOPERMIT;
+  }
 
   private final PermitType permitType;
   private final int permitVersion;
@@ -68,13 +76,13 @@ public class Permit {
   }
 
   public enum PermitType {
-    /** permit which is dedicated by namespace */
+    /** permit which is dedicated by namespace. */
     DEDICATED,
-    /** permit which is shared by all namespaces */
+    /** permit which is shared by all namespaces. */
     SHARED,
-    /** mock permit while no need to get permit */
+    /** mock permit while no need to get permit. */
     DONT_NEED_PERMIT,
-    /** a mock permit while can't get permits */
+    /** a mock permit while can't get permits. */
     NO_PERMIT
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/Permit.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/Permit.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A permit object contains PermitType and PermitVersion.
+ */
+public class Permit {
+  public static Permit DONT_NEED_PERMIT =
+      new Permit(PermitType.DONT_NEED_PERMIT, 0);
+  public static Permit NO_PERMIT =
+      new Permit(PermitType.NO_PERMIT, 0);
+
+  private final PermitType permitType;
+  private final int permitVersion;
+
+  public Permit(PermitType permitType, int version) {
+    this.permitType = permitType;
+    this.permitVersion = version;
+  }
+
+  PermitType getPermitType() {
+    return permitType;
+  }
+
+  int getPermitVersion() {
+    return permitVersion;
+  }
+
+  public boolean isNoPermit() {
+    return this.permitType.equals(PermitType.NO_PERMIT);
+  }
+
+  @VisibleForTesting
+  public boolean isHoldPermit() {
+    return !isNoPermit();
+  }
+
+  public boolean isDontNeedPermit() {
+    return this.permitType.equals(PermitType.DONT_NEED_PERMIT);
+  }
+
+  @Override
+  public String toString() {
+    return "Permit[permitType=" + permitType
+        + ",version=" + permitVersion + "]";
+  }
+
+  public enum PermitType {
+    /** permit which is dedicated by namespace */
+    DEDICATED,
+    /** permit which is shared by all namespaces */
+    SHARED,
+    /** mock permit while no need to get permit */
+    DONT_NEED_PERMIT,
+    /** a mock permit while can't get permits */
+    NO_PERMIT
+  }
+
+  /**
+   * Build Permit instance of each PermitType based on the version.
+   */
+  public static Map<PermitType, Permit> getPermitBaseOnVersion(int version) {
+    Map<PermitType, Permit> permitMap = new HashMap<>();
+    for (PermitType permitType : PermitType.values()) {
+      permitMap.put(permitType, new Permit(permitType, version));
+    }
+    return permitMap;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/RouterRpcFairnessPolicyController.java
@@ -46,7 +46,7 @@ public interface RouterRpcFairnessPolicyController {
    * @param nsId NS id for which a permission to continue is requested.
    * @return true or false based on whether permit is given.
    */
-  boolean acquirePermit(String nsId);
+  Permit acquirePermit(String nsId);
 
   /**
    * Handler threads are expected to invoke this method that signals
@@ -56,7 +56,7 @@ public interface RouterRpcFairnessPolicyController {
    *
    * @param nsId Name service id for which permission release request is made.
    */
-  void releasePermit(String nsId);
+  void releasePermit(String nsId, Permit permit);
 
   /**
    * Shutdown steps to stop accepting new permission requests and clean-up.
@@ -67,4 +67,10 @@ public interface RouterRpcFairnessPolicyController {
    * Returns the JSON string of the available handler for each Ns.
    */
   String getAvailableHandlerOnPerNs();
+
+  /**
+   * A version to ensure that we can correctly recycle permits
+   * after dynamically refreshing the RpcFairnessPolicyController.
+   */
+  int getVersion();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticPermitManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticPermitManager.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hdfs.server.federation.fairness.Permit.PermitType;
+
+/**
+ * A class that manages permits in an exclusive mode.
+ */
+public class StaticPermitManager implements AbstractPermitManager {
+  private final static Logger LOG = LoggerFactory.getLogger(StaticPermitManager.class);
+  private final String nsId;
+  private final int version;
+  private final int permitCap;
+  private final Semaphore dedicatedPermits;
+  private final Map<PermitType, Permit> cachedPermits;
+
+  public StaticPermitManager(
+      final String nsId, final int version,
+      final int permitCap) {
+    this.nsId = nsId;
+    this.version = version;
+    this.permitCap = permitCap;
+    this.dedicatedPermits = new Semaphore(permitCap);
+    this.cachedPermits = Permit.getPermitBaseOnVersion(version);
+    LOG.info("{} has {} dedicated permits.", nsId, permitCap);
+  }
+
+  @Override
+  public String toString() {
+    return "[StaticPermitManager, nsId=" + nsId
+        + ", version=" + version
+        + ", permitCap=" + permitCap
+        + ", availablePermits=" + this.dedicatedPermits.availablePermits()
+        + "]";
+  }
+
+  @Override
+  public Permit acquirePermit() {
+    Permit permit = Permit.NO_PERMIT;
+    try {
+      if (dedicatedPermits.tryAcquire(1, TimeUnit.SECONDS)) {
+        permit = this.cachedPermits.get(PermitType.DEDICATED);
+      }
+    } catch (InterruptedException e) {
+      // ignore
+    }
+    return permit;
+  }
+
+  @Override
+  public void releasePermit(Permit permit) {
+    if (permit.getPermitVersion() == version) {
+      if (permit.getPermitType() == PermitType.DEDICATED) {
+        this.dedicatedPermits.release();
+      }
+    } else {
+      LOG.warn("Wrong permit version for {}, expect {}, actual {}",
+          nsId, version, permit.getPermitVersion());
+    }
+  }
+
+  @Override
+  public void drainPermits() {
+    this.dedicatedPermits.drainPermits();
+  }
+
+  @Override
+  public int availablePermits() {
+    return this.dedicatedPermits.availablePermits();
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticPermitManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/fairness/StaticPermitManager.java
@@ -58,7 +58,7 @@ public class StaticPermitManager implements AbstractPermitManager {
 
   @Override
   public Permit acquirePermit() {
-    Permit permit = Permit.NO_PERMIT;
+    Permit permit = Permit.getNoPermit();
     try {
       if (dedicatedPermits.tryAcquire(1, TimeUnit.SECONDS)) {
         permit = this.cachedPermits.get(PermitType.DEDICATED);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -354,6 +354,11 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       NoRouterRpcFairnessPolicyController.class;
   public static final String DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX =
       FEDERATION_ROUTER_FAIRNESS_PREFIX + "handler.count.";
+  public static final String DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX =
+      FEDERATION_ROUTER_FAIRNESS_PREFIX + "elastic.permits.percent.";
+  public static final String DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT_KEY =
+      FEDERATION_ROUTER_FAIRNESS_PREFIX + "elastic.permits.percent.default";
+  public static final int DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT = 20;
 
   // HDFS Router Federation Rename.
   public static final String DFS_ROUTER_FEDERATION_RENAME_PREFIX =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.hdfs.NameNodeProxiesClient.ProxyAndInfo;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.SnapshotException;
+import org.apache.hadoop.hdfs.server.federation.fairness.Permit;
 import org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessPolicyController;
 import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
@@ -157,7 +158,7 @@ public class RouterRpcClient {
     this.connectionManager = new ConnectionManager(clientConf);
     this.connectionManager.start();
     this.routerRpcFairnessPolicyController =
-        FederationUtil.newFairnessPolicyController(conf);
+        FederationUtil.newFairnessPolicyController(conf, 0);
 
     int numThreads = conf.getInt(
         RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE,
@@ -830,7 +831,7 @@ public class RouterRpcClient {
       throws IOException {
     UserGroupInformation ugi = RouterRpcServer.getRemoteUser();
     RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
-    acquirePermit(nsId, ugi, method, controller);
+    Permit permit = acquirePermit(nsId, ugi, method, controller);
     try {
       List<? extends FederationNamenodeContext> nns =
           getNamenodesForNameservice(nsId);
@@ -840,7 +841,7 @@ public class RouterRpcClient {
       Object[] params = method.getParams(loc);
       return invokeMethod(ugi, nns, proto, m, params);
     } finally {
-      releasePermit(nsId, ugi, method, controller);
+      releasePermit(nsId, ugi, method, controller, permit);
     }
   }
 
@@ -999,7 +1000,7 @@ public class RouterRpcClient {
     // Invoke in priority order
     for (final RemoteLocationContext loc : locations) {
       String ns = loc.getNameserviceId();
-      acquirePermit(ns, ugi, remoteMethod, controller);
+      Permit permit = acquirePermit(ns, ugi, remoteMethod, controller);
       List<? extends FederationNamenodeContext> namenodes =
           getNamenodesForNameservice(ns);
       try {
@@ -1034,7 +1035,7 @@ public class RouterRpcClient {
             "Unexpected exception proxying API " + e.getMessage(), e);
         thrownExceptions.add(ioe);
       } finally {
-        releasePermit(ns, ugi, remoteMethod, controller);
+        releasePermit(ns, ugi, remoteMethod, controller, permit);
       }
     }
 
@@ -1360,7 +1361,7 @@ public class RouterRpcClient {
       T location = locations.iterator().next();
       String ns = location.getNameserviceId();
       RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
-      acquirePermit(ns, ugi, method, controller);
+      Permit permit = acquirePermit(ns, ugi, method, controller);
       final List<? extends FederationNamenodeContext> namenodes =
           getNamenodesForNameservice(ns);
       try {
@@ -1373,7 +1374,7 @@ public class RouterRpcClient {
         // Localize the exception
         throw processException(ioe, location);
       } finally {
-        releasePermit(ns, ugi, method, controller);
+        releasePermit(ns, ugi, method, controller, permit);
       }
     }
 
@@ -1424,7 +1425,7 @@ public class RouterRpcClient {
     }
 
     RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
-    acquirePermit(CONCURRENT_NS, ugi, method, controller);
+    Permit permit = acquirePermit(CONCURRENT_NS, ugi, method, controller);
     try {
       List<Future<Object>> futures = null;
       if (timeOutMs > 0) {
@@ -1482,7 +1483,7 @@ public class RouterRpcClient {
       throw new IOException(
           "Unexpected error while invoking API " + ex.getMessage(), ex);
     } finally {
-      releasePermit(CONCURRENT_NS, ugi, method, controller);
+      releasePermit(CONCURRENT_NS, ugi, method, controller, permit);
     }
   }
 
@@ -1566,11 +1567,13 @@ public class RouterRpcClient {
    * @param controller fairness policy controller to acquire permit from
    * @throws IOException If permit could not be acquired for the nsId.
    */
-  private void acquirePermit(final String nsId, final UserGroupInformation ugi,
+  private Permit acquirePermit(final String nsId, final UserGroupInformation ugi,
       final RemoteMethod m, RouterRpcFairnessPolicyController controller)
       throws IOException {
+    Permit permit = Permit.DONT_NEED_PERMIT;
     if (controller != null) {
-      if (!controller.acquirePermit(nsId)) {
+      permit = controller.acquirePermit(nsId);
+      if (permit.isNoPermit()) {
         // Throw StandByException,
         // Clients could fail over and try another router.
         if (rpcMonitor != null) {
@@ -1586,6 +1589,7 @@ public class RouterRpcClient {
       }
       incrAcceptedPermitForNs(nsId);
     }
+    return permit;
   }
 
   /**
@@ -1597,9 +1601,10 @@ public class RouterRpcClient {
    * @param controller fairness policy controller to release permit from
    */
   private void releasePermit(final String nsId, final UserGroupInformation ugi,
-      final RemoteMethod m, RouterRpcFairnessPolicyController controller) {
+      final RemoteMethod m, RouterRpcFairnessPolicyController controller,
+      Permit permit) {
     if (controller != null) {
-      controller.releasePermit(nsId);
+      controller.releasePermit(nsId, permit);
       LOG.trace("Permit released for ugi: {} for method: {}", ugi,
           m.getMethodName());
     }
@@ -1637,7 +1642,11 @@ public class RouterRpcClient {
   public synchronized String refreshFairnessPolicyController(Configuration conf) {
     RouterRpcFairnessPolicyController newController;
     try {
-      newController = FederationUtil.newFairnessPolicyController(conf);
+      int version = 0;
+      if (routerRpcFairnessPolicyController != null) {
+        version = routerRpcFairnessPolicyController.getVersion();
+      }
+      newController = FederationUtil.newFairnessPolicyController(conf, version);
     } catch (RuntimeException e) {
       LOG.error("Failed to create router fairness policy controller", e);
       return getCurrentFairnessPolicyControllerClassName();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1570,7 +1570,7 @@ public class RouterRpcClient {
   private Permit acquirePermit(final String nsId, final UserGroupInformation ugi,
       final RemoteMethod m, RouterRpcFairnessPolicyController controller)
       throws IOException {
-    Permit permit = Permit.DONT_NEED_PERMIT;
+    Permit permit = Permit.getDontNeedPermit();
     if (controller != null) {
       permit = controller.acquirePermit(nsId);
       if (permit.isNoPermit()) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -724,6 +724,27 @@
   </property>
 
   <property>
+    <name>dfs.federation.router.fairness.elastic.permits.percent.EXAMPLENAMESERVICE</name>
+    <value></value>
+    <description>
+      The maximum percentage of total elastic handler counts that the
+      nameservice EXAMPLENAMESERVICE can use. When the dedicated handlers
+      are used up, this nameservice EXAMPLENAMESERVICE can preempt the total
+      elastic handlers. And this conf is used to limit the maximum of total
+      elastic handlers than this ns can preempt.
+    </description>
+  </property>
+
+  <property>
+    <name>dfs.federation.router.fairness.elastic.permits.percent.default</name>
+    <value>20</value>
+    <description>
+      The default maximum percentage of total elastic handler counts
+      that no specially configured nameservice can use.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.federation.router.federation.rename.bandwidth</name>
     <value>10</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestElasticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestElasticRouterRpcFairnessPolicyController.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.fairness;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
+import org.junit.Test;
+
+import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.hadoop.hdfs.server.federation.fairness.Permit.PermitType;
+
+/**
+ * Test functionality of {@link ElasticRouterRpcFairnessPolicyController).
+ */
+public class TestElasticRouterRpcFairnessPolicyController {
+  private final static String nameServices =
+      "ns1.nn1, ns1.nn2, ns2.nn1, ns2.nn2";
+
+  private void verifyAcquirePermit(RouterRpcFairnessPolicyController controller,
+      String nsId, int dedicatedPermit, int elasticPermit) {
+    for (int i = 0; i < dedicatedPermit; i++) {
+      assertEquals(controller.acquirePermit(nsId)
+          .getPermitType(), PermitType.DEDICATED);
+    }
+    for (int i = 0; i < elasticPermit; i++) {
+      assertEquals(controller.acquirePermit(nsId)
+          .getPermitType(), PermitType.SHARED);
+    }
+    assertEquals(controller.acquirePermit(nsId)
+        .getPermitType(), PermitType.NO_PERMIT);
+  }
+
+  @Test
+  public void testNoElasticPermits() {
+    Configuration conf = createConf(10);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns1", 5);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns2", 2);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + CONCURRENT_NS, 3);
+
+    ElasticRouterRpcFairnessPolicyController controller =
+        new ElasticRouterRpcFairnessPolicyController(conf, 0);
+    assertNotNull(controller);
+    assertEquals(0, controller.getTotalElasticAvailableHandler());
+
+    verifyAcquirePermit(controller, "ns1", 5, 0);
+    verifyAcquirePermit(controller, "ns2", 2, 0);
+    verifyAcquirePermit(controller, CONCURRENT_NS, 3, 0);
+  }
+
+  @Test
+  public void testConfNoUseElasticPermits() {
+    Configuration conf = createConf(20);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns1", 5);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns2", 2);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + CONCURRENT_NS, 3);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_DEFAULT_KEY, 0);
+
+    ElasticRouterRpcFairnessPolicyController controller =
+        new ElasticRouterRpcFairnessPolicyController(conf, 0);
+    assertNotNull(controller);
+    assertEquals(10, controller.getTotalElasticAvailableHandler());
+
+    verifyAcquirePermit(controller, "ns1", 5, 0);
+    verifyAcquirePermit(controller, "ns2", 2, 0);
+    verifyAcquirePermit(controller, CONCURRENT_NS, 3, 0);
+  }
+
+  @Test
+  public void testConfSmallerElasticPermits() {
+    Configuration conf = createConf(20);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns1", 5);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns2", 2);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + CONCURRENT_NS, 3);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + "ns1", 20);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + "ns2", 20);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + CONCURRENT_NS, 20);
+
+    ElasticRouterRpcFairnessPolicyController controller =
+        new ElasticRouterRpcFairnessPolicyController(conf, 0);
+    assertNotNull(controller);
+    assertEquals(10, controller.getTotalElasticAvailableHandler());
+
+    verifyAcquirePermit(controller, "ns1", 5, 2);
+    verifyAcquirePermit(controller, "ns2", 2, 2);
+    verifyAcquirePermit(controller, CONCURRENT_NS, 3, 2);
+    assertEquals(4, controller.getTotalElasticAvailableHandler());
+  }
+
+  @Test
+  public void testConfMoreElasticPermits() {
+    Configuration conf = createConf(20);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns1", 5);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns2", 2);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + CONCURRENT_NS, 3);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + "ns1", 40);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + "ns2", 40);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + CONCURRENT_NS, 40);
+
+    ElasticRouterRpcFairnessPolicyController controller =
+        new ElasticRouterRpcFairnessPolicyController(conf, 0);
+    assertNotNull(controller);
+    assertEquals(10, controller.getTotalElasticAvailableHandler());
+
+    verifyAcquirePermit(controller, "ns1", 5, 4);
+    verifyAcquirePermit(controller, "ns2", 2, 4);
+    verifyAcquirePermit(controller, CONCURRENT_NS, 3, 2);
+    assertEquals(0, controller.getTotalElasticAvailableHandler());
+  }
+
+  @Test
+  public void testConfMoreElasticPermits2() {
+    Configuration conf = createConf(20);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns1", 5);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns2", 2);
+    conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + CONCURRENT_NS, 3);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + "ns1", 100);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + "ns2", 100);
+    conf.setInt(DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX + CONCURRENT_NS, 100);
+
+    ElasticRouterRpcFairnessPolicyController controller =
+        new ElasticRouterRpcFairnessPolicyController(conf, 0);
+    assertNotNull(controller);
+    assertEquals(10, controller.getTotalElasticAvailableHandler());
+
+    verifyAcquirePermit(controller, "ns1", 5, 10);
+    verifyAcquirePermit(controller, "ns2", 2, 0);
+    verifyAcquirePermit(controller, CONCURRENT_NS, 3, 0);
+    assertEquals(0, controller.getTotalElasticAvailableHandler());
+  }
+
+  private Configuration createConf(int handlers) {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFS_ROUTER_HANDLER_COUNT_KEY, handlers);
+    conf.set(DFS_ROUTER_MONITOR_NAMENODE, nameServices);
+    conf.setClass(
+        RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
+        ElasticRouterRpcFairnessPolicyController.class,
+        RouterRpcFairnessPolicyController.class);
+    return conf;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestElasticRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestElasticRouterRpcFairnessPolicyController.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.hdfs.server.federation.fairness.Permit.PermitType;
  * Test functionality of {@link ElasticRouterRpcFairnessPolicyController).
  */
 public class TestElasticRouterRpcFairnessPolicyController {
-  private final static String nameServices =
+  private final static String NAMESERVICES =
       "ns1.nn1, ns1.nn2, ns2.nn1, ns2.nn2";
 
   private void verifyAcquirePermit(RouterRpcFairnessPolicyController controller,
@@ -156,7 +156,7 @@ public class TestElasticRouterRpcFairnessPolicyController {
   private Configuration createConf(int handlers) {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(DFS_ROUTER_HANDLER_COUNT_KEY, handlers);
-    conf.set(DFS_ROUTER_MONITOR_NAMENODE, nameServices);
+    conf.set(DFS_ROUTER_MONITOR_NAMENODE, NAMESERVICES);
     conf.setClass(
         RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS,
         ElasticRouterRpcFairnessPolicyController.class,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterHandlersFairness.java
@@ -137,13 +137,13 @@ public class TestRouterHandlersFairness {
         // take the lock for concurrent NS to block fanout calls
         assertTrue(routerContext.getRouter().getRpcServer()
             .getRPCClient().getRouterRpcFairnessPolicyController()
-            .acquirePermit(RouterRpcFairnessConstants.CONCURRENT_NS));
+            .acquirePermit(RouterRpcFairnessConstants.CONCURRENT_NS).isHoldPermit());
       } else {
         for (String ns : cluster.getNameservices()) {
           LOG.info("Taking lock first for ns: {}", ns);
           assertTrue(routerContext.getRouter().getRpcServer()
               .getRPCClient().getRouterRpcFairnessPolicyController()
-              .acquirePermit(ns));
+              .acquirePermit(ns).isHoldPermit());
         }
       }
     }
@@ -156,6 +156,10 @@ public class TestRouterHandlersFairness {
     assertEquals(latestRejectedPermits - originalRejectedPermits,
         overloadException.get());
 
+    Permit permit = new Permit(Permit.PermitType.DEDICATED,
+        routerContext.getRouter().getRpcServer().getRPCClient()
+            .getRouterRpcFairnessPolicyController().getVersion());
+
     if (fairness) {
       assertTrue(overloadException.get() > 0);
       if (isConcurrent) {
@@ -163,12 +167,12 @@ public class TestRouterHandlersFairness {
         // take the lock for concurrent NS to block fanout calls
         routerContext.getRouter().getRpcServer()
             .getRPCClient().getRouterRpcFairnessPolicyController()
-            .releasePermit(RouterRpcFairnessConstants.CONCURRENT_NS);
+            .releasePermit(RouterRpcFairnessConstants.CONCURRENT_NS, permit);
       } else {
         for (String ns : cluster.getNameservices()) {
           routerContext.getRouter().getRpcServer()
               .getRPCClient().getRouterRpcFairnessPolicyController()
-              .releasePermit(ns);
+              .releasePermit(ns, permit);
         }
       }
     } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
@@ -54,7 +54,8 @@ public class TestRouterRpcFairnessPolicyController {
     RouterRpcFairnessPolicyController routerRpcFairnessPolicyController
         = getFairnessPolicyController(31);
     // One extra handler should be allocated to commons.
-    assertTrue(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+        .isHoldPermit());
     verifyHandlerAllocation(routerRpcFairnessPolicyController);
   }
 
@@ -63,24 +64,30 @@ public class TestRouterRpcFairnessPolicyController {
     Configuration conf = createConf(40);
     conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns1", 30);
     RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
-        FederationUtil.newFairnessPolicyController(conf);
+        FederationUtil.newFairnessPolicyController(conf, 0);
 
     // ns1 should have 30 permits allocated
     for (int i=0; i<30; i++) {
-      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1")
+          .isHoldPermit());
     }
 
     // ns2 should have 5 permits.
     // concurrent should have 5 permits.
     for (int i=0; i<5; i++) {
-      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2")
+          .isHoldPermit());
       assertTrue(
-          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+              .isHoldPermit());
     }
 
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2"));
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1")
+        .isHoldPermit());
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2")
+        .isHoldPermit());
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+        .isHoldPermit());
   }
 
   @Test
@@ -117,7 +124,7 @@ public class TestRouterRpcFairnessPolicyController {
   public void testGetAvailableHandlerOnPerNsForNoFairness() {
     Configuration conf = new Configuration();
     RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
-        FederationUtil.newFairnessPolicyController(conf);
+        FederationUtil.newFairnessPolicyController(conf, 0);
     assertEquals("N/A",
         routerRpcFairnessPolicyController.getAvailableHandlerOnPerNs());
   }
@@ -136,20 +143,26 @@ public class TestRouterRpcFairnessPolicyController {
     conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "ns2", 1);
     conf.setInt(DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX + "concurrent", 1);
     RouterRpcFairnessPolicyController routerRpcFairnessPolicyController =
-        FederationUtil.newFairnessPolicyController(conf);
+        FederationUtil.newFairnessPolicyController(conf, 0);
 
     // ns1, ns2 should have 1 permit each
-    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
-    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1")
+        .isHoldPermit());
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2")
+        .isHoldPermit());
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1")
+        .isHoldPermit());
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2")
+        .isHoldPermit());
 
     // concurrent should have 3 permits
     for (int i=0; i<3; i++) {
       assertTrue(
-          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+              .isHoldPermit());
     }
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+        .isHoldPermit());
   }
 
 
@@ -159,7 +172,7 @@ public class TestRouterRpcFairnessPolicyController {
         .captureLogs(LoggerFactory.getLogger(
             StaticRouterRpcFairnessPolicyController.class));
     try {
-      FederationUtil.newFairnessPolicyController(conf);
+      FederationUtil.newFairnessPolicyController(conf, 0);
     } catch (IllegalArgumentException e) {
       // Ignore the exception as it is expected here.
     }
@@ -172,28 +185,40 @@ public class TestRouterRpcFairnessPolicyController {
 
   private RouterRpcFairnessPolicyController getFairnessPolicyController(
       int handlers) {
-    return FederationUtil.newFairnessPolicyController(createConf(handlers));
+    return FederationUtil.newFairnessPolicyController(createConf(handlers), 0);
   }
 
   private void verifyHandlerAllocation(
       RouterRpcFairnessPolicyController routerRpcFairnessPolicyController) {
     for (int i=0; i<10; i++) {
-      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
-      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1")
+          .isHoldPermit());
+      assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2")
+          .isHoldPermit());
       assertTrue(
-          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+          routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+              .isHoldPermit());
     }
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1"));
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2"));
-    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns1")
+        .isHoldPermit());
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit("ns2")
+        .isHoldPermit());
+    assertFalse(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+        .isHoldPermit());
 
-    routerRpcFairnessPolicyController.releasePermit("ns1");
-    routerRpcFairnessPolicyController.releasePermit("ns2");
-    routerRpcFairnessPolicyController.releasePermit(CONCURRENT_NS);
+    Permit permit = new Permit(Permit.PermitType.DEDICATED,
+        routerRpcFairnessPolicyController.getVersion());
 
-    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1"));
-    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2"));
-    assertTrue(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS));
+    routerRpcFairnessPolicyController.releasePermit("ns1", permit);
+    routerRpcFairnessPolicyController.releasePermit("ns2", permit);
+    routerRpcFairnessPolicyController.releasePermit(CONCURRENT_NS, permit);
+
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns1")
+        .isHoldPermit());
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit("ns2")
+        .isHoldPermit());
+    assertTrue(routerRpcFairnessPolicyController.acquirePermit(CONCURRENT_NS)
+        .isHoldPermit());
   }
 
   private Configuration createConf(int handlers) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
@@ -170,14 +170,14 @@ public class TestRouterRpcFairnessPolicyController {
       int totalDedicatedHandlers) {
     GenericTestUtils.LogCapturer logs = GenericTestUtils.LogCapturer
         .captureLogs(LoggerFactory.getLogger(
-            StaticRouterRpcFairnessPolicyController.class));
+            AbstractRouterRpcFairnessPolicyController.class));
     try {
       FederationUtil.newFairnessPolicyController(conf, 0);
     } catch (IllegalArgumentException e) {
       // Ignore the exception as it is expected here.
     }
     String errorMsg = String.format(
-        StaticRouterRpcFairnessPolicyController.ERROR_MSG, handlerCount,
+        AbstractRouterRpcFairnessPolicyController.ERROR_MSG, handlerCount,
         totalDedicatedHandlers);
     assertTrue("Should contain error message: " + errorMsg,
         logs.getOutput().contains(errorMsg));

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
@@ -51,6 +51,6 @@ public class TestRBFConfigFields extends TestConfigurationFieldsBase {
             + "EXAMPLENAMESERVICE");
     xmlPrefixToSkipCompare = new HashSet<String>();
     xmlPrefixToSkipCompare.add(
-        RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX);;
+        RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
@@ -49,5 +49,7 @@ public class TestRBFConfigFields extends TestConfigurationFieldsBase {
     xmlPrefixToSkipCompare = new HashSet<String>();
     xmlPrefixToSkipCompare.add(
         RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX);
+    xmlPrefixToSkipCompare.add(
+        RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRBFConfigFields.java
@@ -46,10 +46,11 @@ public class TestRBFConfigFields extends TestConfigurationFieldsBase {
 
     // Allocate
     xmlPropsToSkipCompare = new HashSet<String>();
+    xmlPropsToSkipCompare.add(
+        RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX
+            + "EXAMPLENAMESERVICE");
     xmlPrefixToSkipCompare = new HashSet<String>();
     xmlPrefixToSkipCompare.add(
-        RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX);
-    xmlPrefixToSkipCompare.add(
-        RBFConfigKeys.DFS_ROUTER_ELASTIC_PERMITS_PERCENT_KEY_PREFIX);
+        RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX);;
   }
 }


### PR DESCRIPTION
### Description of PR
As we all known, `StaticRouterRpcFairnessPolicyController` is very helpfully for RBF to minimize impact of clients connecting to healthy vs unhealthy nameNodes. 
But in prod environment, the traffic of clients accessing each NS and the pressure of downstream namenodes are dynamically changed. So if we only have one static permit conf, RBF cannot able to adapt to the changes in traffic to achieve optimal results. 

So here I propose an elastic RouterRpcFairnessPolicyController to help RBF adapt to traffic changes to achieve an optimal result.

The overall idea is:
- Each name service can configured the exclusive permits like `StaticRouterRpcFairnessPolicyController`
- TotalPermits is more than sum(NsExclusivePermit) and mark TotalPermits - sum(NsExclusivePermit) as SharedPermits
- Each name service can properly preempt the SharedPermits after it's own exclusive permits is used up.
- But the maximum value of SharedPermits preempted by each nameservice should be limited. Such as 20% of SharedPermits.

Suppose we have 200 handlers and 5 name services, and each name services configured different exclusive Permits, like:
| NS1 | NS2 | NS3 | NS4 | NS5 | Concurrent NS |
|-- | -- | -- | -- | -- | -- |
| 9 | 11 | 8 | 12 | 10 | 50 |

The `sum(NsExclusivePermit)` is 100, and the `SharedPermits = TotalPermits(200) - Sum(NsExclusivePermit)(100) = 100`
Suppose we configure that each nameservice can preempt up to 20% of TotalPermits, marked as `elasticPercent`.

Then from the point view of a single NS, the permits it may be can use are as follow:
- Exclusive Permits, which is cannot be used by other name services.
- Limited SharedPermits, whether is can use so many shared permits depends on the remaining number of SharedPermits, because the SharedPermits is be preempted by all nameservices.

If we configure the `elasticPercent=100`, it means one nameservices can use up all SharedPermits.
If we configure the `elasticPercent=0`, it means nameservice can only use it's exclusive Permits.
If we configure the `elasticPercent=20`, it means that the RBF can tolerate 5 unhealthy name services at the same time.

In our prod environment, we configured as follow, and it works well:
- RBF has 3000 handlers
- Each nameservice has 10 exclusive permits
- `elasticPercent` is 30%

Of course, we need to configure reasonable parameters according to the prod traffic.