### PR TITLE
[Draft] HDFS-13522: Allow routers to use observer namenode without an msync on even read. [Not ready for review]

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AlignmentContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/AlignmentContext.java
@@ -46,7 +46,7 @@ public interface AlignmentContext {
   void updateResponseState(RpcResponseHeaderProto.Builder header);
 
   /**
-   * This is the intended client method call to implement to recieve state info
+   * This is the intended client method call to implement to receive state info
    * during RPC response processing.
    *
    * @param header The RPC response header.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RpcConstants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RpcConstants.java
@@ -39,6 +39,8 @@ public class RpcConstants {
   public static final int INVALID_RETRY_COUNT = -1;
   // Special value to indicate the client does not want routers to read from Observer Namenodes.
   public static final long DISABLED_OBSERVER_READ_STATEID = -1L;
+  // Special value to indicate client request header has nameserviceStateIds set.
+  public static final long REQUEST_HEADER_NAMESPACE_STATEIDS_SET = -2L;
   
  /**
   * The Rpc-connection header is as follows 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RpcConstants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RpcConstants.java
@@ -37,8 +37,6 @@ public class RpcConstants {
   
   
   public static final int INVALID_RETRY_COUNT = -1;
-  // Special value to indicate the client does not want routers to read from Observer Namenodes.
-  public static final long DISABLED_OBSERVER_READ_STATEID = -1L;
   // Special value to indicate client request header has nameserviceStateIds set.
   public static final long REQUEST_HEADER_NAMESPACE_STATEIDS_SET = -2L;
   

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RpcConstants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/RpcConstants.java
@@ -37,6 +37,8 @@ public class RpcConstants {
   
   
   public static final int INVALID_RETRY_COUNT = -1;
+  // Special value to indicate the client does not want routers to read from Observer Namenodes.
+  public static final long DISABLED_OBSERVER_READ_STATEID = -1L;
   
  /**
   * The Rpc-connection header is as follows 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -928,7 +928,7 @@ public abstract class Server {
     private volatile String detailedMetricsName = "";
     final int callId;            // the client's call id
     final int retryCount;        // the retry count of the call
-    long timestampNanos;         // time the call was received
+    private final long timestampNanos; // time the call was received
     long responseTimestampNanos; // time the call was served
     private AtomicInteger responseWaitCount = new AtomicInteger(1);
     final RPC.RpcKind rpcKind;
@@ -1110,6 +1110,10 @@ public abstract class Server {
 
     public void setDeferredError(Throwable t) {
     }
+
+    public long getTimestampNanos() {
+      return timestampNanos;
+    }
   }
 
   /** A RPC extended call queued for handling. */
@@ -1191,7 +1195,7 @@ public abstract class Server {
 
       try {
         value = call(
-            rpcKind, connection.protocolName, rpcRequest, timestampNanos);
+            rpcKind, connection.protocolName, rpcRequest, getTimestampNanos());
       } catch (Throwable e) {
         populateResponseParamsOnError(e, responseParams);
       }

--- a/hadoop-common-project/hadoop-common/src/main/proto/RpcHeader.proto
+++ b/hadoop-common-project/hadoop-common/src/main/proto/RpcHeader.proto
@@ -91,6 +91,7 @@ message RpcRequestHeaderProto { // the header for the RpcRequest
   optional RPCTraceInfoProto traceInfo = 6; // tracing info
   optional RPCCallerContextProto callerContext = 7; // call context
   optional int64 stateId = 8; // The last seen Global State ID
+  map<string, int64> nameserviceStateIds = 9; // Last seen state IDs for multiple nameservices.
 }
 
 
@@ -157,6 +158,7 @@ message RpcResponseHeaderProto {
   optional bytes clientId = 7; // Globally unique client ID
   optional sint32 retryCount = 8 [default = -1];
   optional int64 stateId = 9; // The last written Global State ID
+  map<string, int64> nameserviceStateIds = 10; // Last seen state IDs for multiple nameservices.
 }
 
 message RpcSaslProto {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 import java.io.IOException;
 import java.util.concurrent.atomic.LongAccumulator;
 
-import static org.apache.hadoop.ipc.RpcConstants.DISABLED_OBSERVER_READ_STATEID;
-
 /**
  * Global State Id context for the client.
  * <p>
@@ -43,14 +41,6 @@ public class ClientGSIContext implements AlignmentContext {
   private final LongAccumulator lastSeenStateId =
       new LongAccumulator(Math::max, STATEID_DEFAULT_VALUE);
   private FederatedGSIContext federatedGSIContext = new FederatedGSIContext();
-
-  public void disableObserverRead() {
-    if (lastSeenStateId.get() > DISABLED_OBSERVER_READ_STATEID) {
-      throw new IllegalStateException(
-          "Can't disable observer read after communicate.");
-    }
-    lastSeenStateId.accumulate(DISABLED_OBSERVER_READ_STATEID);
-  }
 
   @Override
   public long getLastSeenStateId() {
@@ -82,10 +72,6 @@ public class ClientGSIContext implements AlignmentContext {
    */
   @Override
   public void receiveResponseState(RpcResponseHeaderProto header) {
-    if (lastSeenStateId.get() == DISABLED_OBSERVER_READ_STATEID) {
-      //Observer read is disabled
-      return;
-    }
     federatedGSIContext.updateStateUsingResponseHeader(header);
     lastSeenStateId.accumulate(header.getStateId());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ClientGSIContext.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 import java.io.IOException;
 import java.util.concurrent.atomic.LongAccumulator;
 
+import static org.apache.hadoop.ipc.RpcConstants.DISABLED_OBSERVER_READ_STATEID;
+
 /**
  * Global State Id context for the client.
  * <p>
@@ -39,6 +41,14 @@ public class ClientGSIContext implements AlignmentContext {
 
   private final LongAccumulator lastSeenStateId =
       new LongAccumulator(Math::max, Long.MIN_VALUE);
+
+  public void disableObserverRead() {
+    if (lastSeenStateId.get() > DISABLED_OBSERVER_READ_STATEID) {
+      throw new IllegalStateException(
+          "Can't disable observer read after communicate.");
+    }
+    lastSeenStateId.accumulate(DISABLED_OBSERVER_READ_STATEID);
+  }
 
   @Override
   public long getLastSeenStateId() {
@@ -66,6 +76,10 @@ public class ClientGSIContext implements AlignmentContext {
    */
   @Override
   public void receiveResponseState(RpcResponseHeaderProto header) {
+    if (lastSeenStateId.get() == DISABLED_OBSERVER_READ_STATEID) {
+      //Observer read is disabled
+      return;
+    }
     lastSeenStateId.accumulate(header.getStateId());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FederatedGSIContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FederatedGSIContext.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.ipc.AlignmentContext;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos;
+
+
+public class FederatedGSIContext {
+  private final Map<String, ClientGSIContext> gsiContextMap = new ConcurrentHashMap<>();
+
+  public void updateStateUsingRequestHeader(RpcHeaderProtos.RpcRequestHeaderProto header) {
+    header.getNameserviceStateIdsMap().forEach(this::updateNameserviceState);
+  }
+
+  public void updateStateUsingResponseHeader(RpcHeaderProtos.RpcResponseHeaderProto header) {
+    header.getNameserviceStateIdsMap().forEach(this::updateNameserviceState);
+  }
+
+  public void updateNameserviceState(String nsId, Long stateId) {
+    if (!gsiContextMap.containsKey(nsId)) {
+      gsiContextMap.putIfAbsent(nsId, new ClientGSIContext());
+    }
+    gsiContextMap.get(nsId).updateLastSeenStateID(stateId);
+  }
+
+  public void setRequestHeaderState(RpcHeaderProtos.RpcRequestHeaderProto.Builder headerBuilder) {
+    gsiContextMap
+        .forEach((k, v) -> headerBuilder.putNameserviceStateIds(k, v.getLastSeenStateId()));
+  }
+
+  public void setResponseHeaderState(RpcHeaderProtos.RpcResponseHeaderProto.Builder headerBuilder) {
+    gsiContextMap
+        .forEach((k, v) -> headerBuilder.putNameserviceStateIds(k, v.getLastSeenStateId()));
+  }
+
+  public AlignmentContext getNameserviceAlignmentContext(String nsId) {
+    gsiContextMap
+        .putIfAbsent(nsId, new ClientGSIContext());
+    return gsiContextMap.get(nsId);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -349,6 +349,18 @@ public class NameNodeProxiesClient {
       boolean withRetries, AtomicBoolean fallbackToSimpleAuth,
       AlignmentContext alignmentContext)
       throws IOException {
+    if (!conf.getBoolean(HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE,
+        HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE_DEFAULT)) {
+      //Disabled observer read
+      if (alignmentContext == null) {
+        alignmentContext = new ClientGSIContext();
+      }
+      if (alignmentContext instanceof ClientGSIContext) {
+        ((ClientGSIContext) alignmentContext).disableObserverRead();
+        LOG.info("Observer read is disabled in client");
+      }
+    }
+
     RPC.setProtocolEngine(conf, ClientNamenodeProtocolPB.class,
         ProtobufRpcEngine2.class);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -349,12 +349,12 @@ public class NameNodeProxiesClient {
       boolean withRetries, AtomicBoolean fallbackToSimpleAuth,
       AlignmentContext alignmentContext)
       throws IOException {
+    if (alignmentContext == null) {
+      alignmentContext = new ClientGSIContext();
+    }
     if (!conf.getBoolean(HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE,
         HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE_DEFAULT)) {
       //Disabled observer read
-      if (alignmentContext == null) {
-        alignmentContext = new ClientGSIContext();
-      }
       if (alignmentContext instanceof ClientGSIContext) {
         ((ClientGSIContext) alignmentContext).disableObserverRead();
         LOG.info("Observer read is disabled in client");

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -352,15 +352,6 @@ public class NameNodeProxiesClient {
     if (alignmentContext == null) {
       alignmentContext = new ClientGSIContext();
     }
-    if (!conf.getBoolean(HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE,
-        HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE_DEFAULT)) {
-      //Disabled observer read
-      if (alignmentContext instanceof ClientGSIContext) {
-        ((ClientGSIContext) alignmentContext).disableObserverRead();
-        LOG.info("Observer read is disabled in client");
-      }
-    }
-
     RPC.setProtocolEngine(conf, ClientNamenodeProtocolPB.class,
         ProtobufRpcEngine2.class);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -79,6 +79,8 @@ public interface HdfsClientConfigKeys {
   String  DFS_NAMENODE_HTTPS_ADDRESS_KEY = "dfs.namenode.https-address";
   String DFS_HA_NAMENODES_KEY_PREFIX = "dfs.ha.namenodes";
   int DFS_NAMENODE_RPC_PORT_DEFAULT = 8020;
+  String DFS_OBSERVER_READ_ENABLE = "dfs.observer.read.enable";
+  boolean DFS_OBSERVER_READ_ENABLE_DEFAULT = true;
   String DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY =
       "dfs.namenode.kerberos.principal";
   String  DFS_CLIENT_WRITE_PACKET_SIZE_KEY = "dfs.client-write-packet-size";

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -79,8 +79,6 @@ public interface HdfsClientConfigKeys {
   String  DFS_NAMENODE_HTTPS_ADDRESS_KEY = "dfs.namenode.https-address";
   String DFS_HA_NAMENODES_KEY_PREFIX = "dfs.ha.namenodes";
   int DFS_NAMENODE_RPC_PORT_DEFAULT = 8020;
-  String DFS_OBSERVER_READ_ENABLE = "dfs.observer.read.enable";
-  boolean DFS_OBSERVER_READ_ENABLE_DEFAULT = true;
   String DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY =
       "dfs.namenode.kerberos.principal";
   String  DFS_CLIENT_WRITE_PACKET_SIZE_KEY = "dfs.client-write-packet-size";

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCMBean.java
@@ -30,6 +30,10 @@ public interface FederationRPCMBean {
 
   long getProxyOps();
 
+  long getActiveProxyOps();
+
+  long getObserverProxyOps();
+
   double getProxyAvg();
 
   long getProcessingOps();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
@@ -29,6 +29,7 @@ import javax.management.StandardMBean;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
 import org.apache.hadoop.hdfs.server.federation.router.RouterRpcMonitor;
 import org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
@@ -147,12 +148,13 @@ public class FederationRPCPerformanceMonitor implements RouterRpcMonitor {
   }
 
   @Override
-  public void proxyOpComplete(boolean success, String nsId) {
+  public void proxyOpComplete(boolean success, String nsId,
+      FederationNamenodeServiceState state) {
     if (success) {
       long proxyTime = getProxyTime();
       if (proxyTime >= 0) {
         if (metrics != null) {
-          metrics.addProxyTime(proxyTime);
+          metrics.addProxyTime(proxyTime, state);
         }
         if (nameserviceRPCMetricsMap != null &&
             nameserviceRPCMetricsMap.containsKey(nsId)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/RBFMetrics.java
@@ -877,7 +877,7 @@ public class RBFMetrics implements RouterMBean, FederationMBean {
       // Fetch the most recent namenode registration
       String nsId = nsInfo.getNameserviceId();
       List<? extends FederationNamenodeContext> nns =
-          namenodeResolver.getNamenodesForNameserviceId(nsId);
+          namenodeResolver.getNamenodesForNameserviceId(nsId, false);
       if (nns != null) {
         FederationNamenodeContext nn = nns.get(0);
         if (nn instanceof MembershipState) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/ActiveNamenodeResolver.java
@@ -44,6 +44,17 @@ import org.apache.hadoop.classification.InterfaceStability;
 public interface ActiveNamenodeResolver {
 
   /**
+   * Report a failed, unavailable NN address for a nameservice or blockPool.
+   *
+   * @param ns Nameservice identifier.
+   * @param failedAddress The address the failed responded to the command.
+   *
+   * @throws IOException If the state store cannot be accessed.
+   */
+  void updateUnavailableNamenode(
+      String ns, InetSocketAddress failedAddress) throws IOException;
+
+  /**
    * Report a successful, active NN address for a nameservice or blockPool.
    *
    * @param ns Nameservice identifier.
@@ -56,20 +67,30 @@ public interface ActiveNamenodeResolver {
 
   /**
    * Returns a prioritized list of the most recent cached registration entries
-   * for a single nameservice ID.
-   * Returns an empty list if none are found. Returns entries in preference of:
+   * for a single nameservice ID. Returns an empty list if none are found.
+   * In the case of not observerRead Returns entries in preference of :
    * <ul>
+   * <li>The most recent ACTIVE NN
+   * <li>The most recent OBSERVER NN
+   * <li>The most recent STANDBY NN
+   * <li>The most recent UNAVAILABLE NN
+   * </ul>
+   *
+   * In the case of observerRead Returns entries in preference of :
+   * <ul>
+   * <li>The most recent OBSERVER NN
    * <li>The most recent ACTIVE NN
    * <li>The most recent STANDBY NN
    * <li>The most recent UNAVAILABLE NN
    * </ul>
    *
    * @param nameserviceId Nameservice identifier.
+   * @param observerRead Observer read case, observer NN will be ranked first
    * @return Prioritized list of namenode contexts.
    * @throws IOException If the state store cannot be accessed.
    */
-  List<? extends FederationNamenodeContext>
-      getNamenodesForNameserviceId(String nameserviceId) throws IOException;
+  List<? extends FederationNamenodeContext> getNamenodesForNameserviceId(
+      String nameserviceId, boolean observerRead) throws IOException;
 
   /**
    * Returns a prioritized list of the most recent cached registration entries
@@ -77,6 +98,7 @@ public interface ActiveNamenodeResolver {
    * Returns an empty list if none are found. Returns entries in preference of:
    * <ul>
    * <li>The most recent ACTIVE NN
+   * <li>The most recent OBSERVER NN
    * <li>The most recent STANDBY NN
    * <li>The most recent UNAVAILABLE NN
    * </ul>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/resolver/MembershipNamenodeResolver.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.federation.resolver;
 
 import static org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState.ACTIVE;
 import static org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState.EXPIRED;
+import static org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState.OBSERVER;
 import static org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState.UNAVAILABLE;
 
 import java.io.IOException;
@@ -73,8 +74,13 @@ public class MembershipNamenodeResolver
   /** Parent router ID. */
   private String routerId;
 
-  /** Cached lookup of NN for nameservice. Invalidated on cache refresh. */
+  /** Cached lookup of NN for nameservice with active state ranked first.
+   *  Invalidated on cache refresh. */
   private Map<String, List<? extends FederationNamenodeContext>> cacheNS;
+  /** Cached lookup of NN for nameservice with observer state ranked first.
+   *  Invalidated on cache refresh. */
+  private Map<String, List<? extends FederationNamenodeContext>>
+      observerFirstCacheNS;
   /** Cached lookup of NN for block pool. Invalidated on cache refresh. */
   private Map<String, List<? extends FederationNamenodeContext>> cacheBP;
 
@@ -84,6 +90,7 @@ public class MembershipNamenodeResolver
     this.stateStore = store;
 
     this.cacheNS = new ConcurrentHashMap<>();
+    this.observerFirstCacheNS = new ConcurrentHashMap<>();
     this.cacheBP = new ConcurrentHashMap<>();
 
     if (this.stateStore != null) {
@@ -133,14 +140,25 @@ public class MembershipNamenodeResolver
     // Force refresh of active NN cache
     cacheBP.clear();
     cacheNS.clear();
+    observerFirstCacheNS.clear();
     return true;
+  }
+
+  @Override public void updateUnavailableNamenode(String nsId,
+      InetSocketAddress address) throws IOException {
+    updateNameNodeState(nsId, address, UNAVAILABLE);
   }
 
   @Override
   public void updateActiveNamenode(
       final String nsId, final InetSocketAddress address) throws IOException {
+    updateNameNodeState(nsId, address, ACTIVE);
+  }
 
-    // Called when we have an RPC miss and successful hit on an alternate NN.
+
+  private void updateNameNodeState(final String nsId,
+      final InetSocketAddress address, FederationNamenodeServiceState state)
+      throws IOException {
     // Temporarily update our cache, it will be overwritten on the next update.
     try {
       MembershipState partial = MembershipState.newInstance();
@@ -160,10 +178,11 @@ public class MembershipNamenodeResolver
         MembershipState record = records.get(0);
         UpdateNamenodeRegistrationRequest updateRequest =
             UpdateNamenodeRegistrationRequest.newInstance(
-                record.getNameserviceId(), record.getNamenodeId(), ACTIVE);
+                record.getNameserviceId(), record.getNamenodeId(), state);
         membership.updateNamenodeRegistration(updateRequest);
 
         cacheNS.remove(nsId);
+        observerFirstCacheNS.remove(nsId);
         // Invalidating the full cacheBp since getting the blockpool id from
         // namespace id is quite costly.
         cacheBP.clear();
@@ -175,9 +194,11 @@ public class MembershipNamenodeResolver
 
   @Override
   public List<? extends FederationNamenodeContext> getNamenodesForNameserviceId(
-      final String nsId) throws IOException {
+      final String nsId, boolean observerRead) throws IOException {
+    Map<String, List<? extends FederationNamenodeContext>> cache
+        = observerRead ? observerFirstCacheNS : cacheNS;
 
-    List<? extends FederationNamenodeContext> ret = cacheNS.get(nsId);
+    List<? extends FederationNamenodeContext> ret = cache.get(nsId);
     if (ret != null) {
       return ret;
     }
@@ -189,7 +210,8 @@ public class MembershipNamenodeResolver
       partial.setNameserviceId(nsId);
       GetNamenodeRegistrationsRequest request =
           GetNamenodeRegistrationsRequest.newInstance(partial);
-      result = getRecentRegistrationForQuery(request, true, false);
+      result = getRecentRegistrationForQuery(request, true,
+          false, observerRead);
     } catch (StateStoreUnavailableException e) {
       LOG.error("Cannot get active NN for {}, State Store unavailable", nsId);
       return null;
@@ -218,7 +240,7 @@ public class MembershipNamenodeResolver
 
     // Cache the response
     ret = Collections.unmodifiableList(result);
-    cacheNS.put(nsId, result);
+    cache.put(nsId, result);
     return ret;
   }
 
@@ -235,7 +257,7 @@ public class MembershipNamenodeResolver
             GetNamenodeRegistrationsRequest.newInstance(partial);
 
         final List<MembershipState> result =
-            getRecentRegistrationForQuery(request, true, false);
+            getRecentRegistrationForQuery(request, true, false, false);
         if (result == null || result.isEmpty()) {
           LOG.error("Cannot locate eligible NNs for {}", bpId);
         } else {
@@ -346,22 +368,34 @@ public class MembershipNamenodeResolver
   }
 
   /**
-   * Picks the most relevant record registration that matches the query. Return
-   * registrations matching the query in this preference: 1) Most recently
-   * updated ACTIVE registration 2) Most recently updated STANDBY registration
-   * (if showStandby) 3) Most recently updated UNAVAILABLE registration (if
-   * showUnavailable). EXPIRED registrations are ignored.
+   * Picks the most relevant record registration that matches the query.
+   * If not observer read,
+   * return registrations matching the query in this preference:
+   * 1) Most recently updated ACTIVE registration
+   * 2) Most recently updated Observer registration
+   * 3) Most recently updated STANDBY registration (if showStandby)
+   * 4) Most recently updated UNAVAILABLE registration (if showUnavailable).
+   *
+   * If observer read,
+   * return registrations matching the query in this preference:
+   * 1) Most recently updated Observer registration
+   * 2) Most recently updated ACTIVE registration
+   * 3) Most recently updated STANDBY registration (if showStandby)
+   * 4) Most recently updated UNAVAILABLE registration (if showUnavailable).
+   *
+   * EXPIRED registrations are ignored.
    *
    * @param request The select query for NN registrations.
    * @param addUnavailable include UNAVAILABLE registrations.
    * @param addExpired include EXPIRED registrations.
+   * @param observerRead  Observer read case, observer NN will be ranked first
    * @return List of memberships or null if no registrations that
    *         both match the query AND the selected states.
    * @throws IOException
    */
   private List<MembershipState> getRecentRegistrationForQuery(
       GetNamenodeRegistrationsRequest request, boolean addUnavailable,
-      boolean addExpired) throws IOException {
+      boolean addExpired, boolean observerRead) throws IOException {
 
     // Retrieve a list of all registrations that match this query.
     // This may include all NN records for a namespace/blockpool, including
@@ -371,24 +405,37 @@ public class MembershipNamenodeResolver
         membershipStore.getNamenodeRegistrations(request);
 
     List<MembershipState> memberships = response.getNamenodeMemberships();
-    if (!addExpired || !addUnavailable) {
-      Iterator<MembershipState> iterator = memberships.iterator();
-      while (iterator.hasNext()) {
-        MembershipState membership = iterator.next();
-        if (membership.getState() == EXPIRED && !addExpired) {
-          iterator.remove();
-        } else if (membership.getState() == UNAVAILABLE && !addUnavailable) {
-          iterator.remove();
-        }
+    List<MembershipState> observerMemberships = new ArrayList<>();
+    Iterator<MembershipState> iterator = memberships.iterator();
+    while (iterator.hasNext()) {
+      MembershipState membership = iterator.next();
+      if (membership.getState() == EXPIRED && !addExpired) {
+        iterator.remove();
+      } else if (membership.getState() == UNAVAILABLE && !addUnavailable) {
+        iterator.remove();
+      } else if (membership.getState() == OBSERVER && observerRead) {
+        iterator.remove();
+        observerMemberships.add(membership);
       }
     }
 
-    List<MembershipState> priorityList = new ArrayList<>();
-    priorityList.addAll(memberships);
-    Collections.sort(priorityList, new NamenodePriorityComparator());
+    if(!observerRead) {
+      Collections.sort(memberships, new NamenodePriorityComparator());
+      LOG.debug("Selected most recent NN {} for query", memberships);
+      return  memberships;
+    } else {
+      List<MembershipState> ret = new ArrayList<>(
+          memberships.size() + observerMemberships.size());
+      Collections.sort(memberships, new NamenodePriorityComparator());
+      if(observerMemberships.size() > 1) {
+        Collections.shuffle(observerMemberships);
+      }
+      ret.addAll(observerMemberships);
+      ret.addAll(memberships);
 
-    LOG.debug("Selected most recent NN {} for query", priorityList);
-    return priorityList;
+      LOG.debug("Selected most recent NN {} for query", ret);
+      return ret;
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionPool.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ConnectionPool.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.SocketFactory;
 
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.ipc.AlignmentContext;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -105,6 +106,8 @@ public class ConnectionPool {
   /** The last time a connection was active. */
   private volatile long lastActiveTime = 0;
 
+  private final AlignmentContext alignmentContext;
+
   /** Map for the protocols and their protobuf implementations. */
   private final static Map<Class<?>, ProtoImpl> PROTO_MAP = new HashMap<>();
   static {
@@ -134,7 +137,8 @@ public class ConnectionPool {
 
   protected ConnectionPool(Configuration config, String address,
       UserGroupInformation user, int minPoolSize, int maxPoolSize,
-      float minActiveRatio, Class<?> proto) throws IOException {
+      float minActiveRatio, Class<?> proto, AlignmentContext alignmentContext)
+      throws IOException {
 
     this.conf = config;
 
@@ -149,6 +153,8 @@ public class ConnectionPool {
     this.minSize = minPoolSize;
     this.maxSize = maxPoolSize;
     this.minActiveRatio = minActiveRatio;
+
+    this.alignmentContext = alignmentContext;
 
     // Add minimum connections to the pool
     for (int i=0; i<this.minSize; i++) {
@@ -393,8 +399,8 @@ public class ConnectionPool {
    * @throws IOException If it cannot get a new connection.
    */
   public ConnectionContext newConnection() throws IOException {
-    return newConnection(
-        this.conf, this.namenodeAddress, this.ugi, this.protocol);
+    return newConnection(this.conf, this.namenodeAddress, this.ugi,
+        this.protocol, alignmentContext);
   }
 
   /**
@@ -407,13 +413,15 @@ public class ConnectionPool {
    * @param conf Configuration for the connection.
    * @param nnAddress Address of server supporting the ClientProtocol.
    * @param ugi User context.
+   * @param alignmentContext client alignment context.
    * @param proto Interface of the protocol.
    * @return proto for the target ClientProtocol that contains the user's
    *         security context.
    * @throws IOException If it cannot be created.
    */
   protected static <T> ConnectionContext newConnection(Configuration conf,
-      String nnAddress, UserGroupInformation ugi, Class<T> proto)
+      String nnAddress, UserGroupInformation ugi, Class<T> proto,
+      AlignmentContext alignmentContext)
       throws IOException {
     if (!PROTO_MAP.containsKey(proto)) {
       String msg = "Unsupported protocol for connection to NameNode: "
@@ -438,7 +446,8 @@ public class ConnectionPool {
     InetSocketAddress socket = NetUtils.createSocketAddr(nnAddress);
     final long version = RPC.getProtocolVersion(classes.protoPb);
     Object proxy = RPC.getProtocolProxy(classes.protoPb, version, socket, ugi,
-        conf, factory, RPC.getRpcTimeout(conf), defaultPolicy, null).getProxy();
+        conf, factory, RPC.getRpcTimeout(conf), defaultPolicy, null,
+        alignmentContext).getProxy();
     T client = newProtoClient(proto, classes, proxy);
     Text dtService = SecurityUtil.buildTokenService(socket);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -181,6 +181,14 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
       FEDERATION_STORE_PREFIX + "enable";
   public static final boolean DFS_ROUTER_STORE_ENABLE_DEFAULT = true;
 
+  public static final String DFS_ROUTER_OBSERVER_READ_ENABLE =
+      FEDERATION_ROUTER_PREFIX + "observer.read.enable";
+  public static final boolean DFS_ROUTER_OBSERVER_READ_ENABLE_DEFAULT = false;
+
+  public static final String DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD =
+      FEDERATION_ROUTER_PREFIX + "observer.auto-msync-period";
+  public static final long DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD_DEFAULT = 0;
+
   public static final String FEDERATION_STORE_SERIALIZER_CLASS =
       FEDERATION_STORE_PREFIX + "serializer";
   public static final Class<StateStoreSerializerPBImpl>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -368,7 +368,7 @@ public class RouterRpcClient {
             ugi.getUserName(), routerUser);
       }
       connection = this.connectionManager.getConnection(
-          connUGI, rpcAddress, proto);
+          connUGI, rpcAddress, proto, nsId);
       LOG.debug("User {} NN {} is using connection {}",
           ugi.getUserName(), rpcAddress, connection);
     } catch (Exception ex) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_C
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_ON_SOCKET_TIMEOUTS_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_TIMEOUT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
-import static org.apache.hadoop.ipc.RpcConstants.DISABLED_OBSERVER_READ_STATEID;
 import static org.apache.hadoop.ipc.RpcConstants.REQUEST_HEADER_NAMESPACE_STATEIDS_SET;
 
 import java.io.EOFException;
@@ -1799,11 +1798,6 @@ public class RouterRpcClient {
    */
   private static boolean isReadCall(Method method) {
     if (!method.isAnnotationPresent(ReadOnly.class)) {
-      return false;
-    }
-    Call call = Server.getCurCall().get();
-    if (call != null && call.getClientStateId() == DISABLED_OBSERVER_READ_STATEID) {
-      // Client disabled observer read
       return false;
     }
     return !method.getAnnotationsByType(ReadOnly.class)[0].activeOnly();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_C
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_ON_SOCKET_TIMEOUTS_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_TIMEOUT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessConstants.CONCURRENT_NS;
+import static org.apache.hadoop.ipc.RpcConstants.DISABLED_OBSERVER_READ_STATEID;
 
 import java.io.EOFException;
 import java.io.FileNotFoundException;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -62,6 +64,7 @@ import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.NameNodeProxiesClient.ProxyAndInfo;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.apache.hadoop.hdfs.protocol.ClientProtocol;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.SnapshotException;
 import org.apache.hadoop.hdfs.server.federation.fairness.RouterRpcFairnessPolicyController;
@@ -69,17 +72,21 @@ import org.apache.hadoop.hdfs.server.federation.resolver.ActiveNamenodeResolver;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
 import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
+import org.apache.hadoop.hdfs.server.namenode.ha.ReadOnly;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.io.retry.RetryPolicy.RetryAction.RetryDecision;
 import org.apache.hadoop.ipc.CallerContext;
+import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ipc.Server.Call;
 import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.net.ConnectTimeoutException;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.Time;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,6 +133,14 @@ public class RouterRpcClient {
   private final RouterRpcMonitor rpcMonitor;
   /** Field separator of CallerContext. */
   private final String contextFieldSeparator;
+  /** Observer read enabled. Default for all nameservices. */
+  private boolean observerReadEnabled;
+  /** Nameservice specific override for enabling or disabling observer read. */
+  private Map<String, Boolean> nsObserverReadEnabled = new ConcurrentHashMap<>();
+  /** Auto msync period. */
+  private long autoMsyncPeriodMs;
+  /** Last msync times. */
+  private Map<String, LongHolder> lastMsyncTimes;
 
   /** Pattern to parse a stack trace line. */
   private static final Pattern STACK_TRACE_PATTERN =
@@ -135,6 +150,17 @@ public class RouterRpcClient {
   private volatile RouterRpcFairnessPolicyController routerRpcFairnessPolicyController;
   private Map<String, LongAdder> rejectedPermitsPerNs = new ConcurrentHashMap<>();
   private Map<String, LongAdder> acceptedPermitsPerNs = new ConcurrentHashMap<>();
+
+
+  private static final Method MSYNC_METHOD;
+
+  static {
+    try {
+      MSYNC_METHOD = ClientProtocol.class.getDeclaredMethod("msync");
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Failed to create msync method instance.", e);
+    }
+  }
 
   /**
    * Create a router RPC client to manage remote procedure calls to NNs.
@@ -193,6 +219,22 @@ public class RouterRpcClient {
     this.retryPolicy = RetryPolicies.failoverOnNetworkException(
         RetryPolicies.TRY_ONCE_THEN_FAIL, maxFailoverAttempts, maxRetryAttempts,
         failoverSleepBaseMillis, failoverSleepMaxMillis);
+    this.observerReadEnabled = conf.getBoolean(
+        RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_ENABLE,
+        RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_ENABLE_DEFAULT);
+    Map<String, String> observerReadOverrides = conf
+        .getPropsWithPrefix(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_ENABLE + ".");
+    observerReadOverrides
+        .forEach((nsId, readEnabled) ->
+            nsObserverReadEnabled.put(nsId, Boolean.valueOf(readEnabled)));
+    if (this.observerReadEnabled) {
+      LOG.info("Observer read is enabled for router.");
+      this.autoMsyncPeriodMs = conf.getTimeDuration(
+          RBFConfigKeys.DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD,
+          RBFConfigKeys.DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD_DEFAULT,
+          TimeUnit.MILLISECONDS);
+      this.lastMsyncTimes = new HashMap<>();
+    }
   }
 
   /**
@@ -445,6 +487,7 @@ public class RouterRpcClient {
    * @param namenodes A prioritized list of namenodes within the same
    *                  nameservice.
    * @param method Remote ClientProtocol method to invoke.
+   * @param skipObserver Skip observer namenodes.
    * @param params Variable list of parameters matching the method.
    * @return The result of invoking the method.
    * @throws ConnectException If it cannot connect to any Namenode.
@@ -455,7 +498,8 @@ public class RouterRpcClient {
   public Object invokeMethod(
       final UserGroupInformation ugi,
       final List<? extends FederationNamenodeContext> namenodes,
-      final Class<?> protocol, final Method method, final Object... params)
+      final Class<?> protocol, final Method method, boolean skipObserver,
+      final Object... params)
           throws ConnectException, StandbyException, IOException {
 
     if (namenodes == null || namenodes.isEmpty()) {
@@ -471,8 +515,13 @@ public class RouterRpcClient {
       rpcMonitor.proxyOp();
     }
     boolean failover = false;
+    boolean tryActive = false;
     Map<FederationNamenodeContext, IOException> ioes = new LinkedHashMap<>();
     for (FederationNamenodeContext namenode : namenodes) {
+      if ((tryActive || skipObserver)
+          && namenode.getState() == FederationNamenodeServiceState.OBSERVER) {
+        continue;
+      }
       ConnectionContext connection = null;
       String nsId = namenode.getNameserviceId();
       String rpcAddress = namenode.getRpcAddress();
@@ -482,13 +531,14 @@ public class RouterRpcClient {
         final Object proxy = client.getProxy();
 
         ret = invoke(nsId, 0, method, proxy, params);
-        if (failover) {
+        if (failover &&
+            FederationNamenodeServiceState.OBSERVER != namenode.getState()) {
           // Success on alternate server, update
           InetSocketAddress address = client.getAddress();
           namenodeResolver.updateActiveNamenode(nsId, address);
         }
         if (this.rpcMonitor != null) {
-          this.rpcMonitor.proxyOpComplete(true, nsId);
+          this.rpcMonitor.proxyOpComplete(true, nsId, namenode.getState());
         }
         if (this.router.getRouterClientMetrics() != null) {
           this.router.getRouterClientMetrics().incInvokedMethod(method);
@@ -496,7 +546,11 @@ public class RouterRpcClient {
         return ret;
       } catch (IOException ioe) {
         ioes.put(namenode, ioe);
-        if (ioe instanceof StandbyException) {
+        if (ioe instanceof ObserverRetryOnActiveException) {
+          LOG.info("Encountered ObserverRetryOnActiveException from {}."
+                  + " Retry active namenode directly.");
+          tryActive = true;
+        } else if (ioe instanceof StandbyException) {
           // Fail over indicated by retry policy and/or NN
           if (this.rpcMonitor != null) {
             this.rpcMonitor.proxyOpFailureStandby(nsId);
@@ -506,10 +560,15 @@ public class RouterRpcClient {
           if (this.rpcMonitor != null) {
             this.rpcMonitor.proxyOpFailureCommunicate(nsId);
           }
-          failover = true;
+          if (FederationNamenodeServiceState.OBSERVER == namenode.getState()) {
+            namenodeResolver.updateUnavailableNamenode(nsId,
+                NetUtils.createSocketAddr(namenode.getRpcAddress()));
+          } else {
+            failover = true;
+          }
         } else if (ioe instanceof RemoteException) {
           if (this.rpcMonitor != null) {
-            this.rpcMonitor.proxyOpComplete(true, nsId);
+            this.rpcMonitor.proxyOpComplete(true, nsId, namenode.getState());
           }
           RemoteException re = (RemoteException) ioe;
           ioe = re.unwrapRemoteException();
@@ -539,7 +598,7 @@ public class RouterRpcClient {
           // Communication retries are handled by the retry policy
           if (this.rpcMonitor != null) {
             this.rpcMonitor.proxyOpFailureCommunicate(nsId);
-            this.rpcMonitor.proxyOpComplete(false, nsId);
+            this.rpcMonitor.proxyOpComplete(false, nsId, namenode.getState());
           }
           throw ioe;
         }
@@ -550,7 +609,7 @@ public class RouterRpcClient {
       }
     }
     if (this.rpcMonitor != null) {
-      this.rpcMonitor.proxyOpComplete(false, null);
+      this.rpcMonitor.proxyOpComplete(false, null, null);
     }
 
     // All namenodes were unavailable or in standby
@@ -701,7 +760,7 @@ public class RouterRpcClient {
    */
   private boolean isClusterUnAvailable(String nsId) throws IOException {
     List<? extends FederationNamenodeContext> nnState = this.namenodeResolver
-        .getNamenodesForNameserviceId(nsId);
+        .getNamenodesForNameserviceId(nsId, false);
 
     if (nnState != null) {
       for (FederationNamenodeContext nnContext : nnState) {
@@ -832,13 +891,15 @@ public class RouterRpcClient {
     RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
     acquirePermit(nsId, ugi, method, controller);
     try {
-      List<? extends FederationNamenodeContext> nns =
-          getNamenodesForNameservice(nsId);
+      boolean isObserverRead = nsObserverReadEnabled.getOrDefault(nsId, observerReadEnabled)
+          && isReadCall(method.getMethod());
+      List<? extends FederationNamenodeContext> nns = msync(nsId, ugi,
+          isObserverRead);
       RemoteLocationContext loc = new RemoteLocation(nsId, "/", "/");
       Class<?> proto = method.getProtocol();
       Method m = method.getMethod();
       Object[] params = method.getParams(loc);
-      return invokeMethod(ugi, nns, proto, m, params);
+      return invokeMethod(ugi, nns, proto, m, !isObserverRead, params);
     } finally {
       releasePermit(nsId, ugi, method, controller);
     }
@@ -915,7 +976,7 @@ public class RouterRpcClient {
    * @throws IOException if the success condition is not met and one of the RPC
    *           calls generated a remote exception.
    */
-  public Object invokeSequential(
+  public <T> T invokeSequential(
       final List<? extends RemoteLocationContext> locations,
       final RemoteMethod remoteMethod) throws IOException {
     return invokeSequential(locations, remoteMethod, null, null);
@@ -1000,12 +1061,15 @@ public class RouterRpcClient {
     for (final RemoteLocationContext loc : locations) {
       String ns = loc.getNameserviceId();
       acquirePermit(ns, ugi, remoteMethod, controller);
+      boolean isObserverRead = nsObserverReadEnabled.getOrDefault(ns, observerReadEnabled)
+          && isReadCall(m);
       List<? extends FederationNamenodeContext> namenodes =
-          getNamenodesForNameservice(ns);
+          msync(ns, ugi, isObserverRead);
       try {
         Class<?> proto = remoteMethod.getProtocol();
         Object[] params = remoteMethod.getParams(loc);
-        Object result = invokeMethod(ugi, namenodes, proto, m, params);
+        Object result = invokeMethod(
+            ugi, namenodes, proto, m, !isObserverRead, params);
         // Check if the result is what we expected
         if (isExpectedClass(expectedResultClass, result) &&
             isExpectedValue(expectedResultValue, result)) {
@@ -1361,12 +1425,15 @@ public class RouterRpcClient {
       String ns = location.getNameserviceId();
       RouterRpcFairnessPolicyController controller = getRouterRpcFairnessPolicyController();
       acquirePermit(ns, ugi, method, controller);
+      boolean isObserverRead = nsObserverReadEnabled.getOrDefault(ns, observerReadEnabled)
+          && isReadCall(m);
       final List<? extends FederationNamenodeContext> namenodes =
-          getNamenodesForNameservice(ns);
+          msync(ns, ugi, isObserverRead);
       try {
         Class<?> proto = method.getProtocol();
         Object[] paramList = method.getParams(location);
-        R result = (R) invokeMethod(ugi, namenodes, proto, m, paramList);
+        R result = (R) invokeMethod(
+            ugi, namenodes, proto, m, !isObserverRead, paramList);
         RemoteResult<T, R> remoteResult = new RemoteResult<>(location, result);
         return Collections.singletonList(remoteResult);
       } catch (IOException ioe) {
@@ -1384,8 +1451,10 @@ public class RouterRpcClient {
     final CallerContext originContext = CallerContext.getCurrent();
     for (final T location : locations) {
       String nsId = location.getNameserviceId();
+      boolean isObserverRead = nsObserverReadEnabled.getOrDefault(nsId, observerReadEnabled)
+          && isReadCall(m);
       final List<? extends FederationNamenodeContext> namenodes =
-          getNamenodesForNameservice(nsId);
+          msync(nsId, ugi, isObserverRead);
       final Class<?> proto = method.getProtocol();
       final Object[] paramList = method.getParams(location);
       if (standby) {
@@ -1402,7 +1471,8 @@ public class RouterRpcClient {
           callables.add(
               () -> {
                 transferThreadLocalContext(originCall, originContext);
-                return invokeMethod(ugi, nnList, proto, m, paramList);
+                return invokeMethod(
+                    ugi, nnList, proto, m, !isObserverRead, paramList);
               });
         }
       } else {
@@ -1411,7 +1481,8 @@ public class RouterRpcClient {
         callables.add(
             () -> {
               transferThreadLocalContext(originCall, originContext);
-              return invokeMethod(ugi, namenodes, proto, m, paramList);
+              return invokeMethod(
+                  ugi, namenodes, proto, m, !isObserverRead, paramList);
             });
       }
     }
@@ -1502,17 +1573,21 @@ public class RouterRpcClient {
 
   /**
    * Get a prioritized list of NNs that share the same nameservice ID (in the
-   * same namespace). NNs that are reported as ACTIVE will be first in the list.
+   * same namespace).
+   * In observer read case, OBSERVER NNs will be first in the list.
+   * Otherwise, ACTIVE NNs will be first in the list.
    *
    * @param nsId The nameservice ID for the namespace.
+   * @param observerRead Read on observer namenode.
    * @return A prioritized list of NNs to use for communication.
    * @throws IOException If a NN cannot be located for the nameservice ID.
    */
   private List<? extends FederationNamenodeContext> getNamenodesForNameservice(
-      final String nsId) throws IOException {
+      final String nsId, boolean observerRead) throws IOException {
 
     final List<? extends FederationNamenodeContext> namenodes =
-        namenodeResolver.getNamenodesForNameserviceId(nsId);
+        namenodeResolver.getNamenodesForNameserviceId(nsId,
+            observerRead);
 
     if (namenodes == null || namenodes.isEmpty()) {
       throw new IOException("Cannot locate a registered namenode for " + nsId +
@@ -1657,5 +1732,85 @@ public class RouterRpcClient {
       return routerRpcFairnessPolicyController.getClass().getCanonicalName();
     }
     return null;
+  }
+
+  private List<? extends FederationNamenodeContext> msync(String ns,
+      UserGroupInformation ugi, boolean isObserverRead) throws IOException {
+    final List<? extends FederationNamenodeContext> namenodes =
+        getNamenodesForNameservice(ns, isObserverRead);
+    if (autoMsyncPeriodMs < 0) {
+      LOG.debug("Skipping msync because "
+          + RBFConfigKeys.DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD
+          + " is less than 0");
+      return namenodes; // no need for msync
+    }
+    if (isObserverRead) {
+      long callStartTime = callTime();
+
+      LongHolder latestMsyncTime = lastMsyncTimes.get(ns);
+
+      if (latestMsyncTime == null) {
+        // initialize
+        synchronized (lastMsyncTimes) {
+          latestMsyncTime = lastMsyncTimes.get(ns);
+          if(latestMsyncTime == null) {
+            latestMsyncTime = new LongHolder(0L);
+            lastMsyncTimes.put(ns, latestMsyncTime);
+          }
+        }
+      }
+
+      if (callStartTime - latestMsyncTime.getValue() > autoMsyncPeriodMs) {
+        synchronized (latestMsyncTime) {
+          if (callStartTime - latestMsyncTime.getValue() > autoMsyncPeriodMs) {
+            long requestTime = Time.monotonicNow();
+            invokeMethod(ugi, namenodes, ClientProtocol.class, MSYNC_METHOD,
+                true, new Object[0]);
+            latestMsyncTime.setValue(requestTime);
+          }
+        }
+      }
+    }
+    return namenodes;
+  }
+
+  private static long callTime() {
+    Call call = Server.getCurCall().get();
+    if(call != null) {
+      return call.getTimestampNanos() / 1000000L;
+    }
+    return Time.monotonicNow();
+  }
+
+  /**
+   * Check if a method is read-only.
+   * @return whether the 'method' is a read-only operation.
+   */
+  private static boolean isReadCall(Method method) {
+    if (!method.isAnnotationPresent(ReadOnly.class)) {
+      return false;
+    }
+    Call call = Server.getCurCall().get();
+    if (call != null && call.getClientStateId() == DISABLED_OBSERVER_READ_STATEID) {
+      // Client disabled observer read
+      return false;
+    }
+    return !method.getAnnotationsByType(ReadOnly.class)[0].activeOnly();
+  }
+
+  private final static class LongHolder {
+    private long value;
+
+    LongHolder(long value) {
+      this.value = value;
+    }
+
+    public void setValue(long value) {
+      this.value = value;
+    }
+
+    public long getValue() {
+      return value;
+    }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.federation.router;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.metrics.FederationRPCMetrics;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
 
 /**
@@ -61,8 +62,9 @@ public interface RouterRpcMonitor {
   /**
    * Mark a proxy operation as completed.
    * @param success If the operation was successful.
+   * @param state proxy namenode state.
    */
-  void proxyOpComplete(boolean success, String nsId);
+  void proxyOpComplete(boolean success, String nsId, FederationNamenodeServiceState state);
 
   /**
    * Failed to proxy an operation to a Namenode because it was in standby.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -252,18 +252,18 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   /**
    * Construct a router RPC server.
    *
-   * @param configuration HDFS Configuration.
+   * @param config HDFS Configuration.
    * @param router A router using this RPC server.
    * @param nnResolver The NN resolver instance to determine active NNs in HA.
    * @param fileResolver File resolver to resolve file paths to subclusters.
    * @throws IOException If the RPC server could not be created.
    */
-  public RouterRpcServer(Configuration configuration, Router router,
+  public RouterRpcServer(Configuration config, Router router,
       ActiveNamenodeResolver nnResolver, FileSubclusterResolver fileResolver)
           throws IOException {
     super(RouterRpcServer.class.getName());
 
-    this.conf = configuration;
+    this.conf = config;
     this.router = router;
     this.namenodeResolver = nnResolver;
     this.subclusterResolver = fileResolver;
@@ -331,6 +331,7 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
         .setnumReaders(readerCount)
         .setQueueSizePerHandler(handlerQueueSize)
         .setVerbose(false)
+        .setAlignmentContext(new RouterStateIdContext())
         .setSecretManager(this.securityManager.getSecretManager())
         .build();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.hdfs.protocol.ClientProtocol;
+import org.apache.hadoop.hdfs.server.namenode.ha.ReadOnly;
+import org.apache.hadoop.ipc.AlignmentContext;
+import org.apache.hadoop.ipc.RetriableException;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcRequestHeaderProto;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
+
+/**
+ * This is the router implementation responsible for passing
+ * client state id to next level.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+class RouterStateIdContext implements AlignmentContext {
+
+  private final HashSet<String> coordinatedMethods;
+
+  RouterStateIdContext() {
+    this.coordinatedMethods = new HashSet<>();
+    // For now, only ClientProtocol methods can be coordinated, so only checking
+    // against ClientProtocol.
+    for (Method method : ClientProtocol.class.getDeclaredMethods()) {
+      if (method.isAnnotationPresent(ReadOnly.class)
+          && method.getAnnotationsByType(ReadOnly.class)[0].isCoordinated()) {
+        coordinatedMethods.add(method.getName());
+      }
+    }
+  }
+
+  @Override
+  public void updateResponseState(RpcResponseHeaderProto.Builder header) {
+ // Do nothing.
+  }
+
+  @Override
+  public void receiveResponseState(RpcResponseHeaderProto header) {
+    // Do nothing.
+  }
+
+  @Override
+  public void updateRequestState(RpcRequestHeaderProto.Builder header) {
+    // Do nothing.
+  }
+
+  @Override
+  public long receiveRequestState(RpcRequestHeaderProto header,
+      long clientWaitTime) throws RetriableException {
+    long clientStateId = header.getStateId();
+    return clientStateId;
+  }
+
+  @Override
+  public long getLastSeenStateId() {
+    return 0;
+  }
+
+  @Override
+  public boolean isCoordinatedCall(String protocolName, String methodName) {
+    return protocolName.equals(ClientProtocol.class.getCanonicalName())
+        && coordinatedMethods.contains(methodName);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterStateIdContext.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcRequestHeaderProto;
 import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 
-import static org.apache.hadoop.ipc.RpcConstants.*;
+import static org.apache.hadoop.ipc.RpcConstants.REQUEST_HEADER_NAMESPACE_STATEIDS_SET;
 
 /**
  * This is the router implementation responsible for passing

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -781,4 +781,20 @@
       (delete the source path directly) and skip (skip both trash and deletion).
     </description>
   </property>
+
+  <property>
+    <name>dfs.federation.router.observer.read.enable</name>
+    <value>false</value>
+    <description>
+      Enable observer read in router. This is value is used across all nameservices
+      except when overridden by dfs.federation.router.observer.read.enable.EXAMPLENAMESERVICE
+      for a particular nameservice.
+    </description>
+  </property>
+
+  <property>
+    <name>dfs.federation.router.observer.auto-msync-period</name>
+    <value>0</value>
+    <description>Observer auto msync period</description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
@@ -398,7 +398,8 @@ public final class FederationTestUtils {
         throw new IOException("Simulate connectionManager throw IOException");
       }
     }).when(spyConnectionManager).getConnection(
-        any(UserGroupInformation.class), any(String.class), any(Class.class));
+        any(UserGroupInformation.class), any(String.class), any(Class.class),
+        any(String.class));
 
     Whitebox.setInternalState(rpcClient, "connectionManager",
         spyConnectionManager);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
@@ -179,7 +179,7 @@ public final class FederationTestUtils {
       public Boolean get() {
         try {
           List<? extends FederationNamenodeContext> namenodes =
-              resolver.getNamenodesForNameserviceId(nsId);
+              resolver.getNamenodesForNameserviceId(nsId, false);
           if (namenodes != null) {
             for (FederationNamenodeContext namenode : namenodes) {
               // Check if this is the Namenode we are checking
@@ -214,7 +214,7 @@ public final class FederationTestUtils {
       public Boolean get() {
         try {
           List<? extends FederationNamenodeContext> nns =
-              resolver.getNamenodesForNameserviceId(nsId);
+              resolver.getNamenodesForNameserviceId(nsId, false);
           for (FederationNamenodeContext nn : nns) {
             if (nn.getState().equals(state)) {
               return true;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -814,6 +814,7 @@ public class MiniRouterDFSCluster {
           .numDataNodes(numDNs)
           .nnTopology(topology)
           .dataNodeConfOverlays(dnConfs)
+          .checkExitOnShutdown(false)
           .storageTypes(storageTypes)
           .racks(racks)
           .build();
@@ -1043,6 +1044,27 @@ public class MiniRouterDFSCluster {
       }
     } catch (Throwable e) {
       LOG.error("Cannot transition to standby", e);
+    }
+  }
+
+  /**
+   * Switch a namenode in a nameservice to be the observer.
+   * @param nsId Nameservice identifier.
+   * @param nnId Namenode identifier.
+   */
+  public void switchToObserver(String nsId, String nnId) {
+    try {
+      int total = cluster.getNumNameNodes();
+      NameNodeInfo[] nns = cluster.getNameNodeInfos();
+      for (int i = 0; i < total; i++) {
+        NameNodeInfo nn = nns[i];
+        if (nn.getNameserviceId().equals(nsId) &&
+            nn.getNamenodeId().equals(nnId)) {
+          cluster.transitionToObserver(i);
+        }
+      }
+    } catch (Throwable e) {
+      LOG.error("Cannot transition to active", e);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRefreshFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRefreshFairnessPolicyController.java
@@ -162,7 +162,8 @@ public class TestRouterRefreshFairnessPolicyController {
       Thread.sleep(sleepTime);
       return null;
     }).when(client)
-        .invokeMethod(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        .invokeMethod(Mockito.any(), Mockito.any(), Mockito.any(),
+            Mockito.any(), Mockito.anyBoolean(), Mockito.any());
 
     // No calls yet
     assertEquals("{}",

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -129,7 +129,7 @@ public class TestNamenodeResolver {
       int resultsCount, FederationNamenodeServiceState state)
           throws IOException {
     List<? extends FederationNamenodeContext> namenodes =
-        namenodeResolver.getNamenodesForNameserviceId(nsId);
+        namenodeResolver.getNamenodesForNameserviceId(nsId, false);
     if (resultsCount == 0) {
       assertNull(namenodes);
     } else {
@@ -291,8 +291,8 @@ public class TestNamenodeResolver {
             HAServiceState.STANDBY)));
     stateStore.refreshCaches(true);
     // Check whether the namenpde state is reported correct as standby.
-    FederationNamenodeContext namenode =
-        namenodeResolver.getNamenodesForNameserviceId(NAMESERVICES[0]).get(0);
+    FederationNamenodeContext namenode = namenodeResolver
+        .getNamenodesForNameserviceId(NAMESERVICES[0], false).get(0);
     assertEquals(FederationNamenodeServiceState.STANDBY, namenode.getState());
     String rpcAddr = namenode.getRpcAddress();
     InetSocketAddress inetAddr = getInetSocketAddress(rpcAddr);
@@ -301,8 +301,8 @@ public class TestNamenodeResolver {
     // RouterRpcClient calls updateActiveNamenode to update the state to active,
     // Check whether correct updated state is returned post update.
     namenodeResolver.updateActiveNamenode(NAMESERVICES[0], inetAddr);
-    FederationNamenodeContext namenode1 =
-        namenodeResolver.getNamenodesForNameserviceId(NAMESERVICES[0]).get(0);
+    FederationNamenodeContext namenode1 = namenodeResolver
+        .getNamenodesForNameserviceId(NAMESERVICES[0], false).get(0);
     assertEquals("The namenode state should be ACTIVE post update.",
         FederationNamenodeServiceState.ACTIVE, namenode1.getState());
   }
@@ -318,8 +318,8 @@ public class TestNamenodeResolver {
 
     InetSocketAddress inetAddr = getInetSocketAddress(rpcAddress);
     namenodeResolver.updateActiveNamenode(NAMESERVICES[0], inetAddr);
-    FederationNamenodeContext namenode =
-        namenodeResolver.getNamenodesForNameserviceId(NAMESERVICES[0]).get(0);
+    FederationNamenodeContext namenode = namenodeResolver
+        .getNamenodesForNameserviceId(NAMESERVICES[0], false).get(0);
     assertEquals("The namenode state should be ACTIVE post update.",
         FederationNamenodeServiceState.ACTIVE, namenode.getState());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestConnectionManager.java
@@ -80,15 +80,15 @@ public class TestConnectionManager {
   public void testCleanup() throws Exception {
     Map<ConnectionPoolId, ConnectionPool> poolMap = connManager.getPools();
 
-    ConnectionPool pool1 = new ConnectionPool(
-        conf, TEST_NN_ADDRESS, TEST_USER1, 0, 10, 0.5f, ClientProtocol.class);
+    ConnectionPool pool1 = new ConnectionPool(conf, TEST_NN_ADDRESS, TEST_USER1,
+        0, 10, 0.5f, ClientProtocol.class, null);
     addConnectionsToPool(pool1, 9, 4);
     poolMap.put(
         new ConnectionPoolId(TEST_USER1, TEST_NN_ADDRESS, ClientProtocol.class),
         pool1);
 
-    ConnectionPool pool2 = new ConnectionPool(
-        conf, TEST_NN_ADDRESS, TEST_USER2, 0, 10, 0.5f, ClientProtocol.class);
+    ConnectionPool pool2 = new ConnectionPool(conf, TEST_NN_ADDRESS, TEST_USER2,
+        0, 10, 0.5f, ClientProtocol.class, null);
     addConnectionsToPool(pool2, 10, 10);
     poolMap.put(
         new ConnectionPoolId(TEST_USER2, TEST_NN_ADDRESS, ClientProtocol.class),
@@ -110,8 +110,8 @@ public class TestConnectionManager {
     checkPoolConnections(TEST_USER2, 10, 10);
 
     // Make sure the number of connections doesn't go below minSize
-    ConnectionPool pool3 = new ConnectionPool(
-        conf, TEST_NN_ADDRESS, TEST_USER3, 2, 10, 0.5f, ClientProtocol.class);
+    ConnectionPool pool3 = new ConnectionPool(conf, TEST_NN_ADDRESS, TEST_USER3,
+        2, 10, 0.5f, ClientProtocol.class, null);
     addConnectionsToPool(pool3, 8, 0);
     poolMap.put(
         new ConnectionPoolId(TEST_USER3, TEST_NN_ADDRESS, ClientProtocol.class),
@@ -135,8 +135,8 @@ public class TestConnectionManager {
   public void testConnectionCreatorWithException() throws Exception {
     // Create a bad connection pool pointing to unresolvable namenode address.
     ConnectionPool badPool = new ConnectionPool(
-            conf, UNRESOLVED_TEST_NN_ADDRESS, TEST_USER1, 0, 10, 0.5f,
-            ClientProtocol.class);
+        conf, UNRESOLVED_TEST_NN_ADDRESS, TEST_USER1, 0, 10, 0.5f,
+        ClientProtocol.class, null);
     BlockingQueue<ConnectionPool> queue = new ArrayBlockingQueue<>(1);
     queue.add(badPool);
     ConnectionManager.ConnectionCreator connectionCreator =
@@ -162,7 +162,7 @@ public class TestConnectionManager {
     // Create a bad connection pool pointing to unresolvable namenode address.
     ConnectionPool badPool = new ConnectionPool(
         conf, UNRESOLVED_TEST_NN_ADDRESS, TEST_USER1, 1, 10, 0.5f,
-        ClientProtocol.class);
+        ClientProtocol.class, null);
   }
 
   @Test
@@ -171,8 +171,8 @@ public class TestConnectionManager {
     final int totalConns = 10;
     int activeConns = 5;
 
-    ConnectionPool pool = new ConnectionPool(
-        conf, TEST_NN_ADDRESS, TEST_USER1, 0, 10, 0.5f, ClientProtocol.class);
+    ConnectionPool pool = new ConnectionPool(conf, TEST_NN_ADDRESS, TEST_USER1,
+        0, 10, 0.5f, ClientProtocol.class, null);
     addConnectionsToPool(pool, totalConns, activeConns);
     poolMap.put(
         new ConnectionPoolId(TEST_USER1, TEST_NN_ADDRESS, ClientProtocol.class),
@@ -196,8 +196,8 @@ public class TestConnectionManager {
 
   @Test
   public void testValidClientIndex() throws Exception {
-    ConnectionPool pool = new ConnectionPool(
-        conf, TEST_NN_ADDRESS, TEST_USER1, 2, 2, 0.5f, ClientProtocol.class);
+    ConnectionPool pool = new ConnectionPool(conf, TEST_NN_ADDRESS, TEST_USER1,
+        2, 2, 0.5f, ClientProtocol.class, null);
     for(int i = -3; i <= 3; i++) {
       pool.getClientIndex().set(i);
       ConnectionContext conn = pool.getConnection();
@@ -212,8 +212,8 @@ public class TestConnectionManager {
     final int totalConns = 10;
     int activeConns = 5;
 
-    ConnectionPool pool = new ConnectionPool(
-        conf, TEST_NN_ADDRESS, TEST_USER1, 0, 10, 0.5f, NamenodeProtocol.class);
+    ConnectionPool pool = new ConnectionPool(conf, TEST_NN_ADDRESS, TEST_USER1,
+        0, 10, 0.5f, NamenodeProtocol.class, null);
     addConnectionsToPool(pool, totalConns, activeConns);
     poolMap.put(
         new ConnectionPoolId(
@@ -286,7 +286,7 @@ public class TestConnectionManager {
 
     // Create one new connection pool
     tmpConnManager.getConnection(TEST_USER1, TEST_NN_ADDRESS,
-        NamenodeProtocol.class);
+        NamenodeProtocol.class, "ns0");
 
     Map<ConnectionPoolId, ConnectionPool> poolMap = tmpConnManager.getPools();
     ConnectionPoolId connectionPoolId = new ConnectionPoolId(TEST_USER1,
@@ -317,6 +317,6 @@ public class TestConnectionManager {
         "Unsupported protocol for connection to NameNode: "
             + TestConnectionManager.class.getName(),
         () -> ConnectionPool.newConnection(conf, TEST_NN_ADDRESS, TEST_USER1,
-            TestConnectionManager.class));
+            TestConnectionManager.class, null));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -191,33 +191,6 @@ public class TestObserverWithRouter {
   }
 
   @Test
-  public void disableObserverReadFromClient() throws Exception {
-    startUpCluster(1);
-    RouterContext routerContext = cluster.getRandomRouter();
-    Configuration conf = routerContext.getConf();
-    conf.setBoolean(HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE, false);
-    FileSystem fileSystem = routerContext.getFileSystem();
-    Path path = new Path("/testFile2");
-    // Send Create call to active
-    fileSystem.create(path).close();
-
-    // Send read request
-    fileSystem.open(path).close();
-
-    long rpcCountForActive = routerContext.getRouter()
-        .getRpcServer().getRPCMetrics().getActiveProxyOps();
-    // Create, close, getBlockLocation call should send to active
-    assertEquals("Three call should send to active", 3,
-        rpcCountForActive);
-
-    long rpcCountForObserver = routerContext.getRouter()
-        .getRpcServer().getRPCMetrics().getObserverProxyOps();
-    assertEquals("No call should send to observer", 0,
-        rpcCountForObserver);
-    fileSystem.close();
-  }
-
-  @Test
   public void testMultipleObserver() throws Exception {
     startUpCluster(2);
     RouterContext routerContext = cluster.getRandomRouter();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -126,8 +126,8 @@ public class TestObserverWithRouter {
 
     long rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
-    // Create, complete and msync calls should be sent to active
-    assertEquals("Three calls should be sent to active", 3, rpcCountForActive);
+    // Create and complete calls should be sent to active
+    assertEquals("Two calls should be sent to active", 2, rpcCountForActive);
 
     long rpcCountForObserver = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getObserverProxyOps();
@@ -179,8 +179,8 @@ public class TestObserverWithRouter {
 
     long rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
-    // Create, complete, msync, getBlockLocation call should send to active
-    assertEquals("Four call should send to active", 4,
+    // Create, complete and getBlockLocation calls should be sent to active
+    assertEquals("Three calls should be sent to active", 3,
         rpcCountForActive);
 
     long rpcCountForObserver = routerContext.getRouter().getRpcServer()
@@ -235,11 +235,11 @@ public class TestObserverWithRouter {
     long rpcCountForActive = routerContext.getRouter().getRpcServer()
         .getRPCMetrics().getActiveProxyOps();
 
-    long expectedActiveRpc = 3;
+    long expectedActiveRpc = 2;
     long expectedObserverRpc = 1;
 
-    // Create, complete, msync call should send to active
-    assertEquals("Three call should send to active",
+    // Create and complete calls should be sent to active
+    assertEquals("Two calls should be sent to active",
         expectedActiveRpc, rpcCountForActive);
 
     long rpcCountForObserver = routerContext.getRouter()
@@ -257,9 +257,9 @@ public class TestObserverWithRouter {
     rpcCountForActive = routerContext.getRouter()
         .getRpcServer().getRPCMetrics().getActiveProxyOps();
 
-    // msync, getBlockLocation call should send to active
-    expectedActiveRpc += 2;
-    assertEquals("Two call should send to active", expectedActiveRpc,
+    // getBlockLocation call should be sent to active
+    expectedActiveRpc += 1;
+    assertEquals("One call should be sent to active", expectedActiveRpc,
         rpcCountForActive);
     expectedObserverRpc += 0;
     rpcCountForObserver = routerContext.getRouter()

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestObserverWithRouter.java
@@ -1,0 +1,396 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.federation.router;
+
+import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.NAMENODES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_NAMENODE_ID_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMESERVICE_ID;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
+import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
+import org.apache.hadoop.hdfs.server.federation.StateStoreDFSCluster;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeContext;
+import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
+import org.apache.hadoop.hdfs.server.federation.resolver.MembershipNamenodeResolver;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.junit.After;
+import org.junit.Test;
+
+public class TestObserverWithRouter {
+
+  private MiniRouterDFSCluster cluster;
+
+  public void startUpCluster(int numberOfObserver) throws Exception {
+    startUpCluster(numberOfObserver, null);
+  }
+
+  public void startUpCluster(int numberOfObserver, Configuration confOverrides) throws Exception {
+    int numberOfNamenode = 2 + numberOfObserver;
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_ENABLE, true);
+    conf.setInt(RBFConfigKeys.DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD, 0);
+    conf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
+    conf.set(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, "0ms");
+    if (confOverrides != null) {
+      conf.addResource(confOverrides);
+    }
+    cluster = new MiniRouterDFSCluster(true, 1, numberOfNamenode);
+    cluster.addNamenodeOverrides(conf);
+    // Start NNs and DNs and wait until ready
+    cluster.startCluster();
+
+    // Making one Namenodes active per nameservice
+    if (cluster.isHighAvailability()) {
+      for (String ns : cluster.getNameservices()) {
+        cluster.switchToActive(ns, NAMENODES[0]);
+        cluster.switchToStandby(ns, NAMENODES[1]);
+        for (int i = 2; i < numberOfNamenode; i++) {
+          cluster.switchToObserver(ns, NAMENODES[i]);
+        }
+      }
+    }
+
+    Configuration routerConf = new RouterConfigBuilder()
+        .metrics()
+        .rpc()
+        .build();
+
+    cluster.addRouterOverrides(conf);
+    cluster.addRouterOverrides(routerConf);
+
+    // Start routers with only an RPC service
+    cluster.startRouters();
+
+    // Register and verify all NNs with all routers
+    cluster.registerNamenodes();
+    cluster.waitNamenodeRegistration();
+    // Setup the mount table
+    cluster.installMockLocations();
+
+    cluster.waitActiveNamespaces();
+  }
+
+  @After
+  public void teardown() throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  @Test
+  public void testObserverRead() throws Exception {
+    startUpCluster(1);
+    RouterContext routerContext = cluster.getRandomRouter();
+    List<? extends FederationNamenodeContext> namenodes = routerContext
+        .getRouter().getNamenodeResolver()
+        .getNamenodesForNameserviceId(cluster.getNameservices().get(0), true);
+    assertTrue("First namenode should be observer", namenodes.get(0).getState()
+        .equals(FederationNamenodeServiceState.OBSERVER));
+    FileSystem fileSystem = routerContext.getFileSystem();
+    Path path = new Path("/testFile");
+    // Send Create call to active
+    fileSystem.create(path).close();
+
+    // Send read request to observer
+    fileSystem.open(path).close();
+
+    long rpcCountForActive = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getActiveProxyOps();
+    // Create, complete and msync calls should be sent to active
+    assertEquals("Three calls should be sent to active", 3, rpcCountForActive);
+
+    long rpcCountForObserver = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getObserverProxyOps();
+    // getBlockLocations should be sent to observer
+    assertEquals("One call should be sent to observer", 1, rpcCountForObserver);
+    fileSystem.close();
+  }
+
+  @Test
+  public void testDisablingObserverReadUsingNameserviceOverride() throws Exception {
+    // Disable observer reads using per-nameservice override
+    Configuration confOverrides = new Configuration(false);
+    confOverrides.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_ENABLE + ".ns0", false);
+    startUpCluster(1, confOverrides);
+
+    RouterContext routerContext = cluster.getRandomRouter();
+    FileSystem fileSystem = routerContext.getFileSystem();
+    Path path = new Path("/testFile");
+    fileSystem.create(path).close();
+    fileSystem.open(path).close();
+    fileSystem.close();
+
+    long rpcCountForActive = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getActiveProxyOps();
+    // Create, complete and read calls should be sent to active
+    assertEquals("Three calls should be sent to active", 3, rpcCountForActive);
+
+    long rpcCountForObserver = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getObserverProxyOps();
+    assertEquals("Zero calls should be sent to observer", 0, rpcCountForObserver);
+  }
+
+  @Test
+  public void testReadWhenObserverIsDown() throws Exception {
+    startUpCluster(1);
+    RouterContext routerContext = cluster.getRandomRouter();
+    FileSystem fileSystem = routerContext.getFileSystem();
+    Path path = new Path("/testFile1");
+    // Send Create call to active
+    fileSystem.create(path).close();
+
+    // Stop observer NN
+    int nnIndex = stopObserver(1);
+
+    assertNotEquals("No observer found", 3, nnIndex);
+
+    // Send read request
+    fileSystem.open(path).close();
+
+    long rpcCountForActive = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getActiveProxyOps();
+    // Create, complete, msync, getBlockLocation call should send to active
+    assertEquals("Four call should send to active", 4,
+        rpcCountForActive);
+
+    long rpcCountForObserver = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getObserverProxyOps();
+    assertEquals("No call should send to observer", 0,
+        rpcCountForObserver);
+    fileSystem.close();
+  }
+
+  @Test
+  public void disableObserverReadFromClient() throws Exception {
+    startUpCluster(1);
+    RouterContext routerContext = cluster.getRandomRouter();
+    Configuration conf = routerContext.getConf();
+    conf.setBoolean(HdfsClientConfigKeys.DFS_OBSERVER_READ_ENABLE, false);
+    FileSystem fileSystem = routerContext.getFileSystem();
+    Path path = new Path("/testFile2");
+    // Send Create call to active
+    fileSystem.create(path).close();
+
+    // Send read request
+    fileSystem.open(path).close();
+
+    long rpcCountForActive = routerContext.getRouter()
+        .getRpcServer().getRPCMetrics().getActiveProxyOps();
+    // Create, close, getBlockLocation call should send to active
+    assertEquals("Three call should send to active", 3,
+        rpcCountForActive);
+
+    long rpcCountForObserver = routerContext.getRouter()
+        .getRpcServer().getRPCMetrics().getObserverProxyOps();
+    assertEquals("No call should send to observer", 0,
+        rpcCountForObserver);
+    fileSystem.close();
+  }
+
+  @Test
+  public void testMultipleObserver() throws Exception {
+    startUpCluster(2);
+    RouterContext routerContext = cluster.getRandomRouter();
+    FileSystem fileSystem = routerContext.getFileSystem();
+    Path path = new Path("/testFile1");
+    // Send Create call to active
+    fileSystem.create(path).close();
+
+    // Stop one observer NN
+    stopObserver(1);
+
+    // Send read request
+    fileSystem.open(path).close();
+
+    long rpcCountForActive = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getActiveProxyOps();
+
+    long expectedActiveRpc = 3;
+    long expectedObserverRpc = 1;
+
+    // Create, complete, msync call should send to active
+    assertEquals("Three call should send to active",
+        expectedActiveRpc, rpcCountForActive);
+
+    long rpcCountForObserver = routerContext.getRouter()
+        .getRpcServer().getRPCMetrics().getObserverProxyOps();
+    // getBlockLocation call should send to observer
+    assertEquals("Read should be success with another observer",
+        expectedObserverRpc, rpcCountForObserver);
+
+    // Stop one observer NN
+    stopObserver(1);
+
+    // Send read request
+    fileSystem.open(path).close();
+
+    rpcCountForActive = routerContext.getRouter()
+        .getRpcServer().getRPCMetrics().getActiveProxyOps();
+
+    // msync, getBlockLocation call should send to active
+    expectedActiveRpc += 2;
+    assertEquals("Two call should send to active", expectedActiveRpc,
+        rpcCountForActive);
+    expectedObserverRpc += 0;
+    rpcCountForObserver = routerContext.getRouter()
+        .getRpcServer().getRPCMetrics().getObserverProxyOps();
+    assertEquals("No call should send to observer",
+        expectedObserverRpc, rpcCountForObserver);
+    fileSystem.close();
+  }
+
+  private int stopObserver(int num) {
+    int nnIndex;
+    for (nnIndex = 0; nnIndex < cluster.getNamenodes().size(); nnIndex++) {
+      NameNode nameNode = cluster.getCluster().getNameNode(nnIndex);
+      if (nameNode != null && nameNode.isObserverState()) {
+        cluster.getCluster().shutdownNameNode(nnIndex);
+        num--;
+        if (num == 0) {
+          break;
+        }
+      }
+    }
+    return nnIndex;
+  }
+
+  // test router observer with multiple to know which observer NN received
+  // requests
+  @Test
+  public void testMultipleObserverRouter() throws Exception {
+    StateStoreDFSCluster innerCluster = null;
+    RouterContext routerContext;
+    MembershipNamenodeResolver resolver;
+
+    String ns0;
+    String ns1;
+    //create 4NN, One Active One Standby and Two Observers
+    innerCluster = new StateStoreDFSCluster(true, 4, 4, TimeUnit.SECONDS.toMillis(5),
+        TimeUnit.SECONDS.toMillis(5));
+    Configuration routerConf =
+        new RouterConfigBuilder().stateStore().admin().rpc()
+            .enableLocalHeartbeat(true).heartbeat().build();
+
+    StringBuilder sb = new StringBuilder();
+    ns0 = innerCluster.getNameservices().get(0);
+    MiniRouterDFSCluster.NamenodeContext context =
+        innerCluster.getNamenodes(ns0).get(1);
+    routerConf.set(DFS_NAMESERVICE_ID, ns0);
+    routerConf.set(DFS_HA_NAMENODE_ID_KEY, context.getNamenodeId());
+
+    // Specify namenodes (ns1.nn0,ns1.nn1) to monitor
+    sb = new StringBuilder();
+    ns1 = innerCluster.getNameservices().get(1);
+    for (MiniRouterDFSCluster.NamenodeContext ctx : innerCluster.getNamenodes(ns1)) {
+      String suffix = ctx.getConfSuffix();
+      if (sb.length() != 0) {
+        sb.append(",");
+      }
+      sb.append(suffix);
+    }
+    routerConf.set(DFS_ROUTER_MONITOR_NAMENODE, sb.toString());
+    routerConf.setBoolean(RBFConfigKeys.DFS_ROUTER_OBSERVER_READ_ENABLE, true);
+    routerConf.setInt(RBFConfigKeys.DFS_ROUTER_OBSERVER_AUTO_MSYNC_PERIOD, 0);
+    routerConf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
+    routerConf.set(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, "0ms");
+
+    innerCluster.addNamenodeOverrides(routerConf);
+    innerCluster.addRouterOverrides(routerConf);
+    innerCluster.startCluster();
+
+    if (innerCluster.isHighAvailability()) {
+      for (String ns : innerCluster.getNameservices()) {
+        innerCluster.switchToActive(ns, NAMENODES[0]);
+        innerCluster.switchToStandby(ns, NAMENODES[1]);
+        for (int i = 2; i < 4; i++) {
+          innerCluster.switchToObserver(ns, NAMENODES[i]);
+        }
+      }
+    }
+    innerCluster.startRouters();
+    innerCluster.waitClusterUp();
+
+    routerContext = innerCluster.getRandomRouter();
+    resolver = (MembershipNamenodeResolver) routerContext.getRouter()
+        .getNamenodeResolver();
+
+    resolver.loadCache(true);
+    List<? extends FederationNamenodeContext> namespaceInfo0 =
+        resolver.getNamenodesForNameserviceId(ns0, true);
+    List<? extends FederationNamenodeContext> namespaceInfo1 =
+        resolver.getNamenodesForNameserviceId(ns1, true);
+    assertEquals(namespaceInfo0.get(0).getState(),
+        FederationNamenodeServiceState.OBSERVER);
+    assertEquals(namespaceInfo0.get(1).getState(),
+        FederationNamenodeServiceState.OBSERVER);
+    assertNotEquals(namespaceInfo0.get(0).getNamenodeId(),
+        namespaceInfo0.get(1).getNamenodeId());
+    assertEquals(namespaceInfo1.get(0).getState(),
+        FederationNamenodeServiceState.OBSERVER);
+  }
+
+  @Test
+  public void testUnavaliableObserverNN() throws Exception {
+    startUpCluster(2);
+    RouterContext routerContext = cluster.getRandomRouter();
+    FileSystem fileSystem = routerContext.getFileSystem();
+
+    stopObserver(2);
+
+    fileSystem.listStatus(new Path("/"));
+
+    long rpcCountForActive = routerContext.getRouter().getRpcServer()
+        .getRPCMetrics().getActiveProxyOps();
+
+    // msync, getBlockLocation  call should send to active when observer
+    // is stoped.
+    assertEquals("Two call should send to active",
+        2, rpcCountForActive);
+
+    fileSystem.close();
+
+    boolean hasUnavailable = false;
+    for(String ns : cluster.getNameservices()) {
+      List<? extends FederationNamenodeContext> nns = routerContext.getRouter()
+          .getNamenodeResolver().getNamenodesForNameserviceId(ns, false);
+      for(FederationNamenodeContext nn : nns) {
+        if(FederationNamenodeServiceState.UNAVAILABLE == nn.getState()) {
+          hasUnavailable = true;
+        }
+      }
+    }
+    // After communicate with unavailable observer namenode,
+    // we will update state to unavailable.
+    assertTrue("There Must has unavailable NN", hasUnavailable);
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -167,7 +167,7 @@ public class TestRouterNamenodeHeartbeat {
     // Verify the locator has matching NN entries for each NS
     for (String ns : cluster.getNameservices()) {
       List<? extends FederationNamenodeContext> nns =
-          namenodeResolver.getNamenodesForNameserviceId(ns);
+          namenodeResolver.getNamenodesForNameserviceId(ns, false);
 
       // Active
       FederationNamenodeContext active = nns.get(0);
@@ -191,7 +191,7 @@ public class TestRouterNamenodeHeartbeat {
 
     // Verify the locator has recorded the failover for the failover NS
     List<? extends FederationNamenodeContext> failoverNSs =
-        namenodeResolver.getNamenodesForNameserviceId(failoverNS);
+        namenodeResolver.getNamenodesForNameserviceId(failoverNS, false);
     // Active
     FederationNamenodeContext active = failoverNSs.get(0);
     assertEquals(NAMENODES[1], active.getNamenodeId());
@@ -202,7 +202,7 @@ public class TestRouterNamenodeHeartbeat {
 
     // Verify the locator has the same records for the other ns
     List<? extends FederationNamenodeContext> normalNss =
-        namenodeResolver.getNamenodesForNameserviceId(normalNs);
+        namenodeResolver.getNamenodesForNameserviceId(normalNs, false);
     // Active
     active = normalNss.get(0);
     assertEquals(NAMENODES[0], active.getNamenodeId());

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeMonitoring.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeMonitoring.java
@@ -204,7 +204,7 @@ public class TestRouterNamenodeMonitoring {
     final List<FederationNamenodeContext> namespaceInfo = new ArrayList<>();
     for (String nsId : nns.keySet()) {
       List<? extends FederationNamenodeContext> nnReports =
-          resolver.getNamenodesForNameserviceId(nsId);
+          resolver.getNamenodesForNameserviceId(nsId, false);
       namespaceInfo.addAll(nnReports);
     }
     for (FederationNamenodeContext nnInfo : namespaceInfo) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeWebScheme.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeWebScheme.java
@@ -194,7 +194,7 @@ public class TestRouterNamenodeWebScheme {
     final List<FederationNamenodeContext> namespaceInfo = new ArrayList<>();
     for (String nsId : nns.keySet()) {
       List<? extends FederationNamenodeContext> nnReports =
-          resolver.getNamenodesForNameserviceId(nsId);
+          resolver.getNamenodesForNameserviceId(nsId, false);
       namespaceInfo.addAll(nnReports);
     }
     for (FederationNamenodeContext nnInfo : namespaceInfo) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCClientRetries.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRPCClientRetries.java
@@ -168,7 +168,7 @@ public class TestRouterRPCClientRetries {
   private void registerInvalidNameReport() throws IOException {
     String ns0 = cluster.getNameservices().get(0);
     List<? extends FederationNamenodeContext> origin = resolver
-        .getNamenodesForNameserviceId(ns0);
+        .getNamenodesForNameserviceId(ns0, false);
     FederationNamenodeContext nnInfo = origin.get(0);
     NamenodeStatusReport report = new NamenodeStatusReport(ns0,
         nnInfo.getNamenodeId(), nnInfo.getRpcAddress(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6446,13 +6446,4 @@
       frequently than this time, the client will give up waiting.
     </description>
   </property>
-  <property>
-    <name>dfs.observer.read.enable</name>
-    <value>true</value>
-    <description>
-      Enables the client to use observer namenode for read operations. With Router Based Federation,
-      it enables the routers to proxy client reads to the observer namenode. This option should not
-      be set to false when clients communicate directly with observer namenodes.
-    </description>
-  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6446,4 +6446,13 @@
       frequently than this time, the client will give up waiting.
     </description>
   </property>
+  <property>
+    <name>dfs.observer.read.enable</name>
+    <value>true</value>
+    <description>
+      Enables the client to use observer namenode for read operations. With Router Based Federation,
+      it enables the routers to proxy client reads to the observer namenode. This option should not
+      be set to false when clients communicate directly with observer namenodes.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -2308,6 +2308,8 @@ public class MiniDFSCluster implements AutoCloseable {
     nn.getHttpServer()
         .setAttribute(ImageServlet.RECENT_IMAGE_CHECK_ENABLED, false);
     info.nameNode = nn;
+    info.nameserviceId = info.conf.get(DFS_NAMESERVICE_ID);
+    info.nnId = info.conf.get(DFS_HA_NAMENODE_ID_KEY);
     info.setStartOpt(startOpt);
     if (waitActive) {
       if (numDataNodes > 0) {


### PR DESCRIPTION
### Description of PR
Allow routers to use observer namenode without an msync on even read.
Is layered on top of the following two

- https://github.com/apache/hadoop/pull/4311
- https://github.com/apache/hadoop/pull/4127 and 

I'm still working on cleaning up this PR to add documentation, pick better variable names and remove unneeded features like "disabling observer read from the client side". I will also move IPC related changes to the first PR in the series (https://github.com/apache/hadoop/pull/4311)

### How was this patch tested?

New unit tests.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

