### PR TITLE
HDFS-16647.Delete unused NameNode#FS_HDFS_IMPL_KEY.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -403,7 +403,6 @@ public class NameNode extends ReconfigurableBase implements
    */
   @Deprecated
   public static final int DEFAULT_PORT = DFS_NAMENODE_RPC_PORT_DEFAULT;
-  public static final String FS_HDFS_IMPL_KEY = "fs.hdfs.impl";
   public static final Logger LOG =
       LoggerFactory.getLogger(NameNode.class.getName());
   public static final Logger stateChangeLog =


### PR DESCRIPTION
### Description of PR
It looks like NameNode#FS_HDFS_IMPL_KEY is not being used anywhere, it would be cleaner to remove it.
Details: HDFS-16647

### How was this patch tested?
Here is just to delete some unused code, it is not too stressful for testing.
