### PR TITLE
HDFS-16466. Implement Linux permission flags on Windows

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/statinfo.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/statinfo.cc
@@ -17,9 +17,11 @@
  */
 
 #include <hdfspp/statinfo.h>
-#include <sys/stat.h>
+
 #include <sstream>
 #include <iomanip>
+
+#include "x-platform/stat.h"
 
 namespace hdfs {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
@@ -19,26 +19,23 @@
 #ifndef NATIVE_LIBHDFSPP_LIB_CROSS_PLATFORM_STAT
 #define NATIVE_LIBHDFSPP_LIB_CROSS_PLATFORM_STAT
 
+#include <sys/stat.h>
+
 #if defined(_WIN32)
 
-// Windows.
-// These macros are derived from POSIX sys/stat.h. Windows defines some of
-// these macros, but not all. Thus, we align with the bits defined by POSIX for
-// all of them to be consistent.
-#define S_IRUSR 0400
-#define S_IWUSR 0200
-#define S_IXUSR 0100
+// Windows defines the macros for user RWX (_S_IREAD, _S_IWRITE and _S_IEXEC),
+// but not for group and others. We implement the permissions for group and
+// others through appropriate bit shifting.
+
+#define S_IRUSR _S_IREAD
+#define S_IWUSR _S_IWRITE
+#define S_IXUSR _S_IEXEC
 #define S_IRGRP (S_IRUSR >> 3)
 #define S_IWGRP (S_IWUSR >> 3)
 #define S_IXGRP (S_IXUSR >> 3)
 #define S_IROTH (S_IRGRP >> 3)
 #define S_IWOTH (S_IWGRP >> 3)
 #define S_IXOTH (S_IXGRP >> 3)
-
-#else
-
-// Linux (or other non-Windows OS).
-#include <sys/stat.h>
 
 #endif
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NATIVE_LIBHDFSPP_LIB_CROSS_PLATFORM_STAT
+#define NATIVE_LIBHDFSPP_LIB_CROSS_PLATFORM_STAT
+
+#if defined(_WIN64)
+
+// Windows.
+#define S_IRUSR 0400
+#define S_IWUSR 0200
+#define S_IXUSR 0100
+#define S_IRGRP (S_IRUSR >> 3)
+#define S_IWGRP (S_IWUSR >> 3)
+#define S_IXGRP (S_IXUSR >> 3)
+#define S_IROTH (S_IRGRP >> 3)
+#define S_IWOTH (S_IWGRP >> 3)
+#define S_IXOTH (S_IXGRP >> 3)
+
+#else
+
+// Linux (or other non-Windows OS).
+#include <sys/stat.h>
+
+#endif
+
+#endif

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
@@ -22,6 +22,9 @@
 #if defined(_WIN32)
 
 // Windows.
+// These are derived from sys/stat.h from POSIX. Windows defines some of these
+// macros, but not all. Thus, we align with the bits defined by POSIX for all of
+// them.
 #define S_IRUSR 0400
 #define S_IWUSR 0200
 #define S_IXUSR 0100

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
@@ -22,9 +22,9 @@
 #if defined(_WIN32)
 
 // Windows.
-// These are derived from sys/stat.h from POSIX. Windows defines some of these
-// macros, but not all. Thus, we align with the bits defined by POSIX for all of
-// them.
+// These macros are derived from POSIX sys/stat.h. Windows defines some of
+// these macros, but not all. Thus, we align with the bits defined by POSIX for
+// all of them.
 #define S_IRUSR 0400
 #define S_IWUSR 0200
 #define S_IXUSR 0100

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
@@ -19,7 +19,7 @@
 #ifndef NATIVE_LIBHDFSPP_LIB_CROSS_PLATFORM_STAT
 #define NATIVE_LIBHDFSPP_LIB_CROSS_PLATFORM_STAT
 
-#if defined(_WIN64)
+#if defined(_WIN32)
 
 // Windows.
 #define S_IRUSR 0400

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/x-platform/stat.h
@@ -24,7 +24,7 @@
 // Windows.
 // These macros are derived from POSIX sys/stat.h. Windows defines some of
 // these macros, but not all. Thus, we align with the bits defined by POSIX for
-// all of them.
+// all of them to be consistent.
 #define S_IRUSR 0400
 #define S_IWUSR 0200
 #define S_IXUSR 0100

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfspp_wrapper.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfspp_wrapper.cc
@@ -20,3 +20,4 @@
 #include "libhdfspp_wrapper_defines.h"
 #include "bindings/c/hdfs.cc"
 #include "libhdfs_wrapper_undefs.h"
+

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfspp_wrapper.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/libhdfspp_wrapper.cc
@@ -20,4 +20,3 @@
 #include "libhdfspp_wrapper_defines.h"
 #include "bindings/c/hdfs.cc"
 #include "libhdfs_wrapper_undefs.h"
-


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[statinfo.cc](https://github.com/apache/hadoop/blob/869317be0a1fdff23be5fc500dcd9ae4ecd7bc29/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/statinfo.cc#L41-L49) uses POSIX permission flags. These flags aren't available for Windows. We need to implement the equivalent flags on Windows to make this cross platform compatible.

### How was this patch tested?
Hadoop Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

