### PR TITLE
HDFS-16650.Optimize the cost of obtaining timestamps in Centralized cache management.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/CacheDirectiveInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/CacheDirectiveInfo.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.hdfs.DFSUtilClient;
+import org.apache.hadoop.util.Time;
 
 /**
  * Describes a path-based cache directive.
@@ -237,7 +238,7 @@ public class CacheDirectiveInfo {
       if (!isRelative) {
         return ms;
       } else {
-        return new Date().getTime() + ms;
+        return Time.now() + ms;
       }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/CacheDirective.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/CacheDirective.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.util.IntrusiveCollection;
 import org.apache.hadoop.util.IntrusiveCollection.Element;
 
 import org.apache.hadoop.util.Preconditions;
+import org.apache.hadoop.util.Time;
 
 /**
  * Namenode class that tracks state related to a cached path.
@@ -118,7 +119,7 @@ public final class CacheDirective implements IntrusiveCollection.Element {
         setBytesCached(bytesCached).
         setFilesNeeded(filesNeeded).
         setFilesCached(filesCached).
-        setHasExpired(new Date().getTime() > expiryTime).
+        setHasExpired(Time.now() > expiryTime).
         build();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CacheReplicationMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CacheReplicationMonitor.java
@@ -23,7 +23,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -321,7 +320,7 @@ public class CacheReplicationMonitor extends Thread implements Closeable {
    */
   private void rescanCacheDirectives() {
     FSDirectory fsDir = namesystem.getFSDirectory();
-    final long now = new Date().getTime();
+    final long now = Time.now();
     for (CacheDirective directive : cacheManager.getCacheDirectives()) {
       scannedDirectives++;
       // Skip processing this entry if it has expired

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/CacheManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/CacheManager.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -384,7 +383,7 @@ public class CacheManager {
       long maxRelativeExpiryTime) throws InvalidRequestException {
     LOG.trace("Validating directive {} pool maxRelativeExpiryTime {}", info,
         maxRelativeExpiryTime);
-    final long now = new Date().getTime();
+    final long now = Time.now();
     final long maxAbsoluteExpiryTime = now + maxRelativeExpiryTime;
     if (info == null || info.getExpiration() == null) {
       return maxAbsoluteExpiryTime;


### PR DESCRIPTION

### Description of PR
Getting timestamps in Centralized cache management is done in the following ways:
long now = new Date().getTime();
This way doesn't seem optimal.
The purpose of pr here is to simplify them.
Details: HDFS-16650

### How was this patch tested?
Here is just a change of method, for the test, the pressure is not too big.

