### PR TITLE
HADOOP-18328. S3A supports S3 on Outposts

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
@@ -26,7 +26,8 @@ import com.amazonaws.arn.Arn;
  * Represents an Arn Resource, this can be an accesspoint or bucket.
  */
 public final class ArnResource {
-  private final static String ACCESSPOINT_ENDPOINT_FORMAT = "s3-accesspoint.%s.amazonaws.com";
+  private final static String S3_ACCESSPOINT_ENDPOINT_FORMAT = "s3-accesspoint.%s.amazonaws.com";
+  private final static String S3_OUTPOSTS_ACCESSPOINT_ENDPOINT_FORMAT = "s3-outposts.%s.amazonaws.com";
 
   /**
    * Resource name.
@@ -69,6 +70,10 @@ public final class ArnResource {
     this.accessPointRegionKey = String.format("accesspoint-%s", region);
   }
 
+  private boolean isOutposts(){
+    return fullArn.contains("s3-outposts");
+  }
+
   /**
    * Resource name.
    * @return resource name.
@@ -106,7 +111,8 @@ public final class ArnResource {
    * @return resource endpoint.
    */
   public String getEndpoint() {
-    return String.format(ACCESSPOINT_ENDPOINT_FORMAT, region);
+    String format = isOutposts() ? S3_OUTPOSTS_ACCESSPOINT_ENDPOINT_FORMAT : S3_ACCESSPOINT_ENDPOINT_FORMAT;
+    return String.format(format, region);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
@@ -56,7 +56,7 @@ public class TestArnResource extends HadoopTestBase {
       String region = testPair[0];
       String partition = testPair[1];
 
-      ArnResource resource = getArnResourceFrom(partition, region, MOCK_ACCOUNT, accessPoint);
+      ArnResource resource = getArnResourceFrom(partition, "s3", region, MOCK_ACCOUNT, accessPoint);
       assertEquals("Access Point name does not match", accessPoint, resource.getName());
       assertEquals("Account Id does not match", MOCK_ACCOUNT, resource.getOwnerAccountId());
       assertEquals("Region does not match", region, resource.getRegion());
@@ -64,12 +64,25 @@ public class TestArnResource extends HadoopTestBase {
   }
 
   @Test
-  public void makeSureEndpointHasTheCorrectFormat() {
+  public void makeSureS3EndpointHasTheCorrectFormat() {
     // Access point (AP) endpoints are different from S3 bucket endpoints, thus when using APs the
     // endpoints for the client are modified. This test makes sure endpoint is set up correctly.
-    ArnResource accessPoint = getArnResourceFrom("aws", "eu-west-1", MOCK_ACCOUNT,
+    ArnResource accessPoint = getArnResourceFrom("aws", "s3", "eu-west-1", MOCK_ACCOUNT,
         "test");
     String expected = "s3-accesspoint.eu-west-1.amazonaws.com";
+
+    Assertions.assertThat(accessPoint.getEndpoint())
+        .describedAs("Endpoint has invalid format. Access Point requests will not work")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void makeSureS3OutpostsEndpointHasTheCorrectFormat() {
+    // Access point (AP) endpoints are different from S3 bucket endpoints, thus when using APs the
+    // endpoints for the client are modified. This test makes sure endpoint is set up correctly.
+    ArnResource accessPoint = getArnResourceFrom("aws", "s3-outposts", "eu-west-1", MOCK_ACCOUNT,
+        "test");
+    String expected = "s3-outposts.eu-west-1.amazonaws.com";
 
     Assertions.assertThat(accessPoint.getEndpoint())
         .describedAs("Endpoint has invalid format. Access Point requests will not work")
@@ -87,15 +100,16 @@ public class TestArnResource extends HadoopTestBase {
   /**
    * Create an {@link ArnResource} from string components
    * @param partition - partition for ARN
+   * @param service - service for ARN
    * @param region - region for ARN
    * @param accountId - accountId for ARN
    * @param resourceName - ARN resource name
    * @return ArnResource described by its properties
    */
-  private ArnResource getArnResourceFrom(String partition, String region, String accountId,
+  private ArnResource getArnResourceFrom(String partition, String service, String region, String accountId,
       String resourceName) {
     // arn:partition:service:region:account-id:resource-type/resource-id
-    String arn = String.format("arn:%s:s3:%s:%s:accesspoint/%s", partition, region, accountId,
+    String arn = String.format("arn:%s:%s:%s:%s:accesspoint/%s", partition, service, region, accountId,
         resourceName);
 
     return ArnResource.accessPointFromArn(arn);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

[HADOOP-18328](https://issues.apache.org/jira/browse/HADOOP-18328) S3A supports S3 on Outposts

I have fixed the endpoint to support [S3 on Outposts](https://aws.amazon.com/blogs/aws/amazon-s3-on-outposts-now-available/). I have also added tests to cover the fixes accordingly.

### How was this patch tested?

I ran `mvn test` and verified that the test passed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

