### PR TITLE
HADOOP-15789. DistCp does not clean staging folder if class extends DistCp. Contributed by Lawrence Andrews.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -473,13 +473,18 @@ public class DistCp extends Configured implements Tool {
     return config;
   }
 
-  private synchronized void cleanup() {
+  /**
+   * Clean the staging folder created by distcp.
+   */
+  protected synchronized void cleanup() {
     try {
       if (metaFolder != null) {
-        if (jobFS != null) {
-          jobFS.delete(metaFolder, true);
+        synchronized (this) {
+          if (jobFS != null) {
+            jobFS.delete(metaFolder, true);
+          }
+          metaFolder = null;
         }
-        metaFolder = null;
       }
     } catch (IOException e) {
       LOG.error("Unable to cleanup meta folder: " + metaFolder, e);


### PR DESCRIPTION
Original Patch in the Jira, Contributor not available now, & Patches don't run CI now, so Copied it to PR to run the build before merge

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?