### PR TITLE
HADOOP-18327.Fix eval expression in hadoop-functions.sh

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1140,10 +1140,10 @@ function hadoop_add_param
   #
   if [[ ! ${!1} =~ $2 ]] ; then
     #shellcheck disable=SC2140
-    eval "$1"="'${!1} $3'"
+    eval "$1"="\"${!1} $3\""
     if [[ ${!1:0:1} = ' ' ]]; then
       #shellcheck disable=SC2140
-      eval "$1"="'${!1# }'"
+      eval "$1"="\"${!1# }\""
     fi
     hadoop_debug "$1 accepted $3"
   else

--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1768,7 +1768,7 @@ function hadoop_java_exec
 
   export CLASSPATH
   #shellcheck disable=SC2086
-  exec "${JAVA}" "-Dproc_${command}" ${HADOOP_OPTS} "${class}" "$@"
+  eval exec '"${JAVA}"' '"-Dproc_${command}"' ${HADOOP_OPTS} '"${class}"' '"$@"'
 }
 
 ## @description  Start a non-privileged daemon in the foreground.
@@ -1805,7 +1805,7 @@ function hadoop_start_daemon
 
   export CLASSPATH
   #shellcheck disable=SC2086
-  exec "${JAVA}" "-Dproc_${command}" ${HADOOP_OPTS} "${class}" "$@"
+  eval exec '"${JAVA}"' '"-Dproc_${command}"' ${HADOOP_OPTS} '"${class}"' '"$@"'
 }
 
 ## @description  Start a non-privileged daemon in the background.


### PR DESCRIPTION
### Description of PR

Need to fix the eval expression.

1. Prefix exec by eval in Hadoop bin scripts Prior to this change, if HADOOP_OPTS contains any arguments that include a space, the command is not parsed correctly. For example, if HADOOP_OPTS="... -XX:OnOutOfMemoryError=\"kill -9 %p\" ...", the bin/hadoop script will fail with the error "Unrecognized option: -9". No amount of clever escaping of the quotes or spaces in the "kill -9 %p" command will fix this. The only alternative appears to be to use 'eval'. Switching to use 'eval' instead of 'exec' also works, but it results in an intermediate bash process being left alive throughout the entire lifetime of the Java proces being started. Using 'exec' prefixed by 'eval' as has been done in this commit gets the best of both worlds, in that options with spaces are parsed correctly, and you don't end up with an intermediate bash process as the parent of the Java process.

2. We can replace single quote with escape-char and a double quote.

JIRA - HADOOP-18327

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

