### PR TITLE
YARN-11198. clean up numa resources from statestore

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/NumaResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/NumaResourceAllocator.java
@@ -73,7 +73,7 @@ public class NumaResourceAllocator {
   private static final String SPACE = "\\s";
   private static final long DEFAULT_NUMA_NODE_MEMORY = 1024;
   private static final int DEFAULT_NUMA_NODE_CPUS = 1;
-  private static final String NUMA_RESOURCE_TYPE = "numa";
+  public static final String NUMA_RESOURCE_TYPE = "numa";
 
   private List<NumaNodeResource> numaNodesList = new ArrayList<>();
   private Map<String, NumaNodeResource> numaNodeIdVsResource = new HashMap<>();
@@ -312,6 +312,8 @@ public class NumaResourceAllocator {
     for (NumaNodeResource numaNode : numaNodesList) {
       numaNode.releaseResources(containerId);
     }
+    // delete key from NM State store
+    context.getNMStateStore().releaseNumaResource(containerId);
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/NumaResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/NumaResourceAllocator.java
@@ -306,7 +306,7 @@ public class NumaResourceAllocator {
    * Release assigned NUMA resources for the container.
    *
    * @param containerId the container ID
-   * @throws ResourceHandlerException while releasing numa resource
+   * @throws ResourceHandlerException when failed to release numa resource
    */
   public synchronized void releaseNumaResource(ContainerId containerId)
       throws ResourceHandlerException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMLeveldbStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMLeveldbStateStoreService.java
@@ -50,8 +50,6 @@ import org.apache.hadoop.yarn.server.api.records.impl.pb.MasterKeyPBImpl;
 import org.apache.hadoop.yarn.server.nodemanager.NodeStatusUpdater;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ResourceMappings;
-import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.
-    numa.NumaResourceAllocator.NUMA_RESOURCE_TYPE;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
@@ -1816,20 +1814,20 @@ public class NMLeveldbStateStoreService extends NMStateStoreService {
     }
   }
   @Override
-  public void releaseNumaResource(ContainerId containerId)  {
-    LOG.info("Release NUMA resource Called for removing from statestore");
+  public void releaseAssignedResources(ContainerId containerId, String resourceType)
+      throws IOException {
+    LOG.debug("releaseAssignedResources: containerId=" + containerId + " resourceType="
+        + resourceType);
     try {
       try (WriteBatch batch = db.createWriteBatch()) {
-        String key = CONTAINERS_KEY_PREFIX + containerId.toString()
-            + CONTAINER_ASSIGNED_RESOURCES_KEY_SUFFIX + NUMA_RESOURCE_TYPE;
+        String key = CONTAINERS_KEY_PREFIX + containerId
+            + CONTAINER_ASSIGNED_RESOURCES_KEY_SUFFIX + resourceType;
         batch.delete(bytes(key));
-      }catch (IOException e) {
-        throw new RuntimeException(e);
+        db.write(batch);
       }
     }catch (DBException e){
       markStoreUnHealthy(e);
-      LOG.error("Failed to delete Key");
-      throw new RuntimeException(e);
+      throw new IOException(e);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
@@ -786,6 +786,12 @@ public abstract class NMStateStoreService extends AbstractService {
       String resourceType, List<Serializable> assignedResources)
       throws IOException;
 
+  /**
+   * Store the assigned resources to a container.
+   * @param containerId Container Id
+   */
+  public void releaseNumaResource(ContainerId containerId){}
+
   protected abstract void initStorage(Configuration conf) throws IOException;
 
   protected abstract void startStorage() throws IOException;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMStateStoreService.java
@@ -787,10 +787,13 @@ public abstract class NMStateStoreService extends AbstractService {
       throws IOException;
 
   /**
-   * Store the assigned resources to a container.
+   * Delete the assigned resources of a container of specific resourceType.
    * @param containerId Container Id
+   * @param resourceType resource Type
+   * @throws IOException while releasing resources
    */
-  public void releaseNumaResource(ContainerId containerId){}
+  public void releaseAssignedResources(ContainerId containerId, String resourceType)
+      throws IOException {}
 
   protected abstract void initStorage(Configuration conf) throws IOException;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/recovery/TestNMLeveldbStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/recovery/TestNMLeveldbStateStoreService.java
@@ -1756,6 +1756,18 @@ public class TestNMLeveldbStateStoreService {
     resources = rcs.getResourceMappings().getAssignedResources("numa");
     Assert.assertEquals(numaRes, resources);
     Assert.assertEquals(numaRes, resourceMappings.getAssignedResources("numa"));
+    // test removing numa resources from state store
+    stateStore.releaseAssignedResources(containerId, "numa");
+    recoveredContainers = loadContainersState(stateStore.getContainerStateIterator());
+    resourceMappings = recoveredContainers.get(0).getResourceMappings();
+    assertTrue(resourceMappings.getAssignedResources("numa").isEmpty());
+
+    // testing calling deletion of non-existing key doesn't break anything
+    try {
+      stateStore.releaseAssignedResources(containerId, "numa");
+    }catch (RuntimeException e){
+      Assert.fail("Should not throw exception while deleting non existing key from statestore");
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[YARN-11198](https://issues.apache.org/jira/browse/YARN-11198)

### How was this patch tested?
created and tested in emr 

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

