### PR TITLE
Hadoop-18330

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -110,6 +110,7 @@ public class DefaultS3ClientFactory extends Configured
   @Override
   public AmazonS3 createS3Client(
       final URI uri,
+      final URI name,
       final S3ClientCreationParameters parameters) throws IOException {
     Configuration conf = getConf();
     bucket = uri.getHost();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -896,7 +896,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withRequestHandlers(auditManager.createRequestHandlers());
 
     s3 = ReflectionUtils.newInstance(s3ClientFactoryClass, conf)
-        .createS3Client(getUri(),
+        .createS3Client(getUri(), name,
             parameters);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -53,11 +53,12 @@ public interface S3ClientFactory {
    * Creates a new {@link AmazonS3} client.
    *
    * @param uri S3A file system URI
+   * @param name S3A file system URI that contains the full path
    * @param parameters parameter object
    * @return S3 client
    * @throws IOException IO problem
    */
-  AmazonS3 createS3Client(URI uri,
+  AmazonS3 createS3Client(URI uri, URI name, 
       S3ClientCreationParameters parameters) throws IOException;
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -181,6 +181,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
             .newStatisticsFromAwsSdk());
     AmazonS3 client = factory.createS3Client(
         new URI("s3a://localhost/"),
+        new URI("s3a://localhost/path/")
         parameters);
     Assertions.assertThat(client.getRegionName())
         .describedAs("Client region name")

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
@@ -34,7 +34,7 @@ import com.amazonaws.services.s3.model.Region;
 public class MockS3ClientFactory implements S3ClientFactory {
 
   @Override
-  public AmazonS3 createS3Client(URI uri,
+  public AmazonS3 createS3Client(URI uri, URI name,
       final S3ClientCreationParameters parameters) {
     AmazonS3 s3 = mock(AmazonS3.class);
     String bucket = uri.getHost();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -593,7 +593,7 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
         .withMetrics(new EmptyS3AStatisticsContext()
             .newStatisticsFromAwsSdk())
         .withUserAgentSuffix("ITestSessionDelegationInFileystem");
-    AmazonS3 s3 = factory.createS3Client(landsat, parameters);
+    AmazonS3 s3 = factory.createS3Client(landsat, landsat, parameters);
 
     return Invoker.once("HEAD", host,
         () -> s3.getObjectMetadata(host, landsat.getPath().substring(1)));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18330 

### Description of PR
Added extra client attribute to the S3ClientCreation Parameters so that the full s3a path can be accessed!

### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

