### PR TITLE
HADOOP-18074 - Partial/Incomplete groups list can be returned in LDAP…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
@@ -547,7 +547,9 @@ public class LdapGroupsMapping
       } catch (NamingException e) {
         // If the first lookup failed, fall back to the typical scenario.
         // In order to force the fallback, we need to reset groups collection.
-        groups.clear();
+        if (groups != null) {
+          groups.clear();
+        }
         LOG.info("Failed to get groups from the first lookup. Initiating " +
                 "the second LDAP query using the user's DN.", e);
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
@@ -512,6 +512,7 @@ public class LdapGroupsMapping
   List<String> doGetGroups(String user, int goUpHierarchy)
       throws NamingException {
     DirContext c = getDirContext();
+    List<String> groups = new ArrayList<>();
 
     // Search for the user. We'll only ever need to look at the first result
     NamingEnumeration<SearchResult> results = c.search(userbaseDN,
@@ -520,11 +521,10 @@ public class LdapGroupsMapping
     if (!results.hasMoreElements()) {
       LOG.debug("doGetGroups({}) returned no groups because the " +
           "user is not found.", user);
-      return new ArrayList<>();
+      return groups;
     }
     SearchResult result = results.nextElement();
 
-    List<String> groups = null;
     if (useOneQuery) {
       try {
         /**
@@ -538,7 +538,6 @@ public class LdapGroupsMapping
               memberOfAttr + "' attribute." +
               "Returned user object: " + result.toString());
         }
-        groups = new ArrayList<>();
         NamingEnumeration groupEnumeration = groupDNAttr.getAll();
         while (groupEnumeration.hasMore()) {
           String groupDN = groupEnumeration.next().toString();
@@ -547,14 +546,12 @@ public class LdapGroupsMapping
       } catch (NamingException e) {
         // If the first lookup failed, fall back to the typical scenario.
         // In order to force the fallback, we need to reset groups collection.
-        if (groups != null) {
-          groups.clear();
-        }
+        groups.clear();
         LOG.info("Failed to get groups from the first lookup. Initiating " +
                 "the second LDAP query using the user's DN.", e);
       }
     }
-    if (groups == null || groups.isEmpty() || goUpHierarchy > 0) {
+    if (groups.isEmpty() || goUpHierarchy > 0) {
       groups = lookupGroup(result, c, goUpHierarchy);
     }
     LOG.debug("doGetGroups({}) returned {}", user, groups);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
@@ -460,7 +460,7 @@ public class LdapGroupsMapping
    * @throws NamingException if unable to find group names
    */
   @VisibleForTesting
-  Set<String> lookupGroup(SearchResult result, DirContext c,
+  List<String> lookupGroup(SearchResult result, DirContext c,
       int goUpHierarchy)
       throws NamingException {
     List<String> groups = new ArrayList<>();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
@@ -58,6 +58,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Iterators;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -458,7 +459,8 @@ public class LdapGroupsMapping
    * @return a list of strings representing group names of the user.
    * @throws NamingException if unable to find group names
    */
-  private List<String> lookupGroup(SearchResult result, DirContext c,
+  @VisibleForTesting
+  Set<String> lookupGroup(SearchResult result, DirContext c,
       int goUpHierarchy)
       throws NamingException {
     List<String> groups = new ArrayList<>();
@@ -544,6 +546,8 @@ public class LdapGroupsMapping
         }
       } catch (NamingException e) {
         // If the first lookup failed, fall back to the typical scenario.
+        // In order to force the fallback, we need to reset groups collection.
+        groups.clear();
         LOG.info("Failed to get groups from the first lookup. Initiating " +
                 "the second LDAP query using the user's DN.", e);
       }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMappingWithOneQuery.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMappingWithOneQuery.java
@@ -18,19 +18,22 @@
 
 package org.apache.hadoop.security;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
+import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+import org.mockito.stubbing.Stubber;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -49,21 +52,36 @@ import static org.mockito.Mockito.when;
 public class TestLdapGroupsMappingWithOneQuery
     extends TestLdapGroupsMappingBase {
 
-  @Before
-  public void setupMocks() throws NamingException {
+  public void setupMocks(List<String> listOfDNs) throws NamingException {
     Attribute groupDN = mock(Attribute.class);
 
     NamingEnumeration<SearchResult> groupNames = getGroupNames();
     doReturn(groupNames).when(groupDN).getAll();
-    String groupName1 = "CN=abc,DC=foo,DC=bar,DC=com";
-    String groupName2 = "CN=xyz,DC=foo,DC=bar,DC=com";
-    String groupName3 = "CN=sss,CN=foo,DC=bar,DC=com";
-    doReturn(groupName1).doReturn(groupName2).doReturn(groupName3).
-        when(groupNames).next();
-    when(groupNames.hasMore()).thenReturn(true).thenReturn(true).
-        thenReturn(true).thenReturn(false);
+    buildListOfGroupDNs(listOfDNs).when(groupNames).next();
+    when(groupNames.hasMore()).
+      thenReturn(true).thenReturn(true).
+      thenReturn(true).thenReturn(false);
 
     when(getAttributes().get(eq("memberOf"))).thenReturn(groupDN);
+  }
+
+  /**
+   * Build and return a list of individually added group DNs such
+   * that calls to .next() will result in a single value each time.
+   *
+   * @param listOfDNs
+   * @return the stubber to use for the .when().next() call
+   */
+  private Stubber buildListOfGroupDNs(List<String> listOfDNs) {
+    Stubber stubber = null;
+    for (String s : listOfDNs) {
+      if (stubber != null) {
+        stubber.doReturn(s);
+      } else {
+        stubber = doReturn(s);
+      }
+    }
+    return stubber;
   }
 
   @Test
@@ -72,25 +90,83 @@ public class TestLdapGroupsMappingWithOneQuery
     // properties, return an array of strings representing its groups.
     String[] testGroups = new String[] {"abc", "xyz", "sss"};
     doTestGetGroups(Arrays.asList(testGroups));
+
+    // test fallback triggered by NamingException
+    doTestGetGroupsWithFallback();
   }
 
   private void doTestGetGroups(List<String> expectedGroups)
       throws NamingException {
+    List<String> groupDns = new ArrayList<>();
+    groupDns.add("CN=abc,DC=foo,DC=bar,DC=com");
+    groupDns.add("CN=xyz,DC=foo,DC=bar,DC=com");
+    groupDns.add("CN=sss,DC=foo,DC=bar,DC=com");
+
+    setupMocks(groupDns);
     String ldapUrl = "ldap://test";
     Configuration conf = getBaseConf(ldapUrl);
     // enable single-query lookup
     conf.set(LdapGroupsMapping.MEMBEROF_ATTR_KEY, "memberOf");
 
-    LdapGroupsMapping groupsMapping = getGroupsMapping();
+    TestLdapGroupsMapping groupsMapping = new TestLdapGroupsMapping();
     groupsMapping.setConf(conf);
     // Username is arbitrary, since the spy is mocked to respond the same,
     // regardless of input
     List<String> groups = groupsMapping.getGroups("some_user");
 
     Assert.assertEquals(expectedGroups, groups);
+    Assert.assertFalse("Second LDAP query should NOT have been called.",
+            groupsMapping.isSecondaryQueryCalled());
 
     // We should have only made one query because single-query lookup is enabled
     verify(getContext(), times(1)).search(anyString(), anyString(),
         any(Object[].class), any(SearchControls.class));
+  }
+
+  private void doTestGetGroupsWithFallback()
+          throws NamingException {
+    List<String> groupDns = new ArrayList<>();
+    groupDns.add("CN=abc,DC=foo,DC=bar,DC=com");
+    groupDns.add("CN=xyz,DC=foo,DC=bar,DC=com");
+    groupDns.add("ipaUniqueID=e4a9a634-bb24-11ec-aec1-06ede52b5fe1," +
+            "CN=sudo,DC=foo,DC=bar,DC=com");
+    setupMocks(groupDns);
+    String ldapUrl = "ldap://test";
+    Configuration conf = getBaseConf(ldapUrl);
+    // enable single-query lookup
+    conf.set(LdapGroupsMapping.MEMBEROF_ATTR_KEY, "memberOf");
+    conf.set(LdapGroupsMapping.LDAP_NUM_ATTEMPTS_KEY, "1");
+
+    TestLdapGroupsMapping groupsMapping = new TestLdapGroupsMapping();
+    groupsMapping.setConf(conf);
+    // Username is arbitrary, since the spy is mocked to respond the same,
+    // regardless of input
+    List<String> groups = groupsMapping.getGroups("some_user");
+
+    // expected to be empty due to invalid memberOf
+    Assert.assertEquals(0, groups.size());
+
+    // expect secondary query to be called: getGroups()
+    Assert.assertTrue("Second LDAP query should have been called.",
+            groupsMapping.isSecondaryQueryCalled());
+
+    // We should have fallen back to the second query because first threw
+    // NamingException expected count is 3 since testGetGroups calls
+    // doTestGetGroups and doTestGetGroupsWithFallback in succession and
+    // the count is across both test scenarios.
+    verify(getContext(), times(3)).search(anyString(), anyString(),
+            any(Object[].class), any(SearchControls.class));
+  }
+
+  private static final class TestLdapGroupsMapping extends LdapGroupsMapping {
+    private boolean secondaryQueryCalled = false;
+    public boolean isSecondaryQueryCalled() {
+      return secondaryQueryCalled;
+    }
+    Set<String> lookupGroup(SearchResult result, DirContext c,
+                                    int goUpHierarchy) throws NamingException {
+      secondaryQueryCalled = true;
+      return super.lookupGroup(result, c, goUpHierarchy);
+    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMappingWithOneQuery.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMappingWithOneQuery.java
@@ -163,7 +163,7 @@ public class TestLdapGroupsMappingWithOneQuery
     public boolean isSecondaryQueryCalled() {
       return secondaryQueryCalled;
     }
-    Set<String> lookupGroup(SearchResult result, DirContext c,
+    List<String> lookupGroup(SearchResult result, DirContext c,
                                     int goUpHierarchy) throws NamingException {
       secondaryQueryCalled = true;
       return super.lookupGroup(result, c, goUpHierarchy);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMappingWithOneQuery.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMappingWithOneQuery.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;


### PR DESCRIPTION
…… (#4503)

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Description of PR
LdapGroupsMapping could return a partial list of group names due to encountering a NamingException while acquiring
the RDN for a DN. This was due to not clearing the partially built list which results in the secondary query not being
attempted. This PR clears the partially built list and forces the secondary query to be called.

How was this patch tested?
Existing unit tests were run and a new unit test added to insure that the secondary query is indeed being called.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

