### PR TITLE
HADOOP-18334. Fix create-release to address removal of GPG_AGENT_INFO in branch-3.2.

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -249,7 +249,9 @@ function startgpgagent
       eval $("${GPGAGENT}" --daemon \
         --options "${LOGDIR}/gpgagent.conf" \
         --log-file="${LOGDIR}/create-release-gpgagent.log")
-      GPGAGENTPID=$(echo "${GPG_AGENT_INFO}" | cut -f 2 -d:)
+      GPGAGENTPID=$(pgrep "${GPGAGENT}")
+      GPG_AGENT_INFO="$HOME/.gnupg/S.gpg-agent:$GPGAGENTPID:1"
+      export GPG_AGENT_INFO
     fi
 
     if [[ -n "${GPG_AGENT_INFO}" ]]; then


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18334

gpg v2.1 and above does not export GPG_AGENT_INFO. create-release script need to export the info by itself to make `--sign` work. It was addressed as part of [HADOOP-16797](https://issues.apache.org/jira/browse/HADOOP-16797) in branch-3.3 and trunk. Since we can not backport aarch64 support to branch-3.2, I filed this issue for branch-3.2 only.