### PR TITLE
HADOOP-18330 S3AFileSystem removes Path when calling createS3Client

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -888,6 +888,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     S3ClientFactory.S3ClientCreationParameters parameters = null;
     parameters = new S3ClientFactory.S3ClientCreationParameters()
         .withCredentialSet(credentials)
+        .withPath(name)
         .withEndpoint(endpoint)
         .withMetrics(statisticsContext.newStatisticsFromAwsSdk())
         .withPathStyleAccess(conf.getBoolean(PATH_STYLE_ACCESS, false))

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -117,6 +117,7 @@ public interface S3ClientFactory {
 
     /**
      * S3A path.
+     * added in HADOOP-18330
      */
     private URI pathUri;
 
@@ -281,6 +282,7 @@ public interface S3ClientFactory {
 
     /**
      * Set full s3a path.
+     * added in HADOOP-18330
      * @param value new value
      * @return the builder
      */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -270,6 +270,11 @@ public interface S3ClientFactory {
       return headers;
     }
 
+    /**
+     * Get the full s3 path.
+     * added in HADOOP-18330
+     * @return path URI
+     */
     public URI getPath() {
       return pathUri;
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -116,6 +116,11 @@ public interface S3ClientFactory {
     private String userAgentSuffix = "";
 
     /**
+     * S3A path.
+     */
+    private URI pathUri;
+
+    /**
      * List of request handlers to include in the chain
      * of request execution in the SDK.
      * @return the handler list
@@ -263,6 +268,21 @@ public interface S3ClientFactory {
      */
     public Map<String, String> getHeaders() {
       return headers;
+    }
+
+    public URI getPath() {
+      return pathUri;
+    }
+
+    /**
+     * Set full s3a path.
+     * @param value new value
+     * @return the builder
+     */
+    public S3ClientCreationParameters withPath(
+            final URI value) {
+      pathUri = value;
+      return this;
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -176,6 +176,7 @@ public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
     S3ClientFactory.S3ClientCreationParameters parameters
         = new S3ClientFactory.S3ClientCreationParameters()
         .withCredentialSet(new AnonymousAWSCredentialsProvider())
+        .withPath(new URI("s3a://localhost/"))
         .withEndpoint(endpoint)
         .withMetrics(new EmptyS3AStatisticsContext()
             .newStatisticsFromAwsSdk());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -590,6 +590,7 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
     S3ClientFactory.S3ClientCreationParameters parameters = null;
     parameters = new S3ClientFactory.S3ClientCreationParameters()
         .withCredentialSet(testingCreds)
+        .withPath(new URI("s3a://localhost/"))
         .withEndpoint(DEFAULT_ENDPOINT)
         .withMetrics(new EmptyS3AStatisticsContext()
             .newStatisticsFromAwsSdk())


### PR DESCRIPTION
First of all, sorry for the multiple PR's, it's because i cant push from my device because of security reasons and have to use https://github.dev/ 

### Description of PR
Added a new parameter object (pathUrl) that holds the full s3a path 

### How was this patch tested?
- Ran all the tests successfully using `mvn clean compile package`.
- Used the jar from above step to successfully read/write to an S3 bucket in us-east. Repeated this 3 times.


### For code changes:

- [ X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

