### PR TITLE
HDFS-16657 Changing pool-level lock to volume-level lock for invalida…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2312,23 +2312,23 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     for (int i = 0; i < invalidBlks.length; i++) {
       final ReplicaInfo removing;
       final FsVolumeImpl v;
-      try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl, bpid)) {
-        final ReplicaInfo info = volumeMap.get(bpid, invalidBlks[i]);
-        if (info == null) {
-          ReplicaInfo infoByBlockId =
-              volumeMap.get(bpid, invalidBlks[i].getBlockId());
-          if (infoByBlockId == null) {
-            // It is okay if the block is not found -- it
-            // may be deleted earlier.
-            LOG.info("Failed to delete replica " + invalidBlks[i]
-                + ": ReplicaInfo not found.");
-          } else {
-            errors.add("Failed to delete replica " + invalidBlks[i]
-                + ": GenerationStamp not matched, existing replica is "
-                + Block.toString(infoByBlockId));
-          }
-          continue;
+      final ReplicaInfo info = volumeMap.get(bpid, invalidBlks[i]);
+      if (info == null) {
+        ReplicaInfo infoByBlockId =
+                volumeMap.get(bpid, invalidBlks[i].getBlockId());
+        if (infoByBlockId == null) {
+          // It is okay if the block is not found -- it
+          // may be deleted earlier.
+          LOG.info("Failed to delete replica " + invalidBlks[i]
+                  + ": ReplicaInfo not found.");
+        } else {
+          errors.add("Failed to delete replica " + invalidBlks[i]
+                  + ": GenerationStamp not matched, existing replica is "
+                  + Block.toString(infoByBlockId));
         }
+        continue;
+      }
+      try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.VOLUME, bpid, info.getStorageUuid())) {
 
         v = (FsVolumeImpl)info.getVolume();
         if (v == null) {


### PR DESCRIPTION
The key code is:

// code placeholder
try {
  File blockFile = new File(info.getBlockURI());
  if (blockFile != null && blockFile.getParentFile() == null) {
    errors.add("Failed to delete replica " + invalidBlks[i]
        +  ". Parent not found for block file: " + blockFile);
    continue;
  }
} catch(IllegalArgumentException e) {
  LOG.warn("Parent directory check failed; replica " + info
      + " is not backed by a local file");
} 
DN is trying to locate parent path of block file, thus there is a disk I/O in pool-level lock. When the disk becomes very busy with high io wait, All the pending threads will be blocked by the pool-level lock, and the time of heartbeat is high. We proposal to change the pool-level lock to volume-level lock for block invalidation