### PR TITLE
HDFS-16659. JournalNode should throw NewerTxnIdException when SinceTxId is bigger than HighestWrittenTxId

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/QuorumJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/QuorumJournalManager.java
@@ -31,6 +31,7 @@ import java.util.PriorityQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.hadoop.hdfs.qjournal.server.NewerTxnIdException;
 import org.apache.hadoop.util.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -522,6 +523,9 @@ public class QuorumJournalManager implements JournalManager {
         Collection<EditLogInputStream> rpcStreams = new ArrayList<>();
         selectRpcInputStreams(rpcStreams, fromTxnId, onlyDurableTxns);
         streams.addAll(rpcStreams);
+        return;
+      } catch (NewerTxnIdException ntie) {
+        // normal situation, we requested newer IDs than any journal has. no new streams
         return;
       } catch (IOException ioe) {
         LOG.warn("Encountered exception while tailing edits >= " + fromTxnId +

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/NewerTxnIdException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/NewerTxnIdException.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.qjournal.server;
+
+import java.io.IOException;
+
+/**
+ * Exception when no edits are available.
+ */
+public class NewerTxnIdException extends IOException {
+  private static final long serialVersionUID = 0L;
+
+  public NewerTxnIdException(String msgFormat, Object... msgArgs) {
+    super(String.format(msgFormat, msgArgs));
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManager.java
@@ -1109,13 +1109,14 @@ public class TestQuorumJournalManager {
   /**
    * Test selecting EditLogInputStream after some journalNode jitter.
    * Suppose there are 3 journalNodes, JN0 ~ JN2.
-   *  1. JN0 has some abnormal cases when Active Namenode is syncing 10 Edits with first txid 11
-   *  2. NameNode just ignore the abnormal JN0 and continue to sync Edits to Journal 1 and 2
-   *  3. JN0 backed to health
+   *  1. JN0 has some abnormal cases when Active Namenode is syncing 10 Edits with first txid 11.
+   *  2. NameNode just ignore the abnormal JN0 and continue to sync Edits to Journal 1 and 2.
+   *  3. JN0 backed to health.
    *  4. NameNode continue sync 10 Edits with first txid 21.
-   *  5. At this point, there are no Edits 11 ~ 30 in the cache of JN0
-   *  6. Observer NameNode try to select EditLogInputStream through getJournaledEdits with since txId 21
-   *  7. JN2 has some abnormal cases and caused a slow response
+   *  5. At this point, there are no Edits 11 ~ 30 in the cache of JN0.
+   *  6. Observer NameNode try to select EditLogInputStream through
+   *     getJournaledEdits with since txId 21.
+   *  7. JN2 has some abnormal cases and caused a slow response.
    */
   @Test
   public void testSelectViaRPCAfterJNJitter() throws Exception {


### PR DESCRIPTION
### Description of PR
JournalNode should throw `CacheMissException` if `sinceTxId` is bigger than `highestWrittenTxId` during handling `getJournaledEdits` rpc from NNs. 
Current logic may cause in-progress EditlogTailer cannot replay any Edits from JournalNodes in some corner cases, resulting in ObserverNameNode cannot handle requests from clients.

Suppose there are 3 journalNodes, JN0 ~ JN1.
* JN0 has some abnormal cases when Active Namenode is syncing 10 Edits with first txid 11
* NameNode just ignore the abnormal JN0 and continue to sync Edits to Journal 1 and 2
* JN0 backed to health
* NameNode continue sync 10 Edits with first txid 21.
* At this point, there are no Edits 11 ~ 30 in the cache of JN0
* Observer NameNode try to select EditLogInputStream through `getJournaledEdits` with since txId 21
* Journal 2 has some abnormal cases and caused a slow response

The expected result is: Response should contain 20 Edits from txId 21 to txId 30 from JN1 and JN2. Because Active NameNode successfully write these Edits to JN1 and JN2 and failed write these edits to JN0.

But in the current implementation,  the response is [Response(0) from JN0, Response(10) from JN1], because  there are some abnormal cases in  JN2, such as GC, bad network,  cause a slow response. So the `maxAllowedTxns` will be 0, NameNode will not replay any Edits.


As above, the root case is that JournalNode should throw Miss Cache Exception when `sinceTxid` is more than `highestWrittenTxId`.

And the bug code as blew:
```
if (sinceTxId > getHighestWrittenTxId()) {
    // Requested edits that don't exist yet; short-circuit the cache here
    metrics.rpcEmptyResponses.incr();
    return GetJournaledEditsResponseProto.newBuilder().setTxnCount(0).build(); 
}
```