### PR TITLE
HDFS-16464. Create only libhdfspp static libraries for Windows

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
@@ -18,11 +18,30 @@
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
+# Need this CMake policy for using the MultiThreaded MSVC runtime library.
+cmake_policy(SET CMP0091 NEW)
+
+# Need this CMake policy for invoking target_link_libraries on a target in any directory.
+cmake_policy(SET CMP0079 NEW)
+
 project(hadoop_hdfs_native_client)
 
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 17)
+
+# Instructs MSVC to use the static version of the runtime library.
+# More info - https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+
+# This indicates that Windows 10 and above are supported.
+# More info - https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
+set(NT_REQUIRED_VERSION 0x0A00)
+add_definitions(-D_WIN32_WINNT=${NT_REQUIRED_VERSION})
+
+# Windows.h defines the "min" and "max" macros which conflicts with the std::min and std::max from C++ STL.
+# Adding the below definition will disable this macro.
+add_definitions(-DNOMINMAX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../../hadoop-common-project/hadoop-common)
 include(HadoopCommon)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/CMakeLists.txt
@@ -30,18 +30,20 @@ enable_testing()
 
 set(CMAKE_CXX_STANDARD 17)
 
-# Instructs MSVC to use the static version of the runtime library.
-# More info - https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+if (MSVC)
+    # Instructs MSVC to use the static version of the runtime library.
+    # More info - https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
 
-# This indicates that Windows 10 and above are supported.
-# More info - https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
-set(NT_REQUIRED_VERSION 0x0A00)
-add_definitions(-D_WIN32_WINNT=${NT_REQUIRED_VERSION})
+    # This indicates that Windows 10 and above are supported.
+    # More info - https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
+    set(NT_REQUIRED_VERSION 0x0A00)
+    add_definitions(-D_WIN32_WINNT=${NT_REQUIRED_VERSION})
 
-# Windows.h defines the "min" and "max" macros which conflicts with the std::min and std::max from C++ STL.
-# Adding the below definition will disable this macro.
-add_definitions(-DNOMINMAX)
+    # Windows.h defines the "min" and "max" macros which conflicts with the std::min and std::max from C++ STL.
+    # Adding the below definition will disable this macro.
+    add_definitions(-DNOMINMAX)
+endif (MSVC)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../../hadoop-common-project/hadoop-common)
 include(HadoopCommon)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
@@ -28,7 +28,7 @@ project (libhdfspp)
 
 cmake_minimum_required(VERSION 2.8)
 
-find_package (Boost 1.72.0 REQUIRED COMPONENTS date_time)
+find_package (Boost 1.72.0 REQUIRED)
 
 enable_testing()
 set(CMAKE_CXX_STANDARD 17)
@@ -274,6 +274,7 @@ endif()
 
 set(LIBHDFSPP_VERSION "0.1.0")
 set(LIBHDFSPP_ALL_OBJECTS $<TARGET_OBJECTS:x_platform_obj> $<TARGET_OBJECTS:bindings_c_obj> $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:rpc_obj> $<TARGET_OBJECTS:reader_obj> $<TARGET_OBJECTS:proto_obj> $<TARGET_OBJECTS:connection_obj> $<TARGET_OBJECTS:common_obj> $<TARGET_OBJECTS:uriparser2_obj>)
+# HDFS-16464: We don't support building Hadoop DLL for Windows yet.
 if (HADOOP_BUILD AND NOT MSVC)
   hadoop_add_dual_library(hdfspp ${EMPTY_FILE_CC} ${LIBHDFSPP_ALL_OBJECTS})
   hadoop_target_link_dual_libraries(hdfspp
@@ -292,8 +293,7 @@ else (HADOOP_BUILD AND NOT MSVC)
     ${PROTOBUF_LIBRARY}
     ${OPENSSL_LIBRARIES}
     ${SASL_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${Boost_LIBRARIES})
+    ${CMAKE_THREAD_LIBS_INIT})
   if(BUILD_SHARED_HDFSPP)
     add_library(hdfspp SHARED ${EMPTY_FILE_CC} ${LIBHDFSPP_ALL_OBJECTS})
     set_target_properties(hdfspp PROPERTIES SOVERSION ${LIBHDFSPP_VERSION})

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
@@ -28,7 +28,7 @@ project (libhdfspp)
 
 cmake_minimum_required(VERSION 2.8)
 
-find_package (Boost 1.72.0 REQUIRED)
+find_package (Boost 1.72.0 REQUIRED COMPONENTS date_time)
 
 enable_testing()
 set(CMAKE_CXX_STANDARD 17)
@@ -274,7 +274,7 @@ endif()
 
 set(LIBHDFSPP_VERSION "0.1.0")
 set(LIBHDFSPP_ALL_OBJECTS $<TARGET_OBJECTS:x_platform_obj> $<TARGET_OBJECTS:bindings_c_obj> $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:rpc_obj> $<TARGET_OBJECTS:reader_obj> $<TARGET_OBJECTS:proto_obj> $<TARGET_OBJECTS:connection_obj> $<TARGET_OBJECTS:common_obj> $<TARGET_OBJECTS:uriparser2_obj>)
-if (HADOOP_BUILD)
+if (HADOOP_BUILD AND NOT MSVC)
   hadoop_add_dual_library(hdfspp ${EMPTY_FILE_CC} ${LIBHDFSPP_ALL_OBJECTS})
   hadoop_target_link_dual_libraries(hdfspp
     ${LIB_DL}
@@ -285,20 +285,20 @@ if (HADOOP_BUILD)
   )
   set_target_properties(hdfspp PROPERTIES SOVERSION ${LIBHDFSPP_VERSION})
   hadoop_dual_output_directory(hdfspp ${OUT_DIR})
-else (HADOOP_BUILD)
+else (HADOOP_BUILD AND NOT MSVC)
   add_library(hdfspp_static STATIC ${EMPTY_FILE_CC} ${LIBHDFSPP_ALL_OBJECTS})
-  target_link_libraries(hdfspp_static
+  target_link_libraries(hdfspp_static PUBLIC
     ${LIB_DL}
     ${PROTOBUF_LIBRARY}
     ${OPENSSL_LIBRARIES}
     ${SASL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
-    )
+    ${Boost_LIBRARIES})
   if(BUILD_SHARED_HDFSPP)
     add_library(hdfspp SHARED ${EMPTY_FILE_CC} ${LIBHDFSPP_ALL_OBJECTS})
     set_target_properties(hdfspp PROPERTIES SOVERSION ${LIBHDFSPP_VERSION})
   endif(BUILD_SHARED_HDFSPP)
-endif (HADOOP_BUILD)
+endif (HADOOP_BUILD AND NOT MSVC)
 
 # Set up make install targets
 # Can be installed to a particular location via "make DESTDIR=... install"

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -568,7 +568,6 @@ TEST(ConfigurationTest, TestUriConversions) {
 }
 
 
-
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -568,6 +568,7 @@ TEST(ConfigurationTest, TestUriConversions) {
 }
 
 
+
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
While building dynamic libraries (.dll) on Windows, there's a constraint that all the dependent libraries be linked dynamically. This poses an issue since Protobuf (which is an HDFS native client dependency) runs into build issues when linked dynamically. There are a few [warning notes](https://github.com/protocolbuffers/protobuf/blob/9ebb31726cef11e4e940b50ec751df4e863e3d2a/cmake/README.md#dlls-vs-static-linking) on the Protobuf repository's build instructions page as well.

Thus, to keep things simple, we can resort to do only static linking and thereby only produce statically linked libraries on Windows. In summary, we'll be providing only Hadoop .lib files initially. We can aim to produce Hadoop DLL on Windows eventually once we're able to resolve Protobuf's DLL issues.

### How was this patch tested?
Hadoop Jenkins CI validation ensures that the Linux components aren't affected. Verified that the static library is produced as a result of successful build on my local Windows system.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

