### PR TITLE
HDFS-16666. Pass CMake args for Windows in pom.xml

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml
@@ -147,7 +147,23 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                     <mkdir dir="${project.build.directory}/native"/>
                     <exec executable="cmake" dir="${project.build.directory}/native"
                           failonerror="true">
-                      <arg line="${basedir}/src/ -DGENERATED_JAVAH=${project.build.directory}/native/javah -DJVM_ARCH_DATA_MODEL=${sun.arch.data.model} -DHADOOP_BUILD=1 -DREQUIRE_FUSE=${require.fuse} -DREQUIRE_VALGRIND=${require.valgrind} -A '${env.PLATFORM}'"/>
+                      <arg line="${basedir}/src/"/>
+                      <arg line="-DGENERATED_JAVAH=${project.build.directory}/native/javah"/>
+                      <arg line="-DJVM_ARCH_DATA_MODEL=${sun.arch.data.model}"/>
+                      <arg line="-DREQUIRE_VALGRIND=${require.valgrind}"/>
+                      <arg line="-DHADOOP_BUILD=1"/>
+                      <arg line="-DREQUIRE_LIBWEBHDFS=${require.libwebhdfs}"/>
+                      <arg line="-DREQUIRE_OPENSSL=${require.openssl}"/>
+                      <arg line="-DCUSTOM_OPENSSL_PREFIX=${openssl.prefix}"/>
+                      <arg line="-DCUSTOM_OPENSSL_LIB=${openssl.lib}"/>
+                      <arg line="-DCUSTOM_OPENSSL_INCLUDE=${openssl.include}"/>
+                      <arg line="-DCMAKE_PREFIX_PATH=${windows.cmake.prefix.path}"/>
+                      <arg line="-DCMAKE_TOOLCHAIN_FILE=${windows.cmake.toolchain.file}"/>
+                      <arg line="-DCMAKE_BUILD_TYPE=${windows.cmake.build.type}"/>
+                      <arg line="-DBUILD_SHARED_HDFSPP=${windows.build.hdfspp.dll}"/>
+                      <arg line="-DNO_SASL=${windows.no.sasl}"/>
+                      <arg line="-DREQUIRE_FUSE=${require.fuse}"/>
+                      <arg line="-A '${env.PLATFORM}'"/>
                       <arg line="${native_cmake_args}"/>
                     </exec>
                     <exec executable="msbuild" dir="${project.build.directory}/native"

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -568,7 +568,6 @@ TEST(ConfigurationTest, TestUriConversions) {
 }
 
 
-
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/configuration_test.cc
@@ -568,6 +568,7 @@ TEST(ConfigurationTest, TestUriConversions) {
 }
 
 
+
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Need to pass the required HDFS CMake related argument for building on Windows. Currently, these are passed - https://github.com/apache/hadoop/blob/34e548cb62ed21c5bba7a82f5f1489ca6bdfb8c4/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml#L150

We need to pass these arguments as well for Windows - https://github.com/apache/hadoop/blob/34e548cb62ed21c5bba7a82f5f1489ca6bdfb8c4/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml#L219-L223

### How was this patch tested?
1. Tested this locally by building on my Windows system.
2. Hadoop Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

