### PR TITLE
HDFS-16667. Use malloc for buffer allocation in uriparser2

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
@@ -129,7 +129,6 @@ TEST(HdfsBuilderTest, TestSet)
   }
 }
 
-
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/hdfs_builder_test.cc
@@ -129,6 +129,7 @@ TEST(HdfsBuilderTest, TestSet)
   }
 }
 
+
 int main(int argc, char *argv[]) {
   /*
    *  The following line must be executed to initialize Google Mock

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c
@@ -71,11 +71,11 @@ static const char *copy_path(const UriPathSegmentA *ps, char **buffer) {
 static int parse_int(const char *first, const char *after_last) {
 	const int size = after_last - first;
 	if (size) {
-               char* buffer = (char*) malloc(size + 1);
+                char* buffer = (char*) malloc(size + 1);
 		memcpyz(buffer, first, size);
-               const int value = atoi(buffer);
-               free(buffer);
-               return value;
+                const int value = atoi(buffer);
+                free(buffer);
+                return value;
 	}
 	return 0;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c
@@ -71,11 +71,11 @@ static const char *copy_path(const UriPathSegmentA *ps, char **buffer) {
 static int parse_int(const char *first, const char *after_last) {
 	const int size = after_last - first;
 	if (size) {
-		char* buffer = (char*) malloc(size + 1);
+               char* buffer = (char*) malloc(size + 1);
 		memcpyz(buffer, first, size);
-		const int value = atoi(buffer);
-		free(buffer);
-		return value;
+               const int value = atoi(buffer);
+               free(buffer);
+               return value;
 	}
 	return 0;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c
@@ -71,9 +71,11 @@ static const char *copy_path(const UriPathSegmentA *ps, char **buffer) {
 static int parse_int(const char *first, const char *after_last) {
 	const int size = after_last - first;
 	if (size) {
-		char buffer[size + 1];
+		char* buffer = (char*) malloc(size + 1);
 		memcpyz(buffer, first, size);
-		return atoi(buffer);
+		const int value = atoi(buffer);
+		free(buffer);
+		return value;
 	}
 	return 0;
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently, a variable is used to specify the array size in uriparser2 -
https://github.com/apache/hadoop/blob/34e548cb62ed21c5bba7a82f5f1489ca6bdfb8c4/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser2.c#L71-L79

This results in the following error on Windows -
```
H:\hadoop-hdfs-project\hadoop-hdfs-native-client\src\out\build\x64-Debug\cl : command line warning D9025: overriding '/W4' with '/w' 
    uriparser2.c
H:\hadoop-hdfs-project\hadoop-hdfs-native-client\src\main\native\libhdfspp\third_party\uriparser2\uriparser2\uriparser2.c(74,23): error C2057: expected constant expression 
H:\hadoop-hdfs-project\hadoop-hdfs-native-client\src\main\native\libhdfspp\third_party\uriparser2\uriparser2\uriparser2.c(74,23): error C2466: cannot allocate an array of constant size 0 
H:\hadoop-hdfs-project\hadoop-hdfs-native-client\src\main\native\libhdfspp\third_party\uriparser2\uriparser2\uriparser2.c(74,24): error C2133: 'buffer': unknown size 
```

I've used malloc to fix this.

### How was this patch tested?
1. Tested this locally by building on my Windows system.
2. Hadoop Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

