### PR TITLE
HDFS-16668. Clean up moverExecutor after each iterations.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Dispatcher.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Dispatcher.java
@@ -1217,6 +1217,8 @@ public class Dispatcher {
       p.proxySource.removePendingBlock(p);
       return;
     }
+    // add target DDatanode only when moveExecutor available;
+    targets.add(p.target);
     moveExecutor.execute(p::dispatch);
   }
 
@@ -1422,6 +1424,12 @@ public class Dispatcher {
     targets.clear();
     globalBlocks.removeAllButRetain(movedBlocks);
     movedBlocks.cleanup();
+  }
+
+  public void reset4Mover() {
+    for(StorageGroup t : targets) {
+      t.getDDatanode().shutdownMoveExecutor();
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/mover/Mover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/mover/Mover.java
@@ -178,6 +178,10 @@ public class Mover {
     }
   }
 
+  void resetData() {
+    dispatcher.reset4Mover();
+  }
+
   private void initStoragePolicies() throws IOException {
     Collection<BlockStoragePolicy> policies =
         dispatcher.getDistributedFileSystem().getAllStoragePolicies();
@@ -686,6 +690,7 @@ public class Mover {
               excludedPinnedBlocks);
 
           final ExitStatus r = m.run();
+          m.resetData();
 
           if (r == ExitStatus.SUCCESS) {
             IOUtils.cleanupWithLogger(LOG, nnc);


### PR DESCRIPTION
A quick fix to clean up moverExecutor after each iterations to avoid thread leaking. Testcases is working on.