### PR TITLE
HADOOP-18348. Change hadoop_start_daemon function $ to BASHPID

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1798,7 +1798,7 @@ function hadoop_start_daemon
 
   # this is for the non-daemon pid creation
   #shellcheck disable=SC2086
-  echo $$ > "${pidfile}" 2>/dev/null
+  echo $BASHPID > "${pidfile}" 2>/dev/null
   if [[ $? -gt 0 ]]; then
     hadoop_error "ERROR:  Cannot write ${command} pid ${pidfile}."
   fi


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
https://issues.apache.org/jira/browse/HADOOP-18348

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

