### PR TITLE
HDFS-16672. Fix lease interval comparison in BlockReportLeaseManager

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockReportLeaseManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockReportLeaseManager.java
@@ -267,7 +267,7 @@ class BlockReportLeaseManager {
 
   private synchronized boolean pruneIfExpired(long monotonicNowMs,
                                               NodeData node) {
-    if (monotonicNowMs < node.leaseTimeMs + leaseExpiryMs) {
+    if (monotonicNowMs - node.leaseTimeMs < leaseExpiryMs) {
       return false;
     }
     LOG.info("Removing expired block report lease 0x{} for DN {}.",


### PR DESCRIPTION
### Description of PR

monotonicNowMs is generated by System.nanoTime(), direct comparison is not recommended.

org.apache.hadoop.hdfs.server.blockmanagement.BlockReportLeaseManager#pruneIfExpired
```java
if (monotonicNowMs < node.leaseTimeMs + leaseExpiryMs) {
  return false;
} 
```

### How was this patch tested?
exist UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

