### PR TITLE
YARN-10793. Upgrade Junit from 4 to 5 in hadoop-yarn-server-applicationhistoryservice

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -34,6 +34,8 @@
     <yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>
   </properties>
 
+
+
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -192,6 +194,21 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryClientService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryClientService.java
@@ -18,13 +18,11 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.IOException;
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationAttemptReportRequest;
@@ -54,8 +52,11 @@ import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineDataManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestApplicationHistoryClientService {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryClientService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryClientService.java
@@ -18,6 +18,11 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -49,9 +54,8 @@ import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineDataManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestApplicationHistoryClientService {
 
@@ -59,7 +63,7 @@ public class TestApplicationHistoryClientService {
   private static TimelineDataManager dataManager;
   private final static int MAX_APPS = 2;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     Configuration conf = new YarnConfiguration();
     TimelineStore store =
@@ -78,7 +82,7 @@ public class TestApplicationHistoryClientService {
   }
 
   @Test
-  public void testApplicationNotFound() throws IOException, YarnException {
+  void testApplicationNotFound() throws IOException, YarnException {
     ApplicationId appId = null;
     appId = ApplicationId.newInstance(0, MAX_APPS + 1);
     GetApplicationReportRequest request =
@@ -87,18 +91,18 @@ public class TestApplicationHistoryClientService {
       @SuppressWarnings("unused")
       GetApplicationReportResponse response =
           clientService.getApplicationReport(request);
-      Assert.fail("Exception should have been thrown before we reach here.");
+      fail("Exception should have been thrown before we reach here.");
     } catch (ApplicationNotFoundException e) {
       //This exception is expected.
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "doesn't exist in the timeline store"));
     } catch (Exception e) {
-      Assert.fail("Undesired exception caught");
+      fail("Undesired exception caught");
     }
   }
 
   @Test
-  public void testApplicationAttemptNotFound() throws IOException, YarnException {
+  void testApplicationAttemptNotFound() throws IOException, YarnException {
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, MAX_APPS + 1);
@@ -108,41 +112,41 @@ public class TestApplicationHistoryClientService {
       @SuppressWarnings("unused")
       GetApplicationAttemptReportResponse response =
           clientService.getApplicationAttemptReport(request);
-      Assert.fail("Exception should have been thrown before we reach here.");
+      fail("Exception should have been thrown before we reach here.");
     } catch (ApplicationAttemptNotFoundException e) {
       //This Exception is expected
       System.out.println(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "doesn't exist in the timeline store"));
     } catch (Exception e) {
-      Assert.fail("Undesired exception caught");
+      fail("Undesired exception caught");
     }
   }
 
   @Test
-  public void testContainerNotFound() throws IOException, YarnException {
-   ApplicationId appId = ApplicationId.newInstance(0, 1);
-   ApplicationAttemptId appAttemptId =
-       ApplicationAttemptId.newInstance(appId, 1);
-   ContainerId containerId = ContainerId.newContainerId(appAttemptId,
-       MAX_APPS + 1);
-   GetContainerReportRequest request =
-       GetContainerReportRequest.newInstance(containerId);
-   try {
-   @SuppressWarnings("unused")
-   GetContainerReportResponse response =
-       clientService.getContainerReport(request);
-   } catch (ContainerNotFoundException e) {
-     //This exception is expected
-     Assert.assertTrue(e.getMessage().contains(
-         "doesn't exist in the timeline store"));
-   }  catch (Exception e) {
-      Assert.fail("Undesired exception caught");
-   }
- }
+  void testContainerNotFound() throws IOException, YarnException {
+    ApplicationId appId = ApplicationId.newInstance(0, 1);
+    ApplicationAttemptId appAttemptId =
+        ApplicationAttemptId.newInstance(appId, 1);
+    ContainerId containerId = ContainerId.newContainerId(appAttemptId,
+        MAX_APPS + 1);
+    GetContainerReportRequest request =
+        GetContainerReportRequest.newInstance(containerId);
+    try {
+      @SuppressWarnings("unused")
+      GetContainerReportResponse response =
+          clientService.getContainerReport(request);
+    } catch (ContainerNotFoundException e) {
+      //This exception is expected
+      assertTrue(e.getMessage().contains(
+          "doesn't exist in the timeline store"));
+    }  catch (Exception e) {
+      fail("Undesired exception caught");
+    }
+  }
 
   @Test
-  public void testApplicationReport() throws IOException, YarnException {
+  void testApplicationReport() throws IOException, YarnException {
     ApplicationId appId = null;
     appId = ApplicationId.newInstance(0, 1);
     GetApplicationReportRequest request =
@@ -150,20 +154,20 @@ public class TestApplicationHistoryClientService {
     GetApplicationReportResponse response =
         clientService.getApplicationReport(request);
     ApplicationReport appReport = response.getApplicationReport();
-    Assert.assertNotNull(appReport);
-    Assert.assertEquals(123, appReport.getApplicationResourceUsageReport()
+    assertNotNull(appReport);
+    assertEquals(123, appReport.getApplicationResourceUsageReport()
         .getMemorySeconds());
-    Assert.assertEquals(345, appReport.getApplicationResourceUsageReport()
+    assertEquals(345, appReport.getApplicationResourceUsageReport()
         .getVcoreSeconds());
-    Assert.assertEquals("application_0_0001", appReport.getApplicationId()
-      .toString());
-    Assert.assertEquals("test app type",
+    assertEquals("application_0_0001", appReport.getApplicationId()
+        .toString());
+    assertEquals("test app type",
         appReport.getApplicationType().toString());
-    Assert.assertEquals("test queue", appReport.getQueue().toString());
+    assertEquals("test queue", appReport.getQueue().toString());
   }
 
   @Test
-  public void testApplications() throws IOException, YarnException {
+  void testApplications() throws IOException, YarnException {
     ApplicationId appId = null;
     appId = ApplicationId.newInstance(0, 1);
     ApplicationId appId1 = ApplicationId.newInstance(0, 2);
@@ -171,9 +175,9 @@ public class TestApplicationHistoryClientService {
     GetApplicationsResponse response =
         clientService.getApplications(request);
     List<ApplicationReport> appReport = response.getApplicationList();
-    Assert.assertNotNull(appReport);
-    Assert.assertEquals(appId, appReport.get(1).getApplicationId());
-    Assert.assertEquals(appId1, appReport.get(0).getApplicationId());
+    assertNotNull(appReport);
+    assertEquals(appId, appReport.get(1).getApplicationId());
+    assertEquals(appId1, appReport.get(0).getApplicationId());
 
     // Create a historyManager, and set the max_apps can be loaded
     // as 1.
@@ -181,7 +185,7 @@ public class TestApplicationHistoryClientService {
     conf.setLong(YarnConfiguration.APPLICATION_HISTORY_MAX_APPS, 1);
     ApplicationHistoryManagerOnTimelineStore historyManager2 =
         new ApplicationHistoryManagerOnTimelineStore(dataManager,
-          new ApplicationACLsManager(conf));
+            new ApplicationACLsManager(conf));
     historyManager2.init(conf);
     historyManager2.start();
     @SuppressWarnings("resource")
@@ -189,14 +193,14 @@ public class TestApplicationHistoryClientService {
         new ApplicationHistoryClientService(historyManager2);
     response = clientService2.getApplications(request);
     appReport = response.getApplicationList();
-    Assert.assertNotNull(appReport);
-    Assert.assertTrue(appReport.size() == 1);
+    assertNotNull(appReport);
+    assertTrue(appReport.size() == 1);
     // Expected to get the appReport for application with appId1
-    Assert.assertEquals(appId1, appReport.get(0).getApplicationId());
+    assertEquals(appId1, appReport.get(0).getApplicationId());
   }
 
   @Test
-  public void testApplicationAttemptReport() throws IOException, YarnException {
+  void testApplicationAttemptReport() throws IOException, YarnException {
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -206,13 +210,13 @@ public class TestApplicationHistoryClientService {
         clientService.getApplicationAttemptReport(request);
     ApplicationAttemptReport attemptReport =
         response.getApplicationAttemptReport();
-    Assert.assertNotNull(attemptReport);
-    Assert.assertEquals("appattempt_0_0001_000001", attemptReport
-      .getApplicationAttemptId().toString());
+    assertNotNull(attemptReport);
+    assertEquals("appattempt_0_0001_000001", attemptReport
+        .getApplicationAttemptId().toString());
   }
 
   @Test
-  public void testApplicationAttempts() throws IOException, YarnException {
+  void testApplicationAttempts() throws IOException, YarnException {
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -224,15 +228,15 @@ public class TestApplicationHistoryClientService {
         clientService.getApplicationAttempts(request);
     List<ApplicationAttemptReport> attemptReports =
         response.getApplicationAttemptList();
-    Assert.assertNotNull(attemptReports);
-    Assert.assertEquals(appAttemptId, attemptReports.get(0)
-      .getApplicationAttemptId());
-    Assert.assertEquals(appAttemptId1, attemptReports.get(1)
-      .getApplicationAttemptId());
+    assertNotNull(attemptReports);
+    assertEquals(appAttemptId, attemptReports.get(0)
+        .getApplicationAttemptId());
+    assertEquals(appAttemptId1, attemptReports.get(1)
+        .getApplicationAttemptId());
   }
 
   @Test
-  public void testContainerReport() throws IOException, YarnException {
+  void testContainerReport() throws IOException, YarnException {
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -242,15 +246,15 @@ public class TestApplicationHistoryClientService {
     GetContainerReportResponse response =
         clientService.getContainerReport(request);
     ContainerReport container = response.getContainerReport();
-    Assert.assertNotNull(container);
-    Assert.assertEquals(containerId, container.getContainerId());
-    Assert.assertEquals("http://0.0.0.0:8188/applicationhistory/logs/" +
+    assertNotNull(container);
+    assertEquals(containerId, container.getContainerId());
+    assertEquals("http://0.0.0.0:8188/applicationhistory/logs/" +
         "test host:100/container_0_0001_01_000001/" +
         "container_0_0001_01_000001/user1", container.getLogUrl());
   }
 
   @Test
-  public void testContainers() throws IOException, YarnException {
+  void testContainers() throws IOException, YarnException {
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -261,8 +265,8 @@ public class TestApplicationHistoryClientService {
     GetContainersResponse response =
         clientService.getContainers(request);
     List<ContainerReport> containers = response.getContainerList();
-    Assert.assertNotNull(containers);
-    Assert.assertEquals(containerId, containers.get(0).getContainerId());
-    Assert.assertEquals(containerId1, containers.get(1).getContainerId());
+    assertNotNull(containers);
+    assertEquals(containerId, containers.get(0).getContainerId());
+    assertEquals(containerId1, containers.get(1).getContainerId());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerImpl.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -27,33 +31,32 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestApplicationHistoryManagerImpl extends
     ApplicationHistoryStoreTestUtils {
-  ApplicationHistoryManagerImpl applicationHistoryManagerImpl = null;
+  private ApplicationHistoryManagerImpl applicationHistoryManagerImpl = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration config = new Configuration();
     config.setClass(YarnConfiguration.APPLICATION_HISTORY_STORE,
-      MemoryApplicationHistoryStore.class, ApplicationHistoryStore.class);
+        MemoryApplicationHistoryStore.class, ApplicationHistoryStore.class);
     applicationHistoryManagerImpl = new ApplicationHistoryManagerImpl();
     applicationHistoryManagerImpl.init(config);
     applicationHistoryManagerImpl.start();
     store = applicationHistoryManagerImpl.getHistoryStore();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     applicationHistoryManagerImpl.stop();
   }
 
   @Test
-  public void testApplicationReport() throws IOException, YarnException {
+  void testApplicationReport() throws IOException, YarnException {
     ApplicationId appId = null;
     appId = ApplicationId.newInstance(0, 1);
     writeApplicationStartData(appId);
@@ -64,17 +67,17 @@ public class TestApplicationHistoryManagerImpl extends
     writeApplicationAttemptFinishData(appAttemptId);
     ApplicationReport appReport =
         applicationHistoryManagerImpl.getApplication(appId);
-    Assert.assertNotNull(appReport);
-    Assert.assertEquals(appId, appReport.getApplicationId());
-    Assert.assertEquals(appAttemptId,
-      appReport.getCurrentApplicationAttemptId());
-    Assert.assertEquals(appAttemptId.toString(), appReport.getHost());
-    Assert.assertEquals("test type", appReport.getApplicationType().toString());
-    Assert.assertEquals("test queue", appReport.getQueue().toString());
+    assertNotNull(appReport);
+    assertEquals(appId, appReport.getApplicationId());
+    assertEquals(appAttemptId,
+        appReport.getCurrentApplicationAttemptId());
+    assertEquals(appAttemptId.toString(), appReport.getHost());
+    assertEquals("test type", appReport.getApplicationType().toString());
+    assertEquals("test queue", appReport.getQueue().toString());
   }
 
   @Test
-  public void testApplications() throws IOException {
+  void testApplications() throws IOException {
     ApplicationId appId1 = ApplicationId.newInstance(0, 1);
     ApplicationId appId2 = ApplicationId.newInstance(0, 2);
     ApplicationId appId3 = ApplicationId.newInstance(0, 3);
@@ -86,10 +89,10 @@ public class TestApplicationHistoryManagerImpl extends
     writeApplicationFinishData(appId3);
     Map<ApplicationId, ApplicationReport> reports =
         applicationHistoryManagerImpl.getApplications(2, 2000L, 5000L);
-    Assert.assertNotNull(reports);
-    Assert.assertEquals(2, reports.size());
-    Assert.assertNull(reports.get("1"));
-    Assert.assertNull(reports.get("2"));
-    Assert.assertNull(reports.get("3"));
+    assertNotNull(reports);
+    assertEquals(2, reports.size());
+    assertNull(reports.get("1"));
+    assertNull(reports.get("2"));
+    assertNull(reports.get("3"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerImpl.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import java.io.IOException;
 import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -31,9 +31,10 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestApplicationHistoryManagerImpl extends
     ApplicationHistoryStoreTestUtils {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerOnTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerOnTimelineStore.java
@@ -18,12 +18,6 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,6 +25,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.SaslRpcServer.AuthMethod;
@@ -63,10 +62,11 @@ import org.apache.hadoop.yarn.server.timeline.TimelineDataManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestApplicationHistoryManagerOnTimelineStore {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerOnTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryManagerOnTimelineStore.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,12 @@
  */
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
@@ -56,16 +62,12 @@ import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineDataManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 public class TestApplicationHistoryManagerOnTimelineStore {
 
   private static final int SCALE = 5;
@@ -75,91 +77,78 @@ public class TestApplicationHistoryManagerOnTimelineStore {
   private UserGroupInformation callerUGI;
   private Configuration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void prepareStore() throws Exception {
     store = createStore(SCALE);
     TimelineEntities entities = new TimelineEntities();
-    entities.addEntity(createApplicationTimelineEntity(
-        ApplicationId.newInstance(0, SCALE + 1), true, true, false, false,
-        YarnApplicationState.FINISHED));
-    entities.addEntity(createApplicationTimelineEntity(
-        ApplicationId.newInstance(0, SCALE + 2), true, false, true, false,
-        YarnApplicationState.FINISHED));
+    entities.addEntity(
+        createApplicationTimelineEntity(ApplicationId.newInstance(0, SCALE + 1), true, true, false,
+            false, YarnApplicationState.FINISHED));
+    entities.addEntity(
+        createApplicationTimelineEntity(ApplicationId.newInstance(0, SCALE + 2), true, false, true,
+            false, YarnApplicationState.FINISHED));
     store.put(entities);
   }
 
   public static TimelineStore createStore(int scale) throws Exception {
-    TimelineStore store = new MemoryTimelineStore();
-    prepareTimelineStore(store, scale);
+    store = new MemoryTimelineStore();
+    prepareTimelineStore(scale);
     return store;
   }
 
-  @Before
-  public void setup() throws Exception {
-    // Only test the ACLs of the generic history
-    TimelineACLsManager aclsManager = new TimelineACLsManager(new YarnConfiguration());
-    aclsManager.setTimelineStore(store);
-    TimelineDataManager dataManager =
-        new TimelineDataManager(store, aclsManager);
-    dataManager.init(conf);
-    ApplicationACLsManager appAclsManager = new ApplicationACLsManager(conf);
-    historyManager =
-        new ApplicationHistoryManagerOnTimelineStore(dataManager, appAclsManager);
-    historyManager.init(conf);
-    historyManager.start();
-  }
-
-  @After
+  @AfterEach
   public void tearDown() {
     if (historyManager != null) {
       historyManager.stop();
     }
   }
 
-  @Parameters
   public static Collection<Object[]> callers() {
     // user1 is the owner
     // user2 is the authorized user
     // user3 is the unauthorized user
     // admin is the admin acl
-    return Arrays.asList(
-        new Object[][] { { "" }, { "user1" }, { "user2" }, { "user3" }, { "admin" } });
+    return Arrays.asList(new Object[][] {{""}, {"user1"}, {"user2"}, {"user3"}, {"admin"}});
   }
 
-  public TestApplicationHistoryManagerOnTimelineStore(String caller) {
+  public void initTestApplicationHistoryManagerOnTimelineStore(String caller) {
     conf = new YarnConfiguration();
     if (!caller.equals("")) {
       callerUGI = UserGroupInformation.createRemoteUser(caller, AuthMethod.SIMPLE);
       conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
       conf.set(YarnConfiguration.YARN_ADMIN_ACL, "admin");
     }
+    TimelineACLsManager aclsManager = new TimelineACLsManager(new YarnConfiguration());
+    aclsManager.setTimelineStore(store);
+    TimelineDataManager dataManager = new TimelineDataManager(store, aclsManager);
+    dataManager.init(conf);
+    ApplicationACLsManager appAclsManager = new ApplicationACLsManager(conf);
+    historyManager = new ApplicationHistoryManagerOnTimelineStore(dataManager, appAclsManager);
+    historyManager.init(conf);
+    historyManager.start();
   }
 
-  private static void prepareTimelineStore(TimelineStore store, int scale)
-      throws Exception {
+  private static void prepareTimelineStore(int scale) throws Exception {
     for (int i = 1; i <= scale; ++i) {
       TimelineEntities entities = new TimelineEntities();
       ApplicationId appId = ApplicationId.newInstance(0, i);
       if (i == 2) {
-        entities.addEntity(createApplicationTimelineEntity(
-            appId, true, false, false, true, YarnApplicationState.FINISHED));
+        entities.addEntity(createApplicationTimelineEntity(appId, true, false, false, true,
+            YarnApplicationState.FINISHED));
       } else if (i == 3) {
-        entities.addEntity(createApplicationTimelineEntity(
-            appId, false, false, false, false, YarnApplicationState.FINISHED,
-            true, false));
+        entities.addEntity(createApplicationTimelineEntity(appId, false, false, false, false,
+            YarnApplicationState.FINISHED, true, false));
       } else if (i == SCALE + 1) {
-        entities.addEntity(createApplicationTimelineEntity(
-            appId, false, false, false, false, YarnApplicationState.FINISHED,
-            false, true));
+        entities.addEntity(createApplicationTimelineEntity(appId, false, false, false, false,
+            YarnApplicationState.FINISHED, false, true));
       } else {
-        entities.addEntity(createApplicationTimelineEntity(
-            appId, false, false, false, false, YarnApplicationState.FINISHED));
+        entities.addEntity(createApplicationTimelineEntity(appId, false, false, false, false,
+            YarnApplicationState.FINISHED));
       }
       store.put(entities);
       for (int j = 1; j <= scale; ++j) {
         entities = new TimelineEntities();
-        ApplicationAttemptId appAttemptId =
-            ApplicationAttemptId.newInstance(appId, j);
+        ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, j);
         entities.addEntity(createAppAttemptTimelineEntity(appAttemptId));
         store.put(entities);
         for (int k = 1; k <= scale; ++k) {
@@ -172,129 +161,119 @@ public class TestApplicationHistoryManagerOnTimelineStore {
     }
     TimelineEntities entities = new TimelineEntities();
     ApplicationId appId = ApplicationId.newInstance(1234, 1);
-    ApplicationAttemptId appAttemptId =
-        ApplicationAttemptId.newInstance(appId, 1);
+    ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
     ContainerId containerId = ContainerId.newContainerId(appAttemptId, 1);
-    entities.addEntity(createApplicationTimelineEntity(
-        appId, true, false, false, false, YarnApplicationState.RUNNING));
+    entities.addEntity(createApplicationTimelineEntity(appId, true, false, false, false,
+        YarnApplicationState.RUNNING));
     entities.addEntity(createAppAttemptTimelineEntity(appAttemptId));
     entities.addEntity(createContainerEntity(containerId));
     store.put(entities);
   }
 
-  @Test
-  public void testGetApplicationReport() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetApplicationReport(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     for (int i = 1; i <= 3; ++i) {
       final ApplicationId appId = ApplicationId.newInstance(0, i);
       ApplicationReport app;
       if (callerUGI == null) {
         app = historyManager.getApplication(appId);
       } else {
-        app =
-            callerUGI.doAs(new PrivilegedExceptionAction<ApplicationReport> () {
+        app = callerUGI.doAs(new PrivilegedExceptionAction<ApplicationReport>() {
           @Override
           public ApplicationReport run() throws Exception {
             return historyManager.getApplication(appId);
           }
         });
       }
-      Assert.assertNotNull(app);
-      Assert.assertEquals(appId, app.getApplicationId());
-      Assert.assertEquals("test app", app.getName());
-      Assert.assertEquals("test app type", app.getApplicationType());
-      Assert.assertEquals("user1", app.getUser());
+      assertNotNull(app);
+      assertEquals(appId, app.getApplicationId());
+      assertEquals("test app", app.getName());
+      assertEquals("test app type", app.getApplicationType());
+      assertEquals("user1", app.getUser());
       if (i == 2) {
         // Change event is fired only in case of app with ID 2, hence verify
         // with updated changes. And make sure last updated change is accepted.
-        Assert.assertEquals("changed queue1", app.getQueue());
-        Assert.assertEquals(Priority.newInstance(6), app.getPriority());
+        assertEquals("changed queue1", app.getQueue());
+        assertEquals(Priority.newInstance(6), app.getPriority());
       } else {
-        Assert.assertEquals("test queue", app.getQueue());
-        Assert.assertEquals(Priority.newInstance(0), app.getPriority());
+        assertEquals("test queue", app.getQueue());
+        assertEquals(Priority.newInstance(0), app.getPriority());
       }
-      Assert.assertEquals(Integer.MAX_VALUE + 2L
-          + app.getApplicationId().getId(), app.getStartTime());
-      Assert.assertEquals(Integer.MAX_VALUE + 1L, app.getSubmitTime());
-      Assert.assertEquals(Integer.MAX_VALUE + 3L
-          + +app.getApplicationId().getId(), app.getFinishTime());
-      Assert.assertTrue(Math.abs(app.getProgress() - 1.0F) < 0.0001);
-      Assert.assertEquals(2, app.getApplicationTags().size());
-      Assert.assertTrue(app.getApplicationTags().contains("Test_APP_TAGS_1"));
-      Assert.assertTrue(app.getApplicationTags().contains("Test_APP_TAGS_2"));
+      assertEquals(Integer.MAX_VALUE + 2L + app.getApplicationId().getId(), app.getStartTime());
+      assertEquals(Integer.MAX_VALUE + 1L, app.getSubmitTime());
+      assertEquals(Integer.MAX_VALUE + 3L + +app.getApplicationId().getId(), app.getFinishTime());
+      assertTrue(Math.abs(app.getProgress() - 1.0F) < 0.0001);
+      assertEquals(2, app.getApplicationTags().size());
+      assertTrue(app.getApplicationTags().contains("Test_APP_TAGS_1"));
+      assertTrue(app.getApplicationTags().contains("Test_APP_TAGS_2"));
       // App 2 doesn't have the ACLs, such that the default ACLs " " will be used.
       // Nobody except admin and owner has access to the details of the app.
-      if ((i != 2 && callerUGI != null &&
-          callerUGI.getShortUserName().equals("user3")) ||
-          (i ==  2 && callerUGI != null &&
-          (callerUGI.getShortUserName().equals("user2") ||
-              callerUGI.getShortUserName().equals("user3")))) {
-        Assert.assertEquals(ApplicationAttemptId.newInstance(appId, -1),
+      if ((i != 2 && callerUGI != null && callerUGI.getShortUserName().equals("user3")) || (i == 2
+          && callerUGI != null && (callerUGI.getShortUserName().equals("user2")
+          || callerUGI.getShortUserName().equals("user3")))) {
+        assertEquals(ApplicationAttemptId.newInstance(appId, -1),
             app.getCurrentApplicationAttemptId());
-        Assert.assertEquals(ApplicationHistoryManagerOnTimelineStore.UNAVAILABLE,
-            app.getHost());
-        Assert.assertEquals(-1, app.getRpcPort());
-        Assert.assertEquals(ApplicationHistoryManagerOnTimelineStore.UNAVAILABLE,
-            app.getTrackingUrl());
-        Assert.assertEquals(ApplicationHistoryManagerOnTimelineStore.UNAVAILABLE,
+        assertEquals(ApplicationHistoryManagerOnTimelineStore.UNAVAILABLE, app.getHost());
+        assertEquals(-1, app.getRpcPort());
+        assertEquals(ApplicationHistoryManagerOnTimelineStore.UNAVAILABLE, app.getTrackingUrl());
+        assertEquals(ApplicationHistoryManagerOnTimelineStore.UNAVAILABLE,
             app.getOriginalTrackingUrl());
-        Assert.assertEquals("", app.getDiagnostics());
+        assertEquals("", app.getDiagnostics());
       } else {
-        Assert.assertEquals(ApplicationAttemptId.newInstance(appId, 1),
+        assertEquals(ApplicationAttemptId.newInstance(appId, 1),
             app.getCurrentApplicationAttemptId());
-        Assert.assertEquals("test host", app.getHost());
-        Assert.assertEquals(100, app.getRpcPort());
-        Assert.assertEquals("test tracking url", app.getTrackingUrl());
-        Assert.assertEquals("test original tracking url",
-            app.getOriginalTrackingUrl());
-        Assert.assertEquals("test diagnostics info", app.getDiagnostics());
+        assertEquals("test host", app.getHost());
+        assertEquals(100, app.getRpcPort());
+        assertEquals("test tracking url", app.getTrackingUrl());
+        assertEquals("test original tracking url", app.getOriginalTrackingUrl());
+        assertEquals("test diagnostics info", app.getDiagnostics());
       }
       ApplicationResourceUsageReport applicationResourceUsageReport =
           app.getApplicationResourceUsageReport();
-      Assert.assertEquals(123,
-          applicationResourceUsageReport.getMemorySeconds());
-      Assert
-          .assertEquals(345, applicationResourceUsageReport.getVcoreSeconds());
+      assertEquals(123, applicationResourceUsageReport.getMemorySeconds());
+      assertEquals(345, applicationResourceUsageReport.getVcoreSeconds());
       long expectedPreemptMemSecs = 456;
       long expectedPreemptVcoreSecs = 789;
       if (i == 3) {
         expectedPreemptMemSecs = 0;
         expectedPreemptVcoreSecs = 0;
       }
-      Assert.assertEquals(expectedPreemptMemSecs,
+      assertEquals(expectedPreemptMemSecs,
           applicationResourceUsageReport.getPreemptedMemorySeconds());
-      Assert
-          .assertEquals(expectedPreemptVcoreSecs, applicationResourceUsageReport
-              .getPreemptedVcoreSeconds());
-      Assert.assertEquals(FinalApplicationStatus.UNDEFINED,
-          app.getFinalApplicationStatus());
-      Assert.assertEquals(YarnApplicationState.FINISHED,
-          app.getYarnApplicationState());
+      assertEquals(expectedPreemptVcoreSecs,
+          applicationResourceUsageReport.getPreemptedVcoreSeconds());
+      assertEquals(FinalApplicationStatus.UNDEFINED, app.getFinalApplicationStatus());
+      assertEquals(YarnApplicationState.FINISHED, app.getYarnApplicationState());
     }
   }
 
-  @Test
-  public void testGetApplicationReportWithNotAttempt() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetApplicationReportWithNotAttempt(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     final ApplicationId appId = ApplicationId.newInstance(0, SCALE + 1);
     ApplicationReport app;
     if (callerUGI == null) {
       app = historyManager.getApplication(appId);
     } else {
-      app =
-          callerUGI.doAs(new PrivilegedExceptionAction<ApplicationReport> () {
-            @Override
-            public ApplicationReport run() throws Exception {
-              return historyManager.getApplication(appId);
-            }
-          });
+      app = callerUGI.doAs(new PrivilegedExceptionAction<ApplicationReport>() {
+        @Override
+        public ApplicationReport run() throws Exception {
+          return historyManager.getApplication(appId);
+        }
+      });
     }
-    Assert.assertNotNull(app);
-    Assert.assertEquals(appId, app.getApplicationId());
-    Assert.assertEquals(ApplicationAttemptId.newInstance(appId, -1),
-        app.getCurrentApplicationAttemptId());
+    assertNotNull(app);
+    assertEquals(appId, app.getApplicationId());
+    assertEquals(ApplicationAttemptId.newInstance(appId, -1), app.getCurrentApplicationAttemptId());
   }
 
-  @Test
-  public void testGetApplicationAttemptReport() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetApplicationAttemptReport(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     final ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1);
     ApplicationAttemptReport appAttempt;
@@ -302,8 +281,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
       appAttempt = historyManager.getApplicationAttempt(appAttemptId);
     } else {
       try {
-        appAttempt =
-            callerUGI.doAs(new PrivilegedExceptionAction<ApplicationAttemptReport> () {
+        appAttempt = callerUGI.doAs(new PrivilegedExceptionAction<ApplicationAttemptReport>() {
           @Override
           public ApplicationAttemptReport run() throws Exception {
             return historyManager.getApplicationAttempt(appAttemptId);
@@ -311,7 +289,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         });
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
           // The exception is expected
-          Assert.fail();
+          fail();
         }
       } catch (AuthorizationException e) {
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
@@ -321,32 +299,29 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         throw e;
       }
     }
-    Assert.assertNotNull(appAttempt);
-    Assert.assertEquals(appAttemptId, appAttempt.getApplicationAttemptId());
-    Assert.assertEquals(ContainerId.newContainerId(appAttemptId, 1),
-        appAttempt.getAMContainerId());
-    Assert.assertEquals("test host", appAttempt.getHost());
-    Assert.assertEquals(100, appAttempt.getRpcPort());
-    Assert.assertEquals("test tracking url", appAttempt.getTrackingUrl());
-    Assert.assertEquals("test original tracking url",
-        appAttempt.getOriginalTrackingUrl());
-    Assert.assertEquals("test diagnostics info", appAttempt.getDiagnostics());
-    Assert.assertEquals(YarnApplicationAttemptState.FINISHED,
-        appAttempt.getYarnApplicationAttemptState());
+    assertNotNull(appAttempt);
+    assertEquals(appAttemptId, appAttempt.getApplicationAttemptId());
+    assertEquals(ContainerId.newContainerId(appAttemptId, 1), appAttempt.getAMContainerId());
+    assertEquals("test host", appAttempt.getHost());
+    assertEquals(100, appAttempt.getRpcPort());
+    assertEquals("test tracking url", appAttempt.getTrackingUrl());
+    assertEquals("test original tracking url", appAttempt.getOriginalTrackingUrl());
+    assertEquals("test diagnostics info", appAttempt.getDiagnostics());
+    assertEquals(YarnApplicationAttemptState.FINISHED, appAttempt.getYarnApplicationAttemptState());
   }
 
-  @Test
-  public void testGetContainerReport() throws Exception {
-    final ContainerId containerId =
-        ContainerId.newContainerId(ApplicationAttemptId.newInstance(
-            ApplicationId.newInstance(0, 1), 1), 1);
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetContainerReport(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
+    final ContainerId containerId = ContainerId.newContainerId(
+        ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1), 1);
     ContainerReport container;
     if (callerUGI == null) {
       container = historyManager.getContainer(containerId);
     } else {
       try {
-        container =
-            callerUGI.doAs(new PrivilegedExceptionAction<ContainerReport> () {
+        container = callerUGI.doAs(new PrivilegedExceptionAction<ContainerReport>() {
           @Override
           public ContainerReport run() throws Exception {
             return historyManager.getContainer(containerId);
@@ -354,7 +329,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         });
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
           // The exception is expected
-          Assert.fail();
+          fail();
         }
       } catch (AuthorizationException e) {
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
@@ -364,61 +339,59 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         throw e;
       }
     }
-    Assert.assertNotNull(container);
-    Assert.assertEquals(Integer.MAX_VALUE + 1L, container.getCreationTime());
-    Assert.assertEquals(Integer.MAX_VALUE + 2L, container.getFinishTime());
-    Assert.assertEquals(Resource.newInstance(-1, -1),
-        container.getAllocatedResource());
-    Assert.assertEquals(NodeId.newInstance("test host", 100),
-        container.getAssignedNode());
-    Assert.assertEquals(Priority.UNDEFINED, container.getPriority());
-    Assert
-        .assertEquals("test diagnostics info", container.getDiagnosticsInfo());
-    Assert.assertEquals(ContainerState.COMPLETE, container.getContainerState());
-    Assert.assertEquals(-1, container.getContainerExitStatus());
-    Assert.assertEquals("http://0.0.0.0:8188/applicationhistory/logs/" +
-        "test host:100/container_0_0001_01_000001/"
-        + "container_0_0001_01_000001/user1", container.getLogUrl());
+    assertNotNull(container);
+    assertEquals(Integer.MAX_VALUE + 1L, container.getCreationTime());
+    assertEquals(Integer.MAX_VALUE + 2L, container.getFinishTime());
+    assertEquals(Resource.newInstance(-1, -1), container.getAllocatedResource());
+    assertEquals(NodeId.newInstance("test host", 100), container.getAssignedNode());
+    assertEquals(Priority.UNDEFINED, container.getPriority());
+    assertEquals("test diagnostics info", container.getDiagnosticsInfo());
+    assertEquals(ContainerState.COMPLETE, container.getContainerState());
+    assertEquals(-1, container.getContainerExitStatus());
+    assertEquals(
+        "http://0.0.0.0:8188/applicationhistory/logs/" + "test host:100/container_0_0001_01_000001/"
+            + "container_0_0001_01_000001/user1", container.getLogUrl());
   }
 
-  @Test
-  public void testGetApplications() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetApplications(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     Collection<ApplicationReport> apps =
-        historyManager.getApplications(Long.MAX_VALUE, 0L, Long.MAX_VALUE)
-          .values();
-    Assert.assertNotNull(apps);
-    Assert.assertEquals(SCALE + 2, apps.size());
+        historyManager.getApplications(Long.MAX_VALUE, 0L, Long.MAX_VALUE).values();
+    assertNotNull(apps);
+    assertEquals(SCALE + 2, apps.size());
     ApplicationId ignoredAppId = ApplicationId.newInstance(0, SCALE + 2);
     for (ApplicationReport app : apps) {
-      Assert.assertNotEquals(ignoredAppId, app.getApplicationId());
+      assertNotEquals(ignoredAppId, app.getApplicationId());
     }
 
     // Get apps by given appStartedTime period
-    apps =
-        historyManager.getApplications(Long.MAX_VALUE, 2147483653L,
-          Long.MAX_VALUE).values();
-    Assert.assertNotNull(apps);
-    Assert.assertEquals(2, apps.size());
+    apps = historyManager.getApplications(Long.MAX_VALUE, 2147483653L, Long.MAX_VALUE).values();
+    assertNotNull(apps);
+    assertEquals(2, apps.size());
   }
 
-  @Test
-  public void testGetApplicationAttempts() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetApplicationAttempts(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     final ApplicationId appId = ApplicationId.newInstance(0, 1);
     Collection<ApplicationAttemptReport> appAttempts;
     if (callerUGI == null) {
       appAttempts = historyManager.getApplicationAttempts(appId).values();
     } else {
       try {
-        appAttempts = callerUGI.doAs(
-            new PrivilegedExceptionAction<Collection<ApplicationAttemptReport>> () {
-          @Override
-          public Collection<ApplicationAttemptReport> run() throws Exception {
-            return historyManager.getApplicationAttempts(appId).values();
-          }
-        });
+        appAttempts =
+            callerUGI.doAs(new PrivilegedExceptionAction<Collection<ApplicationAttemptReport>>() {
+              @Override
+              public Collection<ApplicationAttemptReport> run() throws Exception {
+                return historyManager.getApplicationAttempts(appId).values();
+              }
+            });
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
           // The exception is expected
-          Assert.fail();
+          fail();
         }
       } catch (AuthorizationException e) {
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
@@ -428,12 +401,14 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         throw e;
       }
     }
-    Assert.assertNotNull(appAttempts);
-    Assert.assertEquals(SCALE, appAttempts.size());
+    assertNotNull(appAttempts);
+    assertEquals(SCALE, appAttempts.size());
   }
 
-  @Test
-  public void testGetContainers() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetContainers(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     final ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1);
     Collection<ContainerReport> containers;
@@ -441,8 +416,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
       containers = historyManager.getContainers(appAttemptId).values();
     } else {
       try {
-        containers = callerUGI.doAs(
-            new PrivilegedExceptionAction<Collection<ContainerReport>> () {
+        containers = callerUGI.doAs(new PrivilegedExceptionAction<Collection<ContainerReport>>() {
           @Override
           public Collection<ContainerReport> run() throws Exception {
             return historyManager.getContainers(appAttemptId).values();
@@ -450,7 +424,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         });
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
           // The exception is expected
-          Assert.fail();
+          fail();
         }
       } catch (AuthorizationException e) {
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
@@ -460,12 +434,14 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         throw e;
       }
     }
-    Assert.assertNotNull(containers);
-    Assert.assertEquals(SCALE, containers.size());
+    assertNotNull(containers);
+    assertEquals(SCALE, containers.size());
   }
 
-  @Test
-  public void testGetAMContainer() throws Exception {
+  @MethodSource("callers")
+  @ParameterizedTest
+  void testGetAMContainer(String caller) throws Exception {
+    initTestApplicationHistoryManagerOnTimelineStore(caller);
     final ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1);
     ContainerReport container;
@@ -473,8 +449,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
       container = historyManager.getAMContainer(appAttemptId);
     } else {
       try {
-        container =
-            callerUGI.doAs(new PrivilegedExceptionAction<ContainerReport> () {
+        container = callerUGI.doAs(new PrivilegedExceptionAction<ContainerReport>() {
           @Override
           public ContainerReport run() throws Exception {
             return historyManager.getAMContainer(appAttemptId);
@@ -482,7 +457,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         });
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
           // The exception is expected
-          Assert.fail();
+          fail();
         }
       } catch (AuthorizationException e) {
         if (callerUGI != null && callerUGI.getShortUserName().equals("user3")) {
@@ -492,24 +467,20 @@ public class TestApplicationHistoryManagerOnTimelineStore {
         throw e;
       }
     }
-    Assert.assertNotNull(container);
-    Assert.assertEquals(appAttemptId, container.getContainerId()
-        .getApplicationAttemptId());
+    assertNotNull(container);
+    assertEquals(appAttemptId, container.getContainerId().getApplicationAttemptId());
   }
 
-  private static TimelineEntity createApplicationTimelineEntity(
-      ApplicationId appId, boolean emptyACLs, boolean noAttemptId,
-      boolean wrongAppId, boolean enableUpdateEvent,
+  private static TimelineEntity createApplicationTimelineEntity(ApplicationId appId,
+      boolean emptyACLs, boolean noAttemptId, boolean wrongAppId, boolean enableUpdateEvent,
       YarnApplicationState state) {
-    return createApplicationTimelineEntity(appId, emptyACLs, noAttemptId,
-        wrongAppId, enableUpdateEvent, state, false, false);
+    return createApplicationTimelineEntity(appId, emptyACLs, noAttemptId, wrongAppId,
+        enableUpdateEvent, state, false, false);
   }
 
-  private static TimelineEntity createApplicationTimelineEntity(
-      ApplicationId appId, boolean emptyACLs, boolean noAttemptId,
-      boolean wrongAppId, boolean enableUpdateEvent,
-      YarnApplicationState state, boolean missingPreemptMetrics,
-      boolean missingQueue) {
+  private static TimelineEntity createApplicationTimelineEntity(ApplicationId appId,
+      boolean emptyACLs, boolean noAttemptId, boolean wrongAppId, boolean enableUpdateEvent,
+      YarnApplicationState state, boolean missingPreemptMetrics, boolean missingQueue) {
     TimelineEntity entity = new TimelineEntity();
     entity.setEntityType(ApplicationMetricsConstants.ENTITY_TYPE);
     if (wrongAppId) {
@@ -518,23 +489,17 @@ public class TestApplicationHistoryManagerOnTimelineStore {
       entity.setEntityId(appId.toString());
     }
     entity.setDomainId(TimelineDataManager.DEFAULT_DOMAIN_ID);
-    entity.addPrimaryFilter(
-        TimelineStore.SystemFilter.ENTITY_OWNER.toString(), "yarn");
+    entity.addPrimaryFilter(TimelineStore.SystemFilter.ENTITY_OWNER.toString(), "yarn");
     Map<String, Object> entityInfo = new HashMap<String, Object>();
     entityInfo.put(ApplicationMetricsConstants.NAME_ENTITY_INFO, "test app");
-    entityInfo.put(ApplicationMetricsConstants.TYPE_ENTITY_INFO,
-        "test app type");
+    entityInfo.put(ApplicationMetricsConstants.TYPE_ENTITY_INFO, "test app type");
     entityInfo.put(ApplicationMetricsConstants.USER_ENTITY_INFO, "user1");
     if (!missingQueue) {
-      entityInfo.put(ApplicationMetricsConstants.QUEUE_ENTITY_INFO,
-          "test queue");
+      entityInfo.put(ApplicationMetricsConstants.QUEUE_ENTITY_INFO, "test queue");
     }
-    entityInfo.put(
-        ApplicationMetricsConstants.UNMANAGED_APPLICATION_ENTITY_INFO, "false");
-    entityInfo.put(ApplicationMetricsConstants.APPLICATION_PRIORITY_INFO,
-        Priority.newInstance(0));
-    entityInfo.put(ApplicationMetricsConstants.SUBMITTED_TIME_ENTITY_INFO,
-        Integer.MAX_VALUE + 1L);
+    entityInfo.put(ApplicationMetricsConstants.UNMANAGED_APPLICATION_ENTITY_INFO, "false");
+    entityInfo.put(ApplicationMetricsConstants.APPLICATION_PRIORITY_INFO, Priority.newInstance(0));
+    entityInfo.put(ApplicationMetricsConstants.SUBMITTED_TIME_ENTITY_INFO, Integer.MAX_VALUE + 1L);
     entityInfo.put(ApplicationMetricsConstants.APP_MEM_METRICS, 123);
     entityInfo.put(ApplicationMetricsConstants.APP_CPU_METRICS, 345);
     if (!missingPreemptMetrics) {
@@ -544,8 +509,7 @@ public class TestApplicationHistoryManagerOnTimelineStore {
     if (emptyACLs) {
       entityInfo.put(ApplicationMetricsConstants.APP_VIEW_ACLS_ENTITY_INFO, "");
     } else {
-      entityInfo.put(ApplicationMetricsConstants.APP_VIEW_ACLS_ENTITY_INFO,
-          "user2");
+      entityInfo.put(ApplicationMetricsConstants.APP_VIEW_ACLS_ENTITY_INFO, "user2");
     }
     Set<String> appTags = new HashSet<String>();
     appTags.add("Test_APP_TAGS_1");
@@ -557,16 +521,13 @@ public class TestApplicationHistoryManagerOnTimelineStore {
     tEvent.setTimestamp(Integer.MAX_VALUE + 2L + appId.getId());
     entity.addEvent(tEvent);
     tEvent = new TimelineEvent();
-    tEvent.setEventType(
-        ApplicationMetricsConstants.FINISHED_EVENT_TYPE);
+    tEvent.setEventType(ApplicationMetricsConstants.FINISHED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + 3L + appId.getId());
     Map<String, Object> eventInfo = new HashMap<String, Object>();
-    eventInfo.put(ApplicationMetricsConstants.DIAGNOSTICS_INFO_EVENT_INFO,
-        "test diagnostics info");
+    eventInfo.put(ApplicationMetricsConstants.DIAGNOSTICS_INFO_EVENT_INFO, "test diagnostics info");
     eventInfo.put(ApplicationMetricsConstants.FINAL_STATUS_EVENT_INFO,
         FinalApplicationStatus.UNDEFINED.toString());
-    eventInfo.put(ApplicationMetricsConstants.STATE_EVENT_INFO,
-        state.toString());
+    eventInfo.put(ApplicationMetricsConstants.STATE_EVENT_INFO, state.toString());
     if (!noAttemptId) {
       eventInfo.put(ApplicationMetricsConstants.LATEST_APP_ATTEMPT_EVENT_INFO,
           ApplicationAttemptId.newInstance(appId, 1));
@@ -577,60 +538,51 @@ public class TestApplicationHistoryManagerOnTimelineStore {
     // after YARN_APPLICATION_FINISHED
     // The final YarnApplicationState should not be changed
     tEvent = new TimelineEvent();
-    tEvent.setEventType(
-        ApplicationMetricsConstants.STATE_UPDATED_EVENT_TYPE);
+    tEvent.setEventType(ApplicationMetricsConstants.STATE_UPDATED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + 4L + appId.getId());
     eventInfo = new HashMap<String, Object>();
-    eventInfo.put(ApplicationMetricsConstants.STATE_EVENT_INFO,
-        YarnApplicationState.KILLED);
+    eventInfo.put(ApplicationMetricsConstants.STATE_EVENT_INFO, YarnApplicationState.KILLED);
     tEvent.setEventInfo(eventInfo);
     entity.addEvent(tEvent);
     if (enableUpdateEvent) {
       tEvent = new TimelineEvent();
       long updatedTimeIndex = 4L;
-      createAppModifiedEvent(appId, tEvent, updatedTimeIndex++, "changed queue",
-          5);
+      createAppModifiedEvent(appId, tEvent, updatedTimeIndex++, "changed queue", 5);
       entity.addEvent(tEvent);
       // Change priority alone
       tEvent = new TimelineEvent();
-      createAppModifiedEvent(appId, tEvent, updatedTimeIndex++, "changed queue",
-          6);
+      createAppModifiedEvent(appId, tEvent, updatedTimeIndex++, "changed queue", 6);
       // Now change queue
       tEvent = new TimelineEvent();
-      createAppModifiedEvent(appId, tEvent, updatedTimeIndex++,
-          "changed queue1", 6);
+      createAppModifiedEvent(appId, tEvent, updatedTimeIndex++, "changed queue1", 6);
       entity.addEvent(tEvent);
     }
     return entity;
   }
 
-  private static void createAppModifiedEvent(ApplicationId appId,
-      TimelineEvent tEvent, long updatedTimeIndex, String queue, int priority) {
+  private static void createAppModifiedEvent(ApplicationId appId, TimelineEvent tEvent,
+      long updatedTimeIndex, String queue, int priority) {
     tEvent.setEventType(ApplicationMetricsConstants.UPDATED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + updatedTimeIndex + appId.getId());
     Map<String, Object> eventInfo = new HashMap<String, Object>();
     eventInfo.put(ApplicationMetricsConstants.QUEUE_ENTITY_INFO, queue);
-    eventInfo.put(ApplicationMetricsConstants.APPLICATION_PRIORITY_INFO,
-        priority);
+    eventInfo.put(ApplicationMetricsConstants.APPLICATION_PRIORITY_INFO, priority);
     tEvent.setEventInfo(eventInfo);
   }
 
-  private static TimelineEntity createAppAttemptTimelineEntity(
-      ApplicationAttemptId appAttemptId) {
+  private static TimelineEntity createAppAttemptTimelineEntity(ApplicationAttemptId appAttemptId) {
     TimelineEntity entity = new TimelineEntity();
     entity.setEntityType(AppAttemptMetricsConstants.ENTITY_TYPE);
     entity.setEntityId(appAttemptId.toString());
     entity.setDomainId(TimelineDataManager.DEFAULT_DOMAIN_ID);
     entity.addPrimaryFilter(AppAttemptMetricsConstants.PARENT_PRIMARY_FILTER,
         appAttemptId.getApplicationId().toString());
-    entity.addPrimaryFilter(
-        TimelineStore.SystemFilter.ENTITY_OWNER.toString(), "yarn");
+    entity.addPrimaryFilter(TimelineStore.SystemFilter.ENTITY_OWNER.toString(), "yarn");
     TimelineEvent tEvent = new TimelineEvent();
     tEvent.setEventType(AppAttemptMetricsConstants.REGISTERED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + 1L);
     Map<String, Object> eventInfo = new HashMap<String, Object>();
-    eventInfo.put(AppAttemptMetricsConstants.TRACKING_URL_INFO,
-        "test tracking url");
+    eventInfo.put(AppAttemptMetricsConstants.TRACKING_URL_INFO, "test tracking url");
     eventInfo.put(AppAttemptMetricsConstants.ORIGINAL_TRACKING_URL_INFO,
         "test original tracking url");
     eventInfo.put(AppAttemptMetricsConstants.HOST_INFO, "test host");
@@ -643,12 +595,10 @@ public class TestApplicationHistoryManagerOnTimelineStore {
     tEvent.setEventType(AppAttemptMetricsConstants.FINISHED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + 2L);
     eventInfo = new HashMap<String, Object>();
-    eventInfo.put(AppAttemptMetricsConstants.TRACKING_URL_INFO,
-        "test tracking url");
+    eventInfo.put(AppAttemptMetricsConstants.TRACKING_URL_INFO, "test tracking url");
     eventInfo.put(AppAttemptMetricsConstants.ORIGINAL_TRACKING_URL_INFO,
         "test original tracking url");
-    eventInfo.put(AppAttemptMetricsConstants.DIAGNOSTICS_INFO,
-        "test diagnostics info");
+    eventInfo.put(AppAttemptMetricsConstants.DIAGNOSTICS_INFO, "test diagnostics info");
     eventInfo.put(AppAttemptMetricsConstants.FINAL_STATUS_INFO,
         FinalApplicationStatus.UNDEFINED.toString());
     eventInfo.put(AppAttemptMetricsConstants.STATE_INFO,
@@ -665,33 +615,26 @@ public class TestApplicationHistoryManagerOnTimelineStore {
     entity.setDomainId(TimelineDataManager.DEFAULT_DOMAIN_ID);
     entity.addPrimaryFilter(ContainerMetricsConstants.PARENT_PRIMARIY_FILTER,
         containerId.getApplicationAttemptId().toString());
-    entity.addPrimaryFilter(
-        TimelineStore.SystemFilter.ENTITY_OWNER.toString(), "yarn");
+    entity.addPrimaryFilter(TimelineStore.SystemFilter.ENTITY_OWNER.toString(), "yarn");
     Map<String, Object> entityInfo = new HashMap<String, Object>();
     entityInfo.put(ContainerMetricsConstants.ALLOCATED_MEMORY_INFO, -1);
     entityInfo.put(ContainerMetricsConstants.ALLOCATED_VCORE_INFO, -1);
-    entityInfo.put(ContainerMetricsConstants.ALLOCATED_HOST_INFO,
-        "test host");
+    entityInfo.put(ContainerMetricsConstants.ALLOCATED_HOST_INFO, "test host");
     entityInfo.put(ContainerMetricsConstants.ALLOCATED_PORT_INFO, 100);
-    entityInfo
-        .put(ContainerMetricsConstants.ALLOCATED_PRIORITY_INFO, -1);
-    entityInfo.put(ContainerMetricsConstants
-        .ALLOCATED_HOST_HTTP_ADDRESS_INFO, "http://test:1234");
+    entityInfo.put(ContainerMetricsConstants.ALLOCATED_PRIORITY_INFO, -1);
+    entityInfo.put(ContainerMetricsConstants.ALLOCATED_HOST_HTTP_ADDRESS_INFO, "http://test:1234");
     entity.setOtherInfo(entityInfo);
     TimelineEvent tEvent = new TimelineEvent();
     tEvent.setEventType(ContainerMetricsConstants.CREATED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + 1L);
     entity.addEvent(tEvent);
-    ;
     tEvent = new TimelineEvent();
     tEvent.setEventType(ContainerMetricsConstants.FINISHED_EVENT_TYPE);
     tEvent.setTimestamp(Integer.MAX_VALUE + 2L);
     Map<String, Object> eventInfo = new HashMap<String, Object>();
-    eventInfo.put(ContainerMetricsConstants.DIAGNOSTICS_INFO,
-        "test diagnostics info");
+    eventInfo.put(ContainerMetricsConstants.DIAGNOSTICS_INFO, "test diagnostics info");
     eventInfo.put(ContainerMetricsConstants.EXIT_STATUS_INFO, -1);
-    eventInfo.put(ContainerMetricsConstants.STATE_INFO,
-        ContainerState.COMPLETE.toString());
+    eventInfo.put(ContainerMetricsConstants.STATE_INFO, ContainerState.COMPLETE.toString());
     tEvent.setEventInfo(eventInfo);
     entity.addEvent(tEvent);
     return entity;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryServer.java
@@ -18,9 +18,10 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.lib.StaticUserWebFilter;
@@ -33,8 +34,8 @@ import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.recovery.MemoryTimelineStateStore;
 import org.apache.hadoop.yarn.server.timeline.recovery.TimelineStateStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineAuthenticationFilterInitializer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -48,8 +49,9 @@ import java.util.Map;
 public class TestApplicationHistoryServer {
 
   // simple test init/start/stop ApplicationHistoryServer. Status should change.
-  @Test(timeout = 60000)
-  public void testStartStopServer() throws Exception {
+  @Test
+  @Timeout(60000)
+  void testStartStopServer() throws Exception {
     ApplicationHistoryServer historyServer = new ApplicationHistoryServer();
     Configuration config = new YarnConfiguration();
     config.setClass(YarnConfiguration.TIMELINE_SERVICE_STORE,
@@ -65,7 +67,7 @@ public class TestApplicationHistoryServer {
         historyServer.start();
         fail();
       } catch (IllegalArgumentException e) {
-        Assert.assertTrue(e.getMessage().contains(
+        assertTrue(e.getMessage().contains(
             YarnConfiguration.TIMELINE_SERVICE_HANDLER_THREAD_COUNT));
       }
       config.setInt(YarnConfiguration.TIMELINE_SERVICE_HANDLER_THREAD_COUNT,
@@ -89,8 +91,9 @@ public class TestApplicationHistoryServer {
   }
 
   // test launch method
-  @Test(timeout = 60000)
-  public void testLaunch() throws Exception {
+  @Test
+  @Timeout(60000)
+  void testLaunch() throws Exception {
     ExitUtil.disableSystemExit();
     ApplicationHistoryServer historyServer = null;
     try {
@@ -109,34 +112,37 @@ public class TestApplicationHistoryServer {
     }
   }
 
- //test launch method with -D arguments
- @Test(timeout = 60000)
- public void testLaunchWithArguments() throws Exception {
-   ExitUtil.disableSystemExit();
-   ApplicationHistoryServer historyServer = null;
-   try {
-     // Not able to modify the config of this test case,
-     // but others have been customized to avoid conflicts
-     String[] args = new String[2];
-     args[0]="-D" + YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS + "=4000";
-     args[1]="-D" + YarnConfiguration.TIMELINE_SERVICE_TTL_MS + "=200";
-     historyServer =
-         ApplicationHistoryServer.launchAppHistoryServer(args);
-     Configuration conf = historyServer.getConfig();
-     assertEquals("4000", conf.get(YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS));
-     assertEquals("200", conf.get(YarnConfiguration.TIMELINE_SERVICE_TTL_MS));
-   } catch (ExitUtil.ExitException e) {
-     assertEquals(0, e.status);
-     ExitUtil.resetFirstExitException();
-     fail();
-   } finally {
-     if (historyServer != null) {
-       historyServer.stop();
-     }
-   }
- }
-  @Test(timeout = 240000)
-  public void testFilterOverrides() throws Exception {
+  //test launch method with -D arguments
+  @Test
+  @Timeout(60000)
+  void testLaunchWithArguments() throws Exception {
+    ExitUtil.disableSystemExit();
+    ApplicationHistoryServer historyServer = null;
+    try {
+      // Not able to modify the config of this test case,
+      // but others have been customized to avoid conflicts
+      String[] args = new String[2];
+      args[0] = "-D" + YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS + "=4000";
+      args[1] = "-D" + YarnConfiguration.TIMELINE_SERVICE_TTL_MS + "=200";
+      historyServer =
+          ApplicationHistoryServer.launchAppHistoryServer(args);
+      Configuration conf = historyServer.getConfig();
+      assertEquals("4000", conf.get(YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS));
+      assertEquals("200", conf.get(YarnConfiguration.TIMELINE_SERVICE_TTL_MS));
+    } catch (ExitUtil.ExitException e) {
+      assertEquals(0, e.status);
+      ExitUtil.resetFirstExitException();
+      fail();
+    } finally {
+      if (historyServer != null) {
+        historyServer.stop();
+      }
+    }
+  }
+
+  @Test
+  @Timeout(240000)
+  void testFilterOverrides() throws Exception {
 
     HashMap<String, String> driver = new HashMap<String, String>();
     driver.put("", TimelineAuthenticationFilterInitializer.class.getName());
@@ -144,15 +150,15 @@ public class TestApplicationHistoryServer {
         StaticUserWebFilter.class.getName() + "," +
             TimelineAuthenticationFilterInitializer.class.getName());
     driver.put(AuthenticationFilterInitializer.class.getName(),
-      TimelineAuthenticationFilterInitializer.class.getName());
+        TimelineAuthenticationFilterInitializer.class.getName());
     driver.put(TimelineAuthenticationFilterInitializer.class.getName(),
-      TimelineAuthenticationFilterInitializer.class.getName());
+        TimelineAuthenticationFilterInitializer.class.getName());
     driver.put(AuthenticationFilterInitializer.class.getName() + ","
         + TimelineAuthenticationFilterInitializer.class.getName(),
-      TimelineAuthenticationFilterInitializer.class.getName());
+        TimelineAuthenticationFilterInitializer.class.getName());
     driver.put(AuthenticationFilterInitializer.class.getName() + ", "
         + TimelineAuthenticationFilterInitializer.class.getName(),
-      TimelineAuthenticationFilterInitializer.class.getName());
+        TimelineAuthenticationFilterInitializer.class.getName());
 
     for (Map.Entry<String, String> entry : driver.entrySet()) {
       String filterInitializer = entry.getKey();
@@ -176,8 +182,9 @@ public class TestApplicationHistoryServer {
     }
   }
 
-  @Test(timeout = 240000)
-  public void testHostedUIs() throws Exception {
+  @Test
+  @Timeout(240000)
+  void testHostedUIs() throws Exception {
 
     ApplicationHistoryServer historyServer = new ApplicationHistoryServer();
     Configuration config = new YarnConfiguration();
@@ -209,8 +216,7 @@ public class TestApplicationHistoryServer {
     } finally {
       historyServer.stop();
     }
-    assertEquals("Web file contents should be the same as on disk contents",
-        diskFileStr, connFileStr);
+    assertEquals(diskFileStr, connFileStr, "Web file contents should be the same as on disk contents");
   }
   private String readInputStream(InputStream input) throws Exception {
     ByteArrayOutputStream data = new ByteArrayOutputStream();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryServer.java
@@ -216,7 +216,8 @@ public class TestApplicationHistoryServer {
     } finally {
       historyServer.stop();
     }
-    assertEquals(diskFileStr, connFileStr, "Web file contents should be the same as on disk contents");
+    assertEquals(diskFileStr, connFileStr,
+        "Web file contents should be the same as on disk contents");
   }
   private String readInputStream(InputStream input) throws Exception {
     ByteArrayOutputStream data = new ByteArrayOutputStream();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestApplicationHistoryServer.java
@@ -18,10 +18,17 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.lib.StaticUserWebFilter;
@@ -34,17 +41,11 @@ import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.recovery.MemoryTimelineStateStore;
 import org.apache.hadoop.yarn.server.timeline.recovery.TimelineStateStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineAuthenticationFilterInitializer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestApplicationHistoryServer {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestFileSystemApplicationHistoryStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestFileSystemApplicationHistoryStore.java
@@ -22,8 +22,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.junit.Assert;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -45,9 +48,9 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationAttemptHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ContainerHistoryData;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +64,7 @@ public class TestFileSystemApplicationHistoryStore extends
   private FileSystem fs;
   private Path fsWorkingPath;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     fs = new RawLocalFileSystem();
     initAndStartStore(fs);
@@ -75,8 +78,7 @@ public class TestFileSystemApplicationHistoryStore extends
         new Path("target",
           TestFileSystemApplicationHistoryStore.class.getSimpleName());
     fs.delete(fsWorkingPath, true);
-    conf.set(YarnConfiguration.FS_APPLICATION_HISTORY_STORE_URI,
-      fsWorkingPath.toString());
+    conf.set(YarnConfiguration.FS_APPLICATION_HISTORY_STORE_URI, fsWorkingPath.toString());
     store = new FileSystemApplicationHistoryStore() {
       @Override
       protected FileSystem getFileSystem(Path path, Configuration conf) {
@@ -87,7 +89,7 @@ public class TestFileSystemApplicationHistoryStore extends
     store.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.stop();
     fs.delete(fsWorkingPath, true);
@@ -95,7 +97,7 @@ public class TestFileSystemApplicationHistoryStore extends
   }
 
   @Test
-  public void testReadWriteHistoryData() throws IOException {
+  void testReadWriteHistoryData() throws IOException {
     LOG.info("Starting testReadWriteHistoryData");
     testWriteHistoryData(5);
     testReadHistoryData(5);
@@ -146,58 +148,56 @@ public class TestFileSystemApplicationHistoryStore extends
       int num, boolean missingContainer, boolean missingApplicationAttempt)
           throws IOException {
     // read application history data
-    Assert.assertEquals(num, store.getAllApplications().size());
+    assertEquals(num, store.getAllApplications().size());
     for (int i = 1; i <= num; ++i) {
       ApplicationId appId = ApplicationId.newInstance(0, i);
       ApplicationHistoryData appData = store.getApplication(appId);
-      Assert.assertNotNull(appData);
-      Assert.assertEquals(appId.toString(), appData.getApplicationName());
-      Assert.assertEquals(appId.toString(), appData.getDiagnosticsInfo());
+      assertNotNull(appData);
+      assertEquals(appId.toString(), appData.getApplicationName());
+      assertEquals(appId.toString(), appData.getDiagnosticsInfo());
 
       // read application attempt history data
-      Assert.assertEquals(num, store.getApplicationAttempts(appId).size());
+      assertEquals(num, store.getApplicationAttempts(appId).size());
       for (int j = 1; j <= num; ++j) {
         ApplicationAttemptId appAttemptId =
             ApplicationAttemptId.newInstance(appId, j);
         ApplicationAttemptHistoryData attemptData =
             store.getApplicationAttempt(appAttemptId);
-        Assert.assertNotNull(attemptData);
-        Assert.assertEquals(appAttemptId.toString(), attemptData.getHost());
+        assertNotNull(attemptData);
+        assertEquals(appAttemptId.toString(), attemptData.getHost());
         
         if (missingApplicationAttempt && j == num) {
-          Assert.assertNull(attemptData.getDiagnosticsInfo());
+          assertNull(attemptData.getDiagnosticsInfo());
           continue;
         } else {
-          Assert.assertEquals(appAttemptId.toString(),
+          assertEquals(appAttemptId.toString(),
               attemptData.getDiagnosticsInfo());
         }
 
         // read container history data
-        Assert.assertEquals(num, store.getContainers(appAttemptId).size());
+        assertEquals(num, store.getContainers(appAttemptId).size());
         for (int k = 1; k <= num; ++k) {
           ContainerId containerId = ContainerId.newContainerId(appAttemptId, k);
           ContainerHistoryData containerData = store.getContainer(containerId);
-          Assert.assertNotNull(containerData);
-          Assert.assertEquals(Priority.newInstance(containerId.getId()),
-            containerData.getPriority());
+          assertNotNull(containerData);
+          assertEquals(Priority.newInstance(containerId.getId()), containerData.getPriority());
           if (missingContainer && k == num) {
-            Assert.assertNull(containerData.getDiagnosticsInfo());
+            assertNull(containerData.getDiagnosticsInfo());
           } else {
-            Assert.assertEquals(containerId.toString(),
+            assertEquals(containerId.toString(),
                 containerData.getDiagnosticsInfo());
           }
         }
         ContainerHistoryData masterContainer =
             store.getAMContainer(appAttemptId);
-        Assert.assertNotNull(masterContainer);
-        Assert.assertEquals(ContainerId.newContainerId(appAttemptId, 1),
-          masterContainer.getContainerId());
+        assertNotNull(masterContainer);
+        assertEquals(ContainerId.newContainerId(appAttemptId, 1), masterContainer.getContainerId());
       }
     }
   }
 
   @Test
-  public void testWriteAfterApplicationFinish() throws IOException {
+  void testWriteAfterApplicationFinish() throws IOException {
     LOG.info("Starting testWriteAfterApplicationFinish");
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     writeApplicationStartData(appId);
@@ -207,34 +207,34 @@ public class TestFileSystemApplicationHistoryStore extends
         ApplicationAttemptId.newInstance(appId, 1);
     try {
       writeApplicationAttemptStartData(appAttemptId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is not opened"));
+      assertTrue(e.getMessage().contains("is not opened"));
     }
     try {
       writeApplicationAttemptFinishData(appAttemptId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is not opened"));
+      assertTrue(e.getMessage().contains("is not opened"));
     }
     // write container history data
     ContainerId containerId = ContainerId.newContainerId(appAttemptId, 1);
     try {
       writeContainerStartData(containerId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is not opened"));
+      assertTrue(e.getMessage().contains("is not opened"));
     }
     try {
       writeContainerFinishData(containerId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is not opened"));
+      assertTrue(e.getMessage().contains("is not opened"));
     }
   }
 
   @Test
-  public void testMassiveWriteContainerHistoryData() throws IOException {
+  void testMassiveWriteContainerHistoryData() throws IOException {
     LOG.info("Starting testMassiveWriteContainerHistoryData");
     long mb = 1024 * 1024;
     long usedDiskBefore = fs.getContentSummary(fsWorkingPath).getLength() / mb;
@@ -249,25 +249,25 @@ public class TestFileSystemApplicationHistoryStore extends
     }
     writeApplicationFinishData(appId);
     long usedDiskAfter = fs.getContentSummary(fsWorkingPath).getLength() / mb;
-    Assert.assertTrue((usedDiskAfter - usedDiskBefore) < 20);
+    assertTrue((usedDiskAfter - usedDiskBefore) < 20);
   }
 
   @Test
-  public void testMissingContainerHistoryData() throws IOException {
+  void testMissingContainerHistoryData() throws IOException {
     LOG.info("Starting testMissingContainerHistoryData");
     testWriteHistoryData(3, true, false);
     testReadHistoryData(3, true, false);
   }
-  
+
   @Test
-  public void testMissingApplicationAttemptHistoryData() throws IOException {
+  void testMissingApplicationAttemptHistoryData() throws IOException {
     LOG.info("Starting testMissingApplicationAttemptHistoryData");
     testWriteHistoryData(3, false, true);
     testReadHistoryData(3, false, true);
   }
 
   @Test
-  public void testInitExistingWorkingDirectoryInSafeMode() throws Exception {
+  void testInitExistingWorkingDirectoryInSafeMode() throws Exception {
     LOG.info("Starting testInitExistingWorkingDirectoryInSafeMode");
     tearDown();
 
@@ -280,7 +280,7 @@ public class TestFileSystemApplicationHistoryStore extends
     try {
       initAndStartStore(fileSystem);
     } catch (Exception e) {
-      Assert.fail("Exception should not be thrown: " + e);
+      fail("Exception should not be thrown: " + e);
     }
 
     // Make sure that directory creation was not attempted
@@ -289,7 +289,7 @@ public class TestFileSystemApplicationHistoryStore extends
   }
 
   @Test
-  public void testInitNonExistingWorkingDirectoryInSafeMode() throws Exception {
+  void testInitNonExistingWorkingDirectoryInSafeMode() throws Exception {
     LOG.info("Starting testInitNonExistingWorkingDirectoryInSafeMode");
     tearDown();
 
@@ -302,7 +302,7 @@ public class TestFileSystemApplicationHistoryStore extends
 
     try {
       initAndStartStore(fileSystem);
-      Assert.fail("Exception should have been thrown");
+      fail("Exception should have been thrown");
     } catch (Exception e) {
       // Expected failure
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestFileSystemApplicationHistoryStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestFileSystemApplicationHistoryStore.java
@@ -22,18 +22,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -48,12 +42,19 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationAttemptHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ContainerHistoryData;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class TestFileSystemApplicationHistoryStore extends
     ApplicationHistoryStoreTestUtils {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestMemoryApplicationHistoryStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestMemoryApplicationHistoryStore.java
@@ -18,12 +18,10 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -32,8 +30,11 @@ import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationAttemptHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ContainerHistoryData;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestMemoryApplicationHistoryStore extends
     ApplicationHistoryStoreTestUtils {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestMemoryApplicationHistoryStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestMemoryApplicationHistoryStore.java
@@ -18,9 +18,12 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
-import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
+import java.io.IOException;
 
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -29,27 +32,27 @@ import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationAttemptHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ApplicationHistoryData;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.records.ContainerHistoryData;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestMemoryApplicationHistoryStore extends
     ApplicationHistoryStoreTestUtils {
 
-  @Before
+  @BeforeEach
   public void setup() {
     store = new MemoryApplicationHistoryStore();
   }
 
   @Test
-  public void testReadWriteApplicationHistory() throws Exception {
+  void testReadWriteApplicationHistory() throws Exception {
     // Out of order
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     try {
       writeApplicationFinishData(appId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains(
-        "is stored before the start information"));
+      assertTrue(e.getMessage().contains(
+          "is stored before the start information"));
     }
     // Normal
     int numApps = 5;
@@ -58,42 +61,42 @@ public class TestMemoryApplicationHistoryStore extends
       writeApplicationStartData(appId);
       writeApplicationFinishData(appId);
     }
-    Assert.assertEquals(numApps, store.getAllApplications().size());
+    assertEquals(numApps, store.getAllApplications().size());
     for (int i = 1; i <= numApps; ++i) {
       appId = ApplicationId.newInstance(0, i);
       ApplicationHistoryData data = store.getApplication(appId);
-      Assert.assertNotNull(data);
-      Assert.assertEquals(appId.toString(), data.getApplicationName());
-      Assert.assertEquals(appId.toString(), data.getDiagnosticsInfo());
+      assertNotNull(data);
+      assertEquals(appId.toString(), data.getApplicationName());
+      assertEquals(appId.toString(), data.getDiagnosticsInfo());
     }
     // Write again
     appId = ApplicationId.newInstance(0, 1);
     try {
       writeApplicationStartData(appId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is already stored"));
+      assertTrue(e.getMessage().contains("is already stored"));
     }
     try {
       writeApplicationFinishData(appId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is already stored"));
+      assertTrue(e.getMessage().contains("is already stored"));
     }
   }
 
   @Test
-  public void testReadWriteApplicationAttemptHistory() throws Exception {
+  void testReadWriteApplicationAttemptHistory() throws Exception {
     // Out of order
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
     try {
       writeApplicationAttemptFinishData(appAttemptId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains(
-        "is stored before the start information"));
+      assertTrue(e.getMessage().contains(
+          "is stored before the start information"));
     }
     // Normal
     int numAppAttempts = 5;
@@ -103,36 +106,36 @@ public class TestMemoryApplicationHistoryStore extends
       writeApplicationAttemptStartData(appAttemptId);
       writeApplicationAttemptFinishData(appAttemptId);
     }
-    Assert.assertEquals(numAppAttempts, store.getApplicationAttempts(appId)
-      .size());
+    assertEquals(numAppAttempts, store.getApplicationAttempts(appId)
+        .size());
     for (int i = 1; i <= numAppAttempts; ++i) {
       appAttemptId = ApplicationAttemptId.newInstance(appId, i);
       ApplicationAttemptHistoryData data =
           store.getApplicationAttempt(appAttemptId);
-      Assert.assertNotNull(data);
-      Assert.assertEquals(appAttemptId.toString(), data.getHost());
-      Assert.assertEquals(appAttemptId.toString(), data.getDiagnosticsInfo());
+      assertNotNull(data);
+      assertEquals(appAttemptId.toString(), data.getHost());
+      assertEquals(appAttemptId.toString(), data.getDiagnosticsInfo());
     }
     writeApplicationFinishData(appId);
     // Write again
     appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
     try {
       writeApplicationAttemptStartData(appAttemptId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is already stored"));
+      assertTrue(e.getMessage().contains("is already stored"));
     }
     try {
       writeApplicationAttemptFinishData(appAttemptId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is already stored"));
+      assertTrue(e.getMessage().contains("is already stored"));
     }
   }
 
   @SuppressWarnings("deprecation")
   @Test
-  public void testReadWriteContainerHistory() throws Exception {
+  void testReadWriteContainerHistory() throws Exception {
     // Out of order
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
@@ -140,10 +143,10 @@ public class TestMemoryApplicationHistoryStore extends
     ContainerId containerId = ContainerId.newContainerId(appAttemptId, 1);
     try {
       writeContainerFinishData(containerId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains(
-        "is stored before the start information"));
+      assertTrue(e.getMessage().contains(
+          "is stored before the start information"));
     }
     // Normal
     writeApplicationAttemptStartData(appAttemptId);
@@ -153,39 +156,38 @@ public class TestMemoryApplicationHistoryStore extends
       writeContainerStartData(containerId);
       writeContainerFinishData(containerId);
     }
-    Assert
-      .assertEquals(numContainers, store.getContainers(appAttemptId).size());
+    assertEquals(numContainers, store.getContainers(appAttemptId).size());
     for (int i = 1; i <= numContainers; ++i) {
       containerId = ContainerId.newContainerId(appAttemptId, i);
       ContainerHistoryData data = store.getContainer(containerId);
-      Assert.assertNotNull(data);
-      Assert.assertEquals(Priority.newInstance(containerId.getId()),
-        data.getPriority());
-      Assert.assertEquals(containerId.toString(), data.getDiagnosticsInfo());
+      assertNotNull(data);
+      assertEquals(Priority.newInstance(containerId.getId()),
+          data.getPriority());
+      assertEquals(containerId.toString(), data.getDiagnosticsInfo());
     }
     ContainerHistoryData masterContainer = store.getAMContainer(appAttemptId);
-    Assert.assertNotNull(masterContainer);
-    Assert.assertEquals(ContainerId.newContainerId(appAttemptId, 1),
-      masterContainer.getContainerId());
+    assertNotNull(masterContainer);
+    assertEquals(ContainerId.newContainerId(appAttemptId, 1),
+        masterContainer.getContainerId());
     writeApplicationAttemptFinishData(appAttemptId);
     // Write again
     containerId = ContainerId.newContainerId(appAttemptId, 1);
     try {
       writeContainerStartData(containerId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is already stored"));
+      assertTrue(e.getMessage().contains("is already stored"));
     }
     try {
       writeContainerFinishData(containerId);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("is already stored"));
+      assertTrue(e.getMessage().contains("is already stored"));
     }
   }
 
   @Test
-  public void testMassiveWriteContainerHistory() throws IOException {
+  void testMassiveWriteContainerHistory() throws IOException {
     long mb = 1024 * 1024;
     Runtime runtime = Runtime.getRuntime();
     long usedMemoryBefore = (runtime.totalMemory() - runtime.freeMemory()) / mb;
@@ -199,7 +201,7 @@ public class TestMemoryApplicationHistoryStore extends
       writeContainerFinishData(containerId);
     }
     long usedMemoryAfter = (runtime.totalMemory() - runtime.freeMemory()) / mb;
-    Assert.assertTrue((usedMemoryAfter - usedMemoryBefore) < 400);
+    assertTrue((usedMemoryAfter - usedMemoryBefore) < 400);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebApp.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice.webapp;
 
-import static org.apache.hadoop.yarn.webapp.Params.TITLE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-
 import java.util.Map;
+
+import com.google.inject.Injector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.ApplicationBaseProtocol;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -40,10 +40,11 @@ import org.apache.hadoop.yarn.server.applicationhistoryservice.MemoryApplication
 import org.apache.hadoop.yarn.util.StringHelper;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
-import com.google.inject.Injector;
+import static org.apache.hadoop.yarn.webapp.Params.TITLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebApp.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.yarn.server.applicationhistoryservice.webapp;
 
 import static org.apache.hadoop.yarn.webapp.Params.TITLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.Map;
@@ -38,9 +40,8 @@ import org.apache.hadoop.yarn.server.applicationhistoryservice.MemoryApplication
 import org.apache.hadoop.yarn.util.StringHelper;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.inject.Injector;
 
@@ -50,46 +51,45 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
     this.store = store;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     store = new MemoryApplicationHistoryStore();
   }
 
   @Test
-  public void testAppControllerIndex() throws Exception {
+  void testAppControllerIndex() throws Exception {
     ApplicationHistoryManager ahManager = mock(ApplicationHistoryManager.class);
     Injector injector =
         WebAppTests.createMockInjector(ApplicationHistoryManager.class,
-          ahManager);
+            ahManager);
     AHSController controller = injector.getInstance(AHSController.class);
     controller.index();
-    Assert
-      .assertEquals("Application History", controller.get(TITLE, "unknown"));
+    assertEquals("Application History", controller.get(TITLE, "unknown"));
   }
 
   @Test
-  public void testView() throws Exception {
+  void testView() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
-          mockApplicationHistoryClientService(5, 1, 1));
+            mockApplicationHistoryClientService(5, 1, 1));
     AHSView ahsViewInstance = injector.getInstance(AHSView.class);
 
     ahsViewInstance.render();
     WebAppTests.flushOutput(injector);
 
     ahsViewInstance.set(YarnWebParams.APP_STATE,
-      YarnApplicationState.FAILED.toString());
+        YarnApplicationState.FAILED.toString());
     ahsViewInstance.render();
     WebAppTests.flushOutput(injector);
 
     ahsViewInstance.set(YarnWebParams.APP_STATE, StringHelper.cjoin(
-      YarnApplicationState.FAILED.toString(), YarnApplicationState.KILLED));
+        YarnApplicationState.FAILED.toString(), YarnApplicationState.KILLED));
     ahsViewInstance.render();
     WebAppTests.flushOutput(injector);
   }
 
   @Test
-  public void testAPPViewNaturalSortType() throws Exception {
+  void testAPPViewNaturalSortType() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
             mockApplicationHistoryClientService(5, 1, 1));
@@ -100,11 +100,11 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
     Map<String, String> moreParams =
         ahsViewInstance.context().requestContext().moreParams();
     String appTableColumnsMeta = moreParams.get("ui.dataTables.apps.init");
-    Assert.assertTrue(appTableColumnsMeta.indexOf("natural") != -1);
+    assertTrue(appTableColumnsMeta.indexOf("natural") != -1);
   }
 
   @Test
-  public void testAboutPage() throws Exception {
+  void testAboutPage() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
             mockApplicationHistoryClientService(0, 0, 0));
@@ -118,23 +118,23 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
   }
 
   @Test
-  public void testAppPage() throws Exception {
+  void testAppPage() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
-          mockApplicationHistoryClientService(1, 5, 1));
+            mockApplicationHistoryClientService(1, 5, 1));
     AppPage appPageInstance = injector.getInstance(AppPage.class);
 
     appPageInstance.render();
     WebAppTests.flushOutput(injector);
 
     appPageInstance.set(YarnWebParams.APPLICATION_ID, ApplicationId
-      .newInstance(0, 1).toString());
+        .newInstance(0, 1).toString());
     appPageInstance.render();
     WebAppTests.flushOutput(injector);
   }
 
   @Test
-  public void testAppPageNaturalSortType() throws Exception {
+  void testAppPageNaturalSortType() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
             mockApplicationHistoryClientService(1, 5, 1));
@@ -146,14 +146,14 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
         appPageInstance.context().requestContext().moreParams();
     String attemptsTableColumnsMeta =
         moreParams.get("ui.dataTables.attempts.init");
-    Assert.assertTrue(attemptsTableColumnsMeta.indexOf("natural") != -1);
+    assertTrue(attemptsTableColumnsMeta.indexOf("natural") != -1);
   }
 
   @Test
-  public void testAppAttemptPage() throws Exception {
+  void testAppAttemptPage() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
-          mockApplicationHistoryClientService(1, 1, 5));
+            mockApplicationHistoryClientService(1, 1, 5));
     AppAttemptPage appAttemptPageInstance =
         injector.getInstance(AppAttemptPage.class);
 
@@ -161,14 +161,14 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
     WebAppTests.flushOutput(injector);
 
     appAttemptPageInstance.set(YarnWebParams.APPLICATION_ATTEMPT_ID,
-      ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1)
-        .toString());
+        ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1)
+            .toString());
     appAttemptPageInstance.render();
     WebAppTests.flushOutput(injector);
   }
 
   @Test
-  public void testAppAttemptPageNaturalSortType() throws Exception {
+  void testAppAttemptPageNaturalSortType() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
             mockApplicationHistoryClientService(1, 1, 5));
@@ -179,14 +179,14 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
     Map<String, String> moreParams =
         appAttemptPageInstance.context().requestContext().moreParams();
     String tableColumnsMeta = moreParams.get("ui.dataTables.containers.init");
-    Assert.assertTrue(tableColumnsMeta.indexOf("natural") != -1);
+    assertTrue(tableColumnsMeta.indexOf("natural") != -1);
   }
 
   @Test
-  public void testContainerPage() throws Exception {
+  void testContainerPage() throws Exception {
     Injector injector =
         WebAppTests.createMockInjector(ApplicationBaseProtocol.class,
-          mockApplicationHistoryClientService(1, 1, 1));
+            mockApplicationHistoryClientService(1, 1, 1));
     ContainerPage containerPageInstance =
         injector.getInstance(ContainerPage.class);
 
@@ -194,11 +194,11 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
     WebAppTests.flushOutput(injector);
 
     containerPageInstance.set(
-      YarnWebParams.CONTAINER_ID,
-      ContainerId
-        .newContainerId(
-          ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1),
-          1).toString());
+        YarnWebParams.CONTAINER_ID,
+        ContainerId
+            .newContainerId(
+                ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 1), 1),
+                1).toString());
     containerPageInstance.render();
     WebAppTests.flushOutput(injector);
   }
@@ -230,7 +230,7 @@ public class TestAHSWebApp extends ApplicationHistoryStoreTestUtils {
 
   class MockApplicationHistoryManagerImpl extends ApplicationHistoryManagerImpl {
 
-    public MockApplicationHistoryManagerImpl(ApplicationHistoryStore store) {
+    MockApplicationHistoryManagerImpl(ApplicationHistoryStore store) {
       super();
       init(new YarnConfiguration());
       start();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
@@ -18,16 +18,6 @@
 
 package org.apache.hadoop.yarn.server.applicationhistoryservice.webapp;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -36,11 +26,31 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
+
+import com.google.inject.Guice;
+import com.google.inject.Singleton;
+import com.google.inject.servlet.ServletModule;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.ClientResponse.Status;
+import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -57,6 +67,7 @@ import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineAbout;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.logaggregation.ContainerLogAggregationType;
 import org.apache.hadoop.yarn.logaggregation.ContainerLogFileInfo;
@@ -72,33 +83,22 @@ import org.apache.hadoop.yarn.server.webapp.LogServlet;
 import org.apache.hadoop.yarn.server.webapp.LogWebServiceUtils;
 import org.apache.hadoop.yarn.server.webapp.YarnWebServiceParams;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerLogsInfo;
-import org.apache.hadoop.yarn.api.records.timeline.TimelineAbout;
 import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
-import org.codehaus.jettison.json.JSONArray;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
-import com.google.inject.Guice;
-import com.google.inject.Singleton;
-import com.google.inject.servlet.ServletModule;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.ClientResponse.Status;
-import com.sun.jersey.api.client.GenericType;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
-import com.sun.jersey.test.framework.WebAppDescriptor;
+import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 public class TestAHSWebServices extends JerseyTestBase {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.yarn.server.applicationhistoryservice.webapp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -82,13 +82,12 @@ import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.inject.Guice;
 import com.google.inject.Singleton;
@@ -101,12 +100,11 @@ import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.sun.jersey.test.framework.WebAppDescriptor;
 
-@RunWith(Parameterized.class)
 public class TestAHSWebServices extends JerseyTestBase {
 
   private static ApplicationHistoryClientService historyClientService;
   private static AHSWebServices ahsWebservice;
-  private static final String[] USERS = new String[] { "foo" , "bar" };
+  private static final String[] USERS = new String[]{"foo", "bar"};
   private static final int MAX_APPS = 6;
   private static Configuration conf;
   private static FileSystem fs;
@@ -115,7 +113,7 @@ public class TestAHSWebServices extends JerseyTestBase {
   private static final String NM_WEBADDRESS = "test-nm-web-address:9999";
   private static final String NM_ID = "test:1234";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     conf = new YarnConfiguration();
     TimelineStore store =
@@ -153,7 +151,7 @@ public class TestAHSWebServices extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception {
     if (historyClientService != null) {
       historyClientService.stop();
@@ -162,9 +160,8 @@ public class TestAHSWebServices extends JerseyTestBase {
     fs.delete(new Path(rootLogDir), true);
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> rounds() {
-    return Arrays.asList(new Object[][] { { 0 }, { 1 } });
+    return Arrays.asList(new Object[][]{{0}, {1}});
   }
 
   private static class WebServletModule extends ServletModule {
@@ -179,7 +176,7 @@ public class TestAHSWebServices extends JerseyTestBase {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     GuiceServletConfig.setInjector(
@@ -201,42 +198,45 @@ public class TestAHSWebServices extends JerseyTestBase {
 
   private int round;
 
-  public TestAHSWebServices(int round) {
+  public TestAHSWebServices() {
     super(new WebAppDescriptor.Builder(
-      "org.apache.hadoop.yarn.server.applicationhistoryservice.webapp")
-      .contextListenerClass(GuiceServletConfig.class)
-      .filterClass(com.google.inject.servlet.GuiceFilter.class)
-      .contextPath("jersey-guice-filter").servletPath("/").build());
-    this.round = round;
+        "org.apache.hadoop.yarn.server.applicationhistoryservice.webapp")
+        .contextListenerClass(GuiceServletConfig.class)
+        .filterClass(com.google.inject.servlet.GuiceFilter.class)
+        .contextPath("jersey-guice-filter").servletPath("/").build());
   }
 
-  @Test
-  public void testInvalidApp() {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testInvalidApp(int round) {
+    
     ApplicationId appId = ApplicationId.newInstance(0, MAX_APPS + 1);
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON)
-          .get(ClientResponse.class);
+            .path(appId.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     assertResponseStatusCode("404 not found expected",
         Status.NOT_FOUND, response.getStatusInfo());
   }
 
-  @Test
-  public void testInvalidAttempt() {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testInvalidAttempt(int round) {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, MAX_APPS + 1);
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString()).path("appattempts")
-          .path(appAttemptId.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON)
-          .get(ClientResponse.class);
+            .path(appId.toString()).path("appattempts")
+            .path(appAttemptId.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     if (round == 1) {
       assertResponseStatusCode(Status.FORBIDDEN, response.getStatusInfo());
       return;
@@ -245,8 +245,10 @@ public class TestAHSWebServices extends JerseyTestBase {
         Status.NOT_FOUND, response.getStatusInfo());
   }
 
-  @Test
-  public void testInvalidContainer() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testInvalidContainer(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -255,12 +257,12 @@ public class TestAHSWebServices extends JerseyTestBase {
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString()).path("appattempts")
-          .path(appAttemptId.toString()).path("containers")
-          .path(containerId.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON)
-          .get(ClientResponse.class);
+            .path(appId.toString()).path("appattempts")
+            .path(appAttemptId.toString()).path("containers")
+            .path(containerId.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     if (round == 1) {
       assertResponseStatusCode(Status.FORBIDDEN, response.getStatusInfo());
       return;
@@ -269,27 +271,31 @@ public class TestAHSWebServices extends JerseyTestBase {
         Status.NOT_FOUND, response.getStatusInfo());
   }
 
-  @Test
-  public void testInvalidUri() throws JSONException, Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testInvalidUri(int round) throws JSONException, Exception {
+    
     WebResource r = resource();
     String responseStr = "";
     try {
       responseStr =
           r.path("ws").path("v1").path("applicationhistory").path("bogus")
-            .queryParam("user.name", USERS[round])
-            .accept(MediaType.APPLICATION_JSON).get(String.class);
+              .queryParam("user.name", USERS[round])
+              .accept(MediaType.APPLICATION_JSON).get(String.class);
       fail("should have thrown exception on invalid uri");
     } catch (UniformInterfaceException ue) {
       ClientResponse response = ue.getResponse();
       assertResponseStatusCode(Status.NOT_FOUND, response.getStatusInfo());
 
       WebServicesTestUtils.checkStringMatch(
-        "error string exists and shouldn't", "", responseStr);
+          "error string exists and shouldn't", "", responseStr);
     }
   }
 
-  @Test
-  public void testInvalidUri2() throws JSONException, Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testInvalidUri2(int round) throws JSONException, Exception {
+    
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -300,31 +306,35 @@ public class TestAHSWebServices extends JerseyTestBase {
       ClientResponse response = ue.getResponse();
       assertResponseStatusCode(Status.NOT_FOUND, response.getStatusInfo());
       WebServicesTestUtils.checkStringMatch(
-        "error string exists and shouldn't", "", responseStr);
+          "error string exists and shouldn't", "", responseStr);
     }
   }
 
-  @Test
-  public void testInvalidAccept() throws JSONException, Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testInvalidAccept(int round) throws JSONException, Exception {
+    
     WebResource r = resource();
     String responseStr = "";
     try {
       responseStr =
           r.path("ws").path("v1").path("applicationhistory")
-            .queryParam("user.name", USERS[round])
-            .accept(MediaType.TEXT_PLAIN).get(String.class);
+              .queryParam("user.name", USERS[round])
+              .accept(MediaType.TEXT_PLAIN).get(String.class);
       fail("should have thrown exception on invalid uri");
     } catch (UniformInterfaceException ue) {
       ClientResponse response = ue.getResponse();
       assertResponseStatusCode(Status.INTERNAL_SERVER_ERROR,
           response.getStatusInfo());
       WebServicesTestUtils.checkStringMatch(
-        "error string exists and shouldn't", "", responseStr);
+          "error string exists and shouldn't", "", responseStr);
     }
   }
 
-  @Test
-  public void testAbout() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testAbout(int round) throws Exception {
+    
     WebResource r = resource();
     ClientResponse response = r
         .path("ws").path("v1").path("applicationhistory").path("about")
@@ -335,43 +345,47 @@ public class TestAHSWebServices extends JerseyTestBase {
     TimelineAbout actualAbout = response.getEntity(TimelineAbout.class);
     TimelineAbout expectedAbout =
         TimelineUtils.createTimelineAbout("Generic History Service API");
-    Assert.assertNotNull(
-        "Timeline service about response is null", actualAbout);
-    Assert.assertEquals(expectedAbout.getAbout(), actualAbout.getAbout());
-    Assert.assertEquals(expectedAbout.getTimelineServiceVersion(),
+    assertNotNull(
+        actualAbout, "Timeline service about response is null");
+    assertEquals(expectedAbout.getAbout(), actualAbout.getAbout());
+    assertEquals(expectedAbout.getTimelineServiceVersion(),
         actualAbout.getTimelineServiceVersion());
-    Assert.assertEquals(expectedAbout.getTimelineServiceBuildVersion(),
+    assertEquals(expectedAbout.getTimelineServiceBuildVersion(),
         actualAbout.getTimelineServiceBuildVersion());
-    Assert.assertEquals(expectedAbout.getTimelineServiceVersionBuiltOn(),
+    assertEquals(expectedAbout.getTimelineServiceVersionBuiltOn(),
         actualAbout.getTimelineServiceVersionBuiltOn());
-    Assert.assertEquals(expectedAbout.getHadoopVersion(),
+    assertEquals(expectedAbout.getHadoopVersion(),
         actualAbout.getHadoopVersion());
-    Assert.assertEquals(expectedAbout.getHadoopBuildVersion(),
+    assertEquals(expectedAbout.getHadoopBuildVersion(),
         actualAbout.getHadoopBuildVersion());
-    Assert.assertEquals(expectedAbout.getHadoopVersionBuiltOn(),
+    assertEquals(expectedAbout.getHadoopVersionBuiltOn(),
         actualAbout.getHadoopVersionBuiltOn());
   }
 
-  @Test
-  public void testAppsQuery() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testAppsQuery(int round) throws Exception {
+    
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .queryParam("state", YarnApplicationState.FINISHED.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
+            .queryParam("state", YarnApplicationState.FINISHED.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", MAX_APPS, array.length());
+    assertEquals(MAX_APPS, array.length(), "incorrect number of elements");
   }
 
-  @Test
-  public void testQueueQuery() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testQueueQuery(int round) throws Exception {
+    
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
@@ -382,28 +396,31 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", MAX_APPS - 1,
-        array.length());
+    assertEquals(MAX_APPS - 1,
+        array.length(),
+        "incorrect number of elements");
   }
 
-  @Test
-  public void testSingleApp() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testSingleApp(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON)
-          .get(ClientResponse.class);
+            .path(appId.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject app = json.getJSONObject("app");
     assertEquals(appId.toString(), app.getString("appId"));
     assertEquals("test app", app.get("name"));
@@ -414,23 +431,25 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals("user1", app.get("user"));
     assertEquals("test app type", app.get("type"));
     assertEquals(FinalApplicationStatus.UNDEFINED.toString(),
-      app.get("finalAppStatus"));
+        app.get("finalAppStatus"));
     assertEquals(YarnApplicationState.FINISHED.toString(), app.get("appState"));
-    assertNotNull("Aggregate resource allocation is null",
-        app.get("aggregateResourceAllocation"));
-    assertNotNull("Aggregate Preempted Resource Allocation is null",
-        app.get("aggregatePreemptedResourceAllocation"));
+    assertNotNull(app.get("aggregateResourceAllocation"),
+        "Aggregate resource allocation is null");
+    assertNotNull(app.get("aggregatePreemptedResourceAllocation"),
+        "Aggregate Preempted Resource Allocation is null");
   }
 
-  @Test
-  public void testMultipleAttempts() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testMultipleAttempts(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString()).path("appattempts")
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
+            .path(appId.toString()).path("appattempts")
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     if (round == 1) {
       assertResponseStatusCode(Status.FORBIDDEN, response.getStatusInfo());
       return;
@@ -438,26 +457,28 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject appAttempts = json.getJSONObject("appAttempts");
-    assertEquals("incorrect number of elements", 1, appAttempts.length());
+    assertEquals(1, appAttempts.length(), "incorrect number of elements");
     JSONArray array = appAttempts.getJSONArray("appAttempt");
-    assertEquals("incorrect number of elements", MAX_APPS, array.length());
+    assertEquals(MAX_APPS, array.length(), "incorrect number of elements");
   }
 
-  @Test
-  public void testSingleAttempt() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testSingleAttempt(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString()).path("appattempts")
-          .path(appAttemptId.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON)
-          .get(ClientResponse.class);
+            .path(appId.toString()).path("appattempts")
+            .path(appAttemptId.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     if (round == 1) {
       assertResponseStatusCode(Status.FORBIDDEN, response.getStatusInfo());
       return;
@@ -465,29 +486,31 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject appAttempt = json.getJSONObject("appAttempt");
     assertEquals(appAttemptId.toString(), appAttempt.getString("appAttemptId"));
     assertEquals("test host", appAttempt.getString("host"));
     assertEquals("test diagnostics info",
-      appAttempt.getString("diagnosticsInfo"));
+        appAttempt.getString("diagnosticsInfo"));
     assertEquals("test tracking url", appAttempt.getString("trackingUrl"));
     assertEquals(YarnApplicationAttemptState.FINISHED.toString(),
-      appAttempt.get("appAttemptState"));
+        appAttempt.get("appAttemptState"));
   }
 
-  @Test
-  public void testMultipleContainers() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testMultipleContainers(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString()).path("appattempts")
-          .path(appAttemptId.toString()).path("containers")
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
+            .path(appId.toString()).path("appattempts")
+            .path(appAttemptId.toString()).path("containers")
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     if (round == 1) {
       assertResponseStatusCode(Status.FORBIDDEN, response.getStatusInfo());
       return;
@@ -495,15 +518,17 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject containers = json.getJSONObject("containers");
-    assertEquals("incorrect number of elements", 1, containers.length());
+    assertEquals(1, containers.length(), "incorrect number of elements");
     JSONArray array = containers.getJSONArray("container");
-    assertEquals("incorrect number of elements", MAX_APPS, array.length());
+    assertEquals(MAX_APPS, array.length(), "incorrect number of elements");
   }
 
-  @Test
-  public void testSingleContainer() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  void testSingleContainer(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -511,12 +536,12 @@ public class TestAHSWebServices extends JerseyTestBase {
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
-          .path(appId.toString()).path("appattempts")
-          .path(appAttemptId.toString()).path("containers")
-          .path(containerId.toString())
-          .queryParam("user.name", USERS[round])
-          .accept(MediaType.APPLICATION_JSON)
-          .get(ClientResponse.class);
+            .path(appId.toString()).path("appattempts")
+            .path(appAttemptId.toString()).path("containers")
+            .path(containerId.toString())
+            .queryParam("user.name", USERS[round])
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     if (round == 1) {
       assertResponseStatusCode(Status.FORBIDDEN, response.getStatusInfo());
       return;
@@ -524,14 +549,14 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject container = json.getJSONObject("container");
     assertEquals(containerId.toString(), container.getString("containerId"));
     assertEquals("test diagnostics info", container.getString("diagnosticsInfo"));
     assertEquals("-1", container.getString("allocatedMB"));
     assertEquals("-1", container.getString("allocatedVCores"));
     assertEquals(NodeId.newInstance("test host", 100).toString(),
-      container.getString("assignedNodeId"));
+        container.getString("assignedNodeId"));
     assertEquals("-1", container.getString("priority"));
     Configuration conf = new YarnConfiguration();
     assertEquals(WebAppUtils.getHttpSchemePrefix(conf) +
@@ -539,11 +564,14 @@ public class TestAHSWebServices extends JerseyTestBase {
         "/applicationhistory/logs/test host:100/container_0_0001_01_000001/" +
         "container_0_0001_01_000001/user1", container.getString("logUrl"));
     assertEquals(ContainerState.COMPLETE.toString(),
-      container.getString("containerState"));
+        container.getString("containerState"));
   }
 
-  @Test(timeout = 10000)
-  public void testContainerLogsForFinishedApps() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  @Timeout(10000)
+  void testContainerLogsForFinishedApps(int round) throws Exception {
+    
     String fileName = "syslog";
     String user = "user1";
     NodeId nodeId = NodeId.newInstance("test host", 100);
@@ -653,7 +681,7 @@ public class TestAHSWebServices extends JerseyTestBase {
         (fullTextSize - fileContentSize) + 5);
     assertTrue(fullTextSize >= responseText.getBytes().length);
     assertEquals(new String(responseText.getBytes(),
-        (fullTextSize - fileContentSize - tailTextSize), 5),
+            (fullTextSize - fileContentSize - tailTextSize), 5),
         new String(logMessage.getBytes(), 0, 5));
 
     // specify how many bytes we should get from logs
@@ -672,7 +700,7 @@ public class TestAHSWebServices extends JerseyTestBase {
         (fullTextSize - fileContentSize) + 5);
     assertTrue(fullTextSize >= responseText.getBytes().length);
     assertEquals(new String(responseText.getBytes(),
-        (fullTextSize - fileContentSize - tailTextSize), 5),
+            (fullTextSize - fileContentSize - tailTextSize), 5),
         new String(logMessage.getBytes(), fileContentSize - 5, 5));
 
     // specify the bytes which is larger than the actual file size,
@@ -700,8 +728,11 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertThat(responseText.getBytes()).hasSize(fullTextSize);
   }
 
-  @Test(timeout = 10000)
-  public void testContainerLogsForRunningApps() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  @Timeout(10000)
+  void testContainerLogsForRunningApps(int round) throws Exception {
+    
     String fileName = "syslog";
     String user = "user1";
     ApplicationId appId = ApplicationId.newInstance(
@@ -826,8 +857,11 @@ public class TestAHSWebServices extends JerseyTestBase {
         + ContainerLogAggregationType.AGGREGATED));
   }
 
-  @Test(timeout = 10000)
-  public void testContainerLogsMetaForRunningApps() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  @Timeout(10000)
+  void testContainerLogsMetaForRunningApps(int round) throws Exception {
+    
     String user = "user1";
     ApplicationId appId = ApplicationId.newInstance(
         1234, 1);
@@ -883,10 +917,11 @@ public class TestAHSWebServices extends JerseyTestBase {
         .get(ClientResponse.class);
 
     List<ContainerLogsInfo> responseText = response.getEntity(new GenericType<
-        List<ContainerLogsInfo>>(){});
+        List<ContainerLogsInfo>>(){
+    });
     assertTrue(responseText.size() == 2);
     for (ContainerLogsInfo logInfo : responseText) {
-      if(logInfo.getLogType().equals(
+      if (logInfo.getLogType().equals(
           ContainerLogAggregationType.AGGREGATED.toString())) {
         List<ContainerLogFileInfo> logMeta = logInfo
             .getContainerLogsInfo();
@@ -911,10 +946,11 @@ public class TestAHSWebServices extends JerseyTestBase {
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     responseText = response.getEntity(new GenericType<
-        List<ContainerLogsInfo>>(){});
+        List<ContainerLogsInfo>>(){
+    });
     assertTrue(responseText.size() == 2);
     for (ContainerLogsInfo logInfo : responseText) {
-      if(logInfo.getLogType().equals(
+      if (logInfo.getLogType().equals(
           ContainerLogAggregationType.AGGREGATED.toString())) {
         List<ContainerLogFileInfo> logMeta = logInfo
             .getContainerLogsInfo();
@@ -929,8 +965,11 @@ public class TestAHSWebServices extends JerseyTestBase {
     }
   }
 
-  @Test(timeout = 10000)
-  public void testContainerLogsMetaForFinishedApps() throws Exception {
+  @MethodSource("rounds")
+  @ParameterizedTest
+  @Timeout(10000)
+  void testContainerLogsMetaForFinishedApps(int round) throws Exception {
+    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -951,7 +990,8 @@ public class TestAHSWebServices extends JerseyTestBase {
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     List<ContainerLogsInfo> responseText = response.getEntity(new GenericType<
-        List<ContainerLogsInfo>>(){});
+        List<ContainerLogsInfo>>(){
+    });
     assertTrue(responseText.size() == 1);
     assertEquals(responseText.get(0).getLogType(),
         ContainerLogAggregationType.AGGREGATED.toString());
@@ -971,7 +1011,7 @@ public class TestAHSWebServices extends JerseyTestBase {
       // do not automatically follow the redirection
       // otherwise we get too many redirections exception
       conn.setInstanceFollowRedirects(false);
-      if(conn.getResponseCode() == HttpServletResponse.SC_TEMPORARY_REDIRECT) {
+      if (conn.getResponseCode() == HttpServletResponse.SC_TEMPORARY_REDIRECT) {
         redirectUrl = conn.getHeaderField("Location");
       }
     } catch (Exception e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
@@ -207,7 +207,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testInvalidApp(int round) {
-    
     ApplicationId appId = ApplicationId.newInstance(0, MAX_APPS + 1);
     WebResource r = resource();
     ClientResponse response =
@@ -223,7 +222,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testInvalidAttempt(int round) {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, MAX_APPS + 1);
@@ -246,7 +244,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testInvalidContainer(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -272,7 +269,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testInvalidUri(int round) throws JSONException, Exception {
-    
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -293,7 +289,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testInvalidUri2(int round) throws JSONException, Exception {
-    
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -311,7 +306,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testInvalidAccept(int round) throws JSONException, Exception {
-    
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -332,7 +326,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testAbout(int round) throws Exception {
-    
     WebResource r = resource();
     ClientResponse response = r
         .path("ws").path("v1").path("applicationhistory").path("about")
@@ -363,7 +356,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testAppsQuery(int round) throws Exception {
-    
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
@@ -383,7 +375,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testQueueQuery(int round) throws Exception {
-    
     WebResource r = resource();
     ClientResponse response =
         r.path("ws").path("v1").path("applicationhistory").path("apps")
@@ -406,7 +397,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testSingleApp(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     WebResource r = resource();
     ClientResponse response =
@@ -440,7 +430,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testMultipleAttempts(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     WebResource r = resource();
     ClientResponse response =
@@ -465,7 +454,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testSingleAttempt(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -498,7 +486,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testMultipleContainers(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -526,7 +513,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @MethodSource("rounds")
   @ParameterizedTest
   void testSingleContainer(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);
@@ -720,7 +706,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @ParameterizedTest
   @Timeout(10000)
   void testContainerLogsForRunningApps(int round) throws Exception {
-    
     String fileName = "syslog";
     String user = "user1";
     ApplicationId appId = ApplicationId.newInstance(
@@ -849,7 +834,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @ParameterizedTest
   @Timeout(10000)
   void testContainerLogsMetaForRunningApps(int round) throws Exception {
-    
     String user = "user1";
     ApplicationId appId = ApplicationId.newInstance(
         1234, 1);
@@ -957,7 +941,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @ParameterizedTest
   @Timeout(10000)
   void testContainerLogsMetaForFinishedApps(int round) throws Exception {
-    
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(appId, 1);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/webapp/TestAHSWebServices.java
@@ -196,8 +196,6 @@ public class TestAHSWebServices extends JerseyTestBase {
     }
   }
 
-  private int round;
-
   public TestAHSWebServices() {
     super(new WebAppDescriptor.Builder(
         "org.apache.hadoop.yarn.server.applicationhistoryservice.webapp")
@@ -571,7 +569,6 @@ public class TestAHSWebServices extends JerseyTestBase {
   @ParameterizedTest
   @Timeout(10000)
   void testContainerLogsForFinishedApps(int round) throws Exception {
-    
     String fileName = "syslog";
     String user = "user1";
     NodeId nodeId = NodeId.newInstance("test host", 100);
@@ -581,7 +578,6 @@ public class TestAHSWebServices extends JerseyTestBase {
         appId, 1);
     ContainerId containerId1 = ContainerId.newContainerId(appAttemptId, 1);
     ContainerId containerId100 = ContainerId.newContainerId(appAttemptId, 100);
-
     TestContainerLogsUtils.createContainerLogFileInRemoteFS(conf, fs,
         rootLogDir, appId, Collections.singletonMap(containerId1,
             "Hello." + containerId1),
@@ -601,7 +597,6 @@ public class TestAHSWebServices extends JerseyTestBase {
         .get(ClientResponse.class);
     String responseText = response.getEntity(String.class);
     assertTrue(responseText.contains("Hello." + containerId1));
-
     // Do the same test with new API
     r = resource();
     response = r.path("ws").path("v1")
@@ -612,7 +607,6 @@ public class TestAHSWebServices extends JerseyTestBase {
         .get(ClientResponse.class);
     responseText = response.getEntity(String.class);
     assertTrue(responseText.contains("Hello." + containerId1));
-
     // test whether we can find container log from remote diretory if
     // the containerInfo for this container could not be fetched from AHS.
     r = resource();
@@ -624,7 +618,6 @@ public class TestAHSWebServices extends JerseyTestBase {
         .get(ClientResponse.class);
     responseText = response.getEntity(String.class);
     assertTrue(responseText.contains("Hello." + containerId100));
-
     // Do the same test with new API
     r = resource();
     response = r.path("ws").path("v1")
@@ -635,14 +628,12 @@ public class TestAHSWebServices extends JerseyTestBase {
         .get(ClientResponse.class);
     responseText = response.getEntity(String.class);
     assertTrue(responseText.contains("Hello." + containerId100));
-
     // create an application which can not be found from AHS
     ApplicationId appId100 = ApplicationId.newInstance(0, 100);
     ApplicationAttemptId appAttemptId100 = ApplicationAttemptId.newInstance(
         appId100, 1);
     ContainerId containerId1ForApp100 = ContainerId.newContainerId(
         appAttemptId100, 1);
-
     TestContainerLogsUtils.createContainerLogFileInRemoteFS(conf, fs,
         rootLogDir, appId100,
         Collections.singletonMap(containerId1ForApp100,
@@ -662,7 +653,6 @@ public class TestAHSWebServices extends JerseyTestBase {
         "End of LogType:syslog".length() + 50) + "\n\n";
     int tailTextSize = "\nEnd of LogType:syslog\n".getBytes().length
         + tailEndSeparator.getBytes().length;
-
     String logMessage = "Hello." + containerId1ForApp100;
     int fileContentSize = logMessage.getBytes().length;
     // specify how many bytes we should get from logs
@@ -683,7 +673,6 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(new String(responseText.getBytes(),
             (fullTextSize - fileContentSize - tailTextSize), 5),
         new String(logMessage.getBytes(), 0, 5));
-
     // specify how many bytes we should get from logs
     // if we specify a negative number, it would get the last n bytes from
     // container log
@@ -702,7 +691,6 @@ public class TestAHSWebServices extends JerseyTestBase {
     assertEquals(new String(responseText.getBytes(),
             (fullTextSize - fileContentSize - tailTextSize), 5),
         new String(logMessage.getBytes(), fileContentSize - 5, 5));
-
     // specify the bytes which is larger than the actual file size,
     // we would get the full logs
     r = resource();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestGenericObjectMapper.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestGenericObjectMapper.java
@@ -21,22 +21,22 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.yarn.server.timeline.GenericObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class TestGenericObjectMapper {
 
   @Test
-  public void testEncoding() {
+  void testEncoding() {
     testEncoding(Long.MAX_VALUE);
     testEncoding(Long.MIN_VALUE);
     testEncoding(0l);
@@ -48,21 +48,25 @@ public class TestGenericObjectMapper {
 
   private static void testEncoding(long l) {
     byte[] b = GenericObjectMapper.writeReverseOrderedLong(l);
-    assertEquals("error decoding", l,
-        GenericObjectMapper.readReverseOrderedLong(b, 0));
+    assertEquals(l,
+        GenericObjectMapper.readReverseOrderedLong(b, 0),
+        "error decoding");
     byte[] buf = new byte[16];
     System.arraycopy(b, 0, buf, 5, 8);
-    assertEquals("error decoding at offset", l,
-        GenericObjectMapper.readReverseOrderedLong(buf, 5));
+    assertEquals(l,
+        GenericObjectMapper.readReverseOrderedLong(buf, 5),
+        "error decoding at offset");
     if (l > Long.MIN_VALUE) {
       byte[] a = GenericObjectMapper.writeReverseOrderedLong(l-1);
-      assertEquals("error preserving ordering", 1,
-          WritableComparator.compareBytes(a, 0, a.length, b, 0, b.length));
+      assertEquals(1,
+          WritableComparator.compareBytes(a, 0, a.length, b, 0, b.length),
+          "error preserving ordering");
     }
     if (l < Long.MAX_VALUE) {
       byte[] c = GenericObjectMapper.writeReverseOrderedLong(l+1);
-      assertEquals("error preserving ordering", 1,
-          WritableComparator.compareBytes(b, 0, b.length, c, 0, c.length));
+      assertEquals(1,
+          WritableComparator.compareBytes(b, 0, b.length, c, 0, c.length),
+          "error preserving ordering");
     }
   }
 
@@ -71,15 +75,15 @@ public class TestGenericObjectMapper {
   }
 
   @Test
-  public void testValueTypes() throws IOException {
+  void testValueTypes() throws IOException {
     verify(Integer.MAX_VALUE);
     verify(Integer.MIN_VALUE);
     assertEquals(Integer.MAX_VALUE, GenericObjectMapper.read(
         GenericObjectMapper.write((long) Integer.MAX_VALUE)));
     assertEquals(Integer.MIN_VALUE, GenericObjectMapper.read(
         GenericObjectMapper.write((long) Integer.MIN_VALUE)));
-    verify((long)Integer.MAX_VALUE + 1l);
-    verify((long)Integer.MIN_VALUE - 1l);
+    verify((long) Integer.MAX_VALUE + 1l);
+    verify((long) Integer.MIN_VALUE - 1l);
 
     verify(Long.MAX_VALUE);
     verify(Long.MIN_VALUE);
@@ -93,9 +97,9 @@ public class TestGenericObjectMapper {
     list.add("123");
     list.add("abc");
     verify(list);
-    Map<String,String> map = new HashMap<String,String>();
-    map.put("k1","v1");
-    map.put("k2","v2");
+    Map<String, String> map = new HashMap<String, String>();
+    map.put("k1", "v1");
+    map.put("k2", "v2");
     verify(map);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestGenericObjectMapper.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestGenericObjectMapper.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server.timeline;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.WritableComparator;
-import org.apache.hadoop.yarn.server.timeline.GenericObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -39,11 +38,11 @@ public class TestGenericObjectMapper {
   void testEncoding() {
     testEncoding(Long.MAX_VALUE);
     testEncoding(Long.MIN_VALUE);
-    testEncoding(0l);
-    testEncoding(128l);
-    testEncoding(256l);
-    testEncoding(512l);
-    testEncoding(-256l);
+    testEncoding(0L);
+    testEncoding(128L);
+    testEncoding(256L);
+    testEncoding(512L);
+    testEncoding(-256L);
   }
 
   private static void testEncoding(long l) {
@@ -82,13 +81,13 @@ public class TestGenericObjectMapper {
         GenericObjectMapper.write((long) Integer.MAX_VALUE)));
     assertEquals(Integer.MIN_VALUE, GenericObjectMapper.read(
         GenericObjectMapper.write((long) Integer.MIN_VALUE)));
-    verify((long) Integer.MAX_VALUE + 1l);
-    verify((long) Integer.MIN_VALUE - 1l);
+    verify((long) Integer.MAX_VALUE + 1L);
+    verify((long) Integer.MIN_VALUE - 1L);
 
     verify(Long.MAX_VALUE);
     verify(Long.MIN_VALUE);
 
-    assertEquals(42, GenericObjectMapper.read(GenericObjectMapper.write(42l)));
+    assertEquals(42, GenericObjectMapper.read(GenericObjectMapper.write(42L)));
     verify(42);
     verify(1.23);
     verify("abc");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestGenericObjectMapper.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestGenericObjectMapper.java
@@ -17,18 +17,19 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.io.WritableComparator;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.io.WritableComparator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLeveldbTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLeveldbTimelineStore.java
@@ -17,13 +17,6 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.apache.hadoop.yarn.server.timeline.GenericObjectMapper.writeReverseOrderedLong;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -31,6 +24,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.fusesource.leveldbjni.JniDBFactory;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.Options;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -49,13 +50,13 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse.TimelineP
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.utils.LeveldbIterator;
-import org.fusesource.leveldbjni.JniDBFactory;
-import org.iq80.leveldb.DBException;
-import org.iq80.leveldb.Options;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
+import static org.apache.hadoop.yarn.server.timeline.GenericObjectMapper.writeReverseOrderedLong;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLeveldbTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLeveldbTimelineStore.java
@@ -18,8 +18,11 @@
 package org.apache.hadoop.yarn.server.timeline;
 
 import static org.apache.hadoop.yarn.server.timeline.GenericObjectMapper.writeReverseOrderedLong;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -49,10 +52,9 @@ import org.apache.hadoop.yarn.server.utils.LeveldbIterator;
 import org.fusesource.leveldbjni.JniDBFactory;
 import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.Options;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 @InterfaceAudience.Private
@@ -62,7 +64,7 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
   private File fsPath;
   private Configuration config = new YarnConfiguration();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     fsContext = FileContext.getLocalFSFileContext();
     fsPath = new File("target", this.getClass().getSimpleName() +
@@ -79,14 +81,14 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     loadTestDomainData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.stop();
     fsContext.delete(new Path(fsPath.getAbsolutePath()), true);
   }
 
   @Test
-  public void testRootDirPermission() throws IOException {
+  void testRootDirPermission() throws IOException {
     FileSystem fs = FileSystem.getLocal(new YarnConfiguration());
     FileStatus file = fs.getFileStatus(
         new Path(fsPath.getAbsolutePath(), LeveldbTimelineStore.FILENAME));
@@ -133,7 +135,7 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testCacheSizes() {
+  void testCacheSizes() {
     Configuration conf = new Configuration();
     assertEquals(10000, LeveldbTimelineStore.getStartTimeReadCacheSize(conf));
     assertEquals(10000, LeveldbTimelineStore.getStartTimeWriteCacheSize(conf));
@@ -165,8 +167,8 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testGetEntityTypes() throws IOException {
-    List<String> entityTypes = ((LeveldbTimelineStore)store).getEntityTypes();
+  void testGetEntityTypes() throws IOException {
+    List<String> entityTypes = ((LeveldbTimelineStore) store).getEntityTypes();
     assertEquals(7, entityTypes.size());
     assertEquals("ACL_ENTITY_TYPE_1", entityTypes.get(0));
     assertEquals("OLD_ENTITY_TYPE_1", entityTypes.get(1));
@@ -177,7 +179,7 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testDeleteEntities() throws IOException, InterruptedException {
+  void testDeleteEntities() throws IOException, InterruptedException {
     assertEquals(3, getEntities("type_1").size());
     assertEquals(1, getEntities("type_2").size());
 
@@ -191,7 +193,7 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     List<TimelineEntity> entities = getEntities("type_2");
     assertEquals(1, entities.size());
     verifyEntityInfo(entityId2, entityType2, events2, Collections.singletonMap(
-        entityType1, Collections.singleton(entityId1b)), EMPTY_PRIMARY_FILTERS,
+            entityType1, Collections.singleton(entityId1b)), EMPTY_PRIMARY_FILTERS,
         EMPTY_MAP, entities.get(0), domainId1);
     entities = getEntitiesWithPrimaryFilter("type_1", userFilter);
     assertEquals(2, entities.size());
@@ -201,20 +203,20 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     verifyEntityInfo(entityId6, entityType1, EMPTY_EVENTS, EMPTY_REL_ENTITIES,
         primaryFilters, otherInfo, entities.get(1), domainId2);
 
-    ((LeveldbTimelineStore)store).discardOldEntities(0L);
+    ((LeveldbTimelineStore) store).discardOldEntities(0L);
     assertEquals(2, getEntities("type_1").size());
     assertEquals(0, getEntities("type_2").size());
-    assertEquals(6, ((LeveldbTimelineStore)store).getEntityTypes().size());
+    assertEquals(6, ((LeveldbTimelineStore) store).getEntityTypes().size());
 
-    ((LeveldbTimelineStore)store).discardOldEntities(123L);
+    ((LeveldbTimelineStore) store).discardOldEntities(123L);
     assertEquals(0, getEntities("type_1").size());
     assertEquals(0, getEntities("type_2").size());
-    assertEquals(0, ((LeveldbTimelineStore)store).getEntityTypes().size());
+    assertEquals(0, ((LeveldbTimelineStore) store).getEntityTypes().size());
     assertEquals(0, getEntitiesWithPrimaryFilter("type_1", userFilter).size());
   }
 
   @Test
-  public void testDeleteEntitiesPrimaryFilters()
+  void testDeleteEntitiesPrimaryFilters()
       throws IOException, InterruptedException {
     Map<String, Set<Object>> primaryFilter =
         Collections.singletonMap("user", Collections.singleton(
@@ -243,28 +245,28 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     verifyEntityInfo(entityId6, entityType1, EMPTY_EVENTS, EMPTY_REL_ENTITIES,
         primaryFilters, otherInfo, entities.get(2), domainId2);
 
-    ((LeveldbTimelineStore)store).discardOldEntities(-123L);
+    ((LeveldbTimelineStore) store).discardOldEntities(-123L);
     assertEquals(1, getEntitiesWithPrimaryFilter("type_1", pfPair).size());
     assertEquals(3, getEntitiesWithPrimaryFilter("type_1", userFilter).size());
 
-    ((LeveldbTimelineStore)store).discardOldEntities(123L);
+    ((LeveldbTimelineStore) store).discardOldEntities(123L);
     assertEquals(0, getEntities("type_1").size());
     assertEquals(0, getEntities("type_2").size());
-    assertEquals(0, ((LeveldbTimelineStore)store).getEntityTypes().size());
+    assertEquals(0, ((LeveldbTimelineStore) store).getEntityTypes().size());
 
     assertEquals(0, getEntitiesWithPrimaryFilter("type_1", pfPair).size());
     assertEquals(0, getEntitiesWithPrimaryFilter("type_1", userFilter).size());
   }
 
   @Test
-  public void testFromTsWithDeletion()
+  void testFromTsWithDeletion()
       throws IOException, InterruptedException {
     long l = System.currentTimeMillis();
     assertEquals(3, getEntitiesFromTs("type_1", l).size());
     assertEquals(1, getEntitiesFromTs("type_2", l).size());
     assertEquals(3, getEntitiesFromTsWithPrimaryFilter("type_1", userFilter,
         l).size());
-    ((LeveldbTimelineStore)store).discardOldEntities(123L);
+    ((LeveldbTimelineStore) store).discardOldEntities(123L);
     assertEquals(0, getEntitiesFromTs("type_1", l).size());
     assertEquals(0, getEntitiesFromTs("type_2", l).size());
     assertEquals(0, getEntitiesFromTsWithPrimaryFilter("type_1", userFilter,
@@ -284,22 +286,22 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testCheckVersion() throws IOException {
+  void testCheckVersion() throws IOException {
     LeveldbTimelineStore dbStore = (LeveldbTimelineStore) store;
     // default version
     Version defaultVersion = dbStore.getCurrentVersion();
-    Assert.assertEquals(defaultVersion, dbStore.loadVersion());
+    assertEquals(defaultVersion, dbStore.loadVersion());
 
     // compatible version
     Version compatibleVersion =
         Version.newInstance(defaultVersion.getMajorVersion(),
-          defaultVersion.getMinorVersion() + 2);
+            defaultVersion.getMinorVersion() + 2);
     dbStore.storeVersion(compatibleVersion);
-    Assert.assertEquals(compatibleVersion, dbStore.loadVersion());
+    assertEquals(compatibleVersion, dbStore.loadVersion());
     restartTimelineStore();
     dbStore = (LeveldbTimelineStore) store;
     // overwrite the compatible version
-    Assert.assertEquals(defaultVersion, dbStore.loadVersion());
+    assertEquals(defaultVersion, dbStore.loadVersion());
 
     // incompatible version
     Version incompatibleVersion = Version.newInstance(
@@ -307,24 +309,24 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     dbStore.storeVersion(incompatibleVersion);
     try {
       restartTimelineStore();
-      Assert.fail("Incompatible version, should expect fail here.");
+      fail("Incompatible version, should expect fail here.");
     } catch (ServiceStateException e) {
-      Assert.assertTrue("Exception message mismatch",
-          e.getMessage().contains("Incompatible version for timeline store"));
+      assertTrue(e.getMessage().contains("Incompatible version for timeline store"),
+          "Exception message mismatch");
     }
   }
 
   @Test
-  public void testValidateConfig() throws IOException {
+  void testValidateConfig() throws IOException {
     Configuration copyConfig = new YarnConfiguration(config);
     try {
       Configuration newConfig = new YarnConfiguration(copyConfig);
       newConfig.setLong(YarnConfiguration.TIMELINE_SERVICE_TTL_MS, 0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration.TIMELINE_SERVICE_TTL_MS));
     }
     try {
@@ -333,9 +335,9 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS, 0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS));
     }
     try {
@@ -344,9 +346,9 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_READ_CACHE_SIZE, -1);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_READ_CACHE_SIZE));
     }
     try {
@@ -357,12 +359,11 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
               0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert
-          .assertTrue(e
+      assertTrue(e
               .getMessage().contains(
-                  YarnConfiguration.TIMELINE_SERVICE_LEVELDB_START_TIME_READ_CACHE_SIZE));
+              YarnConfiguration.TIMELINE_SERVICE_LEVELDB_START_TIME_READ_CACHE_SIZE));
     }
     try {
       Configuration newConfig = new YarnConfiguration(copyConfig);
@@ -372,10 +373,9 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
               0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert
-          .assertTrue(e
+      assertTrue(e
               .getMessage()
               .contains(
                   YarnConfiguration.TIMELINE_SERVICE_LEVELDB_START_TIME_WRITE_CACHE_SIZE));
@@ -405,7 +405,7 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testRelatingToNonExistingEntity() throws IOException {
+  void testRelatingToNonExistingEntity() throws IOException {
     TimelineEntity entityToStore = new TimelineEntity();
     entityToStore.setEntityType("TEST_ENTITY_TYPE_1");
     entityToStore.setEntityId("TEST_ENTITY_ID_1");
@@ -416,17 +416,17 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     store.put(entities);
     TimelineEntity entityToGet =
         store.getEntity("TEST_ENTITY_ID_2", "TEST_ENTITY_TYPE_2", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertEquals("DEFAULT", entityToGet.getDomainId());
-    Assert.assertEquals("TEST_ENTITY_TYPE_1",
+    assertNotNull(entityToGet);
+    assertEquals("DEFAULT", entityToGet.getDomainId());
+    assertEquals("TEST_ENTITY_TYPE_1",
         entityToGet.getRelatedEntities().keySet().iterator().next());
-    Assert.assertEquals("TEST_ENTITY_ID_1",
+    assertEquals("TEST_ENTITY_ID_1",
         entityToGet.getRelatedEntities().values().iterator().next()
             .iterator().next());
   }
 
   @Test
-  public void testRelatingToOldEntityWithoutDomainId() throws IOException {
+  void testRelatingToOldEntityWithoutDomainId() throws IOException {
     // New entity is put in the default domain
     TimelineEntity entityToStore = new TimelineEntity();
     entityToStore.setEntityType("NEW_ENTITY_TYPE_1");
@@ -439,11 +439,11 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
 
     TimelineEntity entityToGet =
         store.getEntity("OLD_ENTITY_ID_1", "OLD_ENTITY_TYPE_1", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertNull(entityToGet.getDomainId());
-    Assert.assertEquals("NEW_ENTITY_TYPE_1",
+    assertNotNull(entityToGet);
+    assertNull(entityToGet.getDomainId());
+    assertEquals("NEW_ENTITY_TYPE_1",
         entityToGet.getRelatedEntities().keySet().iterator().next());
-    Assert.assertEquals("NEW_ENTITY_ID_1",
+    assertEquals("NEW_ENTITY_ID_1",
         entityToGet.getRelatedEntities().values().iterator().next()
             .iterator().next());
 
@@ -456,26 +456,26 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
     entities = new TimelineEntities();
     entities.addEntity(entityToStore);
     TimelinePutResponse response = store.put(entities);
-    Assert.assertEquals(1, response.getErrors().size());
-    Assert.assertEquals(TimelinePutError.FORBIDDEN_RELATION,
+    assertEquals(1, response.getErrors().size());
+    assertEquals(TimelinePutError.FORBIDDEN_RELATION,
         response.getErrors().get(0).getErrorCode());
     entityToGet =
         store.getEntity("OLD_ENTITY_ID_1", "OLD_ENTITY_TYPE_1", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertNull(entityToGet.getDomainId());
+    assertNotNull(entityToGet);
+    assertNull(entityToGet.getDomainId());
     // Still have one related entity
-    Assert.assertEquals(1, entityToGet.getRelatedEntities().keySet().size());
-    Assert.assertEquals(1, entityToGet.getRelatedEntities().values()
+    assertEquals(1, entityToGet.getRelatedEntities().keySet().size());
+    assertEquals(1, entityToGet.getRelatedEntities().values()
         .iterator().next().size());
   }
 
-  @Test
   /**
    * Test that LevelDb repair is attempted at least once during
    * serviceInit for LeveldbTimelineStore in case open fails the
    * first time.
    */
-  public void testLevelDbRepair() throws IOException {
+  @Test
+  void testLevelDbRepair() throws IOException {
     LeveldbTimelineStore store = new LeveldbTimelineStore();
 
     JniDBFactory factory = Mockito.mock(JniDBFactory.class);
@@ -496,8 +496,8 @@ public class TestLeveldbTimelineStore extends TimelineStoreTestUtils {
       Mockito.verify(factory, Mockito.times(1))
           .repair(Mockito.any(File.class), Mockito.any(Options.class));
       FileFilter fileFilter = new WildcardFileFilter(
-          "*" + LeveldbTimelineStore.BACKUP_EXT +"*");
-      Assert.assertTrue(path.listFiles(fileFilter).length > 0);
+          "*" + LeveldbTimelineStore.BACKUP_EXT + "*");
+      assertTrue(path.listFiles(fileFilter).length > 0);
     } finally {
       store.close();
       fsContext.delete(new Path(path.getAbsolutePath()), true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestMemoryTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestMemoryTimelineStore.java
@@ -18,14 +18,13 @@
 
 package org.apache.hadoop.yarn.server.timeline;
 
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
-import org.apache.hadoop.yarn.server.timeline.TimelineStore;
+import java.io.IOException;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 public class TestMemoryTimelineStore extends TimelineStoreTestUtils {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestMemoryTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestMemoryTimelineStore.java
@@ -21,15 +21,15 @@ package org.apache.hadoop.yarn.server.timeline;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 public class TestMemoryTimelineStore extends TimelineStoreTestUtils {
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     store = new MemoryTimelineStore();
     store.init(new YarnConfiguration());
@@ -39,7 +39,7 @@ public class TestMemoryTimelineStore extends TimelineStoreTestUtils {
     loadTestDomainData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDB.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDB.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 
 import org.apache.hadoop.conf.Configuration;
@@ -24,9 +26,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.iq80.leveldb.DB;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Test class for verification of RollingLevelDB. */
 public class TestRollingLevelDB {
@@ -53,7 +54,7 @@ public class TestRollingLevelDB {
     }
   };
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     lfs = FileSystem.getLocal(conf);
     File fsPath = new File("target", this.getClass().getSimpleName() +
@@ -65,26 +66,26 @@ public class TestRollingLevelDB {
   }
 
   @Test
-  public void testInsertAfterRollPeriodRollsDB() throws Exception {
+  void testInsertAfterRollPeriodRollsDB() throws Exception {
 
     rollingLevelDB.init(conf);
     long now = rollingLevelDB.currentTimeMillis();
     DB db = rollingLevelDB.getDBForStartTime(now);
     long startTime = rollingLevelDB.getStartTimeFor(db);
-    Assert.assertEquals("Received level db for incorrect start time",
-        rollingLevelDB.computeCurrentCheckMillis(now),
-        startTime);
+    assertEquals(rollingLevelDB.computeCurrentCheckMillis(now),
+        startTime,
+        "Received level db for incorrect start time");
     now = rollingLevelDB.getNextRollingTimeMillis();
     rollingLevelDB.setCurrentTimeMillis(now);
     db = rollingLevelDB.getDBForStartTime(now);
     startTime = rollingLevelDB.getStartTimeFor(db);
-    Assert.assertEquals("Received level db for incorrect start time",
-        rollingLevelDB.computeCurrentCheckMillis(now),
-        startTime);
+    assertEquals(rollingLevelDB.computeCurrentCheckMillis(now),
+        startTime,
+        "Received level db for incorrect start time");
   }
 
   @Test
-  public void testInsertForPreviousPeriodAfterRollPeriodRollsDB()
+  void testInsertForPreviousPeriodAfterRollPeriodRollsDB()
       throws Exception {
 
     rollingLevelDB.init(conf);
@@ -93,8 +94,8 @@ public class TestRollingLevelDB {
     rollingLevelDB.setCurrentTimeMillis(now);
     DB db = rollingLevelDB.getDBForStartTime(now - 1);
     long startTime = rollingLevelDB.getStartTimeFor(db);
-    Assert.assertEquals("Received level db for incorrect start time",
-        rollingLevelDB.computeCurrentCheckMillis(now - 1),
-        startTime);
+    assertEquals(rollingLevelDB.computeCurrentCheckMillis(now - 1),
+        startTime,
+        "Received level db for incorrect start time");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDB.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDB.java
@@ -17,17 +17,18 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.File;
+
+import org.iq80.leveldb.DB;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.iq80.leveldb.DB;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test class for verification of RollingLevelDB. */
 public class TestRollingLevelDB {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
@@ -17,14 +17,17 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+
+import org.eclipse.jetty.util.log.Log;
+import org.fusesource.leveldbjni.JniDBFactory;
+import org.iq80.leveldb.Options;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -43,13 +46,10 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse.TimelineP
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.records.Version;
 
-import org.fusesource.leveldbjni.JniDBFactory;
-import org.iq80.leveldb.Options;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.eclipse.jetty.util.log.Log;
-import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Test class to verify RollingLevelDBTimelineStore. */
 @InterfaceAudience.Private

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestRollingLevelDBTimelineStore.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -43,10 +45,9 @@ import org.apache.hadoop.yarn.server.records.Version;
 
 import org.fusesource.leveldbjni.JniDBFactory;
 import org.iq80.leveldb.Options;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.util.log.Log;
 import org.mockito.Mockito;
 
@@ -58,7 +59,7 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
   private File fsPath;
   private Configuration config = new YarnConfiguration();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     fsContext = FileContext.getLocalFSFileContext();
     fsPath = new File("target", this.getClass().getSimpleName() +
@@ -75,14 +76,14 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
     loadTestDomainData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.stop();
     fsContext.delete(new Path(fsPath.getAbsolutePath()), true);
   }
 
   @Test
-  public void testRootDirPermission() throws IOException {
+  void testRootDirPermission() throws IOException {
     FileSystem fs = FileSystem.getLocal(new YarnConfiguration());
     FileStatus file = fs.getFileStatus(new Path(fsPath.getAbsolutePath(),
         RollingLevelDBTimelineStore.FILENAME));
@@ -130,7 +131,7 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testCacheSizes() {
+  void testCacheSizes() {
     Configuration conf = new Configuration();
     assertEquals(10000,
         RollingLevelDBTimelineStore.getStartTimeReadCacheSize(conf));
@@ -150,48 +151,48 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testCheckVersion() throws IOException {
+  void testCheckVersion() throws IOException {
     RollingLevelDBTimelineStore dbStore = (RollingLevelDBTimelineStore) store;
     // default version
     Version defaultVersion = dbStore.getCurrentVersion();
-    Assert.assertEquals(defaultVersion, dbStore.loadVersion());
+    assertEquals(defaultVersion, dbStore.loadVersion());
 
     // compatible version
     Version compatibleVersion =
         Version.newInstance(defaultVersion.getMajorVersion(),
-          defaultVersion.getMinorVersion() + 2);
+            defaultVersion.getMinorVersion() + 2);
     dbStore.storeVersion(compatibleVersion);
-    Assert.assertEquals(compatibleVersion, dbStore.loadVersion());
+    assertEquals(compatibleVersion, dbStore.loadVersion());
     restartTimelineStore();
     dbStore = (RollingLevelDBTimelineStore) store;
     // overwrite the compatible version
-    Assert.assertEquals(defaultVersion, dbStore.loadVersion());
+    assertEquals(defaultVersion, dbStore.loadVersion());
 
     // incompatible version
     Version incompatibleVersion =
         Version.newInstance(defaultVersion.getMajorVersion() + 1,
-          defaultVersion.getMinorVersion());
+            defaultVersion.getMinorVersion());
     dbStore.storeVersion(incompatibleVersion);
     try {
       restartTimelineStore();
-      Assert.fail("Incompatible version, should expect fail here.");
+      fail("Incompatible version, should expect fail here.");
     } catch (ServiceStateException e) {
-      Assert.assertTrue("Exception message mismatch",
-          e.getMessage().contains("Incompatible version for timeline store"));
+      assertTrue(e.getMessage().contains("Incompatible version for timeline store"),
+          "Exception message mismatch");
     }
   }
 
   @Test
-  public void testValidateConfig() throws IOException {
+  void testValidateConfig() throws IOException {
     Configuration copyConfig = new YarnConfiguration(config);
     try {
       Configuration newConfig = new YarnConfiguration(copyConfig);
       newConfig.setLong(YarnConfiguration.TIMELINE_SERVICE_TTL_MS, 0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration.TIMELINE_SERVICE_TTL_MS));
     }
     try {
@@ -200,9 +201,9 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS, 0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_TTL_INTERVAL_MS));
     }
     try {
@@ -211,9 +212,9 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_READ_CACHE_SIZE, -1);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration.TIMELINE_SERVICE_LEVELDB_READ_CACHE_SIZE));
     }
     try {
@@ -223,25 +224,25 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
           0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration
-          .TIMELINE_SERVICE_LEVELDB_START_TIME_READ_CACHE_SIZE));
+              .TIMELINE_SERVICE_LEVELDB_START_TIME_READ_CACHE_SIZE));
     }
     try {
       Configuration newConfig = new YarnConfiguration(copyConfig);
       newConfig.setLong(
           YarnConfiguration
-          .TIMELINE_SERVICE_LEVELDB_START_TIME_WRITE_CACHE_SIZE,
+              .TIMELINE_SERVICE_LEVELDB_START_TIME_WRITE_CACHE_SIZE,
           0);
       config = newConfig;
       restartTimelineStore();
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           YarnConfiguration
-          .TIMELINE_SERVICE_LEVELDB_START_TIME_WRITE_CACHE_SIZE));
+              .TIMELINE_SERVICE_LEVELDB_START_TIME_WRITE_CACHE_SIZE));
     }
     config = copyConfig;
     restartTimelineStore();
@@ -268,7 +269,7 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testRelatingToNonExistingEntity() throws IOException {
+  void testRelatingToNonExistingEntity() throws IOException {
     TimelineEntity entityToStore = new TimelineEntity();
     entityToStore.setEntityType("TEST_ENTITY_TYPE_1");
     entityToStore.setEntityId("TEST_ENTITY_ID_1");
@@ -279,17 +280,17 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
     store.put(entities);
     TimelineEntity entityToGet =
         store.getEntity("TEST_ENTITY_ID_2", "TEST_ENTITY_TYPE_2", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertEquals("DEFAULT", entityToGet.getDomainId());
-    Assert.assertEquals("TEST_ENTITY_TYPE_1",
+    assertNotNull(entityToGet);
+    assertEquals("DEFAULT", entityToGet.getDomainId());
+    assertEquals("TEST_ENTITY_TYPE_1",
         entityToGet.getRelatedEntities().keySet().iterator().next());
-    Assert.assertEquals("TEST_ENTITY_ID_1",
+    assertEquals("TEST_ENTITY_ID_1",
         entityToGet.getRelatedEntities().values().iterator().next()
             .iterator().next());
   }
 
   @Test
-  public void testRelatingToEntityInSamePut() throws IOException {
+  void testRelatingToEntityInSamePut() throws IOException {
     TimelineEntity entityToRelate = new TimelineEntity();
     entityToRelate.setEntityType("TEST_ENTITY_TYPE_2");
     entityToRelate.setEntityId("TEST_ENTITY_ID_2");
@@ -305,17 +306,17 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
     store.put(entities);
     TimelineEntity entityToGet =
         store.getEntity("TEST_ENTITY_ID_2", "TEST_ENTITY_TYPE_2", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertEquals("TEST_DOMAIN", entityToGet.getDomainId());
-    Assert.assertEquals("TEST_ENTITY_TYPE_1",
+    assertNotNull(entityToGet);
+    assertEquals("TEST_DOMAIN", entityToGet.getDomainId());
+    assertEquals("TEST_ENTITY_TYPE_1",
         entityToGet.getRelatedEntities().keySet().iterator().next());
-    Assert.assertEquals("TEST_ENTITY_ID_1",
+    assertEquals("TEST_ENTITY_ID_1",
         entityToGet.getRelatedEntities().values().iterator().next()
             .iterator().next());
   }
 
   @Test
-  public void testRelatingToOldEntityWithoutDomainId() throws IOException {
+  void testRelatingToOldEntityWithoutDomainId() throws IOException {
     // New entity is put in the default domain
     TimelineEntity entityToStore = new TimelineEntity();
     entityToStore.setEntityType("NEW_ENTITY_TYPE_1");
@@ -328,11 +329,11 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
 
     TimelineEntity entityToGet =
         store.getEntity("OLD_ENTITY_ID_1", "OLD_ENTITY_TYPE_1", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertEquals("DEFAULT", entityToGet.getDomainId());
-    Assert.assertEquals("NEW_ENTITY_TYPE_1",
+    assertNotNull(entityToGet);
+    assertEquals("DEFAULT", entityToGet.getDomainId());
+    assertEquals("NEW_ENTITY_TYPE_1",
         entityToGet.getRelatedEntities().keySet().iterator().next());
-    Assert.assertEquals("NEW_ENTITY_ID_1",
+    assertEquals("NEW_ENTITY_ID_1",
         entityToGet.getRelatedEntities().values().iterator().next()
             .iterator().next());
 
@@ -345,16 +346,16 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
     entities = new TimelineEntities();
     entities.addEntity(entityToStore);
     TimelinePutResponse response = store.put(entities);
-    Assert.assertEquals(1, response.getErrors().size());
-    Assert.assertEquals(TimelinePutError.FORBIDDEN_RELATION,
+    assertEquals(1, response.getErrors().size());
+    assertEquals(TimelinePutError.FORBIDDEN_RELATION,
         response.getErrors().get(0).getErrorCode());
     entityToGet =
         store.getEntity("OLD_ENTITY_ID_1", "OLD_ENTITY_TYPE_1", null);
-    Assert.assertNotNull(entityToGet);
-    Assert.assertEquals("DEFAULT", entityToGet.getDomainId());
+    assertNotNull(entityToGet);
+    assertEquals("DEFAULT", entityToGet.getDomainId());
     // Still have one related entity
-    Assert.assertEquals(1, entityToGet.getRelatedEntities().keySet().size());
-    Assert.assertEquals(1, entityToGet.getRelatedEntities().values()
+    assertEquals(1, entityToGet.getRelatedEntities().keySet().size());
+    assertEquals(1, entityToGet.getRelatedEntities().values()
         .iterator().next().size());
   }
 
@@ -423,12 +424,12 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
     Log.getLog().info("Duration for " + num + ": " + duration);
   }
 
-  @Test
   /**
    * Test that RollingLevelDb repair is attempted at least once during
    * serviceInit for RollingLeveldbTimelineStore in case open fails the
    * first time.
-   */ public void testLevelDbRepair() throws IOException {
+   */ @Test
+  void testLevelDbRepair() throws IOException {
     RollingLevelDBTimelineStore store = new RollingLevelDBTimelineStore();
     JniDBFactory factory = Mockito.mock(JniDBFactory.class);
     Mockito.when(factory.open(Mockito.any(File.class), Mockito.any(Options.class)))
@@ -445,7 +446,7 @@ public class TestRollingLevelDBTimelineStore extends TimelineStoreTestUtils {
           .repair(Mockito.any(File.class), Mockito.any(Options.class));
       FilenameFilter fileFilter =
           new WildcardFileFilter("*" + RollingLevelDBTimelineStore.BACKUP_EXT + "*");
-      Assert.assertTrue(new File(path.getAbsolutePath(), RollingLevelDBTimelineStore.FILENAME)
+      assertTrue(new File(path.getAbsolutePath(), RollingLevelDBTimelineStore.FILENAME)
           .list(fileFilter).length > 0);
     } finally {
       store.close();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestTimelineDataManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestTimelineDataManager.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import java.io.File;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -34,9 +34,10 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.AdminACLsManager;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 public class TestTimelineDataManager extends TimelineStoreTestUtils {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestTimelineDataManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestTimelineDataManager.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.timeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.File;
 
 import org.apache.hadoop.conf.Configuration;
@@ -30,10 +34,9 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.AdminACLsManager;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 public class TestTimelineDataManager extends TimelineStoreTestUtils {
@@ -43,7 +46,7 @@ public class TestTimelineDataManager extends TimelineStoreTestUtils {
   private TimelineDataManager dataManaer;
   private static TimelineACLsManager aclsManager;
   private static AdminACLsManager adminACLsManager;
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     fsPath = new File("target", this.getClass().getSimpleName() +
         "-tmpDir").getAbsoluteFile();
@@ -70,7 +73,7 @@ public class TestTimelineDataManager extends TimelineStoreTestUtils {
     adminACLsManager = new AdminACLsManager(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (store != null) {
       store.stop();
@@ -81,55 +84,55 @@ public class TestTimelineDataManager extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testGetOldEntityWithOutDomainId() throws Exception {
+  void testGetOldEntityWithOutDomainId() throws Exception {
     TimelineEntity entity = dataManaer.getEntity(
         "OLD_ENTITY_TYPE_1", "OLD_ENTITY_ID_1", null,
         UserGroupInformation.getCurrentUser());
-    Assert.assertNotNull(entity);
-    Assert.assertEquals("OLD_ENTITY_ID_1", entity.getEntityId());
-    Assert.assertEquals("OLD_ENTITY_TYPE_1", entity.getEntityType());
-    Assert.assertEquals(
+    assertNotNull(entity);
+    assertEquals("OLD_ENTITY_ID_1", entity.getEntityId());
+    assertEquals("OLD_ENTITY_TYPE_1", entity.getEntityType());
+    assertEquals(
         TimelineDataManager.DEFAULT_DOMAIN_ID, entity.getDomainId());
   }
 
   @Test
-  public void testGetEntitiesAclEnabled() throws Exception {
+  void testGetEntitiesAclEnabled() throws Exception {
     AdminACLsManager oldAdminACLsManager =
-      aclsManager.setAdminACLsManager(adminACLsManager);
+        aclsManager.setAdminACLsManager(adminACLsManager);
     try {
       TimelineEntities entities = dataManaer.getEntities(
-        "ACL_ENTITY_TYPE_1", null, null, null, null, null, null, 1l, null,
-        UserGroupInformation.createUserForTesting("owner_1", new String[] {"group1"}));
-      Assert.assertEquals(1, entities.getEntities().size());
-      Assert.assertEquals("ACL_ENTITY_ID_11",
-        entities.getEntities().get(0).getEntityId());
+          "ACL_ENTITY_TYPE_1", null, null, null, null, null, null, 1l, null,
+          UserGroupInformation.createUserForTesting("owner_1", new String[]{"group1"}));
+      assertEquals(1, entities.getEntities().size());
+      assertEquals("ACL_ENTITY_ID_11",
+          entities.getEntities().get(0).getEntityId());
     } finally {
       aclsManager.setAdminACLsManager(oldAdminACLsManager);
     }
   }
 
   @Test
-  public void testGetOldEntitiesWithOutDomainId() throws Exception {
+  void testGetOldEntitiesWithOutDomainId() throws Exception {
     TimelineEntities entities = dataManaer.getEntities(
         "OLD_ENTITY_TYPE_1", null, null, null, null, null, null, null, null,
         UserGroupInformation.getCurrentUser());
-    Assert.assertEquals(2, entities.getEntities().size());
-    Assert.assertEquals("OLD_ENTITY_ID_2",
+    assertEquals(2, entities.getEntities().size());
+    assertEquals("OLD_ENTITY_ID_2",
         entities.getEntities().get(0).getEntityId());
-    Assert.assertEquals("OLD_ENTITY_TYPE_1",
+    assertEquals("OLD_ENTITY_TYPE_1",
         entities.getEntities().get(0).getEntityType());
-    Assert.assertEquals(TimelineDataManager.DEFAULT_DOMAIN_ID,
+    assertEquals(TimelineDataManager.DEFAULT_DOMAIN_ID,
         entities.getEntities().get(0).getDomainId());
-    Assert.assertEquals("OLD_ENTITY_ID_1",
+    assertEquals("OLD_ENTITY_ID_1",
         entities.getEntities().get(1).getEntityId());
-    Assert.assertEquals("OLD_ENTITY_TYPE_1",
+    assertEquals("OLD_ENTITY_TYPE_1",
         entities.getEntities().get(1).getEntityType());
-    Assert.assertEquals(TimelineDataManager.DEFAULT_DOMAIN_ID,
+    assertEquals(TimelineDataManager.DEFAULT_DOMAIN_ID,
         entities.getEntities().get(1).getDomainId());
   }
 
   @Test
-  public void testUpdatingOldEntityWithoutDomainId() throws Exception {
+  void testUpdatingOldEntityWithoutDomainId() throws Exception {
     // Set the domain to the default domain when updating
     TimelineEntity entity = new TimelineEntity();
     entity.setEntityType("OLD_ENTITY_TYPE_1");
@@ -140,18 +143,18 @@ public class TestTimelineDataManager extends TimelineStoreTestUtils {
     entities.addEntity(entity);
     TimelinePutResponse response = dataManaer.postEntities(
         entities, UserGroupInformation.getCurrentUser());
-    Assert.assertEquals(0, response.getErrors().size());
+    assertEquals(0, response.getErrors().size());
     entity = store.getEntity("OLD_ENTITY_ID_1", "OLD_ENTITY_TYPE_1", null);
-    Assert.assertNotNull(entity);
+    assertNotNull(entity);
     // Even in leveldb, the domain is updated to the default domain Id
-    Assert.assertEquals(
+    assertEquals(
         TimelineDataManager.DEFAULT_DOMAIN_ID, entity.getDomainId());
-    Assert.assertEquals(1, entity.getOtherInfo().size());
-    Assert.assertEquals("NEW_OTHER_INFO_KEY",
+    assertEquals(1, entity.getOtherInfo().size());
+    assertEquals("NEW_OTHER_INFO_KEY",
         entity.getOtherInfo().keySet().iterator().next());
-    Assert.assertEquals("NEW_OTHER_INFO_VALUE",
+    assertEquals("NEW_OTHER_INFO_VALUE",
         entity.getOtherInfo().values().iterator().next());
-    
+
     // Set the domain to the non-default domain when updating
     entity = new TimelineEntity();
     entity.setEntityType("OLD_ENTITY_TYPE_1");
@@ -162,15 +165,15 @@ public class TestTimelineDataManager extends TimelineStoreTestUtils {
     entities.addEntity(entity);
     response = dataManaer.postEntities(
         entities, UserGroupInformation.getCurrentUser());
-    Assert.assertEquals(1, response.getErrors().size());
-    Assert.assertEquals(TimelinePutResponse.TimelinePutError.ACCESS_DENIED,
+    assertEquals(1, response.getErrors().size());
+    assertEquals(TimelinePutResponse.TimelinePutError.ACCESS_DENIED,
         response.getErrors().get(0).getErrorCode());
     entity = store.getEntity("OLD_ENTITY_ID_2", "OLD_ENTITY_TYPE_1", null);
-    Assert.assertNotNull(entity);
+    assertNotNull(entity);
     // In leveldb, the domain Id is still null
-    Assert.assertNull(entity.getDomainId());
+    assertNull(entity.getDomainId());
     // Updating is not executed
-    Assert.assertEquals(0, entity.getOtherInfo().size());
+    assertEquals(0, entity.getOtherInfo().size());
   }
   
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestTimelineDataManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TestTimelineDataManager.java
@@ -101,7 +101,7 @@ public class TestTimelineDataManager extends TimelineStoreTestUtils {
         aclsManager.setAdminACLsManager(adminACLsManager);
     try {
       TimelineEntities entities = dataManaer.getEntities(
-          "ACL_ENTITY_TYPE_1", null, null, null, null, null, null, 1l, null,
+          "ACL_ENTITY_TYPE_1", null, null, null, null, null, null, 1L, null,
           UserGroupInformation.createUserForTesting("owner_1", new String[]{"group1"}));
       assertEquals(1, entities.getEntities().size());
       assertEquals("ACL_ENTITY_ID_11",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TimelineStoreTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TimelineStoreTestUtils.java
@@ -17,10 +17,6 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,15 +31,19 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.hadoop.yarn.api.records.timeline.TimelineDomain;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineDomains;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntities;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEvents.EventsOfOneEntity;
-import org.apache.hadoop.yarn.api.records.timeline.TimelineDomain;
-import org.apache.hadoop.yarn.api.records.timeline.TimelineDomains;
 import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse;
 import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse.TimelinePutError;
 import org.apache.hadoop.yarn.server.timeline.TimelineReader.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TimelineStoreTestUtils {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TimelineStoreTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/TimelineStoreTestUtils.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.timeline;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -503,18 +503,24 @@ public class TimelineStoreTestUtils {
 
   public void testGetEntities() throws IOException {
     // test getting entities
-    assertEquals("nonzero entities size for nonexistent type", 0,
-        getEntities("type_0").size());
-    assertEquals("nonzero entities size for nonexistent type", 0,
-        getEntities("type_3").size());
-    assertEquals("nonzero entities size for nonexistent type", 0,
-        getEntities("type_6").size());
-    assertEquals("nonzero entities size for nonexistent type", 0,
-        getEntitiesWithPrimaryFilter("type_0", userFilter).size());
-    assertEquals("nonzero entities size for nonexistent type", 0,
-        getEntitiesWithPrimaryFilter("type_3", userFilter).size());
-    assertEquals("nonzero entities size for nonexistent type", 0,
-        getEntitiesWithPrimaryFilter("type_6", userFilter).size());
+    assertEquals(0,
+        getEntities("type_0").size(),
+        "nonzero entities size for nonexistent type");
+    assertEquals(0,
+        getEntities("type_3").size(),
+        "nonzero entities size for nonexistent type");
+    assertEquals(0,
+        getEntities("type_6").size(),
+        "nonzero entities size for nonexistent type");
+    assertEquals(0,
+        getEntitiesWithPrimaryFilter("type_0", userFilter).size(),
+        "nonzero entities size for nonexistent type");
+    assertEquals(0,
+        getEntitiesWithPrimaryFilter("type_3", userFilter).size(),
+        "nonzero entities size for nonexistent type");
+    assertEquals(0,
+        getEntitiesWithPrimaryFilter("type_6", userFilter).size(),
+        "nonzero entities size for nonexistent type");
 
     List<TimelineEntity> entities = getEntities("type_1");
     assertEquals(3, entities.size());
@@ -681,15 +687,18 @@ public class TimelineStoreTestUtils {
 
   public void testGetEntitiesWithPrimaryFilters() throws IOException {
     // test using primary filter
-    assertEquals("nonzero entities size for primary filter", 0,
+    assertEquals(0,
         getEntitiesWithPrimaryFilter("type_1",
-            new NameValuePair("none", "none")).size());
-    assertEquals("nonzero entities size for primary filter", 0,
+            new NameValuePair("none", "none")).size(),
+        "nonzero entities size for primary filter");
+    assertEquals(0,
         getEntitiesWithPrimaryFilter("type_2",
-            new NameValuePair("none", "none")).size());
-    assertEquals("nonzero entities size for primary filter", 0,
+            new NameValuePair("none", "none")).size(),
+        "nonzero entities size for primary filter");
+    assertEquals(0,
         getEntitiesWithPrimaryFilter("type_3",
-            new NameValuePair("none", "none")).size());
+            new NameValuePair("none", "none")).size(),
+        "nonzero entities size for primary filter");
 
     List<TimelineEntity> entities = getEntitiesWithPrimaryFilter("type_1",
         userFilter);
@@ -927,13 +936,12 @@ public class TimelineStoreTestUtils {
     if (primaryFilters == null) {
       assertNull(retrievedEntityInfo.getPrimaryFilters());
     } else {
-      assertTrue(primaryFilters.equals(
-          retrievedEntityInfo.getPrimaryFilters()));
+      assertEquals(primaryFilters, retrievedEntityInfo.getPrimaryFilters());
     }
     if (otherInfo == null) {
       assertNull(retrievedEntityInfo.getOtherInfo());
     } else {
-      assertTrue(otherInfo.equals(retrievedEntityInfo.getOtherInfo()));
+      assertEquals(otherInfo, retrievedEntityInfo.getOtherInfo());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/recovery/TestLeveldbTimelineStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/recovery/TestLeveldbTimelineStateStore.java
@@ -18,13 +18,12 @@
 
 package org.apache.hadoop.yarn.server.timeline.recovery;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.File;
 import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -36,9 +35,11 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.client.TimelineDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.timeline.recovery.TimelineStateStore.TimelineServiceState;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestLeveldbTimelineStateStore {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/recovery/TestLeveldbTimelineStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/recovery/TestLeveldbTimelineStateStore.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.yarn.server.timeline.recovery;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,10 +36,9 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.client.TimelineDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.timeline.recovery.TimelineStateStore.TimelineServiceState;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestLeveldbTimelineStateStore {
 
@@ -48,7 +47,7 @@ public class TestLeveldbTimelineStateStore {
   private Configuration conf;
   private TimelineStateStore store;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     fsPath = new File("target", getClass().getSimpleName() +
         "-tmpDir").getAbsoluteFile();
@@ -63,7 +62,7 @@ public class TestLeveldbTimelineStateStore {
         fsPath.getAbsolutePath());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (store != null) {
       store.stop();
@@ -81,11 +80,11 @@ public class TestLeveldbTimelineStateStore {
   }
 
   @Test
-  public void testTokenStore() throws Exception {
+  void testTokenStore() throws Exception {
     initAndStartTimelineServiceStateStoreService();
     TimelineServiceState state = store.loadState();
-    assertTrue("token state not empty", state.tokenState.isEmpty());
-    assertTrue("key state not empty", state.tokenMasterKeyState.isEmpty());
+    assertTrue(state.tokenState.isEmpty(), "token state not empty");
+    assertTrue(state.tokenMasterKeyState.isEmpty(), "key state not empty");
 
     final DelegationKey key1 = new DelegationKey(1, 2, "keyData1".getBytes());
     final TimelineDelegationTokenIdentifier token1 =
@@ -120,19 +119,23 @@ public class TestLeveldbTimelineStateStore {
 
     initAndStartTimelineServiceStateStoreService();
     state = store.loadState();
-    assertEquals("incorrect loaded token count", 2, state.tokenState.size());
-    assertTrue("missing token 1", state.tokenState.containsKey(token1));
-    assertEquals("incorrect token 1 date", tokenDate1,
-        state.tokenState.get(token1));
-    assertTrue("missing token 2", state.tokenState.containsKey(token2));
-    assertEquals("incorrect token 2 date", tokenDate2,
-        state.tokenState.get(token2));
-    assertEquals("incorrect master key count", 1,
-        state.tokenMasterKeyState.size());
-    assertTrue("missing master key 1",
-        state.tokenMasterKeyState.contains(key1));
-    assertEquals("incorrect latest sequence number", 12345678,
-        state.getLatestSequenceNumber());
+    assertEquals(2, state.tokenState.size(), "incorrect loaded token count");
+    assertTrue(state.tokenState.containsKey(token1), "missing token 1");
+    assertEquals(tokenDate1,
+        state.tokenState.get(token1),
+        "incorrect token 1 date");
+    assertTrue(state.tokenState.containsKey(token2), "missing token 2");
+    assertEquals(tokenDate2,
+        state.tokenState.get(token2),
+        "incorrect token 2 date");
+    assertEquals(1,
+        state.tokenMasterKeyState.size(),
+        "incorrect master key count");
+    assertTrue(state.tokenMasterKeyState.contains(key1),
+        "missing master key 1");
+    assertEquals(12345678,
+        state.getLatestSequenceNumber(),
+        "incorrect latest sequence number");
 
     final DelegationKey key2 = new DelegationKey(3, 4, "keyData2".getBytes());
     final DelegationKey key3 = new DelegationKey(5, 6, "keyData3".getBytes());
@@ -154,46 +157,50 @@ public class TestLeveldbTimelineStateStore {
 
     initAndStartTimelineServiceStateStoreService();
     state = store.loadState();
-    assertEquals("incorrect loaded token count", 2, state.tokenState.size());
-    assertFalse("token 1 not removed", state.tokenState.containsKey(token1));
-    assertTrue("missing token 2", state.tokenState.containsKey(token2));
-    assertEquals("incorrect token 2 date", newTokenDate2,
-        state.tokenState.get(token2));
-    assertTrue("missing token 3", state.tokenState.containsKey(token3));
-    assertEquals("incorrect token 3 date", tokenDate3,
-        state.tokenState.get(token3));
-    assertEquals("incorrect master key count", 2,
-        state.tokenMasterKeyState.size());
-    assertFalse("master key 1 not removed",
-        state.tokenMasterKeyState.contains(key1));
-    assertTrue("missing master key 2",
-        state.tokenMasterKeyState.contains(key2));
-    assertTrue("missing master key 3",
-        state.tokenMasterKeyState.contains(key3));
-    assertEquals("incorrect latest sequence number", 12345679,
-        state.getLatestSequenceNumber());
+    assertEquals(2, state.tokenState.size(), "incorrect loaded token count");
+    assertFalse(state.tokenState.containsKey(token1), "token 1 not removed");
+    assertTrue(state.tokenState.containsKey(token2), "missing token 2");
+    assertEquals(newTokenDate2,
+        state.tokenState.get(token2),
+        "incorrect token 2 date");
+    assertTrue(state.tokenState.containsKey(token3), "missing token 3");
+    assertEquals(tokenDate3,
+        state.tokenState.get(token3),
+        "incorrect token 3 date");
+    assertEquals(2,
+        state.tokenMasterKeyState.size(),
+        "incorrect master key count");
+    assertFalse(state.tokenMasterKeyState.contains(key1),
+        "master key 1 not removed");
+    assertTrue(state.tokenMasterKeyState.contains(key2),
+        "missing master key 2");
+    assertTrue(state.tokenMasterKeyState.contains(key3),
+        "missing master key 3");
+    assertEquals(12345679,
+        state.getLatestSequenceNumber(),
+        "incorrect latest sequence number");
     store.close();
   }
 
   @Test
-  public void testCheckVersion() throws IOException {
+  void testCheckVersion() throws IOException {
     LeveldbTimelineStateStore store =
         initAndStartTimelineServiceStateStoreService();
     // default version
     Version defaultVersion = store.getCurrentVersion();
-    Assert.assertEquals(defaultVersion, store.loadVersion());
+    assertEquals(defaultVersion, store.loadVersion());
 
     // compatible version
     Version compatibleVersion =
         Version.newInstance(defaultVersion.getMajorVersion(),
             defaultVersion.getMinorVersion() + 2);
     store.storeVersion(compatibleVersion);
-    Assert.assertEquals(compatibleVersion, store.loadVersion());
+    assertEquals(compatibleVersion, store.loadVersion());
     store.stop();
 
     // overwrite the compatible version
     store = initAndStartTimelineServiceStateStoreService();
-    Assert.assertEquals(defaultVersion, store.loadVersion());
+    assertEquals(defaultVersion, store.loadVersion());
 
     // incompatible version
     Version incompatibleVersion =
@@ -204,10 +211,10 @@ public class TestLeveldbTimelineStateStore {
 
     try {
       initAndStartTimelineServiceStateStoreService();
-      Assert.fail("Incompatible version, should expect fail here.");
+      fail("Incompatible version, should expect fail here.");
     } catch (ServiceStateException e) {
-      Assert.assertTrue("Exception message mismatch",
-          e.getMessage().contains("Incompatible version for timeline state store"));
+      assertTrue(e.getMessage().contains("Incompatible version for timeline state store"),
+          "Exception message mismatch");
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineACLsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineACLsManager.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.timeline.security;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -29,8 +33,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTimelineACLsManager {
 
@@ -45,7 +48,7 @@ public class TestTimelineACLsManager {
   }
 
   @Test
-  public void testYarnACLsNotEnabledForEntity() throws Exception {
+  void testYarnACLsNotEnabledForEntity() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, false);
     TimelineACLsManager timelineACLsManager =
@@ -56,20 +59,20 @@ public class TestTimelineACLsManager {
         TimelineStore.SystemFilter.ENTITY_OWNER
             .toString(), "owner");
     entity.setDomainId("domain_id_1");
-    Assert.assertTrue(
-        "Always true when ACLs are not enabled",
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("user"),
-            ApplicationAccessType.VIEW_APP, entity));
-    Assert.assertTrue(
-        "Always true when ACLs are not enabled",
+            ApplicationAccessType.VIEW_APP, entity),
+        "Always true when ACLs are not enabled");
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("user"),
-            ApplicationAccessType.MODIFY_APP, entity));
+            ApplicationAccessType.MODIFY_APP, entity),
+        "Always true when ACLs are not enabled");
   }
 
   @Test
-  public void testYarnACLsEnabledForEntity() throws Exception {
+  void testYarnACLsEnabledForEntity() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
     conf.set(YarnConfiguration.YARN_ADMIN_ACL, "admin");
@@ -81,51 +84,51 @@ public class TestTimelineACLsManager {
         TimelineStore.SystemFilter.ENTITY_OWNER
             .toString(), "owner");
     entity.setDomainId("domain_id_1");
-    Assert.assertTrue(
-        "Owner should be allowed to view",
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("owner"),
-            ApplicationAccessType.VIEW_APP, entity));
-    Assert.assertTrue(
-        "Reader should be allowed to view",
+            ApplicationAccessType.VIEW_APP, entity),
+        "Owner should be allowed to view");
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("reader"),
-            ApplicationAccessType.VIEW_APP, entity));
-    Assert.assertFalse(
-        "Other shouldn't be allowed to view",
+            ApplicationAccessType.VIEW_APP, entity),
+        "Reader should be allowed to view");
+    assertFalse(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("other"),
-            ApplicationAccessType.VIEW_APP, entity));
-    Assert.assertTrue(
-        "Admin should be allowed to view",
+            ApplicationAccessType.VIEW_APP, entity),
+        "Other shouldn't be allowed to view");
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("admin"),
-            ApplicationAccessType.VIEW_APP, entity));
+            ApplicationAccessType.VIEW_APP, entity),
+        "Admin should be allowed to view");
 
-    Assert.assertTrue(
-        "Owner should be allowed to modify",
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("owner"),
-            ApplicationAccessType.MODIFY_APP, entity));
-    Assert.assertTrue(
-        "Writer should be allowed to modify",
+            ApplicationAccessType.MODIFY_APP, entity),
+        "Owner should be allowed to modify");
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("writer"),
-            ApplicationAccessType.MODIFY_APP, entity));
-    Assert.assertFalse(
-        "Other shouldn't be allowed to modify",
+            ApplicationAccessType.MODIFY_APP, entity),
+        "Writer should be allowed to modify");
+    assertFalse(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("other"),
-            ApplicationAccessType.MODIFY_APP, entity));
-    Assert.assertTrue(
-        "Admin should be allowed to modify",
+            ApplicationAccessType.MODIFY_APP, entity),
+        "Other shouldn't be allowed to modify");
+    assertTrue(
         timelineACLsManager.checkAccess(
             UserGroupInformation.createRemoteUser("admin"),
-            ApplicationAccessType.MODIFY_APP, entity));
+            ApplicationAccessType.MODIFY_APP, entity),
+        "Admin should be allowed to modify");
   }
 
   @Test
-  public void testCorruptedOwnerInfoForEntity() throws Exception {
+  void testCorruptedOwnerInfoForEntity() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
     conf.set(YarnConfiguration.YARN_ADMIN_ACL, "owner");
@@ -137,29 +140,29 @@ public class TestTimelineACLsManager {
       timelineACLsManager.checkAccess(
           UserGroupInformation.createRemoteUser("owner"),
           ApplicationAccessType.VIEW_APP, entity);
-      Assert.fail("Exception is expected");
+      fail("Exception is expected");
     } catch (YarnException e) {
-      Assert.assertTrue("It's not the exact expected exception", e.getMessage()
-          .contains("doesn't exist."));
+      assertTrue(e.getMessage()
+          .contains("doesn't exist."), "It's not the exact expected exception");
     }
   }
 
   @Test
-  public void testYarnACLsNotEnabledForDomain() throws Exception {
+  void testYarnACLsNotEnabledForDomain() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, false);
     TimelineACLsManager timelineACLsManager =
         new TimelineACLsManager(conf);
     TimelineDomain domain = new TimelineDomain();
     domain.setOwner("owner");
-    Assert.assertTrue(
-        "Always true when ACLs are not enabled",
+    assertTrue(
         timelineACLsManager.checkAccess(
-            UserGroupInformation.createRemoteUser("user"), domain));
+            UserGroupInformation.createRemoteUser("user"), domain),
+        "Always true when ACLs are not enabled");
   }
 
   @Test
-  public void testYarnACLsEnabledForDomain() throws Exception {
+  void testYarnACLsEnabledForDomain() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
     conf.set(YarnConfiguration.YARN_ADMIN_ACL, "admin");
@@ -167,22 +170,22 @@ public class TestTimelineACLsManager {
         new TimelineACLsManager(conf);
     TimelineDomain domain = new TimelineDomain();
     domain.setOwner("owner");
-    Assert.assertTrue(
-        "Owner should be allowed to access",
+    assertTrue(
         timelineACLsManager.checkAccess(
-            UserGroupInformation.createRemoteUser("owner"), domain));
-    Assert.assertFalse(
-        "Other shouldn't be allowed to access",
+            UserGroupInformation.createRemoteUser("owner"), domain),
+        "Owner should be allowed to access");
+    assertFalse(
         timelineACLsManager.checkAccess(
-            UserGroupInformation.createRemoteUser("other"), domain));
-    Assert.assertTrue(
-        "Admin should be allowed to access",
+            UserGroupInformation.createRemoteUser("other"), domain),
+        "Other shouldn't be allowed to access");
+    assertTrue(
         timelineACLsManager.checkAccess(
-            UserGroupInformation.createRemoteUser("admin"), domain));
+            UserGroupInformation.createRemoteUser("admin"), domain),
+        "Admin should be allowed to access");
   }
 
   @Test
-  public void testCorruptedOwnerInfoForDomain() throws Exception {
+  void testCorruptedOwnerInfoForDomain() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
     conf.set(YarnConfiguration.YARN_ADMIN_ACL, "owner");
@@ -192,10 +195,10 @@ public class TestTimelineACLsManager {
     try {
       timelineACLsManager.checkAccess(
           UserGroupInformation.createRemoteUser("owner"), domain);
-      Assert.fail("Exception is expected");
+      fail("Exception is expected");
     } catch (YarnException e) {
-      Assert.assertTrue("It's not the exact expected exception", e.getMessage()
-          .contains("is corrupted."));
+      assertTrue(e.getMessage()
+          .contains("is corrupted."), "It's not the exact expected exception");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineACLsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineACLsManager.java
@@ -18,11 +18,9 @@
 
 package org.apache.hadoop.yarn.server.timeline.security;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -33,7 +31,10 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestTimelineACLsManager {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java
@@ -24,6 +24,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileUtil;
@@ -46,19 +53,13 @@ import org.apache.hadoop.yarn.security.client.TimelineDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistoryServer;
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
+
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.TIMELINE_HTTP_AUTH_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test cases for authentication via TimelineAuthenticationFilter while

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java
@@ -47,14 +47,16 @@ import org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistor
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.TIMELINE_HTTP_AUTH_PREFIX;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +64,6 @@ import org.slf4j.LoggerFactory;
  * Test cases for authentication via TimelineAuthenticationFilter while
  * publishing entities for ATSv1.
  */
-@RunWith(Parameterized.class)
 public class TestTimelineAuthenticationFilterForV1 {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestTimelineAuthenticationFilterForV1.class);
@@ -74,7 +75,7 @@ public class TestTimelineAuthenticationFilterForV1 {
 
   private static final File TEST_ROOT_DIR = new File(
       System.getProperty("test.build.dir", "target/test-dir"),
-          TestTimelineAuthenticationFilterForV1.class.getName() + "-root");
+      TestTimelineAuthenticationFilterForV1.class.getName() + "-root");
   private static final File httpSpnegoKeytabFile = new File(
       KerberosTestUtils.getKeytabFile());
   private static final String httpSpnegoPrincipal =
@@ -83,9 +84,8 @@ public class TestTimelineAuthenticationFilterForV1 {
       System.getProperty("test.build.dir", "target/test-dir") + "/"
           + TestTimelineAuthenticationFilterForV1.class.getSimpleName();
 
-  @Parameterized.Parameters
   public static Collection<Object[]> withSsl() {
-    return Arrays.asList(new Object[][] {{false}, {true}});
+    return Arrays.asList(new Object[][]{{false}, {true}});
   }
 
   private static MiniKdc testMiniKDC;
@@ -95,11 +95,11 @@ public class TestTimelineAuthenticationFilterForV1 {
   private static Configuration conf;
   private static boolean withSsl;
 
-  public TestTimelineAuthenticationFilterForV1(boolean withSsl) {
+  public void initTestTimelineAuthenticationFilterForV1(boolean withSsl) {
     TestTimelineAuthenticationFilterForV1.withSsl = withSsl;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     try {
       testMiniKDC = new MiniKdc(MiniKdc.createConf(), TEST_ROOT_DIR);
@@ -167,7 +167,7 @@ public class TestTimelineAuthenticationFilterForV1 {
     return client;
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (testMiniKDC != null) {
       testMiniKDC.stop();
@@ -184,8 +184,10 @@ public class TestTimelineAuthenticationFilterForV1 {
     }
   }
 
-  @Test
-  public void testPutTimelineEntities() throws Exception {
+  @MethodSource("withSsl")
+  @ParameterizedTest
+  void testPutTimelineEntities(boolean withSsl) throws Exception {
+    initTestTimelineAuthenticationFilterForV1(withSsl);
     KerberosTestUtils.doAs(PRINCIPAL, new Callable<Void>() {
       @Override
       public Void call() throws Exception {
@@ -199,20 +201,22 @@ public class TestTimelineAuthenticationFilterForV1 {
         if (putResponse.getErrors().size() > 0) {
           LOG.error("putResponse errors: {}", putResponse.getErrors());
         }
-        Assert.assertTrue("There were some errors in the putResponse",
-            putResponse.getErrors().isEmpty());
+        assertTrue(putResponse.getErrors().isEmpty(),
+            "There were some errors in the putResponse");
         TimelineEntity entityToRead =
             testTimelineServer.getTimelineStore().getEntity("entity1",
                 TestTimelineAuthenticationFilterForV1.class.getName(), null);
-        Assert.assertNotNull("Timeline entity should not be null",
-            entityToRead);
+        assertNotNull(entityToRead,
+            "Timeline entity should not be null");
         return null;
       }
     });
   }
 
-  @Test
-  public void testPutDomains() throws Exception {
+  @MethodSource("withSsl")
+  @ParameterizedTest
+  void testPutDomains(boolean withSsl) throws Exception {
+    initTestTimelineAuthenticationFilterForV1(withSsl);
     KerberosTestUtils.doAs(PRINCIPAL, new Callable<Void>() {
       @Override
       public Void call() throws Exception {
@@ -226,71 +230,72 @@ public class TestTimelineAuthenticationFilterForV1 {
         TimelineDomain domainToRead =
             testTimelineServer.getTimelineStore().getDomain(
                 TestTimelineAuthenticationFilterForV1.class.getName());
-        Assert.assertNotNull("Timeline domain should not be null",
-            domainToRead);
+        assertNotNull(domainToRead,
+            "Timeline domain should not be null");
         return null;
       }
     });
   }
 
-  @Test
-  public void testDelegationTokenOperations() throws Exception {
+  @MethodSource("withSsl")
+  @ParameterizedTest
+  void testDelegationTokenOperations(boolean withSsl) throws Exception {
+    initTestTimelineAuthenticationFilterForV1(withSsl);
     TimelineClient httpUserClient =
         KerberosTestUtils.doAs(PRINCIPAL,
             new Callable<TimelineClient>() {
-            @Override
-            public TimelineClient call() throws Exception {
-              return createTimelineClientForUGI();
-            }
-          });
+              @Override
+              public TimelineClient call() throws Exception {
+                return createTimelineClientForUGI();
+              }
+            });
     UserGroupInformation httpUser =
         KerberosTestUtils.doAs(PRINCIPAL,
             new Callable<UserGroupInformation>() {
-            @Override
-            public UserGroupInformation call() throws Exception {
-              return UserGroupInformation.getCurrentUser();
-            }
-          });
+              @Override
+              public UserGroupInformation call() throws Exception {
+                return UserGroupInformation.getCurrentUser();
+              }
+            });
 
     // Let HTTP user to get the delegation for itself
     Token<TimelineDelegationTokenIdentifier> token =
         httpUserClient.getDelegationToken(httpUser.getShortUserName());
-    Assert.assertNotNull("Delegation token should not be null", token);
+    assertNotNull(token, "Delegation token should not be null");
     TimelineDelegationTokenIdentifier tDT = token.decodeIdentifier();
-    Assert.assertNotNull("Delegation token identifier should not be null",
-        tDT);
-    Assert.assertEquals("Owner of delegation token identifier does not match",
-        new Text(HTTP_USER), tDT.getOwner());
+    assertNotNull(tDT,
+        "Delegation token identifier should not be null");
+    assertEquals(new Text(HTTP_USER), tDT.getOwner(), "Owner of delegation token identifier does not match");
 
     // Renew token
-    Assert.assertFalse("Service field of token should not be empty",
-        token.getService().toString().isEmpty());
+    assertFalse(token.getService().toString().isEmpty(),
+        "Service field of token should not be empty");
     // Renew the token from the token service address
     long renewTime1 = httpUserClient.renewDelegationToken(token);
     Thread.sleep(100);
     token.setService(new Text());
-    Assert.assertTrue("Service field of token should be empty",
-        token.getService().toString().isEmpty());
+    assertTrue(token.getService().toString().isEmpty(),
+        "Service field of token should be empty");
     // If the token service address is not available, it still can be renewed
     // from the configured address
     long renewTime2 = httpUserClient.renewDelegationToken(token);
-    Assert.assertTrue("renewTime2 should be later than renewTime1",
-        renewTime1 < renewTime2);
+    assertTrue(renewTime1 < renewTime2,
+        "renewTime2 should be later than renewTime1");
 
     // Cancel token
-    Assert.assertTrue("Service field of token should be empty",
-        token.getService().toString().isEmpty());
+    assertTrue(token.getService().toString().isEmpty(),
+        "Service field of token should be empty");
     // If the token service address is not available, it still can be canceled
     // from the configured address
     httpUserClient.cancelDelegationToken(token);
     // Renew should not be successful because the token is canceled
     try {
       httpUserClient.renewDelegationToken(token);
-      Assert.fail("Renew of delegation token should not be successful");
+      fail("Renew of delegation token should not be successful");
     } catch (Exception e) {
       LOG.info("Exception while renewing delegation token", e);
-      Assert.assertTrue(e.getMessage().contains(
-            "Renewal request for unknown token"));
+      assertTrue(e.getMessage().contains(
+          "Renewal request for unknown token"));
     }
 
     // Let HTTP user to get the delegation token for FOO user
@@ -304,35 +309,33 @@ public class TestTimelineAuthenticationFilterForV1 {
           }
         });
     token = fooUserClient.getDelegationToken(httpUser.getShortUserName());
-    Assert.assertNotNull("Delegation token should not be null", token);
+    assertNotNull(token, "Delegation token should not be null");
     tDT = token.decodeIdentifier();
-    Assert.assertNotNull("Delegation token identifier should not be null",
-        tDT);
-    Assert.assertEquals("Owner of delegation token is not the expected",
-        new Text(FOO_USER), tDT.getOwner());
-    Assert.assertEquals("Real user of delegation token is not the expected",
-        new Text(HTTP_USER), tDT.getRealUser());
+    assertNotNull(tDT,
+        "Delegation token identifier should not be null");
+    assertEquals(new Text(FOO_USER), tDT.getOwner(), "Owner of delegation token is not the expected");
+    assertEquals(new Text(HTTP_USER), tDT.getRealUser(), "Real user of delegation token is not the expected");
 
     // Renew token as the renewer
     final Token<TimelineDelegationTokenIdentifier> tokenToRenew = token;
     renewTime1 = httpUserClient.renewDelegationToken(tokenToRenew);
     renewTime2 = httpUserClient.renewDelegationToken(tokenToRenew);
-    Assert.assertTrue("renewTime2 should be later than renewTime1",
-        renewTime1 < renewTime2);
+    assertTrue(renewTime1 < renewTime2,
+        "renewTime2 should be later than renewTime1");
 
     // Cancel token
-    Assert.assertFalse("Service field of token should not be empty",
-        tokenToRenew.getService().toString().isEmpty());
+    assertFalse(tokenToRenew.getService().toString().isEmpty(),
+        "Service field of token should not be empty");
     // Cancel the token from the token service address
     fooUserClient.cancelDelegationToken(tokenToRenew);
 
     // Renew should not be successful because the token is canceled
     try {
       httpUserClient.renewDelegationToken(tokenToRenew);
-      Assert.fail("Renew of delegation token should not be successful");
+      fail("Renew of delegation token should not be successful");
     } catch (Exception e) {
       LOG.info("Exception while renewing delegation token", e);
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().contains("Renewal request for unknown token"));
     }
 
@@ -349,10 +352,10 @@ public class TestTimelineAuthenticationFilterForV1 {
 
     try {
       barUserClient.getDelegationToken(httpUser.getShortUserName());
-      Assert.fail("Retrieval of delegation token should not be successful");
+      fail("Retrieval of delegation token should not be successful");
     } catch (Exception e) {
       LOG.info("Exception while retrieving delegation token", e);
-      Assert.assertTrue(e.getCause() instanceof AuthorizationException ||
+      assertTrue(e.getCause() instanceof AuthorizationException ||
           e.getCause() instanceof AuthenticationException);
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java
@@ -95,8 +95,8 @@ public class TestTimelineAuthenticationFilterForV1 {
   private static Configuration conf;
   private static boolean withSsl;
 
-  public void initTestTimelineAuthenticationFilterForV1(boolean withSsl) {
-    TestTimelineAuthenticationFilterForV1.withSsl = withSsl;
+  public void initTestTimelineAuthenticationFilterForV1(boolean isSslEnabled) {
+    TestTimelineAuthenticationFilterForV1.withSsl = isSslEnabled;
   }
 
   @BeforeAll
@@ -186,8 +186,8 @@ public class TestTimelineAuthenticationFilterForV1 {
 
   @MethodSource("withSsl")
   @ParameterizedTest
-  void testPutTimelineEntities(boolean withSsl) throws Exception {
-    initTestTimelineAuthenticationFilterForV1(withSsl);
+  void testPutTimelineEntities(boolean isSslEnabled) throws Exception {
+    initTestTimelineAuthenticationFilterForV1(isSslEnabled);
     KerberosTestUtils.doAs(PRINCIPAL, new Callable<Void>() {
       @Override
       public Void call() throws Exception {
@@ -215,8 +215,8 @@ public class TestTimelineAuthenticationFilterForV1 {
 
   @MethodSource("withSsl")
   @ParameterizedTest
-  void testPutDomains(boolean withSsl) throws Exception {
-    initTestTimelineAuthenticationFilterForV1(withSsl);
+  void testPutDomains(boolean isSslEnabled) throws Exception {
+    initTestTimelineAuthenticationFilterForV1(isSslEnabled);
     KerberosTestUtils.doAs(PRINCIPAL, new Callable<Void>() {
       @Override
       public Void call() throws Exception {
@@ -239,8 +239,8 @@ public class TestTimelineAuthenticationFilterForV1 {
 
   @MethodSource("withSsl")
   @ParameterizedTest
-  void testDelegationTokenOperations(boolean withSsl) throws Exception {
-    initTestTimelineAuthenticationFilterForV1(withSsl);
+  void testDelegationTokenOperations(boolean isSslEnabled) throws Exception {
+    initTestTimelineAuthenticationFilterForV1(isSslEnabled);
     TimelineClient httpUserClient =
         KerberosTestUtils.doAs(PRINCIPAL,
             new Callable<TimelineClient>() {
@@ -265,7 +265,8 @@ public class TestTimelineAuthenticationFilterForV1 {
     TimelineDelegationTokenIdentifier tDT = token.decodeIdentifier();
     assertNotNull(tDT,
         "Delegation token identifier should not be null");
-    assertEquals(new Text(HTTP_USER), tDT.getOwner(), "Owner of delegation token identifier does not match");
+    assertEquals(new Text(HTTP_USER), tDT.getOwner(),
+        "Owner of delegation token identifier does not match");
 
     // Renew token
     assertFalse(token.getService().toString().isEmpty(),
@@ -313,8 +314,10 @@ public class TestTimelineAuthenticationFilterForV1 {
     tDT = token.decodeIdentifier();
     assertNotNull(tDT,
         "Delegation token identifier should not be null");
-    assertEquals(new Text(FOO_USER), tDT.getOwner(), "Owner of delegation token is not the expected");
-    assertEquals(new Text(HTTP_USER), tDT.getRealUser(), "Real user of delegation token is not the expected");
+    assertEquals(new Text(FOO_USER), tDT.getOwner(),
+        "Owner of delegation token is not the expected");
+    assertEquals(new Text(HTTP_USER), tDT.getRealUser(),
+        "Real user of delegation token is not the expected");
 
     // Renew token as the renewer
     final Token<TimelineDelegationTokenIdentifier> tokenToRenew = token;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServices.java
@@ -18,25 +18,12 @@
 
 package org.apache.hadoop.yarn.server.timeline.webapp;
 
-import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -45,17 +32,28 @@ import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 
+import com.google.inject.Guice;
+import com.google.inject.servlet.ServletModule;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.server.PseudoAuthenticationHandler;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthenticationHandler;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineAbout;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineDomain;
+import org.apache.hadoop.yarn.api.records.timeline.TimelineDomains;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntities;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEvents;
-import org.apache.hadoop.yarn.api.records.timeline.TimelineDomain;
-import org.apache.hadoop.yarn.api.records.timeline.TimelineDomains;
 import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse;
 import org.apache.hadoop.yarn.api.records.timeline.TimelinePutResponse.TimelinePutError;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -67,22 +65,23 @@ import org.apache.hadoop.yarn.server.timeline.TimelineDataManager;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineACLsManager;
 import org.apache.hadoop.yarn.server.timeline.security.TimelineAuthenticationFilter;
-import org.apache.hadoop.yarn.api.records.timeline.TimelineAbout;
 import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
-import com.google.inject.Guice;
-import com.google.inject.servlet.ServletModule;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
-import com.sun.jersey.test.framework.WebAppDescriptor;
+import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class TestTimelineWebServices extends JerseyTestBase {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServices.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.yarn.server.timeline.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -70,9 +73,8 @@ import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.inject.Guice;
 import com.google.inject.servlet.ServletModule;
@@ -99,7 +101,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       try {
         store = mockTimelineStore();
       } catch (Exception e) {
-        Assert.fail();
+        fail();
       }
       Configuration conf = new YarnConfiguration();
       conf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, false);
@@ -138,7 +140,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       try {
         taFilter.init(filterConfig);
       } catch (ServletException e) {
-        Assert.fail("Unable to initialize TimelineAuthenticationFilter: " +
+        fail("Unable to initialize TimelineAuthenticationFilter: " +
             e.getMessage());
       }
 
@@ -146,7 +148,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       try {
         doNothing().when(taFilter).init(any(FilterConfig.class));
       } catch (ServletException e) {
-        Assert.fail("Unable to initialize TimelineAuthenticationFilter: " +
+        fail("Unable to initialize TimelineAuthenticationFilter: " +
             e.getMessage());
       }
       filter("/*").through(taFilter);
@@ -158,7 +160,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     GuiceServletConfig.setInjector(
@@ -187,7 +189,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testAbout() throws Exception {
+  void testAbout() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .accept(MediaType.APPLICATION_JSON)
@@ -197,54 +199,54 @@ public class TestTimelineWebServices extends JerseyTestBase {
     TimelineAbout actualAbout = response.getEntity(TimelineAbout.class);
     TimelineAbout expectedAbout =
         TimelineUtils.createTimelineAbout("Timeline API");
-    Assert.assertNotNull(
-        "Timeline service about response is null", actualAbout);
-    Assert.assertEquals(expectedAbout.getAbout(), actualAbout.getAbout());
-    Assert.assertEquals(expectedAbout.getTimelineServiceVersion(),
+    assertNotNull(
+        actualAbout, "Timeline service about response is null");
+    assertEquals(expectedAbout.getAbout(), actualAbout.getAbout());
+    assertEquals(expectedAbout.getTimelineServiceVersion(),
         actualAbout.getTimelineServiceVersion());
-    Assert.assertEquals(expectedAbout.getTimelineServiceBuildVersion(),
+    assertEquals(expectedAbout.getTimelineServiceBuildVersion(),
         actualAbout.getTimelineServiceBuildVersion());
-    Assert.assertEquals(expectedAbout.getTimelineServiceVersionBuiltOn(),
+    assertEquals(expectedAbout.getTimelineServiceVersionBuiltOn(),
         actualAbout.getTimelineServiceVersionBuiltOn());
-    Assert.assertEquals(expectedAbout.getHadoopVersion(),
+    assertEquals(expectedAbout.getHadoopVersion(),
         actualAbout.getHadoopVersion());
-    Assert.assertEquals(expectedAbout.getHadoopBuildVersion(),
+    assertEquals(expectedAbout.getHadoopBuildVersion(),
         actualAbout.getHadoopBuildVersion());
-    Assert.assertEquals(expectedAbout.getHadoopVersionBuiltOn(),
+    assertEquals(expectedAbout.getHadoopVersionBuiltOn(),
         actualAbout.getHadoopVersionBuiltOn());
   }
 
   private static void verifyEntities(TimelineEntities entities) {
-    Assert.assertNotNull(entities);
-    Assert.assertEquals(3, entities.getEntities().size());
+    assertNotNull(entities);
+    assertEquals(3, entities.getEntities().size());
     TimelineEntity entity1 = entities.getEntities().get(0);
-    Assert.assertNotNull(entity1);
-    Assert.assertEquals("id_1", entity1.getEntityId());
-    Assert.assertEquals("type_1", entity1.getEntityType());
-    Assert.assertEquals(123l, entity1.getStartTime().longValue());
-    Assert.assertEquals(2, entity1.getEvents().size());
-    Assert.assertEquals(4, entity1.getPrimaryFilters().size());
-    Assert.assertEquals(4, entity1.getOtherInfo().size());
+    assertNotNull(entity1);
+    assertEquals("id_1", entity1.getEntityId());
+    assertEquals("type_1", entity1.getEntityType());
+    assertEquals(123l, entity1.getStartTime().longValue());
+    assertEquals(2, entity1.getEvents().size());
+    assertEquals(4, entity1.getPrimaryFilters().size());
+    assertEquals(4, entity1.getOtherInfo().size());
     TimelineEntity entity2 = entities.getEntities().get(1);
-    Assert.assertNotNull(entity2);
-    Assert.assertEquals("id_2", entity2.getEntityId());
-    Assert.assertEquals("type_1", entity2.getEntityType());
-    Assert.assertEquals(123l, entity2.getStartTime().longValue());
-    Assert.assertEquals(2, entity2.getEvents().size());
-    Assert.assertEquals(4, entity2.getPrimaryFilters().size());
-    Assert.assertEquals(4, entity2.getOtherInfo().size());
+    assertNotNull(entity2);
+    assertEquals("id_2", entity2.getEntityId());
+    assertEquals("type_1", entity2.getEntityType());
+    assertEquals(123l, entity2.getStartTime().longValue());
+    assertEquals(2, entity2.getEvents().size());
+    assertEquals(4, entity2.getPrimaryFilters().size());
+    assertEquals(4, entity2.getOtherInfo().size());
     TimelineEntity entity3 = entities.getEntities().get(2);
-    Assert.assertNotNull(entity2);
-    Assert.assertEquals("id_6", entity3.getEntityId());
-    Assert.assertEquals("type_1", entity3.getEntityType());
-    Assert.assertEquals(61l, entity3.getStartTime().longValue());
-    Assert.assertEquals(0, entity3.getEvents().size());
-    Assert.assertEquals(4, entity3.getPrimaryFilters().size());
-    Assert.assertEquals(4, entity3.getOtherInfo().size());
+    assertNotNull(entity2);
+    assertEquals("id_6", entity3.getEntityId());
+    assertEquals("type_1", entity3.getEntityType());
+    assertEquals(61l, entity3.getStartTime().longValue());
+    assertEquals(0, entity3.getEvents().size());
+    assertEquals(4, entity3.getPrimaryFilters().size());
+    assertEquals(4, entity3.getOtherInfo().size());
   }
 
   @Test
-  public void testGetEntities() throws Exception {
+  void testGetEntities() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1")
@@ -256,7 +258,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testFromId() throws Exception {
+  void testFromId() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("fromId", "id_2")
@@ -278,7 +280,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testFromTs() throws Exception {
+  void testFromTs() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("fromTs", Long.toString(beforeTime))
@@ -291,7 +293,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
 
     response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("fromTs", Long.toString(
-            System.currentTimeMillis()))
+        System.currentTimeMillis()))
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
@@ -301,7 +303,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testPrimaryFilterString() {
+  void testPrimaryFilterString() {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("primaryFilter", "user:username")
@@ -313,11 +315,11 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testPrimaryFilterInteger() {
+  void testPrimaryFilterInteger() {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("primaryFilter",
-            "appname:" + Integer.toString(Integer.MAX_VALUE))
+        "appname:" + Integer.toString(Integer.MAX_VALUE))
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
@@ -326,11 +328,11 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testPrimaryFilterLong() {
+  void testPrimaryFilterLong() {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("primaryFilter",
-            "long:" + Long.toString((long) Integer.MAX_VALUE + 1l))
+        "long:" + Long.toString((long) Integer.MAX_VALUE + 1l))
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
@@ -339,7 +341,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testSecondaryFilters() {
+  void testSecondaryFilters() {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1")
@@ -353,7 +355,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetEntity() throws Exception {
+  void testGetEntity() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").path("id_1")
@@ -362,17 +364,17 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     TimelineEntity entity = response.getEntity(TimelineEntity.class);
-    Assert.assertNotNull(entity);
-    Assert.assertEquals("id_1", entity.getEntityId());
-    Assert.assertEquals("type_1", entity.getEntityType());
-    Assert.assertEquals(123l, entity.getStartTime().longValue());
-    Assert.assertEquals(2, entity.getEvents().size());
-    Assert.assertEquals(4, entity.getPrimaryFilters().size());
-    Assert.assertEquals(4, entity.getOtherInfo().size());
+    assertNotNull(entity);
+    assertEquals("id_1", entity.getEntityId());
+    assertEquals("type_1", entity.getEntityType());
+    assertEquals(123l, entity.getStartTime().longValue());
+    assertEquals(2, entity.getEvents().size());
+    assertEquals(4, entity.getPrimaryFilters().size());
+    assertEquals(4, entity.getOtherInfo().size());
   }
 
   @Test
-  public void testGetEntityFields1() throws Exception {
+  void testGetEntityFields1() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").path("id_1").queryParam("fields", "events,otherinfo")
@@ -381,37 +383,37 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     TimelineEntity entity = response.getEntity(TimelineEntity.class);
-    Assert.assertNotNull(entity);
-    Assert.assertEquals("id_1", entity.getEntityId());
-    Assert.assertEquals("type_1", entity.getEntityType());
-    Assert.assertEquals(123l, entity.getStartTime().longValue());
-    Assert.assertEquals(2, entity.getEvents().size());
-    Assert.assertEquals(0, entity.getPrimaryFilters().size());
-    Assert.assertEquals(4, entity.getOtherInfo().size());
+    assertNotNull(entity);
+    assertEquals("id_1", entity.getEntityId());
+    assertEquals("type_1", entity.getEntityType());
+    assertEquals(123l, entity.getStartTime().longValue());
+    assertEquals(2, entity.getEvents().size());
+    assertEquals(0, entity.getPrimaryFilters().size());
+    assertEquals(4, entity.getOtherInfo().size());
   }
 
   @Test
-  public void testGetEntityFields2() throws Exception {
+  void testGetEntityFields2() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").path("id_1").queryParam("fields", "lasteventonly," +
-            "primaryfilters,relatedentities")
+        "primaryfilters,relatedentities")
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     TimelineEntity entity = response.getEntity(TimelineEntity.class);
-    Assert.assertNotNull(entity);
-    Assert.assertEquals("id_1", entity.getEntityId());
-    Assert.assertEquals("type_1", entity.getEntityType());
-    Assert.assertEquals(123l, entity.getStartTime().longValue());
-    Assert.assertEquals(1, entity.getEvents().size());
-    Assert.assertEquals(4, entity.getPrimaryFilters().size());
-    Assert.assertEquals(0, entity.getOtherInfo().size());
+    assertNotNull(entity);
+    assertEquals("id_1", entity.getEntityId());
+    assertEquals("type_1", entity.getEntityType());
+    assertEquals(123l, entity.getStartTime().longValue());
+    assertEquals(1, entity.getEvents().size());
+    assertEquals(4, entity.getPrimaryFilters().size());
+    assertEquals(0, entity.getOtherInfo().size());
   }
 
   @Test
-  public void testGetEvents() throws Exception {
+  void testGetEvents() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").path("events")
@@ -421,22 +423,22 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     TimelineEvents events = response.getEntity(TimelineEvents.class);
-    Assert.assertNotNull(events);
-    Assert.assertEquals(1, events.getAllEvents().size());
+    assertNotNull(events);
+    assertEquals(1, events.getAllEvents().size());
     TimelineEvents.EventsOfOneEntity partEvents = events.getAllEvents().get(0);
-    Assert.assertEquals(2, partEvents.getEvents().size());
+    assertEquals(2, partEvents.getEvents().size());
     TimelineEvent event1 = partEvents.getEvents().get(0);
-    Assert.assertEquals(456l, event1.getTimestamp());
-    Assert.assertEquals("end_event", event1.getEventType());
-    Assert.assertEquals(1, event1.getEventInfo().size());
+    assertEquals(456l, event1.getTimestamp());
+    assertEquals("end_event", event1.getEventType());
+    assertEquals(1, event1.getEventInfo().size());
     TimelineEvent event2 = partEvents.getEvents().get(1);
-    Assert.assertEquals(123l, event2.getTimestamp());
-    Assert.assertEquals("start_event", event2.getEventType());
-    Assert.assertEquals(0, event2.getEventInfo().size());
+    assertEquals(123l, event2.getTimestamp());
+    assertEquals("start_event", event2.getEventType());
+    assertEquals(0, event2.getEventInfo().size());
   }
 
   @Test
-  public void testPostEntitiesWithPrimaryFilter() throws Exception {
+  void testPostEntitiesWithPrimaryFilter() throws Exception {
     TimelineEntities entities = new TimelineEntities();
     TimelineEntity entity = new TimelineEntity();
     Map<String, Set<Object>> filters = new HashMap<String, Set<Object>>();
@@ -455,11 +457,11 @@ public class TestTimelineWebServices extends JerseyTestBase {
         .post(ClientResponse.class, entities);
     TimelinePutResponse putResposne =
         response.getEntity(TimelinePutResponse.class);
-    Assert.assertEquals(0, putResposne.getErrors().size());
+    assertEquals(0, putResposne.getErrors().size());
   }
 
   @Test
-  public void testPostEntities() throws Exception {
+  void testPostEntities() throws Exception {
     TimelineEntities entities = new TimelineEntities();
     TimelineEntity entity = new TimelineEntity();
     entity.setEntityId("test id 1");
@@ -486,8 +488,8 @@ public class TestTimelineWebServices extends JerseyTestBase {
         response.getType().toString());
     TimelinePutResponse putResposne =
         response.getEntity(TimelinePutResponse.class);
-    Assert.assertNotNull(putResposne);
-    Assert.assertEquals(0, putResposne.getErrors().size());
+    assertNotNull(putResposne);
+    assertEquals(0, putResposne.getErrors().size());
     // verify the entity exists in the store
     response = r.path("ws").path("v1").path("timeline")
         .path("test type 1").path("test id 1")
@@ -496,13 +498,13 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     entity = response.getEntity(TimelineEntity.class);
-    Assert.assertNotNull(entity);
-    Assert.assertEquals("test id 1", entity.getEntityId());
-    Assert.assertEquals("test type 1", entity.getEntityType());
+    assertNotNull(entity);
+    assertEquals("test id 1", entity.getEntityId());
+    assertEquals("test type 1", entity.getEntityType());
   }
 
   @Test
-  public void testPostIncompleteEntities() throws Exception {
+  void testPostIncompleteEntities() throws Exception {
     TimelineEntities entities = new TimelineEntities();
     TimelineEntity entity1 = new TimelineEntity();
     entity1.setEntityId("test id 1");
@@ -516,14 +518,14 @@ public class TestTimelineWebServices extends JerseyTestBase {
     // One of the entities has no id or type. HTTP 400 will be returned
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .queryParam("user.name", "tester").accept(MediaType.APPLICATION_JSON)
-         .type(MediaType.APPLICATION_JSON).post(ClientResponse.class, entities);
+        .type(MediaType.APPLICATION_JSON).post(ClientResponse.class, entities);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     assertResponseStatusCode(Status.BAD_REQUEST, response.getStatusInfo());
   }
 
   @Test
-  public void testPostEntitiesWithYarnACLsEnabled() throws Exception {
+  void testPostEntitiesWithYarnACLsEnabled() throws Exception {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -544,8 +546,8 @@ public class TestTimelineWebServices extends JerseyTestBase {
           response.getType().toString());
       TimelinePutResponse putResponse =
           response.getEntity(TimelinePutResponse.class);
-      Assert.assertNotNull(putResponse);
-      Assert.assertEquals(0, putResponse.getErrors().size());
+      assertNotNull(putResponse);
+      assertEquals(0, putResponse.getErrors().size());
 
       // override/append timeline data in the same entity with different user
       response = r.path("ws").path("v1").path("timeline")
@@ -556,9 +558,9 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       putResponse = response.getEntity(TimelinePutResponse.class);
-      Assert.assertNotNull(putResponse);
-      Assert.assertEquals(1, putResponse.getErrors().size());
-      Assert.assertEquals(TimelinePutResponse.TimelinePutError.ACCESS_DENIED,
+      assertNotNull(putResponse);
+      assertEquals(1, putResponse.getErrors().size());
+      assertEquals(TimelinePutResponse.TimelinePutError.ACCESS_DENIED,
           putResponse.getErrors().get(0).getErrorCode());
 
       // Cross domain relationship will be rejected
@@ -580,9 +582,9 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       putResponse = response.getEntity(TimelinePutResponse.class);
-      Assert.assertNotNull(putResponse);
-      Assert.assertEquals(1, putResponse.getErrors().size());
-      Assert.assertEquals(TimelinePutError.FORBIDDEN_RELATION,
+      assertNotNull(putResponse);
+      assertEquals(1, putResponse.getErrors().size());
+      assertEquals(TimelinePutError.FORBIDDEN_RELATION,
           putResponse.getErrors().get(0).getErrorCode());
 
       // Make sure the entity has been added anyway even though the
@@ -595,16 +597,16 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       entity = response.getEntity(TimelineEntity.class);
-      Assert.assertNotNull(entity);
-      Assert.assertEquals("test id 3", entity.getEntityId());
-      Assert.assertEquals("test type 2", entity.getEntityType());
+      assertNotNull(entity);
+      assertEquals("test id 3", entity.getEntityId());
+      assertEquals("test type 2", entity.getEntityType());
     } finally {
       timelineACLsManager.setAdminACLsManager(oldAdminACLsManager);
     }
   }
 
   @Test
-  public void testPostEntitiesToDefaultDomain() throws Exception {
+  void testPostEntitiesToDefaultDomain() throws Exception {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -624,8 +626,8 @@ public class TestTimelineWebServices extends JerseyTestBase {
           response.getType().toString());
       TimelinePutResponse putResposne =
           response.getEntity(TimelinePutResponse.class);
-      Assert.assertNotNull(putResposne);
-      Assert.assertEquals(0, putResposne.getErrors().size());
+      assertNotNull(putResposne);
+      assertEquals(0, putResposne.getErrors().size());
       // verify the entity exists in the store
       response = r.path("ws").path("v1").path("timeline")
           .path("test type 7").path("test id 7")
@@ -635,10 +637,10 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       entity = response.getEntity(TimelineEntity.class);
-      Assert.assertNotNull(entity);
-      Assert.assertEquals("test id 7", entity.getEntityId());
-      Assert.assertEquals("test type 7", entity.getEntityType());
-      Assert.assertEquals(TimelineDataManager.DEFAULT_DOMAIN_ID,
+      assertNotNull(entity);
+      assertEquals("test id 7", entity.getEntityId());
+      assertEquals("test type 7", entity.getEntityType());
+      assertEquals(TimelineDataManager.DEFAULT_DOMAIN_ID,
           entity.getDomainId());
     } finally {
       timelineACLsManager.setAdminACLsManager(oldAdminACLsManager);
@@ -646,7 +648,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetEntityWithYarnACLsEnabled() throws Exception {
+  void testGetEntityWithYarnACLsEnabled() throws Exception {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -667,7 +669,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
           response.getType().toString());
       TimelinePutResponse putResponse =
           response.getEntity(TimelinePutResponse.class);
-      Assert.assertEquals(0, putResponse.getErrors().size());
+      assertEquals(0, putResponse.getErrors().size());
       // verify the system data will not be exposed
       // 1. No field specification
       response = r.path("ws").path("v1").path("timeline")
@@ -678,7 +680,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       entity = response.getEntity(TimelineEntity.class);
-      Assert.assertNull(entity.getPrimaryFilters().get(
+      assertNull(entity.getPrimaryFilters().get(
           TimelineStore.SystemFilter.ENTITY_OWNER.toString()));
       // 2. other field
       response = r.path("ws").path("v1").path("timeline")
@@ -690,7 +692,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       entity = response.getEntity(TimelineEntity.class);
-      Assert.assertNull(entity.getPrimaryFilters().get(
+      assertNull(entity.getPrimaryFilters().get(
           TimelineStore.SystemFilter.ENTITY_OWNER.toString()));
       // 3. primaryfilters field
       response = r.path("ws").path("v1").path("timeline")
@@ -702,7 +704,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       entity = response.getEntity(TimelineEntity.class);
-      Assert.assertNull(entity.getPrimaryFilters().get(
+      assertNull(entity.getPrimaryFilters().get(
           TimelineStore.SystemFilter.ENTITY_OWNER.toString()));
 
       // get entity with other user
@@ -720,7 +722,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetEntitiesWithYarnACLsEnabled() {
+  void testGetEntitiesWithYarnACLsEnabled() {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -742,7 +744,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
           response.getType().toString());
       TimelinePutResponse putResponse =
           response.getEntity(TimelinePutResponse.class);
-      Assert.assertEquals(0, putResponse.getErrors().size());
+      assertEquals(0, putResponse.getErrors().size());
 
       // Put entity [4, 5] in domain 2
       entities = new TimelineEntities();
@@ -761,7 +763,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       putResponse = response.getEntity(TimelinePutResponse.class);
-      Assert.assertEquals(0, putResponse.getErrors().size());
+      assertEquals(0, putResponse.getErrors().size());
 
       // Query entities of type 4
       response = r.path("ws").path("v1").path("timeline")
@@ -782,7 +784,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetEventsWithYarnACLsEnabled() {
+  void testGetEventsWithYarnACLsEnabled() {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -808,7 +810,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
           response.getType().toString());
       TimelinePutResponse putResponse =
           response.getEntity(TimelinePutResponse.class);
-      Assert.assertEquals(0, putResponse.getErrors().size());
+      assertEquals(0, putResponse.getErrors().size());
 
       // Put entity [5, 6] in domain 2
       entities = new TimelineEntities();
@@ -831,7 +833,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       putResponse = response.getEntity(TimelinePutResponse.class);
-      Assert.assertEquals(0, putResponse.getErrors().size());
+      assertEquals(0, putResponse.getErrors().size());
 
       // Query events belonging to the entities of type 4
       response = r.path("ws").path("v1").path("timeline")
@@ -852,7 +854,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetDomain() throws Exception {
+  void testGetDomain() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("domain").path("domain_id_1")
@@ -865,7 +867,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetDomainYarnACLsEnabled() {
+  void testGetDomainYarnACLsEnabled() {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -894,7 +896,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetDomains() throws Exception {
+  void testGetDomains() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("domain")
@@ -904,7 +906,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     TimelineDomains domains = response.getEntity(TimelineDomains.class);
-    Assert.assertEquals(2, domains.getDomains().size());
+    assertEquals(2, domains.getDomains().size());
     for (int i = 0; i < domains.getDomains().size(); ++i) {
       verifyDomain(domains.getDomains().get(i),
           i == 0 ? "domain_id_4" : "domain_id_1");
@@ -912,7 +914,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testGetDomainsYarnACLsEnabled() throws Exception {
+  void testGetDomainsYarnACLsEnabled() throws Exception {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -925,7 +927,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       TimelineDomains domains = response.getEntity(TimelineDomains.class);
-      Assert.assertEquals(2, domains.getDomains().size());
+      assertEquals(2, domains.getDomains().size());
       for (int i = 0; i < domains.getDomains().size(); ++i) {
         verifyDomain(domains.getDomains().get(i),
             i == 0 ? "domain_id_4" : "domain_id_1");
@@ -940,14 +942,14 @@ public class TestTimelineWebServices extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       domains = response.getEntity(TimelineDomains.class);
-      Assert.assertEquals(0, domains.getDomains().size());
+      assertEquals(0, domains.getDomains().size());
     } finally {
       timelineACLsManager.setAdminACLsManager(oldAdminACLsManager);
     }
   }
 
   @Test
-  public void testPutDomain() throws Exception {
+  void testPutDomain() throws Exception {
     TimelineDomain domain = new TimelineDomain();
     domain.setId("test_domain_id");
     WebResource r = resource();
@@ -977,10 +979,10 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     domain = response.getEntity(TimelineDomain.class);
-    Assert.assertNotNull(domain);
-    Assert.assertEquals("test_domain_id", domain.getId());
-    Assert.assertEquals("tester", domain.getOwner());
-    Assert.assertEquals(null, domain.getDescription());
+    assertNotNull(domain);
+    assertEquals("test_domain_id", domain.getId());
+    assertEquals("tester", domain.getOwner());
+    assertNull(domain.getDescription());
 
     // Update the domain
     domain.setDescription("test_description");
@@ -1000,13 +1002,13 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     domain = response.getEntity(TimelineDomain.class);
-    Assert.assertNotNull(domain);
-    Assert.assertEquals("test_domain_id", domain.getId());
-    Assert.assertEquals("test_description", domain.getDescription());
+    assertNotNull(domain);
+    assertEquals("test_domain_id", domain.getId());
+    assertEquals("test_description", domain.getDescription());
   }
 
   @Test
-  public void testPutDomainYarnACLsEnabled() throws Exception {
+  void testPutDomainYarnACLsEnabled() throws Exception {
     AdminACLsManager oldAdminACLsManager =
         timelineACLsManager.setAdminACLsManager(adminACLsManager);
     try {
@@ -1035,7 +1037,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testContextFactory() throws Exception {
+  void testContextFactory() throws Exception {
     JAXBContext jaxbContext1 = ContextFactory.createContext(
         new Class[]{TimelineDomain.class}, Collections.EMPTY_MAP);
     JAXBContext jaxbContext2 = ContextFactory.createContext(
@@ -1045,21 +1047,21 @@ public class TestTimelineWebServices extends JerseyTestBase {
     try {
       ContextFactory.createContext(new Class[]{TimelineEntity.class},
           Collections.EMPTY_MAP);
-      Assert.fail("Expected JAXBException");
-    } catch(Exception e) {
+      fail("Expected JAXBException");
+    } catch (Exception e) {
       assertThat(e).isExactlyInstanceOf(JAXBException.class);
     }
   }
 
   private static void verifyDomain(TimelineDomain domain, String domainId) {
-    Assert.assertNotNull(domain);
-    Assert.assertEquals(domainId, domain.getId());
+    assertNotNull(domain);
+    assertEquals(domainId, domain.getId());
     // The specific values have been verified in TestMemoryTimelineStore
-    Assert.assertNotNull(domain.getDescription());
-    Assert.assertNotNull(domain.getOwner());
-    Assert.assertNotNull(domain.getReaders());
-    Assert.assertNotNull(domain.getWriters());
-    Assert.assertNotNull(domain.getCreatedTime());
-    Assert.assertNotNull(domain.getModifiedTime());
+    assertNotNull(domain.getDescription());
+    assertNotNull(domain.getOwner());
+    assertNotNull(domain.getReaders());
+    assertNotNull(domain.getWriters());
+    assertNotNull(domain.getCreatedTime());
+    assertNotNull(domain.getModifiedTime());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServices.java
@@ -223,7 +223,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertNotNull(entity1);
     assertEquals("id_1", entity1.getEntityId());
     assertEquals("type_1", entity1.getEntityType());
-    assertEquals(123l, entity1.getStartTime().longValue());
+    assertEquals(123L, entity1.getStartTime().longValue());
     assertEquals(2, entity1.getEvents().size());
     assertEquals(4, entity1.getPrimaryFilters().size());
     assertEquals(4, entity1.getOtherInfo().size());
@@ -231,7 +231,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertNotNull(entity2);
     assertEquals("id_2", entity2.getEntityId());
     assertEquals("type_1", entity2.getEntityType());
-    assertEquals(123l, entity2.getStartTime().longValue());
+    assertEquals(123L, entity2.getStartTime().longValue());
     assertEquals(2, entity2.getEvents().size());
     assertEquals(4, entity2.getPrimaryFilters().size());
     assertEquals(4, entity2.getOtherInfo().size());
@@ -239,7 +239,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertNotNull(entity2);
     assertEquals("id_6", entity3.getEntityId());
     assertEquals("type_1", entity3.getEntityType());
-    assertEquals(61l, entity3.getStartTime().longValue());
+    assertEquals(61L, entity3.getStartTime().longValue());
     assertEquals(0, entity3.getEvents().size());
     assertEquals(4, entity3.getPrimaryFilters().size());
     assertEquals(4, entity3.getOtherInfo().size());
@@ -332,7 +332,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
         .path("type_1").queryParam("primaryFilter",
-        "long:" + Long.toString((long) Integer.MAX_VALUE + 1l))
+        "long:" + Long.toString((long) Integer.MAX_VALUE + 1L))
         .accept(MediaType.APPLICATION_JSON)
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
@@ -367,7 +367,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertNotNull(entity);
     assertEquals("id_1", entity.getEntityId());
     assertEquals("type_1", entity.getEntityType());
-    assertEquals(123l, entity.getStartTime().longValue());
+    assertEquals(123L, entity.getStartTime().longValue());
     assertEquals(2, entity.getEvents().size());
     assertEquals(4, entity.getPrimaryFilters().size());
     assertEquals(4, entity.getOtherInfo().size());
@@ -386,7 +386,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertNotNull(entity);
     assertEquals("id_1", entity.getEntityId());
     assertEquals("type_1", entity.getEntityType());
-    assertEquals(123l, entity.getStartTime().longValue());
+    assertEquals(123L, entity.getStartTime().longValue());
     assertEquals(2, entity.getEvents().size());
     assertEquals(0, entity.getPrimaryFilters().size());
     assertEquals(4, entity.getOtherInfo().size());
@@ -406,7 +406,7 @@ public class TestTimelineWebServices extends JerseyTestBase {
     assertNotNull(entity);
     assertEquals("id_1", entity.getEntityId());
     assertEquals("type_1", entity.getEntityType());
-    assertEquals(123l, entity.getStartTime().longValue());
+    assertEquals(123L, entity.getStartTime().longValue());
     assertEquals(1, entity.getEvents().size());
     assertEquals(4, entity.getPrimaryFilters().size());
     assertEquals(0, entity.getOtherInfo().size());
@@ -428,11 +428,11 @@ public class TestTimelineWebServices extends JerseyTestBase {
     TimelineEvents.EventsOfOneEntity partEvents = events.getAllEvents().get(0);
     assertEquals(2, partEvents.getEvents().size());
     TimelineEvent event1 = partEvents.getEvents().get(0);
-    assertEquals(456l, event1.getTimestamp());
+    assertEquals(456L, event1.getTimestamp());
     assertEquals("end_event", event1.getEventType());
     assertEquals(1, event1.getEventInfo().size());
     TimelineEvent event2 = partEvents.getEvents().get(1);
-    assertEquals(123l, event2.getTimestamp());
+    assertEquals(123L, event2.getTimestamp());
     assertEquals("start_event", event2.getEventType());
     assertEquals(0, event2.getEventInfo().size());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServicesWithSSL.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServicesWithSSL.java
@@ -18,14 +18,16 @@
 
 package org.apache.hadoop.yarn.server.timeline.webapp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.EnumSet;
+
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
@@ -42,12 +44,10 @@ import org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistor
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineReader.Field;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTimelineWebServicesWithSSL {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServicesWithSSL.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/webapp/TestTimelineWebServicesWithSSL.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.timeline.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -38,10 +42,9 @@ import org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistor
 import org.apache.hadoop.yarn.server.timeline.MemoryTimelineStore;
 import org.apache.hadoop.yarn.server.timeline.TimelineReader.Field;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
@@ -58,7 +61,7 @@ public class TestTimelineWebServicesWithSSL {
   private static TimelineStore store;
   private static Configuration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServer() throws Exception {
     conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -84,7 +87,7 @@ public class TestTimelineWebServicesWithSSL {
     store = timelineServer.getTimelineStore();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownServer() throws Exception {
     if (timelineServer != null) {
       timelineServer.stop();
@@ -92,7 +95,7 @@ public class TestTimelineWebServicesWithSSL {
   }
 
   @Test
-  public void testPutEntities() throws Exception {
+  void testPutEntities() throws Exception {
     TestTimelineClient client = new TestTimelineClient();
     try {
       client.init(conf);
@@ -107,16 +110,16 @@ public class TestTimelineWebServicesWithSSL {
       expectedEntity.addEvent(event);
 
       TimelinePutResponse response = client.putEntities(expectedEntity);
-      Assert.assertEquals(0, response.getErrors().size());
-      Assert.assertTrue(client.resp.toString().contains("https"));
+      assertEquals(0, response.getErrors().size());
+      assertTrue(client.resp.toString().contains("https"));
 
       TimelineEntity actualEntity = store.getEntity(
           expectedEntity.getEntityId(), expectedEntity.getEntityType(),
           EnumSet.allOf(Field.class));
-      Assert.assertNotNull(actualEntity);
-      Assert.assertEquals(
+      assertNotNull(actualEntity);
+      assertEquals(
           expectedEntity.getEntityId(), actualEntity.getEntityId());
-      Assert.assertEquals(
+      assertEquals(
           expectedEntity.getEntityType(), actualEntity.getEntityType());
     } finally {
       client.stop();


### PR DESCRIPTION
### Description of PR

Upgrade Junit from 4 to 5 in hadoop-yarn-server-applicationhistoryservice

JIRA - YARN-10793

### How was this patch tested?

Ran tests in local as well.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

