### PR TITLE
HDFS-16674 : Improve TestDFSIO to support more filesystems

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -29,10 +29,13 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.text.DecimalFormat;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
@@ -479,15 +482,9 @@ public class TestDFSIO implements Tool {
   }
 
   public static void setInputPaths(JobConf conf, Path... inputPaths) {
-    Path path = inputPaths[0];
-    StringBuffer str = new StringBuffer(StringUtils.escapeString(path.toString()));
-    for(int i = 1; i < inputPaths.length;i++) {
-      str.append(StringUtils.COMMA_STR);
-      path = inputPaths[i];
-      str.append(StringUtils.escapeString(path.toString()));
-    }
+    String commaSeparatedPathStr = Arrays.stream(inputPaths).map(Path::toString).map(i->StringUtils.escapeString(i)).collect(Collectors.joining(","));
     conf.set(org.apache.hadoop.mapreduce.lib.input.
-            FileInputFormat.INPUT_DIR, str.toString());
+            FileInputFormat.INPUT_DIR, commaSeparatedPathStr);
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Added support for more filesystems. This will let the same TestDFSIO to be used for testing different filesystem other than HDFS

### How was this patch tested?
Tested with OCI filesystem after building the jar with new changes

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

