### PR TITLE
YARN-11213. DecommissioningNodesWatcher#logDecommissioningNodesStatus…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DecommissioningNodesWatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DecommissioningNodesWatcher.java
@@ -376,7 +376,7 @@ public class DecommissioningNodesWatcher {
               (rmApp.getApplicationType() == null)?
                   "" : rmApp.getApplicationType(),
               100.0 * rmApp.getProgress(),
-              (mclock.getTime() - rmApp.getStartTime()) / 1000));
+              (System.currentTimeMillis() - rmApp.getStartTime()) / 1000));
         }
       }
       LOG.debug("Decommissioning node: " + sb.toString());


### PR DESCRIPTION
### Description of PR
There is a calculation in DecommissioningNodesWatcher#logDecommissioningNodesStatus to calculate app elapsed time:
```
(mclock.getTime() - rmApp.getStartTime()) / 1000
```
But mclock.getTime() is generated from System.nanoTime() / NANOSECONDS_PER_MILLISECOND,

rmApp.getStartTime() is generated from System.currentTimeMillis(), they cannot be compared.

This calculation should be:
```
(System.currentTimeMillis() - rmApp.getStartTime()) / 1000
```
