### PR TITLE
HADOOP-18358. Update commons-math3 from 3.1.1 to 3.6.1.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -309,7 +309,7 @@ org.apache.commons:commons-configuration2:2.1.1
 org.apache.commons:commons-csv:1.0
 org.apache.commons:commons-digester:1.8.1
 org.apache.commons:commons-lang3:3.12.0
-org.apache.commons:commons-math3:3.1.1
+org.apache.commons:commons-math3:3.6.1
 org.apache.commons:commons-text:1.4
 org.apache.commons:commons-validator:1.6
 org.apache.curator:curator-client:5.2.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -122,7 +122,7 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>
-    <commons-math3.version>3.1.1</commons-math3.version>
+    <commons-math3.version>3.6.1</commons-math3.version>
     <commons-net.version>3.6</commons-net.version>
     <commons-text.version>1.4</commons-text.version>
 


### PR DESCRIPTION
JIRA. HADOOP-18358. Update commons-math3 from 3.1.1 to 3.6.1.
I found that commons-math3 can be upgraded from 3.1.1 to 3.6.1. Try to upgrade, local compilation and verification are correct.