### PR TITLE
YARN-11063. Support auto queue creation template wildcards for arbitr…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedQueueTemplate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedQueueTemplate.java
@@ -42,7 +42,6 @@ public class AutoCreatedQueueTemplate {
       AUTO_QUEUE_CREATION_V2_PREFIX + "parent-template.";
 
   private static final String WILDCARD_QUEUE = "*";
-  private static final int MAX_WILDCARD_LEVEL = 1;
 
   private final Map<String, String> templateProperties = new HashMap<>();
   private final Map<String, String> leafOnlyProperties = new HashMap<>();
@@ -86,7 +85,7 @@ public class AutoCreatedQueueTemplate {
   /**
    * Sets the common template properties and parent specific template
    * properties of a child queue based on its parent template settings.
- * @param conf configuration to set
+   * @param conf configuration to set
    * @param childQueuePath child queue path used for prefixing the properties
    */
   public void setTemplateEntriesForChild(CapacitySchedulerConfiguration conf,
@@ -169,8 +168,8 @@ public class AutoCreatedQueueTemplate {
     // start with the most explicit format (without wildcard)
     int wildcardLevel = 0;
     // root can not be wildcarded
-    // MAX_WILDCARD_LEVEL will be configurable in the future
-    int supportedWildcardLevel = Math.min(queuePathMaxIndex, MAX_WILDCARD_LEVEL);
+    int supportedWildcardLevel = Math.min(queuePathMaxIndex,
+            configuration.getMaximumAutoCreatedQueueDepth(queuePath.getFullPath()));
     // Allow root to have template properties
     if (queuePath.isRoot()) {
       supportedWildcardLevel = 0;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAutoCreatedQueueTemplate.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestAutoCreatedQueueTemplate.java
@@ -67,6 +67,22 @@ public class TestAutoCreatedQueueTemplate {
   }
 
   @Test
+  public void testTwoLevelWildcardTemplate() {
+    conf.set(getTemplateKey("root.*", "capacity"), "6w");
+    conf.set(getTemplateKey("root.*.*", "capacity"), "5w");
+
+    new AutoCreatedQueueTemplate(conf, TEST_QUEUE_A)
+            .setTemplateEntriesForChild(conf, TEST_QUEUE_AB.getFullPath());
+    new AutoCreatedQueueTemplate(conf, TEST_QUEUE_AB)
+            .setTemplateEntriesForChild(conf, TEST_QUEUE_ABC.getFullPath());
+
+    Assert.assertEquals("weight is not set", 6f,
+            conf.getNonLabeledQueueWeight(TEST_QUEUE_AB.getFullPath()), 10e-6);
+    Assert.assertEquals("weight is not set", 5f,
+            conf.getNonLabeledQueueWeight(TEST_QUEUE_ABC.getFullPath()), 10e-6);
+  }
+
+  @Test
   public void testIgnoredWhenRootWildcarded() {
     conf.set(getTemplateKey("*", "capacity"), "6w");
     AutoCreatedQueueTemplate template =


### PR DESCRIPTION
…ary queue depths

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

