### PR TITLE
HADOOP-18364. All method metrics related to the RPC protocol should be initialized.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
@@ -21,10 +21,7 @@ package org.apache.hadoop.metrics2.lib;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.HashSet;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -74,20 +71,11 @@ public class MutableRatesWithAggregation extends MutableMetric {
     if (protocolCache.contains(protocol)) {
       return;
     }
-
-    List<Class<?>> protocols = new ArrayList<>();
-    protocols.add(protocol);
-    if (protocol.getDeclaredMethods().length == 0) {
-      protocols.addAll(Arrays.asList(protocol.getInterfaces()));
-    }
-
-    for (Class<?> pClass : protocols) {
-      protocolCache.add(pClass);
-      for (Method method : pClass.getDeclaredMethods()) {
-        String name = method.getName();
-        LOG.debug(name);
-        addMetricIfNotExists(name);
-      }
+    protocolCache.add(protocol);
+    for (Method method : protocol.getMethods()) {
+      String name = method.getName();
+      LOG.debug(name);
+      addMetricIfNotExists(name);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableRatesWithAggregation.java
@@ -21,7 +21,10 @@ package org.apache.hadoop.metrics2.lib;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -71,11 +74,20 @@ public class MutableRatesWithAggregation extends MutableMetric {
     if (protocolCache.contains(protocol)) {
       return;
     }
-    protocolCache.add(protocol);
-    for (Method method : protocol.getDeclaredMethods()) {
-      String name = method.getName();
-      LOG.debug(name);
-      addMetricIfNotExists(name);
+
+    List<Class<?>> protocols = new ArrayList<>();
+    protocols.add(protocol);
+    if (protocol.getDeclaredMethods().length == 0) {
+      protocols.addAll(Arrays.asList(protocol.getInterfaces()));
+    }
+
+    for (Class<?> pClass : protocols) {
+      protocolCache.add(pClass);
+      for (Method method : pClass.getDeclaredMethods()) {
+        String name = method.getName();
+        LOG.debug(name);
+        addMetricIfNotExists(name);
+      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -70,7 +70,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import javax.management.AttributeNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -592,7 +591,7 @@ public class TestDataNodeMetrics {
   }
 
   @Test
-  public void testNNRpcMetricsWithNonHA() throws Exception {
+  public void testNNRpcMetricsWithNonHA() throws IOException {
     Configuration conf = new HdfsConfiguration();
     // setting heartbeat interval to 1 hour to prevent bpServiceActor sends
     // heartbeat periodically to NN during running test case, and bpServiceActor
@@ -600,16 +599,6 @@ public class TestDataNodeMetrics {
     conf.setTimeDuration(DFS_HEARTBEAT_INTERVAL_KEY, 1, TimeUnit.HOURS);
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build();
     cluster.waitActive();
-    final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-    final ObjectName mxbeanName =
-        new ObjectName("Hadoop:service=NameNode," +
-            "name=RpcDetailedActivityForPort" +
-            cluster.getNameNode().getNameNodeAddress().getPort());
-    try {
-      mbs.getAttribute(mxbeanName, "CommitBlockSynchronizationNumOps");
-    } catch (AttributeNotFoundException e) {
-      fail("Datanode protocol metrics have not been fully initialized.");
-    }
     DataNode dn = cluster.getDataNodes().get(0);
     MetricsRecordBuilder rb = getMetrics(dn.getMetrics().name());
     assertCounter("HeartbeatsNumOps", 1L, rb);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -70,6 +70,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import javax.management.AttributeNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -591,7 +592,7 @@ public class TestDataNodeMetrics {
   }
 
   @Test
-  public void testNNRpcMetricsWithNonHA() throws IOException {
+  public void testNNRpcMetricsWithNonHA() throws Exception {
     Configuration conf = new HdfsConfiguration();
     // setting heartbeat interval to 1 hour to prevent bpServiceActor sends
     // heartbeat periodically to NN during running test case, and bpServiceActor
@@ -599,6 +600,16 @@ public class TestDataNodeMetrics {
     conf.setTimeDuration(DFS_HEARTBEAT_INTERVAL_KEY, 1, TimeUnit.HOURS);
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).build();
     cluster.waitActive();
+    final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    final ObjectName mxbeanName =
+        new ObjectName("Hadoop:service=NameNode," +
+            "name=RpcDetailedActivityForPort" +
+            cluster.getNameNode().getNameNodeAddress().getPort());
+    try {
+      mbs.getAttribute(mxbeanName, "CommitBlockSynchronizationNumOps");
+    } catch (AttributeNotFoundException e) {
+      fail("Datanode protocol metrics have not been fully initialized.");
+    }
     DataNode dn = cluster.getDataNodes().get(0);
     MetricsRecordBuilder rb = getMetrics(dn.getMetrics().name());
     assertCounter("HeartbeatsNumOps", 1L, rb);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
@@ -1131,6 +1131,7 @@ public class TestNameNodeMetrics {
     }
 
   }
+
   @Test
   public void testNNRPCMetricIntegrity() {
     RpcDetailedMetrics metrics =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
@@ -48,6 +48,9 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
+
+import org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer;
+import org.apache.hadoop.ipc.metrics.RpcDetailedMetrics;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
@@ -1127,5 +1130,14 @@ public class TestNameNodeMetrics {
       }
     }
 
+  }
+  @Test
+  public void testNNRPCMetricIntegrity() {
+    RpcDetailedMetrics metrics =
+        ((NameNodeRpcServer) cluster.getNameNode()
+            .getRpcServer()).getClientRpcServer().getRpcDetailedMetrics();
+    MetricsRecordBuilder rb = getMetrics(metrics.name());
+    // CommitBlockSynchronizationNumOps should exist.
+    assertCounter("CommitBlockSynchronizationNumOps", 0L, rb);
   }
 }


### PR DESCRIPTION
…initialized.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

