### PR TITLE
HDFS-16676. DatanodeAdminManager$Monitor reports a node as invalid continuously

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -201,7 +201,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         iterkey).iterator();
     final List<DatanodeDescriptor> toRemove = new ArrayList<>();
     final List<DatanodeDescriptor> unhealthyDns = new ArrayList<>();
-    boolean inValidState = false;
+    boolean isValidState = true;
 
     while (it.hasNext() && !exceededNumBlocksPerCheck() && namesystem
         .isRunning()) {
@@ -266,7 +266,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
               // to track maintenance expiration.
               dnAdmin.setInMaintenance(dn);
             } else {
-              inValidState  = true;
+              isValidState  = false;
               Preconditions.checkState(false,
                   "Node %s is in an invalid state! "
                       + "Invalid state: %s %s blocks are on this dn.",
@@ -290,7 +290,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         // an invalid state.
         LOG.warn("DatanodeAdminMonitor caught exception when processing node "
             + "{}.", dn, e);
-        if(!inValidState){
+        if(isValidState){
           getPendingNodes().add(dn);
         } else {
           LOG.warn("Ignoring the node {} which is in invalid state", dn);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminDefaultMonitor.java
@@ -201,6 +201,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         iterkey).iterator();
     final List<DatanodeDescriptor> toRemove = new ArrayList<>();
     final List<DatanodeDescriptor> unhealthyDns = new ArrayList<>();
+    boolean inValidState = false;
 
     while (it.hasNext() && !exceededNumBlocksPerCheck() && namesystem
         .isRunning()) {
@@ -265,6 +266,7 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
               // to track maintenance expiration.
               dnAdmin.setInMaintenance(dn);
             } else {
+              inValidState  = true;
               Preconditions.checkState(false,
                   "Node %s is in an invalid state! "
                       + "Invalid state: %s %s blocks are on this dn.",
@@ -288,7 +290,11 @@ public class DatanodeAdminDefaultMonitor extends DatanodeAdminMonitorBase
         // an invalid state.
         LOG.warn("DatanodeAdminMonitor caught exception when processing node "
             + "{}.", dn, e);
-        getPendingNodes().add(dn);
+        if(!inValidState){
+          getPendingNodes().add(dn);
+        } else {
+          LOG.warn("Ignoring the node {} which is in invalid state", dn);
+        }
         toRemove.add(dn);
         unhealthyDns.remove(dn);
       } finally {


### PR DESCRIPTION
### Description of PR

DatanodeAdminManager$Monitor reports a node as invalid continuously

JIRA - HDFS-16676


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

