### PR TITLE
HADOOP-18363. Fix bug preventing hadoop-metrics2 from emitting metrics to > 1 Ganglia servers

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration2.SubsetConfiguration;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsSink;
 import org.apache.hadoop.metrics2.util.Servers;
 import org.apache.hadoop.net.DNS;
@@ -78,6 +79,11 @@ public abstract class AbstractGangliaSink implements MetricsSink {
   private byte[] buffer = new byte[BUFFER_SIZE];
   private int offset;
   private boolean supportSparseMetrics = SUPPORT_SPARSE_METRICS_DEFAULT;
+
+  @VisibleForTesting
+  public List<? extends SocketAddress> getMetricsServers() {
+    return metricsServers;
+  }
 
   /**
    * Used for visiting Metrics

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
@@ -133,8 +133,10 @@ public abstract class AbstractGangliaSink implements MetricsSink {
     }
 
     // load the gannglia servers from properties
-    metricsServers = Servers.parse(conf.getString(SERVERS_PROPERTY),
-        DEFAULT_PORT);
+    List<String> serversFromConf = conf.getList(String.class, SERVERS_PROPERTY);
+    metricsServers =
+        Servers.parse(serversFromConf.size() > 0 ? String.join(",", serversFromConf) : null,
+            DEFAULT_PORT);
     multicastEnabled = conf.getBoolean(MULTICAST_ENABLED_PROPERTY,
             DEFAULT_MULTICAST_ENABLED);
     multicastTtl = conf.getInt(MULTICAST_TTL_PROPERTY, DEFAULT_MULTICAST_TTL);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration2.SubsetConfiguration;
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsSink;
 import org.apache.hadoop.metrics2.util.Servers;
 import org.apache.hadoop.net.DNS;
@@ -80,7 +79,6 @@ public abstract class AbstractGangliaSink implements MetricsSink {
   private int offset;
   private boolean supportSparseMetrics = SUPPORT_SPARSE_METRICS_DEFAULT;
 
-  @VisibleForTesting
   public List<? extends SocketAddress> getMetricsServers() {
     return metricsServers;
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.metrics2.sink.ganglia;
 import java.io.IOException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,8 @@ public abstract class AbstractGangliaSink implements MetricsSink {
     }
 
     // load the gannglia servers from properties
-    List<String> serversFromConf = conf.getList(String.class, SERVERS_PROPERTY);
+    List<String> serversFromConf =
+        conf.getList(String.class, SERVERS_PROPERTY, new ArrayList<String>());
     metricsServers =
         Servers.parse(serversFromConf.size() > 0 ? String.join(",", serversFromConf) : null,
             DEFAULT_PORT);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package org.apache.hadoop.metrics2.sink.ganglia;
 
 import org.apache.commons.configuration2.SubsetConfiguration;
 import org.apache.hadoop.metrics2.impl.ConfigBuilder;
+
 import org.junit.Test;
 
 import java.net.DatagramSocket;
@@ -30,62 +31,61 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestGangliaSink {
-    @Test
-    public void testShouldCreateDatagramSocketByDefault() throws Exception {
-        SubsetConfiguration conf = new ConfigBuilder()
-                .subset("test.sink.ganglia");
+  @Test
+  public void testShouldCreateDatagramSocketByDefault() throws Exception {
+    SubsetConfiguration conf = new ConfigBuilder().subset("test.sink.ganglia");
 
-        GangliaSink30 gangliaSink = new GangliaSink30();
-        gangliaSink.init(conf);
-        DatagramSocket socket = gangliaSink.getDatagramSocket();
-        assertFalse("Did not create DatagramSocket", socket == null || socket instanceof MulticastSocket);
-    }
+    GangliaSink30 gangliaSink = new GangliaSink30();
+    gangliaSink.init(conf);
+    DatagramSocket socket = gangliaSink.getDatagramSocket();
+    assertFalse("Did not create DatagramSocket",
+        socket == null || socket instanceof MulticastSocket);
+  }
 
-    @Test
-    public void testShouldCreateDatagramSocketIfMulticastIsDisabled() throws Exception {
-        SubsetConfiguration conf = new ConfigBuilder()
-                .add("test.sink.ganglia.multicast", false)
-                .subset("test.sink.ganglia");
-        GangliaSink30 gangliaSink = new GangliaSink30();
-        gangliaSink.init(conf);
-        DatagramSocket socket = gangliaSink.getDatagramSocket();
-        assertFalse("Did not create DatagramSocket", socket == null || socket instanceof MulticastSocket);
-    }
+  @Test
+  public void testShouldCreateDatagramSocketIfMulticastIsDisabled() throws Exception {
+    SubsetConfiguration conf =
+        new ConfigBuilder().add("test.sink.ganglia.multicast", false).subset("test.sink.ganglia");
+    GangliaSink30 gangliaSink = new GangliaSink30();
+    gangliaSink.init(conf);
+    DatagramSocket socket = gangliaSink.getDatagramSocket();
+    assertFalse("Did not create DatagramSocket",
+        socket == null || socket instanceof MulticastSocket);
+  }
 
-    @Test
-    public void testShouldCreateMulticastSocket() throws Exception {
-        SubsetConfiguration conf = new ConfigBuilder()
-                .add("test.sink.ganglia.multicast", true)
-                .subset("test.sink.ganglia");
-        GangliaSink30 gangliaSink = new GangliaSink30();
-        gangliaSink.init(conf);
-        DatagramSocket socket = gangliaSink.getDatagramSocket();
-        assertTrue("Did not create MulticastSocket", socket != null && socket instanceof MulticastSocket);
-        int ttl = ((MulticastSocket) socket).getTimeToLive();
-        assertEquals("Did not set default TTL", 1, ttl);
-    }
+  @Test
+  public void testShouldCreateMulticastSocket() throws Exception {
+    SubsetConfiguration conf =
+        new ConfigBuilder().add("test.sink.ganglia.multicast", true).subset("test.sink.ganglia");
+    GangliaSink30 gangliaSink = new GangliaSink30();
+    gangliaSink.init(conf);
+    DatagramSocket socket = gangliaSink.getDatagramSocket();
+    assertTrue("Did not create MulticastSocket",
+        socket != null && socket instanceof MulticastSocket);
+    int ttl = ((MulticastSocket) socket).getTimeToLive();
+    assertEquals("Did not set default TTL", 1, ttl);
+  }
 
-    @Test
-    public void testShouldSetMulticastSocketTtl() throws Exception {
-        SubsetConfiguration conf = new ConfigBuilder()
-                .add("test.sink.ganglia.multicast", true)
-                .add("test.sink.ganglia.multicast.ttl", 3)
-                .subset("test.sink.ganglia");
-        GangliaSink30 gangliaSink = new GangliaSink30();
-        gangliaSink.init(conf);
-        DatagramSocket socket = gangliaSink.getDatagramSocket();
-        assertTrue("Did not create MulticastSocket", socket != null && socket instanceof MulticastSocket);
-        int ttl = ((MulticastSocket) socket).getTimeToLive();
-        assertEquals("Did not set TTL", 3, ttl);
-    }
+  @Test
+  public void testShouldSetMulticastSocketTtl() throws Exception {
+    SubsetConfiguration conf = new ConfigBuilder().add("test.sink.ganglia.multicast", true)
+        .add("test.sink.ganglia.multicast.ttl", 3).subset("test.sink.ganglia");
+    GangliaSink30 gangliaSink = new GangliaSink30();
+    gangliaSink.init(conf);
+    DatagramSocket socket = gangliaSink.getDatagramSocket();
+    assertTrue("Did not create MulticastSocket",
+        socket != null && socket instanceof MulticastSocket);
+    int ttl = ((MulticastSocket) socket).getTimeToLive();
+    assertEquals("Did not set TTL", 3, ttl);
+  }
 
-    @Test
-    public void testMultipleMetricsServers() {
-        SubsetConfiguration conf =
-            new ConfigBuilder().add("test.sink.ganglia.servers", "server1,server2")
-                .subset("test.sink.ganglia");
-        GangliaSink30 gangliaSink = new GangliaSink30();
-        gangliaSink.init(conf);
-        assertEquals(2, gangliaSink.getMetricsServers().size());
-    }
+  @Test
+  public void testMultipleMetricsServers() {
+    SubsetConfiguration conf =
+        new ConfigBuilder().add("test.sink.ganglia.servers", "server1,server2")
+            .subset("test.sink.ganglia");
+    GangliaSink30 gangliaSink = new GangliaSink30();
+    gangliaSink.init(conf);
+    assertEquals(2, gangliaSink.getMetricsServers().size());
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
@@ -78,4 +78,14 @@ public class TestGangliaSink {
         int ttl = ((MulticastSocket) socket).getTimeToLive();
         assertEquals("Did not set TTL", 3, ttl);
     }
+
+    @Test
+    public void testMultipleMetricsServers() {
+        SubsetConfiguration conf =
+            new ConfigBuilder().add("test.sink.ganglia.servers", "server1,server2")
+                .subset("test.sink.ganglia");
+        GangliaSink30 gangliaSink = new GangliaSink30();
+        gangliaSink.init(conf);
+        assertEquals(2, gangliaSink.getMetricsServers().size());
+    }
 }


### PR DESCRIPTION
### Description of PR
Fix bug preventing hadoop-metrics2 from emitting metrics to > 1 Ganglia servers

JIRA - HADOOP-18363

The patch is tested internally in EMR cluster. (via internal integration test)

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

