### PR TITLE
HDFS-16692. Add detailed scope info in NotEnoughReplicas Reason log

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -909,7 +909,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
       final HashMap<NodeNotChosenReason, Integer> reasonMap =
           CHOOSE_RANDOM_REASONS.get();
       if (!reasonMap.isEmpty()) {
-        LOG.info("Not enough replicas was chosen. Reason: {}", reasonMap);
+        LOG.info("Not enough replicas was chosen in {}. Reason: {}", scope, reasonMap);
       }
       throw new NotEnoughReplicasException(detail);
     }


### PR DESCRIPTION
### Description of PR
When we write some ec data from clients that are not in hdfs cluster, there is a lot of INFO log output, as blew:
```
2022-07-26 15:50:40,973 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=17}
2022-07-26 15:50:40,974 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=18}
2022-07-26 15:50:40,974 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=17}
2022-07-26 15:50:40,975 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=18}
2022-07-26 15:50:40,975 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=17}
2022-07-26 15:50:40,976 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=18}
2022-07-26 15:50:40,976 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=18}
2022-07-26 15:50:40,977 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=18}
2022-07-26 15:50:40,977 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=19}
2022-07-26 15:50:40,977 INFO  blockmanagement.BlockPlacementPolicy (BlockPlacementPolicyDefault.java:chooseRandom(912)) - Not enough replicas was chosen. Reason: {NO_REQUIRED_STORAGE_TYPE=1, TOO_MANY_NODES_ON_RACK=3}
```

I feel that we should add detailed scope info in this log to show the scope that we cannot select any good nodes from. 

It will be convenient for us to quickly locate the scope in which the node cannot be selected for what reason from the log.

