### PR TITLE
HADOOP-18368. Fixes ITestCustomSigner for access point names with '-'

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
@@ -228,10 +228,13 @@ public class ITestCustomSigner extends AbstractS3ATestBase {
       if (service.contains("s3-accesspoint") || service.contains("s3-outposts")
           || service.contains("s3-object-lambda")) {
         // If AccessPoint then bucketName is of format `accessPoint-accountId`;
-        String[] accessPointBits = hostBits[0].split("-");
-        int lastElem = accessPointBits.length - 1;
-        String accountId = accessPointBits[lastElem];
-        String accessPointName = String.join("", Arrays.copyOf(accessPointBits, lastElem));
+        String[] accessPointBits = bucketName.split("-");
+        String accountId = accessPointBits[accessPointBits.length - 1];
+        // Extract the access point name from bucket name. eg: if bucket name is
+        // test-custom-signer-<accountId>, get the access point name test-custom-signer by removing
+        // -<accountId> from the bucket name.
+        String accessPointName =
+            bucketName.substring(0, bucketName.length() - (accountId.length() + 1));
         Arn arn = Arn.builder()
             .withAccountId(accountId)
             .withPartition("aws")

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.s3a.auth;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;


### PR DESCRIPTION
### Description of PR

Jira: https://issues.apache.org/jira/browse/HADOOP-18368

ITestCustomSigner was failing for access point names that had '-', eg: test-custom-signer. This PR updates the logic so access point name is now extracted using substring. Eg, if `bucketName = test-custom-signer-12345678` where `12345678` is the aws account id, we can get access point name by `bucketName.substring(0, bucketName.length() - (accountId.length() + 1))`, with the `+ 1`  being for removing  the`-` before the account id. 

### How was this patch tested?

Since it's only updating the `ITestCustomSigner`, I tested by running`ITestCustomSigner` with:

- Access point name test-custom-signer
- Access point name testcustomsigner
- Access points disabled
