### PR TITLE
HADOOP-18354. Upgrade reload4j to 1.22.2 due to XXE vulnerability (#4607).

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -208,7 +208,7 @@ License Version 2.0:
 hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/checker/AbstractFuture.java
 hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/checker/TimeoutFuture.java
 
-ch.qos.reload4j:reload4j:1.2.18.3
+ch.qos.reload4j:reload4j:1.2.22
 com.aliyun:aliyun-java-sdk-core:3.4.0
 com.aliyun:aliyun-java-sdk-ecs:4.2.0
 com.aliyun:aliyun-java-sdk-ram:3.0.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -79,7 +79,7 @@
 
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.36</slf4j.version>
-    <reload4j.version>1.2.18.3</reload4j.version>
+    <reload4j.version>1.2.22</reload4j.version>
 
     <!-- com.google.re2j version -->
     <re2j.version>1.1</re2j.version>


### PR DESCRIPTION

Contributed by PJ Fanning.
