### PR TITLE
HDFS-16697.Randomly setting “dfs.namenode.resource.checked.volumes.minimum” will always prevent safe mode from being turned off

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -178,6 +178,11 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
+    Preconditions.checkArgument(minimumRedundantVolumes <= volumes.size(), 
+    "The setting for " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
+    " is " + minimumRedundantVolumes +
+    " which is less than the total number of existing storage volumes " + volumes.size() + 
+    " and will result in adding resources and still not being able to turn off safe mode.");
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Add Precondition.checkArgument() for minimumRedundantVolumes to ensure that the value is greater than the number of  NameNode storage volumes to avoid never being able to turn off safe mode afterwards.

JIRA:[HDFS-16697](https://issues.apache.org/jira/browse/HDFS-16697)

### How was this patch tested?

It is found that “dfs.namenode.resource.checked.volumes.minimum” lacks a condition check and an associated exception handling mechanism, which makes it impossible to find the root cause of the impact when a misconfiguration occurs.
This patch provides a check of the configuration items，it will throw a IllegalArgumentException and detailed error message when the value of "dfs.namenode.resource.checked.volumes.minimum" is set greater than the number of  NameNode storage volumes to avoid the misconfiguration from affecting the subsequent operation of the program.