### PR TITLE
HADOOP-18362. Solve ZKFailoverController throw ambiguous exception

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -131,7 +131,12 @@ public class Groups {
           CommonConfigurationKeys.
               HADOOP_SECURITY_GROUPS_CACHE_BACKGROUND_RELOAD_THREADS_DEFAULT);
     parseStaticMapping(conf);
-
+    
+    if(cacheTimeout<=0){
+    throw new IllegalArgumentException(
+       "hadoop.security.groups.cache.secs should be larger than 0",
+        new IllegalArgumentException("hadoop.security.groups.cache.secs should be larger than 0"));
+    }
     this.timer = timer;
     this.cache = CacheBuilder.newBuilder()
       .refreshAfterWrite(cacheTimeout, TimeUnit.MILLISECONDS)

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestGroupsCaching.java
@@ -9,6 +9,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
We modified the Groups.java file, manually checked the cache validity time in the initialization function of this file, and then threw an exception at an earlier position. Because what is thrown in ZKFailoverController.java is the cause of the exception information, which is RuntimeException.getCause(). Also, the cache validity time is used when creating a cacheBuilder. However, the check information in this cacheBuilder class is imperfect, so it leads to imperfection of the thrown information.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

