### PR TITLE
HADOOP-18375. Fix failure of shelltest for hadoop_add_ldlibpath.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/scripts/hadoop-functions_test_helper.bash
+++ b/hadoop-common-project/hadoop-common/src/test/scripts/hadoop-functions_test_helper.bash
@@ -16,6 +16,7 @@
 
 setup() {
 
+  export LD_LIBRARY_PATH=""
   RELTMP="${BATS_TEST_DIRNAME}/../../../target/test-dir/bats.$$.${RANDOM}"
   mkdir -p ${RELTMP}
   TMP=$(cd -P -- "${RELTMP}" >/dev/null && pwd -P)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HADOOP-18375

The hadoop-functions_test_helper.bash assumes that the value of LD_LIBRARY_PATH is blank. 

It is not true in the environment like [RHEL 8 with GCC 9](https://github.com/apache/hadoop/blob/06ac327e881a10f193b1fff14a1eaadf16e08e44/BUILDING.txt#L458-L460).

```
$ grep LD_LIBRARY_PATH /opt/rh/gcc-toolset-9/enable
export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-9/root$rpmlibdir$rpmlibdir32${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-9/root$rpmlibdir$rpmlibdir32:/opt/rh/gcc-toolset-9/root$rpmlibdir/dyninst$rpmlibdir32/dyninst${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
```

Resetting the value of LD_LIBRARY_PATH in the helper script should fix this. The update of environment variable in the tests does not affect outside.
