### PR TITLE
HDFS-16697.Randomly setting “dfs.namenode.resource.checked.volumes.minimum” will always prevent safe mode from being turned off

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,6 +174,11 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
+    Preconditions.checkArgument(minimumRedundantVolumes <= volumes.size(), 
+    "The setting for " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
+    " is " + minimumRedundantVolumes +
+    " which is less than the total number of existing storage volumes " + volumes.size() + 
+    " and will result in adding resources and still not being able to turn off safe mode.");
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -35,8 +35,6 @@ import org.apache.hadoop.hdfs.server.common.Util;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
-import com.google.common.base.Preconditions;
-
 /**
  * 
  * NameNodeResourceChecker provides a method -
@@ -176,11 +174,12 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
-    Preconditions.checkArgument(minimumRedundantVolumes <= volumes.size(), 
-    "The setting for " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
-    " is " + minimumRedundantVolumes +
-    " which is less than the total number of existing storage volumes " + volumes.size() + 
-    " and will result in adding resources and still not being able to turn off safe mode.");
+    if (minimumRedundantVolumes > volumes.size()){
+      throw new IllegalArgumentException(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
+      " is " + minimumRedundantVolumes +
+      " which is greater than the total number of existing storage volumes " + volumes.size() + 
+      " and will result in adding resources and still not being able to turn off safe mode.");
+    }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -35,6 +35,10 @@ import org.apache.hadoop.hdfs.server.common.Util;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
+import com.google.common.collect.Collections2;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+
 /**
  * 
  * NameNodeResourceChecker provides a method -

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,11 +174,16 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
-    if (minimumRedundantVolumes > volumes.size()){
-      throw new IllegalArgumentException(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
-      " is " + minimumRedundantVolumes +
-      " which is greater than the total number of existing storage volumes " + volumes.size() + 
-      " and will result in adding resources and still not being able to turn off safe mode.");
+    try{
+      if (minimumRedundantVolumes > volumes.size()){
+        throw new IllegalArgumentException(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY +
+        " is " + minimumRedundantVolumes +
+        " which is greater than the total number of existing storage volumes " + volumes.size());
+      }
+    }catch(IllegalArgumentException e){
+      LOG.warn(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY +
+      " is greater than the total number of existing storage volumes" +
+      " and will result in adding resources and still not being able to turn off safe mode.", e);
     }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,13 +174,13 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
-    try{
+    try {
       if (minimumRedundantVolumes > volumes.size()){
         throw new IllegalArgumentException(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY +
         " is " + minimumRedundantVolumes +
         " which is greater than the total number of existing storage volumes " + volumes.size());
       }
-    }catch(IllegalArgumentException e){
+    } catch (IllegalArgumentException e){
       LOG.warn(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY +
       " is greater than the total number of existing storage volumes" +
       " and will result in adding resources and still not being able to turn off safe mode.", e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -176,14 +176,16 @@ public class NameNodeResourceChecker {
   public boolean hasAvailableDiskSpace() {
     try {
       if (minimumRedundantVolumes > volumes.size()){
-        throw new IllegalArgumentException(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY +
-        " is " + minimumRedundantVolumes +
-        " which is greater than the total number of existing storage volumes " + volumes.size());
+        throw new IllegalArgumentException("The value of "
+        + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+        + " is " + minimumRedundantVolumes
+        + " which is greater than the total number of existing storage volumes "
+        + volumes.size() + " .");
       }
     } catch (IllegalArgumentException e){
-      LOG.warn(DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY +
-      " is greater than the total number of existing storage volumes" +
-      " and will result in adding resources and still not being able to turn off safe mode.", e);
+      LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+      + " is greater than the total number of existing storage volumes"
+      + " and will result in adding resources and still not being able to turn off safe mode.", e);
     }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -35,9 +35,7 @@ import org.apache.hadoop.hdfs.server.common.Util;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
-import com.google.common.collect.Collections2;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 
 /**
  * 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourceChecker.java
@@ -7,7 +7,9 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
It is found that “dfs.namenode.resource.checked.volumes.minimum” lacks a condition check and an associated exception handling mechanism, which makes it impossible to find the root cause of the impact when a misconfiguration occurs.
Add a mechanism to check the value of minimumRedundantVolumes to ensure that the value is greater than the number of NameNode storage volumes to avoid never being able to turn off safe mode afterwards.

JIRA:[[HDFS-16697](https://issues.apache.org/jira/browse/HDFS-16697)]

### How was this patch tested?
This patch provides a check of the configuration items，it will throw an IllegalArgumentException and a detailed error message when the value is greater than the number of NameNode storage volumes, and printing a warning message in the log in order to solve the problem in time and avoid the misconfiguration from affecting the subsequent operations of the program.