### PR TITLE
YARN-11216. Avoid unnecessary reconstruction of ConfigurationProperties

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -882,8 +882,6 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
       BiConsumer<String, String> propertiesAddListener,
       Consumer<String> propertiesRemoveListener
   ) {
-    assert propertiesAddListener != null : "propertiesAddListener can not be null";
-    assert propertiesRemoveListener != null : "propertiesRemoveListener cannot be null";
     this.properties = null;
     this.propertiesAddListener = propertiesAddListener;
     this.propertiesRemoveListener = propertiesRemoveListener;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -245,8 +245,8 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
   private boolean restrictSystemProps = restrictSystemPropsDefault;
   private boolean allowNullValueProperties = false;
 
-  protected BiConsumer<String, String> propAddListener;
-  protected Consumer<String> propRemoveListener;
+  private BiConsumer<String, String> propAddListener;
+  private Consumer<String> propRemoveListener;
 
 
   private static class Resource {
@@ -876,6 +876,15 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     this.classLoader = other.classLoader;
     this.loadDefaults = other.loadDefaults;
     setQuietMode(other.getQuietMode());
+  }
+
+  protected synchronized void setPropListeners(
+      BiConsumer<String, String> propAddListener,
+      Consumer<String> propRemoveListener
+  ) {
+    this.properties = null;
+    this.propAddListener = propAddListener;
+    this.propRemoveListener = propRemoveListener;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2939,7 +2939,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
   protected synchronized Properties getProps() {
     if (properties == null) {
       properties = propAddListener != null || propRemoveListener != null
-        ? new PropWithListener()
+        ? new PropWithListener(this)
         : new Properties();
       loadProps(properties, 0, true);
     }
@@ -4079,15 +4079,25 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     localUR.put(key, value);
   }
   private class PropWithListener extends Properties {
+
+    private final Configuration configuration;
+
+    public PropWithListener(Configuration configuration) {
+      this.configuration = configuration;
+    }
     @Override
     public synchronized Object setProperty(String key, String value) {
-      propAddListener.accept(key, value);
-      return super.setProperty(key, value);
+      synchronized (configuration) {
+        propAddListener.accept(key, value);
+        return super.setProperty(key, value);
+      }
     }
     @Override
     public synchronized Object remove(Object key) {
-      propRemoveListener.accept(String.valueOf(key));
-      return super.remove(key);
+      synchronized (configuration) {
+        propRemoveListener.accept(String.valueOf(key));
+        return super.remove(key);
+      }
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -1233,7 +1233,8 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public void set(String name, String value) {
     super.set(name, value);
     if (configurationProperties != null) {
-      configurationProperties.set(name, value);
+      //The super#get method used cause the super#set contains some logic
+      configurationProperties.set(super.get(name), value);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -18,15 +18,27 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
-import org.apache.hadoop.classification.VisibleForTesting;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
-import org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule.MappingRule;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.conf.QueueCapacityConfigParser;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placement.MappingRuleCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -43,10 +55,13 @@ import org.apache.hadoop.yarn.security.AccessType;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.QueueMapping;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.QueueMapping.QueueMappingBuilder;
+import org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule.MappingRule;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationSchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AppPriorityACLConfigurationParser.AppPriorityACLKeyType;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.WorkflowPriorityMappingsManager.WorkflowPriorityMapping;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.conf.QueueCapacityConfigParser;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placement.MappingRuleCreator;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.policy.PriorityUtilizationQueueOrderingPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.policy.QueueOrderingPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.MultiNodeLookupPolicy;
@@ -477,6 +492,16 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     if (useLocalConfigurationProvider) {
       addResource(CS_CONFIGURATION_FILE);
     }
+    super.propRemoveListener = prop -> {
+      if (configurationProperties != null) {
+        configurationProperties.unset(prop);
+      }
+    };
+    super.propAddListener = (prop, value) -> {
+      if (configurationProperties != null) {
+        configurationProperties.set(prop, value);
+      }
+    };
   }
 
   static String getUserPrefix(String user) {
@@ -1227,23 +1252,6 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     // Props are always Strings, therefore this cast is safe
     Map<String, String> props = (Map) getProps();
     configurationProperties = new ConfigurationProperties(props, PREFIX);
-  }
-
-  @Override
-  public void set(String name, String value) {
-    super.set(name, value);
-    if (configurationProperties != null) {
-      //The super#get method used cause the super#set contains some logic
-      configurationProperties.set(super.get(name), value);
-    }
-  }
-
-  @Override
-  public void unset(String name) {
-    super.unset(name);
-    if (configurationProperties != null) {
-      configurationProperties.unset(name);
-    }
   }
 
   public void setQueueMaximumAllocationMb(QueuePath queue, int value) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -1219,7 +1219,7 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public void reinitializeConfigurationProperties() {
     // Props are always Strings, therefore this cast is safe
     Map<String, String> props = (Map) getProps();
-    configurationProperties = new ConfigurationProperties(props);
+    configurationProperties = new ConfigurationProperties(props, PREFIX);
   }
 
   public void setQueueMaximumAllocationMb(QueuePath queue, int value) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -1222,6 +1222,22 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     configurationProperties = new ConfigurationProperties(props, PREFIX);
   }
 
+  @Override
+  public void set(String name, String value) {
+    super.set(name, value);
+    if (configurationProperties != null) {
+      configurationProperties.set(name, value);
+    }
+  }
+
+  @Override
+  public void unset(String name) {
+    super.unset(name);
+    if (configurationProperties != null) {
+      configurationProperties.unset(name);
+    }
+  }
+
   public void setQueueMaximumAllocationMb(QueuePath queue, int value) {
     String queuePrefix = getQueuePrefix(queue);
     setInt(queuePrefix + MAXIMUM_ALLOCATION_MB, value);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -533,7 +533,7 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     		getMaximumApplicationMasterResourcePercent());
   }
 
-  public boolean isMaximumApplicationMasterResourcePerQueuePercentPresent(String queue) {
+  public boolean isMaximumApplicationMasterResourcePerQueuePercentSet(String queue) {
     return get(getQueuePrefix(queue) + MAXIMUM_AM_RESOURCE_SUFFIX) != null;
   }
   public void setMaximumApplicationMasterResourcePerQueuePercent(QueuePath queue,
@@ -750,7 +750,7 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     return userLimitFactor;
   }
 
-  public boolean isUserLimitFactorPresent(String queue) {
+  public boolean isUserLimitFactorSet(String queue) {
     return get(getQueuePrefix(queue) + USER_LIMIT_FACTOR) != null;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -492,16 +492,18 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     if (useLocalConfigurationProvider) {
       addResource(CS_CONFIGURATION_FILE);
     }
-    super.propRemoveListener = prop -> {
-      if (configurationProperties != null) {
-        configurationProperties.unset(prop);
-      }
-    };
-    super.propAddListener = (prop, value) -> {
-      if (configurationProperties != null) {
-        configurationProperties.set(prop, value);
-      }
-    };
+    super.setPropListeners(
+        (name, value) -> {
+          if (configurationProperties != null) {
+            configurationProperties.set(name, value);
+          }
+        },
+        name -> {
+          if (configurationProperties != null) {
+            configurationProperties.unset(name);
+          }
+        }
+    );
   }
 
   static String getUserPrefix(String user) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -18,27 +18,15 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule.MappingRule;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.conf.QueueCapacityConfigParser;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placement.MappingRuleCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -55,13 +43,10 @@ import org.apache.hadoop.yarn.security.AccessType;
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.QueueMapping;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.QueueMapping.QueueMappingBuilder;
-import org.apache.hadoop.yarn.server.resourcemanager.placement.csmappingrule.MappingRule;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationSchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AppPriorityACLConfigurationParser.AppPriorityACLKeyType;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.WorkflowPriorityMappingsManager.WorkflowPriorityMapping;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.conf.QueueCapacityConfigParser;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.placement.MappingRuleCreator;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.policy.PriorityUtilizationQueueOrderingPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.policy.QueueOrderingPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.MultiNodeLookupPolicy;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -533,6 +533,9 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     		getMaximumApplicationMasterResourcePercent());
   }
 
+  public boolean isMaximumApplicationMasterResourcePerQueuePercentPresent(String queue) {
+    return get(getQueuePrefix(queue) + MAXIMUM_AM_RESOURCE_SUFFIX) != null;
+  }
   public void setMaximumApplicationMasterResourcePerQueuePercent(QueuePath queue,
       float percent) {
     setFloat(getQueuePrefix(queue) + MAXIMUM_AM_RESOURCE_SUFFIX, percent);
@@ -745,6 +748,10 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
         getFloat(getQueuePrefix(queue) + USER_LIMIT_FACTOR,
             defaultUserLimitFactor);
     return userLimitFactor;
+  }
+
+  public boolean isUserLimitFactorPresent(String queue) {
+    return get(getQueuePrefix(queue) + USER_LIMIT_FACTOR) != null;
   }
 
   public void setUserLimitFactor(QueuePath queuePath, float userLimitFactor) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -225,7 +225,7 @@ public class ConfigurationProperties {
     if (!propertyKeyParts.isEmpty()) {
       return findOrCreatePrefixNode(null, propertyKeyParts.iterator());
     } else {
-      LOG.warn("Empty configuration property");
+      LOG.warn("Empty configuration property: " + name);
       return null;
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -61,6 +61,8 @@ public class ConfigurationProperties {
    * A constructor defined in order to conform to the type used by
    * {@code Configuration}. It must only be called by String keys and values.
    * @param props properties to store
+   * @param whiteListPrefix only those properties will be in the nodes
+   *                        which starts with one of the provided prefixes.
    */
   public ConfigurationProperties(Map<String, String> props, String... whiteListPrefix) {
     this(Maps.filterKeys(props, key -> StringUtils.startsWithAny(key, whiteListPrefix)));
@@ -165,9 +167,8 @@ public class ConfigurationProperties {
 
   /**
    * Stores the given properties in the correct node.
-   *
    * @param props properties that need to be stored
-   * @return
+   * @return the built tree of nodes
    */
   private Map<String, PrefixNode> storePropertiesInPrefixNodes(Map<String, String> props) {
     Map<String, PrefixNode> nodes = new HashMap<>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -27,8 +27,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.classification.VisibleForTesting;
-
 import static org.apache.commons.lang3.StringUtils.startsWithAny;
 import static org.apache.hadoop.thirdparty.com.google.common.collect.Maps.filterKeys;
 
@@ -48,7 +46,6 @@ public class ConfigurationProperties {
   private static final Logger LOG =
       LoggerFactory.getLogger(ConfigurationProperties.class);
 
-  @VisibleForTesting
   private final Map<String, PrefixNode> nodes;
   private static final String DELIMITER = "\\.";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import static org.apache.commons.lang3.StringUtils.startsWithAny;
 import static org.apache.hadoop.thirdparty.com.google.common.collect.Maps.filterKeys;
 
-
 /**
  * A trie storage to preprocess and store configuration properties for optimised
  * retrieval. A node is created for every key part delimited by ".".

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -109,7 +109,7 @@ public class ConfigurationProperties {
   }
 
   /**
-   * Update or create value in the nodes
+   * Update or create value in the nodes.
    * @param name name of the property
    * @param value value of the property
    */
@@ -121,7 +121,7 @@ public class ConfigurationProperties {
   }
 
   /**
-   * Delete value from nodes
+   * Delete value from nodes.
    * @param name name of the property
    */
   public void unset(String name) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -60,7 +60,7 @@ public class ConfigurationProperties {
 
   /**
    * A constructor defined in order to conform to the type used by
-   * {@code Configuration}. It must only be called by String keys and values.
+   * {@code Configuration}. It must only be called with String keys and values.
    * @param props properties to store
    * @param whiteListPrefix only those properties will be in the nodes
    *                        which starts with one of the provided prefixes.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ConfigurationProperties.java
@@ -216,9 +216,9 @@ public class ConfigurationProperties {
   }
 
   /**
-   * Finds the node that matches the whole key or create it, if it does not exist.
+   * Finds the node that matches the whole key or create it if it does not exist.
    * @param name name of the property
-   * @return the found or created node, if the name is empty, than return with null
+   * @return the found or newly created node, otherwise return null if the name is empty
    */
   private PrefixNode getNode(String name) {
     List<String> propertyKeyParts = splitPropertyByDelimiter(name);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -112,35 +112,35 @@ public class TestCapacitySchedulerConfiguration {
 
   /**
    * dfs.nfs.exports.allowed.hosts
-   * prop is deprecated, new we use
+   * prop is deprecated, now we use
    * nfs.exports.allowed.hosts
    * instead
    */
   @Test
   public void testDeprecationFeatureWorks() {
-    final String key1 = "KEY_1";
-    final String key2 = "KEY_2";
-    final String depName = "dfs.nfs.exports.allowed.hosts";
+    final String value1 = "VALUE_1";
+    final String value2 = "VALUE_2";
+    final String deprecatedName = "dfs.nfs.exports.allowed.hosts";
     final String newName = "nfs.exports.allowed.hosts";
     final CapacitySchedulerConfiguration csConf = createDefaultCsConf();
     final ConfigurationProperties properties = csConf.getConfigurationProperties();
 
-    csConf.set(depName, key1);
-    assertEquals(key1, csConf.get(depName));
-    assertEquals(key1, csConf.get(newName));
-    assertEquals(key1, properties.getPropertiesWithPrefix(depName).values().iterator().next());
-    assertEquals(key1, properties.getPropertiesWithPrefix(newName).values().iterator().next());
+    csConf.set(deprecatedName, value1);
+    assertEquals(value1, csConf.get(deprecatedName));
+    assertEquals(value1, csConf.get(newName));
+    assertEquals(value1, properties.getPropertiesWithPrefix(deprecatedName).values().iterator().next());
+    assertEquals(value1, properties.getPropertiesWithPrefix(newName).values().iterator().next());
 
-    csConf.set(depName, key2);
-    assertEquals(key2, csConf.get(depName));
-    assertEquals(key2, csConf.get(newName));
-    assertEquals(key2, properties.getPropertiesWithPrefix(depName).values().iterator().next());
-    assertEquals(key2, properties.getPropertiesWithPrefix(newName).values().iterator().next());
+    csConf.set(deprecatedName, value2);
+    assertEquals(value2, csConf.get(deprecatedName));
+    assertEquals(value2, csConf.get(newName));
+    assertEquals(value2, properties.getPropertiesWithPrefix(deprecatedName).values().iterator().next());
+    assertEquals(value2, properties.getPropertiesWithPrefix(newName).values().iterator().next());
 
     csConf.unset(newName);
-    assertNull(csConf.get(depName));
+    assertNull(csConf.get(deprecatedName));
     assertNull(csConf.get(newName));
-    assertTrue(properties.getPropertiesWithPrefix(depName).isEmpty());
+    assertTrue(properties.getPropertiesWithPrefix(deprecatedName).isEmpty());
     assertTrue(properties.getPropertiesWithPrefix(newName).isEmpty());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -17,15 +17,18 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.QueueACL;
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TestCapacitySchedulerConfiguration {
@@ -105,6 +108,40 @@ public class TestCapacitySchedulerConfiguration {
     assertTrue(acl.getUsers().isEmpty());
     assertTrue(acl.getGroups().isEmpty());
     assertTrue(acl.isAllAllowed());
+  }
+
+  /**
+   * dfs.nfs.exports.allowed.hosts
+   * prop is deprecated, new we use
+   * nfs.exports.allowed.hosts
+   * instead
+   */
+  @Test
+  public void testDeprecationFeatureWorks() {
+    final String key1 = "KEY_1";
+    final String key2 = "KEY_2";
+    final String depName = "dfs.nfs.exports.allowed.hosts";
+    final String newName = "nfs.exports.allowed.hosts";
+    final CapacitySchedulerConfiguration csConf = createDefaultCsConf();
+    final ConfigurationProperties properties = csConf.getConfigurationProperties();
+
+    csConf.set(depName, key1);
+    assertEquals(key1, csConf.get(depName));
+    assertEquals(key1, csConf.get(newName));
+    assertEquals(key1, properties.getPropertiesWithPrefix(depName).values().iterator().next());
+    assertEquals(key1, properties.getPropertiesWithPrefix(newName).values().iterator().next());
+
+    csConf.set(depName, key2);
+    assertEquals(key2, csConf.get(depName));
+    assertEquals(key2, csConf.get(newName));
+    assertEquals(key2, properties.getPropertiesWithPrefix(depName).values().iterator().next());
+    assertEquals(key2, properties.getPropertiesWithPrefix(newName).values().iterator().next());
+
+    csConf.unset(newName);
+    assertNull(csConf.get(depName));
+    assertNull(csConf.get(newName));
+    assertTrue(properties.getPropertiesWithPrefix(depName).isEmpty());
+    assertTrue(properties.getPropertiesWithPrefix(newName).isEmpty());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerConfiguration.java
@@ -17,13 +17,11 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.QueueACL;
 import org.junit.Test;
 
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestConfigurationProperties.java
@@ -122,4 +122,23 @@ public class TestConfigurationProperties {
     Assert.assertEquals(0, propsLongPrefix.size());
     Assert.assertEquals(0, propsNonExistingRootPrefix.size());
   }
+
+  @Test
+  public void testWhiteListConstructor() {
+    ConfigurationProperties configurationProperties =
+        new ConfigurationProperties(PROPERTIES, "root.1", "2");
+
+    Map<String, String> props = configurationProperties
+        .getPropertiesWithPrefix("root", true);
+
+    Assert.assertTrue(props.containsKey("root.1.2.3"));
+    Assert.assertEquals("TEST_VALUE_1", props.get("root.1.2.3"));
+    Assert.assertTrue(props.containsKey("root.1.2"));
+    Assert.assertEquals("TEST_VALUE_3", props.get("root.1.2"));
+    Assert.assertTrue(props.containsKey("root.1.2.4.5"));
+    Assert.assertEquals("TEST_VALUE_3_2", props.get("root.1.2.4.5"));
+    Assert.assertTrue(props.containsKey("root.1.2.4"));
+    Assert.assertEquals("TEST_VALUE_3_1", props.get("root.1.2.4"));
+    Assert.assertFalse(props.containsKey("root"));
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestConfigurationProperties.java
@@ -22,8 +22,11 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class TestConfigurationProperties {
   private static final Map<String, String> PROPERTIES = new HashMap<>();
@@ -157,5 +160,23 @@ public class TestConfigurationProperties {
     props = configurationProperties.getPropertiesWithPrefix("root", true);
     Assert.assertFalse(props.containsKey("root.1"));
     Assert.assertEquals("TEST_VALUE_4", props.get("root.1.2.3"));
+  }
+
+  @Test
+  public void testEmptyConfCanBeReused() {
+    ConfigurationProperties conf = new ConfigurationProperties(Collections.emptyMap());
+    conf.set("root", StringUtils.SPACE);
+    conf.set("root.a", StringUtils.SPACE);
+    Assert.assertEquals(StringUtils.SPACE, conf.getPropertiesWithPrefix(
+        "root.a", true).get("root.a"));
+    conf.unset("root");
+    Assert.assertEquals(StringUtils.SPACE, conf.getPropertiesWithPrefix(
+        "root.a", true).get("root.a"));
+    conf.unset("root.a");
+    Assert.assertNull(conf.getPropertiesWithPrefix(
+        "root.a", true).get("root.a"));
+    conf.set("root.a", StringUtils.SPACE);
+    Assert.assertEquals(StringUtils.SPACE, conf.getPropertiesWithPrefix(
+        "root.a", true).get("root.a"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestConfigurationProperties.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestConfigurationProperties.java
@@ -141,4 +141,21 @@ public class TestConfigurationProperties {
     Assert.assertEquals("TEST_VALUE_3_1", props.get("root.1.2.4"));
     Assert.assertFalse(props.containsKey("root"));
   }
+
+  @Test
+  public void testMutation() {
+    ConfigurationProperties configurationProperties = new ConfigurationProperties(PROPERTIES);
+    Map<String, String> props;
+
+    configurationProperties.set("root.1", "TEST_VALUE_3");
+    configurationProperties.set("root.1.2.3", "TEST_VALUE_4");
+    props = configurationProperties.getPropertiesWithPrefix("root", true);
+    Assert.assertEquals("TEST_VALUE_3", props.get("root.1"));
+    Assert.assertEquals("TEST_VALUE_4", props.get("root.1.2.3"));
+
+    configurationProperties.unset("root.1");
+    props = configurationProperties.getPropertiesWithPrefix("root", true);
+    Assert.assertFalse(props.containsKey("root.1"));
+    Assert.assertEquals("TEST_VALUE_4", props.get("root.1.2.3"));
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

