### PR TITLE
YARN-11237. Fix Bug while disabling proxy failover with Federation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
@@ -107,7 +107,8 @@ public class TestFederationRMFailoverProxyProvider {
     conf.setBoolean(YarnConfiguration.FEDERATION_FLUSH_CACHE_FOR_RM_ADDR,
         facadeFlushCache);
 
-    conf.setBoolean(YarnConfiguration.RM_HA_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.FEDERATION_ENABLED, true);
+    conf.setBoolean(YarnConfiguration.FEDERATION_FAILOVER_ENABLED, true);
     conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
     conf.set(YarnConfiguration.RM_CLUSTER_ID, "cluster1");
     conf.set(YarnConfiguration.RM_HA_IDS, "rm1,rm2,rm3");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -309,7 +309,7 @@ public class RMProxy<T> {
       return true;
     }
     if (HAUtil.isFederationEnabled(conf) && HAUtil.isFederationFailoverEnabled(conf)) {
-      //Considering both federation and federation failover are enabled.
+      // Considering both federation and federation failover are enabled.
       return true;
     }
     return false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -98,9 +98,7 @@ public class RMProxy<T> {
     YarnConfiguration conf = (configuration instanceof YarnConfiguration)
         ? (YarnConfiguration) configuration
         : new YarnConfiguration(configuration);
-    RetryPolicy retryPolicy = createRetryPolicy(conf,
-        (HAUtil.isHAEnabled(conf) || (HAUtil.isFederationEnabled(conf)
-            && HAUtil.isFederationFailoverEnabled(conf))));
+    RetryPolicy retryPolicy = createRetryPolicy(conf, isFailoverEnabled(conf));
     return newProxyInstance(conf, protocol, instance, retryPolicy);
   }
 
@@ -127,8 +125,7 @@ public class RMProxy<T> {
       final Class<T> protocol, RMProxy<T> instance, RetryPolicy retryPolicy)
           throws IOException{
     RMFailoverProxyProvider<T> provider;
-    if (HAUtil.isHAEnabled(conf) || (HAUtil.isFederationEnabled(conf)
-        && HAUtil.isFederationFailoverEnabled(conf))) {
+    if (isFailoverEnabled(conf)) {
       provider = instance.createRMFailoverProxyProvider(conf, protocol);
     } else {
       provider = instance.createNonHaRMFailoverProxyProvider(conf, protocol);
@@ -305,4 +302,17 @@ public class RMProxy<T> {
     return RetryPolicies.retryOtherThanRemoteAndSaslException(
         RetryPolicies.TRY_ONCE_THEN_FAIL, exceptionToPolicyMap);
   }
+
+  private static boolean isFailoverEnabled(YarnConfiguration conf) {
+    if (HAUtil.isHAEnabled(conf)) {
+      // Considering Resource Manager HA is enabled.
+      return true;
+    }
+    if (HAUtil.isFederationEnabled(conf) && HAUtil.isFederationFailoverEnabled(conf)) {
+      //Considering both federation and federation failover are enabled.
+      return true;
+    }
+    return false;
+  }
+
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -99,7 +99,8 @@ public class RMProxy<T> {
         ? (YarnConfiguration) configuration
         : new YarnConfiguration(configuration);
     RetryPolicy retryPolicy = createRetryPolicy(conf,
-        (HAUtil.isHAEnabled(conf) || HAUtil.isFederationFailoverEnabled(conf)));
+        (HAUtil.isHAEnabled(conf) || (HAUtil.isFederationEnabled(conf)
+            && HAUtil.isFederationFailoverEnabled(conf))));
     return newProxyInstance(conf, protocol, instance, retryPolicy);
   }
 
@@ -126,7 +127,8 @@ public class RMProxy<T> {
       final Class<T> protocol, RMProxy<T> instance, RetryPolicy retryPolicy)
           throws IOException{
     RMFailoverProxyProvider<T> provider;
-    if (HAUtil.isHAEnabled(conf) || HAUtil.isFederationEnabled(conf)) {
+    if (HAUtil.isHAEnabled(conf) || (HAUtil.isFederationEnabled(conf)
+        && HAUtil.isFederationFailoverEnabled(conf))) {
       provider = instance.createRMFailoverProxyProvider(conf, protocol);
     } else {
       provider = instance.createNonHaRMFailoverProxyProvider(conf, protocol);


### PR DESCRIPTION
### Description of PR
Fix Bug while disabling proxy failover with Federation

When one disables the use of RM fail over proxy with federation, there is a bug checking a wrong/parent flag `yarn.federation.enabled` whether the federation is used instead of the fail over feature flag `yarn.federation.failover.enabled` of federation. Without this change, when fail over feature is disabled, node manager cannot be started.

JIRA - YARN-11237

### How was this patch tested?
Tested on EMR cluster and modified existing test.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

