### PR TITLE
HDFS-16700. RBF: Record the real client IP carried by the Router in the NameNode log

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/CallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/CallerContext.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 
 import java.nio.charset.Charset;
@@ -119,6 +120,51 @@ public final class CallerContext {
       str += new String(signature, SIGNATURE_ENCODING);
     }
     return str;
+  }
+
+  /**
+   * Try to obtain the value corresponding to the key by parsing the content.
+   * @param content the full content to be parsed.
+   * @param key trying to obtain the value of the key.
+   * @return the value corresponding to the key.
+   */
+  @VisibleForTesting
+  public static String parseSpecialValue(String content, String key) {
+    int posn = content.indexOf(key);
+    if (posn != -1) {
+      posn += key.length();
+      int end = content.indexOf(",", posn);
+      return end == -1 ? content.substring(posn) : content.substring(posn, end);
+    }
+    return null;
+  }
+
+  /**
+   * Get client ip content from caller context.
+   * @param context The context here is obtained from outside.
+   * @return Filter the value carried by 'clientIp:' from the context.
+   *         If not, return null.
+   */
+  public static String getRealClientIp(String context) {
+    if (context != null && !context.equals("")) {
+      String ipKey = CLIENT_IP_STR + Builder.KEY_VALUE_SEPARATOR;
+      return parseSpecialValue(context, ipKey);
+    }
+    return null;
+  }
+
+  /**
+   * Get client port content from caller context.
+   * @param context The context here is obtained from outside.
+   * @return Filter the value carried by 'clientPort:' from the context.
+   *         If not, return null.
+   */
+  public static String getRealClientPort(String context) {
+    if (context != null && !context.equals("")) {
+      String portKey = CLIENT_PORT_STR + Builder.KEY_VALUE_SEPARATOR;
+      return parseSpecialValue(context, portKey);
+    }
+    return null;
   }
 
   /** The caller context builder. */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ipc;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_ENABLED_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_ENABLED_KEY;
 import static org.apache.hadoop.ipc.ProcessingDetails.Timing;
 import static org.apache.hadoop.ipc.RpcConstants.AUTHORIZATION_FAILED_CALL_ID;
 import static org.apache.hadoop.ipc.RpcConstants.CONNECTION_CONTEXT_CALL_ID;
@@ -1110,6 +1112,10 @@ public abstract class Server {
 
     public void setDeferredError(Throwable t) {
     }
+
+    public CallerContext getCallerContext() {
+      return callerContext;
+    }
   }
 
   /** A RPC extended call queued for handling. */
@@ -1351,6 +1357,16 @@ public abstract class Server {
 
     @Override
     public String toString() {
+      boolean isCallerContextEnabled = conf.getBoolean(
+          HADOOP_CALLER_CONTEXT_ENABLED_KEY,
+          HADOOP_CALLER_CONTEXT_ENABLED_DEFAULT);
+      CallerContext context = getCallerContext();
+      if (isCallerContextEnabled && context != null && context.isContextValid()) {
+        String cc = context.getContext();
+        return super.toString() + " " + rpcRequest + " from " + connection +
+            ", client=" + CallerContext.getRealClientIp(cc) + ":" +
+            CallerContext.getRealClientPort(cc);
+      }
       return super.toString() + " " + rpcRequest + " from " + connection;
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -545,9 +545,7 @@ public class NameNode extends ReconfigurableBase implements
     if (cc != null) {
       // if the rpc has a caller context of "clientIp:1.2.3.4,CLI",
       // return "1.2.3.4" as the client machine.
-      String key = CallerContext.CLIENT_IP_STR +
-          CallerContext.Builder.KEY_VALUE_SEPARATOR;
-      return parseSpecialValue(cc, key);
+      return CallerContext.getRealClientIp(cc);
     }
 
     String clientMachine = Server.getRemoteAddress();


### PR DESCRIPTION
### Description of PR
When applying RBF, the ip recorded in the log file saved in the NameNode is still the Router. The real client ip should be logged.
Details: HDFS-16700

### How was this patch tested?
When hadoop.caller.context.enabled=true, you should see the client ip recorded in the NameNode log file.

