### PR TITLE
HDFS-16703. Enable RPC Timeout for some protocols of NameNode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ha.HAServiceProtocol;
 import org.apache.hadoop.hdfs.server.namenode.ha.ClientHAProxyFactory;
 import org.apache.hadoop.hdfs.server.namenode.ha.HAProxyFactory;
 import org.apache.hadoop.ipc.AlignmentContext;
+import org.apache.hadoop.ipc.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -371,7 +372,7 @@ public class NameNodeProxiesClient {
     ClientNamenodeProtocolPB proxy = RPC.getProtocolProxy(
         ClientNamenodeProtocolPB.class, version, address, ugi, conf,
         NetUtils.getDefaultSocketFactory(conf),
-        org.apache.hadoop.ipc.Client.getTimeout(conf), defaultPolicy,
+        Client.getRpcTimeout(conf), defaultPolicy,
         fallbackToSimpleAuth, alignmentContext).getProxy();
 
     if (withRetries) { // create the proxy with retries

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -2072,4 +2072,25 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_LEASE_HARDLIMIT_DEFAULT =
       HdfsClientConfigKeys.DFS_LEASE_HARDLIMIT_DEFAULT;
 
+  public static final String IPC_RPC_TIMEOUT_FOR_ALIASHMAP_PROTOCOL =
+      "ipc.rpc-timeout.for.aliash-map.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_ALIASHMAP_PROTOCOL_DEFAULT = 30000;
+  public static final String IPC_RPC_TIMEOUT_FOR_JOURNAL_PROTOCOL =
+      "ipc.rpc-timeout.for.journal.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_JOURNAL_PROTOCOL_DEFAULT = 30000;
+  public static final String IPC_RPC_TIMEOUT_FOR_REFRESH_AUTHORIZATION_PROTOCOL =
+      "ipc.rpc-timeout.for.refresh-authorization.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_REFRESH_AUTHORIZATION_PROTOCOL_DEFAULT = 0;
+  public static final String IPC_RPC_TIMEOUT_FOR_REFRESH_USER_MAPPING_PROTOCOL =
+      "ipc.rpc-timeout.for.refresh-user-mappings.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_REFRESH_USER_MAPPING_PROTOCOL_DEFAULT = 0;
+  public static final String IPC_RPC_TIMEOUT_FOR_REFRESH_CALL_QUEUE_PROTOCOL =
+      "ipc.rpc-timeout.for.refresh-call-queue.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_REFRESH_CALL_QUEUE_PROTOCOL_DEFAULT = 0;
+  public static final String IPC_RPC_TIMEOUT_FOR_GET_USER_MAPPING_PROTOCOL =
+      "ipc.rpc-timeout.for.get-user-mappings.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_GET_USER_MAPPING_PROTOCOL_DEFAULT = 0;
+  public static final String IPC_RPC_TIMEOUT_FOR_NAMENODE_PROTOCOL =
+      "ipc.rpc-timeout.for.namenode.ms";
+  public static final long IPC_RPC_TIMEOUT_FOR_NAMENODE_PROTOCOL_DEFAULT = 0;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6591,4 +6591,79 @@
       Enables observer reads for clients. This should only be enabled when clients are using routers.
     </description>
   </property>
+  <property>
+    <name>ipc.rpc-timeout.for.aliash-map.ms</name>
+    <value>30000</value>
+  </property>
+  <property>
+    <description>
+      The amount of time the aliasMapProtocol client will wait to read from the namenode
+      before timing out. If the namenode does not report progress more
+      frequently than this time, the client will give up waiting.
+    </description>
+  </property>
+  <property>
+    <name>ipc.rpc-timeout.for.journal.ms</name>
+    <value>30000</value>
+    <description>
+      The amount of time the journalProtocol client will wait to read from the journalnode
+      before timing out. If the journalnode does not report progress more
+      frequently than this time, the client will give up waiting.
+    </description>
+  </property>
+  <property>
+    <name>ipc.rpc-timeout.for.refresh-authorization.ms</name>
+    <value>0</value>
+    <description>
+      The amount of time the refreshAuthorizationPolicyProtocol client will wait
+      to read from the namenode before timing out. If the namenode does not
+      report progress more frequently than this time, the client will give up waiting.
+      The default value of 0 indicates that timeout is disabled,
+      which can be set to the same as ipc.client.rpc-timeout.ms, such as 120s.
+    </description>
+  </property>
+  <property>
+    <name>ipc.rpc-timeout.for.refresh-user-mappings.ms</name>
+    <value>0</value>
+    <description>
+      The amount of time the refreshUserMappingsProtocol client will wait
+      to read from the namenode before timing out. If the namenode does not
+      report progress more frequently than this time, the client will give up waiting.
+      The default value of 0 indicates that timeout is disabled,
+      which can be set to the same as ipc.client.rpc-timeout.ms, such as 120s.
+    </description>
+  </property>
+  <property>
+    <name>ipc.rpc-timeout.for.refresh-call-queue.ms</name>
+    <value>0</value>
+    <description>
+      The amount of time the refreshCallQueueProtocol client will wait
+      to read from the namenode before timing out. If the namenode does not
+      report progress more frequently than this time, the client will give up waiting.
+      The default value of 0 indicates that timeout is disabled,
+      which can be set to the same as ipc.client.rpc-timeout.ms, such as 120s.
+    </description>
+  </property>
+  <property>
+    <name>ipc.rpc-timeout.for.get-user-mappings.ms</name>
+    <value>0</value>
+    <description>
+      The amount of time the getUserMappingsProtocol client will wait
+      to read from the namenode before timing out. If the namenode does not
+      report progress more frequently than this time, the client will give up waiting.
+      The default value of 0 indicates that timeout is disabled,
+      which can be set to the same as ipc.client.rpc-timeout.ms, such as 120s.
+    </description>
+  </property>
+  <property>
+    <name>ipc.rpc-timeout.for.namenode.ms</name>
+    <value>0</value>
+    <description>
+      The amount of time the namenodeProtocol client will wait
+      to read from the namenode before timing out. If the namenode does not
+      report progress more frequently than this time, the client will give up waiting.
+      The default value of 0 indicates that timeout is disabled,
+      which can be set to the same as ipc.client.rpc-timeout.ms, such as 120s.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
### Description of PR
When I read some code about protocol, I found that only ClientNamenodeProtocolPB proxy with RPC timeout, other protocolPB proxy without RPC timeout, such as RefreshAuthorizationPolicyProtocolPB, RefreshUserMappingsProtocolPB, RefreshCallQueueProtocolPB, GetUserMappingsProtocolPB and NamenodeProtocolPB.

If proxy without rpc timeout,  it will be blocked for a long time if the NN machine crash or bad network during writing or reading with NN. 

So I feel that we should enable RPC timeout for all ProtocolPB.

