### PR TITLE
 HDFS-16707. RBF: Expose RouterRpcFairnessPolicyController related request record metrics for each nameservice to Prometheus

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
@@ -185,7 +185,7 @@ public class FederationRPCPerformanceMonitor implements RouterRpcMonitor {
   }
 
   @Override
-  public void ProxyOpPermitRejected(String nsId) {
+  public void proxyOpPermitRejected(String nsId) {
     if (metrics != null) {
       metrics.incrProxyOpPermitRejected();
       
@@ -197,7 +197,7 @@ public class FederationRPCPerformanceMonitor implements RouterRpcMonitor {
   }
 
   @Override
-  public void ProxyOpPermitAccepted(String nsId) {
+  public void proxyOpPermitAccepted(String nsId) {
     if (nameserviceRPCMetricsMap != null &&
         nameserviceRPCMetricsMap.containsKey(nsId)) {
       nameserviceRPCMetricsMap.get(nsId).incrProxyOpPermitAccepted();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
@@ -188,7 +188,6 @@ public class FederationRPCPerformanceMonitor implements RouterRpcMonitor {
   public void proxyOpPermitRejected(String nsId) {
     if (metrics != null) {
       metrics.incrProxyOpPermitRejected();
-      
     }
     if (nameserviceRPCMetricsMap != null &&
         nameserviceRPCMetricsMap.containsKey(nsId)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/FederationRPCPerformanceMonitor.java
@@ -185,6 +185,26 @@ public class FederationRPCPerformanceMonitor implements RouterRpcMonitor {
   }
 
   @Override
+  public void ProxyOpPermitRejected(String nsId) {
+    if (metrics != null) {
+      metrics.incrProxyOpPermitRejected();
+      
+    }
+    if (nameserviceRPCMetricsMap != null &&
+        nameserviceRPCMetricsMap.containsKey(nsId)) {
+      nameserviceRPCMetricsMap.get(nsId).incrProxyOpPermitRejected();
+    }
+  }
+
+  @Override
+  public void ProxyOpPermitAccepted(String nsId) {
+    if (nameserviceRPCMetricsMap != null &&
+        nameserviceRPCMetricsMap.containsKey(nsId)) {
+      nameserviceRPCMetricsMap.get(nsId).incrProxyOpPermitAccepted();
+    }
+  }
+
+  @Override
   public void proxyOpFailureClientOverloaded() {
     if (metrics != null) {
       metrics.incrProxyOpFailureClientOverloaded();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMBean.java
@@ -37,4 +37,7 @@ public interface NameserviceRPCMBean {
 
   long getProxyOpNoNamenodes();
 
+  long getProxyOpPermitRejected();
+
+  long getProxyOpPermitAccepted();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMetrics.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
@@ -37,6 +38,7 @@ public class NameserviceRPCMetrics implements NameserviceRPCMBean {
   public final static String NAMESERVICE_RPC_METRICS_PREFIX = "NameserviceActivity-";
 
   private final String nsId;
+  final MetricsRegistry registry;
 
   @Metric("Time for the Router to proxy an operation to the Nameservice")
   private MutableRate proxy;
@@ -55,17 +57,18 @@ public class NameserviceRPCMetrics implements NameserviceRPCMBean {
   private MutableCounterLong proxyOpPermitAccepted;
 
   public NameserviceRPCMetrics(Configuration conf, String nsId) {
-    this.nsId = nsId;
+    this.nsId = NAMESERVICE_RPC_METRICS_PREFIX + nsId;
+    registry = new MetricsRegistry("NameserviceRPCActivity").tag("ns", "Nameservice", nsId);
   }
 
   public static NameserviceRPCMetrics create(Configuration conf,
       String nameService) {
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    String name = NAMESERVICE_RPC_METRICS_PREFIX + (nameService.isEmpty()
-        ? "UndefinedNameService"+ ThreadLocalRandom.current().nextInt()
-        : nameService);
-    return ms.register(name, "HDFS Federation NameService RPC Metrics",
-        new NameserviceRPCMetrics(conf, name));
+    String nsId = (nameService.isEmpty() ?
+        "UndefinedNameService" + ThreadLocalRandom.current().nextInt() :
+        nameService);
+    return ms.register(NAMESERVICE_RPC_METRICS_PREFIX + nsId,
+        "HDFS Federation NameService RPC Metrics", new NameserviceRPCMetrics(conf, nsId));
   }
 
   public void incrProxyOpFailureStandby() {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMetrics.java
@@ -38,7 +38,7 @@ public class NameserviceRPCMetrics implements NameserviceRPCMBean {
   public final static String NAMESERVICE_RPC_METRICS_PREFIX = "NameserviceActivity-";
 
   private final String nsId;
-  final MetricsRegistry registry;
+  private final MetricsRegistry registry = new MetricsRegistry("NameserviceRPCActivity");
 
   @Metric("Time for the Router to proxy an operation to the Nameservice")
   private MutableRate proxy;
@@ -58,7 +58,7 @@ public class NameserviceRPCMetrics implements NameserviceRPCMBean {
 
   public NameserviceRPCMetrics(Configuration conf, String nsId) {
     this.nsId = NAMESERVICE_RPC_METRICS_PREFIX + nsId;
-    registry = new MetricsRegistry("NameserviceRPCActivity").tag("ns", "Nameservice", nsId);
+    registry.tag("ns", "Nameservice", nsId);
   }
 
   public static NameserviceRPCMetrics create(Configuration conf,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/metrics/NameserviceRPCMetrics.java
@@ -49,6 +49,10 @@ public class NameserviceRPCMetrics implements NameserviceRPCMBean {
   private MutableCounterLong proxyOpFailureCommunicate;
   @Metric("Number of operations to hit no namenodes available")
   private MutableCounterLong proxyOpNoNamenodes;
+  @Metric("Number of operations to hit permit limits")
+  private MutableCounterLong proxyOpPermitRejected;
+  @Metric("Number of operations accepted to hit a namenode")
+  private MutableCounterLong proxyOpPermitAccepted;
 
   public NameserviceRPCMetrics(Configuration conf, String nsId) {
     this.nsId = nsId;
@@ -91,6 +95,23 @@ public class NameserviceRPCMetrics implements NameserviceRPCMBean {
     return proxyOpNoNamenodes.value();
   }
 
+  public void incrProxyOpPermitRejected() {
+    proxyOpPermitRejected.incr();
+  }
+
+  @Override
+  public long getProxyOpPermitRejected() {
+    return proxyOpPermitRejected.value();
+  }
+
+  public void incrProxyOpPermitAccepted() {
+    proxyOpPermitAccepted.incr();
+  }
+
+  @Override
+  public long getProxyOpPermitAccepted() {
+    return proxyOpPermitAccepted.value();
+  }
 
   /**
    * Add the time to proxy an operation from the moment the Router sends it to

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1580,7 +1580,7 @@ public class RouterRpcClient {
         // Throw StandByException,
         // Clients could fail over and try another router.
         if (rpcMonitor != null) {
-          rpcMonitor.ProxyOpPermitRejected(nsId);
+          rpcMonitor.proxyOpPermitRejected(nsId);
         }
         incrRejectedPermitForNs(nsId);
         LOG.debug("Permit denied for ugi: {} for method: {}",
@@ -1590,8 +1590,8 @@ public class RouterRpcClient {
                 " is overloaded for NS: " + nsId;
         throw new StandbyException(msg);
       }
-      if (rpcMonitor!= null) {
-        rpcMonitor.ProxyOpPermitAccepted(nsId);
+      if (rpcMonitor != null) {
+        rpcMonitor.proxyOpPermitAccepted(nsId);
       }
       incrAcceptedPermitForNs(nsId);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -1580,7 +1580,7 @@ public class RouterRpcClient {
         // Throw StandByException,
         // Clients could fail over and try another router.
         if (rpcMonitor != null) {
-          rpcMonitor.getRPCMetrics().incrProxyOpPermitRejected();
+          rpcMonitor.ProxyOpPermitRejected(nsId);
         }
         incrRejectedPermitForNs(nsId);
         LOG.debug("Permit denied for ugi: {} for method: {}",
@@ -1589,6 +1589,9 @@ public class RouterRpcClient {
             "Router " + router.getRouterId() +
                 " is overloaded for NS: " + nsId;
         throw new StandbyException(msg);
+      }
+      if (rpcMonitor!= null) {
+        rpcMonitor.ProxyOpPermitAccepted(nsId);
       }
       incrAcceptedPermitForNs(nsId);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
@@ -74,17 +74,17 @@ public interface RouterRpcMonitor {
    * exception.
    */
   void proxyOpFailureCommunicate(String nsId);
-  
+
   /**
    * Rejected to proxy an operation to a Namenode.
    */
-  void ProxyOpPermitRejected(String nsId);
+  void proxyOpPermitRejected(String nsId);
 
   /**
    * Accepted to proxy an operation to a Namenode.
    */
-  void ProxyOpPermitAccepted(String nsId);
-  
+  void proxyOpPermitAccepted(String nsId);
+
   /**
    * Failed to proxy an operation to a Namenode because the client was
    * overloaded.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcMonitor.java
@@ -74,7 +74,17 @@ public interface RouterRpcMonitor {
    * exception.
    */
   void proxyOpFailureCommunicate(String nsId);
+  
+  /**
+   * Rejected to proxy an operation to a Namenode.
+   */
+  void ProxyOpPermitRejected(String nsId);
 
+  /**
+   * Accepted to proxy an operation to a Namenode.
+   */
+  void ProxyOpPermitAccepted(String nsId);
+  
   /**
    * Failed to proxy an operation to a Namenode because the client was
    * overloaded.


### PR DESCRIPTION
### Description of PR
[HDFS-16302](https://issues.apache.org/jira/browse/HDFS-16302) intoduced request record for each namespace, but it is only exposed in /jmx endpoint and in json format, not very convenient.
this patch exposed these metrics in /prom endpoint for Prometheus

### How was this patch tested?
manual testing
