### PR TITLE
HDFS-16709. Remove redundant cast in FSEditLogOp.class

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
@@ -823,7 +823,7 @@ public abstract class FSEditLogOp {
     }
 
     static AddOp getInstance(OpInstanceCache cache) {
-      return (AddOp) cache.get(OP_ADD);
+      return cache.get(OP_ADD);
     }
 
     @Override
@@ -851,7 +851,7 @@ public abstract class FSEditLogOp {
     }
 
     static CloseOp getInstance(OpInstanceCache cache) {
-      return (CloseOp)cache.get(OP_CLOSE);
+      return cache.get(OP_CLOSE);
     }
 
     @Override
@@ -969,7 +969,7 @@ public abstract class FSEditLogOp {
     }
     
     static AddBlockOp getInstance(OpInstanceCache cache) {
-      return (AddBlockOp) cache.get(OP_ADD_BLOCK);
+      return cache.get(OP_ADD_BLOCK);
     }
 
     @Override
@@ -1081,7 +1081,7 @@ public abstract class FSEditLogOp {
     }
     
     static UpdateBlocksOp getInstance(OpInstanceCache cache) {
-      return (UpdateBlocksOp)cache.get(OP_UPDATE_BLOCKS);
+      return cache.get(OP_UPDATE_BLOCKS);
     }
 
     @Override
@@ -1175,7 +1175,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetReplicationOp getInstance(OpInstanceCache cache) {
-      return (SetReplicationOp)cache.get(OP_SET_REPLICATION);
+      return cache.get(OP_SET_REPLICATION);
     }
 
     @Override
@@ -1254,7 +1254,7 @@ public abstract class FSEditLogOp {
     }
 
     static ConcatDeleteOp getInstance(OpInstanceCache cache) {
-      return (ConcatDeleteOp)cache.get(OP_CONCAT_DELETE);
+      return cache.get(OP_CONCAT_DELETE);
     }
 
     @Override
@@ -1412,7 +1412,7 @@ public abstract class FSEditLogOp {
     }
 
     static RenameOldOp getInstance(OpInstanceCache cache) {
-      return (RenameOldOp)cache.get(OP_RENAME_OLD);
+      return cache.get(OP_RENAME_OLD);
     }
 
     @Override
@@ -1524,7 +1524,7 @@ public abstract class FSEditLogOp {
     }
 
     static DeleteOp getInstance(OpInstanceCache cache) {
-      return (DeleteOp)cache.get(OP_DELETE);
+      return cache.get(OP_DELETE);
     }
 
     @Override
@@ -1625,7 +1625,7 @@ public abstract class FSEditLogOp {
     }
     
     static MkdirOp getInstance(OpInstanceCache cache) {
-      return (MkdirOp)cache.get(OP_MKDIR);
+      return cache.get(OP_MKDIR);
     }
 
     @Override
@@ -1798,7 +1798,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetGenstampV1Op getInstance(OpInstanceCache cache) {
-      return (SetGenstampV1Op)cache.get(OP_SET_GENSTAMP_V1);
+      return cache.get(OP_SET_GENSTAMP_V1);
     }
 
     @Override
@@ -1864,7 +1864,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetGenstampV2Op getInstance(OpInstanceCache cache) {
-      return (SetGenstampV2Op)cache.get(OP_SET_GENSTAMP_V2);
+      return cache.get(OP_SET_GENSTAMP_V2);
     }
 
     @Override
@@ -1922,7 +1922,7 @@ public abstract class FSEditLogOp {
     }
 
     static AllocateBlockIdOp getInstance(OpInstanceCache cache) {
-      return (AllocateBlockIdOp)cache.get(OP_ALLOCATE_BLOCK_ID);
+      return cache.get(OP_ALLOCATE_BLOCK_ID);
     }
 
     @Override
@@ -1981,7 +1981,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetPermissionsOp getInstance(OpInstanceCache cache) {
-      return (SetPermissionsOp)cache.get(OP_SET_PERMISSIONS);
+      return cache.get(OP_SET_PERMISSIONS);
     }
 
     @Override
@@ -2054,7 +2054,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetOwnerOp getInstance(OpInstanceCache cache) {
-      return (SetOwnerOp)cache.get(OP_SET_OWNER);
+      return cache.get(OP_SET_OWNER);
     }
 
     @Override
@@ -2141,7 +2141,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetNSQuotaOp getInstance(OpInstanceCache cache) {
-      return (SetNSQuotaOp)cache.get(OP_SET_NS_QUOTA);
+      return cache.get(OP_SET_NS_QUOTA);
     }
 
     @Override
@@ -2199,7 +2199,7 @@ public abstract class FSEditLogOp {
     }
 
     static ClearNSQuotaOp getInstance(OpInstanceCache cache) {
-      return (ClearNSQuotaOp)cache.get(OP_CLEAR_NS_QUOTA);
+      return cache.get(OP_CLEAR_NS_QUOTA);
     }
 
     @Override
@@ -2253,7 +2253,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetQuotaOp getInstance(OpInstanceCache cache) {
-      return (SetQuotaOp)cache.get(OP_SET_QUOTA);
+      return cache.get(OP_SET_QUOTA);
     }
 
     @Override
@@ -2338,7 +2338,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetQuotaByStorageTypeOp getInstance(OpInstanceCache cache) {
-      return (SetQuotaByStorageTypeOp)cache.get(OP_SET_QUOTA_BY_STORAGETYPE);
+      return cache.get(OP_SET_QUOTA_BY_STORAGETYPE);
     }
 
     @Override
@@ -2421,7 +2421,7 @@ public abstract class FSEditLogOp {
     }
 
     static TimesOp getInstance(OpInstanceCache cache) {
-      return (TimesOp)cache.get(OP_TIMES);
+      return cache.get(OP_TIMES);
     }
 
     @Override
@@ -2530,7 +2530,7 @@ public abstract class FSEditLogOp {
     }
 
     static SymlinkOp getInstance(OpInstanceCache cache) {
-      return (SymlinkOp)cache.get(OP_SYMLINK);
+      return cache.get(OP_SYMLINK);
     }
 
     @Override
@@ -2689,7 +2689,7 @@ public abstract class FSEditLogOp {
     }
 
     static RenameOp getInstance(OpInstanceCache cache) {
-      return (RenameOp)cache.get(OP_RENAME);
+      return cache.get(OP_RENAME);
     }
 
     @Override
@@ -2854,7 +2854,7 @@ public abstract class FSEditLogOp {
     }
 
     static TruncateOp getInstance(OpInstanceCache cache) {
-      return (TruncateOp)cache.get(OP_TRUNCATE);
+      return cache.get(OP_TRUNCATE);
     }
 
     @Override
@@ -2988,7 +2988,7 @@ public abstract class FSEditLogOp {
     }
 
     static ReassignLeaseOp getInstance(OpInstanceCache cache) {
-      return (ReassignLeaseOp)cache.get(OP_REASSIGN_LEASE);
+      return cache.get(OP_REASSIGN_LEASE);
     }
 
     @Override
@@ -3070,7 +3070,7 @@ public abstract class FSEditLogOp {
     }
 
     static GetDelegationTokenOp getInstance(OpInstanceCache cache) {
-      return (GetDelegationTokenOp)cache.get(OP_GET_DELEGATION_TOKEN);
+      return cache.get(OP_GET_DELEGATION_TOKEN);
     }
 
     @Override
@@ -3149,7 +3149,7 @@ public abstract class FSEditLogOp {
     }
 
     static RenewDelegationTokenOp getInstance(OpInstanceCache cache) {
-      return (RenewDelegationTokenOp)cache.get(OP_RENEW_DELEGATION_TOKEN);
+      return cache.get(OP_RENEW_DELEGATION_TOKEN);
     }
 
     @Override
@@ -3227,7 +3227,7 @@ public abstract class FSEditLogOp {
     }
 
     static CancelDelegationTokenOp getInstance(OpInstanceCache cache) {
-      return (CancelDelegationTokenOp)cache.get(OP_CANCEL_DELEGATION_TOKEN);
+      return cache.get(OP_CANCEL_DELEGATION_TOKEN);
     }
 
     @Override
@@ -3286,7 +3286,7 @@ public abstract class FSEditLogOp {
     }
 
     static UpdateMasterKeyOp getInstance(OpInstanceCache cache) {
-      return (UpdateMasterKeyOp)cache.get(OP_UPDATE_MASTER_KEY);
+      return cache.get(OP_UPDATE_MASTER_KEY);
     }
 
     @Override
@@ -3345,7 +3345,7 @@ public abstract class FSEditLogOp {
 
     static LogSegmentOp getInstance(OpInstanceCache cache,
         FSEditLogOpCodes code) {
-      return (LogSegmentOp)cache.get(code);
+      return cache.get(code);
     }
 
     @Override
@@ -3404,7 +3404,7 @@ public abstract class FSEditLogOp {
     }
 
     static InvalidOp getInstance(OpInstanceCache cache) {
-      return (InvalidOp)cache.get(OP_INVALID);
+      return cache.get(OP_INVALID);
     }
 
     @Override
@@ -3457,7 +3457,7 @@ public abstract class FSEditLogOp {
     }
     
     static CreateSnapshotOp getInstance(OpInstanceCache cache) {
-      return (CreateSnapshotOp)cache.get(OP_CREATE_SNAPSHOT);
+      return cache.get(OP_CREATE_SNAPSHOT);
     }
 
     @Override
@@ -3562,7 +3562,7 @@ public abstract class FSEditLogOp {
     }
     
     static DeleteSnapshotOp getInstance(OpInstanceCache cache) {
-      return (DeleteSnapshotOp)cache.get(OP_DELETE_SNAPSHOT);
+      return cache.get(OP_DELETE_SNAPSHOT);
     }
 
     @Override
@@ -3669,7 +3669,7 @@ public abstract class FSEditLogOp {
     }
     
     static RenameSnapshotOp getInstance(OpInstanceCache cache) {
-      return (RenameSnapshotOp) cache.get(OP_RENAME_SNAPSHOT);
+      return cache.get(OP_RENAME_SNAPSHOT);
     }
 
     @Override
@@ -3788,7 +3788,7 @@ public abstract class FSEditLogOp {
     }
 
     static AllowSnapshotOp getInstance(OpInstanceCache cache) {
-      return (AllowSnapshotOp) cache.get(OP_ALLOW_SNAPSHOT);
+      return cache.get(OP_ALLOW_SNAPSHOT);
     }
 
     @Override
@@ -3847,7 +3847,7 @@ public abstract class FSEditLogOp {
     }
 
     static DisallowSnapshotOp getInstance(OpInstanceCache cache) {
-      return (DisallowSnapshotOp) cache.get(OP_DISALLOW_SNAPSHOT);
+      return cache.get(OP_DISALLOW_SNAPSHOT);
     }
 
     void resetSubFields() {
@@ -3901,7 +3901,7 @@ public abstract class FSEditLogOp {
     }
 
     static AddCacheDirectiveInfoOp getInstance(OpInstanceCache cache) {
-      return (AddCacheDirectiveInfoOp) cache.get(OP_ADD_CACHE_DIRECTIVE);
+      return cache.get(OP_ADD_CACHE_DIRECTIVE);
     }
 
     @Override
@@ -3971,7 +3971,7 @@ public abstract class FSEditLogOp {
     }
 
     static ModifyCacheDirectiveInfoOp getInstance(OpInstanceCache cache) {
-      return (ModifyCacheDirectiveInfoOp) cache.get(OP_MODIFY_CACHE_DIRECTIVE);
+      return cache.get(OP_MODIFY_CACHE_DIRECTIVE);
     }
 
     @Override
@@ -4047,7 +4047,7 @@ public abstract class FSEditLogOp {
     }
 
     static RemoveCacheDirectiveInfoOp getInstance(OpInstanceCache cache) {
-      return (RemoveCacheDirectiveInfoOp) cache.get(OP_REMOVE_CACHE_DIRECTIVE);
+      return cache.get(OP_REMOVE_CACHE_DIRECTIVE);
     }
 
     @Override
@@ -4104,7 +4104,7 @@ public abstract class FSEditLogOp {
     }
 
     static AddCachePoolOp getInstance(OpInstanceCache cache) {
-      return (AddCachePoolOp) cache.get(OP_ADD_CACHE_POOL);
+      return cache.get(OP_ADD_CACHE_POOL);
     }
 
     @Override
@@ -4170,7 +4170,7 @@ public abstract class FSEditLogOp {
     }
 
     static ModifyCachePoolOp getInstance(OpInstanceCache cache) {
-      return (ModifyCachePoolOp) cache.get(OP_MODIFY_CACHE_POOL);
+      return cache.get(OP_MODIFY_CACHE_POOL);
     }
 
     @Override
@@ -4243,7 +4243,7 @@ public abstract class FSEditLogOp {
     }
 
     static RemoveCachePoolOp getInstance(OpInstanceCache cache) {
-      return (RemoveCachePoolOp) cache.get(OP_REMOVE_CACHE_POOL);
+      return cache.get(OP_REMOVE_CACHE_POOL);
     }
 
     @Override
@@ -4300,7 +4300,7 @@ public abstract class FSEditLogOp {
     }
     
     static RemoveXAttrOp getInstance(OpInstanceCache cache) {
-      return (RemoveXAttrOp) cache.get(OP_REMOVE_XATTR);
+      return cache.get(OP_REMOVE_XATTR);
     }
 
     @Override
@@ -4353,7 +4353,7 @@ public abstract class FSEditLogOp {
     }
     
     static SetXAttrOp getInstance(OpInstanceCache cache) {
-      return (SetXAttrOp) cache.get(OP_SET_XATTR);
+      return cache.get(OP_SET_XATTR);
     }
 
     @Override
@@ -4406,7 +4406,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetAclOp getInstance(OpInstanceCache cache) {
-      return (SetAclOp) cache.get(OP_SET_ACL);
+      return cache.get(OP_SET_ACL);
     }
 
     @Override
@@ -4507,8 +4507,7 @@ public abstract class FSEditLogOp {
     }
 
     static AddErasureCodingPolicyOp getInstance(OpInstanceCache cache) {
-      return (AddErasureCodingPolicyOp) cache
-          .get(OP_ADD_ERASURE_CODING_POLICY);
+      return cache.get(OP_ADD_ERASURE_CODING_POLICY);
     }
 
     @Override
@@ -4620,8 +4619,7 @@ public abstract class FSEditLogOp {
     }
 
     static EnableErasureCodingPolicyOp getInstance(OpInstanceCache cache) {
-      return (EnableErasureCodingPolicyOp) cache
-          .get(OP_ENABLE_ERASURE_CODING_POLICY);
+      return cache.get(OP_ENABLE_ERASURE_CODING_POLICY);
     }
 
     @Override
@@ -4689,8 +4687,7 @@ public abstract class FSEditLogOp {
     }
 
     static DisableErasureCodingPolicyOp getInstance(OpInstanceCache cache) {
-      return (DisableErasureCodingPolicyOp) cache
-          .get(OP_DISABLE_ERASURE_CODING_POLICY);
+      return cache.get(OP_DISABLE_ERASURE_CODING_POLICY);
     }
 
     @Override
@@ -4756,8 +4753,7 @@ public abstract class FSEditLogOp {
     }
 
     static RemoveErasureCodingPolicyOp getInstance(OpInstanceCache cache) {
-      return (RemoveErasureCodingPolicyOp) cache
-          .get(OP_REMOVE_ERASURE_CODING_POLICY);
+      return cache.get(OP_REMOVE_ERASURE_CODING_POLICY);
     }
 
     @Override
@@ -4879,7 +4875,7 @@ public abstract class FSEditLogOp {
     }
 
     static SetStoragePolicyOp getInstance(OpInstanceCache cache) {
-      return (SetStoragePolicyOp) cache.get(OP_SET_STORAGE_POLICY);
+      return cache.get(OP_SET_STORAGE_POLICY);
     }
 
     @Override
@@ -4946,7 +4942,7 @@ public abstract class FSEditLogOp {
     }
 
     static RollingUpgradeStartOp getInstance(OpInstanceCache cache) {
-      return (RollingUpgradeStartOp) cache.get(OP_ROLLING_UPGRADE_START);
+      return cache.get(OP_ROLLING_UPGRADE_START);
     }
   }
 
@@ -4956,7 +4952,7 @@ public abstract class FSEditLogOp {
     }
 
     static RollingUpgradeFinalizeOp getInstance(OpInstanceCache cache) {
-      return (RollingUpgradeFinalizeOp) cache.get(OP_ROLLING_UPGRADE_FINALIZE);
+      return cache.get(OP_ROLLING_UPGRADE_FINALIZE);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
@@ -581,8 +581,8 @@ public class TestEditLogRace {
   }
 
   static SetOwnerOp getSetOwnerOp(OpInstanceCache cache, String group) {
-    return ((SetOwnerOp)cache.get(OP_SET_OWNER))
-        .setSource("/").setUser("u").setGroup(group);
+    SetOwnerOp setOwnerOp = cache.get(OP_SET_OWNER);
+    return setOwnerOp.setSource("/").setUser("u").setGroup(group);
   }
 
   static class BlockingOpMatcher implements ArgumentMatcher<FSEditLogOp> {


### PR DESCRIPTION
### Description of PR

When I read some class about Edits of NameNode, I found that there are much redundant cast in FSEditLogOp.class, I feel that we should remove them.

Such as:
```
static UpdateBlocksOp getInstance(OpInstanceCache cache) {
  return (UpdateBlocksOp)cache.get(OP_UPDATE_BLOCKS);
}
``` 

Because cache.get() have cast the response to T, so we can remove the redundant cast.
```
@SuppressWarnings("unchecked")
public <T extends FSEditLogOp> T get(FSEditLogOpCodes opCode) {
  return useCache ? (T)CACHE.get().get(opCode) : (T)newInstance(opCode);
} 
```

