### PR TITLE
HDFS-16712. Fix incorrect placeholder in DataNode.java

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -3642,7 +3642,7 @@ public class DataNode extends ReconfigurableBase
     try {
       return getDiskBalancer().queryWorkStatus().toJsonString();
     } catch (IOException ex) {
-      LOG.debug("Reading diskbalancer Status failed. ex:{}", ex);
+      LOG.debug("Reading diskbalancer Status failed.", ex);
       return "";
     }
   }


### PR DESCRIPTION
### Description of PR
Fix incorrect placeholder in DataNode.java
```
public String getDiskBalancerStatus() {
  try {
    return getDiskBalancer().queryWorkStatus().toJsonString();
  } catch (IOException ex) {
    // incorrect placeholder
    LOG.debug("Reading diskbalancer Status failed. ex:{}", ex);
    return "";
  }
} 
```


