### PR TITLE
HDFS-16687. RouterFsckServlet replicates code from DfsServlet base class

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterFsckServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterFsckServlet.java
@@ -25,20 +25,19 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdfs.server.common.JspHelper;
+import org.apache.hadoop.hdfs.server.namenode.DfsServlet;
 import org.apache.hadoop.security.UserGroupInformation;
 
 /**
  * This class is used in Namesystem's web server to do fsck on namenode.
  */
 @InterfaceAudience.Private
-public class RouterFsckServlet extends HttpServlet {
+public class RouterFsckServlet extends DfsServlet {
   /** for java.io.Serializable. */
   private static final long serialVersionUID = 1L;
 
@@ -67,15 +66,4 @@ public class RouterFsckServlet extends HttpServlet {
     }
   }
 
-  /**
-   * Copy from {@link org.apache.hadoop.hdfs.server.namenode.DfsServlet}.
-   * @param request Http request from the user
-   * @param conf configuration
-   * @return ugi of the requested user
-   * @throws IOException failed to get ugi
-   */
-  protected UserGroupInformation getUGI(HttpServletRequest request,
-      Configuration conf) throws IOException {
-    return JspHelper.getUGI(getServletContext(), request, conf);
-  }
 }


### PR DESCRIPTION
### Description of PR

RouterFsckServlet replicates the method "getUGI(HttpServletRequest request, Configuration conf)" from DfsServlet instead of just extending DfsServlet.  This change is just a refactor, which replaces the copy with the original base class.

### How was this patch tested?

The fsck endpoint was called using curl, verifying that the Kerberos checks performed as expected.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

