### PR TITLE
HADOOP-17234. Addendum. Add .asf.yaml to allow github and jira integration.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,4 +22,4 @@ notifications:
   commits:      common-commits@hadoop.apache.org
   issues:       common-issues@hadoop.apache.org
   pullrequests: common-issues@hadoop.apache.org
-  jira_options: link label worklog
+  jira_options: comment link label


### PR DESCRIPTION
### Description of PR
**Addendum to the previous change**
Disables WorkLog entries & TimeTracking, which we aren't using, and tough to follow and shoots redundant mails. Instead the Jira comments as well as the Github Pr comments can all be seen together on the Jira.

https://issues.apache.org/jira/browse/INFRA-23544?focusedCommentId=17574650&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17574650

### How was this patch tested?

Saw an example posted in INFRA-23544, Rest will get to know post merge only. :-) 

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?