### PR TITLE
HADOOP-18090 Exclude com/jcraft/jsch classes from being shaded/relocated

### DIFF
--- a/hadoop-client-modules/hadoop-client-minicluster/pom.xml
+++ b/hadoop-client-modules/hadoop-client-minicluster/pom.xml
@@ -475,11 +475,6 @@
       <artifactId>kfs</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch</artifactId>
-      <optional>true</optional>
-    </dependency>
     <!-- add back in transitive dependencies of hadoop-mapreduce-client-app removed in client -->
     <!-- Skipping javax.servlet:servlet-api because it's in client -->
     <dependency>

--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -108,6 +108,12 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+      <optional>true</optional>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
### Description of PR
Spark 3.2.0 transitively introduces hadoop-client-api and hadoop-client-runtime dependencies.

When we create a SFTPFileSystem instance (org.apache.hadoop.fs.sftp.SFTPFileSystem) it tries to load the relocated classes from com.jcraft.jsch package.

The filesystem instance creation fails with error:

```
java.lang.ClassNotFoundException: org.apache.hadoop.shaded.com.jcraft.jsch.SftpException
    at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357) 
```


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

