### PR TITLE
HADOOP-18366. Fix ITestS3Select.testSelectSeekFullLandsat is timing out.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
@@ -415,7 +415,7 @@ public class ITestS3SelectLandsat extends AbstractS3SelectTest {
       long increment = 64 * _1KB;
 
       // seek forward, comparing bytes
-      for(offset = 32 * _1KB; offset < actualLen; offset += increment) {
+      for(offset = 32 * _1KB; offset < _1MB; offset += increment) {
         seek(seekStream, offset);
         assertEquals("Seek position in " + seekStream,
             offset, seekStream.getPos());
@@ -423,11 +423,7 @@ public class ITestS3SelectLandsat extends AbstractS3SelectTest {
         assertEquals("byte at seek position",
             dataset[(int) seekStream.getPos()], seekStream.read());
       }
-      for(; offset < len; offset += _1MB) {
-        seek(seekStream, offset);
-        assertEquals("Seek position in " + seekStream,
-            offset, seekStream.getPos());
-      }
+      
       // there's no knowledge of how much data is left, but with Gzip
       // involved there can be a lot. To keep the test duration down,
       // this test, unlike the simpler one, doesn't try to read past the

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/select/ITestS3SelectLandsat.java
@@ -423,7 +423,6 @@ public class ITestS3SelectLandsat extends AbstractS3SelectTest {
         assertEquals("byte at seek position",
             dataset[(int) seekStream.getPos()], seekStream.read());
       }
-      
       // there's no knowledge of how much data is left, but with Gzip
       // involved there can be a lot. To keep the test duration down,
       // this test, unlike the simpler one, doesn't try to read past the


### PR DESCRIPTION
### Description of PR

Reduces the size of the data read to 1MB from the landsat file. Previously we were reading the entire file of ~42MB. 

### How was this patch tested?

Tested by running `ITestS3Select` against eu-west-1. All tests pass, testSelectFullLandsat passes in 44s with debug logging on, 13s with debug logging off. With debug logging off, the original testSelectFullLandsat (which reads the whole file), is completing in 17s. 


