### PR TITLE
HADOOP-18373. IOStatisticsContext tuning

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -480,13 +480,13 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
    * Thread-level IOStats Support.
    * {@value}
    */
-  public static final String THREAD_LEVEL_IOSTATISTICS_ENABLED =
-      "fs.thread.level.iostatistics.enabled";
+  public static final String IOSTATISTICS_THREAD_LEVEL_ENABLED =
+      "fs.iostatistics.thread.level.enabled";
 
   /**
    * Default value for Thread-level IOStats Support is true.
    */
-  public static final boolean THREAD_LEVEL_IOSTATISTICS_ENABLED_DEFAULT =
+  public static final boolean IOSTATISTICS_THREAD_LEVEL_ENABLED_DEFAULT =
       true;
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsContext.java
@@ -86,8 +86,8 @@ public interface IOStatisticsContext extends IOStatisticsSource {
    *
    * @return if the thread-level IO statistics enabled.
    */
-  static boolean getIOStatisticsThreadLevelEnabled() {
-    return IOStatisticsContextIntegration.getIOStatisticsThreadLevelEnabled();
+  static boolean enabled() {
+    return IOStatisticsContextIntegration.isIOStatisticsThreadLevelEnabled();
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/IOStatisticsContext.java
@@ -80,4 +80,14 @@ public interface IOStatisticsContext extends IOStatisticsSource {
     IOStatisticsContextIntegration.setThreadIOStatisticsContext(
         statisticsContext);
   }
+
+  /**
+   * Static probe to check if the thread-level IO statistics enabled.
+   *
+   * @return if the thread-level IO statistics enabled.
+   */
+  static boolean getIOStatisticsThreadLevelEnabled() {
+    return IOStatisticsContextIntegration.getIOStatisticsThreadLevelEnabled();
+  }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsContextIntegration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsContextIntegration.java
@@ -85,7 +85,7 @@ public final class IOStatisticsContextIntegration {
    *
    * @return if the thread-level IO statistics enabled.
    */
-  public static boolean getIOStatisticsThreadLevelEnabled() {
+  public static boolean isIOStatisticsThreadLevelEnabled() {
     return isThreadIOStatsEnabled;
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsContextIntegration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/impl/IOStatisticsContextIntegration.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.impl.WeakReferenceThreadMap;
 import org.apache.hadoop.fs.statistics.IOStatisticsContext;
 
-import static org.apache.hadoop.fs.CommonConfigurationKeys.THREAD_LEVEL_IOSTATISTICS_ENABLED;
-import static org.apache.hadoop.fs.CommonConfigurationKeys.THREAD_LEVEL_IOSTATISTICS_ENABLED_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeys.IOSTATISTICS_THREAD_LEVEL_ENABLED;
+import static org.apache.hadoop.fs.CommonConfigurationKeys.IOSTATISTICS_THREAD_LEVEL_ENABLED_DEFAULT;
 
 /**
  * A Utility class for IOStatisticsContext, which helps in creating and
@@ -76,8 +76,17 @@ public final class IOStatisticsContextIntegration {
     // Work out if the current context has thread level IOStatistics enabled.
     final Configuration configuration = new Configuration();
     isThreadIOStatsEnabled =
-        configuration.getBoolean(THREAD_LEVEL_IOSTATISTICS_ENABLED,
-            THREAD_LEVEL_IOSTATISTICS_ENABLED_DEFAULT);
+        configuration.getBoolean(IOSTATISTICS_THREAD_LEVEL_ENABLED,
+            IOSTATISTICS_THREAD_LEVEL_ENABLED_DEFAULT);
+  }
+
+  /**
+   * Static probe to check if the thread-level IO statistics enabled.
+   *
+   * @return if the thread-level IO statistics enabled.
+   */
+  public static boolean getIOStatisticsThreadLevelEnabled() {
+    return isThreadIOStatsEnabled;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -153,7 +153,8 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
    * @return thread context
    */
   private static IOStatisticsContext getAndResetThreadStatisticsContext() {
-    assertTrue(IOStatisticsContext.getIOStatisticsThreadLevelEnabled());
+    assertTrue("thread-level IOStatistics should be enabled by default",
+        IOStatisticsContext.enabled());
     IOStatisticsContext context =
         IOStatisticsContext.getCurrentIOStatisticsContext();
     context.reset();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -153,6 +153,7 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
    * @return thread context
    */
   private static IOStatisticsContext getAndResetThreadStatisticsContext() {
+    assertTrue(IOStatisticsContext.getIOStatisticsThreadLevelEnabled());
     IOStatisticsContext context =
         IOStatisticsContext.getCurrentIOStatisticsContext();
     context.reset();

--- a/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
@@ -178,6 +178,12 @@
     <value>true</value>
   </property>
 
+  <!-- Enable IOStatisticsContext support for Thread level. -->
+  <property>
+    <name>fs.iostatistics.thread.level.enabled</name>
+    <value>true</value>
+  </property>
+
   <!--
   To run these tests.
 


### PR DESCRIPTION
### Description of PR
Tuning of the IOStatisticsContext code

change property name to "fs.iostatistics...." for consistent naming

Edit core-site.xml to always collect context iOStatistics

