### PR TITLE
HDFS-16653.Safe mode related operations cannot be performed when “dfs.client.mmap.cache.size” is set to a negative number

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
@@ -385,7 +385,7 @@ public class ShortCircuitCache implements Closeable {
     Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0);
     this.maxNonMmappedEvictableLifespanMs = maxNonMmappedEvictableLifespanMs;
     Preconditions.checkArgument(maxEvictableMmapedSize >= 0,
-    "Invalid argument: " + HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY + 
+    "Invalid argument: " + HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY +
     " must be greater than zero.");
     this.maxEvictableMmapedSize = maxEvictableMmapedSize;
     Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/shortcircuit/ShortCircuitCache.java
@@ -37,6 +37,7 @@ import org.apache.commons.collections.map.LinkedMap;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.ExtendedBlockId;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.client.impl.DfsClientConf.ShortCircuitConf;
 import org.apache.hadoop.hdfs.net.DomainPeer;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -383,7 +384,9 @@ public class ShortCircuitCache implements Closeable {
     this.maxTotalSize = maxTotalSize;
     Preconditions.checkArgument(maxNonMmappedEvictableLifespanMs >= 0);
     this.maxNonMmappedEvictableLifespanMs = maxNonMmappedEvictableLifespanMs;
-    Preconditions.checkArgument(maxEvictableMmapedSize >= 0);
+    Preconditions.checkArgument(maxEvictableMmapedSize >= 0,
+    "Invalid argument: " + HdfsClientConfigKeys.Mmap.CACHE_SIZE_KEY + 
+    " must be greater than zero.");
     this.maxEvictableMmapedSize = maxEvictableMmapedSize;
     Preconditions.checkArgument(maxEvictableMmapedLifespanMs >= 0);
     this.maxEvictableMmapedLifespanMs = maxEvictableMmapedLifespanMs;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitShm.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/shortcircuit/TestShortCircuitShm.java
@@ -9,6 +9,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,6 +174,11 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
+    Preconditions.checkArgument(minimumRedundantVolumes <= volumes.size(), 
+    "The setting for " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
+    " is " + minimumRedundantVolumes +
+    " which is less than the total number of existing storage volumes " + volumes.size() + 
+    " and will result in adding resources and still not being able to turn off safe mode.");
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,11 +174,6 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
-    Preconditions.checkArgument(minimumRedundantVolumes <= volumes.size(), 
-    "The setting for " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY + 
-    " is " + minimumRedundantVolumes +
-    " which is less than the total number of existing storage volumes " + volumes.size() + 
-    " and will result in adding resources and still not being able to turn off safe mode.");
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When the configuration item “dfs.client.mmap.cache.size” is set to a negative number, it will cause /hadoop/bin hdfs dfsadmin -safemode provides all the operation options including enter, leave, get, wait and forceExit are invalid, the terminal returns security mode is null and no exceptions are thrown.
[HDFS-16653](https://issues.apache.org/jira/browse/HDFS-16653)

### How was this patch tested?
This patch improves the check mechanism related to “dfs.client.mmap.cache.size”, and give a clear indication when the configuration is abnormal in order to solve the problem in time and reduce the impact on the safe mode related operations.
