### PR TITLE
YARN-6539. Create SecureLogin inside Router.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4107,6 +4107,14 @@ public class YarnConfiguration extends Configuration {
   public static final long DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT =
       TimeUnit.SECONDS.toMillis(30);
 
+  /** The Kerberos keytab for the yarn router.*/
+  public static final String ROUTER_KEYTAB = ROUTER_PREFIX + "keytab";
+
+  /** The Kerberos principal for the timeline server.*/
+  public static final String ROUTER_PRINCIPAL = ROUTER_PREFIX + "principal";
+
+
+
   ////////////////////////////////
   // CSI Volume configs
   ////////////////////////////////

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4108,10 +4108,14 @@ public class YarnConfiguration extends Configuration {
       TimeUnit.SECONDS.toMillis(30);
 
   /** The Kerberos keytab for the yarn router.*/
-  public static final String ROUTER_KEYTAB = ROUTER_PREFIX + "keytab";
+  public static final String ROUTER_KEYTAB = ROUTER_PREFIX + "keytab.file";
 
-  /** The Kerberos principal for the timeline server.*/
-  public static final String ROUTER_PRINCIPAL = ROUTER_PREFIX + "principal";
+  /** The Kerberos principal for the yarn router.*/
+  public static final String ROUTER_PRINCIPAL = ROUTER_PREFIX + "kerberos.principal";
+
+  /** The Kerberos principal hostname for the yarn router.*/
+  public static final String ROUTER_KERBEROS_PRINCIPAL_HOSTNAME_KEY = ROUTER_PREFIX +
+      "kerberos.principal.hostname";
 
   ////////////////////////////////
   // CSI Volume configs

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4113,8 +4113,6 @@ public class YarnConfiguration extends Configuration {
   /** The Kerberos principal for the timeline server.*/
   public static final String ROUTER_PRINCIPAL = ROUTER_PREFIX + "principal";
 
-
-
   ////////////////////////////////
   // CSI Volume configs
   ////////////////////////////////

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -4888,4 +4888,17 @@
       default implementation LocalityAppPlacementAllocator is used.
     </description>
   </property>
+
+  <property>
+    <name>yarn.router.keytab</name>
+    <value>/etc/krb5.keytab</value>
+    <description>The keytab for the router.</description>
+  </property>
+
+  <property>
+    <name>yarn.router.principal</name>
+    <value></value>
+    <description>The Kerberos principal for the resource manager.</description>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -4890,15 +4890,35 @@
   </property>
 
   <property>
-    <name>yarn.router.keytab</name>
-    <value>/etc/krb5.keytab</value>
-    <description>The keytab for the router.</description>
+    <name>yarn.router.keytab.file</name>
+    <value></value>
+    <description>
+       The keytab file used by router to login as its
+       service principal. The principal name is configured with
+       dfs.federation.router.kerberos.principal.
+    </description>
   </property>
 
   <property>
-    <name>yarn.router.principal</name>
+    <name>yarn.router.kerberos.principal</name>
     <value></value>
-    <description>The Kerberos principal for the resource manager.</description>
+    <description>
+      The Router service principal. This is typically set to
+      router/_HOST@REALM.TLD. Each Router will substitute _HOST with its
+      own fully qualified hostname at startup. The _HOST placeholder
+      allows using the same configuration setting on both Router setup.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.router.kerberos.principal.hostname</name>
+    <value></value>
+    <description>
+      Optional.
+      The hostname for the Router containing this
+      configuration file. Will be different for each machine.
+      Defaults to current hostname.
+    </description>
   </property>
 
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterId.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterId.java
@@ -43,6 +43,14 @@ public abstract class SubClusterId implements Comparable<SubClusterId> {
     return id;
   }
 
+  @Private
+  @Unstable
+  public static SubClusterId newInstance(Integer subClusterId) {
+    SubClusterId id = Records.newRecord(SubClusterId.class);
+    id.setId(String.valueOf(subClusterId));
+    return id;
+  }
+
   /**
    * Get the string identifier of the <em>subcluster</em> which is unique across
    * the federated cluster. The identifier is static, i.e. preserved across

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -609,4 +609,10 @@ public final class FederationStateStoreFacade {
   protected interface Func<T, TResult> {
     TResult invoke(T input) throws Exception;
   }
+
+
+  @VisibleForTesting
+  public FederationStateStore getStateStore() {
+    return stateStore;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/uam/UnmanagedApplicationManager.java
@@ -382,8 +382,13 @@ public class UnmanagedApplicationManager {
   protected Token<AMRMTokenIdentifier> initializeUnmanagedAM(
       ApplicationId appId) throws IOException, YarnException {
     try {
-      UserGroupInformation appSubmitter =
-          UserGroupInformation.createRemoteUser(this.submitter);
+      UserGroupInformation appSubmitter;
+      if (UserGroupInformation.isSecurityEnabled()) {
+        appSubmitter = UserGroupInformation.createProxyUser(this.submitter,
+            UserGroupInformation.getLoginUser());
+      } else {
+        appSubmitter = UserGroupInformation.createRemoteUser(this.submitter);
+      }
       this.rmClient = createRMProxy(ApplicationClientProtocol.class, this.conf,
           appSubmitter, null);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -459,8 +459,13 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       // Get the running containers from home RM, note that we will also get the
       // AM container itself from here. We don't need it, but no harm to put the
       // map as well.
-      UserGroupInformation appSubmitter = UserGroupInformation
-          .createRemoteUser(getApplicationContext().getUser());
+      UserGroupInformation appSubmitter;
+      if (UserGroupInformation.isSecurityEnabled()) {
+        appSubmitter = UserGroupInformation.createProxyUser(getApplicationContext().getUser(),
+            UserGroupInformation.getLoginUser());
+      } else {
+        appSubmitter = UserGroupInformation.createRemoteUser(getApplicationContext().getUser());
+      }
       ApplicationClientProtocol rmClient =
           createHomeRMProxy(getApplicationContext(),
               ApplicationClientProtocol.class, appSubmitter);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
@@ -116,6 +116,19 @@
       <artifactId>guice</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
+import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.service.CompositeService;
 import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.ShutdownHookManager;
@@ -88,7 +89,8 @@ public class Router extends CompositeService {
   }
 
   protected void doSecureLogin() throws IOException {
-    // TODO YARN-6539 Create SecureLogin inside Router
+    SecurityUtil.login(this.conf, YarnConfiguration.ROUTER_KEYTAB,
+        YarnConfiguration.ROUTER_PRINCIPAL);
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.yarn.server.router;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -90,7 +92,7 @@ public class Router extends CompositeService {
 
   protected void doSecureLogin() throws IOException {
     SecurityUtil.login(this.conf, YarnConfiguration.ROUTER_KEYTAB,
-        YarnConfiguration.ROUTER_PRINCIPAL);
+        YarnConfiguration.ROUTER_PRINCIPAL, getHostName(this.conf));
   }
 
   @Override
@@ -198,11 +200,30 @@ public class Router extends CompositeService {
     }
   }
 
+  @VisibleForTesting
   public RouterClientRMService getClientRMProxyService() {
     return clientRMProxyService;
   }
 
+  @VisibleForTesting
   public RouterRMAdminService getRmAdminProxyService() {
     return rmAdminProxyService;
+  }
+
+  /**
+   * Returns the hostname for this Router. If the hostname is not
+   * explicitly configured in the given config, then it is determined.
+   *
+   * @param config configuration
+   * @return the hostname (NB: may not be a FQDN)
+   * @throws UnknownHostException if the hostname cannot be determined
+   */
+  private String getHostName(Configuration config)
+      throws UnknownHostException {
+    String name = config.get(YarnConfiguration.ROUTER_KERBEROS_PRINCIPAL_HOSTNAME_KEY);
+    if (name == null) {
+      name = InetAddress.getLocalHost().getHostName();
+    }
+    return name;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/Router.java
@@ -197,4 +197,12 @@ public class Router extends CompositeService {
       System.exit(-1);
     }
   }
+
+  public RouterClientRMService getClientRMProxyService() {
+    return clientRMProxyService;
+  }
+
+  public RouterRMAdminService getRmAdminProxyService() {
+    return rmAdminProxyService;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/AbstractClientRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/AbstractClientRequestInterceptor.java
@@ -106,8 +106,9 @@ public abstract class AbstractClientRequestInterceptor
     try {
       // Do not create a proxy user if user name matches the user name on
       // current UGI
-      if (userName.equalsIgnoreCase(
-          UserGroupInformation.getCurrentUser().getUserName())) {
+      if (UserGroupInformation.isSecurityEnabled()) {
+        user = UserGroupInformation.createProxyUser(userName, UserGroupInformation.getLoginUser());
+      } else if (userName.equalsIgnoreCase(UserGroupInformation.getCurrentUser().getUserName())) {
         user = UserGroupInformation.getCurrentUser();
       } else {
         user = UserGroupInformation.createProxyUser(userName,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -1623,4 +1623,14 @@ public class FederationClientInterceptor
         String.format("Can't Found applicationId = %s in any sub clusters", applicationId);
     throw new YarnException(errorMsg);
   }
+
+  @VisibleForTesting
+  public FederationStateStoreFacade getFederationFacade() {
+    return federationFacade;
+  }
+
+  @VisibleForTesting
+  public Map<SubClusterId, ApplicationClientProtocol> getClientRMProxies() {
+    return clientRMProxies;
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
@@ -617,6 +617,7 @@ public class RouterClientRMService extends AbstractService
     }
   }
 
+  @VisibleForTesting
   public Map<String, RequestInterceptorChainWrapper> getUserPipelineMap() {
     return userPipelineMap;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/RouterClientRMService.java
@@ -473,7 +473,7 @@ public class RouterClientRMService extends AbstractService
   }
 
   @VisibleForTesting
-  protected RequestInterceptorChainWrapper getInterceptorChain()
+  public RequestInterceptorChainWrapper getInterceptorChain()
       throws IOException {
     String user = UserGroupInformation.getCurrentUser().getUserName();
     RequestInterceptorChainWrapper chain = userPipelineMap.get(user);
@@ -615,5 +615,9 @@ public class RouterClientRMService extends AbstractService
     protected void finalize() {
       rootInterceptor.shutdown();
     }
+  }
+
+  public Map<String, RequestInterceptorChainWrapper> getUserPipelineMap() {
+    return userPipelineMap;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/DefaultRMAdminRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/DefaultRMAdminRequestInterceptor.java
@@ -80,8 +80,9 @@ public class DefaultRMAdminRequestInterceptor
     try {
       // Do not create a proxy user if user name matches the user name on
       // current UGI
-      if (userName.equalsIgnoreCase(
-          UserGroupInformation.getCurrentUser().getUserName())) {
+      if (UserGroupInformation.isSecurityEnabled()) {
+        user = UserGroupInformation.createProxyUser(userName, UserGroupInformation.getLoginUser());
+      } else if (userName.equalsIgnoreCase(UserGroupInformation.getCurrentUser().getUserName())) {
         user = UserGroupInformation.getCurrentUser();
       } else {
         user = UserGroupInformation.createProxyUser(userName,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/RouterRMAdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/RouterRMAdminService.java
@@ -186,7 +186,7 @@ public class RouterRMAdminService extends AbstractService
   }
 
   @VisibleForTesting
-  protected RequestInterceptorChainWrapper getInterceptorChain()
+  public RequestInterceptorChainWrapper getInterceptorChain()
       throws IOException {
     String user = UserGroupInformation.getCurrentUser().getUserName();
     RequestInterceptorChainWrapper chain = userPipelineMap.get(user);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -62,14 +62,14 @@ public class AbstractSecureRouterTest {
 
   public static final String KERBEROS = "kerberos";
 
-  protected static MiniKdc kdc;
-  protected static File keytab_router;
-  protected static File kdcWorkDir;
-  protected static Properties kdcConf;
+  private static MiniKdc kdc;
+  private static File routerKeytab;
+  private static File kdcWorkDir;
+  private static Properties kdcConf;
 
-  protected Router router = null;
+  private Router router = null;
 
-  protected static Configuration conf;
+  private static Configuration conf;
 
   @BeforeClass
   public static void beforeSecureRouterTestClass() throws Exception {
@@ -84,7 +84,7 @@ public class AbstractSecureRouterTest {
         CLIENT_RM_FEDERATION_CLIENT_INTERCEPTOR);
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, KERBEROS);
     conf.set(YarnConfiguration.ROUTER_PRINCIPAL, ROUTER_LOCALHOST_REALM);
-    conf.set(YarnConfiguration.ROUTER_KEYTAB, keytab_router.getAbsolutePath());
+    conf.set(YarnConfiguration.ROUTER_KEYTAB, routerKeytab.getAbsolutePath());
   }
 
   /**
@@ -105,7 +105,7 @@ public class AbstractSecureRouterTest {
     kdc = new MiniKdc(kdcConf, kdcWorkDir);
     kdc.start();
 
-    keytab_router = createKeytab(ROUTER, "router.keytab");
+    routerKeytab = createKeytab(ROUTER, "router.keytab");
   }
 
   /**
@@ -134,7 +134,7 @@ public class AbstractSecureRouterTest {
    *
    * @throws Exception an error occurred.
    */
-  protected synchronized void startSecureRouter() throws Exception {
+  public synchronized void startSecureRouter() throws Exception {
     Assert.assertNull("Router is already running", router);
     UserGroupInformation.setConfiguration(conf);
     router = new Router();
@@ -166,10 +166,23 @@ public class AbstractSecureRouterTest {
     }
   }
 
+  /**
+   * Stop the entire test service.
+   *
+   * @throws Exception an error occurred.
+   */
   @After
   public void afterSecureRouterTest() throws Exception {
     LOG.info("teardown of router instance.");
     stopSecureRouter();
     teardownKDC();
+  }
+
+  public static MiniKdc getKdc() {
+    return kdc;
+  }
+
+  public Router getRouter() {
+    return router;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.router.secure;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.router.Router;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Properties;
+
+public class AbstractSecureRouterTest {
+
+  public static final String REALM = "EXAMPLE.COM";
+
+  public static final String ROUTER = "router";
+  public static final String LOCALHOST = "localhost";
+  public static final String IP127001 = "127.0.0.1";
+  public static final String ROUTER_LOCALHOST = "router/" + LOCALHOST;
+  public static final String ROUTER_127001 = "router/" + IP127001;
+  public static final String ROUTER_REALM = "router@" + REALM;
+  public static final String ROUTER_LOCALHOST_REALM = ROUTER_LOCALHOST + "@" + REALM;
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractSecureRouterTest.class);
+
+  public static final Configuration CONF;
+
+  static {
+    CONF = new Configuration();
+    CONF.set("hadoop.security.authentication", "kerberos");
+    CONF.setBoolean("hadoop.security.authorization", true);
+  }
+
+  public static final String SUN_SECURITY_KRB5_DEBUG = "sun.security.krb5.debug";
+
+  public static final String CLIENT_RM_FEDERATION_CLIENT_INTERCEPTOR =
+      "org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor";
+
+  public static final String KERBEROS = "kerberos";
+
+  protected static MiniKdc kdc;
+  protected static File keytab_router;
+  protected static File kdcWorkDir;
+  protected static Properties kdcConf;
+
+  protected Router router = null;
+
+  protected static Configuration conf;
+
+  @BeforeClass
+  public static void beforeSecureRouterTestClass() throws Exception {
+
+    // Sets up the KDC and Principals.
+    setupKDCAndPrincipals();
+
+    // Init YarnConfiguration
+    conf = new YarnConfiguration();
+    conf.set(YarnConfiguration.ROUTER_BIND_HOST, "0.0.0.0");
+    conf.set(YarnConfiguration.ROUTER_CLIENTRM_INTERCEPTOR_CLASS_PIPELINE,
+        CLIENT_RM_FEDERATION_CLIENT_INTERCEPTOR);
+    conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, KERBEROS);
+    conf.set(YarnConfiguration.ROUTER_PRINCIPAL, ROUTER_LOCALHOST_REALM);
+    conf.set(YarnConfiguration.ROUTER_KEYTAB, keytab_router.getAbsolutePath());
+  }
+
+  /**
+   * Sets up the KDC and Principals.
+   *
+   * @throws Exception an error occurred.
+   */
+  public static void setupKDCAndPrincipals() throws Exception {
+    // set up the KDC
+    File target = new File(System.getProperty("test.dir", "target"));
+    kdcWorkDir = new File(target, "kdc");
+    kdcWorkDir.mkdirs();
+    if (!kdcWorkDir.mkdirs()) {
+      Assert.assertTrue(kdcWorkDir.isDirectory());
+    }
+    kdcConf = MiniKdc.createConf();
+    kdcConf.setProperty(MiniKdc.DEBUG, "true");
+    kdc = new MiniKdc(kdcConf, kdcWorkDir);
+    kdc.start();
+
+    keytab_router = createKeytab(ROUTER, "router.keytab");
+  }
+
+  /**
+   * Create the keytab for the given principal, includes
+   * raw principal and $principal/localhost.
+   *
+   * @param principal principal short name.
+   * @param filename filename of keytab.
+   * @return file of keytab.
+   * @throws Exception an error occurred.
+   */
+  public static File createKeytab(String principal, String filename) throws Exception {
+    Assert.assertTrue("empty principal", StringUtils.isNotBlank(principal));
+    Assert.assertTrue("empty host", StringUtils.isNotBlank(filename));
+    Assert.assertNotNull("Null KDC", kdc);
+    File keytab = new File(kdcWorkDir, filename);
+    kdc.createPrincipal(keytab,
+        principal,
+        principal + "/localhost",
+        principal + "/127.0.0.1");
+    return keytab;
+  }
+
+  /**
+   * Start the router in safe mode.
+   *
+   * @throws Exception an error occurred.
+   */
+  protected synchronized void startSecureRouter() throws Exception {
+    Assert.assertNull("Router is already running", router);
+    UserGroupInformation.setConfiguration(conf);
+    router = new Router();
+    router.init(conf);
+    router.start();
+  }
+
+  /**
+   * Shut down the KDC service.
+   *
+   * @throws Exception an error occurred.
+   */
+  public static void teardownKDC() throws Exception {
+    if (kdc != null) {
+      kdc.stop();
+      kdc = null;
+    }
+  }
+
+  /**
+   * Stop the router in safe mode.
+   *
+   * @throws Exception an error occurred.
+   */
+  protected synchronized void stopSecureRouter() throws Exception {
+    if (router != null) {
+      router.stop();
+      router = null;
+    }
+  }
+
+  @After
+  public void afterSecureRouterTest() throws Exception {
+    LOG.info("teardown of router instance.");
+    stopSecureRouter();
+    teardownKDC();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -22,28 +22,18 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
-import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
 import org.apache.hadoop.yarn.server.resourcemanager.TestRMRestart;
 import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor;
-import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
-import org.apache.hadoop.yarn.server.router.rmadmin.DefaultRMAdminRequestInterceptor;
-import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestSecureLogins extends AbstractSecureRouterTest{
+public class TestSecureLogins extends AbstractSecureRouterTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestSecureLogins.class);
 
@@ -35,7 +35,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest{
   @Test
   public void testRouterSecureLogin() throws Exception {
     startSecureRouter();
-    router.stop();
+    getRouter().stop();
   }
 
   public static String getPrincipalAndRealm(String principal) {
@@ -43,6 +43,6 @@ public class TestSecureLogins extends AbstractSecureRouterTest{
   }
 
   protected static String getRealm() {
-    return kdc.getRealm();
+    return getKdc().getRealm();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
@@ -17,10 +17,20 @@
  */
 package org.apache.hadoop.yarn.server.router.secure;
 
+import org.apache.hadoop.service.Service;
+import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsResponse;
+import org.apache.hadoop.yarn.api.records.YarnClusterMetrics;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RefreshNodesRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RefreshNodesResponse;
+import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
+import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 public class TestSecureLogins extends AbstractSecureRouterTest {
 
@@ -34,8 +44,42 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
 
   @Test
   public void testRouterSecureLogin() throws Exception {
-    startSecureRouter();
-    getRouter().stop();
+    startSecureRouter(false);
+
+    List<Service> services = this.getRouter().getServices();
+    Assert.assertNotNull(services);
+    Assert.assertEquals(3, services.size());
+
+    stopSecureRouter();
+  }
+
+  @Test
+  public void testRouterClientRMProxyService() throws Exception {
+    startSecureRouter(true);
+
+    // Test the simple rpc call of the Router in the Secure environment
+    RouterClientRMService routerClientRMService = this.getRouter().getClientRMProxyService();
+    GetClusterMetricsRequest metricsRequest = GetClusterMetricsRequest.newInstance();
+    GetClusterMetricsResponse metricsResponse = routerClientRMService.getClusterMetrics(metricsRequest);
+    Assert.assertNotNull(metricsResponse);
+    YarnClusterMetrics clusterMetrics = metricsResponse.getClusterMetrics();
+    Assert.assertEquals(4, clusterMetrics.getNumNodeManagers());
+    Assert.assertEquals(0, clusterMetrics.getNumLostNodeManagers());
+
+    stopSecureRouter();
+  }
+
+  @Test
+  public void testRouterRMAdminService() throws Exception {
+    startSecureRouter(true);
+
+    RouterRMAdminService routerRMAdminService = this.getRouter().getRmAdminProxyService();
+    RefreshNodesRequest refreshNodesRequest = RefreshNodesRequest.newInstance();
+    RefreshNodesResponse refreshNodesResponse =
+        routerRMAdminService.refreshNodes(refreshNodesRequest);
+    Assert.assertNotNull(refreshNodesResponse);
+
+    stopSecureRouter();
   }
 
   public static String getPrincipalAndRealm(String principal) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.router.secure;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestSecureLogins extends AbstractSecureRouterTest{
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestSecureLogins.class);
+
+  @Test
+  public void testHasRealm() throws Throwable {
+    Assert.assertNotNull(getRealm());
+    LOG.info("Router principal = {}", getPrincipalAndRealm(ROUTER_LOCALHOST));
+  }
+
+  @Test
+  public void testRouterSecureLogin() throws Exception {
+    startSecureRouter();
+    router.stop();
+  }
+
+  public static String getPrincipalAndRealm(String principal) {
+    return principal + "@" + getRealm();
+  }
+
+  protected static String getRealm() {
+    return kdc.getRealm();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/Federation.md
@@ -258,6 +258,16 @@ Optional:
 |`yarn.federation.cache-ttl.secs` | `60` | The Router caches informations, and this is the time to leave before the cache is invalidated. |
 |`yarn.router.webapp.interceptor-class.pipeline` | `org.apache.hadoop.yarn.server.router.webapp.FederationInterceptorREST` | A comma-separated list of interceptor classes to be run at the router when interfacing with the client via REST interface. The last step of this pipeline must be the Federation Interceptor REST. |
 
+Security:
+
+Kerberos supported in federation.
+
+| Property | Example | Description |
+|:---- |:---- |
+| `yarn.router.keytab.file` |  | The keytab file used by router to login as its service principal. The principal name is configured with 'yarn.router.kerberos.principal'.|
+| `yarn.router.kerberos.principal` | | The Router service principal. This is typically set to router/_HOST@REALM.TLD. Each Router will substitute _HOST with its own fully qualified hostname at startup. The _HOST placeholder allows using the same configuration setting on all Routers in setup. |
+| `yarn.router.kerberos.principal.hostname` |  | Optional. The hostname for the Router containing this configuration file.  Will be different for each machine. Defaults to current hostname. |
+
 ###ON NMs:
 
 These are extra configurations that should appear in the **conf/yarn-site.xml** at each NodeManager.


### PR DESCRIPTION
JIRA. YARN-6539. Create SecureLogin inside Router.

The purpose of this pr is to serve the subsequent development and testing of DelegationToken-related APIs, complete the following:
1.Router supports SecureLogin.
2.UnmanagedApplicationManager supports ProxyUser.
3.Amrmproxy Interceptor supports ProxyUser.
4.Write code to support RouterSecure tests, covering RouterSecureLogin、RouterClientRMProxyService、RouterRMAdminService Basic Test.
5.TestSecurityMockRM is used in the test to support the DelegationToken test.
