### PR TITLE
HADOOP-18395. Performance improvement in hadoop-common Text#find

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -200,7 +200,7 @@ public class Text extends BinaryComparable
           while (tgt.hasRemaining()) {
             if (!src.hasRemaining()) { // src expired first
               // the remaining bytes in src will always smaller than tgt,
-              // so we can return -1 directory
+              // so we can return -1 directly
               return -1;
             }
             if (!(tgt.get() == src.get())) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -199,10 +199,9 @@ public class Text extends BinaryComparable
           int pos = src.position()-1;
           while (tgt.hasRemaining()) {
             if (!src.hasRemaining()) { // src expired first
-              tgt.reset();
-              src.reset();
-              found = false;
-              break;
+              // the remaining bytes in src will always smaller than tgt,
+              // so we can return -1 directory
+              return -1;
             }
             if (!(tgt.get() == src.get())) {
               tgt.reset();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestText.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestText.java
@@ -238,6 +238,7 @@ public class TestText {
     assertThat(text.find("ac")).isEqualTo(-1);
     assertThat(text.find("\u20ac")).isEqualTo(4);
     assertThat(text.find("\u20ac", 5)).isEqualTo(11);
+    assertThat(text.find("cd\u20acq")).isEqualTo(-1);
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestText.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestText.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
+import java.util.Arrays;
 import java.util.Random;
 import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Bytes;
@@ -239,6 +240,17 @@ public class TestText {
     assertThat(text.find("\u20ac")).isEqualTo(4);
     assertThat(text.find("\u20ac", 5)).isEqualTo(11);
     assertThat(text.find("cd\u20acq")).isEqualTo(-1);
+  }
+
+  @Test(timeout = 10000)
+  public void testFindWithTimeout() throws Exception {
+    byte[] bytes = new byte[1000000];
+    Arrays.fill(bytes, (byte) 97);
+    String what = new String(bytes);
+    bytes[0] = (byte) 98;
+    Text text = new Text(bytes);
+
+    assertThat(text.find(what)).isEqualTo(-1);
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-18395](https://issues.apache.org/jira/browse/HADOOP-18395)
  The current implementation reset src and tgt to the mark and continues searching when tgt has remaining and src expired first. which is probably not necessary.
  In some cases, this commit can reduce the complexity from O(n²) to O(n), which can significantly improve performance, as in the following example.
```java
  public void testFindWithTimeout() throws Exception {
    byte[] bytes = new byte[1000000];
    Arrays.fill(bytes, (byte) 97);
    String what = new String(bytes);
    bytes[0] = (byte) 98;
    Text text = new Text(bytes);

    assertThat(text.find(what)).isEqualTo(-1);
  }
```

### How was this patch tested?
unit test in org.apache.hadoop.io.TestText#testFind