### PR TITLE
HADOOP-18397. Shutdown AWSSecurityTokenService when its resources are no longer in use

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialBinding.java
@@ -207,9 +207,11 @@ public final class MarshalledCredentialBinding {
               stsEndpoint.isEmpty() ? null : stsEndpoint,
               stsRegion)
               .build();
-      return fromSTSCredentials(
-          STSClientFactory.createClientConnection(tokenService, invoker)
-              .requestSessionCredentials(duration, TimeUnit.SECONDS));
+      try (STSClientFactory.STSClient stsClient = STSClientFactory.createClientConnection(
+          tokenService, invoker)) {
+        return fromSTSCredentials(stsClient.requestSessionCredentials(duration,
+            TimeUnit.SECONDS));
+      }
     } catch (SdkClientException e) {
       if (stsRegion.isEmpty()) {
         LOG.error("Region must be provided when requesting session credentials.",

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
@@ -149,12 +149,10 @@ public class STSClientFactory {
    * @param tokenService STS instance
    * @param invoker invoker to use
    * @return an STS client bonded to that interface.
-   * @throws IOException on any failure
    */
   public static STSClient createClientConnection(
       final AWSSecurityTokenService tokenService,
-      final Invoker invoker)
-      throws IOException {
+      final Invoker invoker) {
     return new STSClient(tokenService, invoker);
   }
 
@@ -175,12 +173,9 @@ public class STSClientFactory {
 
     @Override
     public void close() throws IOException {
-      try {
-        tokenService.shutdown();
-      } catch (UnsupportedOperationException ignored) {
-        // ignore this, as it is what the STS client currently
-        // does.
-      }
+      // Since we are not using AbstractAWSSecurityTokenService, we
+      // don't need to worry about catching UnsupportedOperationException.
+      tokenService.shutdown();
     }
 
     /**


### PR DESCRIPTION
### Description of PR
AWSSecurityTokenService resources can be released whenever they are no longer in use. The documentation of AWSSecurityTokenService#shutdown says while it is not important for client to compulsorily shutdown the token service, client can definitely perform early release whenever client no longer requires token service resources. We achieve this by making STSClient closable, so we can certainly utilize it in all places where it's suitable.
