### PR TITLE
HDFS-16686. GetJournalEditServlet fails to authorize valid Kerberos request

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
@@ -522,9 +522,7 @@ public class TestRollingUpgrade {
 
   private void testQuery(int nnCount) throws Exception{
     final Configuration conf = new Configuration();
-    MiniQJMHACluster cluster = null;
-    try {
-      cluster = new MiniQJMHACluster.Builder(conf).setNumNameNodes(nnCount).build();
+    try (MiniQJMHACluster cluster = new MiniQJMHACluster.Builder(conf).setNumNameNodes(nnCount).build()) {
       MiniDFSCluster dfsCluster = cluster.getDfsCluster();
       dfsCluster.waitActive();
 
@@ -554,10 +552,6 @@ public class TestRollingUpgrade {
       // The NN should have a copy of the fsimage in case of rollbacks.
       Assert.assertTrue(dfsCluster.getNamesystem(0).getFSImage()
               .hasRollbackFSImage());
-    } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
     }
   }
 
@@ -648,11 +642,10 @@ public class TestRollingUpgrade {
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_CHECKPOINT_PERIOD_KEY, 1);
 
-    MiniQJMHACluster cluster = null;
     final Path foo = new Path("/foo");
 
-    try {
-      cluster = new MiniQJMHACluster.Builder(conf).setNumNameNodes(nnCount).build();
+    try (MiniQJMHACluster cluster = new MiniQJMHACluster.Builder(conf).setNumNameNodes(nnCount)
+        .build()) {
       MiniDFSCluster dfsCluster = cluster.getDfsCluster();
       dfsCluster.waitActive();
 
@@ -674,10 +667,6 @@ public class TestRollingUpgrade {
         verifyNNCheckpoint(dfsCluster, txid, i);
       }
 
-    } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
@@ -307,9 +307,7 @@ public class TestRollingUpgrade {
   public void testRollback() throws Exception {
     // start a cluster
     final Configuration conf = new HdfsConfiguration();
-    MiniDFSCluster cluster = null;
-    try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    try (MiniDFSCluster cluster  = new MiniDFSCluster.Builder(conf).numDataNodes(1).build()) {
       cluster.waitActive();
 
       final Path foo = new Path("/foo");
@@ -349,8 +347,6 @@ public class TestRollingUpgrade {
 
       startRollingUpgrade(foo, bar, file, data, cluster);
       rollbackRollingUpgrade(foo, bar, file, data, cluster);
-    } finally {
-      if(cluster != null) cluster.shutdown();
     }
   }
 
@@ -558,9 +554,7 @@ public class TestRollingUpgrade {
   @Test (timeout = 300000)
   public void testQueryAfterRestart() throws IOException, InterruptedException {
     final Configuration conf = new Configuration();
-    MiniDFSCluster cluster = null;
-    try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build()) {
       cluster.waitActive();
       DistributedFileSystem dfs = cluster.getFileSystem();
 
@@ -574,10 +568,6 @@ public class TestRollingUpgrade {
 
       cluster.restartNameNodes();
       dfs.rollingUpgrade(RollingUpgradeAction.QUERY);
-    } finally {
-      if (cluster != null) {
-        cluster.shutdown();
-      }
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
@@ -83,7 +83,7 @@ public class TestRollingUpgrade {
   }
 
   @Rule
-  public TemporaryFolder folder= new TemporaryFolder();
+  public TemporaryFolder folder = new TemporaryFolder();
 
   /**
    * Create a default HDFS configuration which has test-specific data directories.  This is
@@ -427,7 +427,7 @@ public class TestRollingUpgrade {
   public void testDFSAdminDatanodeUpgradeControlCommands() throws Exception {
     // start a cluster
     final Configuration conf = getHdfsConfiguration();
-    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build()){
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build()) {
       cluster.waitActive();
       final DFSAdmin dfsadmin = new DFSAdmin(conf);
       DataNode dn = cluster.getDataNodes().get(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestRollingUpgrade.java
@@ -87,9 +87,7 @@ public class TestRollingUpgrade {
   public void testDFSAdminRollingUpgradeCommands() throws Exception {
     // start a cluster
     final Configuration conf = new HdfsConfiguration();
-    MiniDFSCluster cluster = null;
-    try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build()) {
       cluster.waitActive();
 
       final Path foo = new Path("/foo");
@@ -149,8 +147,6 @@ public class TestRollingUpgrade {
         Assert.assertTrue(dfs.exists(bar));
         Assert.assertTrue(dfs.exists(baz));
       }
-    } finally {
-      if(cluster != null) cluster.shutdown();
     }
   }
 
@@ -173,114 +169,115 @@ public class TestRollingUpgrade {
     LOG.info("nn2Dir=" + nn2Dir);
 
     final Configuration conf = new HdfsConfiguration();
-    final MiniJournalCluster mjc = new MiniJournalCluster.Builder(conf).build();
-    mjc.waitActive();
-    setConf(conf, nn1Dir, mjc);
+    try (MiniJournalCluster mjc = new MiniJournalCluster.Builder(conf).build()) {
+      mjc.waitActive();
+      setConf(conf, nn1Dir, mjc);
 
-    {
-      // Start the cluster once to generate the dfs dirs
-      final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
-        .numDataNodes(0)
-        .manageNameDfsDirs(false)
-        .checkExitOnShutdown(false)
-        .build();
-      // Shutdown the cluster before making a copy of the namenode dir to release
-      // all file locks, otherwise, the copy will fail on some platforms.
-      cluster.shutdown();
-    }
-
-    MiniDFSCluster cluster2 = null;
-    try {
-      // Start a second NN pointed to the same quorum.
-      // We need to copy the image dir from the first NN -- or else
-      // the new NN will just be rejected because of Namespace mismatch.
-      FileUtil.fullyDelete(nn2Dir);
-      FileUtil.copy(nn1Dir, FileSystem.getLocal(conf).getRaw(),
-          new Path(nn2Dir.getAbsolutePath()), false, conf);
-
-      // Start the cluster again
-      final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
-        .numDataNodes(0)
-        .format(false)
-        .manageNameDfsDirs(false)
-        .checkExitOnShutdown(false)
-        .build();
-
-      final Path foo = new Path("/foo");
-      final Path bar = new Path("/bar");
-      final Path baz = new Path("/baz");
-
-      final RollingUpgradeInfo info1;
       {
-        final DistributedFileSystem dfs = cluster.getFileSystem();
-        dfs.mkdirs(foo);
-
-        //start rolling upgrade
-        dfs.setSafeMode(SafeModeAction.SAFEMODE_ENTER);
-        info1 = dfs.rollingUpgrade(RollingUpgradeAction.PREPARE);
-        dfs.setSafeMode(SafeModeAction.SAFEMODE_LEAVE);
-        LOG.info("START\n" + info1);
-
-        //query rolling upgrade
-        assertEquals(info1, dfs.rollingUpgrade(RollingUpgradeAction.QUERY));
-
-        dfs.mkdirs(bar);
+        // Start the cluster once to generate the dfs dirs
+        final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+            .numDataNodes(0)
+            .manageNameDfsDirs(false)
+            .checkExitOnShutdown(false)
+            .build();
+        // Shutdown the cluster before making a copy of the namenode dir to release
+        // all file locks, otherwise, the copy will fail on some platforms.
         cluster.shutdown();
       }
 
-      // cluster2 takes over QJM
-      final Configuration conf2 = setConf(new Configuration(), nn2Dir, mjc);
-      cluster2 = new MiniDFSCluster.Builder(conf2)
-        .numDataNodes(0)
-        .format(false)
-        .manageNameDfsDirs(false)
-        .build();
-      final DistributedFileSystem dfs2 = cluster2.getFileSystem();
-
-      // Check that cluster2 sees the edits made on cluster1
-      Assert.assertTrue(dfs2.exists(foo));
-      Assert.assertTrue(dfs2.exists(bar));
-      Assert.assertFalse(dfs2.exists(baz));
-
-      //query rolling upgrade in cluster2
-      assertEquals(info1, dfs2.rollingUpgrade(RollingUpgradeAction.QUERY));
-
-      dfs2.mkdirs(baz);
-
-      LOG.info("RESTART cluster 2");
-      cluster2.restartNameNode();
-      assertEquals(info1, dfs2.rollingUpgrade(RollingUpgradeAction.QUERY));
-      Assert.assertTrue(dfs2.exists(foo));
-      Assert.assertTrue(dfs2.exists(bar));
-      Assert.assertTrue(dfs2.exists(baz));
-
-      //restart cluster with -upgrade should fail.
+      MiniDFSCluster cluster2 = null;
       try {
-        cluster2.restartNameNode("-upgrade");
-      } catch(IOException e) {
-        LOG.info("The exception is expected.", e);
+        // Start a second NN pointed to the same quorum.
+        // We need to copy the image dir from the first NN -- or else
+        // the new NN will just be rejected because of Namespace mismatch.
+        FileUtil.fullyDelete(nn2Dir);
+        FileUtil.copy(nn1Dir, FileSystem.getLocal(conf).getRaw(),
+            new Path(nn2Dir.getAbsolutePath()), false, conf);
+
+        // Start the cluster again
+        final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+            .numDataNodes(0)
+            .format(false)
+            .manageNameDfsDirs(false)
+            .checkExitOnShutdown(false)
+            .build();
+
+        final Path foo = new Path("/foo");
+        final Path bar = new Path("/bar");
+        final Path baz = new Path("/baz");
+
+        final RollingUpgradeInfo info1;
+        {
+          final DistributedFileSystem dfs = cluster.getFileSystem();
+          dfs.mkdirs(foo);
+
+          //start rolling upgrade
+          dfs.setSafeMode(SafeModeAction.SAFEMODE_ENTER);
+          info1 = dfs.rollingUpgrade(RollingUpgradeAction.PREPARE);
+          dfs.setSafeMode(SafeModeAction.SAFEMODE_LEAVE);
+          LOG.info("START\n" + info1);
+
+          //query rolling upgrade
+          assertEquals(info1, dfs.rollingUpgrade(RollingUpgradeAction.QUERY));
+
+          dfs.mkdirs(bar);
+          cluster.shutdown();
+        }
+
+        // cluster2 takes over QJM
+        final Configuration conf2 = setConf(new Configuration(), nn2Dir, mjc);
+        cluster2 = new MiniDFSCluster.Builder(conf2)
+            .numDataNodes(0)
+            .format(false)
+            .manageNameDfsDirs(false)
+            .build();
+        final DistributedFileSystem dfs2 = cluster2.getFileSystem();
+
+        // Check that cluster2 sees the edits made on cluster1
+        Assert.assertTrue(dfs2.exists(foo));
+        Assert.assertTrue(dfs2.exists(bar));
+        Assert.assertFalse(dfs2.exists(baz));
+
+        //query rolling upgrade in cluster2
+        assertEquals(info1, dfs2.rollingUpgrade(RollingUpgradeAction.QUERY));
+
+        dfs2.mkdirs(baz);
+
+        LOG.info("RESTART cluster 2");
+        cluster2.restartNameNode();
+        assertEquals(info1, dfs2.rollingUpgrade(RollingUpgradeAction.QUERY));
+        Assert.assertTrue(dfs2.exists(foo));
+        Assert.assertTrue(dfs2.exists(bar));
+        Assert.assertTrue(dfs2.exists(baz));
+
+        //restart cluster with -upgrade should fail.
+        try {
+          cluster2.restartNameNode("-upgrade");
+        } catch (IOException e) {
+          LOG.info("The exception is expected.", e);
+        }
+
+        LOG.info("RESTART cluster 2 again");
+        cluster2.restartNameNode();
+        assertEquals(info1, dfs2.rollingUpgrade(RollingUpgradeAction.QUERY));
+        Assert.assertTrue(dfs2.exists(foo));
+        Assert.assertTrue(dfs2.exists(bar));
+        Assert.assertTrue(dfs2.exists(baz));
+
+        //finalize rolling upgrade
+        final RollingUpgradeInfo finalize = dfs2.rollingUpgrade(
+            RollingUpgradeAction.FINALIZE);
+        Assert.assertTrue(finalize.isFinalized());
+
+        LOG.info("RESTART cluster 2 with regular startup option");
+        cluster2.getNameNodeInfos()[0].setStartOpt(StartupOption.REGULAR);
+        cluster2.restartNameNode();
+        Assert.assertTrue(dfs2.exists(foo));
+        Assert.assertTrue(dfs2.exists(bar));
+        Assert.assertTrue(dfs2.exists(baz));
+      } finally {
+        if (cluster2 != null) cluster2.shutdown();
       }
-
-      LOG.info("RESTART cluster 2 again");
-      cluster2.restartNameNode();
-      assertEquals(info1, dfs2.rollingUpgrade(RollingUpgradeAction.QUERY));
-      Assert.assertTrue(dfs2.exists(foo));
-      Assert.assertTrue(dfs2.exists(bar));
-      Assert.assertTrue(dfs2.exists(baz));
-
-      //finalize rolling upgrade
-      final RollingUpgradeInfo finalize = dfs2.rollingUpgrade(
-          RollingUpgradeAction.FINALIZE);
-      Assert.assertTrue(finalize.isFinalized());
-
-      LOG.info("RESTART cluster 2 with regular startup option");
-      cluster2.getNameNodeInfos()[0].setStartOpt(StartupOption.REGULAR);
-      cluster2.restartNameNode();
-      Assert.assertTrue(dfs2.exists(foo));
-      Assert.assertTrue(dfs2.exists(bar));
-      Assert.assertTrue(dfs2.exists(baz));
-    } finally {
-      if (cluster2 != null) cluster2.shutdown();
     }
   }
 
@@ -408,9 +405,7 @@ public class TestRollingUpgrade {
   public void testDFSAdminDatanodeUpgradeControlCommands() throws Exception {
     // start a cluster
     final Configuration conf = new HdfsConfiguration();
-    MiniDFSCluster cluster = null;
-    try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build()){
       cluster.waitActive();
       final DFSAdmin dfsadmin = new DFSAdmin(conf);
       DataNode dn = cluster.getDataNodes().get(0);
@@ -431,8 +426,6 @@ public class TestRollingUpgrade {
 
       // ping should fail.
       assertEquals(-1, dfsadmin.run(args1));
-    } finally {
-      if (cluster != null) cluster.shutdown();
     }
   }
 
@@ -691,7 +684,8 @@ public class TestRollingUpgrade {
   /**
    * Verify that the namenode at the given index has an FSImage with a TxId up to txid-1
    */
-  private void verifyNNCheckpoint(MiniDFSCluster dfsCluster, long txid, int nnIndex) throws InterruptedException {
+  private void verifyNNCheckpoint(MiniDFSCluster dfsCluster, long txid, int nnIndex)
+      throws InterruptedException {
     int retries = 0;
     while (++retries < 5) {
       NNStorage storage = dfsCluster.getNamesystem(nnIndex).getFSImage()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniQJMHACluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniQJMHACluster.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-public class MiniQJMHACluster {
+public class MiniQJMHACluster implements AutoCloseable {
   private MiniDFSCluster cluster;
   private MiniJournalCluster journalCluster;
   private final Configuration conf;
@@ -185,8 +185,18 @@ public class MiniQJMHACluster {
     return journalCluster;
   }
 
-  public void shutdown() throws IOException {
+  public void shutdown() {
     cluster.shutdown();
-    journalCluster.shutdown();
+    try {
+      journalCluster.shutdown();
+    } catch (IOException shutdownFailure) {
+      LOG.warn("Exception while closing journal cluster", shutdownFailure);
+    }
   }
+
+  @Override
+  public void close() {
+    shutdown();
+  }
+
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniQJMHACluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/MiniQJMHACluster.java
@@ -185,18 +185,19 @@ public class MiniQJMHACluster implements AutoCloseable {
     return journalCluster;
   }
 
-  public void shutdown() {
+  public void shutdown() throws IOException {
     cluster.shutdown();
-    try {
-      journalCluster.shutdown();
-    } catch (IOException shutdownFailure) {
-      LOG.warn("Exception while closing journal cluster", shutdownFailure);
-    }
+    journalCluster.shutdown();
   }
 
   @Override
   public void close() {
-    shutdown();
+    try {
+      shutdown();
+    } catch (IOException shutdownFailure) {
+      LOG.warn("Exception while closing journal cluster", shutdownFailure);
+    }
+
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.hdfs.qjournal.server;
 
 import org.apache.hadoop.conf.Configuration;
@@ -21,29 +37,29 @@ import static org.mockito.Mockito.when;
 
 public class TestGetJournalEditServlet {
 
-  private final static Configuration conf = new HdfsConfiguration();
+  private final static Configuration CONF = new HdfsConfiguration();
 
-  private final static GetJournalEditServlet servlet = new GetJournalEditServlet();
+  private final static GetJournalEditServlet SERVLET = new GetJournalEditServlet();
 
   @BeforeClass
   public static void setUp() throws ServletException {
     LogManager.getLogger(GetJournalEditServlet.class).setLevel(Level.DEBUG);
 
     // Configure Hadoop
-    conf.set(DFSConfigKeys.FS_DEFAULT_NAME_KEY, "hdfs://localhost:4321/");
-    conf.set(DFSConfigKeys.HADOOP_SECURITY_AUTH_TO_LOCAL,
+    CONF.set(DFSConfigKeys.FS_DEFAULT_NAME_KEY, "hdfs://localhost:4321/");
+    CONF.set(DFSConfigKeys.HADOOP_SECURITY_AUTH_TO_LOCAL,
         "RULE:[2:$1/$2@$0]([nsdj]n/.*@REALM\\.TLD)s/.*/hdfs/\nDEFAULT");
-    conf.set(DFSConfigKeys.DFS_NAMESERVICES, "ns");
-    conf.set(DFSConfigKeys.DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY, "nn/_HOST@REALM.TLD");
+    CONF.set(DFSConfigKeys.DFS_NAMESERVICES, "ns");
+    CONF.set(DFSConfigKeys.DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY, "nn/_HOST@REALM.TLD");
 
     // Configure Kerberos UGI
-    UserGroupInformation.setConfiguration(conf);
+    UserGroupInformation.setConfiguration(CONF);
     UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(
         "jn/somehost@REALM.TLD"));
 
     // Initialize the servlet
     ServletConfig config = mock(ServletConfig.class);
-    servlet.init(config);
+    SERVLET.init(config);
   }
 
   /**
@@ -55,7 +71,7 @@ public class TestGetJournalEditServlet {
   public void testWithoutUser() throws IOException {
     // Test: Make a request without specifying a user
     HttpServletRequest request = mock(HttpServletRequest.class);
-    boolean isValid = servlet.isValidRequestor(request, conf);
+    boolean isValid = SERVLET.isValidRequestor(request, CONF);
 
     // Verify: The request is invalid
     assertThat(isValid).isFalse();
@@ -71,7 +87,7 @@ public class TestGetJournalEditServlet {
     // Test: Make a request from a namenode
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getParameter(UserParam.NAME)).thenReturn("nn/localhost@REALM.TLD");
-    boolean isValid = servlet.isValidRequestor(request, conf);
+    boolean isValid = SERVLET.isValidRequestor(request, CONF);
 
     assertThat(isValid).isTrue();
   }
@@ -86,7 +102,7 @@ public class TestGetJournalEditServlet {
     // Test: Make a request from a namenode
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getParameter(UserParam.NAME)).thenReturn("jn/localhost@REALM.TLD");
-    boolean isValid = servlet.isValidRequestor(request, conf);
+    boolean isValid = SERVLET.isValidRequestor(request, CONF);
 
     assertThat(isValid).isTrue();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
@@ -21,8 +21,6 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.web.resources.UserParam;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,8 +41,6 @@ public class TestGetJournalEditServlet {
 
   @BeforeClass
   public static void setUp() throws ServletException {
-    LogManager.getLogger(GetJournalEditServlet.class).setLevel(Level.DEBUG);
-
     // Configure Hadoop
     CONF.set(DFSConfigKeys.FS_DEFAULT_NAME_KEY, "hdfs://localhost:4321/");
     CONF.set(DFSConfigKeys.HADOOP_SECURITY_AUTH_TO_LOCAL,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestGetJournalEditServlet.java
@@ -1,0 +1,94 @@
+package org.apache.hadoop.hdfs.qjournal.server;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.web.resources.UserParam;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestGetJournalEditServlet {
+
+  private final static Configuration conf = new HdfsConfiguration();
+
+  private final static GetJournalEditServlet servlet = new GetJournalEditServlet();
+
+  @BeforeClass
+  public static void setUp() throws ServletException {
+    LogManager.getLogger(GetJournalEditServlet.class).setLevel(Level.DEBUG);
+
+    // Configure Hadoop
+    conf.set(DFSConfigKeys.FS_DEFAULT_NAME_KEY, "hdfs://localhost:4321/");
+    conf.set(DFSConfigKeys.HADOOP_SECURITY_AUTH_TO_LOCAL,
+        "RULE:[2:$1/$2@$0]([nsdj]n/.*@REALM\\.TLD)s/.*/hdfs/\nDEFAULT");
+    conf.set(DFSConfigKeys.DFS_NAMESERVICES, "ns");
+    conf.set(DFSConfigKeys.DFS_NAMENODE_KERBEROS_PRINCIPAL_KEY, "nn/_HOST@REALM.TLD");
+
+    // Configure Kerberos UGI
+    UserGroupInformation.setConfiguration(conf);
+    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(
+        "jn/somehost@REALM.TLD"));
+
+    // Initialize the servlet
+    ServletConfig config = mock(ServletConfig.class);
+    servlet.init(config);
+  }
+
+  /**
+   * Unauthenticated user should be rejected.
+   *
+   * @throws IOException for unexpected validation failures
+   */
+  @Test
+  public void testWithoutUser() throws IOException {
+    // Test: Make a request without specifying a user
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    boolean isValid = servlet.isValidRequestor(request, conf);
+
+    // Verify: The request is invalid
+    assertThat(isValid).isFalse();
+  }
+
+  /**
+   * Namenode requests should be authorized, since it will match the configured namenode.
+   *
+   * @throws IOException for unexpected validation failures
+   */
+  @Test
+  public void testRequestNameNode() throws IOException, ServletException {
+    // Test: Make a request from a namenode
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameter(UserParam.NAME)).thenReturn("nn/localhost@REALM.TLD");
+    boolean isValid = servlet.isValidRequestor(request, conf);
+
+    assertThat(isValid).isTrue();
+  }
+
+  /**
+   * There is a fallback using the short name, which is used by journalnodes.
+   *
+   * @throws IOException for unexpected validation failures
+   */
+  @Test
+  public void testRequestShortName() throws IOException {
+    // Test: Make a request from a namenode
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameter(UserParam.NAME)).thenReturn("jn/localhost@REALM.TLD");
+    boolean isValid = servlet.isValidRequestor(request, conf);
+
+    assertThat(isValid).isTrue();
+  }
+
+}


### PR DESCRIPTION
### Description of PR

GetJournalEditServlet uses request.getRemoteuser() to determine the remoteShortName for Kerberos authorization, which fails to match when the JournalNode uses its own Kerberos principal (e.g. jn/<hostname>@<realm>).

This can be fixed by using the UserGroupInformation provided by the base DfsServlet class using the getUGI(request, conf) call.

### How was this patch tested?

Integration tests were performed against an HA configuration running in Kubernetes, running Java 11.  With the patch, exceptions which had previously reported expected Kerberos principals which included an IP address string were eliminated.  

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

