### PR TITLE
HDFS-16688. Unresolved Hosts during startup are not synced by JournalNodes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -675,6 +675,12 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_ENABLED_DEFAULT = false;
 
   public static final String
+      DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_REQUIRED =
+      "dfs.namenode.edits.qjournals.resolution-required";
+  public static final boolean
+      DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_REQUIRED_DEFAULT = true;
+
+  public static final String
       DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_RESOLVER_IMPL =
       "dfs.namenode.edits.qjournals.resolver.impl";
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannel.java
@@ -599,7 +599,12 @@ public class IPCLoggerChannel implements AsyncLogger {
 
   @Override
   public String toString() {
-    return InetAddresses.toAddrString(addr.getAddress()) + ':' + addr.getPort();
+    if (addr.isUnresolved()) {
+      return addr.getHostName() + ":" + addr.getPort();
+    } else {
+      return InetAddresses.toAddrString(addr.getAddress()) + ':' +
+          addr.getPort();
+    }
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannelMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/client/IPCLoggerChannelMetrics.java
@@ -104,7 +104,12 @@ class IPCLoggerChannelMetrics {
 
   private static String getName(IPCLoggerChannel ch) {
     InetSocketAddress addr = ch.getRemoteAddress();
-    String addrStr = addr.getAddress().getHostAddress();
+    String addrStr;
+    if (addr.isUnresolved()) {
+      addrStr = addr.getHostName();
+    } else {
+      addrStr = addr.getAddress().getHostAddress();
+    }
     
     // IPv6 addresses have colons, which aren't allowed as part of
     // MBean names. Replace with '.'

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Util.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Util.java
@@ -406,9 +406,8 @@ public final class Util {
       } else {
         InetSocketAddress isa = NetUtils.createSocketAddr(
             addr, DFSConfigKeys.DFS_JOURNALNODE_RPC_PORT_DEFAULT);
-        if (isa.isUnresolved()) {
-          throw new UnknownHostException(addr);
-        }
+        // The resulting address may be unresolved, but that will be corrected within Client once the
+        // server becomes available.
         addrs.add(isa);
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Util.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/Util.java
@@ -378,6 +378,11 @@ public final class Util {
     boolean resolveNeeded = conf.getBoolean(
         DFSConfigKeys.DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_ENABLED,
         DFSConfigKeys.DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_ENABLED_DEFAULT);
+    // If not required, the resulting address may be unresolved, but that can be corrected within
+    // the client once the server becomes available.
+    boolean resolveRequired = conf.getBoolean(
+        DFSConfigKeys.DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_REQUIRED,
+        DFSConfigKeys.DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_REQUIRED_DEFAULT);
     DomainNameResolver dnr = DomainNameResolverFactory.newInstance(
         conf,
         DFSConfigKeys.DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_RESOLVER_IMPL);
@@ -394,7 +399,7 @@ public final class Util {
         // QJM should just use FQDN
         String[] hostnames = dnr
             .getAllResolvedHostnameByDomainName(isa.getHostName(), true);
-        if (hostnames.length == 0) {
+        if (hostnames.length == 0 && resolveRequired) {
           throw new UnknownHostException(addr);
         }
         for (String h : hostnames) {
@@ -406,8 +411,9 @@ public final class Util {
       } else {
         InetSocketAddress isa = NetUtils.createSocketAddr(
             addr, DFSConfigKeys.DFS_JOURNALNODE_RPC_PORT_DEFAULT);
-        // The resulting address may be unresolved, but that will be corrected within Client once the
-        // server becomes available.
+        if (isa.isUnresolved() && resolveRequired) {
+          throw new UnknownHostException(addr);
+        }
         addrs.add(isa);
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -508,7 +508,20 @@
   <description>
     Determines if the given qjournals address is a domain name which needs to
     be resolved.
-    This is used by namenode to resolve qjournals.
+    This is used by namenode to resolve qjournals, and journalnode for syncing.
+  </description>
+</property>
+
+<property>
+  <name>dfs.namenode.edits.qjournals.resolution-required</name>
+  <value>true</value>
+  <description>
+    Determines if the given qjournals address is a domain name which is
+    required to be resolved.
+    if resolution is required, then unresolvable addresses are ignored.
+    if resolution is not required, then the address may be temporarily
+    unresolved, allowing the client to resolve it later.
+    This is used by namenode to resolve qjournals, and journalnode for syncing.
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
@@ -38,6 +38,8 @@ import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdfs.qjournal.MiniJournalCluster;
@@ -192,7 +194,8 @@ public class TestQJMWithFaults {
   }
   
   /**
-   * Expect {@link UnknownHostException} if a hostname can't be resolved.
+   * Expect an unresolved address if a hostname can't be resolved, but allowing the QJM to be
+   * configured.
    */
   @Test
   public void testUnresolvableHostName() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
@@ -29,6 +29,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -191,8 +192,7 @@ public class TestQJMWithFaults {
   }
   
   /**
-   * Expect an unresolved address if a hostname can't be resolved, but allowing the QJM to be
-   * configured.
+   * Expect {@link UnknownHostException} if a hostname can't be resolved.
    */
   @Test
   public void testUnresolvableHostName() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
@@ -29,7 +29,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -63,8 +62,6 @@ import org.mockito.stubbing.Answer;
 
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -125,6 +125,11 @@ public class TestJournalNode {
       conf.set(DFSConfigKeys.DFS_NAMENODE_SHARED_EDITS_DIR_KEY,
           "qjournal://jn0:9900;jn1:9901/" + journalId);
     } else if (testName.getMethodName().equals(
+        "testJournalNodeSyncerStartWhenSyncEnabledAndUnresolved")) {
+      conf.set(DFSConfigKeys.DFS_NAMENODE_SHARED_EDITS_DIR_KEY,
+          "qjournal://jn0:9900;jn1:9901/" + journalId);
+      conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_EDITS_QJOURNALS_RESOLUTION_REQUIRED, false);
+    } else if (testName.getMethodName().equals(
         "testJournalNodeSyncwithFederationTypeConfigWithNameServiceId")) {
       conf.set(DFSConfigKeys.DFS_NAMENODE_SHARED_EDITS_DIR_KEY +".ns1",
           "qjournal://journalnode0:9900;journalnode0:9901/" + journalId);
@@ -570,6 +575,12 @@ public class TestJournalNode {
 
   }
 
+  /**
+   * Require resolution.  Syncer must not start when there aren't any other known journal
+   * nodes due to the required resolution.
+   *
+   * @throws IOException if unable to get or create the journal
+   */
   @Test
   public void testJournalNodeSyncerNotStartWhenSyncEnabled()
       throws IOException {
@@ -593,6 +604,20 @@ public class TestJournalNode {
 
   }
 
+  /**
+   * Attempt resolution, but allow unresolved.  Syncer must start because there are other potential
+   * journal nodes and syncing is enabled.  The syncing will include the unresolved addresses in
+   * syncing so that once the target server is available it can be included in syncing.
+   *
+   * @throws IOException if unable to get or create the journal
+   */
+  @Test
+  public void testJournalNodeSyncerStartWhenSyncEnabledAndUnresolved()
+      throws IOException {
+    jn.getOrCreateJournal(journalId);
+    Assert.assertEquals(true,
+        jn.getJournalSyncerStatus(journalId));
+  }
 
   @Test
   public void testJournalNodeSyncwithFederationTypeConfigWithNameServiceId()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestGetConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestGetConf.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestGetConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestGetConf.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -487,6 +488,7 @@ public class TestGetConf {
    * Test handling of unresolvable journal node hosts.  They are still configured assuming that
    * they will be resolvable in the future.
   */
+  @Test(expected = UnknownHostException.class, timeout = 10000)
   public void testUnknownJournalNodeHost()
       throws URISyntaxException, IOException {
     String journalsBaseUri = "qjournal://jn1:8020;jn2:8020;jn3:8020";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestGetConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestGetConf.java
@@ -484,10 +484,10 @@ public class TestGetConf {
     conf.clear();
   }
 
-  /*
-   ** Test for unknown journal node host exception.
+  /**
+   * Test handling of unresolvable journal node hosts.  They are still configured assuming that
+   * they will be resolvable in the future.
   */
-  @Test(expected = UnknownHostException.class, timeout = 10000)
   public void testUnknownJournalNodeHost()
       throws URISyntaxException, IOException {
     String journalsBaseUri = "qjournal://jn1:8020;jn2:8020;jn3:8020";


### PR DESCRIPTION
### Description of PR

During the JournalNode startup, it builds the list of servers in the JournalNode set, ignoring hostnames that cannot be resolved.  In environments with dynamic IP address allocations this means that the JournalNodeSyncer will never sync with hosts that aren't resolvable during startup.

Allow unresolved names during startup, so that when the hosts become available they will be included in JournalNode synchronization.  This also requires that mechanisms that return a string representation which includes the IP address had to be updated to handle unresolved addresses.

Resolution continues to be required by default.  This patch adds a new configuration which allows the requirement to be disabled, enabling support for unresolved addresses.

### How was this patch tested?

Integration tests were performed against an HA configuration running in Kubernetes, running Java 11.  Starting the cluster with fewer replicas than the list of JournalNodes listed in the configurations started, and the logs showed attempts to sync against the missing replicas.  Missing instances of the JournalNode were incorporated into synchronization and NameNode shared edits once they were started without any intervention.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

