### PR TITLE
HADOOP-18385. ITestS3ACannedACLs failure; fixed by adding in a span

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ACannedACLs.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ACannedACLs.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.audit.S3AAuditConstants;
 import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
 
 import static org.apache.hadoop.fs.s3a.Constants.CANNED_ACL;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
@@ -64,15 +65,17 @@ public class ITestS3ACannedACLs extends AbstractS3ATestBase {
   @Test
   public void testCreatedObjectsHaveACLs() throws Throwable {
     S3AFileSystem fs = getFileSystem();
-    Path dir = methodPath();
-    fs.mkdirs(dir);
-    assertObjectHasLoggingGrant(dir, false);
-    Path path = new Path(dir, "1");
-    ContractTestUtils.touch(fs, path);
-    assertObjectHasLoggingGrant(path, true);
-    Path path2 = new Path(dir, "2");
-    fs.rename(path, path2);
-    assertObjectHasLoggingGrant(path2, true);
+    try (AuditSpan span = span()) {
+      Path dir = methodPath();
+      fs.mkdirs(dir);
+      assertObjectHasLoggingGrant(dir, false);
+      Path path = new Path(dir, "1");
+      ContractTestUtils.touch(fs, path);
+      assertObjectHasLoggingGrant(path, true);
+      Path path2 = new Path(dir, "2");
+      fs.rename(path, path2);
+      assertObjectHasLoggingGrant(path2, true);
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR

ITestS3ACannedACLs failure; fixed by adding in a span

JIRA - HADOOP-18385


### How was this patch tested?

Ran integration test in `us-west-2` region

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ACannedACLs
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.005 s - in org.apache.hadoop.fs.s3a.ITestS3ACannedACLs
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31.160 s
[INFO] Finished at: 2022-08-11T23:31:25+01:00
[INFO] ------------------------------------------------------------------------

```




### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

