### PR TITLE
HADOOP-18383. Codecs with @DoNotPool annotation are not closed causing memory leak

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/AlreadyClosedException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/AlreadyClosedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.io.compress;
+
+import java.io.IOException;
+
+/**
+ * An exception class for when a closed compressor/decopressor is being used
+ * {@link org.apache.hadoop.io.compress.Compressor}
+ * {@link org.apache.hadoop.io.compress.Decompressor}
+ */
+public class AlreadyClosedException extends IOException {
+
+  public AlreadyClosedException(String message) {
+    super(message);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/AlreadyClosedException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/AlreadyClosedException.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.io.compress;
 import java.io.IOException;
 
 /**
- * An exception class for when a closed compressor/decopressor is being used
+ * An exception class for when a closed compressor/decopressor is being used.
  * {@link org.apache.hadoop.io.compress.Compressor}
  * {@link org.apache.hadoop.io.compress.Decompressor}
  */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecPool.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecPool.java
@@ -205,6 +205,7 @@ public class CodecPool {
     }
     // if the compressor can't be reused, don't pool it.
     if (compressor.getClass().isAnnotationPresent(DoNotPool.class)) {
+      compressor.end();
       return;
     }
     compressor.reset();
@@ -225,6 +226,7 @@ public class CodecPool {
     }
     // if the decompressor can't be reused, don't pool it.
     if (decompressor.getClass().isAnnotationPresent(DoNotPool.class)) {
+      decompressor.end();
       return;
     }
     decompressor.reset();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipDecompressor.java
@@ -23,6 +23,7 @@ import java.util.zip.Checksum;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
+import org.apache.hadoop.io.compress.AlreadyClosedException;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.hadoop.io.compress.DoNotPool;
 import org.apache.hadoop.util.DataChecksum;
@@ -105,7 +106,11 @@ public class BuiltInGzipDecompressor implements Decompressor {
      * Immediately after the trailer (and potentially prior to the next gzip
      * member/substream header), without reset() having been called.
      */
-    FINISHED;
+    FINISHED,
+    /**
+     * Immediately after end() has been called.
+     */
+    ENDED;
   }
 
   /**
@@ -181,6 +186,10 @@ public class BuiltInGzipDecompressor implements Decompressor {
   public synchronized int decompress(byte[] b, int off, int len)
   throws IOException {
     int numAvailBytes = 0;
+
+    if (state == GzipStateLabel.ENDED) {
+      throw new AlreadyClosedException("decompress called on closed decompressor");
+    }
 
     if (state != GzipStateLabel.DEFLATE_STREAM) {
       executeHeaderState();
@@ -472,6 +481,8 @@ public class BuiltInGzipDecompressor implements Decompressor {
   @Override
   public synchronized void end() {
     inflater.end();
+
+    state = GzipStateLabel.ENDED;
   }
 
   /**


### PR DESCRIPTION
### Description of PR
Explicitly call `end()` when returning `Decompressor` implementations with `DoNotPool` annotation to the `CodecPool`.

### How was this patch tested?
I created the following [project](https://github.com/kevins-29/hadoop-gzip-memory-leak) to demo the leak. You can run the demo with 

``` shell
./gradlew run --args=1024
``` 

and then monitor the memory usage using

```shell
while true; do echo \"$(date +%Y-%m-%d' '%H:%M:%S)\",$(pmap -x <PID> | grep "total kB" | awk '{print $4}'); sleep 10; done;
```

### Results - Before Patch

```
"2022-08-13 10:57:29",1377812
"2022-08-13 10:57:39",1379596
"2022-08-13 10:57:49",1396284
"2022-08-13 10:57:59",1364696
"2022-08-13 10:58:09",1387352
"2022-08-13 10:58:19",1392296
"2022-08-13 10:58:29",1387392
"2022-08-13 10:58:39",1396184
"2022-08-13 10:58:49",1397320
"2022-08-13 10:58:59",1397348
"2022-08-13 10:59:09",1397392
"2022-08-13 10:59:19",1397412
"2022-08-13 10:59:29",1397436
"2022-08-13 10:59:39",1397452
"2022-08-13 10:59:49",1397480
"2022-08-13 10:59:59",1397504
"2022-08-13 11:00:09",1397536
"2022-08-13 11:00:19",1397536
"2022-08-13 11:00:29",1397568
"2022-08-13 11:00:39",1397600
"2022-08-13 11:00:49",1397648
"2022-08-13 11:00:59",1397676
"2022-08-13 11:01:09",1398232
"2022-08-13 11:01:19",1398232
"2022-08-13 11:01:29",1398816
"2022-08-13 11:01:39",1398816
"2022-08-13 11:01:49",1398816
"2022-08-13 11:01:59",1398816
"2022-08-13 11:02:09",1398816
"2022-08-13 11:02:19",1398852
"2022-08-13 11:02:29",1398852
```

### Results - After Patch
```
"2022-08-13 11:03:31",1102440
"2022-08-13 11:03:41",1102496
"2022-08-13 11:03:51",1102600
"2022-08-13 11:04:01",1102600
"2022-08-13 11:04:11",1102600
"2022-08-13 11:04:21",1102532
"2022-08-13 11:04:31",1102532
"2022-08-13 11:04:41",1102532
"2022-08-13 11:04:51",1102532
"2022-08-13 11:05:01",1102532
"2022-08-13 11:05:11",1102532
"2022-08-13 11:05:21",1102532
"2022-08-13 11:05:31",1102532
"2022-08-13 11:05:41",1102532
"2022-08-13 11:05:51",1102532
"2022-08-13 11:06:01",1102532
"2022-08-13 11:06:11",1102532
"2022-08-13 11:06:21",1102532
"2022-08-13 11:06:31",1102532
"2022-08-13 11:06:41",1102532
"2022-08-13 11:06:51",1102532
"2022-08-13 11:07:01",1102532
"2022-08-13 11:07:11",1102532
"2022-08-13 11:07:21",1102532
"2022-08-13 11:07:31",1102532
"2022-08-13 11:07:41",1102532
"2022-08-13 11:07:51",1102532
"2022-08-13 11:08:01",1102532
"2022-08-13 11:08:11",1102532
"2022-08-13 11:08:21",1102532
"2022-08-13 11:08:31",1102532
```


