### PR TITLE
HADOOP-16806: AWS AssumedRoleCredentialProvider needs ExternalId add

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -79,6 +79,14 @@ public final class Constants {
   public static final String ASSUMED_ROLE_ARN =
       "fs.s3a.assumed.role.arn";
 
+
+  /**
+   * External ID for the assumed role request, must be valid characters according
+   * to the AWS APIs: {@value}.
+   */
+  public static final String ASSUMED_ROLE_EXTERNAL_ID =
+      "fs.s3a.assumed.role.externalid";
+
   /**
    * Session name for the assumed role, must be valid characters according
    * to the AWS APIs: {@value}.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
@@ -82,6 +82,8 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
 
   private final String arn;
 
+  private final String externalId;
+
   private final AWSCredentialProviderList credentialsToSTS;
 
   private final Invoker invoker;
@@ -118,16 +120,21 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
         buildSessionName());
     duration = conf.getTimeDuration(ASSUMED_ROLE_SESSION_DURATION,
         ASSUMED_ROLE_SESSION_DURATION_DEFAULT, TimeUnit.SECONDS);
+    externalId = conf.getTrimmed(ASSUMED_ROLE_EXTERNAL_ID);
     String policy = conf.getTrimmed(ASSUMED_ROLE_POLICY, "");
-
     LOG.debug("{}", this);
     STSAssumeRoleSessionCredentialsProvider.Builder builder
         = new STSAssumeRoleSessionCredentialsProvider.Builder(arn, sessionName);
     builder.withRoleSessionDurationSeconds((int) duration);
+    if (StringUtils.isNotEmpty(externalId)) {
+      LOG.debug("External Id {}", externalId);
+      builder.withExternalId(externalId);
+    }
     if (StringUtils.isNotEmpty(policy)) {
       LOG.debug("Scope down policy {}", policy);
       builder.withScopeDownPolicy(policy);
     }
+
     String endpoint = conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT, "");
     String region = conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT_REGION,
         ASSUMED_ROLE_STS_ENDPOINT_REGION_DEFAULT);
@@ -199,7 +206,8 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
     final StringBuilder sb = new StringBuilder(
         "AssumedRoleCredentialProvider{");
     sb.append("role='").append(arn).append('\'');
-    sb.append(", session'").append(sessionName).append('\'');
+    sb.append(", session='").append(sessionName).append('\'');
+    sb.append(", externalId='").append(externalId).append('\'');
     sb.append(", duration=").append(duration);
     sb.append('}');
     return sb.toString();

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
@@ -143,6 +143,14 @@ Here are the full set of configuration options.
 </property>
 
 <property>
+  <name>fs.s3a.assumed.role.externalid</name>
+  <value />
+  <description>
+    Optional externalId to specify when assuming a role
+  </description>
+</property>
+
+<property>
   <name>fs.s3a.assumed.role.session.name</name>
   <value />
   <description>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/assumed_roles.md
@@ -655,7 +655,7 @@ The security token included in the request is invalid.
   ... 25 more
 ```
 
-### <a name="invalid_session"></a> `AWSSecurityTokenServiceExceptiond`: "Member must satisfy regular expression pattern: `[\w+=,.@-]*`"
+### <a name="invalid_session"></a> `AWSSecurityTokenServiceException`: "Member must satisfy regular expression pattern: `[\w+=,.@-]*`"
 
 
 The session name, as set in `fs.s3a.assumed.role.session.name` must match the wildcard `[\w+=,.@-]*`.
@@ -693,6 +693,34 @@ Caused by: com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceExc
   at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1303)
 ```
 
+Similarly, if `fs.s3a.assumed.role.externalid` is specified, it must match the same wildcard `[\w+=,.@-]*`.
+
+```
+org.apache.hadoop.fs.s3a.AWSBadRequestException:
+ Instantiate org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider:
+   com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException:
+   1 validation error detected: Value 'invalid external id' at 'externalId' failed to satisfy constraint:
+   Member must satisfy regular expression pattern: [\w+=,.@:\/-]*
+   (Service: AWSSecurityTokenService; Status Code: 400; Error Code: ValidationError;
+  at org.apache.hadoop.fs.s3a.S3AUtils.translateException(S3AUtils.java:241)
+  at org.apache.hadoop.fs.s3a.S3AUtils.createAWSCredentialProvider(S3AUtils.java:730)
+  at org.apache.hadoop.fs.s3a.S3AUtils.buildAWSProviderList(S3AUtils.java:644)
+  at org.apache.hadoop.fs.s3a.S3AUtils.createAWSCredentialProviderSet(S3AUtils.java:577)
+  at org.apache.hadoop.fs.s3a.S3AFileSystem.bindAWSClient(S3AFileSystem.java:878)
+  at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:523)
+  at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3563)
+  at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:553)
+  at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
+
+Caused by: com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException:
+    1 validation error detected: Value 'invalid external id' at 'externalId'
+    failed to satisfy constraint:
+    Member must satisfy regular expression pattern: [\w+=,.@:\/-]*
+    (Service: AWSSecurityTokenService; Status Code: 400; Error Code: ValidationError; Request ID: 2f53f2c9-ef6a-4561-ba43-bdec489136ae; Proxy: null)
+  at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879)
+  at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418)
+  at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387)
+```
 
 ### <a name="access_denied"></a> `java.nio.file.AccessDeniedException` within a FileSystem API call
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -153,6 +153,20 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
   }
 
   @Test
+  public void testCreateCredentialProviderWithExternalId() throws IOException {
+    describe("Create the credential provider");
+
+    Configuration conf = createValidRoleConfWithExternalId();
+    conf.set(ASSUMED_ROLE_EXTERNAL_ID, "anExternalId");
+    try (AssumedRoleCredentialProvider provider
+                 = new AssumedRoleCredentialProvider(uri, conf)) {
+      LOG.info("Provider is {}", provider);
+      AWSCredentials credentials = provider.getCredentials();
+      assertNotNull("Null credentials from " + provider, credentials);
+    }
+  }
+
+  @Test
   public void testCreateCredentialProviderNoURI() throws IOException {
     describe("Create the credential provider");
 
@@ -179,6 +193,12 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     conf.set(ASSUMED_ROLE_SESSION_NAME, "valid");
     conf.set(ASSUMED_ROLE_SESSION_DURATION, "45m");
     bindRolePolicy(conf, RESTRICTED_POLICY);
+    return conf;
+  }
+
+  protected Configuration createValidRoleConfWithExternalId() throws JsonProcessingException {
+    Configuration conf = createValidRoleConf();
+    conf.set(ASSUMED_ROLE_EXTERNAL_ID, "someId");
     return conf;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -153,20 +153,6 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
   }
 
   @Test
-  public void testCreateCredentialProviderWithExternalId() throws IOException {
-    describe("Create the credential provider");
-
-    Configuration conf = createValidRoleConfWithExternalId();
-    conf.set(ASSUMED_ROLE_EXTERNAL_ID, "anExternalId");
-    try (AssumedRoleCredentialProvider provider
-                 = new AssumedRoleCredentialProvider(uri, conf)) {
-      LOG.info("Provider is {}", provider);
-      AWSCredentials credentials = provider.getCredentials();
-      assertNotNull("Null credentials from " + provider, credentials);
-    }
-  }
-
-  @Test
   public void testCreateCredentialProviderNoURI() throws IOException {
     describe("Create the credential provider");
 
@@ -196,12 +182,6 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     return conf;
   }
 
-  protected Configuration createValidRoleConfWithExternalId() throws JsonProcessingException {
-    Configuration conf = createValidRoleConf();
-    conf.set(ASSUMED_ROLE_EXTERNAL_ID, "someId");
-    return conf;
-  }
-
   @Test
   public void testAssumedInvalidRole() throws Throwable {
     Configuration conf = new Configuration();
@@ -209,6 +189,14 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     interceptClosing(AWSSecurityTokenServiceException.class,
         "",
         () -> new AssumedRoleCredentialProvider(uri, conf));
+  }
+
+  @Test
+  public void testAssumedRoleBadExternalId() throws Throwable {
+    describe("Attempt to create the FS with an invalid external id");
+    Configuration conf = createAssumedRoleConfig();
+    conf.set(ASSUMED_ROLE_EXTERNAL_ID, "invalid_external_id!");
+    expectFileSystemCreateFailure(conf, AWSBadRequestException.class, "");
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
@@ -39,6 +39,11 @@
   </property>
 
   <property>
+    <name>fs.s3a.bucket.landsat-pds.endpoint.region</name>
+    <value>us-west-2</value>
+  </property>
+
+  <property>
     <name>fs.s3a.bucket.landsat-pds.multipart.purge</name>
     <value>false</value>
     <description>Don't try to purge uploads in the read-only bucket, as

--- a/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
@@ -34,7 +34,7 @@
 
   <property>
     <name>fs.s3a.bucket.landsat-pds.endpoint</name>
-    <value>${central.endpoint}</value>
+    <value>${oregon.endpoint}</value>
     <description>The endpoint for s3a://landsat-pds URLs</description>
   </property>
 
@@ -66,7 +66,7 @@
 
   <property>
     <name>fs.s3a.bucket.usgs-landsat.endpoint</name>
-    <value>${central.endpoint}</value>
+    <value>${oregon.endpoint}</value>
   </property>
 
   <property>

--- a/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
+++ b/hadoop-tools/hadoop-aws/src/test/resources/core-site.xml
@@ -70,6 +70,11 @@
   </property>
 
   <property>
+    <name>fs.s3a.bucket.usgs-landsat.endpoint.region</name>
+    <value>us-west-2</value>
+  </property>
+
+  <property>
     <name>fs.s3a.bucket.usgs-landsat.requester.pays.enabled</name>
     <value>true</value>
     <description>usgs-landsat requires requester pays enabled</description>


### PR DESCRIPTION
### Description of PR

This applies an `externalId` value to the `STSAssumeRoleSessionCredentialsProvider.Builder`, if provided in the Hadoop config field `fs.s3a.assumed.role.externalid`.

This allows for AWS resources to have a trust policy for `sts:AssumeRole` that can match on the externalId which is now provided as part of the assume role request, in order to solve the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html)

I'm happy to take guidance on an improved unit test or any other changes. I'm relatively unfamiliar with the Hadoop unit testing framework.

### How was this patch tested?

Manual testing, and now running in a production SaaS offering.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

