### PR TITLE
YARN-11254. hadoop-minikdc dependency duplicated in hadoop-yarn-server-nodemanager pom.xml

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -205,11 +205,6 @@
       <artifactId>hadoop-minikdc</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-minikdc</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
### Description of PR
Remove duplicate hadoop-minikdc dependency.
https://issues.apache.org/jira/browse/YARN-11254