### PR TITLE
HADOOP-18408. ABFS: Setting correct value of requireRenameResilience for nonHNS configuration 

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
@@ -115,7 +115,7 @@ public class TestRenameStageFailure extends AbstractManifestCommitterTest {
    * Does this test suite require rename resilience in the store/FS?
    * @return true if the store operations are resilient.
    */
-  protected boolean requireRenameResilience() {
+  protected boolean requireRenameResilience() throws IOException {
     return false;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
@@ -121,6 +121,7 @@ public class TestRenameStageFailure extends AbstractManifestCommitterTest {
 
   @Test
   public void testResilienceAsExpected() throws Throwable {
+    Assume.assumeTrue(etagsPreserved);
     Assertions.assertThat(isResilientCommit())
         .describedAs("resilient commit support")
         .isEqualTo(requireRenameResilience());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
@@ -121,7 +121,6 @@ public class TestRenameStageFailure extends AbstractManifestCommitterTest {
 
   @Test
   public void testResilienceAsExpected() throws Throwable {
-    Assume.assumeTrue(etagsPreserved);
     Assertions.assertThat(isResilientCommit())
         .describedAs("resilient commit support")
         .isEqualTo(requireRenameResilience());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -149,6 +149,17 @@ public abstract class AbstractAbfsIntegrationTest extends
     return fs.getIsNamespaceEnabled(getTestTracingContext(fs, false));
   }
 
+  public static TracingContext getSampleTracingContext(AzureBlobFileSystem fs,
+      boolean needsPrimaryReqId) {
+    String correlationId, fsId;
+    TracingHeaderFormat format;
+    correlationId = "test-corr-id";
+    fsId = "test-filesystem-id";
+    format = TracingHeaderFormat.ALL_ID_FORMAT;
+    return new TracingContext(correlationId, fsId,
+        FSOperationType.TEST_OP, needsPrimaryReqId, format, null);
+  }
+
   public TracingContext getTestTracingContext(AzureBlobFileSystem fs,
       boolean needsPrimaryReqId) {
     String correlationId, fsId;
@@ -166,7 +177,6 @@ public abstract class AbstractAbfsIntegrationTest extends
     return new TracingContext(correlationId, fsId,
         FSOperationType.TEST_OP, needsPrimaryReqId, format, null);
   }
-
 
   @Before
   public void setup() throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -45,7 +45,7 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
   public void setup() throws Exception {
     binding.setup();
     super.setup();
-  }
+    }
 
   @Override
   protected Configuration createConfiguration() {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.azurebfs.commit;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
 import org.apache.hadoop.fs.azurebfs.contract.AbfsFileSystemContract;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
@@ -41,6 +42,12 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
     binding = new ABFSContractTestBinding();
   }
 
+  protected boolean isNamespaceEnabled() {
+    FileSystem fs = getFileSystem();
+    String namespaceEnabled = fs.getConf().get("fs.azure.test.namespace.enabled");
+    return namespaceEnabled.equals("true");
+  }
+
   @Override
   public void setup() throws Exception {
     binding.setup();
@@ -59,7 +66,11 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
 
   @Override
   protected boolean requireRenameResilience() {
-    return true;
+    if (isNamespaceEnabled()) {
+      return true;
+    }
+
+    return false;
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -68,7 +68,6 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
     if (isNamespaceEnabled()) {
       return true;
     }
-
     return false;
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -45,9 +45,8 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
   protected boolean isNamespaceEnabled() {
     FileSystem fs = getFileSystem();
     String namespaceEnabled = fs.getConf().get("fs.azure.test.namespace.enabled");
-    return namespaceEnabled.equals("true");
+    return ("true").equals(namespaceEnabled);
   }
-
   @Override
   public void setup() throws Exception {
     binding.setup();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -52,7 +52,7 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
   public void setup() throws Exception {
     binding.setup();
     super.setup();
-    }
+  }
 
   @Override
   protected Configuration createConfiguration() {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -19,12 +19,13 @@
 package org.apache.hadoop.fs.azurebfs.commit;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
 import org.apache.hadoop.fs.azurebfs.contract.AbfsFileSystemContract;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.TestRenameStageFailure;
-
 /**
  * Rename failure logic on ABFS.
  * This will go through the resilient rename operation.
@@ -42,10 +43,9 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
     binding = new ABFSContractTestBinding();
   }
 
-  protected boolean isNamespaceEnabled() {
-    FileSystem fs = getFileSystem();
-    String namespaceEnabled = fs.getConf().get("fs.azure.test.namespace.enabled");
-    return ("true").equals(namespaceEnabled);
+  protected boolean isNamespaceEnabled() throws AzureBlobFileSystemException {
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) getFileSystem();
+    return fs.getAbfsStore().getIsNamespaceEnabled(AbstractAbfsIntegrationTest.getSampleTracingContext(fs, false));
   }
 
   @Override
@@ -65,11 +65,8 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
   }
 
   @Override
-  protected boolean requireRenameResilience() {
-    if (isNamespaceEnabled()) {
-      return true;
-    }
-    return false;
+  protected boolean requireRenameResilience() throws AzureBlobFileSystemException {
+    return isNamespaceEnabled();
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsRenameStageFailure.java
@@ -47,6 +47,7 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
     String namespaceEnabled = fs.getConf().get("fs.azure.test.namespace.enabled");
     return ("true").equals(namespaceEnabled);
   }
+
   @Override
   public void setup() throws Exception {
     binding.setup();
@@ -68,6 +69,7 @@ public class ITestAbfsRenameStageFailure extends TestRenameStageFailure {
     if (isNamespaceEnabled()) {
       return true;
     }
+
     return false;
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->
This commit ignores the testResilienceAsExpected test in ITestAbfsRenameStageFailure. 

ITestAbfsRenameStageFailure fails for the NonHNS SharedKey configuration - 

`[ERROR] ITestAbfsRenameStageFailure>TestRenameStageFailure.testResilienceAsExpected:126 [resilient commit support] expected:<[tru]e> but was:<[fals]e>
`
The check for whether ResilientCommits are possible depends on whether etags are preserved in rename or not. If not, an exception is thrown which leads the ResilientCommitByRename flag to remain set to `null` and ultimately causes the test failure.
In case of nonHNS accounts, as etags are not preserved in rename, the test run is not valid. Hence for this particular configuration the test has been ignored. 