### PR TITLE
HDFS-16733.Improve INode#isRoot().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
@@ -73,7 +73,8 @@ public abstract class INode implements INodeAttributes, Diff.Element<byte[]> {
    * Check whether this is the root inode.
    */
   final boolean isRoot() {
-    return getLocalNameBytes().length == 0;
+    // Note: There is no restriction that id must be equal to INodeId#ROOT_INODE_ID
+    return getLocalNameBytes() == null || getLocalNameBytes().length == 0;
   }
 
   /** Get the {@link PermissionStatus} */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestINodeFile.java
@@ -1265,4 +1265,15 @@ public class TestINodeFile {
           qu.getFileAndDirectoryCount());
     }
   }
+
+  @Test
+  public void testIsRoot() {
+    INodeDirectory root = new INodeDirectory(HdfsConstants.GRANDFATHER_INODE_ID,
+        null, perm, 0L);
+    INodeFile file = new INodeFile(HdfsConstants.GRANDFATHER_INODE_ID + 1,
+        "file".getBytes(), perm, 0, 0, null, (short) 1, 0);
+    file.setParent(root);
+    Assert.assertTrue(root.isRoot());
+    Assert.assertFalse(file.isRoot());
+  }
 }


### PR DESCRIPTION
### Description of PR
When constructing an INodeFile or INodeDirectory, if the given name is null, an exception will be thrown when checking whether it is root.
Details: HDFS-16733

### How was this patch tested?
When constructing an INodeFile or INodeDirectory, if the given name is null, an exception will not occur when checking whether it is root.

