### PR TITLE
YARN-11269. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timeline-pluginstorage

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/pom.xml
@@ -71,7 +71,7 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-common</artifactId>
     </dependency>
@@ -127,6 +127,21 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/PluginStoreTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/PluginStoreTestUtils.java
@@ -49,8 +49,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Utility methods related to the ATS v1.5 plugin storage tests.
@@ -176,10 +176,8 @@ public class PluginStoreTestUtils {
         UserGroupInformation.getLoginUser());
     assertNotNull(entity1);
     assertNotNull(entity2);
-    assertEquals("Failed to read out entity 1",
-        (Long) 123l, entity1.getStartTime());
-    assertEquals("Failed to read out entity 2",
-        (Long) 456l, entity2.getStartTime());
+    assertEquals((Long) 123l, entity1.getStartTime(), "Failed to read out entity 1");
+    assertEquals((Long) 456l, entity2.getStartTime(), "Failed to read out entity 2");
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
@@ -43,14 +43,12 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.timeline.EntityGroupFSTimelineStore.AppState;
 import org.apache.hadoop.yarn.server.timeline.TimelineReader.Field;
 import org.apache.hadoop.yarn.util.ConverterUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -78,11 +76,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -118,12 +117,18 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   private EntityGroupFSTimelineStore store;
   private TimelineEntity entityNew;
 
-  @Rule
-  public TestName currTestName = new TestName();
+  @Test
+  void getTestInfo(TestInfo testInfo) { // Automatically injected
+    System.out.println(testInfo.getDisplayName());
+    System.out.println(testInfo.getTestMethod());
+    System.out.println(testInfo.getTestClass());
+    System.out.println(testInfo.getTags());
+  }
+
   private File rootDir;
   private File testJar;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     config.setBoolean(YarnConfiguration.TIMELINE_SERVICE_TTL_ENABLE, false);
     config.set(
@@ -163,8 +168,8 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
         testActiveDirPath.toString());
   }
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  public void setup(TestInfo testInfo) throws Exception {
     for (ApplicationId appId : sampleAppIds) {
       Path attemotDirPath =
           new Path(new Path(testActiveDirPath, appId.toString()),
@@ -173,7 +178,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     }
 
     store = new EntityGroupFSTimelineStore();
-    if (currTestName.getMethodName().contains("Plugin")) {
+    if (testInfo.getDisplayName().contains("Plugin")) {
       rootDir = GenericTestUtils.getTestDir(getClass()
           .getSimpleName());
       if (!rootDir.exists()) {
@@ -201,7 +206,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     store.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.stop();
     for (ApplicationId appId : sampleAppIds) {
@@ -213,7 +218,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception {
     hdfsCluster.shutdown();
     FileContext fileContext = FileContext.getLocalFSFileContext();
@@ -222,10 +227,10 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testAppLogsScanLogs() throws Exception {
+  void testAppLogsScanLogs() throws Exception {
     EntityGroupFSTimelineStore.AppLogs appLogs =
         store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-        AppState.COMPLETED);
+            AppState.COMPLETED);
     appLogs.scanForLogs();
     List<LogInfo> summaryLogs = appLogs.getSummaryLogs();
     List<LogInfo> detailLogs = appLogs.getDetailLogs();
@@ -245,13 +250,13 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testAppLogsDomainLogLastlyScanned() throws Exception {
+  void testAppLogsDomainLogLastlyScanned() throws Exception {
     EntityGroupFSTimelineStore.AppLogs appLogs =
-            store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-                    AppState.COMPLETED);
+        store.new AppLogs(mainTestAppId, mainTestAppDirPath,
+            AppState.COMPLETED);
     Path attemptDirPath = new Path(new Path(testActiveDirPath,
             mainTestAppId.toString()),
-            getAttemptDirName(mainTestAppId));
+        getAttemptDirName(mainTestAppId));
     //Delete the domain log from AppDirPath so first scan won't find it
     fs.delete(new Path(attemptDirPath, TEST_DOMAIN_LOG_FILE_NAME), false);
     appLogs.scanForLogs();
@@ -261,7 +266,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
 
     //Generate the domain log
     FSDataOutputStream out = fs.create(
-            new Path(attemptDirPath, TEST_DOMAIN_LOG_FILE_NAME));
+        new Path(attemptDirPath, TEST_DOMAIN_LOG_FILE_NAME));
     out.close();
 
     appLogs.scanForLogs();
@@ -270,10 +275,10 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testMoveToDone() throws Exception {
+  void testMoveToDone() throws Exception {
     EntityGroupFSTimelineStore.AppLogs appLogs =
         store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-        AppState.COMPLETED);
+            AppState.COMPLETED);
     Path pathBefore = appLogs.getAppDirPath();
     appLogs.moveToDone();
     Path pathAfter = appLogs.getAppDirPath();
@@ -284,13 +289,13 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testParseSummaryLogs() throws Exception {
+  void testParseSummaryLogs() throws Exception {
     TimelineDataManager tdm = PluginStoreTestUtils.getTdmWithMemStore(config);
     MutableCounterLong scanned = store.metrics.getEntitiesReadToSummary();
     long beforeScan = scanned.value();
     EntityGroupFSTimelineStore.AppLogs appLogs =
         store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-        AppState.COMPLETED);
+            AppState.COMPLETED);
     appLogs.scanForLogs();
     appLogs.parseSummaryLogs(tdm);
     PluginStoreTestUtils.verifyTestEntities(tdm);
@@ -298,31 +303,31 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testWithAnonymousUser() throws Exception {
+  void testWithAnonymousUser() throws Exception {
     try {
       TimelineDataManager tdm = PluginStoreTestUtils.getTdmWithMemStore(config);
       EntityGroupFSTimelineStore.AppLogs appLogs =
-              store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-                      AppState.COMPLETED);
+          store.new AppLogs(mainTestAppId, mainTestAppDirPath,
+              AppState.COMPLETED);
       FileStatus fileStatus = mock(FileStatus.class);
       when(fileStatus.getOwner()).thenReturn(null);
       appLogs.scanForLogs();
       appLogs.parseSummaryLogs(tdm);
       PluginStoreTestUtils.verifyTestEntities(tdm);
     } catch (IllegalArgumentException ie) {
-      Assert.fail("No exception needs to be thrown as anonymous user is configured");
+      fail("No exception needs to be thrown as anonymous user is configured");
     }
   }
 
   @Test
-  public void testCleanLogs() throws Exception {
+  void testCleanLogs() throws Exception {
     // Create test dirs and files
     // Irrelevant file, should not be reclaimed
     String appDirName = mainTestAppId.toString();
     String attemptDirName = ApplicationAttemptId.appAttemptIdStrPrefix
         + appDirName + "_1";
     Path irrelevantFilePath = new Path(
-            testDoneDirPath, "irrelevant.log");
+        testDoneDirPath, "irrelevant.log");
     FSDataOutputStream stream = fs.create(irrelevantFilePath);
     stream.close();
     // Irrelevant directory, should not be reclaimed
@@ -395,7 +400,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testCleanBuckets() throws Exception {
+  void testCleanBuckets() throws Exception {
     // ClusterTimeStampDir with App Log Dirs
     Path clusterTimeStampDir1 = new Path(testDoneDirPath,
         Long.toString(sampleAppIds.get(0).getClusterTimestamp()));
@@ -441,17 +446,17 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testNullCheckGetEntityTimelines() throws Exception {
+  void testNullCheckGetEntityTimelines() throws Exception {
     try {
       store.getEntityTimelines("YARN_APPLICATION", null, null, null, null,
           null);
     } catch (NullPointerException e) {
-      Assert.fail("NPE when getEntityTimelines called with Null EntityIds");
+      fail("NPE when getEntityTimelines called with Null EntityIds");
     }
   }
 
   @Test
-  public void testPluginRead() throws Exception {
+  void testPluginRead() throws Exception {
     // Verify precondition
     assertEquals(EntityGroupPlugInForTest.class.getName(),
         store.getConfig().get(
@@ -459,8 +464,8 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     List<TimelineEntityGroupPlugin> currPlugins = store.getPlugins();
     for (TimelineEntityGroupPlugin plugin : currPlugins) {
       ClassLoader pluginClassLoader = plugin.getClass().getClassLoader();
-      assertTrue("Should set up ApplicationClassLoader",
-          pluginClassLoader instanceof ApplicationClassLoader);
+      assertTrue(pluginClassLoader instanceof ApplicationClassLoader,
+          "Should set up ApplicationClassLoader");
       URL[] paths = ((URLClassLoader) pluginClassLoader).getURLs();
       boolean foundJAR = false;
       for (URL path : paths) {
@@ -468,13 +473,13 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
           foundJAR = true;
         }
       }
-      assertTrue("Not found path " + testJar.getAbsolutePath()
-          + " for plugin " + plugin.getClass().getName(), foundJAR);
+      assertTrue(foundJAR, "Not found path " + testJar.getAbsolutePath()
+          + " for plugin " + plugin.getClass().getName());
     }
     // Load data and cache item, prepare timeline store by making a cache item
     EntityGroupFSTimelineStore.AppLogs appLogs =
         store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-        AppState.COMPLETED);
+            AppState.COMPLETED);
     EntityCacheItem cacheItem = new EntityCacheItem(
         EntityGroupPlugInForTest.getStandardTimelineGroupId(mainTestAppId),
         config);
@@ -514,11 +519,11 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testSummaryRead() throws Exception {
+  void testSummaryRead() throws Exception {
     // Load data
     EntityGroupFSTimelineStore.AppLogs appLogs =
         store.new AppLogs(mainTestAppId, mainTestAppDirPath,
-        AppState.COMPLETED);
+            AppState.COMPLETED);
     MutableCounterLong summaryLogEntityRead
         = store.metrics.getGetEntityToSummaryOps();
     long numEntityReadBefore = summaryLogEntityRead.value();
@@ -543,7 +548,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testGetEntityPluginRead() throws Exception {
+  void testGetEntityPluginRead() throws Exception {
     EntityGroupFSTimelineStore store = null;
     ApplicationId appId =
         ApplicationId.fromString("application_1501509265053_0001");
@@ -571,7 +576,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testScanActiveLogsWithInvalidFile() throws Exception {
+  void testScanActiveLogsWithInvalidFile() throws Exception {
     Path invalidFile = new Path(testActiveDirPath, "invalidfile");
     try {
       if (!fs.exists(invalidFile)) {
@@ -579,7 +584,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
       }
       store.scanActiveLogs();
     } catch (StackOverflowError error) {
-      Assert.fail("EntityLogScanner crashed with StackOverflowError");
+      fail("EntityLogScanner crashed with StackOverflowError");
     } finally {
       if (fs.exists(invalidFile)) {
         fs.delete(invalidFile, false);
@@ -588,7 +593,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testScanActiveLogsAndMoveToDonePluginRead() throws Exception {
+  void testScanActiveLogsAndMoveToDonePluginRead() throws Exception {
     EntityGroupFSTimelineStore store = null;
     ApplicationId appId =
         ApplicationId.fromString("application_1501509265053_0002");
@@ -637,7 +642,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testIfAnyDuplicateEntities() throws Exception {
+  void testIfAnyDuplicateEntities() throws Exception {
     // Create an application with some entities
     ApplicationId appId =
         ApplicationId.fromString("application_1501509265053_0002");
@@ -683,15 +688,14 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
           return TestTimelineStore.getEntitiesCount() == 2;
         }
       }, 100, 10000);
-      assertEquals("Wrong Initial Entities Count",
-          2, TestTimelineStore.getEntitiesCount());
+      assertEquals(2, TestTimelineStore.getEntitiesCount(), "Wrong Initial Entities Count");
 
       // Append the Summary log file with few more entities
       TimelineEntities entities = PluginStoreTestUtils.generateTestEntities();
       FSDataOutputStream outStream = fs.append(
           new Path(attemptDirPath, TEST_SUMMARY_LOG_FILE_NAME));
       JsonGenerator jsonGenerator
-          = new JsonFactory().createGenerator((OutputStream)outStream);
+          = new JsonFactory().createGenerator((OutputStream) outStream);
       jsonGenerator.setPrettyPrinter(new MinimalPrettyPrinter("\n"));
       ObjectMapper objMapper = new ObjectMapper();
       objMapper.setAnnotationIntrospector(
@@ -710,8 +714,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
           return TestTimelineStore.getEntitiesCount() == 4;
         }
       }, 100, 10000);
-      assertEquals("Duplicate Entities present",
-          4, TestTimelineStore.getEntitiesCount());
+      assertEquals(4, TestTimelineStore.getEntitiesCount(), "Duplicate Entities present");
 
     } finally {
       if (newStore != null) {
@@ -722,7 +725,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testStateStoreAndRecovery() throws Exception {
+  void testStateStoreAndRecovery() throws Exception {
     // Prepare the AppLogs Data
     EntityGroupFSTimelineStore.AppLogs appLogs =
         store.new AppLogs(mainTestAppId, mainTestAppDirPath, AppState.COMPLETED);
@@ -736,7 +739,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     try (DataOutputStream dataOutputStream = fs.create(checkpointFile)) {
       store.storeLogFiles(logsList, dataOutputStream);
     } catch (IOException e) {
-      Assert.fail("Failed to store the log files");
+      fail("Failed to store the log files");
     }
 
     // Recover the Log files and validate the contents
@@ -748,14 +751,14 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
         String logFileName = logInfo.getAttemptDirName() +
             Path.SEPARATOR + logInfo.getFilename();
         Pair<Long, Long> pair = logFiles.get(logFileName);
-        assertNotNull("Failed to recover " + logFileName, pair);
-        assertTrue("LastProcessedTime is not same",
-            logInfo.getLastProcessedTime() == pair.getLeft());
-        assertTrue("Offset is not same",
-            logInfo.getOffset() == pair.getRight());
+        assertNotNull(pair, "Failed to recover " + logFileName);
+        assertTrue(logInfo.getLastProcessedTime() == pair.getLeft(),
+            "LastProcessedTime is not same");
+        assertTrue(logInfo.getOffset() == pair.getRight(),
+            "Offset is not same");
       }
     } catch (IOException e) {
-      Assert.fail("Failed to recover the log files");
+      fail("Failed to recover the log files");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestEntityGroupFSTimelineStore.java
@@ -117,14 +117,6 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
   private EntityGroupFSTimelineStore store;
   private TimelineEntity entityNew;
 
-  @Test
-  void getTestInfo(TestInfo testInfo) { // Automatically injected
-    System.out.println(testInfo.getDisplayName());
-    System.out.println(testInfo.getTestMethod());
-    System.out.println(testInfo.getTestClass());
-    System.out.println(testInfo.getTags());
-  }
-
   private File rootDir;
   private File testJar;
 
@@ -178,7 +170,7 @@ public class TestEntityGroupFSTimelineStore extends TimelineStoreTestUtils {
     }
 
     store = new EntityGroupFSTimelineStore();
-    if (testInfo.getDisplayName().contains("Plugin")) {
+    if (testInfo.getTestMethod().get().getName().contains("Plugin")) {
       rootDir = GenericTestUtils.getTestDir(getClass()
           .getSimpleName());
       if (!rootDir.exists()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLevelDBCacheTimelineStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLevelDBCacheTimelineStore.java
@@ -20,16 +20,17 @@ package org.apache.hadoop.yarn.server.timeline;
 
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 public class TestLevelDBCacheTimelineStore extends TimelineStoreTestUtils {
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     store = new LevelDBCacheTimelineStore("app1");
     store.init(new YarnConfiguration());
@@ -39,7 +40,7 @@ public class TestLevelDBCacheTimelineStore extends TimelineStoreTestUtils {
     loadTestDomainData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.stop();
   }
@@ -49,13 +50,13 @@ public class TestLevelDBCacheTimelineStore extends TimelineStoreTestUtils {
   }
 
   @Test
-  public void testDefaultConstructor() {
+  void testDefaultConstructor() {
     TimelineStore store = null;
     try {
       store = ReflectionUtils.newInstance(LevelDBCacheTimelineStore.class,
           new YarnConfiguration());
     } finally {
-      assertNotNull("LevelDBCacheTimelineStore failed to instantiate", store);
+      assertNotNull(store, "LevelDBCacheTimelineStore failed to instantiate");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLogInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestLogInfo.java
@@ -34,18 +34,18 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelineDomain;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntities;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLogInfo {
 
@@ -75,7 +75,7 @@ public class TestLogInfo {
 
   private static final short FILE_LOG_DIR_PERMISSIONS = 0770;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     config.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR.toString());
     HdfsConfiguration hdfsConfig = new HdfsConfiguration();
@@ -101,7 +101,7 @@ public class TestLogInfo {
     writeBrokenFile(new Path(testAppDirPath, TEST_BROKEN_FILE_NAME));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     jsonGenerator.close();
     outStream.close();
@@ -110,7 +110,7 @@ public class TestLogInfo {
   }
 
   @Test
-  public void testMatchesGroupId() throws Exception {
+  void testMatchesGroupId() throws Exception {
     String testGroupId = "app1_group1";
     // Match
     EntityLogInfo testLogInfo = new EntityLogInfo(TEST_ATTEMPT_DIR_NAME,
@@ -145,7 +145,7 @@ public class TestLogInfo {
   }
 
   @Test
-  public void testParseEntity() throws Exception {
+  void testParseEntity() throws Exception {
     // Load test data
     TimelineDataManager tdm = PluginStoreTestUtils.getTdmWithMemStore(config);
     EntityLogInfo testLogInfo = new EntityLogInfo(TEST_ATTEMPT_DIR_NAME,
@@ -159,7 +159,7 @@ public class TestLogInfo {
   }
 
   @Test
-  public void testParseBrokenEntity() throws Exception {
+  void testParseBrokenEntity() throws Exception {
     // Load test data
     TimelineDataManager tdm = PluginStoreTestUtils.getTdmWithMemStore(config);
     EntityLogInfo testLogInfo = new EntityLogInfo(TEST_ATTEMPT_DIR_NAME,
@@ -177,7 +177,7 @@ public class TestLogInfo {
   }
 
   @Test
-  public void testParseDomain() throws Exception {
+  void testParseDomain() throws Exception {
     // Load test data
     TimelineDataManager tdm = PluginStoreTestUtils.getTdmWithMemStore(config);
     DomainLogInfo domainLogInfo = new DomainLogInfo(TEST_ATTEMPT_DIR_NAME,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestOverrideTimelineStoreYarnClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/src/test/java/org/apache/hadoop/yarn/server/timeline/TestOverrideTimelineStoreYarnClient.java
@@ -22,20 +22,21 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestOverrideTimelineStoreYarnClient {
 
   @Test
-  public void testLifecycleAndOverride() throws Throwable {
+  void testLifecycleAndOverride() throws Throwable {
     YarnConfiguration conf = new YarnConfiguration();
-    try(NoRMStore store = new NoRMStore()) {
+    try (NoRMStore store = new NoRMStore()) {
       store.init(conf);
       store.start();
-      Assert.assertEquals(EntityGroupFSTimelineStore.AppState.ACTIVE,
+      assertEquals(EntityGroupFSTimelineStore.AppState.ACTIVE,
           store.getAppState(ApplicationId.newInstance(1, 1)));
       store.stop();
     }


### PR DESCRIPTION
### Description of PR

Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timeline-pluginstorage

JIRA - YARN-11269


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

