### PR TITLE
YARN-11265. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-sharedcachemanager

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/pom.xml
@@ -77,6 +77,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependency>
+    <groupId>org.junit.platform</groupId>
+    <artifactId>junit-platform-launcher</artifactId>
+    <scope>test</scope>
+  </dependency>
   
   <build>
       <plugins>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/pom.xml
@@ -76,12 +76,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-  <dependency>
-    <groupId>org.junit.platform</groupId>
-    <artifactId>junit-platform-launcher</artifactId>
-    <scope>test</scope>
-  </dependency>
   
   <build>
       <plugins>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>hadoop-yarn-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -70,6 +65,16 @@
       <artifactId>hadoop-yarn-server-tests</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestCleanerTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestCleanerTask.java
@@ -18,6 +18,18 @@
 
 package org.apache.hadoop.yarn.server.sharedcachemanager;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.sharedcachemanager.metrics.CleanerMetrics;
+import org.apache.hadoop.yarn.server.sharedcachemanager.store.SCMStore;
+
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -26,17 +38,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.server.sharedcachemanager.metrics.CleanerMetrics;
-import org.apache.hadoop.yarn.server.sharedcachemanager.store.SCMStore;
-import org.junit.Test;
 
 public class TestCleanerTask {
   private static final String ROOT =
@@ -47,7 +48,7 @@ public class TestCleanerTask {
       YarnConfiguration.DEFAULT_SHARED_CACHE_NESTED_LEVEL;
 
   @Test
-  public void testNonExistentRoot() throws Exception {
+  void testNonExistentRoot() throws Exception {
     FileSystem fs = mock(FileSystem.class);
     CleanerMetrics metrics = mock(CleanerMetrics.class);
     SCMStore store = mock(SCMStore.class);
@@ -64,7 +65,7 @@ public class TestCleanerTask {
   }
 
   @Test
-  public void testProcessFreshResource() throws Exception {
+  void testProcessFreshResource() throws Exception {
     FileSystem fs = mock(FileSystem.class);
     CleanerMetrics metrics = mock(CleanerMetrics.class);
     SCMStore store = mock(SCMStore.class);
@@ -89,7 +90,7 @@ public class TestCleanerTask {
   }
 
   @Test
-  public void testProcessEvictableResource() throws Exception {
+  void testProcessEvictableResource() throws Exception {
     FileSystem fs = mock(FileSystem.class);
     CleanerMetrics metrics = mock(CleanerMetrics.class);
     SCMStore store = mock(SCMStore.class);
@@ -125,7 +126,7 @@ public class TestCleanerTask {
   }
 
   @Test
-  public void testResourceIsInUseHasAnActiveApp() throws Exception {
+  void testResourceIsInUseHasAnActiveApp() throws Exception {
     FileSystem fs = mock(FileSystem.class);
     CleanerMetrics metrics = mock(CleanerMetrics.class);
     SCMStore store = mock(SCMStore.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestRemoteAppChecker.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestRemoteAppChecker.java
@@ -18,11 +18,8 @@
 
 package org.apache.hadoop.yarn.server.sharedcachemanager;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -32,14 +29,18 @@ import org.apache.hadoop.yarn.api.records.impl.pb.ApplicationReportPBImpl;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.impl.YarnClientImpl;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
-import org.junit.After;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 public class TestRemoteAppChecker {
 
   private RemoteAppChecker checker;
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (checker != null) {
       checker.stop();
@@ -61,7 +62,7 @@ public class TestRemoteAppChecker {
   }
 
   @Test
-  public void testNonExistentApp() throws Exception {
+  void testNonExistentApp() throws Exception {
     YarnClient client = createCheckerWithMockedClient();
     ApplicationId id = ApplicationId.newInstance(1, 1);
 
@@ -76,7 +77,7 @@ public class TestRemoteAppChecker {
   }
 
   @Test
-  public void testRunningApp() throws Exception {
+  void testRunningApp() throws Exception {
     YarnClient client = createCheckerWithMockedClient();
     ApplicationId id = ApplicationId.newInstance(1, 1);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestSCMAdminProtocolService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestSCMAdminProtocolService.java
@@ -18,36 +18,37 @@
 
 package org.apache.hadoop.yarn.server.sharedcachemanager;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.yarn.server.api.SCMAdminProtocol;
-import org.apache.hadoop.yarn.server.api.protocolrecords.RunSharedCacheCleanerTaskRequest;
-import org.apache.hadoop.yarn.server.api.protocolrecords.RunSharedCacheCleanerTaskResponse;
-import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RunSharedCacheCleanerTaskResponsePBImpl;
 import org.apache.hadoop.yarn.client.SCMAdmin;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.ipc.YarnRPC;
+import org.apache.hadoop.yarn.server.api.SCMAdminProtocol;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RunSharedCacheCleanerTaskRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RunSharedCacheCleanerTaskResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RunSharedCacheCleanerTaskResponsePBImpl;
 import org.apache.hadoop.yarn.server.sharedcachemanager.store.InMemorySCMStore;
 import org.apache.hadoop.yarn.server.sharedcachemanager.store.SCMStore;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Basic unit tests for the SCM Admin Protocol Service and SCMAdmin.
@@ -63,7 +64,7 @@ public class TestSCMAdminProtocolService {
   private final RecordFactory recordFactory = RecordFactoryProvider
       .getRecordFactory(null);
 
-  @Before
+  @BeforeEach
   public void startUp() {
     Configuration conf = new Configuration();
     conf.set(YarnConfiguration.SCM_STORE_CLASS,
@@ -95,7 +96,7 @@ public class TestSCMAdminProtocolService {
     };
   }
 
-  @After
+  @AfterEach
   public void cleanUpTest() {
     if (service != null) {
       service.stop();
@@ -107,18 +108,18 @@ public class TestSCMAdminProtocolService {
   }
 
   @Test
-  public void testRunCleanerTask() throws Exception {
+  void testRunCleanerTask() throws Exception {
     doNothing().when(cleaner).runCleanerTask();
     RunSharedCacheCleanerTaskRequest request =
         recordFactory.newRecordInstance(RunSharedCacheCleanerTaskRequest.class);
     RunSharedCacheCleanerTaskResponse response = SCMAdminProxy.runCleanerTask(request);
-    Assert.assertTrue("cleaner task request isn't accepted", response.getAccepted());
+    assertTrue(response.getAccepted(), "cleaner task request isn't accepted");
     verify(service, times(1)).runCleanerTask(any(RunSharedCacheCleanerTaskRequest.class));
   }
 
   @Test
-  public void testRunCleanerTaskCLI() throws Exception {
-    String[] args = { "-runCleanerTask" };
+  void testRunCleanerTaskCLI() throws Exception {
+    String[] args = {"-runCleanerTask"};
     RunSharedCacheCleanerTaskResponse rp =
         new RunSharedCacheCleanerTaskResponsePBImpl();
     rp.setAccepted(true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestSharedCacheUploaderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/TestSharedCacheUploaderService.java
@@ -18,16 +18,16 @@
 
 package org.apache.hadoop.yarn.server.sharedcachemanager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.spy;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.RPC;
@@ -41,11 +41,12 @@ import org.apache.hadoop.yarn.server.sharedcachemanager.metrics.SharedCacheUploa
 import org.apache.hadoop.yarn.server.sharedcachemanager.store.InMemorySCMStore;
 import org.apache.hadoop.yarn.server.sharedcachemanager.store.SCMStore;
 import org.apache.hadoop.yarn.server.sharedcachemanager.store.SharedCacheResourceReference;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
 
 
 /**
@@ -54,7 +55,7 @@ import org.junit.Test;
 public class TestSharedCacheUploaderService {
   private static File testDir = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTestDirs() throws IOException {
     testDir = new File("target",
         TestSharedCacheUploaderService.class.getCanonicalName());
@@ -63,7 +64,7 @@ public class TestSharedCacheUploaderService {
     testDir = testDir.getAbsoluteFile();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupTestDirs() throws IOException {
     if (testDir != null) {
       testDir.delete();
@@ -76,7 +77,7 @@ public class TestSharedCacheUploaderService {
   private final RecordFactory recordFactory = RecordFactoryProvider
       .getRecordFactory(null);
 
-  @Before
+  @BeforeEach
   public void startUp() {
     Configuration conf = new Configuration();
     conf.set(YarnConfiguration.SCM_STORE_CLASS,
@@ -103,7 +104,7 @@ public class TestSharedCacheUploaderService {
             SCMUploaderProtocol.class, scmAddress, conf);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     if (store != null) {
       store.stop();
@@ -119,7 +120,7 @@ public class TestSharedCacheUploaderService {
   }
 
   @Test
-  public void testNotify_noEntry() throws Exception {
+  void testNotify_noEntry() throws Exception {
     long accepted =
         SharedCacheUploaderMetrics.getInstance().getAcceptedUploads();
 
@@ -134,14 +135,15 @@ public class TestSharedCacheUploaderService {
     assertEquals(0, set.size());
 
     assertEquals(
-        "NM upload metrics aren't updated.", 1,
+        1,
         SharedCacheUploaderMetrics.getInstance().getAcceptedUploads() -
-            accepted);
+            accepted,
+        "NM upload metrics aren't updated.");
 
   }
 
   @Test
-  public void testNotify_entryExists_differentName() throws Exception {
+  void testNotify_entryExists_differentName() throws Exception {
 
     long rejected =
         SharedCacheUploaderMetrics.getInstance().getRejectUploads();
@@ -157,14 +159,15 @@ public class TestSharedCacheUploaderService {
     assertNotNull(set);
     assertEquals(0, set.size());
     assertEquals(
-        "NM upload metrics aren't updated.", 1,
+        1,
         SharedCacheUploaderMetrics.getInstance().getRejectUploads() -
-            rejected);
+            rejected,
+        "NM upload metrics aren't updated.");
 
   }
 
   @Test
-  public void testNotify_entryExists_sameName() throws Exception {
+  void testNotify_entryExists_sameName() throws Exception {
 
     long accepted =
         SharedCacheUploaderMetrics.getInstance().getAcceptedUploads();
@@ -180,9 +183,10 @@ public class TestSharedCacheUploaderService {
     assertNotNull(set);
     assertEquals(0, set.size());
     assertEquals(
-        "NM upload metrics aren't updated.", 1,
+        1,
         SharedCacheUploaderMetrics.getInstance().getAcceptedUploads() -
-            accepted);
+            accepted,
+        "NM upload metrics aren't updated.");
 
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/metrics/TestCleanerMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/metrics/TestCleanerMetrics.java
@@ -17,24 +17,25 @@
  */
 package org.apache.hadoop.yarn.server.sharedcachemanager.metrics;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestCleanerMetrics {
 
   Configuration conf = new Configuration();
   CleanerMetrics cleanerMetrics;
 
-  @Before
+  @BeforeEach
   public void init() {
     cleanerMetrics = CleanerMetrics.getInstance();
   }
 
   @Test
-  public void testMetricsOverMultiplePeriods() {
+  void testMetricsOverMultiplePeriods() {
     simulateACleanerRun();
     assertMetrics(4, 4, 1, 1);
     simulateACleanerRun();
@@ -51,14 +52,14 @@ public class TestCleanerMetrics {
 
   void assertMetrics(int proc, int totalProc, int del, int totalDel) {
     assertEquals(
-        "Processed files in the last period are not measured correctly", proc,
-        cleanerMetrics.getProcessedFiles());
-    assertEquals("Total processed files are not measured correctly",
-        totalProc, cleanerMetrics.getTotalProcessedFiles());
-    assertEquals(
-        "Deleted files in the last period are not measured correctly", del,
-        cleanerMetrics.getDeletedFiles());
-    assertEquals("Total deleted files are not measured correctly",
-        totalDel, cleanerMetrics.getTotalDeletedFiles());
+        proc,
+        cleanerMetrics.getProcessedFiles(),
+        "Processed files in the last period are not measured correctly");
+    assertEquals(totalProc, cleanerMetrics.getTotalProcessedFiles(),
+        "Total processed files are not measured correctly");
+    assertEquals(del, cleanerMetrics.getDeletedFiles(),
+        "Deleted files in the last period are not measured correctly");
+    assertEquals(totalDel, cleanerMetrics.getTotalDeletedFiles(),
+        "Total deleted files are not measured correctly");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/store/SCMStoreBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/store/SCMStoreBaseTest.java
@@ -18,9 +18,10 @@
 
 package org.apache.hadoop.yarn.server.sharedcachemanager.store;
 
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
 
 /**
  * All test classes that test an SCMStore implementation must extend this class.
@@ -33,7 +34,7 @@ public abstract class SCMStoreBaseTest {
   abstract Class<? extends SCMStore> getStoreClass();
 
   @Test
-  public void TestZeroArgConstructor() throws Exception {
+  void TestZeroArgConstructor() throws Exception {
     // Test that the SCMStore implementation class is compatible with
     // ReflectionUtils#newInstance
     ReflectionUtils.newInstance(getStoreClass(), new Configuration());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/store/TestInMemorySCMStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/src/test/java/org/apache/hadoop/yarn/server/sharedcachemanager/store/TestInMemorySCMStore.java
@@ -18,16 +18,6 @@
 
 package org.apache.hadoop.yarn.server.sharedcachemanager.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,6 +31,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -48,9 +42,16 @@ import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.sharedcachemanager.AppChecker;
 import org.apache.hadoop.yarn.server.sharedcachemanager.DummyAppChecker;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 public class TestInMemorySCMStore extends SCMStoreBaseTest {
 
@@ -62,13 +63,13 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
     return InMemorySCMStore.class;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.checker = spy(new DummyAppChecker());
     this.store = spy(new InMemorySCMStore(checker));
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (this.store != null) {
       this.store.stop();
@@ -117,7 +118,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testAddResourceConcurrency() throws Exception {
+  void testAddResourceConcurrency() throws Exception {
     startEmptyStore();
     final String key = "key1";
     int count = 5;
@@ -140,7 +141,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
     start.countDown();
     // check the result; they should all agree with the value
     Set<String> results = new HashSet<String>();
-    for (Future<String> future: futures) {
+    for (Future<String> future : futures) {
       results.add(future.get());
     }
     assertSame(1, results.size());
@@ -148,7 +149,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testAddResourceRefNonExistentResource() throws Exception {
+  void testAddResourceRefNonExistentResource() throws Exception {
     startEmptyStore();
     String key = "key1";
     ApplicationId id = createAppId(1, 1L);
@@ -158,7 +159,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testRemoveResourceEmptyRefs() throws Exception {
+  void testRemoveResourceEmptyRefs() throws Exception {
     startEmptyStore();
     String key = "key1";
     String fileName = "foo.jar";
@@ -169,7 +170,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testAddResourceRefRemoveResource() throws Exception {
+  void testAddResourceRefRemoveResource() throws Exception {
     startEmptyStore();
     String key = "key1";
     ApplicationId id = createAppId(1, 1L);
@@ -186,7 +187,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testAddResourceRefConcurrency() throws Exception {
+  void testAddResourceRefConcurrency() throws Exception {
     startEmptyStore();
     final String key = "key1";
     final String user = "user";
@@ -215,7 +216,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
     start.countDown();
     // check the result
     Set<String> results = new HashSet<String>();
-    for (Future<String> future: futures) {
+    for (Future<String> future : futures) {
       results.add(future.get());
     }
     // they should all have the same file name
@@ -228,7 +229,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testAddResourceRefAddResourceConcurrency() throws Exception {
+  void testAddResourceRefAddResourceConcurrency() throws Exception {
     startEmptyStore();
     final String key = "key1";
     final String fileName = "foo.jar";
@@ -265,7 +266,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testRemoveRef() throws Exception {
+  void testRemoveRef() throws Exception {
     startEmptyStore();
     String key = "key1";
     String fileName = "foo.jar";
@@ -287,7 +288,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testBootstrapping() throws Exception {
+  void testBootstrapping() throws Exception {
     Map<String, String> initialCachedResources = startStoreWithResources();
     int count = initialCachedResources.size();
     ApplicationId id = createAppId(1, 1L);
@@ -306,7 +307,7 @@ public class TestInMemorySCMStore extends SCMStoreBaseTest {
   }
 
   @Test
-  public void testEvictableWithInitialApps() throws Exception {
+  void testEvictableWithInitialApps() throws Exception {
     startStoreWithApps();
     assertFalse(store.isResourceEvictable("key", mock(FileStatus.class)));
   }


### PR DESCRIPTION
### Description of PR

Upgrade JUnit from 4 to 5 in hadoop-yarn-server-sharedcachemanager

JIRA - YARN-11265

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

