### PR TITLE
YARN-11270. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timelineservice-hbase-client

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
@@ -136,6 +136,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
@@ -126,6 +126,16 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -256,12 +266,6 @@
           <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestHBaseTimelineStorageUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestHBaseTimelineStorageUtils.java
@@ -24,15 +24,17 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for HBaseTimelineStorageUtils static methos.
@@ -41,7 +43,7 @@ public class TestHBaseTimelineStorageUtils {
 
   private String hbaseConfigPath = "target/hbase-site.xml";
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     // Input Hbase Configuration
     Configuration hbaseConf = new Configuration();
@@ -60,25 +62,26 @@ public class TestHBaseTimelineStorageUtils {
     os.close();
   }
 
-  @Test(expected=NullPointerException.class)
-  public void testGetTimelineServiceHBaseConfNullArgument() throws Exception {
-    HBaseTimelineStorageUtils.getTimelineServiceHBaseConf(null);
+  @Test
+  void testGetTimelineServiceHBaseConfNullArgument() throws Exception {
+    assertThrows(NullPointerException.class, () -> {
+      HBaseTimelineStorageUtils.getTimelineServiceHBaseConf(null);
+    });
   }
 
   @Test
-  public void testWithHbaseConfAtLocalFileSystem() throws IOException {
+  void testWithHbaseConfAtLocalFileSystem() throws IOException {
     // Verifying With Hbase Conf from Local FileSystem
     Configuration conf = new Configuration();
     conf.set(YarnConfiguration.TIMELINE_SERVICE_HBASE_CONFIGURATION_FILE,
         hbaseConfigPath);
     Configuration hbaseConfFromLocal =
         HBaseTimelineStorageUtils.getTimelineServiceHBaseConf(conf);
-    Assert.assertEquals("Failed to read hbase config from Local FileSystem",
-        "test", hbaseConfFromLocal.get("input"));
+    assertEquals("test", hbaseConfFromLocal.get("input"), "Failed to read hbase config from Local FileSystem");
   }
 
   @Test
-  public void testWithHbaseConfAtHdfsFileSystem() throws IOException {
+  void testWithHbaseConfAtHdfsFileSystem() throws IOException {
     MiniDFSCluster hdfsCluster = null;
     try {
       HdfsConfiguration hdfsConfig = new HdfsConfiguration();
@@ -95,8 +98,7 @@ public class TestHBaseTimelineStorageUtils {
           path.toString());
       Configuration hbaseConfFromHdfs =
           HBaseTimelineStorageUtils.getTimelineServiceHBaseConf(conf);
-      Assert.assertEquals("Failed to read hbase config from Hdfs FileSystem",
-          "test", hbaseConfFromHdfs.get("input"));
+      assertEquals("test", hbaseConfFromHdfs.get("input"), "Failed to read hbase config from Hdfs FileSystem");
     } finally {
       if (hdfsCluster != null) {
         hdfsCluster.shutdown();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestHBaseTimelineStorageUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestHBaseTimelineStorageUtils.java
@@ -77,7 +77,8 @@ public class TestHBaseTimelineStorageUtils {
         hbaseConfigPath);
     Configuration hbaseConfFromLocal =
         HBaseTimelineStorageUtils.getTimelineServiceHBaseConf(conf);
-    assertEquals("test", hbaseConfFromLocal.get("input"), "Failed to read hbase config from Local FileSystem");
+    assertEquals("test", hbaseConfFromLocal.get("input"),
+        "Failed to read hbase config from Local FileSystem");
   }
 
   @Test
@@ -98,7 +99,8 @@ public class TestHBaseTimelineStorageUtils {
           path.toString());
       Configuration hbaseConfFromHdfs =
           HBaseTimelineStorageUtils.getTimelineServiceHBaseConf(conf);
-      assertEquals("test", hbaseConfFromHdfs.get("input"), "Failed to read hbase config from Hdfs FileSystem");
+      assertEquals("test", hbaseConfFromHdfs.get("input"),
+          "Failed to read hbase config from Hdfs FileSystem");
     } finally {
       if (hdfsCluster != null) {
         hdfsCluster.shutdown();


### PR DESCRIPTION
### Description of PR

Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timelineservice-hbase-client

JIRA - YARN-11270


### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

