### PR TITLE
YARN-11271. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timelineservice-hbase-common

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/pom.xml
@@ -131,6 +131,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/pom.xml
@@ -121,6 +121,16 @@
       <artifactId>hadoop-shaded-guava</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -138,12 +148,6 @@
           <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestCustomApplicationIdConversion.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestCustomApplicationIdConversion.java
@@ -17,9 +17,11 @@
  */
 package org.apache.hadoop.yarn.server.timelineservice.storage.common;
 
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for HBaseTimelineStorageUtils.convertApplicationIdToString(),
@@ -29,11 +31,11 @@ import org.junit.Test;
  */
 public class TestCustomApplicationIdConversion {
   @Test
-  public void testConvertAplicationIdToString() {
+  void testConvertAplicationIdToString() {
     ApplicationId applicationId = ApplicationId.newInstance(0, 1);
     String applicationIdStr =
         HBaseTimelineSchemaUtils.convertApplicationIdToString(applicationId);
-    Assert.assertEquals(applicationId,
+    assertEquals(applicationId,
         ApplicationId.fromString(applicationIdStr));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestKeyConverters.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestKeyConverters.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.yarn.server.timelineservice.storage.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for key converters for various tables' row keys.
@@ -33,7 +34,7 @@ import org.junit.Test;
 public class TestKeyConverters {
 
   @Test
-  public void testAppIdKeyConverter() {
+  void testAppIdKeyConverter() {
     AppIdKeyConverter appIdKeyConverter = new AppIdKeyConverter();
     long currentTs = System.currentTimeMillis();
     ApplicationId appId1 = ApplicationId.newInstance(currentTs, 1);
@@ -48,23 +49,20 @@ public class TestKeyConverters {
     // App ids' should be encoded in a manner wherein descending order
     // is maintained.
     assertTrue(
-        "Ordering of app ids' is incorrect",
         Bytes.compareTo(appIdBytes1, appIdBytes2) > 0
             && Bytes.compareTo(appIdBytes1, appIdBytes3) > 0
-            && Bytes.compareTo(appIdBytes2, appIdBytes3) > 0);
+            && Bytes.compareTo(appIdBytes2, appIdBytes3) > 0,
+        "Ordering of app ids' is incorrect");
     String decodedAppId1 = appIdKeyConverter.decode(appIdBytes1);
     String decodedAppId2 = appIdKeyConverter.decode(appIdBytes2);
     String decodedAppId3 = appIdKeyConverter.decode(appIdBytes3);
-    assertTrue("Decoded app id is not same as the app id encoded",
-        appIdStr1.equals(decodedAppId1));
-    assertTrue("Decoded app id is not same as the app id encoded",
-        appIdStr2.equals(decodedAppId2));
-    assertTrue("Decoded app id is not same as the app id encoded",
-        appIdStr3.equals(decodedAppId3));
+    assertEquals(appIdStr1, decodedAppId1);
+    assertEquals(appIdStr2, decodedAppId2);
+    assertEquals(appIdStr3, decodedAppId3);
   }
 
   @Test
-  public void testEventColumnNameConverter() {
+  void testEventColumnNameConverter() {
     String eventId = "=foo_=eve=nt=";
     byte[] valSepBytes = Bytes.toBytes(Separator.VALUES.getValue());
     byte[] maxByteArr =
@@ -91,7 +89,7 @@ public class TestKeyConverters {
   }
 
   @Test
-  public void testLongKeyConverter() {
+  void testLongKeyConverter() {
     LongKeyConverter longKeyConverter = new LongKeyConverter();
     confirmLongKeyConverter(longKeyConverter, Long.MIN_VALUE);
     confirmLongKeyConverter(longKeyConverter, -1234567890L);
@@ -113,7 +111,7 @@ public class TestKeyConverters {
   }
 
   @Test
-  public void testStringKeyConverter() {
+  void testStringKeyConverter() {
     StringKeyConverter stringKeyConverter = new StringKeyConverter();
     String phrase = "QuackAttack now!";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestRowKeys.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestRowKeys.java
@@ -17,8 +17,7 @@
  */
 package org.apache.hadoop.yarn.server.timelineservice.storage.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -26,14 +25,16 @@ import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEntity;
 import org.apache.hadoop.yarn.server.timelineservice.storage.application.ApplicationRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.application.ApplicationRowKeyPrefix;
 import org.apache.hadoop.yarn.server.timelineservice.storage.apptoflow.AppToFlowRowKey;
+import org.apache.hadoop.yarn.server.timelineservice.storage.domain.DomainRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.entity.EntityRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.entity.EntityRowKeyPrefix;
 import org.apache.hadoop.yarn.server.timelineservice.storage.flow.FlowActivityRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.flow.FlowActivityRowKeyPrefix;
 import org.apache.hadoop.yarn.server.timelineservice.storage.flow.FlowRunRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.subapplication.SubApplicationRowKey;
-import org.apache.hadoop.yarn.server.timelineservice.storage.domain.DomainRowKey;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -81,14 +82,14 @@ public class TestRowKeys {
     int sepLen = QUALIFIER_SEP_BYTES.length;
     for (int i = 0; i < sepLen; i++) {
       assertTrue(
-          "Row key prefix not encoded properly.",
           byteRowKeyPrefix[byteRowKeyPrefix.length - sepLen + i] ==
-              QUALIFIER_SEP_BYTES[i]);
+              QUALIFIER_SEP_BYTES[i],
+          "Row key prefix not encoded properly.");
     }
   }
 
   @Test
-  public void testApplicationRowKey() {
+  void testApplicationRowKey() {
     byte[] byteRowKey =
         new ApplicationRowKey(CLUSTER, USER, FLOW_NAME, FLOW_RUN_ID,
             APPLICATION_ID).getRowKey();
@@ -104,7 +105,7 @@ public class TestRowKeys {
             .getRowKeyPrefix();
     byte[][] splits =
         Separator.QUALIFIERS.split(byteRowKeyPrefix,
-            new int[] {Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
+            new int[]{Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
                 Separator.VARIABLE_SIZE, Bytes.SIZEOF_LONG,
                 Separator.VARIABLE_SIZE});
     assertEquals(5, splits.length);
@@ -118,9 +119,9 @@ public class TestRowKeys {
     byteRowKeyPrefix =
         new ApplicationRowKeyPrefix(CLUSTER, USER, FLOW_NAME).getRowKeyPrefix();
     splits =
-        Separator.QUALIFIERS.split(byteRowKeyPrefix, new int[] {
+        Separator.QUALIFIERS.split(byteRowKeyPrefix, new int[]{
             Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
-            Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE });
+            Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE});
     assertEquals(4, splits.length);
     assertEquals(0, splits[3].length);
     assertEquals(FLOW_NAME,
@@ -133,14 +134,14 @@ public class TestRowKeys {
    * corresponding rowkey.
    */
   @Test
-  public void testAppToFlowRowKey() {
+  void testAppToFlowRowKey() {
     byte[] byteRowKey = new AppToFlowRowKey(APPLICATION_ID).getRowKey();
     AppToFlowRowKey rowKey = AppToFlowRowKey.parseRowKey(byteRowKey);
     assertEquals(APPLICATION_ID, rowKey.getAppId());
   }
 
   @Test
-  public void testEntityRowKey() {
+  void testEntityRowKey() {
     TimelineEntity entity = new TimelineEntity();
     entity.setId("!ent!ity!!id!");
     entity.setType("entity!Type");
@@ -163,14 +164,14 @@ public class TestRowKeys {
     byte[] byteRowKeyPrefix =
         new EntityRowKeyPrefix(CLUSTER, USER, FLOW_NAME, FLOW_RUN_ID,
             APPLICATION_ID, entity.getType(), null, null)
-                .getRowKeyPrefix();
+            .getRowKeyPrefix();
     byte[][] splits =
         Separator.QUALIFIERS.split(
             byteRowKeyPrefix,
-            new int[] {Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
+            new int[]{Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
                 Separator.VARIABLE_SIZE, Bytes.SIZEOF_LONG,
                 AppIdKeyConverter.getKeySize(), Separator.VARIABLE_SIZE,
-                Bytes.SIZEOF_LONG, Separator.VARIABLE_SIZE });
+                Bytes.SIZEOF_LONG, Separator.VARIABLE_SIZE});
     assertEquals(7, splits.length);
     assertEquals(APPLICATION_ID, new AppIdKeyConverter().decode(splits[4]));
     assertEquals(entity.getType(),
@@ -183,7 +184,7 @@ public class TestRowKeys {
     splits =
         Separator.QUALIFIERS.split(
             byteRowKeyPrefix,
-            new int[] {Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
+            new int[]{Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
                 Separator.VARIABLE_SIZE, Bytes.SIZEOF_LONG,
                 AppIdKeyConverter.getKeySize(), Separator.VARIABLE_SIZE});
     assertEquals(6, splits.length);
@@ -194,7 +195,7 @@ public class TestRowKeys {
   }
 
   @Test
-  public void testFlowActivityRowKey() {
+  void testFlowActivityRowKey() {
     Long ts = 1459900830000L;
     Long dayTimestamp = HBaseTimelineSchemaUtils.getTopOfTheDayTimestamp(ts);
     byte[] byteRowKey =
@@ -208,8 +209,8 @@ public class TestRowKeys {
     byte[] byteRowKeyPrefix =
         new FlowActivityRowKeyPrefix(CLUSTER).getRowKeyPrefix();
     byte[][] splits =
-        Separator.QUALIFIERS.split(byteRowKeyPrefix, new int[] {
-            Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE });
+        Separator.QUALIFIERS.split(byteRowKeyPrefix, new int[]{
+            Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE});
     assertEquals(2, splits.length);
     assertEquals(0, splits[1].length);
     assertEquals(CLUSTER,
@@ -220,7 +221,7 @@ public class TestRowKeys {
         new FlowActivityRowKeyPrefix(CLUSTER, ts).getRowKeyPrefix();
     splits =
         Separator.QUALIFIERS.split(byteRowKeyPrefix,
-            new int[] {Separator.VARIABLE_SIZE, Bytes.SIZEOF_LONG,
+            new int[]{Separator.VARIABLE_SIZE, Bytes.SIZEOF_LONG,
                 Separator.VARIABLE_SIZE});
     assertEquals(3, splits.length);
     assertEquals(0, splits[2].length);
@@ -232,7 +233,7 @@ public class TestRowKeys {
   }
 
   @Test
-  public void testFlowRunRowKey() {
+  void testFlowRunRowKey() {
     byte[] byteRowKey =
         new FlowRunRowKey(CLUSTER, USER, FLOW_NAME, FLOW_RUN_ID).getRowKey();
     FlowRunRowKey rowKey = FlowRunRowKey.parseRowKey(byteRowKey);
@@ -244,9 +245,9 @@ public class TestRowKeys {
     byte[] byteRowKeyPrefix =
         new FlowRunRowKey(CLUSTER, USER, FLOW_NAME, null).getRowKey();
     byte[][] splits =
-        Separator.QUALIFIERS.split(byteRowKeyPrefix, new int[] {
+        Separator.QUALIFIERS.split(byteRowKeyPrefix, new int[]{
             Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE,
-            Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE });
+            Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE});
     assertEquals(4, splits.length);
     assertEquals(0, splits[3].length);
     assertEquals(FLOW_NAME,
@@ -255,7 +256,7 @@ public class TestRowKeys {
   }
 
   @Test
-  public void testSubAppRowKey() {
+  void testSubAppRowKey() {
     TimelineEntity entity = new TimelineEntity();
     entity.setId("entity1");
     entity.setType("DAG");
@@ -275,7 +276,7 @@ public class TestRowKeys {
   }
 
   @Test
-  public void testDomainRowKey() {
+  void testDomainRowKey() {
     String clusterId = "cluster1@dc1";
     String domainId = "helloworld";
     byte[] byteRowKey =
@@ -291,7 +292,7 @@ public class TestRowKeys {
   }
 
   @Test
-  public void testDomainRowKeySpecialChars() {
+  void testDomainRowKeySpecialChars() {
     String clusterId = "cluster1!temp!dc1";
     String domainId = "hello=world";
     byte[] byteRowKey =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestRowKeysAsString.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestRowKeysAsString.java
@@ -17,7 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.timelineservice.storage.common;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEntity;
@@ -27,7 +28,8 @@ import org.apache.hadoop.yarn.server.timelineservice.storage.entity.EntityRowKey
 import org.apache.hadoop.yarn.server.timelineservice.storage.flow.FlowActivityRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.flow.FlowRunRowKey;
 import org.apache.hadoop.yarn.server.timelineservice.storage.subapplication.SubApplicationRowKey;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for row key as string.
@@ -50,8 +52,9 @@ public class TestRowKeysAsString {
   private final static String APPLICATION_ID =
       ApplicationId.newInstance(System.currentTimeMillis(), 1).toString();
 
-  @Test(timeout = 10000)
-  public void testApplicationRow() {
+  @Test
+  @Timeout(10000)
+  void testApplicationRow() {
     String rowKeyAsString = new ApplicationRowKey(CLUSTER, USER, FLOW_NAME,
         FLOW_RUN_ID, APPLICATION_ID).getRowKeyAsString();
     ApplicationRowKey rowKey =
@@ -63,8 +66,9 @@ public class TestRowKeysAsString {
     assertEquals(APPLICATION_ID, rowKey.getAppId());
   }
 
-  @Test(timeout = 10000)
-  public void testEntityRowKey() {
+  @Test
+  @Timeout(10000)
+  void testEntityRowKey() {
     char del = TimelineReaderUtils.DEFAULT_DELIMITER_CHAR;
     char esc = TimelineReaderUtils.DEFAULT_ESCAPE_CHAR;
     String id = del + esc + "ent" + esc + del + "ity" + esc + del + esc + "id"
@@ -78,7 +82,7 @@ public class TestRowKeysAsString {
     String rowKeyAsString =
         new EntityRowKey(CLUSTER, USER, FLOW_NAME, FLOW_RUN_ID, APPLICATION_ID,
             entity.getType(), entity.getIdPrefix(), entity.getId())
-                .getRowKeyAsString();
+            .getRowKeyAsString();
     EntityRowKey rowKey = EntityRowKey.parseRowKeyFromString(rowKeyAsString);
     assertEquals(CLUSTER, rowKey.getClusterId());
     assertEquals(USER, rowKey.getUserId());
@@ -91,8 +95,9 @@ public class TestRowKeysAsString {
 
   }
 
-  @Test(timeout = 10000)
-  public void testFlowActivityRowKey() {
+  @Test
+  @Timeout(10000)
+  void testFlowActivityRowKey() {
     Long ts = 1459900830000L;
     Long dayTimestamp = HBaseTimelineSchemaUtils.getTopOfTheDayTimestamp(ts);
     String rowKeyAsString = new FlowActivityRowKey(CLUSTER, ts, USER, FLOW_NAME)
@@ -105,8 +110,9 @@ public class TestRowKeysAsString {
     assertEquals(FLOW_NAME, rowKey.getFlowName());
   }
 
-  @Test(timeout = 10000)
-  public void testFlowRunRowKey() {
+  @Test
+  @Timeout(10000)
+  void testFlowRunRowKey() {
     String rowKeyAsString =
         new FlowRunRowKey(CLUSTER, USER, FLOW_NAME, FLOW_RUN_ID)
             .getRowKeyAsString();
@@ -117,8 +123,9 @@ public class TestRowKeysAsString {
     assertEquals(FLOW_RUN_ID, rowKey.getFlowRunId());
   }
 
-  @Test(timeout = 10000)
-  public void testSubApplicationRowKey() {
+  @Test
+  @Timeout(10000)
+  void testSubApplicationRowKey() {
     char del = TimelineReaderUtils.DEFAULT_DELIMITER_CHAR;
     char esc = TimelineReaderUtils.DEFAULT_ESCAPE_CHAR;
     String id = del + esc + "ent" + esc + del + "ity" + esc + del + esc + "id"
@@ -131,7 +138,7 @@ public class TestRowKeysAsString {
 
     String rowKeyAsString = new SubApplicationRowKey(SUB_APP_USER, CLUSTER,
         entity.getType(), entity.getIdPrefix(), entity.getId(), USER)
-            .getRowKeyAsString();
+        .getRowKeyAsString();
     SubApplicationRowKey rowKey = SubApplicationRowKey
         .parseRowKeyFromString(rowKeyAsString);
     assertEquals(SUB_APP_USER, rowKey.getSubAppUserId());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestSeparator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/common/TestSeparator.java
@@ -16,19 +16,19 @@
  */
 package org.apache.hadoop.yarn.server.timelineservice.storage.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Test;
-
 import org.apache.hadoop.thirdparty.com.google.common.collect.Iterables;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestSeparator {
 
@@ -40,7 +40,7 @@ public class TestSeparator {
    *
    */
   @Test
-  public void testEncodeDecodeString() {
+  void testEncodeDecodeString() {
 
     for (Separator separator : Separator.values()) {
       testEncodeDecode(separator, "");
@@ -65,11 +65,11 @@ public class TestSeparator {
     String encoded = separator.encode(token);
     String decoded = separator.decode(encoded);
     String msg = "token:" + token + " separator:" + separator + ".";
-    assertEquals(msg, token, decoded);
+    assertEquals(token, decoded, msg);
   }
 
   @Test
-  public void testEncodeDecode() {
+  void testEncodeDecode() {
     testEncodeDecode("Dr.", Separator.QUALIFIERS);
     testEncodeDecode("Heinz", Separator.QUALIFIERS, Separator.QUALIFIERS);
     testEncodeDecode("Doofenshmirtz", Separator.QUALIFIERS, null,
@@ -81,15 +81,16 @@ public class TestSeparator {
         Separator.VALUES, Separator.SPACE);
 
   }
+
   @Test
-  public void testEncodedValues() {
+  void testEncodedValues() {
     testEncodeDecode("Double-escape %2$ and %9$ or %%2$ or %%3$, nor  %%%2$" +
         "= no problem!",
         Separator.QUALIFIERS, Separator.VALUES, Separator.SPACE, Separator.TAB);
   }
 
   @Test
-  public void testSplits() {
+  void testSplits() {
     byte[] maxLongBytes = Bytes.toBytes(Long.MAX_VALUE);
     byte[] maxIntBytes = Bytes.toBytes(Integer.MAX_VALUE);
     for (Separator separator : Separator.values()) {
@@ -128,7 +129,7 @@ public class TestSeparator {
       longVal1Arr = Bytes.add(sepByteArr, Bytes.copy(maxLongBytes,
           sepByteArr.length, 4 - sepByteArr.length), sepByteArr);
       longVal1Arr = Bytes.add(longVal1Arr, Bytes.copy(maxLongBytes, 4, 3 -
-              sepByteArr.length), sepByteArr);
+          sepByteArr.length), sepByteArr);
       arr = separator.join(Bytes.toBytes(separator.encode(str1)), longVal1Arr,
           Bytes.toBytes(separator.encode(str2)), intVal1Arr);
       splits = separator.split(arr, sizes);
@@ -154,14 +155,16 @@ public class TestSeparator {
             Bytes.SIZEOF_INT, 7};
         splits = separator.split(arr, sizes2);
         fail("Exception should have been thrown.");
-      } catch (IllegalArgumentException e) {}
+      } catch (IllegalArgumentException e) {
+      }
 
       try {
         int[] sizes2 = {Separator.VARIABLE_SIZE, Separator.VARIABLE_SIZE, 2,
             Bytes.SIZEOF_LONG};
         splits = separator.split(arr, sizes2);
         fail("Exception should have been thrown.");
-      } catch (IllegalArgumentException e) {}
+      } catch (IllegalArgumentException e) {
+      }
     }
   }
 
@@ -179,7 +182,7 @@ public class TestSeparator {
   }
 
   @Test
-  public void testJoinStripped() {
+  void testJoinStripped() {
     List<String> stringList = new ArrayList<String>(0);
     stringList.add("nothing");
 


### PR DESCRIPTION
### Description of PR

Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timelineservice-hbase-common

JIRA - YARN-11271

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

