### PR TITLE
YARN-11261. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-web-proxy

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
@@ -114,6 +114,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/pom.xml
@@ -70,11 +70,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -109,6 +104,16 @@
       <artifactId>grizzly-http-servlet</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>
@@ -124,7 +129,6 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestAppReportFetcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestAppReportFetcher.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestAppReportFetcher {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestAppReportFetcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestAppReportFetcher.java
@@ -20,6 +20,10 @@ package org.apache.hadoop.yarn.server.webproxy;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.ApplicationHistoryProtocol;
@@ -29,10 +33,9 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestAppReportFetcher {
 
@@ -42,7 +45,7 @@ public class TestAppReportFetcher {
   private static AppReportFetcher fetcher;
   private final String appNotFoundExceptionMsg = "APP NOT FOUND";
 
-  @After
+  @AfterEach
   public void cleanUp() {
     historyManager = null;
     appManager = null;
@@ -63,29 +66,29 @@ public class TestAppReportFetcher {
   }
 
   @Test
-  public void testFetchReportAHSEnabled() throws YarnException, IOException {
+  void testFetchReportAHSEnabled() throws YarnException, IOException {
     testHelper(true);
     Mockito.verify(historyManager, Mockito.times(1))
-    .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
+        .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
     Mockito.verify(appManager, Mockito.times(1))
-    .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
+        .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
   }
 
   @Test
-  public void testFetchReportAHSDisabled() throws YarnException, IOException {
+  void testFetchReportAHSDisabled() throws YarnException, IOException {
     try {
       testHelper(false);
     } catch (ApplicationNotFoundException e) {
-      Assert.assertTrue(e.getMessage() == appNotFoundExceptionMsg);
+      assertTrue(e.getMessage() == appNotFoundExceptionMsg);
       /* RM will not know of the app and Application History Service is disabled
        * So we will not try to get the report from AHS and RM will throw
        * ApplicationNotFoundException
        */
     }
     Mockito.verify(appManager, Mockito.times(1))
-    .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
+        .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
     if (historyManager != null) {
-      Assert.fail("HistoryManager should be null as AHS is disabled");
+      fail("HistoryManager should be null as AHS is disabled");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestAppReportFetcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestAppReportFetcher.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -79,7 +80,7 @@ public class TestAppReportFetcher {
     try {
       testHelper(false);
     } catch (ApplicationNotFoundException e) {
-      assertTrue(e.getMessage() == appNotFoundExceptionMsg);
+      assertEquals(appNotFoundExceptionMsg, e.getMessage());
       /* RM will not know of the app and Application History Service is disabled
        * So we will not try to get the report from AHS and RM will throw
        * ApplicationNotFoundException

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyCA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyCA.java
@@ -18,20 +18,6 @@
 
 package org.apache.hadoop.yarn.server.webproxy;
 
-import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
-import javax.security.auth.x500.X500Principal;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyPair;
@@ -52,109 +38,132 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestProxyCA {
 
   @Test
-  public void testInit() throws Exception {
+  void testInit() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
-    Assert.assertNull(proxyCA.getX509KeyManager());
-    Assert.assertNull(proxyCA.getHostnameVerifier());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getX509KeyManager());
+    assertNull(proxyCA.getHostnameVerifier());
 
     proxyCA.init();
-    Assert.assertNotNull(proxyCA.getCaCert());
-    Assert.assertNotNull(proxyCA.getCaKeyPair());
-    Assert.assertNotNull(proxyCA.getX509KeyManager());
-    Assert.assertNotNull(proxyCA.getHostnameVerifier());
+    assertNotNull(proxyCA.getCaCert());
+    assertNotNull(proxyCA.getCaKeyPair());
+    assertNotNull(proxyCA.getX509KeyManager());
+    assertNotNull(proxyCA.getHostnameVerifier());
   }
 
   @Test
-  public void testInit2Null() throws Exception {
+  void testInit2Null() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
-    Assert.assertNull(proxyCA.getX509KeyManager());
-    Assert.assertNull(proxyCA.getHostnameVerifier());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getX509KeyManager());
+    assertNull(proxyCA.getHostnameVerifier());
 
     // null certificate and private key
     proxyCA.init(null, null);
-    Assert.assertNotNull(proxyCA.getCaCert());
-    Assert.assertNotNull(proxyCA.getCaKeyPair());
-    Assert.assertNotNull(proxyCA.getX509KeyManager());
-    Assert.assertNotNull(proxyCA.getHostnameVerifier());
+    assertNotNull(proxyCA.getCaCert());
+    assertNotNull(proxyCA.getCaKeyPair());
+    assertNotNull(proxyCA.getX509KeyManager());
+    assertNotNull(proxyCA.getHostnameVerifier());
   }
 
   @Test
-  public void testInit2Mismatch() throws Exception {
+  void testInit2Mismatch() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
-    Assert.assertNull(proxyCA.getX509KeyManager());
-    Assert.assertNull(proxyCA.getHostnameVerifier());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getX509KeyManager());
+    assertNull(proxyCA.getHostnameVerifier());
 
     // certificate and private key don't match
     CertKeyPair pair1 = createCertAndKeyPair();
     CertKeyPair pair2 = createCertAndKeyPair();
-    Assert.assertNotEquals(pair1.getCert(), pair2.getCert());
-    Assert.assertNotEquals(pair1.getKeyPair().getPrivate(),
+    assertNotEquals(pair1.getCert(), pair2.getCert());
+    assertNotEquals(pair1.getKeyPair().getPrivate(),
         pair2.getKeyPair().getPrivate());
-    Assert.assertNotEquals(pair1.getKeyPair().getPublic(),
+    assertNotEquals(pair1.getKeyPair().getPublic(),
         pair2.getKeyPair().getPublic());
     proxyCA.init(pair1.getCert(), pair2.getKeyPair().getPrivate());
-    Assert.assertNotNull(proxyCA.getCaCert());
-    Assert.assertNotNull(proxyCA.getCaKeyPair());
-    Assert.assertNotNull(proxyCA.getX509KeyManager());
-    Assert.assertNotNull(proxyCA.getHostnameVerifier());
-    Assert.assertNotEquals(proxyCA.getCaCert(), pair1.getCert());
-    Assert.assertNotEquals(proxyCA.getCaKeyPair().getPrivate(),
+    assertNotNull(proxyCA.getCaCert());
+    assertNotNull(proxyCA.getCaKeyPair());
+    assertNotNull(proxyCA.getX509KeyManager());
+    assertNotNull(proxyCA.getHostnameVerifier());
+    assertNotEquals(proxyCA.getCaCert(), pair1.getCert());
+    assertNotEquals(proxyCA.getCaKeyPair().getPrivate(),
         pair2.getKeyPair().getPrivate());
-    Assert.assertNotEquals(proxyCA.getCaKeyPair().getPublic(),
+    assertNotEquals(proxyCA.getCaKeyPair().getPublic(),
         pair2.getKeyPair().getPublic());
   }
 
   @Test
-  public void testInit2Invalid() throws Exception {
+  void testInit2Invalid() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
-    Assert.assertNull(proxyCA.getX509KeyManager());
-    Assert.assertNull(proxyCA.getHostnameVerifier());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getX509KeyManager());
+    assertNull(proxyCA.getHostnameVerifier());
 
     // Invalid key - fail the verification
     X509Certificate certificate = Mockito.mock(X509Certificate.class);
     PrivateKey privateKey = Mockito.mock(PrivateKey.class);
     try {
       proxyCA.init(certificate, privateKey);
-      Assert.fail("Expected InvalidKeyException");
+      fail("Expected InvalidKeyException");
     } catch (InvalidKeyException e) {
       // expected
     }
   }
 
   @Test
-  public void testInit2() throws Exception {
+  void testInit2() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
-    Assert.assertNull(proxyCA.getX509KeyManager());
-    Assert.assertNull(proxyCA.getHostnameVerifier());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getX509KeyManager());
+    assertNull(proxyCA.getHostnameVerifier());
 
     // certificate and private key do match
     CertKeyPair pair = createCertAndKeyPair();
     proxyCA.init(pair.getCert(), pair.getKeyPair().getPrivate());
-    Assert.assertEquals(pair.getCert(), proxyCA.getCaCert());
-    Assert.assertEquals(pair.getKeyPair().getPrivate(),
+    assertEquals(pair.getCert(), proxyCA.getCaCert());
+    assertEquals(pair.getKeyPair().getPrivate(),
         proxyCA.getCaKeyPair().getPrivate());
-    Assert.assertEquals(pair.getKeyPair().getPublic(),
+    assertEquals(pair.getKeyPair().getPublic(),
         proxyCA.getCaKeyPair().getPublic());
-    Assert.assertNotNull(proxyCA.getX509KeyManager());
-    Assert.assertNotNull(proxyCA.getHostnameVerifier());
+    assertNotNull(proxyCA.getX509KeyManager());
+    assertNotNull(proxyCA.getHostnameVerifier());
   }
 
   @Test
-  public void testCreateChildKeyStore() throws Exception {
+  void testCreateChildKeyStore() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     ApplicationId appId =
@@ -163,29 +172,29 @@ public class TestProxyCA {
         "password");
     KeyStore keyStore = KeyStoreTestUtil.bytesToKeyStore(keystoreBytes,
         "password");
-    Assert.assertEquals(1, keyStore.size());
+    assertEquals(1, keyStore.size());
     Certificate[] certChain = keyStore.getCertificateChain("server");
-    Assert.assertEquals(2, certChain.length);
+    assertEquals(2, certChain.length);
     X509Certificate caCert = (X509Certificate) certChain[1];
     X509Certificate cert = (X509Certificate) certChain[0];
 
     // check child cert
-    Assert.assertEquals(caCert.getSubjectX500Principal().toString(),
+    assertEquals(caCert.getSubjectX500Principal().toString(),
         cert.getIssuerDN().toString());
-    Assert.assertEquals(new X500Principal("CN=" + appId),
+    assertEquals(new X500Principal("CN=" + appId),
         cert.getSubjectX500Principal());
-    Assert.assertFalse("Found multiple fields in X500 Principal, when there " +
-            "should have only been one: " + cert.getSubjectX500Principal(),
-        cert.getSubjectX500Principal().toString().contains(","));
-    Assert.assertEquals("SHA512withRSA", cert.getSigAlgName());
-    Assert.assertEquals(cert.getNotBefore(), cert.getNotAfter());
-    Assert.assertTrue("Expected certificate to be expired but was not: "
-        + cert.getNotAfter(), cert.getNotAfter().before(new Date()));
-    Assert.assertEquals(new X500Principal("CN=" + appId).toString(),
+    assertFalse(cert.getSubjectX500Principal().toString().contains(","),
+        "Found multiple fields in X500 Principal, when there " +
+            "should have only been one: " + cert.getSubjectX500Principal());
+    assertEquals("SHA512withRSA", cert.getSigAlgName());
+    assertEquals(cert.getNotBefore(), cert.getNotAfter());
+    assertTrue(cert.getNotAfter().before(new Date()),
+        "Expected certificate to be expired but was not: " + cert.getNotAfter());
+    assertEquals(new X500Principal("CN=" + appId).toString(),
         cert.getSubjectDN().toString());
     Key privateKey = keyStore.getKey("server", "password".toCharArray());
-    Assert.assertEquals("RSA", privateKey.getAlgorithm());
-    Assert.assertEquals(-1, cert.getBasicConstraints());
+    assertEquals("RSA", privateKey.getAlgorithm());
+    assertEquals(-1, cert.getBasicConstraints());
 
     // verify signature on child cert
     PublicKey caPublicKey = caCert.getPublicKey();
@@ -193,7 +202,7 @@ public class TestProxyCA {
 
     // check CA cert
     checkCACert(caCert);
-    Assert.assertEquals(proxyCA.getCaCert(), caCert);
+    assertEquals(proxyCA.getCaCert(), caCert);
 
     // verify signature on CA cert
     caCert.verify(caPublicKey);
@@ -202,24 +211,24 @@ public class TestProxyCA {
     PrivateKey caPrivateKey =
         proxyCA.getX509KeyManager().getPrivateKey(null);
     checkPrivatePublicKeys(caPrivateKey, caPublicKey);
-    Assert.assertEquals(proxyCA.getCaKeyPair().getPublic(), caPublicKey);
-    Assert.assertEquals(proxyCA.getCaKeyPair().getPrivate(), caPrivateKey);
+    assertEquals(proxyCA.getCaKeyPair().getPublic(), caPublicKey);
+    assertEquals(proxyCA.getCaKeyPair().getPrivate(), caPrivateKey);
   }
 
   @Test
-  public void testGetChildTrustStore() throws Exception {
+  void testGetChildTrustStore() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     byte[] truststoreBytes = proxyCA.getChildTrustStore("password");
     KeyStore truststore = KeyStoreTestUtil.bytesToKeyStore(truststoreBytes,
         "password");
-    Assert.assertEquals(1, truststore.size());
+    assertEquals(1, truststore.size());
     X509Certificate caCert =
         (X509Certificate) truststore.getCertificate("client");
 
     // check CA cert
     checkCACert(caCert);
-    Assert.assertEquals(proxyCA.getCaCert(), caCert);
+    assertEquals(proxyCA.getCaCert(), caCert);
 
     // verify signature on CA cert
     PublicKey caPublicKey = caCert.getPublicKey();
@@ -229,12 +238,12 @@ public class TestProxyCA {
     PrivateKey caPrivateKey =
         proxyCA.getX509KeyManager().getPrivateKey(null);
     checkPrivatePublicKeys(caPrivateKey, caPublicKey);
-    Assert.assertEquals(proxyCA.getCaKeyPair().getPublic(), caPublicKey);
-    Assert.assertEquals(proxyCA.getCaKeyPair().getPrivate(), caPrivateKey);
+    assertEquals(proxyCA.getCaKeyPair().getPublic(), caPublicKey);
+    assertEquals(proxyCA.getCaKeyPair().getPrivate(), caPrivateKey);
   }
 
   @Test
-  public void testGenerateKeyStorePassword() throws Exception {
+  void testGenerateKeyStorePassword() throws Exception {
     // We can't possibly test every possible string, but we can at least verify
     // a few things about a few of the generated strings as a sanity check
     ProxyCA proxyCA = new ProxyCA();
@@ -243,23 +252,23 @@ public class TestProxyCA {
 
     for (int i = 0; i < 5; i++) {
       String password = proxyCA.generateKeyStorePassword();
-      Assert.assertEquals(16, password.length());
+      assertEquals(16, password.length());
       for (char c : password.toCharArray()) {
-        Assert.assertFalse("Found character '" + c + "' in password '"
-            + password + "' which is outside of the expected range", c < ' ');
-        Assert.assertFalse("Found character '" + c + "' in password '"
-            + password + "' which is outside of the expected range", c > 'z');
+        assertFalse(c < ' ', "Found character '" + c + "' in password '"
+            + password + "' which is outside of the expected range");
+        assertFalse(c > 'z', "Found character '" + c + "' in password '"
+            + password + "' which is outside of the expected range");
       }
-      Assert.assertFalse("Password " + password
-          + " was generated twice, which is _extremely_ unlikely"
-          + " and shouldn't practically happen: " + passwords,
-          passwords.contains(password));
+      assertFalse(passwords.contains(password),
+          "Password " + password
+              + " was generated twice, which is _extremely_ unlikely"
+              + " and shouldn't practically happen: " + passwords);
       passwords.add(password);
     }
   }
 
   @Test
-  public void testCreateTrustManagerDefaultTrustManager() throws Exception {
+  void testCreateTrustManagerDefaultTrustManager() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509TrustManager defaultTrustManager = Mockito.mock(X509TrustManager.class);
@@ -272,13 +281,13 @@ public class TestProxyCA {
             "CN=foo", KeyStoreTestUtil.generateKeyPair("RSA"), 30,
             "SHA1withRSA")});
 
-    Assert.assertArrayEquals(defaultTrustManager.getAcceptedIssuers(),
+    assertArrayEquals(defaultTrustManager.getAcceptedIssuers(),
         trustManager.getAcceptedIssuers());
     trustManager.checkClientTrusted(null, null);
   }
 
   @Test
-  public void testCreateTrustManagerYarnCert() throws Exception {
+  void testCreateTrustManagerYarnCert() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509TrustManager defaultTrustManager = Mockito.mock(X509TrustManager.class);
@@ -297,7 +306,7 @@ public class TestProxyCA {
   }
 
   @Test
-  public void testCreateTrustManagerWrongApp() throws Exception {
+  void testCreateTrustManagerWrongApp() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509TrustManager defaultTrustManager = Mockito.mock(X509TrustManager.class);
@@ -314,15 +323,15 @@ public class TestProxyCA {
             .getCertificateChain("server"));
     try {
       trustManager.checkServerTrusted(certChain, "RSA");
-      Assert.fail("Should have thrown a CertificateException, but did not");
+      fail("Should have thrown a CertificateException, but did not");
     } catch (CertificateException ce) {
-      Assert.assertEquals("Expected to find Subject X500 Principal with CN=" +
+      assertEquals("Expected to find Subject X500 Principal with CN=" +
           appId + " but found CN=" + appId2, ce.getMessage());
     }
   }
 
   @Test
-  public void testCreateTrustManagerWrongRM() throws Exception {
+  void testCreateTrustManagerWrongRM() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509TrustManager defaultTrustManager = Mockito.mock(X509TrustManager.class);
@@ -345,7 +354,7 @@ public class TestProxyCA {
   }
 
   @Test
-  public void testCreateTrustManagerRealCert() throws Exception {
+  void testCreateTrustManagerRealCert() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509TrustManager defaultTrustManager = Mockito.mock(X509TrustManager.class);
@@ -357,8 +366,8 @@ public class TestProxyCA {
     // "real" cert
     X509Certificate[]
         certChain = new X509Certificate[]{
-        KeyStoreTestUtil.generateCertificate("CN=foo.com",
-            KeyStoreTestUtil.generateKeyPair("RSA"), 30, "SHA1withRSA")};
+            KeyStoreTestUtil.generateCertificate("CN=foo.com",
+                KeyStoreTestUtil.generateKeyPair("RSA"), 30, "SHA1withRSA")};
     Mockito.verify(defaultTrustManager, Mockito.times(0))
         .checkServerTrusted(certChain, "RSA");
     trustManager.checkServerTrusted(certChain, "RSA");
@@ -379,7 +388,7 @@ public class TestProxyCA {
   }
 
   @Test
-  public void testCreateTrustManagerExceptions() throws Exception {
+  void testCreateTrustManagerExceptions() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509TrustManager defaultTrustManager = Mockito.mock(X509TrustManager.class);
@@ -409,37 +418,37 @@ public class TestProxyCA {
   }
 
   @Test
-  public void testCreateKeyManager() throws Exception {
+  void testCreateKeyManager() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     X509KeyManager keyManager = proxyCA.getX509KeyManager();
 
-    Assert.assertArrayEquals(new String[]{"client"},
+    assertArrayEquals(new String[]{"client"},
         keyManager.getClientAliases(null, null));
-    Assert.assertEquals("client",
+    assertEquals("client",
         keyManager.chooseClientAlias(null, null, null));
-    Assert.assertNull(keyManager.getServerAliases(null, null));
-    Assert.assertNull(keyManager.chooseServerAlias(null, null, null));
+    assertNull(keyManager.getServerAliases(null, null));
+    assertNull(keyManager.chooseServerAlias(null, null, null));
 
     byte[] truststoreBytes = proxyCA.getChildTrustStore("password");
     KeyStore truststore = KeyStoreTestUtil.bytesToKeyStore(truststoreBytes,
         "password");
-    Assert.assertEquals(1, truststore.size());
+    assertEquals(1, truststore.size());
     X509Certificate caCert =
         (X509Certificate) truststore.getCertificate("client");
-    Assert.assertArrayEquals(new X509Certificate[]{caCert},
+    assertArrayEquals(new X509Certificate[]{caCert},
         keyManager.getCertificateChain(null));
-    Assert.assertEquals(proxyCA.getCaCert(), caCert);
+    assertEquals(proxyCA.getCaCert(), caCert);
 
     PrivateKey caPrivateKey = keyManager.getPrivateKey(null);
     PublicKey caPublicKey = caCert.getPublicKey();
     checkPrivatePublicKeys(caPrivateKey, caPublicKey);
-    Assert.assertEquals(proxyCA.getCaKeyPair().getPublic(), caPublicKey);
-    Assert.assertEquals(proxyCA.getCaKeyPair().getPrivate(), caPrivateKey);
+    assertEquals(proxyCA.getCaKeyPair().getPublic(), caPublicKey);
+    assertEquals(proxyCA.getCaKeyPair().getPrivate(), caPrivateKey);
   }
 
   @Test
-  public void testCreateHostnameVerifier() throws Exception {
+  void testCreateHostnameVerifier() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     HostnameVerifier verifier = proxyCA.getHostnameVerifier();
@@ -450,11 +459,11 @@ public class TestProxyCA {
             proxyCA.createChildKeyStore(
                 ApplicationId.newInstance(System.currentTimeMillis(), 1),
                 "password"), "password").getCertificateChain("server"));
-    Assert.assertTrue(verifier.verify("foo", sslSession));
+    assertTrue(verifier.verify("foo", sslSession));
   }
 
   @Test
-  public void testCreateHostnameVerifierSSLPeerUnverifiedException()
+  void testCreateHostnameVerifierSSLPeerUnverifiedException()
       throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
@@ -463,11 +472,11 @@ public class TestProxyCA {
     SSLSession sslSession = Mockito.mock(SSLSession.class);
     Mockito.when(sslSession.getPeerCertificates()).thenThrow(
         new SSLPeerUnverifiedException(""));
-    Assert.assertFalse(verifier.verify("foo", sslSession));
+    assertFalse(verifier.verify("foo", sslSession));
   }
 
   @Test
-  public void testCreateHostnameVerifierWrongRM() throws Exception {
+  void testCreateHostnameVerifierWrongRM() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     HostnameVerifier verifier = proxyCA.getHostnameVerifier();
@@ -480,11 +489,11 @@ public class TestProxyCA {
             proxyCA2.createChildKeyStore(
                 ApplicationId.newInstance(System.currentTimeMillis(), 1),
                 "password"), "password").getCertificateChain("server"));
-    Assert.assertFalse(verifier.verify("foo", sslSession));
+    assertFalse(verifier.verify("foo", sslSession));
   }
 
   @Test
-  public void testCreateHostnameVerifierExceptions() throws Exception {
+  void testCreateHostnameVerifierExceptions() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     HostnameVerifier verifier = proxyCA.getHostnameVerifier();
@@ -510,12 +519,12 @@ public class TestProxyCA {
               return certChain;
             }
           });
-      Assert.assertFalse(verifier.verify("foo", sslSession));
+      assertFalse(verifier.verify("foo", sslSession));
     }
   }
 
   @Test
-  public void testCreateHostnameVerifierRealCert() throws Exception {
+  void testCreateHostnameVerifierRealCert() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     HostnameVerifier verifier = proxyCA.getHostnameVerifier();
@@ -534,11 +543,11 @@ public class TestProxyCA {
             return certChain;
           }
         });
-    Assert.assertTrue(verifier.verify("foo.com", sslSession));
+    assertTrue(verifier.verify("foo.com", sslSession));
   }
 
   @Test
-  public void testCreateHostnameVerifierRealCertBad() throws Exception {
+  void testCreateHostnameVerifierRealCertBad() throws Exception {
     ProxyCA proxyCA = new ProxyCA();
     proxyCA.init();
     HostnameVerifier verifier = proxyCA.getHostnameVerifier();
@@ -557,27 +566,27 @@ public class TestProxyCA {
             return certChain;
           }
         });
-    Assert.assertFalse(verifier.verify("bar.com", sslSession));
+    assertFalse(verifier.verify("bar.com", sslSession));
   }
 
   private void checkCACert(X509Certificate caCert) {
-    Assert.assertEquals(caCert.getSubjectX500Principal().toString(),
+    assertEquals(caCert.getSubjectX500Principal().toString(),
         caCert.getIssuerDN().toString());
-    Assert.assertEquals(caCert.getSubjectX500Principal().toString(),
+    assertEquals(caCert.getSubjectX500Principal().toString(),
         caCert.getSubjectDN().toString());
-    Assert.assertTrue("Expected CA certificate X500 Principal to start with" +
-            " 'OU=YARN-', but did not: " + caCert.getSubjectX500Principal(),
-        caCert.getSubjectX500Principal().toString().startsWith("OU=YARN-"));
-    Assert.assertFalse("Found multiple fields in X500 Principal, when there " +
-            "should have only been one: " + caCert.getSubjectX500Principal(),
-        caCert.getSubjectX500Principal().toString().contains(","));
-    Assert.assertEquals("SHA512withRSA", caCert.getSigAlgName());
-    Assert.assertEquals(
+    assertTrue(caCert.getSubjectX500Principal().toString().startsWith("OU=YARN-"),
+        "Expected CA certificate X500 Principal to start with" +
+            " 'OU=YARN-', but did not: " + caCert.getSubjectX500Principal());
+    assertFalse(caCert.getSubjectX500Principal().toString().contains(","),
+        "Found multiple fields in X500 Principal, when there " +
+            "should have only been one: " + caCert.getSubjectX500Principal());
+    assertEquals("SHA512withRSA", caCert.getSigAlgName());
+    assertEquals(
         new GregorianCalendar(2037, Calendar.DECEMBER, 31).getTime(),
         caCert.getNotAfter());
-    Assert.assertTrue("Expected certificate to have started but was not: "
-        + caCert.getNotBefore(), caCert.getNotBefore().before(new Date()));
-    Assert.assertEquals(0, caCert.getBasicConstraints());
+    assertTrue(caCert.getNotBefore().before(new Date()),
+        "Expected certificate to have started but was not: " + caCert.getNotBefore());
+    assertEquals(0, caCert.getBasicConstraints());
   }
 
   private void checkPrivatePublicKeys(PrivateKey privateKey,
@@ -592,7 +601,7 @@ public class TestProxyCA {
     signer = Signature.getInstance("SHA512withRSA");
     signer.initVerify(publicKey);
     signer.update(data);
-    Assert.assertTrue(signer.verify(sig));
+    assertTrue(signer.verify(sig));
   }
 
   private X509Certificate[] castCertificateArrayToX509CertificateArray(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUriUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestProxyUriUtils.java
@@ -18,59 +18,64 @@
 
 package org.apache.hadoop.yarn.server.webproxy;
 
-import static org.junit.Assert.*;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.TrackingUriPlugin;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class TestProxyUriUtils {
   @Test
-  public void testGetPathApplicationId() {
-    assertEquals("/proxy/application_100_0001", 
+  void testGetPathApplicationId() {
+    assertEquals("/proxy/application_100_0001",
         ProxyUriUtils.getPath(BuilderUtils.newApplicationId(100l, 1)));
-    assertEquals("/proxy/application_6384623_0005", 
+    assertEquals("/proxy/application_6384623_0005",
         ProxyUriUtils.getPath(BuilderUtils.newApplicationId(6384623l, 5)));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetPathApplicationIdBad() {
-    ProxyUriUtils.getPath(null);
-  }
-  
   @Test
-  public void testGetPathApplicationIdString() {
-    assertEquals("/proxy/application_6384623_0005", 
+  void testGetPathApplicationIdBad() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      ProxyUriUtils.getPath(null);
+    });
+  }
+
+  @Test
+  void testGetPathApplicationIdString() {
+    assertEquals("/proxy/application_6384623_0005",
         ProxyUriUtils.getPath(BuilderUtils.newApplicationId(6384623l, 5), null));
     assertEquals("/proxy/application_6384623_0005/static/app",
         ProxyUriUtils.getPath(BuilderUtils.newApplicationId(6384623l, 5), "/static/app"));
-    assertEquals("/proxy/application_6384623_0005/", 
+    assertEquals("/proxy/application_6384623_0005/",
         ProxyUriUtils.getPath(BuilderUtils.newApplicationId(6384623l, 5), "/"));
-    assertEquals("/proxy/application_6384623_0005/some/path", 
+    assertEquals("/proxy/application_6384623_0005/some/path",
         ProxyUriUtils.getPath(BuilderUtils.newApplicationId(6384623l, 5), "some/path"));
   }
-  
-  @Test 
-  public void testGetPathAndQuery() {
+
+  @Test
+  void testGetPathAndQuery() {
     assertEquals("/proxy/application_6384623_0005/static/app?foo=bar",
-    ProxyUriUtils.getPathAndQuery(BuilderUtils.newApplicationId(6384623l, 5), "/static/app", 
-        "?foo=bar", false));
-    
+        ProxyUriUtils.getPathAndQuery(BuilderUtils.newApplicationId(6384623l, 5), "/static/app",
+            "?foo=bar", false));
+
     assertEquals("/proxy/application_6384623_0005/static/app?foo=bar&bad=good&proxyapproved=true",
-        ProxyUriUtils.getPathAndQuery(BuilderUtils.newApplicationId(6384623l, 5), "/static/app", 
+        ProxyUriUtils.getPathAndQuery(BuilderUtils.newApplicationId(6384623l, 5), "/static/app",
             "foo=bar&bad=good", true));
   }
 
   @Test
-  public void testGetProxyUri() throws Exception {
+  void testGetProxyUri() throws Exception {
     URI originalUri = new URI("http://host.com/static/foo?bar=bar");
     URI proxyUri = new URI("http://proxy.net:8080/");
     ApplicationId id = BuilderUtils.newApplicationId(6384623l, 5);
@@ -79,9 +84,9 @@ public class TestProxyUriUtils {
     assertEquals(expected, result);
   }
 
-  
+
   @Test
-  public void testGetProxyUriNull() throws Exception {
+  void testGetProxyUriNull() throws Exception {
     URI originalUri = null;
     URI proxyUri = new URI("http://proxy.net:8080/");
     ApplicationId id = BuilderUtils.newApplicationId(6384623l, 5);
@@ -91,7 +96,7 @@ public class TestProxyUriUtils {
   }
 
   @Test
-  public void testGetProxyUriFromPluginsReturnsNullIfNoPlugins()
+  void testGetProxyUriFromPluginsReturnsNullIfNoPlugins()
       throws URISyntaxException {
     ApplicationId id = BuilderUtils.newApplicationId(6384623l, 5);
     List<TrackingUriPlugin> list =
@@ -100,7 +105,7 @@ public class TestProxyUriUtils {
   }
 
   @Test
-  public void testGetProxyUriFromPluginsReturnsValidUriWhenAble()
+  void testGetProxyUriFromPluginsReturnsValidUriWhenAble()
       throws URISyntaxException {
     ApplicationId id = BuilderUtils.newApplicationId(6384623l, 5);
     List<TrackingUriPlugin> list =
@@ -119,6 +124,6 @@ public class TestProxyUriUtils {
     });
     URI result = ProxyUriUtils.getUriFromTrackingPlugins(id, list);
     assertNotNull(result);
-    
+
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServer.java
@@ -18,17 +18,17 @@
 
 package org.apache.hadoop.yarn.server.webproxy;
 
-import static org.junit.Assert.assertEquals;
+import java.net.InetSocketAddress;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.service.Service.STATE;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
-import java.net.InetSocketAddress;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestWebAppProxyServer {
   private WebAppProxyServer webAppProxy = null;
@@ -36,20 +36,20 @@ public class TestWebAppProxyServer {
   private final String proxyAddress = "localhost:" + port;
   private YarnConfiguration conf = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new YarnConfiguration();
     conf.set(YarnConfiguration.PROXY_ADDRESS, proxyAddress);
     webAppProxy = new WebAppProxyServer();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     webAppProxy.stop();
   }
 
   @Test
-  public void testStart() {
+  void testStart() {
     webAppProxy.init(conf);
     assertEquals(STATE.INITED, webAppProxy.getServiceState());
     webAppProxy.start();
@@ -62,7 +62,7 @@ public class TestWebAppProxyServer {
   }
 
   @Test
-  public void testStartWithBindHost() {
+  void testStartWithBindHost() {
     String bindHost = "0.0.0.0";
     conf.set(YarnConfiguration.PROXY_BIND_HOST, bindHost);
     webAppProxy.init(conf);
@@ -80,12 +80,12 @@ public class TestWebAppProxyServer {
 
 
   @Test
-  public void testBindAddress() {
+  void testBindAddress() {
     conf = new YarnConfiguration();
 
     InetSocketAddress defaultBindAddress = WebAppProxyServer.getBindAddress(conf);
-    Assert.assertEquals("Web Proxy default bind address port is incorrect",
-        YarnConfiguration.DEFAULT_PROXY_PORT,
-        defaultBindAddress.getPort());
+    assertEquals(YarnConfiguration.DEFAULT_PROXY_PORT,
+        defaultBindAddress.getPort(),
+        "Web Proxy default bind address port is incorrect");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilter.java
@@ -22,44 +22,45 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Enumeration;
 import java.util.Collections;
-import java.util.Map;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.servlet.FilterConfig;
-import javax.servlet.FilterChain;
+import java.util.function.Supplier;
 import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
-import javax.servlet.ServletResponse;
-import javax.servlet.ServletRequest;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.function.Supplier;
-import org.apache.hadoop.http.TestHttpServer;
-import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.yarn.server.webproxy.ProxyUtils;
-import org.apache.hadoop.yarn.server.webproxy.WebAppProxyServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.glassfish.grizzly.servlet.HttpServletResponseImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
+
+import org.apache.hadoop.http.TestHttpServer;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.yarn.server.webproxy.ProxyUtils;
+import org.apache.hadoop.yarn.server.webproxy.WebAppProxyServlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test AmIpFilter. Requests to a no declared hosts should has way through
@@ -114,9 +115,10 @@ public class TestAmFilter {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   @SuppressWarnings("deprecation")
-  public void filterNullCookies() throws Exception {
+  void filterNullCookies() throws Exception {
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
     Mockito.when(request.getCookies()).thenReturn(null);
@@ -145,7 +147,7 @@ public class TestAmFilter {
   }
 
   @Test
-  public void testFindRedirectUrl() throws Exception {
+  void testFindRedirectUrl() throws Exception {
     final String rm1 = "rm1";
     final String rm2 = "rm2";
     // generate a valid URL
@@ -159,7 +161,7 @@ public class TestAmFilter {
     spy.proxyUriBases = new HashMap<>();
     spy.proxyUriBases.put(rm1, rm1Url);
     spy.proxyUriBases.put(rm2, rm2Url);
-    spy.rmUrls = new String[] { rm1, rm2 };
+    spy.rmUrls = new String[]{rm1, rm2};
 
     assertThat(spy.findRedirectUrl()).isEqualTo(rm1Url);
   }
@@ -179,8 +181,9 @@ public class TestAmFilter {
     return server.getURI().toString() + servletPath;
   }
 
-  @Test(timeout = 2000)
-  public void testProxyUpdate() throws Exception {
+  @Test
+  @Timeout(2000)
+  void testProxyUpdate() throws Exception {
     Map<String, String> params = new HashMap<>();
     params.put(AmIpFilter.PROXY_HOSTS, proxyHost);
     params.put(AmIpFilter.PROXY_URI_BASES, proxyUri);
@@ -220,9 +223,10 @@ public class TestAmFilter {
   /**
    * Test AmIpFilter
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10000)
   @SuppressWarnings("deprecation")
-  public void testFilter() throws Exception {
+  void testFilter() throws Exception {
     Map<String, String> params = new HashMap<String, String>();
     params.put(AmIpFilter.PROXY_HOST, proxyHost);
     params.put(AmIpFilter.PROXY_URI_BASE, proxyUri);
@@ -286,7 +290,7 @@ public class TestAmFilter {
     assertTrue(doFilterRequest.contains("HttpServletRequest"));
 
     // cookie added
-    Cookie[] cookies = new Cookie[] {
+    Cookie[] cookies = new Cookie[]{
         new Cookie(WebAppProxyServlet.PROXY_USER_COOKIE_NAME, "user")
     };
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilterInitializer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilterInitializer.java
@@ -22,9 +22,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.FilterContainer;
 import org.apache.hadoop.http.HttpConfig;
@@ -32,12 +33,15 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 /**
  * Test class for {@Link AmFilterInitializer}.
  */
 public class TestAmFilterInitializer {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     NetUtils.addStaticResolution("host1", "172.0.0.1");
     NetUtils.addStaticResolution("host2", "172.0.0.1");
@@ -48,7 +52,7 @@ public class TestAmFilterInitializer {
   }
 
   @Test
-  public void testInitFilter() {
+  void testInitFilter() {
     // Check PROXY_ADDRESS
     MockFilterContainer con = new MockFilterContainer();
     Configuration conf = new Configuration(false);
@@ -60,7 +64,7 @@ public class TestAmFilterInitializer {
     assertEquals("host1", con.givenParameters.get(AmIpFilter.PROXY_HOSTS));
     assertEquals("http://host1:1000/foo",
         con.givenParameters.get(AmIpFilter.PROXY_URI_BASES));
-    assertEquals(null, con.givenParameters.get(AmFilterInitializer.RM_HA_URLS));
+    assertNull(con.givenParameters.get(AmFilterInitializer.RM_HA_URLS));
 
     // Check a single RM_WEBAPP_ADDRESS
     con = new MockFilterContainer();
@@ -73,7 +77,7 @@ public class TestAmFilterInitializer {
     assertEquals("host2", con.givenParameters.get(AmIpFilter.PROXY_HOSTS));
     assertEquals("http://host2:2000/foo",
         con.givenParameters.get(AmIpFilter.PROXY_URI_BASES));
-    assertEquals(null, con.givenParameters.get(AmFilterInitializer.RM_HA_URLS));
+    assertNull(con.givenParameters.get(AmFilterInitializer.RM_HA_URLS));
 
     // Check multiple RM_WEBAPP_ADDRESSes (RM HA)
     con = new MockFilterContainer();
@@ -134,7 +138,7 @@ public class TestAmFilterInitializer {
   }
 
   @Test
-  public void testGetProxyHostsAndPortsForAmFilter() {
+  void testGetProxyHostsAndPortsForAmFilter() {
 
     // Check no configs given
     Configuration conf = new Configuration(false);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestSecureAmFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestSecureAmFilter.java
@@ -21,28 +21,29 @@ package org.apache.hadoop.yarn.server.webproxy.amfilter;
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
-import java.util.Set;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.AuthenticationFilterInitializer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.KerberosTestUtils;
-import org.apache.hadoop.security.AuthenticationFilterInitializer;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test AmIpFilter. Requests to a no declared hosts should has way through
@@ -63,7 +64,7 @@ public class TestSecureAmFilter {
   private static boolean miniKDCStarted = false;
   private static MiniKdc testMiniKDC;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     rmconf.setBoolean(YarnConfiguration.YARN_ACL_ENABLE, true);
     rmconf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
@@ -88,11 +89,11 @@ public class TestSecureAmFilter {
       testMiniKDC = new MiniKdc(MiniKdc.createConf(), TEST_ROOT_DIR);
       setupKDC();
     } catch (Exception e) {
-      assertTrue("Couldn't create MiniKDC", false);
+      assertTrue(false, "Couldn't create MiniKDC");
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (testMiniKDC != null) {
       testMiniKDC.stop();
@@ -125,7 +126,7 @@ public class TestSecureAmFilter {
   }
 
   @Test
-  public void testFindRedirectUrl() throws Exception {
+  void testFindRedirectUrl() throws Exception {
     final String rm1 = "rm1";
     final String rm2 = "rm2";
     // generate a valid URL
@@ -139,7 +140,7 @@ public class TestSecureAmFilter {
     spy.proxyUriBases = new HashMap<>();
     spy.proxyUriBases.put(rm1, rm1Url);
     spy.proxyUriBases.put(rm2, rm2Url);
-    spy.rmUrls = new String[] {rm1, rm2};
+    spy.rmUrls = new String[]{rm1, rm2};
 
     assertTrue(spy.isValidUrl(rm1Url));
     assertFalse(spy.isValidUrl(rm2Url));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestSecureAmFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestSecureAmFilter.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test AmIpFilter. Requests to a no declared hosts should has way through
@@ -89,7 +90,7 @@ public class TestSecureAmFilter {
       testMiniKDC = new MiniKdc(MiniKdc.createConf(), TEST_ROOT_DIR);
       setupKDC();
     } catch (Exception e) {
-      assertTrue(false, "Couldn't create MiniKDC");
+      fail("Couldn't create MiniKDC");
     }
   }
 


### PR DESCRIPTION
### Description of PR

Upgrade JUnit from 4 to 5 in hadoop-yarn-server-web-proxy

JIRA - YARN-11261

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

