### PR TITLE
YARN-11245. Upgrade JUnit from 4 to 5 in hadoop-yarn-csi

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -92,6 +92,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <type>test-jar</type>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestCsiAdaptorService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestCsiAdaptorService.java
@@ -42,10 +42,9 @@ import org.apache.hadoop.yarn.client.NMProxy;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.ipc.YarnRPC;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,6 +52,9 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.yarn.api.protocolrecords.ValidateVolumeCapabilitiesRequest.AccessMode.MULTI_NODE_MULTI_WRITER;
 import static org.apache.hadoop.yarn.api.protocolrecords.ValidateVolumeCapabilitiesRequest.VolumeType.FILE_SYSTEM;
 
@@ -64,7 +66,7 @@ public class TestCsiAdaptorService {
   private static File testRoot = null;
   private static String domainSocket = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws IOException {
     testRoot = GenericTestUtils.getTestDir("csi-test");
     File socketPath = new File(testRoot, "csi.sock");
@@ -72,7 +74,7 @@ public class TestCsiAdaptorService {
     domainSocket = "unix://" + socketPath.getAbsolutePath();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException {
     if (testRoot != null) {
       FileUtils.deleteDirectory(testRoot);
@@ -113,7 +115,7 @@ public class TestCsiAdaptorService {
   }
 
   @Test
-  public void testValidateVolume() throws IOException, YarnException {
+  void testValidateVolume() throws IOException, YarnException {
     ServerSocket ss = new ServerSocket(0);
     ss.close();
     InetSocketAddress address = new InetSocketAddress(ss.getLocalPort());
@@ -145,20 +147,20 @@ public class TestCsiAdaptorService {
           ValidateVolumeCapabilitiesRequest request) throws YarnException,
           IOException {
         // validate we get all info from the request
-        Assert.assertEquals("volume-id-0000123", request.getVolumeId());
-        Assert.assertEquals(1, request.getVolumeCapabilities().size());
-        Assert.assertEquals(Csi.VolumeCapability.AccessMode
+        assertEquals("volume-id-0000123", request.getVolumeId());
+        assertEquals(1, request.getVolumeCapabilities().size());
+        assertEquals(Csi.VolumeCapability.AccessMode
                 .newBuilder().setModeValue(5).build().getMode().name(),
             request.getVolumeCapabilities().get(0).getAccessMode().name());
-        Assert.assertEquals(2, request.getVolumeCapabilities().get(0)
+        assertEquals(2, request.getVolumeCapabilities().get(0)
             .getMountFlags().size());
-        Assert.assertTrue(request.getVolumeCapabilities().get(0)
+        assertTrue(request.getVolumeCapabilities().get(0)
             .getMountFlags().contains("mountFlag1"));
-        Assert.assertTrue(request.getVolumeCapabilities().get(0)
+        assertTrue(request.getVolumeCapabilities().get(0)
             .getMountFlags().contains("mountFlag2"));
-        Assert.assertEquals(2, request.getVolumeAttributes().size());
-        Assert.assertEquals("v1", request.getVolumeAttributes().get("k1"));
-        Assert.assertEquals("v2", request.getVolumeAttributes().get("k2"));
+        assertEquals(2, request.getVolumeAttributes().size());
+        assertEquals("v1", request.getVolumeAttributes().get("k1"));
+        assertEquals("v2", request.getVolumeAttributes().get("k2"));
         // return a fake result
         return ValidateVolumeCapabilitiesResponse
             .newInstance(false, "this is a test");
@@ -178,22 +180,22 @@ public class TestCsiAdaptorService {
                   ImmutableList.of(
                       new ValidateVolumeCapabilitiesRequest
                           .VolumeCapability(
-                              MULTI_NODE_MULTI_WRITER, FILE_SYSTEM,
+                          MULTI_NODE_MULTI_WRITER, FILE_SYSTEM,
                           ImmutableList.of("mountFlag1", "mountFlag2"))),
-              ImmutableMap.of("k1", "v1", "k2", "v2"));
+                  ImmutableMap.of("k1", "v1", "k2", "v2"));
 
       ValidateVolumeCapabilitiesResponse response = client
           .validateVolumeCapacity(request);
 
-      Assert.assertEquals(false, response.isSupported());
-      Assert.assertEquals("this is a test", response.getResponseMessage());
+      assertEquals(false, response.isSupported());
+      assertEquals("this is a test", response.getResponseMessage());
     } finally {
       service.stop();
     }
   }
 
   @Test
-  public void testValidateVolumeWithNMProxy() throws Exception {
+  void testValidateVolumeWithNMProxy() throws Exception {
     ServerSocket ss = new ServerSocket(0);
     ss.close();
     InetSocketAddress address = new InetSocketAddress(ss.getLocalPort());
@@ -225,21 +227,21 @@ public class TestCsiAdaptorService {
           ValidateVolumeCapabilitiesRequest request)
           throws YarnException, IOException {
         // validate we get all info from the request
-        Assert.assertEquals("volume-id-0000123", request.getVolumeId());
-        Assert.assertEquals(1, request.getVolumeCapabilities().size());
-        Assert.assertEquals(
+        assertEquals("volume-id-0000123", request.getVolumeId());
+        assertEquals(1, request.getVolumeCapabilities().size());
+        assertEquals(
             Csi.VolumeCapability.AccessMode.newBuilder().setModeValue(5)
                 .build().getMode().name(),
             request.getVolumeCapabilities().get(0).getAccessMode().name());
-        Assert.assertEquals(2,
+        assertEquals(2,
             request.getVolumeCapabilities().get(0).getMountFlags().size());
-        Assert.assertTrue(request.getVolumeCapabilities().get(0).getMountFlags()
+        assertTrue(request.getVolumeCapabilities().get(0).getMountFlags()
             .contains("mountFlag1"));
-        Assert.assertTrue(request.getVolumeCapabilities().get(0).getMountFlags()
+        assertTrue(request.getVolumeCapabilities().get(0).getMountFlags()
             .contains("mountFlag2"));
-        Assert.assertEquals(2, request.getVolumeAttributes().size());
-        Assert.assertEquals("v1", request.getVolumeAttributes().get("k1"));
-        Assert.assertEquals("v2", request.getVolumeAttributes().get("k2"));
+        assertEquals(2, request.getVolumeAttributes().size());
+        assertEquals("v1", request.getVolumeAttributes().get("k1"));
+        assertEquals("v2", request.getVolumeAttributes().get("k2"));
         // return a fake result
         return ValidateVolumeCapabilitiesResponse
             .newInstance(false, "this is a test");
@@ -261,50 +263,59 @@ public class TestCsiAdaptorService {
             .newInstance("volume-id-0000123",
                 ImmutableList.of(new ValidateVolumeCapabilitiesRequest
                     .VolumeCapability(
-                        MULTI_NODE_MULTI_WRITER, FILE_SYSTEM,
+                    MULTI_NODE_MULTI_WRITER, FILE_SYSTEM,
                     ImmutableList.of("mountFlag1", "mountFlag2"))),
                 ImmutableMap.of("k1", "v1", "k2", "v2"));
 
     ValidateVolumeCapabilitiesResponse response = adaptorClient
         .validateVolumeCapacity(request);
-    Assert.assertEquals(false, response.isSupported());
-    Assert.assertEquals("this is a test", response.getResponseMessage());
+    assertEquals(false, response.isSupported());
+    assertEquals("this is a test", response.getResponseMessage());
 
     service.stop();
   }
 
-  @Test (expected = ServiceStateException.class)
-  public void testMissingConfiguration() {
-    Configuration conf = new Configuration();
-    CsiAdaptorProtocolService service =
-        new CsiAdaptorProtocolService(new FakeCsiAdaptor() {});
-    service.init(conf);
-  }
-
-  @Test (expected = ServiceStateException.class)
-  public void testInvalidServicePort() {
-    Configuration conf = new Configuration();
-    conf.set(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
-        + "test-driver-0001.address",
-        "0.0.0.0:-100"); // this is an invalid address
-    CsiAdaptorProtocolService service =
-        new CsiAdaptorProtocolService(new FakeCsiAdaptor() {});
-    service.init(conf);
-  }
-
-  @Test (expected = ServiceStateException.class)
-  public void testInvalidHost() {
-    Configuration conf = new Configuration();
-    conf.set(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
-            + "test-driver-0001.address",
-        "192.0.1:8999"); // this is an invalid ip address
-    CsiAdaptorProtocolService service =
-        new CsiAdaptorProtocolService(new FakeCsiAdaptor() {});
-    service.init(conf);
+  @Test
+  void testMissingConfiguration() {
+    assertThrows(ServiceStateException.class, () -> {
+      Configuration conf = new Configuration();
+      CsiAdaptorProtocolService service =
+          new CsiAdaptorProtocolService(new FakeCsiAdaptor() {
+          });
+      service.init(conf);
+    });
   }
 
   @Test
-  public void testCustomizedAdaptor() throws IOException, YarnException {
+  void testInvalidServicePort() {
+    assertThrows(ServiceStateException.class, () -> {
+      Configuration conf = new Configuration();
+      conf.set(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
+          + "test-driver-0001.address",
+          "0.0.0.0:-100"); // this is an invalid address
+      CsiAdaptorProtocolService service =
+          new CsiAdaptorProtocolService(new FakeCsiAdaptor() {
+          });
+      service.init(conf);
+    });
+  }
+
+  @Test
+  void testInvalidHost() {
+    assertThrows(ServiceStateException.class, () -> {
+      Configuration conf = new Configuration();
+      conf.set(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
+          + "test-driver-0001.address",
+          "192.0.1:8999"); // this is an invalid ip address
+      CsiAdaptorProtocolService service =
+          new CsiAdaptorProtocolService(new FakeCsiAdaptor() {
+          });
+      service.init(conf);
+    });
+  }
+
+  @Test
+  void testCustomizedAdaptor() throws IOException, YarnException {
     ServerSocket ss = new ServerSocket(0);
     ss.close();
     InetSocketAddress address = new InetSocketAddress(ss.getLocalPort());
@@ -349,15 +360,15 @@ public class TestCsiAdaptorService {
 
     ValidateVolumeCapabilitiesResponse response = adaptorClient
         .validateVolumeCapacity(request);
-    Assert.assertEquals(true, response.isSupported());
-    Assert.assertEquals("verified via MockCsiAdaptor",
+    assertEquals(true, response.isSupported());
+    assertEquals("verified via MockCsiAdaptor",
         response.getResponseMessage());
 
     services.stop();
   }
 
   @Test
-  public void testMultipleCsiAdaptors() throws IOException, YarnException {
+  void testMultipleCsiAdaptors() throws IOException, YarnException {
     ServerSocket driver1Addr = new ServerSocket(0);
     ServerSocket driver2Addr = new ServerSocket(0);
 
@@ -374,22 +385,22 @@ public class TestCsiAdaptorService {
 
     // customized-driver-1
     conf.setSocketAddr(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
-            + "customized-driver-1.address", address1);
+        + "customized-driver-1.address", address1);
     conf.set(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
-            + "customized-driver-1.class",
+        + "customized-driver-1.class",
         "org.apache.hadoop.yarn.csi.adaptor.MockCsiAdaptor");
     conf.set(YarnConfiguration.NM_CSI_DRIVER_PREFIX
-            + "customized-driver-1.endpoint",
+        + "customized-driver-1.endpoint",
         "unix:///tmp/customized-driver-1.sock");
 
     // customized-driver-2
     conf.setSocketAddr(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
         + "customized-driver-2.address", address2);
     conf.set(YarnConfiguration.NM_CSI_ADAPTOR_PREFIX
-            + "customized-driver-2.class",
+        + "customized-driver-2.class",
         "org.apache.hadoop.yarn.csi.adaptor.MockCsiAdaptor");
     conf.set(YarnConfiguration.NM_CSI_DRIVER_PREFIX
-            + "customized-driver-2.endpoint",
+        + "customized-driver-2.endpoint",
         "unix:///tmp/customized-driver-2.sock");
 
     driver1Addr.close();
@@ -427,8 +438,8 @@ public class TestCsiAdaptorService {
 
     ValidateVolumeCapabilitiesResponse response = client1
         .validateVolumeCapacity(request);
-    Assert.assertEquals(true, response.isSupported());
-    Assert.assertEquals("verified via MockCsiAdaptor",
+    assertEquals(true, response.isSupported());
+    assertEquals("verified via MockCsiAdaptor",
         response.getResponseMessage());
 
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestGetPluginInfoRequestResponse.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestGetPluginInfoRequestResponse.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.yarn.api.protocolrecords.GetPluginInfoResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetPluginInfoRequestPBImpl;
 import org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetPluginInfoResponsePBImpl;
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Verify the integrity of GetPluginInfoRequest and GetPluginInfoResponse.
@@ -30,37 +32,37 @@ import org.junit.Test;
 public class TestGetPluginInfoRequestResponse {
 
   @Test
-  public void testGetPluginInfoRequestPBRecord() {
+  void testGetPluginInfoRequestPBRecord() {
     CsiAdaptorProtos.GetPluginInfoRequest requestProto =
         CsiAdaptorProtos.GetPluginInfoRequest.newBuilder().build();
     GetPluginInfoRequestPBImpl pbImpl =
         new GetPluginInfoRequestPBImpl(requestProto);
-    Assert.assertNotNull(pbImpl);
-    Assert.assertEquals(requestProto, pbImpl.getProto());
+    assertNotNull(pbImpl);
+    assertEquals(requestProto, pbImpl.getProto());
   }
 
   @Test
-  public void testGetPluginInfoResponsePBRecord() {
+  void testGetPluginInfoResponsePBRecord() {
     CsiAdaptorProtos.GetPluginInfoResponse responseProto =
         CsiAdaptorProtos.GetPluginInfoResponse.newBuilder()
-        .setName("test-driver")
-        .setVendorVersion("1.0.1")
-        .build();
+            .setName("test-driver")
+            .setVendorVersion("1.0.1")
+            .build();
 
     GetPluginInfoResponsePBImpl pbImpl =
         new GetPluginInfoResponsePBImpl(responseProto);
-    Assert.assertEquals("test-driver", pbImpl.getDriverName());
-    Assert.assertEquals("1.0.1", pbImpl.getVersion());
-    Assert.assertEquals(responseProto, pbImpl.getProto());
+    assertEquals("test-driver", pbImpl.getDriverName());
+    assertEquals("1.0.1", pbImpl.getVersion());
+    assertEquals(responseProto, pbImpl.getProto());
 
     GetPluginInfoResponse pbImpl2 = GetPluginInfoResponsePBImpl
         .newInstance("test-driver", "1.0.1");
-    Assert.assertEquals("test-driver", pbImpl2.getDriverName());
-    Assert.assertEquals("1.0.1", pbImpl2.getVersion());
+    assertEquals("test-driver", pbImpl2.getDriverName());
+    assertEquals("1.0.1", pbImpl2.getVersion());
 
     CsiAdaptorProtos.GetPluginInfoResponse proto =
         ((GetPluginInfoResponsePBImpl) pbImpl2).getProto();
-    Assert.assertEquals("test-driver", proto.getName());
-    Assert.assertEquals("1.0.1", proto.getVendorVersion());
+    assertEquals("test-driver", proto.getName());
+    assertEquals("1.0.1", proto.getVendorVersion());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestNodePublishVolumeRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestNodePublishVolumeRequest.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.yarn.api.protocolrecords.impl.pb.NodePublishVolumeReque
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos;
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos.VolumeCapability.AccessMode;
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos.VolumeCapability.VolumeType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * UT for NodePublishVolumeRequest.
@@ -30,7 +32,7 @@ import org.junit.Test;
 public class TestNodePublishVolumeRequest {
 
   @Test
-  public void testPBRecord() {
+  void testPBRecord() {
     CsiAdaptorProtos.VolumeCapability capability =
         CsiAdaptorProtos.VolumeCapability.newBuilder()
             .setAccessMode(AccessMode.MULTI_NODE_READER_ONLY)
@@ -47,9 +49,9 @@ public class TestNodePublishVolumeRequest {
 
     NodePublishVolumeRequestPBImpl pbImpl =
         new NodePublishVolumeRequestPBImpl(proto);
-    Assert.assertEquals("test-vol-000001", pbImpl.getVolumeId());
-    Assert.assertEquals("/mnt/data", pbImpl.getTargetPath());
-    Assert.assertEquals("/mnt/staging", pbImpl.getStagingPath());
-    Assert.assertFalse(pbImpl.getReadOnly());
+    assertEquals("test-vol-000001", pbImpl.getVolumeId());
+    assertEquals("/mnt/data", pbImpl.getTargetPath());
+    assertEquals("/mnt/staging", pbImpl.getStagingPath());
+    assertFalse(pbImpl.getReadOnly());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestValidateVolumeCapabilityRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestValidateVolumeCapabilityRequest.java
@@ -26,11 +26,11 @@ import org.apache.hadoop.yarn.proto.CsiAdaptorProtos;
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos.VolumeCapability.AccessMode;
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos.VolumeCapability.VolumeType;
 import org.apache.hadoop.yarn.proto.YarnProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.yarn.api.protocolrecords.ValidateVolumeCapabilitiesRequest.AccessMode.MULTI_NODE_MULTI_WRITER;
 import static org.apache.hadoop.yarn.api.protocolrecords.ValidateVolumeCapabilitiesRequest.VolumeType.FILE_SYSTEM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * UT for message exchanges.
@@ -38,7 +38,7 @@ import static org.apache.hadoop.yarn.api.protocolrecords.ValidateVolumeCapabilit
 public class TestValidateVolumeCapabilityRequest {
 
   @Test
-  public void testPBRecord() {
+  void testPBRecord() {
     CsiAdaptorProtos.VolumeCapability vcProto =
         CsiAdaptorProtos.VolumeCapability.newBuilder()
             .setAccessMode(AccessMode.MULTI_NODE_MULTI_WRITER)
@@ -64,22 +64,22 @@ public class TestValidateVolumeCapabilityRequest {
     ValidateVolumeCapabilitiesRequestPBImpl request =
         new ValidateVolumeCapabilitiesRequestPBImpl(requestProto);
 
-    Assert.assertEquals("volume-id-0000001", request.getVolumeId());
-    Assert.assertEquals(2, request.getVolumeAttributes().size());
-    Assert.assertEquals("value0", request.getVolumeAttributes().get("attr0"));
-    Assert.assertEquals("value1", request.getVolumeAttributes().get("attr1"));
-    Assert.assertEquals(1, request.getVolumeCapabilities().size());
+    assertEquals("volume-id-0000001", request.getVolumeId());
+    assertEquals(2, request.getVolumeAttributes().size());
+    assertEquals("value0", request.getVolumeAttributes().get("attr0"));
+    assertEquals("value1", request.getVolumeAttributes().get("attr1"));
+    assertEquals(1, request.getVolumeCapabilities().size());
     VolumeCapability vc =
         request.getVolumeCapabilities().get(0);
-    Assert.assertEquals(MULTI_NODE_MULTI_WRITER, vc.getAccessMode());
-    Assert.assertEquals(FILE_SYSTEM, vc.getVolumeType());
-    Assert.assertEquals(2, vc.getMountFlags().size());
+    assertEquals(MULTI_NODE_MULTI_WRITER, vc.getAccessMode());
+    assertEquals(FILE_SYSTEM, vc.getVolumeType());
+    assertEquals(2, vc.getMountFlags().size());
 
-    Assert.assertEquals(requestProto, request.getProto());
+    assertEquals(requestProto, request.getProto());
   }
 
   @Test
-  public void testNewInstance() {
+  void testNewInstance() {
     ValidateVolumeCapabilitiesRequest pbImpl =
         ValidateVolumeCapabilitiesRequestPBImpl
             .newInstance("volume-id-0000123",
@@ -89,25 +89,25 @@ public class TestValidateVolumeCapabilityRequest {
                         ImmutableList.of("mountFlag1", "mountFlag2"))),
                 ImmutableMap.of("k1", "v1", "k2", "v2"));
 
-    Assert.assertEquals("volume-id-0000123", pbImpl.getVolumeId());
-    Assert.assertEquals(1, pbImpl.getVolumeCapabilities().size());
-    Assert.assertEquals(FILE_SYSTEM,
+    assertEquals("volume-id-0000123", pbImpl.getVolumeId());
+    assertEquals(1, pbImpl.getVolumeCapabilities().size());
+    assertEquals(FILE_SYSTEM,
         pbImpl.getVolumeCapabilities().get(0).getVolumeType());
-    Assert.assertEquals(MULTI_NODE_MULTI_WRITER,
+    assertEquals(MULTI_NODE_MULTI_WRITER,
         pbImpl.getVolumeCapabilities().get(0).getAccessMode());
-    Assert.assertEquals(2, pbImpl.getVolumeAttributes().size());
+    assertEquals(2, pbImpl.getVolumeAttributes().size());
 
     CsiAdaptorProtos.ValidateVolumeCapabilitiesRequest proto =
         ((ValidateVolumeCapabilitiesRequestPBImpl) pbImpl).getProto();
-    Assert.assertEquals("volume-id-0000123", proto.getVolumeId());
-    Assert.assertEquals(1, proto.getVolumeCapabilitiesCount());
-    Assert.assertEquals(AccessMode.MULTI_NODE_MULTI_WRITER,
+    assertEquals("volume-id-0000123", proto.getVolumeId());
+    assertEquals(1, proto.getVolumeCapabilitiesCount());
+    assertEquals(AccessMode.MULTI_NODE_MULTI_WRITER,
         proto.getVolumeCapabilities(0).getAccessMode());
-    Assert.assertEquals(VolumeType.FILE_SYSTEM,
+    assertEquals(VolumeType.FILE_SYSTEM,
         proto.getVolumeCapabilities(0).getVolumeType());
-    Assert.assertEquals(2, proto.getVolumeCapabilities(0)
+    assertEquals(2, proto.getVolumeCapabilities(0)
         .getMountFlagsCount());
-    Assert.assertEquals(2, proto.getVolumeCapabilities(0)
+    assertEquals(2, proto.getVolumeCapabilities(0)
         .getMountFlagsList().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestValidateVolumeCapabilityResponse.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/adaptor/TestValidateVolumeCapabilityResponse.java
@@ -20,8 +20,9 @@ package org.apache.hadoop.yarn.csi.adaptor;
 import org.apache.hadoop.yarn.api.protocolrecords.ValidateVolumeCapabilitiesResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.impl.pb.ValidateVolumeCapabilitiesResponsePBImpl;
 import org.apache.hadoop.yarn.proto.CsiAdaptorProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * UT for message exchanges.
@@ -29,33 +30,33 @@ import org.junit.Test;
 public class TestValidateVolumeCapabilityResponse {
 
   @Test
-  public void testPBRecord() {
+  void testPBRecord() {
     CsiAdaptorProtos.ValidateVolumeCapabilitiesResponse proto =
         CsiAdaptorProtos.ValidateVolumeCapabilitiesResponse.newBuilder()
-        .setSupported(true)
-        .setMessage("capability is supported")
-        .build();
+            .setSupported(true)
+            .setMessage("capability is supported")
+            .build();
 
     ValidateVolumeCapabilitiesResponsePBImpl pbImpl =
         new ValidateVolumeCapabilitiesResponsePBImpl(proto);
 
-    Assert.assertEquals(true, pbImpl.isSupported());
-    Assert.assertEquals("capability is supported", pbImpl.getResponseMessage());
-    Assert.assertEquals(proto, pbImpl.getProto());
+    assertEquals(true, pbImpl.isSupported());
+    assertEquals("capability is supported", pbImpl.getResponseMessage());
+    assertEquals(proto, pbImpl.getProto());
   }
 
   @Test
-  public void testNewInstance() {
+  void testNewInstance() {
     ValidateVolumeCapabilitiesResponse pbImpl =
         ValidateVolumeCapabilitiesResponsePBImpl
             .newInstance(false, "capability not supported");
-    Assert.assertEquals(false, pbImpl.isSupported());
-    Assert.assertEquals("capability not supported",
+    assertEquals(false, pbImpl.isSupported());
+    assertEquals("capability not supported",
         pbImpl.getResponseMessage());
 
     CsiAdaptorProtos.ValidateVolumeCapabilitiesResponse proto =
         ((ValidateVolumeCapabilitiesResponsePBImpl) pbImpl).getProto();
-    Assert.assertEquals(false, proto.getSupported());
-    Assert.assertEquals("capability not supported", proto.getMessage());
+    assertEquals(false, proto.getSupported());
+    assertEquals("capability not supported", proto.getMessage());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/src/test/java/org/apache/hadoop/yarn/csi/client/TestCsiClient.java
@@ -20,18 +20,19 @@ package org.apache.hadoop.yarn.csi.client;
 
 import csi.v0.Csi;
 import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class for CSI client.
@@ -42,7 +43,7 @@ public class TestCsiClient {
   private static String domainSocket = null;
   private static FakeCsiDriver driver = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws IOException {
     // Use /tmp to fix bind failure caused by the long file name
     File tmpDir = new File(System.getProperty("java.io.tmpdir"));
@@ -55,27 +56,27 @@ public class TestCsiClient {
     driver = new FakeCsiDriver(domainSocket);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException {
     if (testRoot != null) {
       FileUtils.deleteDirectory(testRoot);
     }
   }
 
-  @Before
+  @BeforeEach
   public void beforeMethod() {
     // Skip tests on non-linux systems
     String osName = System.getProperty("os.name").toLowerCase();
-    Assume.assumeTrue(osName.contains("nix") || osName.contains("nux"));
+    Assumptions.assumeTrue(osName.contains("nix") || osName.contains("nux"));
   }
 
   @Test
-  public void testIdentityService() throws IOException {
+  void testIdentityService() throws IOException {
     try {
       driver.start();
       CsiClient client = new CsiClientImpl(domainSocket);
       Csi.GetPluginInfoResponse response = client.getPluginInfo();
-      Assert.assertEquals("fake-csi-identity-service", response.getName());
+      assertEquals("fake-csi-identity-service", response.getName());
     } finally {
       driver.stop();
     }


### PR DESCRIPTION
### Description of PR

Upgrade JUnit from 4 to 5 in hadoop-yarn-csi

JIRA - YARN-11245

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

