### PR TITLE
HDFS-16736. Link to Boost library in libhdfspp

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
@@ -28,7 +28,7 @@ project (libhdfspp)
 
 cmake_minimum_required(VERSION 2.8)
 
-find_package (Boost 1.72.0 REQUIRED)
+find_package (Boost 1.72.0 REQUIRED COMPONENTS date_time)
 
 enable_testing()
 set(CMAKE_CXX_STANDARD 17)
@@ -283,7 +283,7 @@ if (HADOOP_BUILD AND NOT MSVC)
     ${OPENSSL_LIBRARIES}
     ${SASL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
-  )
+    ${Boost_LIBRARIES})
   set_target_properties(hdfspp PROPERTIES SOVERSION ${LIBHDFSPP_VERSION})
   hadoop_dual_output_directory(hdfspp ${OUT_DIR})
 else (HADOOP_BUILD AND NOT MSVC)
@@ -293,7 +293,8 @@ else (HADOOP_BUILD AND NOT MSVC)
     ${PROTOBUF_LIBRARY}
     ${OPENSSL_LIBRARIES}
     ${SASL_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT})
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${Boost_LIBRARIES})
   if(BUILD_SHARED_HDFSPP)
     add_library(hdfspp SHARED ${EMPTY_FILE_CC} ${LIBHDFSPP_ALL_OBJECTS})
     set_target_properties(hdfspp PROPERTIES SOVERSION ${LIBHDFSPP_VERSION})

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/CMakeLists.txt
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+find_package (Boost 1.72.0 REQUIRED)
+
 if(NEED_LINK_DL)
    set(LIB_DL dl)
 endif()

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/common/CMakeLists.txt
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-find_package (Boost 1.72.0 REQUIRED)
-
 if(NEED_LINK_DL)
    set(LIB_DL dl)
 endif()

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/CMakeLists.txt
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-find_package(Boost 1.72.0 REQUIRED COMPONENTS date_time)
-
 list(APPEND rpc_object_items $<TARGET_OBJECTS:x_platform_obj> rpc_connection_impl.cc rpc_engine.cc namenode_tracker.cc request.cc sasl_protocol.cc sasl_engine.cc)
 if (CMAKE_USING_CYRUS_SASL)
   list(APPEND rpc_object_items cyrus_sasl_engine.cc)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/rpc/CMakeLists.txt
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+find_package(Boost 1.72.0 REQUIRED COMPONENTS date_time)
+
 list(APPEND rpc_object_items $<TARGET_OBJECTS:x_platform_obj> rpc_connection_impl.cc rpc_engine.cc namenode_tracker.cc request.cc sasl_protocol.cc sasl_engine.cc)
 if (CMAKE_USING_CYRUS_SASL)
   list(APPEND rpc_object_items cyrus_sasl_engine.cc)
@@ -30,3 +32,4 @@ target_include_directories(rpc_obj PRIVATE ../../lib)
 add_dependencies(rpc_obj proto)
 add_library(rpc $<TARGET_OBJECTS:rpc_obj>)
 target_include_directories(rpc PRIVATE ../../lib)
+target_link_libraries(rpc PRIVATE ${Boost_LIBRARIES})

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-find_package(Boost 1.72.0 REQUIRED COMPONENTS date_time)
-
 # Delegate some functionality to libhdfs, until libhdfspp is complete.
 set (LIBHDFS_SRC_DIR ../../libhdfs)
 set (LIBHDFS_TESTS_DIR ../../libhdfs-tests)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-find_package(Boost REQUIRED COMPONENTS date_time)
+find_package(Boost 1.72.0 REQUIRED COMPONENTS date_time)
 
 # Delegate some functionality to libhdfs, until libhdfspp is complete.
 set (LIBHDFS_SRC_DIR ../../libhdfs)


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The compilation of HDFS Native Client fails on Windows 10 due to the following error -
```
[exec] "H:\hadoop-hdfs-project\hadoop-hdfs-native-client\target\native\main\native\libhdfspp\tests\logging_test.vcxproj" (default target) (105) ->
[exec]   rpc.lib(rpc_engine.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) public: __cdecl boost::gregorian::greg_month::greg_month(unsigned short)" (__imp_??0greg_month@gregorian@boost@@QEAA@G@Z) referenced in function "private: static class boost::posix_time::ptime __cdecl boost::date_time::microsec_clock<class boost::posix_time::ptime>::create_time(struct tm * (__cdecl*)(__int64 const *,struct tm *))" (?create_time@?$microsec_clock@Vptime@posix_time@boost@@@date_time@boost@@CA?AVptime@posix_time@3@P6APEAUtm@@PEB_JPEAU6@@Z@Z) [H:\hadoop-hdfs-project\hadoop-hdfs-native-client\target\native\main\native\libhdfspp\tests\logging_test.vcxproj]
[exec]   rpc.lib(request.obj) : error LNK2001: unresolved external symbol "__declspec(dllimport) public: __cdecl boost::gregorian::greg_month::greg_month(unsigned short)" (__imp_??0greg_month@gregorian@boost@@QEAA@G@Z) [H:\hadoop-hdfs-project\hadoop-hdfs-native-client\target\native\main\native\libhdfspp\tests\logging_test.vcxproj]
[exec]   H:\hadoop-hdfs-project\hadoop-hdfs-native-client\target\native\main\native\libhdfspp\tests\RelWithDebInfo\logging_test.exe : fatal error LNK1120: 1 unresolved externals [H:\hadoop-hdfs-project\hadoop-hdfs-native-client\target\native\main\native\libhdfspp\tests\logging_test.vcxproj]
```

This PR links `libhdfspp` against the Boost library to resolve this error.


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

