### PR TITLE
HADOOP-18279. Cancel fileMonitoringTimer even if trustManager isn't defined

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -319,8 +319,10 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
    */
   @Override
   public synchronized void destroy() {
-    if (trustManager != null) {
+    if (fileMonitoringTimer != null) {
       fileMonitoringTimer.cancel();
+    }
+    if (trustManager != null) {
       trustManager = null;
       keyManagers = null;
       trustManagers = null;


### PR DESCRIPTION
Backport from trunk.  The key stores factory starts a timer for monitoring file changes that should be reloaded.  The call to destroy() doesn't cancel the timer when a trust manager isn't defined.  This leaves the timer running, during shutdown.  This can be seen in unit tests that do not stop when the test completes.

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

