### PR TITLE
YARN-11277. Trigger log-dir deletion by size for NonAggregatingLogHandler

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -4959,6 +4959,17 @@ public class YarnConfiguration extends Configuration {
   public static final String APPS_CACHE_EXPIRE = YARN_PREFIX + "apps.cache.expire";
   public static final String DEFAULT_APPS_CACHE_EXPIRE = "30s";
 
+  /** Enabled trigger log-dir deletion by size for NonAggregatingLogHandler. */
+  public static final String NM_LOG_TRIGGER_DELETE_BY_SIZE_ENABLED = NM_PREFIX +
+      "log.trigger.delete.by-size.enabled";
+  public static final boolean DEFAULT_NM_LOG_TRIGGER_DELETE_BY_SIZE_ENABLED = false;
+
+  /** Trigger log-dir deletion when the total log size of an app is greater than
+   *  yarn.nodemanager.log.delete.threshold.
+   *  Depends on yarn.nodemanager.log.trigger.delete.by-size.enabled = true. */
+  public static final String NM_LOG_DELETE_THRESHOLD = NM_PREFIX + "log.delete.threshold";
+  public static final long DEFAULT_NM_LOG_DELETE_THRESHOLD = 100L * 1024 * 1024 * 1024;
+
   public YarnConfiguration() {
     super();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -5290,4 +5290,27 @@
     </description>
   </property>
 
+  <property>
+    <name>yarn.nodemanager.log.trigger.delete.by-size.enabled</name>
+    <value>false</value>
+    <description>
+      Optional.
+      Enabled trigger log-dir deletion by size for NonAggregatingLogHandler
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.log.delete.threshold</name>
+    <value>100g</value>
+    <description>
+      Optional.
+      Trigger log-dir deletion when the total log size of an app is greater than
+      yarn.nodemanager.log.delete.threshold and
+      yarn.nodemanager.log.trigger.delete.by-size.enabled = true.
+      You can use the following suffix (case insensitive): k(kilo), m(mega), g(giga), t(tera), p(peta),
+      e(exa) to specify the size (such as 128k, 512m, 1g, etc.),
+      Or provide complete size in bytes (such as 134217728 for 128 MB).
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/NonAggregatingLogHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/NonAggregatingLogHandler.java
@@ -71,6 +71,8 @@ public class NonAggregatingLogHandler extends AbstractService implements
   private final LocalDirsHandlerService dirsHandler;
   private final NMStateStoreService stateStore;
   private long deleteDelaySeconds;
+  private boolean enableTriggerDeleteBySize;
+  private long deleteThreshold;
   private ScheduledThreadPoolExecutor sched;
 
   public NonAggregatingLogHandler(Dispatcher dispatcher,
@@ -90,6 +92,12 @@ public class NonAggregatingLogHandler extends AbstractService implements
     this.deleteDelaySeconds =
         conf.getLong(YarnConfiguration.NM_LOG_RETAIN_SECONDS,
                 YarnConfiguration.DEFAULT_NM_LOG_RETAIN_SECONDS);
+    this.enableTriggerDeleteBySize =
+        conf.getBoolean(YarnConfiguration.NM_LOG_TRIGGER_DELETE_BY_SIZE_ENABLED,
+        YarnConfiguration.DEFAULT_NM_LOG_TRIGGER_DELETE_BY_SIZE_ENABLED);
+    this.deleteThreshold =
+        conf.getLongBytes(YarnConfiguration.NM_LOG_DELETE_THRESHOLD,
+        YarnConfiguration.DEFAULT_NM_LOG_DELETE_THRESHOLD);
     sched = createScheduledThreadPoolExecutor(conf);
     super.serviceInit(conf);
     recover();
@@ -165,13 +173,9 @@ public class NonAggregatingLogHandler extends AbstractService implements
         LogHandlerAppFinishedEvent appFinishedEvent =
             (LogHandlerAppFinishedEvent) event;
         ApplicationId appId = appFinishedEvent.getApplicationId();
-        // Schedule - so that logs are available on the UI till they're deleted.
-        LOG.info("Scheduling Log Deletion for application: "
-            + appId + ", with delay of "
-            + this.deleteDelaySeconds + " seconds");
         String user = appOwners.remove(appId);
         if (user == null) {
-          LOG.error("Unable to locate user for " + appId);
+          LOG.error("Unable to locate user for {}", appId);
           // send LOG_HANDLING_FAILED out
           NonAggregatingLogHandler.this.dispatcher.getEventHandler().handle(
               new ApplicationEvent(appId,
@@ -191,8 +195,20 @@ public class NonAggregatingLogHandler extends AbstractService implements
           LOG.error("Unable to record log deleter state", e);
         }
         try {
-          sched.schedule(logDeleter, this.deleteDelaySeconds,
-              TimeUnit.SECONDS);
+          boolean logDeleterStarted = false;
+          if (enableTriggerDeleteBySize) {
+            final long appLogSize = calculateSizeOfAppLogs(user, appId);
+            if (appLogSize >= deleteThreshold) {
+              LOG.info("Log Deletion for application: {}, with no delay, size={}", appId, appLogSize);
+              sched.schedule(logDeleter, 0, TimeUnit.SECONDS);
+              logDeleterStarted = true;
+            }
+          }
+          if (!logDeleterStarted) {
+            LOG.info("Scheduling Log Deletion for application: {}, with delay of {} seconds",
+                appId, this.deleteDelaySeconds);
+            sched.schedule(logDeleter, this.deleteDelaySeconds, TimeUnit.SECONDS);
+          }
         } catch (RejectedExecutionException e) {
           // Handling this event in local thread before starting threads
           // or after calling sched.shutdownNow().
@@ -200,7 +216,6 @@ public class NonAggregatingLogHandler extends AbstractService implements
         }
         break;
       default:
-        ; // Ignore
     }
   }
 
@@ -218,6 +233,24 @@ public class NonAggregatingLogHandler extends AbstractService implements
             YarnConfiguration.NM_LOG_DELETION_THREADS_COUNT,
             YarnConfiguration.DEFAULT_NM_LOG_DELETE_THREAD_COUNT), tf);
     return sched;
+  }
+
+  private long calculateSizeOfAppLogs(String user, ApplicationId applicationId) {
+    FileContext lfs = getLocalFileContext(getConfig());
+    long appLogsSize = 0L;
+    for (String rootLogDir : dirsHandler.getLogDirsForCleanup()) {
+      Path logDir = new Path(rootLogDir, applicationId.toString());
+      try {
+        appLogsSize += lfs.getFileStatus(logDir).getLen();
+      } catch (UnsupportedFileSystemException ue) {
+        LOG.warn("Unsupported file system used for log dir {}", logDir, ue);
+        continue;
+      } catch (IOException ie) {
+        LOG.error("Unable to getFileStatus for {}", logDir, ie);
+        continue;
+      }
+    }
+    return appLogsSize;
   }
 
   class LogDeleterRunnable implements Runnable {


### PR DESCRIPTION
JIRA: YARN-11277. trigger deletion of log-dir by size for NonAggregatingLogHandler

In our yarn cluster, the log files of some containers are too large, which causes the NodeManager to frequently switch to the unhealthy state. For logs that are too large, we can consider deleting them directly without delaying yarn.nodemanager.log.retain-seconds.