### PR TITLE
HADOOP-18388. Allow dynamic groupSearchFilter in LdapGroupsMapping.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/LdapGroupsMapping.java
@@ -817,7 +817,6 @@ public class LdapGroupsMapping
     if(groupSearchFilterParamCSV!=null && !groupSearchFilterParamCSV.isEmpty()) {
       LOG.debug("Using custom group search filters: {}", groupSearchFilterParamCSV);
       groupSearchFilterParams = groupSearchFilterParamCSV.split(",");
-      LOG.debug("Using custom group search filters: {}", groupSearchFilterParams);
     }
 
     int dirSearchTimeout = conf.getInt(DIRECTORY_SEARCH_TIMEOUT,

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -586,6 +586,18 @@
 </property>
 
 <property>
+  <name>hadoop.security.group.mapping.ldap.group.search.filter.pattern</name>
+  <value></value>
+  <description>
+    Comma separated values that needs to be substituted in the group search
+    filter during group lookup. The values are substituted in the order they
+    appear in the list, the first value will replace {0} the second {1} and
+    so on.
+  </description>
+</property>
+
+
+<property>
   <name>hadoop.security.group.mapping.providers</name>
   <value></value>
   <description>

--- a/hadoop-common-project/hadoop-common/src/site/markdown/GroupsMapping.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/GroupsMapping.md
@@ -85,6 +85,11 @@ This is the limit for each ldap query.  If `hadoop.security.group.mapping.ldap.s
 `hadoop.security.group.mapping.ldap.base` configures how far to walk up the groups hierarchy when resolving groups.
 By default, with a limit of 0, in order to be considered a member of a group, the user must be an explicit member in LDAP.  Otherwise, it will traverse the group hierarchy `hadoop.security.group.mapping.ldap.search.group.hierarchy.levels` levels up.
 
+It is possible to have specific group search filters with different arguments using
+the conf `hadoop.security.group.mapping.ldap.group.search.filter.pattern`, we can configure comma separated values here and the values configured will be fetched from the LDAP attributes and will be replaced in the group
+search filter in the order they appear here, say if the first entry here is uid, so uid will be fetched from the attributes and the value fetched
+will be used in place of {0} in the group search filter, similarly the second value configured will replace {1} and so on.
+
 ### Bind user(s) ###
 If the LDAP server does not support anonymous binds,
 set the distinguished name of the user to bind in `hadoop.security.group.mapping.ldap.bind.user`.

--- a/hadoop-common-project/hadoop-common/src/site/markdown/GroupsMapping.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/GroupsMapping.md
@@ -85,10 +85,13 @@ This is the limit for each ldap query.  If `hadoop.security.group.mapping.ldap.s
 `hadoop.security.group.mapping.ldap.base` configures how far to walk up the groups hierarchy when resolving groups.
 By default, with a limit of 0, in order to be considered a member of a group, the user must be an explicit member in LDAP.  Otherwise, it will traverse the group hierarchy `hadoop.security.group.mapping.ldap.search.group.hierarchy.levels` levels up.
 
-It is possible to have specific group search filters with different arguments using
-the conf `hadoop.security.group.mapping.ldap.group.search.filter.pattern`, we can configure comma separated values here and the values configured will be fetched from the LDAP attributes and will be replaced in the group
+It is possible to have custom group search filters with different arguments using
+the configuration `hadoop.security.group.mapping.ldap.group.search.filter.pattern`, we can configure comma separated values here and the values configured will be fetched from the LDAP attributes and will be replaced in the group
 search filter in the order they appear here, say if the first entry here is uid, so uid will be fetched from the attributes and the value fetched
 will be used in place of {0} in the group search filter, similarly the second value configured will replace {1} and so on.
+
+Note: If `hadoop.security.group.mapping.ldap.group.search.filter.pattern` is configured, the group search will always be done assuming this group
+search filter pattern irrespective of any other parameters.
 
 ### Bind user(s) ###
 If the LDAP server does not support anonymous binds,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
@@ -152,7 +152,7 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
     groupsMapping.setConf(conf);
 
     // The group search filter should be resolved and should be passed as the
-    // bellow.
+    // below.
     String groupFilter = "(|(memberUid={0})(uname={1}))(objectClass=group)";
     String[] resolvedFilterArgs =
         new String[] {"CN=some_user,DC=test,DC=com", "some_user"};

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,6 +46,8 @@ import java.util.HashSet;
 
 import javax.naming.CommunicationException;
 import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchControls;
 
 import org.apache.hadoop.conf.Configuration;
@@ -118,6 +122,50 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
     String baseDN = " dc=xxx,dc=com ";
     conf.set(LdapGroupsMapping.BASE_DN_KEY, baseDN);
     doTestGetGroupsWithBaseDN(conf, baseDN.trim(), baseDN.trim());
+  }
+
+  @Test
+  public void testGetGroupsWithDynamicGroupFilter() throws Exception {
+    // Set basic mock stuff.
+    Configuration conf = getBaseConf(TEST_LDAP_URL);
+    String baseDN = "dc=xxx,dc=com";
+    conf.set(LdapGroupsMapping.BASE_DN_KEY, baseDN);
+    Attributes attributes = getAttributes();
+
+    // Set the groupFilter attributed to take the csv.
+    Attribute groupFilterAttr = mock(Attribute.class);
+    when(groupFilterAttr.get()).thenReturn("userDN,userName");
+    when(attributes.get(eq("groupfilter"))).thenReturn(groupFilterAttr);
+
+    // Set the value for userName attribute that is to be used as part of the
+    // group filter at argument 1.
+    final String userName = "some_user";
+    Attribute userNameAttr = mock(Attribute.class);
+    when(userNameAttr.get()).thenReturn(userName);
+    when(attributes.get(eq("userName"))).thenReturn(userNameAttr);
+
+    // Set the dynamic group search filter.
+    final String groupSearchFilter =
+        "(|(memberUid={0})(uname={1}))" + "(objectClass=group)";
+    conf.set(LdapGroupsMapping.GROUP_SEARCH_FILTER_KEY, groupSearchFilter);
+
+    final LdapGroupsMapping groupsMapping = getGroupsMapping();
+    groupsMapping.setConf(conf);
+
+    // The group search filter should be resolved and should be passed as the
+    // bellow.
+    String resolvedGroupFilter = "(&(|(memberUid=CN=some_user,DC=test,DC=com)"
+        + "(uname=some_user))(objectClass=group)(member={0}))";
+
+    // Return groups only if the resolved filter is passed.
+    when(getContext()
+        .search(anyString(), eq(resolvedGroupFilter), any(Object[].class),
+            any(SearchControls.class)))
+        .thenReturn(getUserNames(), getGroupNames());
+
+    // Check the group filter got resolved and get the desired values.
+    List<String> groups = groupsMapping.getGroups(userName);
+    Assert.assertEquals(Arrays.asList(getTestGroups()), groups);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
@@ -134,7 +134,7 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
     Attributes attributes = getAttributes();
 
     // Set the groupFilter conf to take the csv.
-    conf.set(GROUP_SEARCH_FILTER_PATTERN,"userDN,userName");
+    conf.set(GROUP_SEARCH_FILTER_PATTERN, "userDN,userName");
 
     // Set the value for userName attribute that is to be used as part of the
     // group filter at argument 1.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.security;
 
 import static org.apache.hadoop.security.LdapGroupsMapping.CONNECTION_TIMEOUT;
+import static org.apache.hadoop.security.LdapGroupsMapping.GROUP_SEARCH_FILTER_PATTERN;
 import static org.apache.hadoop.security.LdapGroupsMapping.LDAP_NUM_ATTEMPTS_KEY;
 import static org.apache.hadoop.security.LdapGroupsMapping.READ_TIMEOUT;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
@@ -27,7 +28,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -133,10 +133,8 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
     conf.set(LdapGroupsMapping.BASE_DN_KEY, baseDN);
     Attributes attributes = getAttributes();
 
-    // Set the groupFilter attributed to take the csv.
-    Attribute groupFilterAttr = mock(Attribute.class);
-    when(groupFilterAttr.get()).thenReturn("userDN,userName");
-    when(attributes.get(eq("groupfilter"))).thenReturn(groupFilterAttr);
+    // Set the groupFilter conf to take the csv.
+    conf.set(GROUP_SEARCH_FILTER_PATTERN,"userDN,userName");
 
     // Set the value for userName attribute that is to be used as part of the
     // group filter at argument 1.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -154,12 +155,13 @@ public class TestLdapGroupsMapping extends TestLdapGroupsMappingBase {
 
     // The group search filter should be resolved and should be passed as the
     // bellow.
-    String resolvedGroupFilter = "(&(|(memberUid=CN=some_user,DC=test,DC=com)"
-        + "(uname=some_user))(objectClass=group)(member={0}))";
+    String groupFilter = "(|(memberUid={0})(uname={1}))(objectClass=group)";
+    String[] resolvedFilterArgs =
+        new String[] {"CN=some_user,DC=test,DC=com", "some_user"};
 
     // Return groups only if the resolved filter is passed.
     when(getContext()
-        .search(anyString(), eq(resolvedGroupFilter), any(Object[].class),
+        .search(anyString(), eq(groupFilter), eq(resolvedFilterArgs),
             any(SearchControls.class)))
         .thenReturn(getUserNames(), getGroupNames());
 


### PR DESCRIPTION
### Description of PR

Allow Dynamic Group Search Filter in LdapGroupsMapping

### How was this patch tested?

Unit Test. (WIP: In actual env)

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

