### PR TITLE
HADOOP-18418. Upgrade bundled Tomcat to 8.5.82

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -100,7 +100,7 @@
     <curator.version>2.13.0</curator.version>
     <findbugs.version>3.0.5</findbugs.version>
 
-    <tomcat.version>8.5.81</tomcat.version>
+    <tomcat.version>8.5.82</tomcat.version>
     <joda-time.version>2.9.4</joda-time.version>
 
     <!-- Required for testing LDAP integration -->


### PR DESCRIPTION
### Description of PR

JIRA - HADOOP-18418

Currently we are using 8.5.81 which is affected by CVE-2022-34305

More Details - https://github.com/advisories/GHSA-6j88-6whg-x687

Lets upgrade  to 8.5.82


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

