### PR TITLE
HADOOP-16674. Fix when TestDNS.testRDNS can fail with ServiceUnavailableException

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestDNS.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestDNS.java
@@ -25,10 +25,12 @@ import java.net.InetAddress;
 
 import javax.naming.CommunicationException;
 import javax.naming.NameNotFoundException;
+import javax.naming.ServiceUnavailableException;
 
 import org.apache.hadoop.util.Time;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,7 +169,7 @@ public class TestDNS {
     try {
       String s = DNS.reverseDns(localhost, null);
       LOG.info("Local reverse DNS hostname is " + s);
-    } catch (NameNotFoundException | CommunicationException e) {
+    } catch (NameNotFoundException | CommunicationException | ServiceUnavailableException e) {
       if (!localhost.isLinkLocalAddress() || localhost.isLoopbackAddress()) {
         //these addresses probably won't work with rDNS anyway, unless someone
         //has unusual entries in their DNS server mapping 1.0.0.127 to localhost
@@ -176,6 +178,7 @@ public class TestDNS {
                 + " Loopback=" + localhost.isLoopbackAddress()
                 + " Linklocal=" + localhost.isLinkLocalAddress());
       }
+      Assume.assumeNoException(e);
     }
   }
 


### PR DESCRIPTION
### Description of PR

Fix when TestDNS.testRDNS can fail with ServiceUnavailableException

JIRA - HADOOP-16674

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

