### PR TITLE
HADOOP-18415. Replace Sets.newHashSet() in hadoop-tools

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
@@ -23,6 +23,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -33,7 +35,6 @@ import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException;
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.util.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +111,7 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
         Arrays.asList(
             SimpleAWSCredentialsProvider.class,
             EnvironmentVariableCredentialsProvider.class),
-        Sets.newHashSet(this.getClass()));
+        new HashSet<>(Collections.singletonList(this.getClass())));
     LOG.debug("Credentials to obtain role credentials: {}", credentialsToSTS);
 
     // then the STS binding

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
@@ -24,13 +24,13 @@ import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import org.apache.hadoop.util.Sets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -180,7 +180,7 @@ public class TestS3AAWSCredentialsProvider {
         ASSUMED_ROLE_CREDENTIALS_PROVIDER,
         Arrays.asList(
             EnvironmentVariableCredentialsProvider.class),
-        Sets.newHashSet());
+        new HashSet<>());
     assertTrue("empty credentials", credentials.size() > 0);
 
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/integration/ITestS3ACommitterMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/integration/ITestS3ACommitterMRJob.java
@@ -28,13 +28,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.util.Sets;
 import org.assertj.core.api.Assertions;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
@@ -220,7 +220,7 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
 
     // create all the input files on the local FS.
     List<String> expectedFiles = new ArrayList<>(numFiles);
-    Set<String> expectedKeys = Sets.newHashSet();
+    Set<String> expectedKeys = new HashSet<>();
     for (int i = 0; i < numFiles; i += 1) {
       File file = localFilesDir.newFile(i + ".text");
       try (FileOutputStream out = new FileOutputStream(file)) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
@@ -35,7 +35,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 
-import org.apache.hadoop.util.Sets;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -447,7 +446,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     assertEquals("Should have correct number of pending commits",
         files.size(), pending.size());
 
-    Set<String> keys = Sets.newHashSet();
+    Set<String> keys = new HashSet<>();
     for (SinglePendingCommit commit : pending) {
       assertEquals("Should write to the correct bucket: " + commit,
           BUCKET, commit.getBucket());
@@ -709,7 +708,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
       int numTasks, int numFiles)
       throws IOException {
     results.resetUploads();
-    Set<String> uploads = Sets.newHashSet();
+    Set<String> uploads = new HashSet<>();
 
     for (int taskId = 0; taskId < numTasks; taskId += 1) {
       TaskAttemptID attemptID = new TaskAttemptID(
@@ -746,7 +745,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
       throws IOException {
     Path attemptPath = staging.getTaskAttemptPath(attempt);
 
-    Set<String> files = Sets.newHashSet();
+    Set<String> files = new HashSet<>();
     for (int i = 0; i < numFiles; i += 1) {
       Path outPath = writeOutputFile(
           attempt.getTaskAttemptID(), attemptPath, UUID.randomUUID().toString(),

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingPartitionedTaskCommit.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingPartitionedTaskCommit.java
@@ -20,13 +20,13 @@ package org.apache.hadoop.fs.s3a.commit.staging;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import org.apache.hadoop.util.Lists;
-import org.apache.hadoop.util.Sets;
 import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -145,7 +145,7 @@ public class TestStagingPartitionedTaskCommit
    */
   protected void verifyFilesCreated(
       final PartitionedStagingCommitter committer) {
-    Set<String> files = Sets.newHashSet();
+    Set<String> files = new HashSet<>();
     for (InitiateMultipartUploadRequest request :
         getMockResults().getRequests().values()) {
       assertEquals(BUCKET, request.getBucketName());
@@ -185,7 +185,7 @@ public class TestStagingPartitionedTaskCommit
   }
 
   public Set<String> buildExpectedList(StagingCommitter committer) {
-    Set<String> expected = Sets.newHashSet();
+    Set<String> expected = new HashSet<>();
     boolean unique = committer.useUniqueFilenames();
     for (String relative : relativeFiles) {
       expected.add(OUTPUT_PREFIX +

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyListing.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyListing.java
@@ -33,9 +33,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.hadoop.util.Sets;
 
 /**
  * The CopyListing abstraction is responsible for how the list of
@@ -163,8 +163,8 @@ public abstract class CopyListing extends Configured {
       CopyListingFileStatus lastFileStatus = new CopyListingFileStatus();
 
       Text currentKey = new Text();
-      Set<URI> aclSupportCheckFsSet = Sets.newHashSet();
-      Set<URI> xAttrSupportCheckFsSet = Sets.newHashSet();
+      Set<URI> aclSupportCheckFsSet = new HashSet<>();
+      Set<URI> xAttrSupportCheckFsSet = new HashSet<>();
       long idx = 0;
       while (reader.next(currentKey)) {
         if (currentKey.equals(lastKey)) {

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.tools.dynamometer;
 
-import org.apache.hadoop.util.Sets;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +33,9 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -271,12 +273,12 @@ public class TestDynamometerInfra {
     RMNodeLabelsManager nodeLabelManager = miniYARNCluster.getResourceManager()
         .getRMContext().getNodeLabelManager();
     nodeLabelManager.addToCluserNodeLabelsWithDefaultExclusivity(
-        Sets.newHashSet(NAMENODE_NODELABEL, DATANODE_NODELABEL));
+        new HashSet<>(Arrays.asList(NAMENODE_NODELABEL, DATANODE_NODELABEL)));
     Map<NodeId, Set<String>> nodeLabels = new HashMap<>();
     nodeLabels.put(miniYARNCluster.getNodeManager(0).getNMContext().getNodeId(),
-        Sets.newHashSet(NAMENODE_NODELABEL));
+        new HashSet<>(Collections.singletonList(NAMENODE_NODELABEL)));
     nodeLabels.put(miniYARNCluster.getNodeManager(1).getNMContext().getNodeId(),
-        Sets.newHashSet(DATANODE_NODELABEL));
+        new HashSet<>(Collections.singletonList(DATANODE_NODELABEL)));
     nodeLabelManager.addLabelsToNode(nodeLabels);
   }
 


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

[HADOOP-18415](https://issues.apache.org/jira/browse/HADOOP-18415)

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

