### PR TITLE
HADOOP-18416. fix ITestS3AIOStatisticsContext test failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -253,6 +253,7 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
     // Worker thread work and wait for it to finish.
     TestWorkerThread workerThread = new TestWorkerThread(path, null);
     long workerThreadID = workerThread.getId();
+    LOG.info("Worker thread ID: {} ", workerThreadID);
     workerThread.start();
     workerThread.join();
 
@@ -463,6 +464,8 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
 
     @Override
     public void run() {
+      // Setting the worker thread's name.
+      Thread.currentThread().setName("worker thread");
       S3AFileSystem fs = getFileSystem();
       byte[] data = new byte[BYTES_SMALL];
 
@@ -470,6 +473,9 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
       if (ioStatisticsContext != null) {
         IOStatisticsContext.setThreadIOStatisticsContext(ioStatisticsContext);
       }
+      // Storing context in a field to not loose the reference in a GC.
+      IOStatisticsContext ioStatisticsContextWorkerThread =
+          getCurrentIOStatisticsContext();
 
       // Write in the worker thread.
       try (FSDataOutputStream out = fs.create(workerThreadPath)) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.util.functional.TaskPool;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertCapabilities;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.disablePrefetching;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
@@ -67,6 +68,7 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
   @Override
   protected Configuration createConfiguration() {
     Configuration configuration = super.createConfiguration();
+    disablePrefetching(configuration);
     enableIOStatisticsContext();
     return configuration;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -473,7 +473,7 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
       if (ioStatisticsContext != null) {
         IOStatisticsContext.setThreadIOStatisticsContext(ioStatisticsContext);
       }
-      // Storing context in a field to not loose the reference in a GC.
+      // Storing context in a field to not lose the reference in a GC.
       IOStatisticsContext ioStatisticsContextWorkerThread =
           getCurrentIOStatisticsContext();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1498,8 +1498,11 @@ public final class S3ATestUtils {
     }
   }
 
-
-
-
-
+  /**
+   * Disable Prefetching streams from S3AFileSystem in tests.
+   * @param conf Configuration to remove the prefetch property from.
+   */
+  public static void disablePrefetching(Configuration conf) {
+    removeBaseAndBucketOverrides(conf, PREFETCH_ENABLED_KEY);
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fixing test failures in ITestS3AIOStatisticsContext, caused by reference getting lost due to GC midway the test intermittenly.

### How was this patch tested?
Region: `ap-south-1`

`[INFO] Results:  Tests run: 426, Failures: 0, Errors: 0, Skipped: 4`
`[INFO] Results: Tests run: 1144, Failures: 0, Errors: 0, Skipped: 146`
`[INFO] Results: Tests run: 124, Failures: 0, Errors: 1, Skipped: 10 ` (Timeout)
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

