### PR TITLE
HADOOP-18426. Improve the accuracy of MutableStat mean.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleStat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleStat.java
@@ -91,7 +91,7 @@ public class SampleStat {
     }
     else {
       // The Welford method for numerical stability
-      a1 = a0 + (x - a0) / numSamples;
+      a1 = a0 + (x - a0 * nSamples) / numSamples;
       s1 = s0 + (x - a0) * (x - a1);
       a0 = a1;
       s0 = s1;
@@ -117,7 +117,7 @@ public class SampleStat {
    * @return  the arithmetic mean of the samples
    */
   public double mean() {
-    return numSamples > 0 ? (total / numSamples) : 0.0;
+    return numSamples > 0 ? a1 : 0.0;
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -328,6 +328,9 @@ public class TestMutableMetrics {
     MutableStat stat = registry.newStat("Test", "Test", "Ops", "Val", false);
 
     long sample = 1000000000000009L;
+    // Sample 100 identical numbers, the mean should be the same as the sample
+    // value. We can check that if the calculation of the mean is not accurate
+    // because the sum of the sample values is too large.
     for (int i = 0; i < 100; i++) {
       stat.add(1, sample);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -321,6 +321,22 @@ public class TestMutableMetrics {
     assertGauge("TestAvgVal", 1.5, rb);
   }
 
+  @Test
+  public void testLargeMutableStatAdd() {
+    MetricsRecordBuilder rb = mockMetricsRecordBuilder();
+    MetricsRegistry registry = new MetricsRegistry("test");
+    MutableStat stat = registry.newStat("Test", "Test", "Ops", "Val", false);
+
+    long sample = 1000000000000009L;
+    for (int i = 0; i < 100; i++) {
+      stat.add(1, sample);
+    }
+    registry.snapshot(rb, false);
+
+    assertCounter("TestNumOps", 100L, rb);
+    assertGauge("TestAvgVal", (double) sample, rb);
+  }
+
   /**
    * Ensure that quantile estimates from {@link MutableQuantiles} are within
    * specified error bounds.


### PR DESCRIPTION
### Description of PR
The current MutableStat mean calculation method is more prone to loss accuracy because the sum of samples is too large.
we can process each sample on its own to improve mean accuracy.

### How was this patch tested?
Add a new UT.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

