### PR TITLE
HDFS-16750. NameNode should use NameNode.getRemoteUser() to log audit event to avoid possible NPE

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -160,6 +160,7 @@ import org.apache.hadoop.hdfs.server.datanode.checker.StorageLocationChecker;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.BlockPoolSlice;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
+import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.util.*;
 import org.apache.hadoop.hdfs.client.BlockReportOptions;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
@@ -1439,7 +1440,7 @@ public class DataNode extends ReconfigurableBase
       return;
     }
     // Try to get the ugi in the RPC call.
-    UserGroupInformation callerUgi = ipcServer.getRemoteUser();
+    UserGroupInformation callerUgi = Server.getRemoteUser();
     if (callerUgi == null) {
       // This is not from RPC.
       callerUgi = UserGroupInformation.getCurrentUser();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -417,7 +417,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   private void logAuditEvent(boolean succeeded, String cmd, String src,
       String dst, FileStatus stat) throws IOException {
     if (isAuditEnabled() && isExternalInvocation()) {
-      logAuditEvent(succeeded, Server.getRemoteUser(), Server.getRemoteIp(),
+      logAuditEvent(succeeded, NameNode.getRemoteUser(), Server.getRemoteIp(),
           cmd, src, dst, stat);
     }
   }


### PR DESCRIPTION
### Description of PR

NameNode should use NameNode.getRemoteUser() to log audit event to avoid possible NPE.

The relate code is: 
```
private void logAuditEvent(boolean succeeded, String cmd, String src,
    String dst, FileStatus stat) throws IOException {
  if (isAuditEnabled() && isExternalInvocation()) {
    logAuditEvent(succeeded, Server.getRemoteUser(), Server.getRemoteIp(),
        cmd, src, dst, stat);
  }
}

// the ugi may be null.
private void logAuditEvent(boolean succeeded,
    UserGroupInformation ugi, InetAddress addr, String cmd, String src,
    String dst, FileStatus status) {
  final String ugiStr = ugi.toString();
  ...
} 
```

