### PR TITLE
HADOOP-18429. fix infinite loop in MutableGaugeFloat#incr(float)

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableGaugeFloat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableGaugeFloat.java
@@ -69,7 +69,7 @@ public class MutableGaugeFloat extends MutableGauge {
 
   private void incr(float delta) {
     while (true) {
-      float current = value.get();
+      float current = Float.intBitsToFloat(value.get());
       float next = current + delta;
       if (compareAndSet(current, next)) {
         setChanged();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -442,11 +442,11 @@ public class TestMutableMetrics {
   }
 
   /**
-   * Test {@link MutableGaugeFloat#incr()}
+   * Test {@link MutableGaugeFloat#incr()}.
    */
   @Test(timeout = 30000)
   public void testMutableGaugeFloat() {
-    MutableGaugeFloat mgf = new MutableGaugeFloat(Context,3.2f);
+    MutableGaugeFloat mgf = new MutableGaugeFloat(Context, 3.2f);
     assertEquals(3.2f, mgf.value(), 0.0);
     mgf.incr();
     assertEquals(4.2f, mgf.value(), 0.0);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -440,7 +440,10 @@ public class TestMutableMetrics {
     verify(mb, times(2)).addGauge(
         info("FooNumOps", "Number of ops for stat with 5s interval"), (long) 0);
   }
-  
+
+  /**
+   * Test {@link MutableGaugeFloat#incr()}
+   */
   @Test(timeout = 30000)
   public void testMutableGaugeFloat() {
     MutableGaugeFloat mgf = new MutableGaugeFloat(Context,3.2f);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.metrics2.lib;
 
+import static org.apache.hadoop.metrics2.impl.MsInfo.Context;
 import static org.apache.hadoop.metrics2.lib.Interns.info;
 import static org.apache.hadoop.test.MetricsAsserts.*;
 import static org.mockito.AdditionalMatchers.eq;
@@ -438,5 +439,13 @@ public class TestMutableMetrics {
     quantiles.snapshot(mb, false);
     verify(mb, times(2)).addGauge(
         info("FooNumOps", "Number of ops for stat with 5s interval"), (long) 0);
+  }
+  
+  @Test(timeout = 30000)
+  public void testMutableGaugeFloat() {
+    MutableGaugeFloat mgf = new MutableGaugeFloat(Context,3.2f);
+    assertEquals(3.2f, mgf.value(), 0.0);
+    mgf.incr();
+    assertEquals(4.2f, mgf.value(), 0.0);
   }
 }


### PR DESCRIPTION
### Description of PR
JIRA - [HADOOP-18429](https://issues.apache.org/jira/browse/HADOOP-18429)
The Unit Test get stuck in an infinite loop
```java
public void testMutableGaugeFloat() {
    MutableGaugeFloat mgf = new MutableGaugeFloat(Context,3.2f);
    assertEquals(3.2f, mgf.value(), 0.0);
    mgf.incr();
    assertEquals(4.2f, mgf.value(), 0.0);
  }
``` 

The current implementation converts the value from int to float, causing the compareAndSet method to get stuck.
```java
private final boolean compareAndSet(float expect, float update) {
  return value.compareAndSet(Float.floatToIntBits(expect),
      Float.floatToIntBits(update));
}

private void incr(float delta) {
  while (true) {
    float current = value.get();
    float next = current + delta;
    if (compareAndSet(current, next)) {
      setChanged();
      return;
    }
  }
} 
```

Perhaps it could be:
```java
private void incr(float delta) {
  while (true) {
    float current = Float.intBitsToFloat(value.get());
    float next = current + delta;
    if (compareAndSet(current, next)) {
      setChanged();
      return;
    }
  }
}
```

### How was this patch tested?
unit test in TestMutableMetrics#testMutableGaugeFloat()

