### PR TITLE
YARN-11287. Fix NoClassDefFoundError after YARN-10793(#4603)

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -212,6 +212,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>de.ruedigermoeller</groupId>
       <artifactId>fst</artifactId>
       <version>2.50</version>


### PR DESCRIPTION
JIRA: YARN-11287. Fix NoClassDefFoundError: org/junit/platform/launcher/core/LauncherFactory After YARN-10793(https://github.com/apache/hadoop/pull/4603).

After executing the yarn-project global unit test, I found the following error:

```
ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M1:test (default-test) on project hadoop-yarn-server-applicationhistoryservice: Execution default-test of goal org.apache.maven.plugins:maven-surefire-
plugin:3.0.0-M1:test failed: java.lang.NoClassDefFoundError: org/junit/platform/launcher/core/LauncherFactory: org.junit.platform.launcher.core.LauncherFactory -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :hadoop-yarn-server-applicationhistoryservice 
```