### PR TITLE
YARN-11288. fix the invalid RPATH of container-executor

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -30,7 +30,7 @@
     <!-- Basedir eeded for generating FindBugs warnings using parent pom -->
     <yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>
     <container-executor.conf.dir>../etc/hadoop</container-executor.conf.dir>
-    <extra.libhadoop.rpath>../lib/native</extra.libhadoop.rpath>
+    <extra.libhadoop.rpath></extra.libhadoop.rpath>
     <container-executor.additional_cflags></container-executor.additional_cflags>
   </properties>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/CMakeLists.txt
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/CMakeLists.txt
@@ -163,9 +163,9 @@ add_executable(container-executor
 # the directory containing container-executor. However, $ORIGIN is not supported by
 # all operating systems.
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|SunOS")
-    set(RPATH "\$ORIGIN/")
+    set(RPATH "\$ORIGIN/../lib/native")
     if(EXTRA_LIBHADOOP_RPATH)
-        set(RPATH "${RPATH}:${EXTRA_LIBHADOOP_RPATH}/")
+        set(RPATH "${RPATH}:${EXTRA_LIBHADOOP_RPATH}")
     endif()
     message("RPATH SET AS ${RPATH}.")
     set_target_properties(container-executor PROPERTIES INSTALL_RPATH "${RPATH}")
@@ -187,9 +187,9 @@ add_executable(test-container-executor
 # the directory containing test-container-executor. However, $ORIGIN is not supported by
 # all operating systems.
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|SunOS")
-    set(RPATH "\$ORIGIN/")
+    set(RPATH "\$ORIGIN/../lib/native")
     if(EXTRA_LIBHADOOP_RPATH)
-        set(RPATH "${RPATH}:${EXTRA_LIBHADOOP_RPATH}/")
+        set(RPATH "${RPATH}:${EXTRA_LIBHADOOP_RPATH}")
     endif()
     message("RPATH SET AS ${RPATH}.")
     set_target_properties(test-container-executor PROPERTIES INSTALL_RPATH "${RPATH}")


### PR DESCRIPTION
YARN-11288. INSTALL_RPATH need absolute path, and setting the default rpath of container-executor. 