### PR TITLE
YARN-11256. Remove redundant params from the buildCommandExecutor

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
@@ -340,10 +340,8 @@ public class DefaultContainerExecutor extends ContainerExecutor {
       }
 
       shExec = buildCommandExecutor(sb.getWrapperScriptPath().toString(),
-              containerIdStr, user, pidFile, container.getResource(),
-              new File(containerWorkDir.toUri().getPath()),
-              container.getLaunchContext().getEnvironment(),
-              numaCommands);
+              user, pidFile, new File(containerWorkDir.toUri().getPath()),
+              container, numaCommands);
 
       if (isContainerActive(containerId)) {
         shExec.execute();
@@ -405,24 +403,24 @@ public class DefaultContainerExecutor extends ContainerExecutor {
    * Create a new {@link ShellCommandExecutor} using the parameters.
    *
    * @param wrapperScriptPath the path to the script to execute
-   * @param containerIdStr the container ID
    * @param user the application owner's username
    * @param pidFile the path to the container's PID file
-   * @param resource this parameter controls memory and CPU limits.
    * @param workDir If not-null, specifies the directory which should be set
    * as the current working directory for the command. If null,
    * the current working directory is not modified.
-   * @param environment the container environment
+   * @param container the container reference
    * @param numaCommands list of prefix numa commands
    * @return the new {@link ShellCommandExecutor}
    * @see ShellCommandExecutor
    */
   protected CommandExecutor buildCommandExecutor(String wrapperScriptPath,
-                            String containerIdStr, String user, Path pidFile, Resource resource,
-                            File workDir, Map<String, String> environment, String[] numaCommands) {
+                            String user, Path pidFile, File workDir,
+                            Container container, String[] numaCommands) {
+
 
     String[] command = getRunCommand(wrapperScriptPath,
-        containerIdStr, user, pidFile, this.getConf(), resource);
+        container.getContainerId().toString(), user, pidFile, this.getConf(),
+            container.getResource());
 
     // check if numa commands are passed and append it as prefix commands
     if(numaCommands != null && numaCommands.length!=0) {
@@ -433,7 +431,7 @@ public class DefaultContainerExecutor extends ContainerExecutor {
     return new ShellCommandExecutor(
         command,
         workDir,
-        environment,
+        container.getLaunchContext().getEnvironment(),
         0L,
         false);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.RandomUtils;
@@ -50,7 +49,6 @@ import org.apache.hadoop.util.Shell.CommandExecutor;
 import org.apache.hadoop.util.Shell.ExitCodeException;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
 import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.ConfigurationException;
 import org.apache.hadoop.yarn.exceptions.YarnException;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -717,11 +718,11 @@ public class WindowsSecureContainerExecutor extends DefaultContainerExecutor {
 
   @Override
   protected CommandExecutor buildCommandExecutor(String wrapperScriptPath,
-      String containerIdStr, String userName, Path pidFile, Resource resource,
-      File wordDir, Map<String, String> environment, String[] numaCommands) {
+       String userName, Path pidFile, File wordDir,
+       Container container, String[] numaCommands) {
      return new WintuilsProcessStubExecutor(
          wordDir.toString(),
-         containerIdStr, userName, pidFile.toString(),
+         container.getContainerId().toString(), userName, pidFile.toString(),
          "cmd /c " + wrapperScriptPath);
    }
    

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/WindowsSecureContainerExecutor.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.io.nativeio.NativeIOException;
 import org.apache.hadoop.util.NativeCodeLoader;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.CommandExecutor;
-import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ContainerLocalizer;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[YARN-11256](https://issues.apache.org/jira/browse/YARN-11256)

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

