### PR TITLE
HDFS-16755. TestQJMWithFaults.testUnresolvableHostName() can fail due to unexpected host resolution

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
@@ -198,7 +198,7 @@ public class TestQJMWithFaults {
   public void testUnresolvableHostName() throws Exception {
     expectedException.expect(UnknownHostException.class);
     new QuorumJournalManager(conf,
-        new URI("qjournal://" + "bogus:12345" + "/" + JID), FAKE_NSINFO);
+        new URI("qjournal://" + "bogus.invalid:12345" + "/" + JID), FAKE_NSINFO);
   }
 
   /**


### PR DESCRIPTION
### Description of PR

Tests that want to use an unresolvable address may actually resolve in some environments.  Replacing host names like "bogus" with a IETF RFC 2606 domain name avoids the issue.

Use ".invalid" domain from IETF RFC 2606 to ensure that the host "bogus" doesn't resolve.

### How was this patch tested?

Test were executed through both Maven Surefire and the IDE to demonstrate that this change resulted in the expected test result.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

