### PR TITLE
HDFS-16753. WebHDFSHandler should reject non-compliant requests

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/WebHdfsHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/WebHdfsHandler.java
@@ -330,6 +330,7 @@ public class WebHdfsHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
   private static DFSClient newDfsClient
     (String nnId, Configuration conf) throws IOException {
+    Preconditions.checkArgument(nnId != null);
     URI uri = URI.create(HDFS_URI_SCHEME + "://" + nnId);
     return new DFSClient(uri, conf);
   }


### PR DESCRIPTION
### Description of PR

When the nnId is not provided to the WebHDFSClient, the request uses null to generate a URI using a host name of "null" to construct a DFSClient instance.  In environments where the host name "null" doesn't resolve, the test passes due to the unresolvable name.  If the host name "null" does resolve, then this results in repeated attempts through the retry mechanism, eventually causing a timeout and a failed test result.

This change make the parameter a precondition for constructing the DFSClient, which throws an exception, rejecting the request, and return the expected 400 status code.

Make a non-null nnId a precondition for creating a DFSClient.

### How was this patch tested?

The patch was tested using both Maven Surefire and an IDE to demonstrate that the expected 400 status code was returned when the parameter was missing.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

