### PR TITLE
HDFS-16754. UnderConstruct file with completed but missed block should be able to recover lease

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3705,8 +3705,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       curBlock = blocks[nrCompleteBlocks];
       if(!curBlock.isComplete())
         break;
-      assert blockManager.hasMinStorage(curBlock) :
-              "A COMPLETE block is not minimally replicated in " + src;
+      if (!blockManager.hasMinStorage(curBlock)) {
+        LOG.warn("A COMPLETE block {} is not minimally replicated in {}.", curBlock, src);
+      }
     }
 
     // If there are no incomplete blocks associated with this file,


### PR DESCRIPTION
### Description of PR
During looking into the logic of RecoverLease, I guess there is a bug:
```
int nrCompleteBlocks;
BlockInfo curBlock = null;
for(nrCompleteBlocks = 0; nrCompleteBlocks < nrBlocks; nrCompleteBlocks++) {
  curBlock = blocks[nrCompleteBlocks];
  if(!curBlock.isComplete())
    break;
  // Why?
  assert blockManager.hasMinStorage(curBlock) :
          "A COMPLETE block is not minimally replicated in " + src;
} 
```
RecoverLease just try to align all replicas of the last block of one UnderConstruct file.
So if the UC file with some completed blocks, which may missed all replicas, should be able to recoverLease.

