### PR TITLE
HDFS-16721.Improve the check code of “dfs.client.socket-timeout”.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -212,6 +212,8 @@ public class DfsClientConf {
         DFS_DATA_TRANSFER_CLIENT_TCPNODELAY_DEFAULT);
     socketTimeout = conf.getInt(DFS_CLIENT_SOCKET_TIMEOUT_KEY,
         HdfsConstants.READ_TIMEOUT);
+    Preconditions.checkArgument(socketTimeout >= 0, "The value of " +
+        DFS_CLIENT_SOCKET_TIMEOUT_KEY + " can't be negative.");
     socketSendBufferSize = conf.getInt(DFS_CLIENT_SOCKET_SEND_BUFFER_SIZE_KEY,
         DFS_CLIENT_SOCKET_SEND_BUFFER_SIZE_DEFAULT);
     /** dfs.write.packet.size is an internal config variable */


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
"dfs.client.socket-timeout" as the default timeout value for all sockets is applied in multiple places, it is a configuration item with significant impact, but the value of this configuration item is not checked in the source code and cannot be corrected in time when it is set to an abnormal value, which affects the normal use of the program.
[[[HDFS-16721](https://issues.apache.org/jira/browse/HDFS-16721)](https://issues.apache.org/jira/browse/HDFS-16721)](https://issues.apache.org/jira/browse/HDFS-16721)

### How was this patch tested?
This patch uses Precondition.checkArgument() to refine the code for checking this configuration item.
