### PR TITLE
HDFS-16697.Add code to check for minimumRedundantVolumes.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -174,6 +174,19 @@ public class NameNodeResourceChecker {
    *         otherwise.
    */
   public boolean hasAvailableDiskSpace() {
+    try {
+      if (minimumRedundantVolumes > volumes.size()){
+        throw new IllegalArgumentException("The value of "
+        + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+        + " is " + minimumRedundantVolumes
+        + " which is greater than the total number of existing storage volumes "
+        + volumes.size() + " .");
+      }
+    } catch (IllegalArgumentException e){
+      LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
+      + " is greater than the total number of existing storage volumes"
+      + " and will result in adding resources and still not being able to turn off safe mode.", e);
+    }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeResourceChecker.java
@@ -184,8 +184,8 @@ public class NameNodeResourceChecker {
       }
     } catch (IllegalArgumentException e){
       LOG.warn("The value of " + DFSConfigKeys.DFS_NAMENODE_CHECKED_VOLUMES_MINIMUM_KEY
-      + " is greater than the total number of existing storage volumes"
-      + " and will result in adding resources and still not being able to turn off safe mode.", e);
+        + " is greater than the total number of existing storage volumes"
+        + " and will result in adding resources and still not being able to turn off safe mode.", e);
     }
     return NameNodeResourcePolicy.areResourcesAvailable(volumes.values(),
         minimumRedundantVolumes);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
It is found that “dfs.namenode.resource.checked.volumes.minimum” lacks a condition check and an associated exception handling mechanism, which makes it impossible to find the root cause of the impact when a misconfiguration occurs.
Add a mechanism to check the value of minimumRedundantVolumes to ensure that the value is greater than the number of NameNode storage volumes to avoid never being able to turn off safe mode afterwards.

JIRA:[[[HDFS-16697](https://issues.apache.org/jira/browse/HDFS-16697)](https://issues.apache.org/jira/browse/HDFS-16697)]

### How was this patch tested?
This patch provides a check of the configuration items，it will throw an IllegalArgumentException and a detailed error message when the value is greater than the number of NameNode storage volumes, and printing a warning message in the log in order to solve the problem in time and avoid the misconfiguration from affecting the subsequent operations of the program.
