### PR TITLE
HDFS-16762. Make the default value of dfs.federation.router.client.allow-partial-listing as false.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RBFConfigKeys.java
@@ -158,7 +158,7 @@ public class RBFConfigKeys extends CommonConfigurationKeysPublic {
   public static final boolean DFS_ROUTER_CLIENT_REJECT_OVERLOAD_DEFAULT = false;
   public static final String DFS_ROUTER_ALLOW_PARTIAL_LIST =
       FEDERATION_ROUTER_PREFIX + "client.allow-partial-listing";
-  public static final boolean DFS_ROUTER_ALLOW_PARTIAL_LIST_DEFAULT = true;
+  public static final boolean DFS_ROUTER_ALLOW_PARTIAL_LIST_DEFAULT = false;
   public static final String DFS_ROUTER_CLIENT_MOUNT_TIME_OUT =
       FEDERATION_ROUTER_PREFIX + "client.mount-status.time-out";
   public static final long DFS_ROUTER_CLIENT_MOUNT_TIME_OUT_DEFAULT =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/resources/hdfs-rbf-default.xml
@@ -604,11 +604,12 @@
 
   <property>
     <name>dfs.federation.router.client.allow-partial-listing</name>
-    <value>true</value>
+    <value>false</value>
     <description>
       If the Router can return a partial list of files in a multi-destination mount point when one of the subclusters is unavailable.
       True may return a partial list of files if a subcluster is down.
       False will fail the request if one is unavailable.
+      Making default value as false to avoid users get a partial list but they don't know.
     </description>
   </property>
 


### PR DESCRIPTION

### Description of PR
https://issues.apache.org/jira/browse/HDFS-16762

 AS the default value of **_dfs.federation.router.client.allow-partial-listing is true_**,  the hdfs client will got partial result when one or more of the subclusters are unavailable for no permissions or other Exceptions, but **_user may not know_**. It will lead to some fault. 

So I think it's better to make the default value as false.



