### PR TITLE
HADOOP-18444 Add Support for localized trash for ViewFileSystem in Trash.moveToAppropriateTrash

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
@@ -98,30 +98,24 @@ public class Trash extends Configured {
     }
 
     /*
-     * In HADOOP-18144, we fixed the logical path vs. target path bug of getTrashRoot() in ViewFileSystem.
-     * moveToTrash works for ViewFileSystem now. ViewFileSystem will do path resolution internally by itself.
+     * In HADOOP-18144, we changed getTrashRoot() in ViewFileSystem to return a
+     * viewFS path, instead of a targetFS path. moveToTrash works for
+     * ViewFileSystem now. ViewFileSystem will do path resolution internally by
+     * itself.
      *
      * When localized trash flag is enabled:
-     *    1). if fs is a ViewFileSystem, we can initialize Trash() with this ViewFileSystem object;
-     *    2). When fs is not a ViewFileSystem, the only place we would need to resolve a path is for symbolic links.
-     *        However, symlink is not enabled in Hadoop due to the complexity to support it (HADOOP-10019).
+     *    1). if fs is a ViewFileSystem, we can initialize Trash() with a
+     *        ViewFileSystem object;
+     *    2). When fs is not a ViewFileSystem, the only place we would need to
+     *        resolve a path is for symbolic links. However, symlink is not
+     *        enabled in Hadoop due to the complexity to support it
+     *        (HADOOP-10019).
      */
     if (conf.getBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT,
         CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT)) {
-      // Save the original config in savedValue for localized trash config.
-      String savedValue = fs.getConf().get(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT);
-      fs.getConf().setBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, true);
+      //TODO: Create a new FS object, to ensure the latest conf is used.
       Trash trash = new Trash(fs, conf);
-      boolean res = trash.moveToTrash(p);
-
-      // Restore the original value of localized trash config
-      if (savedValue != null) {
-        fs.getConf().set(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT, savedValue);
-      } else {
-        fs.getConf().unset(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT);
-      }
-
-      return res;
+      return trash.moveToTrash(p);
     }
 
     Trash trash = new Trash(fullyResolvedFs, conf);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Trash.java
@@ -113,7 +113,6 @@ public class Trash extends Configured {
      */
     if (conf.getBoolean(CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT,
         CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT_DEFAULT)) {
-      //TODO: Create a new FS object, to ensure the latest conf is used.
       Trash trash = new Trash(fs, conf);
       return trash.moveToTrash(p);
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Trash.moveToAppropriateTrash was added to hadoop in HADOOP-7284, because the authors found out Trash/hadoop cli -rm did not work for viewFS. The reason **I believe** is when we initialized a Trash object with a ViewFileSystem object and a ViewFileSystem path, the original getTrashRoot() in ViewFileSystem returns a targeFS path. This leads to the wrong FS exception when we use a ViewFileSystem object to operate on a targetFS path. 

`java.lang.IllegalArgumentException: Wrong FS: file:/Users/xinglin/projs/hadoop-branchs/trunk/hadoop-common-project/hadoop-common/target/test/data/testTrash/.Trash/Current/data, expected: viewfs:/`


In [HADOOP-18144](https://issues.apache.org/jira/browse/HADOOP-18144), we have fixed getTrashRoot in ViewFileSystem, to return a ViewFileSystem path. Thus, moveToTrash() works now when we initialize the Trash object with a ViewFileSystem object and a ViewFileSystem path.

The existing moveToAppropriateTrash implementation is also causing a problem for the fix we put in HADOOP-18144. The reason is it first resolves a path and then uses the resolvedFs, to initialize the trash object. As a result, it uses getTrashRoot() implementation from targetFs. The fix we put in HADOOP-18144 in ViewFileSystem is bypassed and not used. 

With this patch, we check whether the localized trash policy flag is set. If this is true, we initialize the Trash object with the ViewFileSystem FS object and call moveToTrash() with the logical path directly. 

### How was this patch tested?

Passed a new test added to TestViewFsTrash

`mvn test -Dtest="TestViewFsTrash"`


