### PR TITLE
HADOOP-18446. [SBN read] Add a re-queue metric to RpcMetrics to quantify the number of re-queued RPCs

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -3142,6 +3142,7 @@ public abstract class Server {
         throws IOException, InterruptedException {
       try {
         internalQueueCall(call, false);
+        rpcMetrics.incrRequeueCalls();
       } catch (RpcServerException rse) {
         call.doResponse(rse.getCause(), rse.getRpcStatusProto());
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -128,6 +128,8 @@ public class RpcMetrics {
   MutableCounterLong rpcClientBackoff;
   @Metric("Number of Slow RPC calls")
   MutableCounterLong rpcSlowCalls;
+  @Metric("Number of requeue calls")
+  MutableCounterLong rpcRequeueCalls;
 
   @Metric("Number of open connections") public int numOpenConnections() {
     return server.getNumOpenConnections();
@@ -305,6 +307,13 @@ public class RpcMetrics {
   }
 
   /**
+   * Increments the Requeue Calls counter.
+   */
+  public void incrRequeueCalls() {
+    rpcRequeueCalls.incr();
+  }
+
+  /**
    * Returns a MutableRate Counter.
    * @return Mutable Rate
    */
@@ -342,6 +351,15 @@ public class RpcMetrics {
    */
   public long getRpcSlowCalls() {
     return rpcSlowCalls.value();
+  }
+
+  /**
+   * Returns the number of requeue calls;
+   * @return long
+   */
+  @VisibleForTesting
+  public long getRpcRequeueCalls() {
+    return rpcRequeueCalls.value();
   }
 
   public MutableRate getDeferredRpcProcessingTime() {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -354,7 +354,7 @@ public class RpcMetrics {
   }
 
   /**
-   * Returns the number of requeue calls;
+   * Returns the number of requeue calls.
    * @return long
    */
   @VisibleForTesting

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6997,16 +6997,6 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   public EditLogTailer getEditLogTailer() {
     return editLogTailer;
   }
-
-  @VisibleForTesting
-  public void startNewEditLogTailer(Configuration conf) throws IOException {
-    if (this.editLogTailer != null) {
-      this.editLogTailer.stop();
-    }
-
-    this.editLogTailer = new EditLogTailer(this, conf);
-    this.editLogTailer.start();
-  }
   
   @VisibleForTesting
   public void setEditLogTailerForTests(EditLogTailer tailer) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6997,6 +6997,16 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
   public EditLogTailer getEditLogTailer() {
     return editLogTailer;
   }
+
+  @VisibleForTesting
+  public void startNewEditLogTailer(Configuration conf) throws IOException {
+    if (this.editLogTailer != null) {
+      this.editLogTailer.stop();
+    }
+
+    this.editLogTailer = new EditLogTailer(this, conf);
+    this.editLogTailer.start();
+  }
   
   @VisibleForTesting
   public void setEditLogTailerForTests(EditLogTailer tailer) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_EN
 import static org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter.getServiceState;
 import static org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,7 +37,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
@@ -61,9 +65,11 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLog;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
+import org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer;
 import org.apache.hadoop.hdfs.server.namenode.TestFsck;
 import org.apache.hadoop.hdfs.tools.GetGroups;
 import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
+import org.apache.hadoop.ipc.metrics.RpcMetrics;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.junit.After;
@@ -122,6 +128,42 @@ public class TestObserverNode {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
     }
+  }
+
+  @Test
+  public void testObserverRequeue() throws Exception {
+    ScheduledExecutorService interruptor =
+        Executors.newScheduledThreadPool(1);
+
+    EditLogTailer observerEditlogTailer = dfsCluster.getNameNode(2)
+        .getNamesystem().getEditLogTailer();
+    RpcMetrics obRpcMetrics = ((NameNodeRpcServer)dfsCluster
+        .getNameNodeRpc(2)).getClientRpcServer().getRpcMetrics();
+
+    // Stop EditlogTailer of Observer NameNode.
+    observerEditlogTailer.stop();
+
+    long oldRequeueNum = obRpcMetrics.getRpcRequeueCalls();
+
+    ScheduledFuture<FileStatus> scheduledFuture = interruptor.schedule(
+        () -> {
+          Path tmpTestPath = new Path("/TestObserverRequeue");
+          dfs.create(tmpTestPath, (short)1).close();
+          assertSentTo(0);
+          // This operation will be blocked in ObserverNameNode
+          // until EditlogTailer tailed edits from journalNode.
+          FileStatus fileStatus = dfs.getFileStatus(tmpTestPath);
+          assertSentTo(2);
+          return fileStatus;
+        }, 0, TimeUnit.SECONDS);
+    Thread.sleep(1000);
+    observerEditlogTailer.doTailEdits();
+    FileStatus fileStatus = scheduledFuture.get(1000, TimeUnit.MILLISECONDS);
+    assertNotNull(fileStatus);
+
+    assertTrue(obRpcMetrics.getRpcRequeueCalls() > oldRequeueNum);
+    dfsCluster.getNameNode(2).getNamesystem()
+        .startNewEditLogTailer(dfsCluster.getConfiguration(2));
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
Add a reQueue metric to RpcMetrics.java to quantify the number of RPCs reQueued. Because Observer NameNode will re-queue the rpc if the call processing should be postponed.
There is no any metric to quantify the number of re-queue RPCs, so I think we should do it.


