### PR TITLE
HADOOP-18449. Upgrade hadolint to 2.10.0

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ignored:
+  - DL3059

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN pkg-resolver/install-common-pkgs.sh
 RUN pkg-resolver/install-spotbugs.sh ubuntu:focal
 RUN pkg-resolver/install-boost.sh ubuntu:focal
 RUN pkg-resolver/install-protobuf.sh ubuntu:focal
-RUN pkg-resolver/install-hadolint.sh ubuntu:focal
+RUN pkg-resolver/install-hadolint.sh ubuntu:focal 2.10.0
 RUN pkg-resolver/install-intel-isa-l.sh ubuntu:focal
 
 ###

--- a/dev-support/docker/Dockerfile_centos_7
+++ b/dev-support/docker/Dockerfile_centos_7
@@ -33,13 +33,14 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 ######
 # Install packages from yum
 ######
-# hadolint ignore=DL3008,SC2046
+# hadolint ignore=DL3008,SC2046,DL3033
 RUN yum update -y \
     && yum groupinstall -y "Development Tools" \
     && yum install -y \
         centos-release-scl \
         python3 \
-    && yum install -y $(pkg-resolver/resolve.py centos:7)
+    && yum install -y $(pkg-resolver/resolve.py centos:7) \
+    && yum clean all
 
 # Set GCC 9 as the default C/C++ compiler
 RUN echo "source /opt/rh/devtoolset-9/enable" >> /etc/bashrc
@@ -93,4 +94,5 @@ RUN pkg-resolver/install-boost.sh centos:7
 RUN pkg-resolver/install-spotbugs.sh centos:7
 RUN pkg-resolver/install-nodejs.sh centos:7
 RUN pkg-resolver/install-git.sh centos:7
+RUN pkg-resolver/install-hadolint.sh centos:7 2.10.0
 RUN pkg-resolver/install-common-pkgs.sh

--- a/dev-support/docker/Dockerfile_centos_8
+++ b/dev-support/docker/Dockerfile_centos_8
@@ -40,26 +40,28 @@ RUN pkg-resolver/set-vault-as-baseurl-centos.sh centos:8
 ######
 # Install packages from yum
 ######
-# hadolint ignore=DL3008,SC2046
+# hadolint ignore=DL3008,SC2046,DL3033
 RUN yum update -y \
     && yum install -y python3 \
-    && yum install -y $(pkg-resolver/resolve.py centos:8)
+    && yum install -y $(pkg-resolver/resolve.py centos:8) \
+    && yum clean all
 
 ####
 # Install EPEL
 ####
 RUN pkg-resolver/install-epel.sh centos:8
 
+# hadolint ignore=DL3033,DL3041
 RUN dnf --enablerepo=powertools install -y \
     doxygen \
     snappy-devel \
-    yasm
-
-RUN dnf install -y \
-    bouncycastle \
-    gcc-toolset-9-gcc \
-    gcc-toolset-9-gcc-c++ \
-    libpmem-devel
+    yasm \
+    && dnf install -y \
+      bouncycastle \
+      gcc-toolset-9-gcc \
+      gcc-toolset-9-gcc-c++ \
+      libpmem-devel \
+    && dnf clean all
 
 # Set GCC 9 as the default C/C++ compiler
 RUN echo "source /opt/rh/gcc-toolset-9/enable" >> /etc/bashrc
@@ -115,4 +117,5 @@ RUN pkg-resolver/install-boost.sh centos:8
 RUN pkg-resolver/install-spotbugs.sh centos:8
 RUN pkg-resolver/install-protobuf.sh centos:8
 RUN pkg-resolver/install-zstandard.sh centos:8
+RUN pkg-resolver/install-hadolint.sh centos:8 2.10.0
 RUN pkg-resolver/install-common-pkgs.sh

--- a/dev-support/docker/Dockerfile_debian_10
+++ b/dev-support/docker/Dockerfile_debian_10
@@ -86,7 +86,7 @@ RUN pkg-resolver/install-cmake.sh debian:10
 RUN pkg-resolver/install-spotbugs.sh debian:10
 RUN pkg-resolver/install-boost.sh debian:10
 RUN pkg-resolver/install-protobuf.sh debian:10
-RUN pkg-resolver/install-hadolint.sh debian:10
+RUN pkg-resolver/install-hadolint.sh debian:10 2.10.0
 RUN pkg-resolver/install-intel-isa-l.sh debian:10
 
 ###

--- a/dev-support/docker/pkg-resolver/install-hadolint.sh
+++ b/dev-support/docker/pkg-resolver/install-hadolint.sh
@@ -27,9 +27,24 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-curl -L -s -S \
-  https://github.com/hadolint/hadolint/releases/download/v1.11.1/hadolint-Linux-x86_64 \
-  -o /bin/hadolint &&
-  chmod a+rx /bin/hadolint &&
-  shasum -a 512 /bin/hadolint |
-  awk '$1!="734e37c1f6619cbbd86b9b249e69c9af8ee1ea87a2b1ff71dccda412e9dac35e63425225a95d71572091a3f0a11e9a04c2fc25d9e91b840530c26af32b9891ca" {exit(1)}'
+default_version="1.11.1"
+version_to_install=$default_version
+if [ -n "$2" ]; then
+  version_to_install="$2"
+fi
+
+if [ "$version_to_install" == "1.11.1" ]; then
+  curl -L -s -S \
+    https://github.com/hadolint/hadolint/releases/download/v1.11.1/hadolint-Linux-x86_64 \
+    -o /bin/hadolint &&
+    chmod a+rx /bin/hadolint &&
+    shasum -a 512 /bin/hadolint |
+    awk '$1!="734e37c1f6619cbbd86b9b249e69c9af8ee1ea87a2b1ff71dccda412e9dac35e63425225a95d71572091a3f0a11e9a04c2fc25d9e91b840530c26af32b9891ca" {exit(1)}'
+elif [ "$version_to_install" == "2.10.0" ]; then
+  curl -L -s -S \
+    https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64 \
+    -o /bin/hadolint &&
+    chmod a+rx /bin/hadolint &&
+    shasum -a 512 /bin/hadolint |
+    awk '$1!="4816c95243bedf15476d2225f487fc17465495fb2031e1a4797d82a26db83a1edb63e4fed084b80cef17d5eb67eb45508caadaf7cd0252fb061187113991a338" {exit(1)}'
+fi


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The current version of hadolint (1.11.1) is only suitable for linting Linux commands in Dockerfile. It fails to recognize Windows command syntax.
[HADOOP-18133](https://issues.apache.org/jira/browse/HADOOP-18133) adds Dockerfile for Windows. Thus, it's essential to upgrade hadolint to 2.10.0 which has the ability to recognize Windows command syntax.

### How was this patch tested?

Hadoop Jenkins CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

