### PR TITLE
HADOOP-18453. Fix typo: a os-native -> an os-native

### DIFF
--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.10.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.10.0.xml
@@ -11247,7 +11247,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11260,7 +11260,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11274,7 +11274,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.10.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.10.2.xml
@@ -11308,7 +11308,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11321,7 +11321,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11335,7 +11335,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.6.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.6.0.xml
@@ -11496,7 +11496,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11509,7 +11509,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11523,7 +11523,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.7.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.7.2.xml
@@ -9277,7 +9277,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -9290,7 +9290,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -9304,7 +9304,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.8.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.8.0.xml
@@ -10366,7 +10366,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -10379,7 +10379,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -10393,7 +10393,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.8.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.8.2.xml
@@ -10408,7 +10408,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -10421,7 +10421,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -10435,7 +10435,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.8.3.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_2.8.3.xml
@@ -10623,7 +10623,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -10636,7 +10636,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -10650,7 +10650,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.1.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.1.2.xml
@@ -11468,7 +11468,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11481,7 +11481,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11494,7 +11494,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell
+      <![CDATA[Convert an os-native filename to a path that works for the shell
  and avoids script injection attacks.
  @param file The filename to convert
  @return The unix pathname
@@ -11509,7 +11509,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.2.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.2.2.xml
@@ -11779,7 +11779,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11792,7 +11792,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11805,7 +11805,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell
+      <![CDATA[Convert an os-native filename to a path that works for the shell
  and avoids script injection attacks.
  @param file The filename to convert
  @return The unix pathname
@@ -11820,7 +11820,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.2.4.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.2.4.xml
@@ -11789,7 +11789,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11802,7 +11802,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -11815,7 +11815,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell
+      <![CDATA[Convert an os-native filename to a path that works for the shell
  and avoids script injection attacks.
  @param file The filename to convert
  @return The unix pathname
@@ -11830,7 +11830,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.3.3.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.3.3.xml
@@ -12406,7 +12406,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -12419,7 +12419,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -12432,7 +12432,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell
+      <![CDATA[Convert an os-native filename to a path that works for the shell
  and avoids script injection attacks.
  @param file The filename to convert
  @return The unix pathname
@@ -12447,7 +12447,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.3.4.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/Apache_Hadoop_Common_3.3.4.xml
@@ -12406,7 +12406,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -12419,7 +12419,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -12432,7 +12432,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell
+      <![CDATA[Convert an os-native filename to a path that works for the shell
  and avoids script injection attacks.
  @param file The filename to convert
  @return The unix pathname
@@ -12447,7 +12447,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop-core_0.20.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop-core_0.20.0.xml
@@ -3972,7 +3972,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3985,7 +3985,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3999,7 +3999,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop-core_0.21.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop-core_0.21.0.xml
@@ -5900,7 +5900,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -5913,7 +5913,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -5927,7 +5927,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop-core_0.22.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop-core_0.22.0.xml
@@ -6907,7 +6907,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -6920,7 +6920,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -6934,7 +6934,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.17.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.17.0.xml
@@ -9018,7 +9018,7 @@ order written.</p>]]>
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -9031,7 +9031,7 @@ order written.</p>]]>
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.18.1.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.18.1.xml
@@ -9563,7 +9563,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -9576,7 +9576,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.18.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.18.2.xml
@@ -3573,7 +3573,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3586,7 +3586,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.18.3.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.18.3.xml
@@ -3573,7 +3573,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3586,7 +3586,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.19.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.19.0.xml
@@ -3805,7 +3805,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3818,7 +3818,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3832,7 +3832,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.19.1.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.19.1.xml
@@ -3805,7 +3805,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3818,7 +3818,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3832,7 +3832,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.19.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.19.2.xml
@@ -3805,7 +3805,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3818,7 +3818,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3832,7 +3832,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.20.0.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.20.0.xml
@@ -3969,7 +3969,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3982,7 +3982,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3996,7 +3996,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.20.1.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.20.1.xml
@@ -3969,7 +3969,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3982,7 +3982,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3996,7 +3996,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.20.2.xml
+++ b/hadoop-common-project/hadoop-common/dev-support/jdiff/hadoop_0.20.2.xml
@@ -3969,7 +3969,7 @@
       <param name="filename" type="java.lang.String"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param filename The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3982,7 +3982,7 @@
       <param name="file" type="java.io.File"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @return The unix pathname
  @throws IOException on windows, there can be problems with the subprocess]]>
@@ -3996,7 +3996,7 @@
       <param name="makeCanonicalPath" type="boolean"/>
       <exception name="IOException" type="java.io.IOException"/>
       <doc>
-      <![CDATA[Convert a os-native filename to a path that works for the shell.
+      <![CDATA[Convert an os-native filename to a path that works for the shell.
  @param file The filename to convert
  @param makeCanonicalPath 
           Whether to make canonical path for the file passed

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileUtil.java
@@ -649,7 +649,7 @@ public class FileUtil {
   }
 
   /**
-   * Convert a os-native filename to a path that works for the shell.
+   * Convert an os-native filename to a path that works for the shell.
    * @param filename The filename to convert
    * @return The unix pathname
    * @throws IOException on windows, there can be problems with the subprocess
@@ -659,7 +659,7 @@ public class FileUtil {
   }
 
   /**
-   * Convert a os-native filename to a path that works for the shell.
+   * Convert an os-native filename to a path that works for the shell.
    * @param file The filename to convert
    * @return The unix pathname
    * @throws IOException on windows, there can be problems with the subprocess
@@ -669,7 +669,7 @@ public class FileUtil {
   }
 
   /**
-   * Convert a os-native filename to a path that works for the shell
+   * Convert an os-native filename to a path that works for the shell
    * and avoids script injection attacks.
    * @param file The filename to convert
    * @return The unix pathname
@@ -685,7 +685,7 @@ public class FileUtil {
   }
 
   /**
-   * Convert a os-native filename to a path that works for the shell.
+   * Convert an os-native filename to a path that works for the shell.
    * @param file The filename to convert
    * @param makeCanonicalPath
    *          Whether to make canonical path for the file passed

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ResourceCalculatorProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ResourceCalculatorProcessTree.java
@@ -182,7 +182,7 @@ public abstract class ResourceCalculatorProcessTree extends Configured {
       }
     }
 
-    // No class given, try a os specific class
+    // No class given, try an os specific class
     if (ProcfsBasedProcessTree.isAvailable()) {
       return new ProcfsBasedProcessTree(pid);
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

There is a comment in FileUtil.java:

>  Convert a os-native filename to a path that works for the shell.

That "a os-native" should be "an os-native".

Several more comments from other files are fixed in the same way.


### How was this patch tested?

It only fixes comments, which doesn't affect the performance.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

