### PR TITLE
YARN-11207. Add configuration to disable queue's user limit.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -118,6 +118,8 @@ public class AbstractLeafQueue extends AbstractCSQueue {
 
   private final UsersManager usersManager;
 
+  private boolean userLimitEnabled;
+
   // cache last cluster resource to compute actual capacity
   private Resource lastClusterResource = Resources.none();
 
@@ -189,6 +191,8 @@ public class AbstractLeafQueue extends AbstractCSQueue {
 
       setOrderingPolicy(
           configuration.<FiCaSchedulerApp>getAppOrderingPolicy(getQueuePath()));
+
+      userLimitEnabled = configuration.getUserLimitEnabled(getQueuePath());
 
       usersManager.setUserLimit(configuration.getUserLimit(getQueuePath()));
       usersManager.setUserLimitFactor(configuration.getUserLimitFactor(getQueuePath()));
@@ -270,6 +274,7 @@ public class AbstractLeafQueue extends AbstractCSQueue {
               getEffectiveCapacity(CommonNodeLabelsManager.NO_LABEL) + "\n"
               + " , effectiveMaxResource=" +
               getEffectiveMaxCapacity(CommonNodeLabelsManager.NO_LABEL)
+              + "\n" + "userLimitEnabled = " + userLimitEnabled
               + "\n" + "userLimit = " + usersManager.getUserLimit()
               + " [= configuredUserLimit ]" + "\n" + "userLimitFactor = "
               + usersManager.getUserLimitFactor()
@@ -378,6 +383,11 @@ public class AbstractLeafQueue extends AbstractCSQueue {
   void setUserLimitFactor(float userLimitFactor) {
     usersManager.setUserLimitFactor(userLimitFactor);
     usersManager.userLimitNeedsRecompute();
+  }
+
+  @VisibleForTesting
+  void setUserLimitEnabled(boolean userLimitEnabled) {
+    this.userLimitEnabled = userLimitEnabled;
   }
 
   @Override
@@ -1224,44 +1234,46 @@ public class AbstractLeafQueue extends AbstractCSQueue {
         }
       }
 
-      CachedUserLimit cul = userLimits.get(application.getUser());
-      Resource cachedUserLimit = null;
-      if (cul != null) {
-        cachedUserLimit = cul.userLimit;
-      }
-      Resource userLimit = computeUserLimitAndSetHeadroom(application,
-          clusterResource, candidates.getPartition(), schedulingMode,
-          cachedUserLimit);
-      if (cul == null) {
-        cul = new CachedUserLimit(userLimit);
-        CachedUserLimit retVal =
-            userLimits.putIfAbsent(application.getUser(), cul);
-        if (retVal != null) {
-          // another thread updated the user limit cache before us
-          cul = retVal;
-          userLimit = cul.userLimit;
+      if (userLimitEnabled) {
+        CachedUserLimit cul = userLimits.get(application.getUser());
+        Resource cachedUserLimit = null;
+        if (cul != null) {
+          cachedUserLimit = cul.userLimit;
         }
-      }
-      // Check user limit
-      boolean userAssignable = true;
-      if (!cul.canAssign && Resources.fitsIn(appReserved, cul.reservation)) {
-        userAssignable = false;
-      } else {
-        userAssignable = canAssignToUser(clusterResource, application.getUser(),
-            userLimit, application, candidates.getPartition(),
-            currentResourceLimits);
-        if (!userAssignable && Resources.fitsIn(cul.reservation, appReserved)) {
-          cul.canAssign = false;
-          cul.reservation = appReserved;
+        Resource userLimit = computeUserLimitAndSetHeadroom(application,
+                clusterResource, candidates.getPartition(), schedulingMode,
+                cachedUserLimit);
+        if (cul == null) {
+          cul = new CachedUserLimit(userLimit);
+          CachedUserLimit retVal =
+                  userLimits.putIfAbsent(application.getUser(), cul);
+          if (retVal != null) {
+            // another thread updated the user limit cache before us
+            cul = retVal;
+            userLimit = cul.userLimit;
+          }
         }
-      }
-      if (!userAssignable) {
-        application.updateAMContainerDiagnostics(AMState.ACTIVATED,
-            "User capacity has reached its maximum limit.");
-        ActivitiesLogger.APP.recordRejectedAppActivityFromLeafQueue(
-            activitiesManager, node, application, application.getPriority(),
-            ActivityDiagnosticConstant.QUEUE_HIT_USER_MAX_CAPACITY_LIMIT);
-        continue;
+        // Check user limit
+        boolean userAssignable = true;
+        if (!cul.canAssign && Resources.fitsIn(appReserved, cul.reservation)) {
+          userAssignable = false;
+        } else {
+          userAssignable = canAssignToUser(clusterResource, application.getUser(),
+                  userLimit, application, candidates.getPartition(),
+                  currentResourceLimits);
+          if (!userAssignable && Resources.fitsIn(cul.reservation, appReserved)) {
+            cul.canAssign = false;
+            cul.reservation = appReserved;
+          }
+        }
+        if (!userAssignable) {
+          application.updateAMContainerDiagnostics(AMState.ACTIVATED,
+                  "User capacity has reached its maximum limit.");
+          ActivitiesLogger.APP.recordRejectedAppActivityFromLeafQueue(
+                  activitiesManager, node, application, application.getPriority(),
+                  ActivityDiagnosticConstant.QUEUE_HIT_USER_MAX_CAPACITY_LIMIT);
+          continue;
+        }
       }
 
       // Try to schedule
@@ -1324,7 +1336,7 @@ public class AbstractLeafQueue extends AbstractCSQueue {
         allocation.getAllocatedOrReservedContainer();
 
     // Do not check limits when allocation from a reserved container
-    if (allocation.getAllocateFromReservedContainer() == null) {
+    if (allocation.getAllocateFromReservedContainer() == null && userLimitEnabled) {
       readLock.lock();
       try {
         FiCaSchedulerApp app =
@@ -1972,16 +1984,18 @@ public class AbstractLeafQueue extends AbstractCSQueue {
       // activate the pending applications if possible
       activateApplications();
 
-      // In case of any resource change, invalidate recalculateULCount to clear
-      // the computed user-limit.
-      usersManager.userLimitNeedsRecompute();
+      if (userLimitEnabled) {
+        // In case of any resource change, invalidate recalculateULCount to clear
+        // the computed user-limit.
+        usersManager.userLimitNeedsRecompute();
 
-      // Update application properties
-      for (FiCaSchedulerApp application : orderingPolicy
-          .getSchedulableEntities()) {
-        computeUserLimitAndSetHeadroom(application, clusterResource,
-            RMNodeLabelsManager.NO_LABEL,
-            SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY, null);
+        // Update application properties
+        for (FiCaSchedulerApp application : orderingPolicy
+                .getSchedulableEntities()) {
+          computeUserLimitAndSetHeadroom(application, clusterResource,
+                  RMNodeLabelsManager.NO_LABEL,
+                  SchedulingMode.RESPECT_PARTITION_EXCLUSIVITY, null);
+        }
       }
     } finally {
       writeLock.unlock();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -120,6 +120,9 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public static final String USER_LIMIT = "minimum-user-limit-percent";
 
   @Private
+  public static final String USER_LIMIT_ENABLE = "user-limit-enable";
+
+  @Private
   public static final String USER_LIMIT_FACTOR = "user-limit-factor";
 
   @Private
@@ -205,6 +208,9 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
 
   @Private
   public static final int DEFAULT_USER_LIMIT = 100;
+
+  @Private
+  public static final boolean DEFAULT_USER_LIMIT_ENABLE = true;
 
   @Private
   public static final float DEFAULT_USER_LIMIT_FACTOR = 1.0f;
@@ -734,6 +740,13 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     setFloat(PREFIX + USER_LIMIT, defaultUserLimit);
   }
 
+  public boolean getUserLimitEnabled(String queue) {
+    boolean userLimitEnabled = getBoolean(
+            getQueuePrefix(queue) + USER_LIMIT_ENABLE,
+            DEFAULT_USER_LIMIT_ENABLE);
+    return userLimitEnabled;
+  }
+  
   public float getUserLimitFactor(String queue) {
     float defaultUserLimitFactor = getFloat(PREFIX + USER_LIMIT_FACTOR, DEFAULT_USER_LIMIT_FACTOR);
     float userLimitFactor =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -746,7 +746,7 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
             DEFAULT_USER_LIMIT_ENABLE);
     return userLimitEnabled;
   }
-  
+
   public float getUserLimitFactor(String queue) {
     float defaultUserLimitFactor = getFloat(PREFIX + USER_LIMIT_FACTOR, DEFAULT_USER_LIMIT_FACTOR);
     float userLimitFactor =


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
In our cluster, a queue is only used by one user, so there is no need to limit user resource.

I think we can add a config to disable queue's user limit, and user limit is enabled by default.


