### PR TITLE
YARN-11305. Fix TestLogAggregationService#testLocalFileDeletionAfterUpload Failed After YARN-11241(#4703).

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -202,7 +202,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   private void verifyLocalFileDeletion(
-      LogAggregationService logAggregationService,Long clusterTimeStamp) throws Exception {
+      LogAggregationService logAggregationService, Long clusterTimeStamp) throws Exception {
     logAggregationService.init(this.conf);
     logAggregationService.start();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -203,10 +203,12 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   private void verifyLocalFileDeletion(
-      LogAggregationService logAggregationService, Long clusterTimeStamp) throws Exception {
+      LogAggregationService logAggregationService) throws Exception {
     logAggregationService.init(this.conf);
     logAggregationService.start();
 
+    Random random = new Random(System.currentTimeMillis());
+    long clusterTimeStamp = random.nextLong();
     ApplicationId application1 = BuilderUtils.newApplicationId(clusterTimeStamp, 1);
 
     // AppLogDir should be created
@@ -246,15 +248,9 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
       String containerIdStr = container11.toString();
       File containerLogDir = new File(app1LogDir, containerIdStr);
-      int count = 0;
-      int maxAttempts = 50;
       for (String fileType : new String[]{"stdout", "stderr", "syslog"}) {
         File f = new File(containerLogDir, fileType);
-        count = 0;
-        while ((f.exists()) && (count < maxAttempts)) {
-          count++;
-          Thread.sleep(1000);
-        }
+        GenericTestUtils.waitFor(() -> !f.exists(), 1000, 1000 * 50);
         Assert.assertFalse("File [" + f + "] was not deleted", f.exists());
       }
       Assert.assertFalse("Directory [" + app1LogDir + "] was not deleted",
@@ -311,7 +307,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     LogAggregationService logAggregationService = spy(
         new LogAggregationService(dispatcher, this.context, this.delSrvc,
                                   super.dirsHandler));
-    verifyLocalFileDeletion(logAggregationService, 1234L);
+    verifyLocalFileDeletion(logAggregationService);
   }
 
   @Test
@@ -325,7 +321,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         this.remoteRootLogDir.getAbsolutePath());
     LogAggregationService logAggregationService = spy(
         new LogAggregationService(dispatcher, this.context, this.delSrvc, super.dirsHandler));
-    verifyLocalFileDeletion(logAggregationService, 4321L);
+    verifyLocalFileDeletion(logAggregationService);
   }
 
   @Test
@@ -345,7 +341,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     LogAggregationService logAggregationService = spy(
         new LogAggregationService(dispatcher, this.context, this.delSrvc,
             dirsHandler));
-    verifyLocalFileDeletion(logAggregationService, 5678L);
+    verifyLocalFileDeletion(logAggregationService);
   }
 
   /* Test to verify fix for YARN-3793 */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -202,11 +202,11 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   private void verifyLocalFileDeletion(
-      LogAggregationService logAggregationService) throws Exception {
+      LogAggregationService logAggregationService,Long clusterTimeStamp) throws Exception {
     logAggregationService.init(this.conf);
     logAggregationService.start();
 
-    ApplicationId application1 = BuilderUtils.newApplicationId(1234, 1);
+    ApplicationId application1 = BuilderUtils.newApplicationId(clusterTimeStamp, 1);
 
     // AppLogDir should be created
     File app1LogDir =
@@ -252,7 +252,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         count = 0;
         while ((f.exists()) && (count < maxAttempts)) {
           count++;
-          Thread.sleep(100);
+          Thread.sleep(1000);
         }
         Assert.assertFalse("File [" + f + "] was not deleted", f.exists());
       }
@@ -310,7 +310,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     LogAggregationService logAggregationService = spy(
         new LogAggregationService(dispatcher, this.context, this.delSrvc,
                                   super.dirsHandler));
-    verifyLocalFileDeletion(logAggregationService);
+    verifyLocalFileDeletion(logAggregationService, 1234L);
   }
 
   @Test
@@ -324,7 +324,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         this.remoteRootLogDir.getAbsolutePath());
     LogAggregationService logAggregationService = spy(
         new LogAggregationService(dispatcher, this.context, this.delSrvc, super.dirsHandler));
-    verifyLocalFileDeletion(logAggregationService);
+    verifyLocalFileDeletion(logAggregationService, 4321L);
   }
 
   @Test
@@ -344,7 +344,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     LogAggregationService logAggregationService = spy(
         new LogAggregationService(dispatcher, this.context, this.delSrvc,
             dirsHandler));
-    verifyLocalFileDeletion(logAggregationService);
+    verifyLocalFileDeletion(logAggregationService, 5678L);
   }
 
   /* Test to verify fix for YARN-3793 */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -56,6 +56,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
YARN-11305. Fix TestLogAggregationService#testLocalFileDeletionAfterUpload Failed After YARN-11241(#4703).

ERROR Message:
```
Directory [/home/jenkins/jenkins-home/workspace/hadoop-multibranch_PR-4846/ubuntu-focal/src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/target/TestLogAggregationService-localLogDir/application_1234_0001] was not deleted 
```

testReport:
https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-4846/23/testReport/


Yarn's unit tests, with parallel mode enabled
```
/usr/bin/mvn --batch-mode -Dmaven.repo.local=/home/jenkins/jenkins-home/workspace/hadoop-multibranch_PR-4846/yetus-m2/hadoop-trunk-patch-0 -Ptest-patch -Dsurefire.rerunFailingTestsCount=2 -Pparallel-tests -P!shelltest -Pnative -Drequire.fuse -Drequire.openssl -Drequire.snappy -Drequire.valgrind -Drequire.zstd -Drequire.test.libhadoop -Pyarn-ui clean test -fae
```

Because the automatically generated application_id is the same, testLocalFileDeletionAfterUpload is affected by testLocalFileRemainsAfterUploadOnCleanupDisable

testLocalFileDeletionAfterUpload needs to check that the log of an application is deleted, and testLocalFileRemainsAfterUploadOnCleanupDisable regenerates the log of the same application.