### PR TITLE
HDFS-16776 Erasure Coding: The length of targets should be checked when DN gets a reconstruction task

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedReconstructor.java
@@ -119,7 +119,6 @@ abstract class StripedReconstructor {
   private ErasureCodingWorker erasureCodingWorker;
   private final CachingStrategy cachingStrategy;
   private long maxTargetLength = 0L;
-  private int liveIndiceNum = 0;
   private final BitSet liveBitSet;
   private final BitSet excludeBitSet;
 
@@ -137,9 +136,6 @@ abstract class StripedReconstructor {
     liveBitSet = new BitSet(
         ecPolicy.getNumDataUnits() + ecPolicy.getNumParityUnits());
     for (int i = 0; i < stripedReconInfo.getLiveIndices().length; i++) {
-      if(!liveBitSet.get(stripedReconInfo.getLiveIndices()[i])){
-        liveIndiceNum++;
-      }
       liveBitSet.set(stripedReconInfo.getLiveIndices()[i]);
     }
     excludeBitSet = new BitSet(
@@ -292,8 +288,8 @@ abstract class StripedReconstructor {
     return decoder;
   }
 
-  int getIndicesNum(){
-    return liveIndiceNum;
+  int getNumLiveBlocks(){
+    return liveBitSet.cardinality();
   }
 
   void cleanup() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedReconstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedReconstructor.java
@@ -119,6 +119,7 @@ abstract class StripedReconstructor {
   private ErasureCodingWorker erasureCodingWorker;
   private final CachingStrategy cachingStrategy;
   private long maxTargetLength = 0L;
+  private int liveIndiceNum = 0;
   private final BitSet liveBitSet;
   private final BitSet excludeBitSet;
 
@@ -136,6 +137,9 @@ abstract class StripedReconstructor {
     liveBitSet = new BitSet(
         ecPolicy.getNumDataUnits() + ecPolicy.getNumParityUnits());
     for (int i = 0; i < stripedReconInfo.getLiveIndices().length; i++) {
+      if(!liveBitSet.get(stripedReconInfo.getLiveIndices()[i])){
+        liveIndiceNum++;
+      }
       liveBitSet.set(stripedReconInfo.getLiveIndices()[i]);
     }
     excludeBitSet = new BitSet(
@@ -286,6 +290,10 @@ abstract class StripedReconstructor {
 
   RawErasureDecoder getDecoder() {
     return decoder;
+  }
+
+  int getIndicesNum(){
+    return liveIndiceNum;
   }
 
   void cleanup() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
@@ -84,7 +84,7 @@ class StripedWriter {
     writers = new StripedBlockWriter[targets.length];
 
     targetIndices = new short[targets.length];
-    Preconditions.checkArgument(targetIndices.length <= reconstructor.getIndicesNum(),
+    Preconditions.checkArgument(targetIndices.length <= dataBlkNum + parityBlkNum - reconstructor.getIndicesNum(),
             "Reconstrutcion work gets too much targets.");
     Preconditions.checkArgument(targetIndices.length <= parityBlkNum,
         "Too much missed striped blocks.");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
@@ -84,6 +84,8 @@ class StripedWriter {
     writers = new StripedBlockWriter[targets.length];
 
     targetIndices = new short[targets.length];
+    Preconditions.checkArgument(targetIndices.length <= reconstructor.getIndicesNum(),
+            "Reconstrutcion work gets too much targets.");
     Preconditions.checkArgument(targetIndices.length <= parityBlkNum,
         "Too much missed striped blocks.");
     initTargetIndices();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
@@ -85,7 +85,7 @@ class StripedWriter {
     targetIndices = new short[targets.length];
     Preconditions.checkArgument(
             targetIndices.length <= dataBlkNum + parityBlkNum - reconstructor.getNumLiveBlocks(),
-            "Reconstrutcion work gets too much targets.");
+            "Reconstruction work gets too much targets.");
     Preconditions.checkArgument(targetIndices.length <= parityBlkNum,
         "Too much missed striped blocks.");
     initTargetIndices();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/erasurecode/StripedWriter.java
@@ -82,9 +82,9 @@ class StripedWriter {
     assert targetStorageIds != null;
 
     writers = new StripedBlockWriter[targets.length];
-
     targetIndices = new short[targets.length];
-    Preconditions.checkArgument(targetIndices.length <= dataBlkNum + parityBlkNum - reconstructor.getIndicesNum(),
+    Preconditions.checkArgument(
+            targetIndices.length <= dataBlkNum + parityBlkNum - reconstructor.getNumLiveBlocks(),
             "Reconstrutcion work gets too much targets.");
     Preconditions.checkArgument(targetIndices.length <= parityBlkNum,
         "Too much missed striped blocks.");


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [HDFS-16776](https://issues.apache.org/jira/browse/HDFS-16776)
The length of targets should be checked when DN gets a EC reconstruction task.For some reason ([HDFS-14768](https://issues.apache.org/jira/browse/HDFS-14768), [HDFS-16739](https://issues.apache.org/jira/browse/HDFS-16739)) , the length of targets will be larger than additionalReplRequired which causes some elements in targets get the default value 0. It may trigger the bug which leads to the data corrupttion just like [HDFS-14768](https://issues.apache.org/jira/browse/HDFS-14768).