### PR TITLE
HDFS-16775.Improve BlockPlacementPolicyRackFaultTolerant's chooseOnce

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -710,17 +710,20 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
       return chooseRandom(localRack, excludedNodes,
           blocksize, maxNodesPerRack, results, avoidStaleNodes, storageTypes);
     } catch (NotEnoughReplicasException e) {
-      // find the next replica and retry with its rack
-      for(DatanodeStorageInfo resultStorage : results) {
-        DatanodeDescriptor nextNode = resultStorage.getDatanodeDescriptor();
-        if (nextNode != localMachine) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Failed to choose from local rack (location = {}), retry with the rack "
-                + "of the next replica (location = {})", localRack,
-                nextNode.getNetworkLocation(), e);
+      if  (maxNodesPerRack > 1) {
+        // if maxNodesPerRack > 1 and find the next replica and retry with its rack
+
+        for (DatanodeStorageInfo resultStorage : results) {
+          DatanodeDescriptor nextNode = resultStorage.getDatanodeDescriptor();
+          if (nextNode != localMachine) {
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("Failed to choose from local rack (location = {}), retry with the rack "
+                      + "of the next replica (location = {})", localRack,
+                  nextNode.getNetworkLocation(), e);
+            }
+            return chooseFromNextRack(nextNode, excludedNodes, blocksize,
+                maxNodesPerRack, results, avoidStaleNodes, storageTypes);
           }
-          return chooseFromNextRack(nextNode, excludedNodes, blocksize,
-              maxNodesPerRack, results, avoidStaleNodes, storageTypes);
         }
       }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
@@ -218,14 +218,26 @@ public class BlockPlacementPolicyRackFaultTolerant extends BlockPlacementPolicyD
     if (numOfReplicas == 0) {
       return writer;
     }
-    writer = chooseLocalStorage(writer, excludedNodes, blocksize,
-        maxNodesPerRack, results, avoidStaleNodes, storageTypes, true)
-        .getDatanodeDescriptor();
-    if (--numOfReplicas == 0) {
-      return writer;
+
+    // results list is the target nodes already chosen and exclude DECOMMISSIONING nodes,
+    // if node is DECOMMISSIONING and try a node on local rack, otherwise choose randomly,
+    // Here is a point to explain, currently we only consider the scenario
+    // where maxNodesPerRack is 1.
+    boolean isInResult = results.contains(writer);
+    if (!isInResult) {
+      writer = chooseLocalStorage(writer, excludedNodes, blocksize,
+          maxNodesPerRack, results, avoidStaleNodes, storageTypes, true)
+          .getDatanodeDescriptor();
+      if (--numOfReplicas == 0) {
+        return writer;
+      }
     }
-    chooseRandom(numOfReplicas, NodeBase.ROOT, excludedNodes, blocksize,
-        maxNodesPerRack, results, avoidStaleNodes, storageTypes);
+
+    DatanodeStorageInfo datanodeStorageInfo = chooseRandom(numOfReplicas, NodeBase.ROOT,
+        excludedNodes, blocksize, maxNodesPerRack, results, avoidStaleNodes, storageTypes);
+    if (isInResult) {
+      writer = datanodeStorageInfo.getDatanodeDescriptor();
+    }
     return writer;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerant.java
@@ -223,7 +223,9 @@ public class BlockPlacementPolicyRackFaultTolerant extends BlockPlacementPolicyD
     // if node is DECOMMISSIONING and try a node on local rack, otherwise choose randomly,
     // Here is a point to explain, currently we only consider the scenario
     // where maxNodesPerRack is 1.
-    boolean isInResult = results.contains(writer);
+    final Node tmpWriter = writer;
+    boolean isInResult = results.stream().anyMatch(datanodeStorageInfo ->
+        datanodeStorageInfo.getDatanodeDescriptor().getName().equals(tmpWriter.getName()));
     if (!isInResult) {
       writer = chooseLocalStorage(writer, excludedNodes, blocksize,
           maxNodesPerRack, results, avoidStaleNodes, storageTypes, true)


### PR DESCRIPTION
### Description of PR
HDFS-16775.

### For code changes:

Improve BlockPlacementPolicyRackFaultTolerant's chooseOnce

this seriously affects the datanode  decommissioning speed
The process of choose target dn for the current EC : 
chooseLocalStorage->chooseLocalRack->chooseFromNextRack->chooseRandom

1.chooseLocalStorage choose localMachine as the target ,and localMachine is srcNodes[0], it maybe not decommissioning and was in the excluded list, so is not available
2.chooseLocalRack choose one node from the rack that localMachine is on, maybe the rack maybe has already exists one node ,so is not available
3.chooseFromNextRack choose next node on the srcNodes retry with its rack, maybe the rack has already exists one node, so is not available
4.last retry choose randomly

So, optimize for ec block choose target logic.
results list is the target nodes already chosen and exclude DECOMMISSIONING nodes,
if node is DECOMMISSIONING and try a node on local rack, otherwise choose randomly,
