### PR TITLE
HDFS-16774.Improve async delete replica on datanode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeFaultInjector.java
@@ -157,4 +157,9 @@ public class DataNodeFaultInjector {
   public void badDecoding(ByteBuffer[] outputs) {}
 
   public void markSlow(String dnAddr, int[] replies) {}
+
+  /**
+   * Just delay delete replica a while.
+   */
+  public void delayDeleteReplica() {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -31,12 +31,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.apache.hadoop.hdfs.ExtendedBlockId;
-import org.apache.hadoop.hdfs.protocol.Block;
-import org.apache.hadoop.hdfs.server.common.DataNodeLockManager;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeFaultInjector;
-import org.apache.hadoop.hdfs.server.datanode.ReplicaInPipeline;
-import org.apache.hadoop.util.AutoCloseableLock;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -340,9 +340,10 @@ class FsDatasetAsyncDiskService {
     @Override
     public void run() {
       try {
-        // For testing. Normally no-op.
+        // For testing, simulate the case asynchronously deletion of the
+        // replica task stacked pending.
         DataNodeFaultInjector.get().delayDeleteReplica();
-        if (!removeReplicaFromMem()){
+        if (!fsdatasetImpl.removeReplicaFromMem(block, volume)){
           return;
         }
 
@@ -370,89 +371,6 @@ class FsDatasetAsyncDiskService {
       } finally {
         IOUtils.cleanupWithLogger(null, this.volumeRef);
       }
-    }
-
-    private boolean removeReplicaFromMem() {
-      try (AutoCloseableLock lock = fsdatasetImpl.acquireDatasetLockManager().writeLock(
-          DataNodeLockManager.LockLevel.BLOCK_POOl, block.getBlockPoolId())) {
-        final ReplicaInfo info = fsdatasetImpl.volumeMap
-            .get(block.getBlockPoolId(), block.getLocalBlock());
-        if (info == null) {
-          ReplicaInfo infoByBlockId =
-              fsdatasetImpl.volumeMap.get(block.getBlockPoolId(),
-                  block.getLocalBlock().getBlockId());
-          if (infoByBlockId == null) {
-            // It is okay if the block is not found -- it
-            // may be deleted earlier.
-            LOG.info("Failed to delete replica " + block.getLocalBlock()
-                + ": ReplicaInfo not found in removeReplicaFromMem.");
-          } else {
-            LOG.error("Failed to delete replica " + block.getLocalBlock()
-                + ": GenerationStamp not matched, existing replica is "
-                + Block.toString(infoByBlockId) + " in removeReplicaFromMem.");
-          }
-          return false;
-        }
-
-        FsVolumeImpl v = (FsVolumeImpl)info.getVolume();
-        if (v == null) {
-          LOG.error("Failed to delete replica " + block.getLocalBlock()
-              +  ". No volume for this replica " + info + " in removeReplicaFromMem.");
-          return false;
-        }
-
-        try {
-          File blockFile = new File(info.getBlockURI());
-          if (blockFile != null && blockFile.getParentFile() == null) {
-            LOG.error("Failed to delete replica " + block.getLocalBlock()
-                +  ". Parent not found for block file: " + blockFile
-                + " in removeReplicaFromMem.");
-            return false;
-          }
-        } catch(IllegalArgumentException e) {
-          LOG.warn("Parent directory check failed; replica {} is " +
-              "not backed by a local file in removeReplicaFromMem.", info);
-        }
-
-        if (!this.volume.getStorageID().equals(v.getStorageID())) {
-          LOG.error("Failed to delete replica " + block.getLocalBlock()
-              +  ". Appear different volumes, oldVolume=" + this.volume + " and newVolume=" + v
-              +  " for this replica in removeReplicaFromMem.");
-          return false;
-        }
-
-        ReplicaInfo removing = fsdatasetImpl.volumeMap.remove(block.getBlockPoolId(),
-            block.getLocalBlock());
-        fsdatasetImpl.addDeletingBlock(block.getBlockPoolId(), removing.getBlockId());
-        LOG.debug("Block file {} is to be deleted", removing.getBlockURI());
-        datanode.getMetrics().incrBlocksRemoved(1);
-        if (removing instanceof ReplicaInPipeline) {
-          ((ReplicaInPipeline) removing).releaseAllBytesReserved();
-        }
-      }
-
-      if (volume.isTransientStorage()) {
-        RamDiskReplicaTracker.RamDiskReplica replicaInfo =
-            fsdatasetImpl.ramDiskReplicaTracker.getReplica(block.getBlockPoolId(),
-                block.getLocalBlock().getBlockId());
-        if (replicaInfo != null) {
-          if (!replicaInfo.getIsPersisted()) {
-            datanode.getMetrics().incrRamDiskBlocksDeletedBeforeLazyPersisted();
-          }
-          fsdatasetImpl.ramDiskReplicaTracker.discardReplica(replicaInfo.getBlockPoolId(),
-              replicaInfo.getBlockId(), true);
-        }
-      }
-
-      // If a DFSClient has the replica in its cache of short-circuit file
-      // descriptors (and the client is using ShortCircuitShm), invalidate it.
-      datanode.getShortCircuitRegistry().processBlockInvalidation(
-          new ExtendedBlockId(block.getLocalBlock().getBlockId(), block.getBlockPoolId()));
-
-      // If the block is cached, start uncaching it.
-      fsdatasetImpl.cacheManager.uncacheBlock(
-          block.getBlockPoolId(), block.getLocalBlock().getBlockId());
-      return true;
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetAsyncDiskService.java
@@ -343,7 +343,7 @@ class FsDatasetAsyncDiskService {
         // For testing, simulate the case asynchronously deletion of the
         // replica task stacked pending.
         DataNodeFaultInjector.get().delayDeleteReplica();
-        if (!fsdatasetImpl.removeReplicaFromMem(block, volume)){
+        if (!fsdatasetImpl.removeReplicaFromMem(block, volume)) {
           return;
         }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2401,7 +2401,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   }
 
   /**
-   * Remove Replica from ReplicaMap
+   * Remove Replica from ReplicaMap.
    *
    * @param block
    * @param volume

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2407,7 +2407,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
    * @param volume
    * @return
    */
-  public boolean removeReplicaFromMem(final ExtendedBlock block, final FsVolumeImpl volume) {
+  boolean removeReplicaFromMem(final ExtendedBlock block, final FsVolumeImpl volume) {
     final String blockPoolId = block.getBlockPoolId();
     final Block localBlock = block.getLocalBlock();
     final long blockId = localBlock.getBlockId();
@@ -2428,7 +2428,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         return false;
       }
 
-      FsVolumeImpl v = (FsVolumeImpl)info.getVolume();
+      FsVolumeImpl v = (FsVolumeImpl) info.getVolume();
       if (v == null) {
         LOG.error("Failed to delete replica {}. No volume for this replica {} " +
             "in removeReplicaFromMem.", localBlock, info);
@@ -2437,7 +2437,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
       try {
         File blockFile = new File(info.getBlockURI());
-        if (blockFile != null && blockFile.getParentFile() == null) {
+        if (blockFile.getParentFile() == null) {
           LOG.error("Failed to delete replica {}. Parent not found for block file: {} " +
               "in removeReplicaFromMem.", localBlock, blockFile);
           return false;
@@ -2478,7 +2478,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     // If a DFSClient has the replica in its cache of short-circuit file
     // descriptors (and the client is using ShortCircuitShm), invalidate it.
     datanode.getShortCircuitRegistry().processBlockInvalidation(
-        new ExtendedBlockId(blockId, blockPoolId));
+        ExtendedBlockId.fromExtendedBlock(block));
 
     // If the block is cached, start uncaching it.
     cacheManager.uncacheBlock(blockPoolId, blockId);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2411,17 +2411,15 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
     final String blockPoolId = block.getBlockPoolId();
     final Block localBlock = block.getLocalBlock();
     final long blockId = localBlock.getBlockId();
-    try (AutoCloseableLock lock = lockManager.writeLock(
-        LockLevel.BLOCK_POOl, blockPoolId)) {
+    try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl, blockPoolId)) {
       final ReplicaInfo info = volumeMap.get(blockPoolId, localBlock);
       if (info == null) {
-        ReplicaInfo infoByBlockId =
-            volumeMap.get(blockPoolId, blockId);
+        ReplicaInfo infoByBlockId = volumeMap.get(blockPoolId, blockId);
         if (infoByBlockId == null) {
           // It is okay if the block is not found -- it
           // may be deleted earlier.
           LOG.info("Failed to delete replica {}: ReplicaInfo not found " +
-                  "in removeReplicaFromMem.", localBlock);
+              "in removeReplicaFromMem.", localBlock);
         } else {
           LOG.error("Failed to delete replica {}: GenerationStamp not matched, " +
               "existing replica is {} in removeReplicaFromMem.",
@@ -2432,16 +2430,16 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
       FsVolumeImpl v = (FsVolumeImpl)info.getVolume();
       if (v == null) {
-        LOG.error("Failed to delete replica {}. No volume for this replica {} "
-            + "in removeReplicaFromMem.", localBlock, info);
+        LOG.error("Failed to delete replica {}. No volume for this replica {} " +
+            "in removeReplicaFromMem.", localBlock, info);
         return false;
       }
 
       try {
         File blockFile = new File(info.getBlockURI());
         if (blockFile != null && blockFile.getParentFile() == null) {
-          LOG.error("Failed to delete replica {}. Parent not found for block file: {} "
-              + "in removeReplicaFromMem.", localBlock, blockFile);
+          LOG.error("Failed to delete replica {}. Parent not found for block file: {} " +
+              "in removeReplicaFromMem.", localBlock, blockFile);
           return false;
         }
       } catch(IllegalArgumentException e) {
@@ -2450,8 +2448,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       }
 
       if (!volume.getStorageID().equals(v.getStorageID())) {
-        LOG.error("Failed to delete replica {}. Appear different volumes, oldVolume={}" +
-            " and newVolume={} for this replica in removeReplicaFromMem.",
+        LOG.error("Failed to delete replica {}. Appear different volumes, oldVolume: {} " +
+            "and newVolume: {} for this replica in removeReplicaFromMem.",
             localBlock, volume, v);
         return false;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -2408,13 +2408,13 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
    * @return
    */
   boolean removeReplicaFromMem(final ExtendedBlock block, final FsVolumeImpl volume) {
-    final String blockPoolId = block.getBlockPoolId();
+    final String bpid = block.getBlockPoolId();
     final Block localBlock = block.getLocalBlock();
     final long blockId = localBlock.getBlockId();
-    try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl, blockPoolId)) {
-      final ReplicaInfo info = volumeMap.get(blockPoolId, localBlock);
+    try (AutoCloseableLock lock = lockManager.writeLock(LockLevel.BLOCK_POOl, bpid)) {
+      final ReplicaInfo info = volumeMap.get(bpid, localBlock);
       if (info == null) {
-        ReplicaInfo infoByBlockId = volumeMap.get(blockPoolId, blockId);
+        ReplicaInfo infoByBlockId = volumeMap.get(bpid, blockId);
         if (infoByBlockId == null) {
           // It is okay if the block is not found -- it
           // may be deleted earlier.
@@ -2454,8 +2454,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         return false;
       }
 
-      ReplicaInfo removing = volumeMap.remove(blockPoolId, localBlock);
-      addDeletingBlock(blockPoolId, removing.getBlockId());
+      ReplicaInfo removing = volumeMap.remove(bpid, localBlock);
+      addDeletingBlock(bpid, removing.getBlockId());
       LOG.debug("Block file {} is to be deleted", removing.getBlockURI());
       datanode.getMetrics().incrBlocksRemoved(1);
       if (removing instanceof ReplicaInPipeline) {
@@ -2465,7 +2465,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
     if (volume.isTransientStorage()) {
       RamDiskReplicaTracker.RamDiskReplica replicaInfo = ramDiskReplicaTracker.
-          getReplica(blockPoolId, blockId);
+          getReplica(bpid, blockId);
       if (replicaInfo != null) {
         if (!replicaInfo.getIsPersisted()) {
           datanode.getMetrics().incrRamDiskBlocksDeletedBeforeLazyPersisted();
@@ -2481,7 +2481,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         ExtendedBlockId.fromExtendedBlock(block));
 
     // If the block is cached, start uncaching it.
-    cacheManager.uncacheBlock(blockPoolId, blockId);
+    cacheManager.uncacheBlock(bpid, blockId);
     return true;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -25,10 +25,13 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.fs.DF;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
+import org.apache.hadoop.hdfs.server.datanode.DataNodeFaultInjector;
 import org.apache.hadoop.hdfs.server.datanode.DataSetLockManager;
 import org.apache.hadoop.hdfs.server.datanode.DirectoryScanner;
 import org.apache.hadoop.hdfs.server.datanode.LocalReplica;
@@ -1828,6 +1831,94 @@ public class TestFsDatasetImpl {
       assertEquals(3, metrics.getTransferIoQuantiles().length);
       assertEquals(2, metrics.getNativeCopyIoSampleCount());
       assertEquals(3, metrics.getNativeCopyIoQuantiles().length);
+    }
+  }
+
+  @Test
+  public void testAysncDiskServiceDeleteReplica()
+      throws IOException, InterruptedException, TimeoutException {
+    HdfsConfiguration conf = new HdfsConfiguration();
+    // Bump up replication interval.
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY, 10);
+    MiniDFSCluster cluster =
+        new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    DistributedFileSystem fs = cluster.getFileSystem();
+    String bpid = cluster.getNamesystem().getBlockPoolId();
+    DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
+    final Semaphore semaphore = new Semaphore(0);
+    try {
+      cluster.waitActive();
+      final DataNodeFaultInjector injector = new DataNodeFaultInjector() {
+        @Override
+        public void delayDeleteReplica() {
+          // Lets wait for the remove replia process
+          try {
+            semaphore.acquire(1);
+          } catch (InterruptedException e) {
+            // ignore
+          }
+        }
+      };
+      DataNodeFaultInjector.set(injector);
+
+      // Create file.
+      Path path = new Path("/testfile");
+      DFSTestUtil.createFile(fs, path, 1024, (short) 3, 0);
+      DFSTestUtil.waitReplication(fs, path, (short) 3);
+      LocatedBlock lb = DFSTestUtil.getAllBlocks(fs, path).get(0);
+      ExtendedBlock extendedBlock = lb.getBlock();
+      DatanodeInfo[] loc = lb.getLocations();
+      assertEquals(3, loc.length);
+
+      // DN side.
+      DataNode dn = cluster.getDataNode(loc[0].getIpcPort());
+      final FsDatasetImpl ds = (FsDatasetImpl) DataNodeTestUtils.getFSDataset(dn);
+      List<Block> blockList = com.google.common.collect.Lists.newArrayList(extendedBlock.getLocalBlock());
+      assertNotNull(ds.getStoredBlock(bpid, extendedBlock.getBlockId()));
+      ds.invalidate(bpid, blockList.toArray(new Block[0]));
+
+      // Test get blocks and datanodes.
+      loc = DFSTestUtil.getAllBlocks(fs, path).get(0).getLocations();
+      assertEquals(3, loc.length);
+      List<String> uuids = com.google.common.collect.Lists.newArrayList();
+      for (DatanodeInfo datanodeInfo : loc) {
+        uuids.add(datanodeInfo.getDatanodeUuid());
+      }
+      assertTrue(uuids.contains(dn.getDatanodeUuid()));
+
+      // Do verification that the first replication shouldn't be deleted from the memory first.
+      // Because the namenode still contains this replica, so client will try to read it.
+      // If this replica is deleted from memory, the client would got an ReplicaNotFoundException.
+      assertNotNull(ds.getStoredBlock(bpid, extendedBlock.getBlockId()));
+
+      // Make it resume the removeReplicaFromMem method
+      semaphore.release(1);
+
+      // Sleep for 1 second so that datanode can complete invalidate.
+      GenericTestUtils.waitFor(new com.google.common.base.Supplier<Boolean>() {
+        @Override public Boolean get() {
+          return ds.asyncDiskService.countPendingDeletions() == 0;
+        }
+      }, 100, 1000);
+
+      // Sleep for two heartbeat times (default a heartbeat interval is 3 second).
+      Thread.sleep(6000);
+
+      // Test get blocks and datanodes again.
+      loc = DFSTestUtil.getAllBlocks(fs, path).get(0).getLocations();
+      assertEquals(2, loc.length);
+      uuids = com.google.common.collect.Lists.newArrayList();
+      for (DatanodeInfo datanodeInfo : loc) {
+        uuids.add(datanodeInfo.getDatanodeUuid());
+      }
+      // The namenode does not contain this replica.
+      assertFalse(uuids.contains(dn.getDatanodeUuid()));
+
+      // This replica has deleted from datanode memory.
+      assertNull(ds.getStoredBlock(bpid, extendedBlock.getBlockId()));
+    } finally {
+      cluster.shutdown();
+      DataNodeFaultInjector.set(oldInjector);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1896,9 +1896,9 @@ public class TestFsDatasetImpl {
       // Make it resume the removeReplicaFromMem method.
       semaphore.release(1);
 
-      // Sleep for 1 second so that datanode can complete invalidate.
-      GenericTestUtils.waitFor(() -> ds.asyncDiskService.countPendingDeletions() == 0,
-          100, 1000);
+      // Waiting for the async deletion task finish.
+      GenericTestUtils.waitFor(() ->
+          ds.asyncDiskService.countPendingDeletions() == 0, 100, 1000);
 
       // Sleep for two heartbeat times.
       Thread.sleep(conf.getTimeDuration(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1840,10 +1840,10 @@ public class TestFsDatasetImpl {
   @Test
   public void testAysncDiskServiceDeleteReplica()
       throws IOException, InterruptedException, TimeoutException {
-    HdfsConfiguration conf = new HdfsConfiguration();
+    HdfsConfiguration config = new HdfsConfiguration();
     // Bump up replication interval.
-    conf.setInt(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY, 10);
-    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
+    config.setInt(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY, 10);
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(config).numDataNodes(3).build();
     DistributedFileSystem fs = cluster.getFileSystem();
     String bpid = cluster.getNamesystem().getBlockPoolId();
     DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
@@ -1901,7 +1901,7 @@ public class TestFsDatasetImpl {
           ds.asyncDiskService.countPendingDeletions() == 0, 100, 1000);
 
       // Sleep for two heartbeat times.
-      Thread.sleep(conf.getTimeDuration(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY,
+      Thread.sleep(config.getTimeDuration(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY,
           DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_DEFAULT,
           TimeUnit.SECONDS, TimeUnit.MILLISECONDS) * 2);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetImpl.java
@@ -1835,8 +1835,7 @@ public class TestFsDatasetImpl {
   }
 
   /**
-   * If delete the block asynchronously task stacked pending,
-   * It's ok get the replica from the ReplicaMap
+   * The block should be in the replicaMap if the async deletion task is pending.
    */
   @Test
   public void testAysncDiskServiceDeleteReplica()


### PR DESCRIPTION

### Description of PR
HDFS-16774.Improve async delete replica on datanode

In our online cluster, a large number of ReplicaNotFoundExceptions occur when client reads the data.
After tracing the root cause, it is caused by the asynchronous deletion of the replica operation has many stacked pending deletion caused ReplicationNotFoundException.
Current the asynchronous delete of the replica operation process is as follows：
1.remove the replica from the ReplicaMap
2.delete the replica file on the disk [blocked in threadpool]
3.notifying namenode through IBR [blocked in threadpool]

In order to avoid similar problems as much as possible, consider optimizing the execution flow：
The deleting replica from ReplicaMap, deleting replica from disk and notifying namenode through IBR are processed in the same asynchronous thread.




