### PR TITLE
HADOOP-18443. Upgrade snakeyaml to 1.32

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -362,7 +362,7 @@ org.ehcache:ehcache:3.3.1
 org.lz4:lz4-java:1.7.1
 org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.0.5
-org.yaml:snakeyaml:1.31:
+org.yaml:snakeyaml:1.32
 org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 
 

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -197,7 +197,7 @@
     <declared.hadoop.version>${hadoop.version}</declared.hadoop.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
-    <snakeyaml.version>1.31</snakeyaml.version>
+    <snakeyaml.version>1.32</snakeyaml.version>
     <hbase.one.version>1.7.1</hbase.one.version>
     <hbase.two.version>2.2.4</hbase.two.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
### Description of PR

Upgrade snakeyaml to 1.32 to mitigate [CVE-2022-38752](https://github.com/advisories/GHSA-9w3m-gqgf-c4p9)

JIRA - HADOOP-18443

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

