### PR TITLE
HADOOP-18462. InstrumentedWriteLock should consider Reentrant case

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/InstrumentedReadLock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/InstrumentedReadLock.java
@@ -44,12 +44,7 @@ public class InstrumentedReadLock extends InstrumentedLock {
    * there can be multiple threads that hold the read lock concurrently.
    */
   private final ThreadLocal<Long> readLockHeldTimeStamp =
-      new ThreadLocal<Long>() {
-    @Override
-    protected Long initialValue() {
-      return Long.MAX_VALUE;
-    };
-  };
+      ThreadLocal.withInitial(() -> Long.MAX_VALUE);
 
   public InstrumentedReadLock(String name, Logger logger,
       ReentrantReadWriteLock readWriteLock,


### PR DESCRIPTION
### Description of PR

During looking into the InstrumentedWriteLock and InstrumentedReadLock, I found that InstrumentedReadLock consider reentrant case when checking log, but InstrumentedWriteLock does not consider reentrant case. 

So I think InstrumentedWriteLock should consider it.

