### PR TITLE
HADOOP-18341: upgrade commons-configuration2 to 2.8.0 and commons-text to 1.9. Contributed by PJ Fanning.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -118,7 +118,7 @@
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <commons-math3.version>3.1.1</commons-math3.version>
     <commons-net.version>3.6</commons-net.version>
-    <commons-text.version>1.4</commons-text.version>
+    <commons-text.version>1.9</commons-text.version>
 
     <!-- Apache Ratis version -->
     <ratis.version>0.3.0-eca3531-SNAPSHOT</ratis.version>
@@ -1078,7 +1078,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
-        <version>2.1.1</version>
+        <version>2.8.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Relates to #4578