### PR TITLE
HADOOP-18463. Add an integration test process data asynchronously during vectored read.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.impl.FutureIOSupport;
-import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.io.WeakReferencedElasticByteBufferPool;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.hadoop.util.functional.FutureIO;
@@ -420,11 +419,11 @@ public abstract class AbstractContractVectoredReadTest extends AbstractFSContrac
     // Read the data and perform custom operation. Here we are just
     // validating it with original data.
     FutureIO.awaitFuture(data.thenAccept(buffer -> {
-              assertDatasetEquals((int) res.getOffset(),
-                      "vecRead", buffer, res.getLength(), DATASET);
-              // return buffer to the pool once read.
-              pool.putBuffer(buffer);
-            }), VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      assertDatasetEquals((int) res.getOffset(),
+              "vecRead", buffer, res.getLength(), DATASET);
+      // return buffer to the pool once read.
+      pool.putBuffer(buffer);
+    }), VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     // countdown to notify main thread that processing has been done.
     countDownLatch.countDown();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractVectoredReadTest.java
@@ -408,7 +408,8 @@ public abstract class AbstractContractVectoredReadTest extends AbstractFSContrac
         ContractTestUtils.fail("Timeout/Error while processing vectored io results");
       }
     } finally {
-      HadoopExecutors.shutdown(dataProcessor, LOG, 100, TimeUnit.SECONDS);
+      HadoopExecutors.shutdown(dataProcessor, LOG,
+              VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
   }
 
@@ -423,7 +424,8 @@ public abstract class AbstractContractVectoredReadTest extends AbstractFSContrac
               "vecRead", buffer, res.getLength(), DATASET);
       // return buffer to the pool once read.
       pool.putBuffer(buffer);
-    }), VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }),
+    VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     // countdown to notify main thread that processing has been done.
     countDownLatch.countDown();


### PR DESCRIPTION

part of HADOOP-18103.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

