### PR TITLE
HDFS-16780. Add ErasureCodePolicy information to the response of GET_BLOCK_LOCATIONS in NamenodeWebHdfsMethods

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/JsonUtilClient.java
@@ -155,20 +155,7 @@ public class JsonUtilClient {
     if (snapshotEnabledBit != null && snapshotEnabledBit) {
       f.add(HdfsFileStatus.Flags.SNAPSHOT_ENABLED);
     }
-
-    Map<String, Object> ecPolicyObj = (Map) m.get("ecPolicyObj");
-    ErasureCodingPolicy ecPolicy = null;
-    if (ecPolicyObj != null) {
-      Map<String, String> extraOptions = (Map) ecPolicyObj.get("extraOptions");
-      ECSchema ecSchema = new ECSchema((String) ecPolicyObj.get("codecName"),
-          (int) ((Number) ecPolicyObj.get("numDataUnits")).longValue(),
-          (int) ((Number) ecPolicyObj.get("numParityUnits")).longValue(),
-          extraOptions);
-      ecPolicy = new ErasureCodingPolicy((String) ecPolicyObj.get("name"),
-          ecSchema, (int) ((Number) ecPolicyObj.get("cellSize")).longValue(),
-          (byte) (int) ((Number) ecPolicyObj.get("id")).longValue());
-
-    }
+    ErasureCodingPolicy ecPolicy = toECPolicy((Map<?, ?>) m.get("ecPolicyObj"));
 
     final long aTime = ((Number) m.get("accessTime")).longValue();
     final long mTime = ((Number) m.get("modificationTime")).longValue();
@@ -707,8 +694,9 @@ public class JsonUtilClient {
     final LocatedBlock lastLocatedBlock = toLocatedBlock(
         (Map<?, ?>) m.get("lastLocatedBlock"));
     final boolean isLastBlockComplete = (Boolean)m.get("isLastBlockComplete");
+    ErasureCodingPolicy ecPolicy = toECPolicy((Map<?, ?>) m.get("ecPolicyObj"));
     return new LocatedBlocks(fileLength, isUnderConstruction, locatedBlocks,
-        lastLocatedBlock, isLastBlockComplete, null, null);
+        lastLocatedBlock, isLastBlockComplete, null, ecPolicy);
   }
 
   public static Collection<BlockStoragePolicy> getStoragePolicies(
@@ -755,7 +743,8 @@ public class JsonUtilClient {
     int cellsize = ((Number) m.get("cellSize")).intValue();
     int dataunits = ((Number) m.get("numDataUnits")).intValue();
     int parityunits = ((Number) m.get("numParityUnits")).intValue();
-    ECSchema ecs = new ECSchema(codec, dataunits, parityunits);
+    Map<String, String> extraOptions = (Map<String, String>) m.get("extraOptions");
+    ECSchema ecs = new ECSchema(codec, dataunits, parityunits, extraOptions);
     return new ErasureCodingPolicy(name, ecs, cellsize, id);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/JsonUtil.java
@@ -342,6 +342,9 @@ public class JsonUtil {
     m.put("locatedBlocks", toJsonArray(locatedblocks.getLocatedBlocks()));
     m.put("lastLocatedBlock", toJsonMap(locatedblocks.getLastLocatedBlock()));
     m.put("isLastBlockComplete", locatedblocks.isLastBlockComplete());
+    if (locatedblocks.getErasureCodingPolicy() != null) {
+      m.put("ecPolicyObj", getEcPolicyAsMap(locatedblocks.getErasureCodingPolicy()));
+    }
     return toJsonString(LocatedBlocks.class, m);
   }
 


### PR DESCRIPTION
### Description of PR
The response of GET_BLOCK_LOCATIONS in NamenodeWebHdfsMethods does not contain the ErasureCodingPolicy information. Add it to make it easier for EndUser to get the EC policy from the result of GET_BLOCK_LOCATIONS.


