### PR TITLE
HADOOP-18465. Fix S3A SSE test skip when encryption is disabled

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -79,7 +79,7 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
   };
 
   protected void requireEncryptedFileSystem() {
-    skipIfEncryptionTestsDisabled(getFileSystem().getConf());
+    skipIfEncryptionTestsDisabled(createConfiguration());
   }
 
   /**
@@ -91,8 +91,8 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
   @Override
   public void setup() throws Exception {
     try {
-      super.setup();
       requireEncryptedFileSystem();
+      super.setup();
     } catch (AccessDeniedException e) {
       skip("Bucket does not allow " + getSSEAlgorithm() + " encryption method");
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -78,6 +78,14 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
       0, 1, 2, 3, 4, 5, 254, 255, 256, 257, 2 ^ 12 - 1
   };
 
+  /**
+   * Skips the tests if encryption is not enabled in configuration.
+   *
+   * @implNote We can use {@link #createConfiguration()} here since
+   * it does not depend on any per-bucket based configuration.
+   * Otherwise, we would need to grab the configuration from an
+   * instance of {@link S3AFileSystem}.
+   */
   protected void requireEncryptedFileSystem() {
     skipIfEncryptionTestsDisabled(createConfiguration());
   }


### PR DESCRIPTION
### Description of PR

When running integration tests against an S3-compatible endpoint without SSE support, tests would fail despite marking `test.fs.s3a.encryption.enabled` as false.

### How was this patch tested?

#### Against eu-west-1, no special configuration. Encryption enabled.

I see these failures - looks unrelated. Tests for encryption are passing. Third time they went away and everything is passing.

```
[ERROR] Failures:
[ERROR]   ITestS3AIOStatisticsContext.testThreadSharingIOStatistics:294->assertThreadStatisticsForThread:377 [Bytes read are not as expected for thread : 70] expected:<[150]L> but was:<[85]L>
[ERROR]   ITestS3APrefetchingInputStream.testRandomReadLargeFile:158 [Gauge named stream_read_blocks_in_cache with expected value 2] expected:<[2]L> but was:<[1]L>
[INFO]
[ERROR] Tests run: 1143, Failures: 2, Errors: 0, Skipped: 186
```

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.451 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSDefaultKey
```

#### Against an S3-compatible endpoint without SSE support, running only ITestS3AEncryptionSSEKMSDefaultKey.

Works for me :) Only tried ITestS3AEncryptionSSEKMSDefaultKey - there's a lot breaking both before and after this change, still need to figure that bit out later.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

