### PR TITLE
HADOOP-18416. fix ITestS3AIOStatisticsContext test failure

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1488,4 +1488,13 @@ public final class S3ATestUtils {
       throw new AssertionError("Not an S3AInputStream: " + inner);
     }
   }
+
+  /**
+   * Disable Prefetching streams from S3AFileSystem in tests.
+   * @param conf Configuration to remove the prefetch property from.
+   */
+  public static void disablePrefetching(Configuration conf) {
+    // TODO: Reinstate once HADOOP-18028 is merged.
+    // removeBaseAndBucketOverrides(conf, PREFETCH_ENABLED_KEY);
+  }
 }


### PR DESCRIPTION
Follow on to HADOOP-17461.

### Description of PR
backport from trunk for test fix, also contains a commented out portion **(to be added once prefetch jira is in branch-3.3)**

### How was this patch tested?
`mvn clean verify -Dparallel-tests -DtestsThreadCount=4 -Dscale`

`[WARNING] Tests run: 417, Failures: 0, Errors: 0, Skipped: 4`
`[WARNING] Tests run: 1147, Failures: 0, Errors: 0, Skipped: 146`
`[ERROR] Tests run: 124, Failures: 0, Errors: 1, Skipped: 10` (timeout error, unrelated)

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

