### PR TITLE
HADOOP-18468: jettison 1.5.1 (CVE fix)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -343,7 +343,7 @@ org.apache.kerby:token-provider:2.0.2
 org.apache.solr:solr-solrj:8.8.2
 org.apache.yetus:audience-annotations:0.5.0
 org.apache.zookeeper:zookeeper:3.6.3
-org.codehaus.jettison:jettison:1.1
+org.codehaus.jettison:jettison:1.5.1
 org.eclipse.jetty:jetty-annotations:9.4.48.v20220622
 org.eclipse.jetty:jetty-http:9.4.48.v20220622
 org.eclipse.jetty:jetty-io:9.4.48.v20220622

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1498,7 +1498,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.1</version>
+        <version>1.5.1</version>
         <exclusions>
           <exclusion>
             <groupId>stax</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Guice;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.api.client.ClientResponse;
@@ -334,7 +336,12 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     JSONObject json = response.getEntity(JSONObject.class);
     String actual = json.toString(2);
     updateTestDataAutomatically(expectedResourceFilename, actual);
-    assertEquals(getResourceAsString(expectedResourceFilename), actual);
+    assertEquals(prettyPrintJson(getResourceAsString(expectedResourceFilename)), prettyPrintJson(actual));
+  }
+
+  private static String prettyPrintJson(String in) throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(in));
   }
 
   public static void assertJsonType(ClientResponse response) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -336,12 +336,16 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     JSONObject json = response.getEntity(JSONObject.class);
     String actual = json.toString(2);
     updateTestDataAutomatically(expectedResourceFilename, actual);
-    assertEquals(prettyPrintJson(getResourceAsString(expectedResourceFilename)), prettyPrintJson(actual));
+    assertEquals(
+        prettyPrintJson(getResourceAsString(expectedResourceFilename)),
+        prettyPrintJson(actual));
   }
 
   private static String prettyPrintJson(String in) throws JsonProcessingException {
     ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(in));
+    return objectMapper
+        .writerWithDefaultPrettyPrinter()
+        .writeValueAsString(objectMapper.readTree(in));
   }
 
   public static void assertJsonType(ClientResponse response) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

A fix for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40149


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

