### PR TITLE
HDFS-16784: replace readLock with writeLock in #DatanodeAdminBackoffM…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -633,7 +633,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
     }
 
     for (DatanodeStorageInfo s : storage) {
-      namesystem.readLock();
+      namesystem.writeLock();
       try {
         // As the lock is dropped and re-taken between each storage, we need
         // to check the storage is still present before processing it, as it
@@ -659,7 +659,7 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
           numBlocksChecked++;
         }
       } finally {
-        namesystem.readUnlock("scanDatanodeStorage");
+        namesystem.writeUnlock("scanDatanodeStorage");
       }
     }
   }


### PR DESCRIPTION
In #DatanodeAdminBackoffMonitor.scanDatanodeStorage, it uses a read lock to protect the function #isBlockReplicatedOk.

But we found that the function #isBlockReplicatedOk may update the #neededReconstruction under certain conditions.

![image](https://user-images.githubusercontent.com/2844826/192719789-b9e2a572-9607-4569-8ac3-dba7680e200b.png)


Should we replace the read lock with write lock?