### PR TITLE
HDFS-16785. Avoid to hold write lock to improve performance when add volume.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -522,7 +522,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
 
     for (final NamespaceInfo nsInfo : nsInfos) {
       String bpid = nsInfo.getBlockPoolID();
-      try (AutoCloseDataSetLock l = lockManager.writeLock(LockLevel.BLOCK_POOl, bpid)) {
+      try {
         fsVolume.addBlockPool(bpid, this.conf, this.timer);
         fsVolume.getVolumeMap(bpid, tempVolumeMap, ramDiskReplicaTracker);
       } catch (IOException e) {


### PR DESCRIPTION
### Description of PR

When patching the fine-grained locking of datanode, I  found that `addVolume` will hold the write block of the BP lock to scan the new volume to get the blocks. If we try to add one full volume that was fixed offline before, i will hold the write lock for a long time.

The related code as bellows:
```
for (final NamespaceInfo nsInfo : nsInfos) {
  String bpid = nsInfo.getBlockPoolID();
  try (AutoCloseDataSetLock l = lockManager.writeLock(LockLevel.BLOCK_POOl, bpid)) {
    fsVolume.addBlockPool(bpid, this.conf, this.timer);
    fsVolume.getVolumeMap(bpid, tempVolumeMap, ramDiskReplicaTracker);
  } catch (IOException e) {
    LOG.warn("Caught exception when adding " + fsVolume +
        ". Will throw later.", e);
    exceptions.add(e);
  }
}
```
And I noticed that this lock is added by HDFS-15382, means that this logic was not with lock before.

