### PR TITLE
YARN-11321. Add RMWebServices#getSchedulerOverview.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
@@ -48,7 +48,7 @@ public abstract class JerseyTestBase extends JerseyTest {
   }
 
   public void verifyClusterSchedulerOverView(JSONObject json, String expectedSchedulerType)
-     throws Exception {
+    throws Exception {
 
     // why json contains 8 elements because we defined 8 fields
     assertEquals("incorrect number of elements in: " + json, 8, json.length());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
@@ -25,9 +25,6 @@ import org.apache.hadoop.net.ServerSocketUtil;
 
 import com.sun.jersey.test.framework.JerseyTest;
 import com.sun.jersey.test.framework.WebAppDescriptor;
-import org.codehaus.jettison.json.JSONObject;
-
-import static org.junit.Assert.assertEquals;
 
 public abstract class JerseyTestBase extends JerseyTest {
   public JerseyTestBase(WebAppDescriptor appDescriptor) {
@@ -45,50 +42,5 @@ public abstract class JerseyTestBase extends JerseyTest {
       // not received.
     }
     return super.getPort(jerseyPort);
-  }
-
-  public void verifyClusterSchedulerOverView(JSONObject json, String expectedSchedulerType)
-    throws Exception {
-
-    // why json contains 8 elements because we defined 8 fields
-    assertEquals("incorrect number of elements in: " + json, 8, json.length());
-
-    // 1.Verify that the schedulerType is as expected
-    String schedulerType = json.getString("schedulerType");
-    assertEquals(expectedSchedulerType, schedulerType);
-
-    // 2.Verify that schedulingResourceType is as expected
-    String schedulingResourceType = json.getString("schedulingResourceType");
-    assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
-
-    // 3.Verify that minimumAllocation is as expected
-    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
-    String minMemory = minimumAllocation.getString("memory");
-    String minVCores = minimumAllocation.getString("vCores");
-    assertEquals("1024", minMemory);
-    assertEquals("1", minVCores);
-
-    // 4.Verify that maximumAllocation is as expected
-    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
-    String maxMemory = maximumAllocation.getString("memory");
-    String maxVCores = maximumAllocation.getString("vCores");
-    assertEquals("8192", maxMemory);
-    assertEquals("4", maxVCores);
-
-    // 5.Verify that schedulerBusy is as expected
-    int schedulerBusy = json.getInt("schedulerBusy");
-    assertEquals(-1, schedulerBusy);
-
-    // 6.Verify that rmDispatcherEventQueueSize is as expected
-    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
-    assertEquals(0, rmDispatcherEventQueueSize);
-
-    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
-    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
-    assertEquals(0, schedulerDispatcherEventQueueSize);
-
-    // 8.Verify that applicationPriority is as expected
-    int applicationPriority = json.getInt("applicationPriority");
-    assertEquals(0, applicationPriority);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
@@ -25,6 +25,9 @@ import org.apache.hadoop.net.ServerSocketUtil;
 
 import com.sun.jersey.test.framework.JerseyTest;
 import com.sun.jersey.test.framework.WebAppDescriptor;
+import org.codehaus.jettison.json.JSONObject;
+
+import static org.junit.Assert.assertEquals;
 
 public abstract class JerseyTestBase extends JerseyTest {
   public JerseyTestBase(WebAppDescriptor appDescriptor) {
@@ -42,5 +45,50 @@ public abstract class JerseyTestBase extends JerseyTest {
       // not received.
     }
     return super.getPort(jerseyPort);
+  }
+
+  public void verifyClusterSchedulerOverView(JSONObject json, String expectedSchedulerType)
+     throws Exception {
+
+    // why json contains 8 elements because we defined 8 fields
+    assertEquals("incorrect number of elements in: " + json, 8, json.length());
+
+    // 1.Verify that the schedulerType is as expected
+    String schedulerType = json.getString("schedulerType");
+    assertEquals(expectedSchedulerType, schedulerType);
+
+    // 2.Verify that schedulingResourceType is as expected
+    String schedulingResourceType = json.getString("schedulingResourceType");
+    assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
+
+    // 3.Verify that minimumAllocation is as expected
+    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
+    String minMemory = minimumAllocation.getString("memory");
+    String minVCores = minimumAllocation.getString("vCores");
+    assertEquals("1024", minMemory);
+    assertEquals("1", minVCores);
+
+    // 4.Verify that maximumAllocation is as expected
+    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
+    String maxMemory = maximumAllocation.getString("memory");
+    String maxVCores = maximumAllocation.getString("vCores");
+    assertEquals("8192", maxMemory);
+    assertEquals("4", maxVCores);
+
+    // 5.Verify that schedulerBusy is as expected
+    int schedulerBusy = json.getInt("schedulerBusy");
+    assertEquals(-1, schedulerBusy);
+
+    // 6.Verify that rmDispatcherEventQueueSize is as expected
+    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
+    assertEquals(0, rmDispatcherEventQueueSize);
+
+    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
+    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
+    assertEquals(0, schedulerDispatcherEventQueueSize);
+
+    // 8.Verify that applicationPriority is as expected
+    int applicationPriority = json.getInt("applicationPriority");
+    assertEquals(0, applicationPriority);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWSConsts.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWSConsts.java
@@ -57,6 +57,9 @@ public final class RMWSConsts {
   /** Path for {@code RMWebServiceProtocol#dumpSchedulerLogs}. */
   public static final String SCHEDULER_LOGS = "/scheduler/logs";
 
+  /** Path for {@code RMWebServiceProtocol#getSchedulerOverview}. */
+  public static final String SCHEDULER_OVERVIEW = "/scheduler-overview";
+
   /**
    * Path for {@code RMWebServiceProtocol#validateAndGetSchedulerConfiguration}.
    */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -202,6 +202,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.BulkActivitiesIn
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.SchedulerTypeInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.StatisticsItemInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ConfigVersionInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.SchedulerOverviewInfo;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.server.webapp.WebServices;
@@ -2941,5 +2942,15 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
           .entity(e.getMessage()).build();
     }
     return Response.status(Status.OK).build();
+  }
+
+  @GET
+  @Path(RMWSConsts.SCHEDULER_OVERVIEW)
+  @Produces({ MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
+      MediaType.APPLICATION_XML + "; " + JettyUtils.UTF_8 })
+  public SchedulerOverviewInfo getSchedulerOverview() {
+    initForReadableEndpoints();
+    ResourceScheduler rs = rm.getResourceScheduler();
+    return new SchedulerOverviewInfo(rs);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/SchedulerOverviewInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/SchedulerOverviewInfo.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.resourcemanager.webapp.dao;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.yarn.api.records.ResourceTypeInfo;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
+import org.apache.hadoop.yarn.util.resource.ResourceUtils;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "scheduler")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SchedulerOverviewInfo {
+
+  private String schedulerType;
+  private String schedulingResourceType;
+  private ResourceInfo minimumAllocation;
+  private ResourceInfo maximumAllocation;
+  private int applicationPriority;
+  private int schedulerBusy;
+  private int rmDispatcherEventQueueSize;
+  private int schedulerDispatcherEventQueueSize;
+
+  // JAXB needs this
+  public SchedulerOverviewInfo() {
+
+  }
+
+  public SchedulerOverviewInfo(ResourceScheduler rs) {
+    // Parse the schedule type
+    if (rs instanceof CapacityScheduler) {
+      this.schedulerType = "Capacity Scheduler";
+    } else if (rs instanceof FairScheduler) {
+      this.schedulerType = "Fair Scheduler";
+    } else if (rs instanceof FifoScheduler) {
+      this.schedulerType = "Fifo Scheduler";
+    } else {
+      this.schedulerType = rs.getClass().getSimpleName();
+    }
+
+    // Parse and allocate resource information
+    this.minimumAllocation = new ResourceInfo(rs.getMinimumResourceCapability());
+    this.maximumAllocation = new ResourceInfo(rs.getMaximumResourceCapability());
+
+    // Parse App Priority
+    this.applicationPriority = rs.getMaxClusterLevelAppPriority().getPriority();
+
+    // Resolving resource types
+    List<ResourceTypeInfo> resourceTypeInfos = ResourceUtils.getResourcesTypeInfo();
+    resourceTypeInfos.sort((o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName()));
+    this.schedulingResourceType = StringUtils.join(resourceTypeInfos, ",");
+
+    // clusterMetrics
+    ClusterMetricsInfo clusterMetrics = new ClusterMetricsInfo(rs);
+    this.schedulerBusy = clusterMetrics.getRmSchedulerBusyPercent();
+    this.rmDispatcherEventQueueSize = clusterMetrics.getRmEventQueueSize();
+    this.schedulerDispatcherEventQueueSize = clusterMetrics.getSchedulerEventQueueSize();
+  }
+
+  public String getSchedulerType() {
+    return schedulerType;
+  }
+
+  public String getSchedulingResourceType() {
+    return schedulingResourceType;
+  }
+
+  public ResourceInfo getMinimumAllocation() {
+    return minimumAllocation;
+  }
+
+  public ResourceInfo getMaximumAllocation() {
+    return maximumAllocation;
+  }
+
+  public int getApplicationPriority() {
+    return applicationPriority;
+  }
+
+  public int getSchedulerBusy() {
+    return schedulerBusy;
+  }
+
+  public int getRmDispatcherEventQueueSize() {
+    return rmDispatcherEventQueueSize;
+  }
+
+  public int getSchedulerDispatcherEventQueueSize() {
+    return schedulerDispatcherEventQueueSize;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -1111,52 +1111,6 @@ public class TestRMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    verifyClusterSchedulerOverViewFifo(json);
-  }
-
-  public void verifyClusterSchedulerOverViewFifo(JSONObject json)
-      throws Exception {
-
-    // why json contains 8 elements because we defined 8 fields
-    assertEquals("incorrect number of elements in: " + json, 8, json.length());
-
-    // 1.Verify that the schedulerType is as expected
-    String schedulerType = json.getString("schedulerType");
-    Assert.assertEquals("Fifo Scheduler", schedulerType);
-    System.out.println(schedulerType);
-
-    // 2.Verify that schedulingResourceType is as expected
-    String schedulingResourceType = json.getString("schedulingResourceType");
-    Assert.assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
-
-    // 3.Verify that minimumAllocation is as expected
-    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
-    String minMemory = minimumAllocation.getString("memory");
-    String minVCores = minimumAllocation.getString("vCores");
-    Assert.assertEquals("1024", minMemory);
-    Assert.assertEquals("1", minVCores);
-
-    // 4.Verify that maximumAllocation is as expected
-    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
-    String maxMemory = maximumAllocation.getString("memory");
-    String maxVCores = maximumAllocation.getString("vCores");
-    Assert.assertEquals("8192", maxMemory);
-    Assert.assertEquals("4", maxVCores);
-
-    // 5.Verify that schedulerBusy is as expected
-    int schedulerBusy = json.getInt("schedulerBusy");
-    Assert.assertEquals(-1, schedulerBusy);
-
-    // 6.Verify that rmDispatcherEventQueueSize is as expected
-    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
-    Assert.assertEquals(0, rmDispatcherEventQueueSize);
-
-    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
-    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
-    Assert.assertEquals(0, schedulerDispatcherEventQueueSize);
-
-    // 8.Verify that applicationPriority is as expected
-    int applicationPriority = json.getInt("applicationPriority");
-    Assert.assertEquals(0, applicationPriority);
+    verifyClusterSchedulerOverView(json, "Fifo Scheduler");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -1113,4 +1113,49 @@ public class TestRMWebServices extends JerseyTestBase {
     JSONObject json = response.getEntity(JSONObject.class);
     verifyClusterSchedulerOverView(json, "Fifo Scheduler");
   }
+
+  public static void verifyClusterSchedulerOverView(JSONObject json, String expectedSchedulerType)
+      throws Exception {
+
+    // why json contains 8 elements because we defined 8 fields
+    assertEquals("incorrect number of elements in: " + json, 8, json.length());
+
+    // 1.Verify that the schedulerType is as expected
+    String schedulerType = json.getString("schedulerType");
+    assertEquals(expectedSchedulerType, schedulerType);
+
+    // 2.Verify that schedulingResourceType is as expected
+    String schedulingResourceType = json.getString("schedulingResourceType");
+    assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
+
+    // 3.Verify that minimumAllocation is as expected
+    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
+    String minMemory = minimumAllocation.getString("memory");
+    String minVCores = minimumAllocation.getString("vCores");
+    assertEquals("1024", minMemory);
+    assertEquals("1", minVCores);
+
+    // 4.Verify that maximumAllocation is as expected
+    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
+    String maxMemory = maximumAllocation.getString("memory");
+    String maxVCores = maximumAllocation.getString("vCores");
+    assertEquals("8192", maxMemory);
+    assertEquals("4", maxVCores);
+
+    // 5.Verify that schedulerBusy is as expected
+    int schedulerBusy = json.getInt("schedulerBusy");
+    assertEquals(-1, schedulerBusy);
+
+    // 6.Verify that rmDispatcherEventQueueSize is as expected
+    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
+    assertEquals(0, rmDispatcherEventQueueSize);
+
+    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
+    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
+    assertEquals(0, schedulerDispatcherEventQueueSize);
+
+    // 8.Verify that applicationPriority is as expected
+    int applicationPriority = json.getInt("applicationPriority");
+    assertEquals(0, applicationPriority);
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -1099,8 +1099,10 @@ public class TestRMWebServices extends JerseyTestBase {
     return  webService;
   }
 
+  // In the case of testing FifoScheduler,
+  // whether the returned overview results meet expectations.
   @Test
-  public void testClusterSchedulerOverviewFifo() throws JSONException, Exception {
+  public void testClusterSchedulerOverviewFifo() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("cluster")
         .path("scheduler-overview").accept(MediaType.APPLICATION_JSON)
@@ -1109,11 +1111,10 @@ public class TestRMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    verifyClusterSchedulerFifoOverView(json);
-    System.out.println(json);
+    verifyClusterSchedulerOverViewFifo(json);
   }
 
-  public void verifyClusterSchedulerFifoOverView(JSONObject json)
+  public void verifyClusterSchedulerOverViewFifo(JSONObject json)
       throws Exception {
 
     // why json contains 8 elements because we defined 8 fields

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -1099,4 +1099,63 @@ public class TestRMWebServices extends JerseyTestBase {
     return  webService;
   }
 
+  @Test
+  public void testClusterSchedulerOverviewFifo() throws JSONException, Exception {
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("cluster")
+        .path("scheduler-overview").accept(MediaType.APPLICATION_JSON)
+        .get(ClientResponse.class);
+
+    assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
+        response.getType().toString());
+    JSONObject json = response.getEntity(JSONObject.class);
+    verifyClusterSchedulerFifoOverView(json);
+    System.out.println(json);
+  }
+
+  public void verifyClusterSchedulerFifoOverView(JSONObject json)
+      throws Exception {
+
+    // why json contains 8 elements because we defined 8 fields
+    assertEquals("incorrect number of elements in: " + json, 8, json.length());
+
+    // 1.Verify that the schedulerType is as expected
+    String schedulerType = json.getString("schedulerType");
+    Assert.assertEquals("Fifo Scheduler", schedulerType);
+    System.out.println(schedulerType);
+
+    // 2.Verify that schedulingResourceType is as expected
+    String schedulingResourceType = json.getString("schedulingResourceType");
+    Assert.assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
+
+    // 3.Verify that minimumAllocation is as expected
+    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
+    String minMemory = minimumAllocation.getString("memory");
+    String minVCores = minimumAllocation.getString("vCores");
+    Assert.assertEquals("1024", minMemory);
+    Assert.assertEquals("1", minVCores);
+
+    // 4.Verify that maximumAllocation is as expected
+    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
+    String maxMemory = maximumAllocation.getString("memory");
+    String maxVCores = maximumAllocation.getString("vCores");
+    Assert.assertEquals("8192", maxMemory);
+    Assert.assertEquals("4", maxVCores);
+
+    // 5.Verify that schedulerBusy is as expected
+    int schedulerBusy = json.getInt("schedulerBusy");
+    Assert.assertEquals(-1, schedulerBusy);
+
+    // 6.Verify that rmDispatcherEventQueueSize is as expected
+    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
+    Assert.assertEquals(0, rmDispatcherEventQueueSize);
+
+    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
+    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
+    Assert.assertEquals(0, schedulerDispatcherEventQueueSize);
+
+    // 8.Verify that applicationPriority is as expected
+    int applicationPriority = json.getInt("applicationPriority");
+    Assert.assertEquals(0, applicationPriority);
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -413,6 +413,6 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    verifyClusterSchedulerOverView(json, "Capacity Scheduler");
+    TestRMWebServices.verifyClusterSchedulerOverView(json, "Capacity Scheduler");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 import com.google.inject.Guice;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.sun.jersey.test.framework.WebAppDescriptor;
 
@@ -401,5 +402,64 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     conf.set(YarnConfiguration.RM_PLACEMENT_CONSTRAINTS_HANDLER,
         YarnConfiguration.SCHEDULER_RM_PLACEMENT_CONSTRAINTS_HANDLER);
     return new MockRM(conf);
+  }
+
+  @Test
+  public void testClusterSchedulerOverviewCapacity() throws Exception {
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("cluster")
+        .path("scheduler-overview").accept(MediaType.APPLICATION_JSON)
+        .get(ClientResponse.class);
+    assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
+        response.getType().toString());
+    JSONObject json = response.getEntity(JSONObject.class);
+    System.out.println(json);
+    verifyClusterSchedulerOverViewFairCapacity(json);
+  }
+
+  public void verifyClusterSchedulerOverViewFairCapacity(JSONObject json)
+      throws Exception {
+
+    // why json contains 8 elements because we defined 8 fields
+    assertEquals("incorrect number of elements in: " + json, 8, json.length());
+
+    // 1.Verify that the schedulerType is as expected
+    String schedulerType = json.getString("schedulerType");
+    Assert.assertEquals("Capacity Scheduler", schedulerType);
+    System.out.println(schedulerType);
+
+    // 2.Verify that schedulingResourceType is as expected
+    String schedulingResourceType = json.getString("schedulingResourceType");
+    Assert.assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
+
+    // 3.Verify that minimumAllocation is as expected
+    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
+    String minMemory = minimumAllocation.getString("memory");
+    String minVCores = minimumAllocation.getString("vCores");
+    Assert.assertEquals("1024", minMemory);
+    Assert.assertEquals("1", minVCores);
+
+    // 4.Verify that maximumAllocation is as expected
+    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
+    String maxMemory = maximumAllocation.getString("memory");
+    String maxVCores = maximumAllocation.getString("vCores");
+    Assert.assertEquals("8192", maxMemory);
+    Assert.assertEquals("4", maxVCores);
+
+    // 5.Verify that schedulerBusy is as expected
+    int schedulerBusy = json.getInt("schedulerBusy");
+    Assert.assertEquals(-1, schedulerBusy);
+
+    // 6.Verify that rmDispatcherEventQueueSize is as expected
+    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
+    Assert.assertEquals(0, rmDispatcherEventQueueSize);
+
+    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
+    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
+    Assert.assertEquals(0, schedulerDispatcherEventQueueSize);
+
+    // 8.Verify that applicationPriority is as expected
+    int applicationPriority = json.getInt("applicationPriority");
+    Assert.assertEquals(0, applicationPriority);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySched.java
@@ -413,53 +413,6 @@ public class TestRMWebServicesCapacitySched extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    System.out.println(json);
-    verifyClusterSchedulerOverViewFairCapacity(json);
-  }
-
-  public void verifyClusterSchedulerOverViewFairCapacity(JSONObject json)
-      throws Exception {
-
-    // why json contains 8 elements because we defined 8 fields
-    assertEquals("incorrect number of elements in: " + json, 8, json.length());
-
-    // 1.Verify that the schedulerType is as expected
-    String schedulerType = json.getString("schedulerType");
-    Assert.assertEquals("Capacity Scheduler", schedulerType);
-    System.out.println(schedulerType);
-
-    // 2.Verify that schedulingResourceType is as expected
-    String schedulingResourceType = json.getString("schedulingResourceType");
-    Assert.assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
-
-    // 3.Verify that minimumAllocation is as expected
-    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
-    String minMemory = minimumAllocation.getString("memory");
-    String minVCores = minimumAllocation.getString("vCores");
-    Assert.assertEquals("1024", minMemory);
-    Assert.assertEquals("1", minVCores);
-
-    // 4.Verify that maximumAllocation is as expected
-    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
-    String maxMemory = maximumAllocation.getString("memory");
-    String maxVCores = maximumAllocation.getString("vCores");
-    Assert.assertEquals("8192", maxMemory);
-    Assert.assertEquals("4", maxVCores);
-
-    // 5.Verify that schedulerBusy is as expected
-    int schedulerBusy = json.getInt("schedulerBusy");
-    Assert.assertEquals(-1, schedulerBusy);
-
-    // 6.Verify that rmDispatcherEventQueueSize is as expected
-    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
-    Assert.assertEquals(0, rmDispatcherEventQueueSize);
-
-    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
-    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
-    Assert.assertEquals(0, schedulerDispatcherEventQueueSize);
-
-    // 8.Verify that applicationPriority is as expected
-    int applicationPriority = json.getInt("applicationPriority");
-    Assert.assertEquals(0, applicationPriority);
+    verifyClusterSchedulerOverView(json, "Capacity Scheduler");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import javax.ws.rs.core.MediaType;
@@ -157,4 +158,61 @@ public class TestRMWebServicesFairScheduler extends JerseyTestBase {
     assertEquals("root", rootQueue.getString("queueName"));
   }
 
+  @Test
+  public void testClusterSchedulerOverviewFair() throws Exception {
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("cluster")
+        .path("scheduler-overview").accept(MediaType.APPLICATION_JSON)
+        .get(ClientResponse.class);
+    assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
+        response.getType().toString());
+    JSONObject json = response.getEntity(JSONObject.class);
+    verifyClusterSchedulerOverViewFair(json);
+  }
+
+  public void verifyClusterSchedulerOverViewFair(JSONObject json)
+      throws Exception {
+
+    // why json contains 8 elements because we defined 8 fields
+    assertEquals("incorrect number of elements in: " + json, 8, json.length());
+
+    // 1.Verify that the schedulerType is as expected
+    String schedulerType = json.getString("schedulerType");
+    Assert.assertEquals("Fair Scheduler", schedulerType);
+    System.out.println(schedulerType);
+
+    // 2.Verify that schedulingResourceType is as expected
+    String schedulingResourceType = json.getString("schedulingResourceType");
+    Assert.assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
+
+    // 3.Verify that minimumAllocation is as expected
+    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
+    String minMemory = minimumAllocation.getString("memory");
+    String minVCores = minimumAllocation.getString("vCores");
+    Assert.assertEquals("1024", minMemory);
+    Assert.assertEquals("1", minVCores);
+
+    // 4.Verify that maximumAllocation is as expected
+    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
+    String maxMemory = maximumAllocation.getString("memory");
+    String maxVCores = maximumAllocation.getString("vCores");
+    Assert.assertEquals("8192", maxMemory);
+    Assert.assertEquals("4", maxVCores);
+
+    // 5.Verify that schedulerBusy is as expected
+    int schedulerBusy = json.getInt("schedulerBusy");
+    Assert.assertEquals(-1, schedulerBusy);
+
+    // 6.Verify that rmDispatcherEventQueueSize is as expected
+    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
+    Assert.assertEquals(0, rmDispatcherEventQueueSize);
+
+    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
+    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
+    Assert.assertEquals(0, schedulerDispatcherEventQueueSize);
+
+    // 8.Verify that applicationPriority is as expected
+    int applicationPriority = json.getInt("applicationPriority");
+    Assert.assertEquals(0, applicationPriority);
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
@@ -167,52 +167,6 @@ public class TestRMWebServicesFairScheduler extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    verifyClusterSchedulerOverViewFair(json);
-  }
-
-  public void verifyClusterSchedulerOverViewFair(JSONObject json)
-      throws Exception {
-
-    // why json contains 8 elements because we defined 8 fields
-    assertEquals("incorrect number of elements in: " + json, 8, json.length());
-
-    // 1.Verify that the schedulerType is as expected
-    String schedulerType = json.getString("schedulerType");
-    Assert.assertEquals("Fair Scheduler", schedulerType);
-    System.out.println(schedulerType);
-
-    // 2.Verify that schedulingResourceType is as expected
-    String schedulingResourceType = json.getString("schedulingResourceType");
-    Assert.assertEquals("memory-mb (unit=Mi),vcores", schedulingResourceType);
-
-    // 3.Verify that minimumAllocation is as expected
-    JSONObject minimumAllocation = json.getJSONObject("minimumAllocation");
-    String minMemory = minimumAllocation.getString("memory");
-    String minVCores = minimumAllocation.getString("vCores");
-    Assert.assertEquals("1024", minMemory);
-    Assert.assertEquals("1", minVCores);
-
-    // 4.Verify that maximumAllocation is as expected
-    JSONObject maximumAllocation = json.getJSONObject("maximumAllocation");
-    String maxMemory = maximumAllocation.getString("memory");
-    String maxVCores = maximumAllocation.getString("vCores");
-    Assert.assertEquals("8192", maxMemory);
-    Assert.assertEquals("4", maxVCores);
-
-    // 5.Verify that schedulerBusy is as expected
-    int schedulerBusy = json.getInt("schedulerBusy");
-    Assert.assertEquals(-1, schedulerBusy);
-
-    // 6.Verify that rmDispatcherEventQueueSize is as expected
-    int rmDispatcherEventQueueSize = json.getInt("rmDispatcherEventQueueSize");
-    Assert.assertEquals(0, rmDispatcherEventQueueSize);
-
-    // 7.Verify that schedulerDispatcherEventQueueSize is as expected
-    int schedulerDispatcherEventQueueSize = json.getInt("schedulerDispatcherEventQueueSize");
-    Assert.assertEquals(0, schedulerDispatcherEventQueueSize);
-
-    // 8.Verify that applicationPriority is as expected
-    int applicationPriority = json.getInt("applicationPriority");
-    Assert.assertEquals(0, applicationPriority);
+    verifyClusterSchedulerOverView(json, "Fair Scheduler");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import javax.ws.rs.core.MediaType;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.QueueManager
 
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.JAXBContextResolver;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWebServices;
+import org.apache.hadoop.yarn.server.resourcemanager.webapp.TestRMWebServices;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
@@ -166,6 +167,6 @@ public class TestRMWebServicesFairScheduler extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    verifyClusterSchedulerOverView(json, "Fair Scheduler");
+    TestRMWebServices.verifyClusterSchedulerOverView(json, "Fair Scheduler");
   }
 }


### PR DESCRIPTION
JIRA: YARN-11321. Add RMWebServices#getSchedulerOverview.

In the pr of completing the Yarn Federation Router About Page, it was found that some Scheduler indicators are non-accumulative indicators. It is necessary to redefine a new method to obtain related indicators. Add the `getSchedulerOverview` method in `RMWebServices` to obtain Scheduler overview information, including the following

| Cols  | 
| ------------- | 
| Scheduler Type  | 
| Scheduling Resource Type | 
| Minimum Allocation  | 
| Maximum Allocation | 
| Maximum Cluster Application Priority | 
| Scheduler Busy % | 
| RM Dispatcher EventQueue Size % | 

The new method will be tested, covering 3 Scheduler, `Fifo Scheduler`, `Fair Scheduler` , `Capacity Scheduler`.