### PR TITLE
HDFS-16787. Remove the redundant lock in DataSetLockManager#removeLock

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
@@ -233,7 +233,6 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
   public void removeLock(LockLevel level, String... resources) {
     String lockName = generateLockName(level, resources);
     try (AutoCloseDataSetLock lock = writeLock(level, resources)) {
-      lock.lock();
       lockMap.removeLock(lockName);
     }
   }


### PR DESCRIPTION
### Description of PR
During patching the datanode fine-grained locking, found there is a redundant lock in DataSetLockManager#removeLock, and the code as bellow:
```
@Override
public void removeLock(LockLevel level, String... resources) {
  String lockName = generateLockName(level, resources);
  try (AutoCloseDataSetLock lock = writeLock(level, resources)) {
    // Here, this lock is redundant.
    lock.lock();
    lockMap.removeLock(lockName);
  }
} 
```

