### PR TITLE
YARN-6169 message on empty configuration file improved

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/configuration.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/configuration.c
@@ -546,8 +546,8 @@ int read_config(const char *file_path, struct configuration *cfg) {
 
   if (cfg->size == 0) {
     free_configuration(cfg);
-    fprintf(ERRORFILE, "Invalid configuration provided in %s\n", file_path);
-    return INVALID_CONFIG_FILE;
+    fprintf(ERRORFILE, "Empty configuration file provided %s\n", file_path);
+    exit(INVALID_CONFIG_FILE);
   }
   return 0;
 }


### PR DESCRIPTION
JIRA: YARN-6169 
### Description of PR
container-executor message on empty configuration file can be improved
If the configuration file is empty, we get the following error message:
Invalid configuration provided in /root/etc/hadoop/container-executor.cfg
This is does not provide enough details to figure out what is the issue at the first glance. We should use something like 'Empty configuration file provided...'

