### PR TITLE
YARN-11325 Added missing handling of operator “subtractTestNonNegative” in class “RLESparseResourceAllocation”

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/RLESparseResourceAllocation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/RLESparseResourceAllocation.java
@@ -440,8 +440,18 @@ public class RLESparseResourceAllocation {
       if (eB == null || eB.getValue() == null) {
         return null;
       }
-      if (op == RLEOperator.subtract) {
-        return Resources.negate(eB.getValue());
+      if (op == RLEOperator.subtract
+          || op == RLEOperator.subtractTestNonNegative) {
+        Resource val = Resources.negate(eB.getValue());
+        // test for negative value and throws
+        if (op == RLEOperator.subtractTestNonNegative
+            && (Resources.fitsIn(val, ZERO_RESOURCE)
+                && !Resources.equals(val, ZERO_RESOURCE))) {
+          throw new PlanningException(
+              "RLESparseResourceAllocation: merge failed as the "
+                  + "resulting RLESparseResourceAllocation would be negative");
+        }
+        return val;
       } else {
         return eB.getValue();
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestRLESparseResourceAllocation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestRLESparseResourceAllocation.java
@@ -236,6 +236,23 @@ public class TestRLESparseResourceAllocation {
       // Expected!
     }
 
+    // try with null value of an entry in a
+    a.put(10L, null);
+    b.put(11L, Resource.newInstance(10, 5));
+
+    rleA = new RLESparseResourceAllocation(a, new DefaultResourceCalculator());
+    rleB = new RLESparseResourceAllocation(b, new DefaultResourceCalculator());
+
+    try {
+      RLESparseResourceAllocation out =
+          RLESparseResourceAllocation.merge(new DefaultResourceCalculator(),
+              Resource.newInstance(100 * 128 * 1024, 100 * 32), rleA, rleB,
+              RLEOperator.subtractTestNonNegative, 0, 60);
+      fail();
+    } catch (PlanningException pe) {
+      // Expected!
+    }
+
     // trying a case that should work
     a.put(10L, Resource.newInstance(10, 6));
     b.put(11L, Resource.newInstance(5, 6));


### PR DESCRIPTION
### Description of PR
JIRA - [YARN-11325](https://issues.apache.org/jira/browse/YARN-11325)

### How was this patch tested?
Modified the existing unit test `testMergesubtractTestNonNegative` in test class `TestRLESparseResourceAllocation` to verify the code change.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

