### PR TITLE
HADOOP-18471. Fixed ArrayIndexOutOfBoundsException in class DefaultStringifier

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -158,6 +158,10 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
+    if (items == null || items.length == 0) {
+      conf.set(keyName, "");
+      return;
+    }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 
         GenericsUtil.getClass(items[0]));
     try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/DefaultStringifier.java
@@ -158,9 +158,8 @@ public class DefaultStringifier<T> implements Stringifier<T> {
   public static <K> void storeArray(Configuration conf, K[] items,
       String keyName) throws IOException {
 
-    if (items == null || items.length == 0) {
-      conf.set(keyName, "");
-      return;
+    if (items.length == 0) {
+      throw new IndexOutOfBoundsException();
     }
     DefaultStringifier<K> stringifier = new DefaultStringifier<K>(conf, 
         GenericsUtil.getClass(items[0]));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -104,9 +104,12 @@ public class TestDefaultStringifier {
 
     String keyName = "test.defaultstringifier.key2";
 
-    Integer[] array = new Integer[] {1,2,3,4,5};
+    Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
 
 
+    DefaultStringifier.storeArray(conf, emptyArray, keyName);
+    assertEquals(0
+        , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class TestDefaultStringifier {
 
@@ -99,7 +99,7 @@ public class TestDefaultStringifier {
   }
 
   @Test
-  public void testStoreLoadArray() throws IOException {
+  public void testStoreLoadArray() throws Exception {
     LOG.info("Testing DefaultStringifier#storeArray() and #loadArray()");
     conf.set("io.serializations", "org.apache.hadoop.io.serializer.JavaSerialization");
 
@@ -108,12 +108,8 @@ public class TestDefaultStringifier {
     Integer[] array = new Integer[] {1,2,3,4,5};
 
 
-    try {
-      DefaultStringifier.storeArray(conf, new Integer[] {}, keyName);
-      fail("Should have thrown an IndexOutOfBoundsException");
-    } catch (IndexOutOfBoundsException e) {
-      // pass
-    }
+    intercept(IndexOutOfBoundsException.class, () ->
+        DefaultStringifier.storeArray(conf, new Integer[] {}, keyName));
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestDefaultStringifier.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestDefaultStringifier {
 
@@ -104,12 +105,15 @@ public class TestDefaultStringifier {
 
     String keyName = "test.defaultstringifier.key2";
 
-    Integer[] array = new Integer[] {1,2,3,4,5}, emptyArray = new Integer[] {};
+    Integer[] array = new Integer[] {1,2,3,4,5};
 
 
-    DefaultStringifier.storeArray(conf, emptyArray, keyName);
-    assertEquals(0
-        , DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class).length);
+    try {
+      DefaultStringifier.storeArray(conf, new Integer[] {}, keyName);
+      fail("Should have thrown an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException e) {
+      // pass
+    }
     DefaultStringifier.storeArray(conf, array, keyName);
 
     Integer[] claimedArray = DefaultStringifier.<Integer>loadArray(conf, keyName, Integer.class);


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-18471](https://issues.apache.org/jira/browse/HADOOP-18471)

### How was this patch tested?
Modified an existing unit test `testStoreLoadArray` of test class `TestDefaultStringifier` to verify.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

