### PR TITLE
YARN-6766 HelperMethod added in AppsBlock class

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -129,11 +129,11 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
     return true;
   }
 
-  private static String printAppInfo(long appInfoFunc) {
-    if (appInfoFunc == -1) {
+  private static String printAppInfo(long value) {
+    if (value == -1) {
       return "N/A";
     }
-    return String.valueOf(appInfoFunc);
+    return String.valueOf(value);
   }
 
   @Override public void render(Block html) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -128,15 +128,14 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
     }
     return true;
   }
-  private long appInfoFunc;
+
   public String printData(long appInfoFunc) {
-    this.appInfoFunc=appInfoFunc;
-    if (appInfoFunc == -1) {
+    if (appInfoFunc== -1) {
       return "N/A";
-    } else {
-      return String.valueOf(appInfoFunc);
     }
+    return String.valueOf(appInfoFunc);
   }
+
   @Override public void render(Block html) {
     TBODY<TABLE<Hamlet>> tbody = html.
       table("#apps").

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -128,12 +128,14 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
     }
     return true;
   }
-  public long appInfo_func;
-  public String printData(long appInfo_func){
-    if (appInfo_func==-1)
+  private long appInfoFunc;
+  public String printData(long appInfoFunc) {
+    this.appInfoFunc=appInfoFunc;
+    if (appInfoFunc == -1) {
       return "N/A";
-    else
-      return String.valueOf(appInfo_func);
+    } else {
+      return String.valueOf(appInfoFunc);
+    }
   }
   @Override public void render(Block html) {
     TBODY<TABLE<Hamlet>> tbody = html.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -129,8 +129,8 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
     return true;
   }
 
-  public String printAppInfo(long appInfoFunc) {
-    if (appInfoFunc== -1) {
+  private static String printAppInfo(long appInfoFunc) {
+    if (appInfoFunc == -1) {
       return "N/A";
     }
     return String.valueOf(appInfoFunc);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -128,8 +128,13 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
     }
     return true;
   }
-
-
+  public long appInfo_func;
+  public String printData(long appInfo_func){
+    if (appInfo_func==-1)
+      return "N/A";
+    else
+      return String.valueOf(appInfo_func);
+  }
   @Override public void render(Block html) {
     TBODY<TABLE<Hamlet>> tbody = html.
       table("#apps").
@@ -193,16 +198,16 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
       .append(appInfo.getFinishTime()).append("\",\"")
       .append(appInfo.getState()).append("\",\"")
       .append(appInfo.getFinalStatus()).append("\",\"")
-      .append(appInfo.getRunningContainers() == -1 ? "N/A" : String
-         .valueOf(appInfo.getRunningContainers())).append("\",\"")
-      .append(appInfo.getAllocatedVCores() == -1 ? "N/A" : String
-        .valueOf(appInfo.getAllocatedVCores())).append("\",\"")
-      .append(appInfo.getAllocatedMB() == -1 ? "N/A" : String
-        .valueOf(appInfo.getAllocatedMB())).append("\",\"")
-      .append(appInfo.getReservedVCores() == -1 ? "N/A" : String
-        .valueOf(appInfo.getReservedVCores())).append("\",\"")
-      .append(appInfo.getReservedMB() == -1 ? "N/A" : String
-        .valueOf(appInfo.getReservedMB())).append("\",\"")
+      .append(printData(appInfo.getRunningContainers()))
+      .append("\",\"")
+      .append(printData(appInfo.getAllocatedVCores()))
+      .append("\",\"")
+      .append(printData(appInfo.getAllocatedMB()))
+      .append("\",\"")
+      .append(printData(appInfo.getReservedVCores()))
+      .append("\",\"")
+      .append(printData(appInfo.getReservedMB()))
+      .append("\",\"")
       // Progress bar
       .append("<br title='").append(percent)
       .append("'> <div class='").append(C_PROGRESSBAR).append("' title='")

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/FairSchedulerAppsBlock.java
@@ -129,7 +129,7 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
     return true;
   }
 
-  public String printData(long appInfoFunc) {
+  public String printAppInfo(long appInfoFunc) {
     if (appInfoFunc== -1) {
       return "N/A";
     }
@@ -199,15 +199,15 @@ public class FairSchedulerAppsBlock extends HtmlBlock {
       .append(appInfo.getFinishTime()).append("\",\"")
       .append(appInfo.getState()).append("\",\"")
       .append(appInfo.getFinalStatus()).append("\",\"")
-      .append(printData(appInfo.getRunningContainers()))
+      .append(printAppInfo(appInfo.getRunningContainers()))
       .append("\",\"")
-      .append(printData(appInfo.getAllocatedVCores()))
+      .append(printAppInfo(appInfo.getAllocatedVCores()))
       .append("\",\"")
-      .append(printData(appInfo.getAllocatedMB()))
+      .append(printAppInfo(appInfo.getAllocatedMB()))
       .append("\",\"")
-      .append(printData(appInfo.getReservedVCores()))
+      .append(printAppInfo(appInfo.getReservedVCores()))
       .append("\",\"")
-      .append(printData(appInfo.getReservedMB()))
+      .append(printAppInfo(appInfo.getReservedMB()))
       .append("\",\"")
       // Progress bar
       .append("<br title='").append(percent)


### PR DESCRIPTION
[YARN-6766](https://issues.apache.org/jira/browse/YARN-6766)

Description of PR

The various *AppsBlock classes are riddled with statements like:
`.append(appInfo.getReservedVCores() == -1 ? "N/A" : String.valueOf(appInfo.getReservedVCores()))`
The code would be much cleaner if there were a utility method for that operation, e.g.:
`.append(printData(appInfo.getReservedCores()))`