### PR TITLE
HADOOP-18476. Abfs and S3A FileContext bindings to close wrapped filesystems in finalizer

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3A.java
@@ -33,11 +33,12 @@ import java.net.URISyntaxException;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
-public class S3A extends DelegateToFileSystem{
+public class S3A extends DelegateToFileSystem {
 
   public S3A(URI theUri, Configuration conf)
-          throws IOException, URISyntaxException {
-    super(theUri, new S3AFileSystem(), conf, "s3a", false);
+      throws IOException, URISyntaxException {
+    super(theUri, new S3AFileSystem(), conf,
+      "s3a", false);
   }
 
   @Override
@@ -53,5 +54,14 @@ public class S3A extends DelegateToFileSystem{
     sb.append("; fsImpl=").append(fsImpl);
     sb.append('}');
     return sb.toString();
+  }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3A.java
@@ -37,8 +37,7 @@ public class S3A extends DelegateToFileSystem {
 
   public S3A(URI theUri, Configuration conf)
       throws IOException, URISyntaxException {
-    super(theUri, new S3AFileSystem(), conf,
-      "s3a", false);
+    super(theUri, new S3AFileSystem(), conf, "s3a", false);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/Abfs.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/Abfs.java
@@ -43,4 +43,13 @@ public class Abfs extends DelegateToFileSystem {
   public int getUriDefaultPort() {
     return -1;
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/Abfss.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/Abfss.java
@@ -43,4 +43,13 @@ public class Abfss extends DelegateToFileSystem {
   public int getUriDefaultPort() {
     return -1;
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }


### PR DESCRIPTION

Not a fan of finalize, especially as FileContext delete on exit seems trouble. The class holds strong references so finalize() won't be called, ever.

Ignoring that, and avoiding something major like making everything closeable, the abfs and s3a bindings should close their wrapped FS in close.

### How was this patch tested?

s3a tests: london, scale
abfs: cardiff, scale

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

