### PR TITLE
HADOOP-18481. Don't warn on EnvironmentCredentialsProvider.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -640,8 +640,10 @@ public final class S3AUtils {
     AWSCredentialProviderList providers = new AWSCredentialProviderList();
     for (Class<?> aClass : awsClasses) {
 
-      if (!aClass.getSimpleName().equals("EnvironmentVariableCredentialsProvider")
-          && aClass.getName().contains(AWS_AUTH_CLASS_PREFIX)) {
+      // List of V1 credential providers that will be migrated with V2 upgrade
+      if (!Arrays.asList("EnvironmentVariableCredentialsProvider",
+              "EC2ContainerCredentialsProviderWrapper", "InstanceProfileCredentialsProvider")
+          .contains(aClass.getSimpleName()) && aClass.getName().contains(AWS_AUTH_CLASS_PREFIX)) {
         V2Migration.v1ProviderReferenced(aClass.getName());
       }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -640,7 +640,8 @@ public final class S3AUtils {
     AWSCredentialProviderList providers = new AWSCredentialProviderList();
     for (Class<?> aClass : awsClasses) {
 
-      if (aClass.getName().contains(AWS_AUTH_CLASS_PREFIX)) {
+      if (!aClass.getSimpleName().equals("EnvironmentVariableCredentialsProvider")
+          && aClass.getName().contains(AWS_AUTH_CLASS_PREFIX)) {
         V2Migration.v1ProviderReferenced(aClass.getName());
       }
 


### PR DESCRIPTION
### Description of PR

[JIRA](https://issues.apache.org/jira/browse/HADOOP-18481)

This PR prevents logging of V1 Credential provider warning for `EnvironmentCredentialsProvider`.

### How was this patch tested?

Ran an integration test, checked what's logged. No warning logged for `EnvironmentCredentialsProvider`, warning logged when I set cred provider as `com.amazonaws.auth.InstanceProfileCredentialsProvider`