### PR TITLE
YARN-11328. Refactoring part of the code of SQLFederationStateStore.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/bin/FederationStateStore/SQLServer/FederationStateStoreStoredProcs.sql
+++ b/hadoop-yarn-project/hadoop-yarn/bin/FederationStateStore/SQLServer/FederationStateStoreStoredProcs.sql
@@ -24,10 +24,10 @@ IF OBJECT_ID ( '[sp_addApplicationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_addApplicationHomeSubCluster]
-    @applicationId VARCHAR(64),
-    @homeSubCluster VARCHAR(256),
-    @storedHomeSubCluster VARCHAR(256) OUTPUT,
-    @rowCount int OUTPUT
+    @applicationId_IN VARCHAR(64),
+    @homeSubCluster_IN VARCHAR(256),
+    @storedHomeSubCluster_OUT VARCHAR(256) OUTPUT,
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -37,21 +37,21 @@ AS BEGIN
             -- Otherwise don't change the current mapping.
             IF NOT EXISTS (SELECT TOP 1 *
                        FROM [dbo].[applicationsHomeSubCluster]
-                       WHERE [applicationId] = @applicationId)
+                       WHERE [applicationId] = @applicationId_IN)
 
                 INSERT INTO [dbo].[applicationsHomeSubCluster] (
                     [applicationId],
                     [homeSubCluster])
                 VALUES (
-                    @applicationId,
-                    @homeSubCluster);
+                    @applicationId_IN,
+                    @homeSubCluster_IN);
             -- End of the IF block
 
-            SELECT @rowCount = @@ROWCOUNT;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
-            SELECT @storedHomeSubCluster = [homeSubCluster]
+            SELECT @storedHomeSubCluster_OUT = [homeSubCluster]
             FROM [dbo].[applicationsHomeSubCluster]
-            WHERE [applicationId] = @applicationId;
+            WHERE [applicationId] = @applicationId_IN;
 
         COMMIT TRAN
     END TRY
@@ -75,9 +75,9 @@ IF OBJECT_ID ( '[sp_updateApplicationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_updateApplicationHomeSubCluster]
-    @applicationId VARCHAR(64),
-    @homeSubCluster VARCHAR(256),
-    @rowCount int OUTPUT
+    @applicationId_IN VARCHAR(64),
+    @homeSubCluster_IN VARCHAR(256),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -85,9 +85,9 @@ AS BEGIN
         BEGIN TRAN
 
             UPDATE [dbo].[applicationsHomeSubCluster]
-            SET [homeSubCluster] = @homeSubCluster
-            WHERE [applicationId] = @applicationid;
-            SELECT @rowCount = @@ROWCOUNT;
+            SET [homeSubCluster] = @homeSubCluster_IN
+            WHERE [applicationId] = @applicationId_IN;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -111,8 +111,8 @@ IF OBJECT_ID ( '[sp_getApplicationsHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_getApplicationsHomeSubCluster]
-    @limit int,
-    @homeSubCluster VARCHAR(256)
+    @limit_IN int,
+    @homeSubCluster_IN VARCHAR(256)
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -128,8 +128,8 @@ AS BEGIN
                  [createTime],
                  row_number() over(order by [createTime] desc) AS app_rank
              FROM [dbo].[applicationsHomeSubCluster]
-             WHERE [homeSubCluster] = @homeSubCluster OR @homeSubCluster = '') AS applicationsHomeSubCluster
-        WHERE app_rank <= @limit;
+             WHERE [homeSubCluster] = @homeSubCluster_IN OR @homeSubCluster = '') AS applicationsHomeSubCluster
+        WHERE app_rank <= @limit_IN;
 
     END TRY
 
@@ -150,16 +150,16 @@ IF OBJECT_ID ( '[sp_getApplicationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_getApplicationHomeSubCluster]
-    @applicationId VARCHAR(64),
-    @homeSubCluster VARCHAR(256) OUTPUT
+    @applicationId_IN VARCHAR(64),
+    @homeSubCluster_OUT VARCHAR(256) OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
     BEGIN TRY
 
-        SELECT @homeSubCluster = [homeSubCluster]
+        SELECT @homeSubCluster_OUT = [homeSubCluster]
         FROM [dbo].[applicationsHomeSubCluster]
-        WHERE [applicationId] = @applicationid;
+        WHERE [applicationId] = @applicationId_IN;
 
     END TRY
 
@@ -181,8 +181,8 @@ IF OBJECT_ID ( '[sp_deleteApplicationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_deleteApplicationHomeSubCluster]
-    @applicationId VARCHAR(64),
-    @rowCount int OUTPUT
+    @applicationId_IN VARCHAR(64),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -190,8 +190,8 @@ AS BEGIN
         BEGIN TRAN
 
             DELETE FROM [dbo].[applicationsHomeSubCluster]
-            WHERE [applicationId] = @applicationId;
-            SELECT @rowCount = @@ROWCOUNT;
+            WHERE [applicationId] = @applicationId_IN;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -215,15 +215,15 @@ IF OBJECT_ID ( '[sp_registerSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_registerSubCluster]
-    @subClusterId VARCHAR(256),
-    @amRMServiceAddress VARCHAR(256),
-    @clientRMServiceAddress VARCHAR(256),
-    @rmAdminServiceAddress VARCHAR(256),
-    @rmWebServiceAddress VARCHAR(256),
-    @state VARCHAR(32),
-    @lastStartTime BIGINT,
-    @capability VARCHAR(6000),
-    @rowCount int OUTPUT
+    @subClusterId_IN VARCHAR(256),
+    @amRMServiceAddress_IN VARCHAR(256),
+    @clientRMServiceAddress_IN VARCHAR(256),
+    @rmAdminServiceAddress_IN VARCHAR(256),
+    @rmWebServiceAddress_IN VARCHAR(256),
+    @state_IN VARCHAR(32),
+    @lastStartTime_IN BIGINT,
+    @capability_IN VARCHAR(6000),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -231,7 +231,7 @@ AS BEGIN
         BEGIN TRAN
 
             DELETE FROM [dbo].[membership]
-            WHERE [subClusterId] = @subClusterId;
+            WHERE [subClusterId] = @subClusterId_IN;
             INSERT INTO [dbo].[membership] (
                 [subClusterId],
                 [amRMServiceAddress],
@@ -243,16 +243,16 @@ AS BEGIN
                 [lastStartTime],
                 [capability] )
             VALUES (
-                @subClusterId,
-                @amRMServiceAddress,
-                @clientRMServiceAddress,
-                @rmAdminServiceAddress,
-                @rmWebServiceAddress,
+                @subClusterId_IN,
+                @amRMServiceAddress_IN,
+                @clientRMServiceAddress_IN,
+                @rmAdminServiceAddress_IN,
+                @rmWebServiceAddress_IN,
                 GETUTCDATE(),
-                @state,
-                @lastStartTime,
-                @capability);
-            SELECT @rowCount = @@ROWCOUNT;
+                @state_IN,
+                @lastStartTime_IN,
+                @capability_IN);
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -303,32 +303,32 @@ IF OBJECT_ID ( '[sp_getSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_getSubCluster]
-    @subClusterId VARCHAR(256),
-    @amRMServiceAddress VARCHAR(256) OUTPUT,
-    @clientRMServiceAddress VARCHAR(256) OUTPUT,
-    @rmAdminServiceAddress VARCHAR(256) OUTPUT,
-    @rmWebServiceAddress VARCHAR(256) OUTPUT,
-    @lastHeartbeat DATETIME2 OUTPUT,
-    @state VARCHAR(256) OUTPUT,
-    @lastStartTime BIGINT OUTPUT,
-    @capability VARCHAR(6000) OUTPUT
+    @subClusterId_IN VARCHAR(256),
+    @amRMServiceAddress_OUT VARCHAR(256) OUTPUT,
+    @clientRMServiceAddress_OUT VARCHAR(256) OUTPUT,
+    @rmAdminServiceAddress_OUT VARCHAR(256) OUTPUT,
+    @rmWebServiceAddress_OUT VARCHAR(256) OUTPUT,
+    @lastHeartBeat_OUT DATETIME2 OUTPUT,
+    @state_OUT VARCHAR(256) OUTPUT,
+    @lastStartTime_OUT BIGINT OUTPUT,
+    @capability_OUT VARCHAR(6000) OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
     BEGIN TRY
         BEGIN TRAN
 
-            SELECT @subClusterId = [subClusterId],
-                   @amRMServiceAddress = [amRMServiceAddress],
-                   @clientRMServiceAddress = [clientRMServiceAddress],
-                   @rmAdminServiceAddress = [rmAdminServiceAddress],
-                   @rmWebServiceAddress = [rmWebServiceAddress],
-                   @lastHeartBeat = [lastHeartBeat],
-                   @state = [state],
-                   @lastStartTime = [lastStartTime],
-                   @capability = [capability]
+            SELECT @subClusterId_IN = [subClusterId],
+                   @amRMServiceAddress_OUT = [amRMServiceAddress],
+                   @clientRMServiceAddress_OUT = [clientRMServiceAddress],
+                   @rmAdminServiceAddress_OUT = [rmAdminServiceAddress],
+                   @rmWebServiceAddress_OUT = [rmWebServiceAddress],
+                   @lastHeartBeat_OUT = [lastHeartBeat],
+                   @state_OUT = [state],
+                   @lastStartTime_OUT = [lastStartTime],
+                   @capability_OUT = [capability]
             FROM [dbo].[membership]
-            WHERE [subClusterId] = @subClusterId
+            WHERE [subClusterId] = @subClusterId_IN
 
         COMMIT TRAN
     END TRY
@@ -353,10 +353,10 @@ IF OBJECT_ID ( '[sp_subClusterHeartbeat]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_subClusterHeartbeat]
-    @subClusterId VARCHAR(256),
-    @state VARCHAR(256),
-    @capability VARCHAR(6000),
-    @rowCount int OUTPUT
+    @subClusterId_IN VARCHAR(256),
+    @state_IN VARCHAR(256),
+    @capability_IN VARCHAR(6000),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -364,11 +364,11 @@ AS BEGIN
         BEGIN TRAN
 
             UPDATE [dbo].[membership]
-            SET [state] = @state,
+            SET [state] = @state_IN,
                 [lastHeartbeat] = GETUTCDATE(),
-                [capability] = @capability
-            WHERE [subClusterId] = @subClusterId;
-            SELECT @rowCount = @@ROWCOUNT;
+                [capability] = @capability_IN
+            WHERE [subClusterId] = @subClusterId_IN;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -392,9 +392,9 @@ IF OBJECT_ID ( '[sp_deregisterSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_deregisterSubCluster]
-    @subClusterId VARCHAR(256),
-    @state VARCHAR(256),
-    @rowCount int OUTPUT
+    @subClusterId_IN VARCHAR(256),
+    @state_IN VARCHAR(256),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -402,9 +402,9 @@ AS BEGIN
         BEGIN TRAN
 
             UPDATE [dbo].[membership]
-            SET [state] = @state
-            WHERE [subClusterId] = @subClusterId;
-            SELECT @rowCount = @@ROWCOUNT;
+            SET [state] = @state_IN
+            WHERE [subClusterId] = @subClusterId_IN;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -428,10 +428,10 @@ IF OBJECT_ID ( '[sp_setPolicyConfiguration]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_setPolicyConfiguration]
-    @queue VARCHAR(256),
-    @policyType VARCHAR(256),
-    @params VARBINARY(512),
-    @rowCount int OUTPUT
+    @queue_IN VARCHAR(256),
+    @policyType_IN VARCHAR(256),
+    @params_IN VARBINARY(512),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -439,16 +439,16 @@ AS BEGIN
         BEGIN TRAN
 
             DELETE FROM [dbo].[policies]
-            WHERE [queue] = @queue;
+            WHERE [queue] = @queue_IN;
             INSERT INTO [dbo].[policies] (
                 [queue],
                 [policyType],
                 [params])
             VALUES (
-                @queue,
-                @policyType,
-                @params);
-            SELECT @rowCount = @@ROWCOUNT;
+                @queue_IN,
+                @policyType_IN,
+                @params_IN);
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -472,18 +472,18 @@ IF OBJECT_ID ( '[sp_getPolicyConfiguration]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_getPolicyConfiguration]
-    @queue VARCHAR(256),
-    @policyType VARCHAR(256) OUTPUT,
-    @params VARBINARY(6000) OUTPUT
+    @queue_IN VARCHAR(256),
+    @policyType_OUT VARCHAR(256) OUTPUT,
+    @params_OUT VARBINARY(6000) OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
     BEGIN TRY
 
-        SELECT @policyType = [policyType],
-               @params = [params]
+        SELECT @policyType_OUT = [policyType],
+               @params_OUT = [params]
         FROM [dbo].[policies]
-        WHERE [queue] = @queue
+        WHERE [queue] = @queue_IN
 
     END TRY
 
@@ -524,15 +524,15 @@ AS BEGIN
 END;
 GO
 
-IF OBJECT_ID ( '[sp_addApplicationHomeSubCluster]', 'P' ) IS NOT NULL
-    DROP PROCEDURE [sp_addApplicationHomeSubCluster];
+IF OBJECT_ID ( '[sp_addReservationHomeSubCluster]', 'P' ) IS NOT NULL
+    DROP PROCEDURE [sp_addReservationHomeSubCluster];
 GO
 
 CREATE PROCEDURE [dbo].[sp_addReservationHomeSubCluster]
-    @reservationId VARCHAR(128),
-    @homeSubCluster VARCHAR(256),
-    @storedHomeSubCluster VARCHAR(256) OUTPUT,
-    @rowCount int OUTPUT
+    @reservationId_IN VARCHAR(128),
+    @homeSubCluster_IN VARCHAR(256),
+    @storedHomeSubCluster_OUT VARCHAR(256) OUTPUT,
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -542,21 +542,21 @@ AS BEGIN
             -- Otherwise don't change the current mapping.
             IF NOT EXISTS (SELECT TOP 1 *
                        FROM [dbo].[reservationsHomeSubCluster]
-                       WHERE [reservationId] = @reservationId)
+                       WHERE [reservationId] = @reservationId_IN)
 
                 INSERT INTO [dbo].[reservationsHomeSubCluster] (
                     [reservationId],
                     [homeSubCluster])
                 VALUES (
-                    @reservationId,
-                    @homeSubCluster);
+                    @reservationId_IN,
+                    @homeSubCluster_IN);
             -- End of the IF block
 
-            SELECT @rowCount = @@ROWCOUNT;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
-            SELECT @storedHomeSubCluster = [homeSubCluster]
+            SELECT @storedHomeSubCluster_OUT = [homeSubCluster]
             FROM [dbo].[reservationsHomeSubCluster]
-            WHERE [reservationId] = @reservationId;
+            WHERE [reservationId] = @reservationId_IN;
 
         COMMIT TRAN
     END TRY
@@ -580,9 +580,9 @@ IF OBJECT_ID ( '[sp_updateReservationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_updateReservationHomeSubCluster]
-    @reservationId VARCHAR(128),
-    @homeSubCluster VARCHAR(256),
-    @rowCount int OUTPUT
+    @reservationId_IN VARCHAR(128),
+    @homeSubCluster_IN VARCHAR(256),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -590,9 +590,9 @@ AS BEGIN
         BEGIN TRAN
 
             UPDATE [dbo].[reservationsHomeSubCluster]
-            SET [homeSubCluster] = @homeSubCluster
-            WHERE [reservationId] = @reservationId;
-            SELECT @rowCount = @@ROWCOUNT;
+            SET [homeSubCluster] = @homeSubCluster_IN
+            WHERE [reservationId] = @reservationId_IN;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY
@@ -641,16 +641,16 @@ IF OBJECT_ID ( '[sp_getReservationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_getReservationHomeSubCluster]
-    @reservationId VARCHAR(128),
-    @homeSubCluster VARCHAR(256) OUTPUT
+    @reservationId_IN VARCHAR(128),
+    @homeSubCluster_OUT VARCHAR(256) OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
     BEGIN TRY
 
-        SELECT @homeSubCluster = [homeSubCluster]
+        SELECT @homeSubCluster_OUT = [homeSubCluster]
         FROM [dbo].[reservationsHomeSubCluster]
-        WHERE [reservationId] = @reservationId;
+        WHERE [reservationId] = @reservationId_IN;
 
     END TRY
 
@@ -672,8 +672,8 @@ IF OBJECT_ID ( '[sp_deleteReservationHomeSubCluster]', 'P' ) IS NOT NULL
 GO
 
 CREATE PROCEDURE [dbo].[sp_deleteReservationHomeSubCluster]
-    @reservationId VARCHAR(128),
-    @rowCount int OUTPUT
+    @reservationId_IN VARCHAR(128),
+    @rowCount_OUT int OUTPUT
 AS BEGIN
     DECLARE @errorMessage nvarchar(4000)
 
@@ -681,8 +681,8 @@ AS BEGIN
         BEGIN TRAN
 
             DELETE FROM [dbo].[reservationsHomeSubCluster]
-            WHERE [reservationId] = @reservationId;
-            SELECT @rowCount = @@ROWCOUNT;
+            WHERE [reservationId] = @reservationId_IN;
+            SELECT @rowCount_OUT = @@ROWCOUNT;
 
         COMMIT TRAN
     END TRY

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
@@ -321,7 +321,6 @@ public class SQLFederationStateStore implements FederationStateStore {
             "Wrong behavior during deregistration of SubCluster %s from the StateStore.",
             subClusterId);
       }
-
       LOG.info("Deregistered the SubCluster {} state to {}.", subClusterId, state.toString());
       FederationStateStoreClientMetrics.succeededStateStoreCall(stopTime - startTime);
 
@@ -366,14 +365,14 @@ public class SQLFederationStateStore implements FederationStateStore {
       // did not update the subcluster into FederationStateStore
       int rowCount = cstmt.getInt("rowCount_OUT");
       if (rowCount == 0) {
-        String errMsg = "SubCluster " + subClusterId + " does not exist; cannot heartbeat";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "SubCluster %s does not exist; cannot heartbeat.", subClusterId);
       }
       // Check the ROWCOUNT value, if it is different from 1 it means the call
       // had a wrong behavior. Maybe the database is not set correctly.
       if (rowCount != 1) {
-        String errMsg = "Wrong behavior during the heartbeat of SubCluster " + subClusterId;
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Wrong behavior during the heartbeat of SubCluster %s.", subClusterId);
       }
 
       LOG.info("Heartbeated the StateStore for the specified SubCluster {}.", subClusterId);
@@ -381,8 +380,8 @@ public class SQLFederationStateStore implements FederationStateStore {
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to heartbeat the StateStore for the specified SubCluster " + subClusterId, e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to heartbeat the StateStore for the specified SubCluster %s.", subClusterId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -449,14 +448,14 @@ public class SQLFederationStateStore implements FederationStateStore {
       try {
         FederationMembershipStateStoreInputValidator.checkSubClusterInfo(subClusterInfo);
       } catch (FederationStateStoreInvalidInputException e) {
-        String errMsg = "SubCluster " + subClusterId.toString() + " does not exist";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(e, LOG,
+            "SubCluster %s does not exist.", subClusterId);
       }
       LOG.debug("Got the information about the specified SubCluster {}", subClusterInfo);
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to obtain the SubCluster information for " + subClusterId, e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to obtain the SubCluster information for %s.", subClusterId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -504,8 +503,8 @@ public class SQLFederationStateStore implements FederationStateStore {
         try {
           FederationMembershipStateStoreInputValidator.checkSubClusterInfo(subClusterInfo);
         } catch (FederationStateStoreInvalidInputException e) {
-          String errMsg = "SubCluster " + subClusterId.toString() + " is not valid";
-          FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+          FederationStateStoreUtils.logAndThrowStoreException(e, LOG,
+              "SubCluster %s is not valid.", subClusterId);
         }
 
         // Filter the inactive
@@ -575,8 +574,8 @@ public class SQLFederationStateStore implements FederationStateStore {
         } else if (cstmt.getInt("rowCount_OUT") != 1) {
           // Check the ROWCOUNT value, if it is different from 1 it means the
           // call had a wrong behavior. Maybe the database is not set correctly.
-          String errMsg = "Wrong behavior during the insertion of SubCluster " + subClusterId;
-          FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+          FederationStateStoreUtils.logAndThrowStoreException(LOG,
+              "Wrong behavior during the insertion of SubCluster %s.", subClusterId);
         }
 
         LOG.info("Insert into the StateStore the application: {} in SubCluster: {}.",
@@ -585,16 +584,16 @@ public class SQLFederationStateStore implements FederationStateStore {
         // Check the ROWCOUNT value, if it is different from 0 it means the call
         // did edited the table
         if (rowCount != 0) {
-          String errMsg = "The application " + appId + " does exist but was overwritten";
-          FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+          FederationStateStoreUtils.logAndThrowStoreException(LOG,
+              "The application %s does exist but was overwritten.", appId);
         }
         LOG.info("Application: {} already present with SubCluster: {}.", appId, subClusterHome);
       }
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to insert the newly generated application " + appId, e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to insert the newly generated application %s.", appId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -635,15 +634,14 @@ public class SQLFederationStateStore implements FederationStateStore {
       // did not update the application into FederationStateStore
       int rowCount = cstmt.getInt("rowCount_OUT");
       if (rowCount == 0) {
-        String errMsg = "Application " + appId + " does not exist";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Application %s does not exist.", appId);
       }
       // Check the ROWCOUNT value, if it is different from 1 it means the call
       // had a wrong behavior. Maybe the database is not set correctly.
       if (cstmt.getInt("rowCount_OUT") != 1) {
-        String errMsg =
-            "Wrong behavior during the update of SubCluster " + subClusterId;
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Wrong behavior during the update of SubCluster %s.", subClusterId);
       }
 
       LOG.info("Update the SubCluster to {} for application {} in the StateStore",
@@ -651,8 +649,8 @@ public class SQLFederationStateStore implements FederationStateStore {
       FederationStateStoreClientMetrics.succeededStateStoreCall(stopTime - startTime);
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to update the application " + appId, e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to update the application %s.", appId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -670,11 +668,13 @@ public class SQLFederationStateStore implements FederationStateStore {
 
     SubClusterId homeRM = null;
 
+    ApplicationId applicationId = request.getApplicationId();
+
     try {
       cstmt = getCallableStatement(CALL_SP_GET_APPLICATION_HOME_SUBCLUSTER);
 
       // Set the parameters for the stored procedure
-      cstmt.setString("applicationId_IN", request.getApplicationId().toString());
+      cstmt.setString("applicationId_IN", applicationId.toString());
       cstmt.registerOutParameter("homeSubCluster_OUT", java.sql.Types.VARCHAR);
 
       // Execute the query
@@ -686,20 +686,20 @@ public class SQLFederationStateStore implements FederationStateStore {
       if (homeSubCluster != null) {
         homeRM = SubClusterId.newInstance(homeSubCluster);
       } else {
-        String errMsg = "Application " + request.getApplicationId() + " does not exist";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Application %s does not exist.", applicationId);
       }
 
       LOG.debug("Got the information about the specified application {}."
-          + " The AM is running in {}", request.getApplicationId(), homeRM);
+          + " The AM is running in {}", applicationId, homeRM);
 
       FederationStateStoreClientMetrics.succeededStateStoreCall(stopTime - startTime);
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to obtain the application information for the specified application " +
-          request.getApplicationId(), e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to obtain the application information for the specified application %s.",
+          applicationId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -767,12 +767,12 @@ public class SQLFederationStateStore implements FederationStateStore {
     FederationApplicationHomeSubClusterStoreInputValidator.validate(request);
 
     CallableStatement cstmt = null;
-
+    ApplicationId applicationId = request.getApplicationId();
     try {
       cstmt = getCallableStatement(CALL_SP_DELETE_APPLICATION_HOME_SUBCLUSTER);
 
       // Set the parameters for the stored procedure
-      cstmt.setString("applicationId_IN", request.getApplicationId().toString());
+      cstmt.setString("applicationId_IN", applicationId.toString());
       cstmt.registerOutParameter("rowCount_OUT", java.sql.Types.INTEGER);
 
       // Execute the query
@@ -784,15 +784,14 @@ public class SQLFederationStateStore implements FederationStateStore {
       // did not delete the application from FederationStateStore
       int rowCount = cstmt.getInt("rowCount_OUT");
       if (rowCount == 0) {
-        String errMsg = "Application " + request.getApplicationId() + " does not exist";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Application %s does not exist.", applicationId);
       }
       // Check the ROWCOUNT value, if it is different from 1 it means the call
       // had a wrong behavior. Maybe the database is not set correctly.
       if (cstmt.getInt("rowCount_OUT") != 1) {
-        String errMsg = "Wrong behavior during deleting the application "
-            + request.getApplicationId();
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Wrong behavior during deleting the application %s.", applicationId);
       }
 
       LOG.info("Delete from the StateStore the application: {}", request.getApplicationId());
@@ -800,8 +799,8 @@ public class SQLFederationStateStore implements FederationStateStore {
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to delete the application " + request.getApplicationId(), e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to delete the application %s.", applicationId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -849,8 +848,8 @@ public class SQLFederationStateStore implements FederationStateStore {
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to select the policy for the queue :" + request.getQueue(), e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to select the policy for the queue : %s." + request.getQueue());
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -887,15 +886,14 @@ public class SQLFederationStateStore implements FederationStateStore {
       // did not add a new policy into FederationStateStore
       int rowCount = cstmt.getInt("rowCount_OUT");
       if (rowCount == 0) {
-        String errMsg = "The policy " + policyConf.getQueue()
-            + " was not insert into the StateStore";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "The policy %s was not insert into the StateStore.", policyConf.getQueue());
       }
       // Check the ROWCOUNT value, if it is different from 1 it means the call
       // had a wrong behavior. Maybe the database is not set correctly.
       if (rowCount != 1) {
-        String errMsg = "Wrong behavior during insert the policy " + policyConf.getQueue();
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Wrong behavior during insert the policy %s.", policyConf.getQueue());
       }
 
       LOG.info("Insert into the state store the policy for the queue: {}.", policyConf.getQueue());
@@ -903,8 +901,8 @@ public class SQLFederationStateStore implements FederationStateStore {
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to insert the newly generated policy for the queue :" + policyConf.getQueue(), e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to insert the newly generated policy for the queue : %s.", policyConf.getQueue());
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
@@ -226,13 +226,11 @@ public class SQLFederationStateStore implements FederationStateStore {
       SubClusterRegisterRequest registerSubClusterRequest) throws YarnException {
 
     // Input validator
-    FederationMembershipStateStoreInputValidator
-        .validate(registerSubClusterRequest);
+    FederationMembershipStateStoreInputValidator.validate(registerSubClusterRequest);
 
     CallableStatement cstmt = null;
 
-    SubClusterInfo subClusterInfo =
-        registerSubClusterRequest.getSubClusterInfo();
+    SubClusterInfo subClusterInfo = registerSubClusterRequest.getSubClusterInfo();
     SubClusterId subClusterId = subClusterInfo.getSubClusterId();
 
     try {
@@ -258,24 +256,24 @@ public class SQLFederationStateStore implements FederationStateStore {
       // did not add a new subcluster into FederationStateStore
       int rowCount = cstmt.getInt("rowCount_OUT");
       if (rowCount == 0) {
-        String errMsg = "SubCluster " + subClusterId + " was not registered into the StateStore";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "SubCluster %s was not registered into the StateStore.", subClusterId);
       }
       // Check the ROWCOUNT value, if it is different from 1 it means the call
       // had a wrong behavior. Maybe the database is not set correctly.
       if (rowCount != 1) {
-        String errMsg = "Wrong behavior during registration of SubCluster "
-            + subClusterId + " into the StateStore";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Wrong behavior during registration of SubCluster %s into the StateStore",
+            subClusterId);
       }
 
-      LOG.info("Registered the SubCluster {} into the StateStore", subClusterId);
+      LOG.info("Registered the SubCluster {} into the StateStore.", subClusterId);
       FederationStateStoreClientMetrics.succeededStateStoreCall(stopTime - startTime);
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to register the SubCluster " + subClusterId + " into the StateStore", e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e,
+          LOG, "Unable to register the SubCluster %s into the StateStore.", subClusterId);
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);
@@ -289,8 +287,7 @@ public class SQLFederationStateStore implements FederationStateStore {
       SubClusterDeregisterRequest subClusterDeregisterRequest) throws YarnException {
 
     // Input validator
-    FederationMembershipStateStoreInputValidator
-        .validate(subClusterDeregisterRequest);
+    FederationMembershipStateStoreInputValidator.validate(subClusterDeregisterRequest);
 
     CallableStatement cstmt = null;
 
@@ -312,16 +309,17 @@ public class SQLFederationStateStore implements FederationStateStore {
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not deregister the subcluster into FederationStateStore
-      if (cstmt.getInt("rowCount_OUT") == 0) {
-        String errMsg = "SubCluster " + subClusterId + " not found";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+      int rowCount = cstmt.getInt("rowCount_OUT");
+      if (rowCount == 0) {
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "SubCluster %s not found.", subClusterId);
       }
       // Check the ROWCOUNT value, if it is different from 1 it means the call
       // had a wrong behavior. Maybe the database is not set correctly.
-      if (cstmt.getInt("rowCount_OUT") != 1) {
-        String errMsg = "Wrong behavior during deregistration of SubCluster "
-            + subClusterId + " from the StateStore";
-        FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
+      if (rowCount != 1) {
+        FederationStateStoreUtils.logAndThrowStoreException(LOG,
+            "Wrong behavior during deregistration of SubCluster %s from the StateStore.",
+            subClusterId);
       }
 
       LOG.info("Deregistered the SubCluster {} state to {}.", subClusterId, state.toString());
@@ -329,9 +327,8 @@ public class SQLFederationStateStore implements FederationStateStore {
 
     } catch (SQLException e) {
       FederationStateStoreClientMetrics.failedStateStoreCall();
-      FederationStateStoreUtils.logAndThrowRetriableException(LOG,
-          "Unable to deregister the sub-cluster " + subClusterId +
-          " state to " + state.toString(), e);
+      FederationStateStoreUtils.logAndThrowRetriableException(e, LOG,
+          "Unable to deregister the sub-cluster %s state to %s.", subClusterId, state.toString());
     } finally {
       // Return to the pool the CallableStatement
       FederationStateStoreUtils.returnToPool(LOG, cstmt);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/utils/FederationStateStoreUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/utils/FederationStateStoreUtils.java
@@ -162,6 +162,29 @@ public final class FederationStateStoreUtils {
     throw new FederationStateStoreException(errMsg);
   }
 
+
+  /**
+   * Throws an <code>FederationStateStoreException</code> due to an error in
+   * <code>FederationStateStore</code>.
+   *
+   * @param t the throwable raised in the called class.
+   * @param log the logger interface.
+   * @param errMsgFormat the error message format string.
+   * @param args referenced by the format specifiers in the format string.
+   * @throws YarnException on failure
+   */
+  public static void logAndThrowStoreException(
+      Throwable t, Logger log, String errMsgFormat, Object... args) throws YarnException {
+    String errMsg = String.format(errMsgFormat, args);
+    if (t != null) {
+      log.error(errMsg, t);
+      throw new FederationStateStoreException(errMsg, t);
+    } else {
+      log.error(errMsg);
+      throw new FederationStateStoreException(errMsg);
+    }
+  }
+
   /**
    * Throws an <code>FederationStateStoreInvalidInputException</code> due to an
    * error in <code>FederationStateStore</code>.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/HSQLDBFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/HSQLDBFederationStateStore.java
@@ -325,7 +325,7 @@ public class HSQLDBFederationStateStore extends SQLFederationStateStore {
     try {
       conf.setInt(YarnConfiguration.FEDERATION_STATESTORE_MAX_APPLICATIONS, 10);
       super.init(conf);
-      conn = super.conn;
+      conn = super.getConn();
 
       LOG.info("Database Init: Start");
 
@@ -365,7 +365,7 @@ public class HSQLDBFederationStateStore extends SQLFederationStateStore {
   public void initConnection(Configuration conf) {
     try {
       super.init(conf);
-      conn = super.conn;
+      conn = super.getConn();
     } catch (YarnException e1) {
       LOG.error("ERROR: failed open connection to HSQLDB DB {}.", e1.getMessage());
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestSQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestSQLFederationStateStore.java
@@ -447,7 +447,7 @@ public class TestSQLFederationStateStore extends FederationStateStoreBaseTest {
 
     SQLFederationStateStore sqlFederationStateStore = (SQLFederationStateStore) stateStore;
 
-    Connection conn =  sqlFederationStateStore.conn;
+    Connection conn =  sqlFederationStateStore.getConn();
     conn.prepareStatement(SP_DROP_ADDRESERVATIONHOMESUBCLUSTER).execute();
     conn.prepareStatement(SP_ADDRESERVATIONHOMESUBCLUSTER2).execute();
 
@@ -484,7 +484,7 @@ public class TestSQLFederationStateStore extends FederationStateStoreBaseTest {
 
     SQLFederationStateStore sqlFederationStateStore = (SQLFederationStateStore) stateStore;
 
-    Connection conn =  sqlFederationStateStore.conn;
+    Connection conn =  sqlFederationStateStore.getConn();
     conn.prepareStatement(SP_DROP_UPDATERESERVATIONHOMESUBCLUSTER).execute();
     conn.prepareStatement(SP_UPDATERESERVATIONHOMESUBCLUSTER2).execute();
 
@@ -530,7 +530,7 @@ public class TestSQLFederationStateStore extends FederationStateStoreBaseTest {
 
     SQLFederationStateStore sqlFederationStateStore = (SQLFederationStateStore) stateStore;
 
-    Connection conn =  sqlFederationStateStore.conn;
+    Connection conn =  sqlFederationStateStore.getConn();
     conn.prepareStatement(SP_DROP_DELETERESERVATIONHOMESUBCLUSTER).execute();
     conn.prepareStatement(SP_DELETERESERVATIONHOMESUBCLUSTER2).execute();
 


### PR DESCRIPTION
JIRA: YARN-11328. Refactoring part of the code of SQLFederationStateStore.

1. When passing parameters to the database, use the field name instead of Index to increase the readability of the code.
2. Modify some logs and use {} instead of string splicing.
3. Other CheckStyle bug fixes.