### PR TITLE
HADOOP-18465. Fix S3A SSE test skip when encryption is disabled

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractTestS3AEncryption.java
@@ -78,8 +78,16 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
       0, 1, 2, 3, 4, 5, 254, 255, 256, 257, 2 ^ 12 - 1
   };
 
+  /**
+   * Skips the tests if encryption is not enabled in configuration.
+   *
+   * @implNote We can use {@link #createConfiguration()} here since
+   * it does not depend on any per-bucket based configuration.
+   * Otherwise, we would need to grab the configuration from an
+   * instance of {@link S3AFileSystem}.
+   */
   protected void requireEncryptedFileSystem() {
-    skipIfEncryptionTestsDisabled(getFileSystem().getConf());
+    skipIfEncryptionTestsDisabled(createConfiguration());
   }
 
   /**
@@ -91,8 +99,8 @@ public abstract class AbstractTestS3AEncryption extends AbstractS3ATestBase {
   @Override
   public void setup() throws Exception {
     try {
-      super.setup();
       requireEncryptedFileSystem();
+      super.setup();
     } catch (AccessDeniedException e) {
       skip("Bucket does not allow " + getSSEAlgorithm() + " encryption method");
     }


### PR DESCRIPTION
### Description of PR

**Note: This is the same as #4925 but against `branch-3.3`.**

When running integration tests against an S3-compatible endpoint without SSE support, tests would fail despite marking `test.fs.s3a.encryption.enabled` as false.

### How was this patch tested?

#### Against eu-west-1, no special configuration. Encryption enabled.

Two test failures, look unrelated.

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestS3APrefetchingInputStream.testRandomReadLargeFile:158 [Gauge named stream_read_blocks_in_cache with expected value 2] expected:<[2]L> but was:<[1]L>
[ERROR] Errors:
[ERROR]   ITestS3AFailureHandling.testMultiObjectDeleteLargeNumKeys » NullPointer
[INFO]
[ERROR] Tests run: 1143, Failures: 1, Errors: 1, Skipped: 186
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

