### PR TITLE
HADOOP-18482. Update ITestS3APrefetchingInputStream to skip if CSV test file unavailable

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3APrefetchingInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3APrefetchingInputStream.java
@@ -90,11 +90,12 @@ public class ITestS3APrefetchingInputStream extends AbstractS3ACostTest {
 
   private void openFS() throws Exception {
     Configuration conf = getConfiguration();
+    String largeFileUri = S3ATestUtils.getCSVTestFile(conf);
 
-    largeFile = new Path(DEFAULT_CSVTEST_FILE);
+    largeFile = new Path(largeFileUri);
     blockSize = conf.getInt(PREFETCH_BLOCK_SIZE_KEY, PREFETCH_BLOCK_DEFAULT_SIZE);
     largeFileFS = new S3AFileSystem();
-    largeFileFS.initialize(new URI(DEFAULT_CSVTEST_FILE), getConfiguration());
+    largeFileFS.initialize(new URI(largeFileUri), getConfiguration());
     FileStatus fileStatus = largeFileFS.getFileStatus(largeFile);
     largeFileSize = fileStatus.getLen();
     numBlocks = calculateNumBlocks(largeFileSize, blockSize);


### PR DESCRIPTION
### Description of PR

HADOOP-18482

This test still runs (and fails) when we set the CSV file configuration to empty. It's meant to skip.

### How was this patch tested?

- Run against bucket in `eu-west-1`: passing
- Run against a private S3 endpoint that does not contain file, so empty space: passing (skipping the right tests)

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

