### PR TITLE
HADOOP-18483. Exclude Dockerfile_windows_10 from hadolint

### DIFF
--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dev-support/docker/Dockerfile_windows_10


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
HADOOP-18133 tries to add Dockerfile for Windows 10 for building Hadoop. However, hadolint fails to run on *Dockerfile_windows_10* since the version of hadolint (1.1.1) used in Hadoop CI doesn't support parsing of the Windows command syntax.

HADOOP-18449 tries to upgrade the version of hadolint to the latest (2.10.0). However, it runs into some GPG issues on Centos 8.

Thus, we're going to exclude `Dockerfile_windows_10` from getting hadolint-ed for the time being. There's a bug in Yetus that prevents exclusion of the file if the exclusion rule and the Dockerfile are added in the same PR - https://github.com/apache/yetus/pull/289#issuecomment-1263813381. Thus, this PR adds the exclusion rule first and then the Dockerfile will be added in another PR.

### How was this patch tested?
Hadoop Jenkins CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

