### PR TITLE
HDFS-16798. SerialNumberMap should decrease current counter if the item exist

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SerialNumberMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/SerialNumberMap.java
@@ -68,6 +68,7 @@ public class SerialNumberMap<T> {
       }
       Integer old = t2i.putIfAbsent(t, sn);
       if (old != null) {
+        current.getAndDecrement();
         return old;
       }
       i2t.put(sn, t);


### PR DESCRIPTION
### Description of PR

During looking into some code related XATTR, I found there is a bug in SerialNumberMap, as bellow:
```
public int get(T t) {
  if (t == null) {
    return 0;
  }
  Integer sn = t2i.get(t);
  if (sn == null) {
    sn = current.getAndIncrement();
    if (sn > max) {
      current.getAndDecrement();
      throw new IllegalStateException(name + ": serial number map is full");
    }
    Integer old = t2i.putIfAbsent(t, sn);
    if (old != null) {
      // here: if the old is not null, we should decrease the current value.
      return old;
    }
    i2t.put(sn, t);
  }
  return sn;
} 
```

This bug will only cause that the capacity of serialNumberMap is less than expected, no other impact.

