### PR TITLE
YARN-11334. [Federation] Improve SubClusterState#fromString parameter and LogMessage.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterState.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterState.java
@@ -70,15 +70,15 @@ public enum SubClusterState {
   /**
    * Convert a string into {@code SubClusterState}.
    *
-   * @param x the string to convert in SubClusterState
+   * @param state the string to convert in SubClusterState
    * @return the respective {@code SubClusterState}
    */
-  public static SubClusterState fromString(String x) {
+  public static SubClusterState fromString(String state) {
     try {
-      return SubClusterState.valueOf(x);
+      return SubClusterState.valueOf(state);
     } catch (Exception e) {
-      LOG.error("Invalid SubCluster State value in the StateStore does not"
-          + " match with the YARN Federation standard.");
+      LOG.error("Invalid SubCluster State value({}) in the StateStore does not"
+          + " match with the YARN Federation standard.", state);
       return null;
     }
   }


### PR DESCRIPTION
JIRA: YARN-11334. [Federation] Improve SubClusterState#fromString parameter and LogMessage.

The SubClusterState object has a fromString method, which can be improved in the following 2 places

```
/**
 * Convert a string into {@code SubClusterState}.
 *
 * @param x the string to convert in SubClusterState
 * @return the respective {@code SubClusterState}
 */
public static SubClusterState fromString(String x) {
  try {
    return SubClusterState.valueOf(x);
  } catch (Exception e) {
    LOG.error("Invalid SubCluster State value in the StateStore does not"
        + " match with the YARN Federation standard.");
    return null;
  }
} 
```

- The parameter is named x, which cannot well express the meaning of the input parameter.
- The error log does not print the error value.
