### PR TITLE
HADOOP-18503. Upgrade Upgrade Huawei OBS client to 3.22.3.1

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <esdk.version>3.20.4.2</esdk.version>
+    <esdk.version>3.22.3.1</esdk.version>
   </properties>
 
   <profiles>
@@ -161,10 +161,6 @@
       <artifactId>esdk-obs-java</artifactId>
       <version>${esdk.version}</version>
       <exclusions>
-        <exclusion>
-          <artifactId>okio</artifactId>
-          <groupId>com.squareup.okio</groupId>
-        </exclusion>
         <exclusion>
           <artifactId>log4j-core</artifactId>
           <groupId>org.apache.logging.log4j</groupId>

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/main/java/org/apache/hadoop/fs/obs/OBSListing.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/main/java/org/apache/hadoop/fs/obs/OBSListing.java
@@ -453,7 +453,7 @@ class OBSListing {
       }
 
       // prefixes: always directories
-      for (ObsObject prefix : objects.getExtenedCommonPrefixes()) {
+      for (ObsObject prefix : objects.getExtendCommonPrefixes()) {
         String key = prefix.getObjectKey();
         Path keyPath = OBSCommonUtils.keyToQualifiedPath(owner, key);
         if (acceptor.accept(keyPath, key) && filter.accept(keyPath)) {


### PR DESCRIPTION
### Description of PR

Currently, the Huawei OBS client depends on OkHttp[1], we should upgrade it to the latest version[2] to get rid of OkHttp, to unblock removing OkHttp from Hadoop. Why remove OkHttp? Because the new OkHttp depends on Kotlin but Hadoop only uses it in a few places, replacing OkHttp w/ existing Apache Http client could avoid depending on Kotlin libs.

[1] https://mvnrepository.com/artifact/com.huaweicloud/esdk-obs-java/3.20.4.2
[2] https://mvnrepository.com/artifact/com.huaweicloud/esdk-obs-java/3.22.3.1

### How was this patch tested?

Existing test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

