### PR TITLE
HDFS-13507. RBF RouterAdmin disable update functionality in add cmd and supports add/update one mount table with different destination

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/dev-support/findbugsExcludeFile.xml
@@ -31,4 +31,16 @@
     <Method name="setNss" />
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>
+  <!-- Only to be used by Router Admin while preparing for bulk add request -->
+  <Match>
+    <Class name="org.apache.hadoop.hdfs.tools.federation.AddMountAttributes" />
+    <Method name="getDestinations" />
+    <Bug pattern="EI_EXPOSE_REP" />
+  </Match>
+  <!-- Only to be used by Router Admin while preparing for bulk add request -->
+  <Match>
+    <Class name="org.apache.hadoop.hdfs.tools.federation.AddMountAttributes" />
+    <Method name="setDestinations" />
+    <Bug pattern="EI_EXPOSE_REP2" />
+  </Match>
 </FindBugsFilter>

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterAdminServer.java
@@ -362,6 +362,9 @@ public class RouterAdminServer extends AbstractService
     List<MountTable> mountTables = request.getEntries();
     for (MountTable mountTable : mountTables) {
       verifyMaxComponentLength(mountTable);
+      if (mountTableExists(mountTable)) {
+        throw new IOException("Mountable " + mountTable.getSourcePath() + " already exists.");
+      }
     }
     if (this.mountTableCheckDestination) {
       for (MountTable mountTable : mountTables) {
@@ -423,6 +426,20 @@ public class RouterAdminServer extends AbstractService
       throw new IllegalArgumentException(
           "File not found in downstream nameservices: " + StringUtils.join(",", nsIds));
     }
+  }
+
+  /** Return true if the input mountTable exists, else return false.
+   *
+   * @param mountTable mountTable needs to be checked
+   */
+  private boolean mountTableExists(MountTable mountTable) throws IOException {
+    ActiveNamenodeResolver resolver = router.getNamenodeResolver();
+    if (resolver instanceof MountTableResolver) {
+      MountTableResolver mResolver = (MountTableResolver) resolver;
+      MountTable oldEntry = mResolver.getMountPoint(mountTable.getSourcePath());
+      return oldEntry != null;
+    }
+    return false;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/MountTable.java
@@ -198,15 +198,6 @@ public abstract class MountTable extends BaseRecord {
   public abstract void setDestinations(List<RemoteLocation> dests);
 
   /**
-   * Add a new destination to this mount table entry.
-   *
-   * @param nsId Name service identifier.
-   * @param path Path in the remote name service.
-   * @return If the destination was added.
-   */
-  public abstract boolean addDestination(String nsId, String path);
-
-  /**
    * Check if the entry is read only.
    *
    * @return If the entry is read only.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/impl/pb/MountTablePBImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/store/records/impl/pb/MountTablePBImpl.java
@@ -130,27 +130,6 @@ public class MountTablePBImpl extends MountTable implements PBRecord {
   }
 
   @Override
-  public boolean addDestination(String nsId, String path) {
-    // Check if the location is already there
-    List<RemoteLocation> dests = getDestinations();
-    for (RemoteLocation dest : dests) {
-      if (dest.getNameserviceId().equals(nsId) && dest.getDest().equals(path)) {
-        return false;
-      }
-    }
-
-    // Add it to the existing list
-    Builder builder = this.translator.getBuilder();
-    RemoteLocationProto.Builder itemBuilder =
-        RemoteLocationProto.newBuilder();
-    itemBuilder.setNameserviceId(nsId);
-    itemBuilder.setPath(path);
-    RemoteLocationProto item = itemBuilder.build();
-    builder.addDestinations(item);
-    return true;
-  }
-
-  @Override
   public void setDateModified(long time) {
     this.translator.getBuilder().setDateModified(time);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/AddMountAttributes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/tools/federation/AddMountAttributes.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdfs.tools.federation;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.hadoop.hdfs.server.federation.resolver.order.DestinationOrder;
@@ -32,7 +31,7 @@ public class AddMountAttributes {
 
   private String mount;
   private String[] nss;
-  private String dest;
+  private String[] destinations;
   private boolean readonly;
   private boolean faultTolerant;
   private DestinationOrder order;
@@ -55,12 +54,12 @@ public class AddMountAttributes {
     this.nss = nss;
   }
 
-  public String getDest() {
-    return dest;
+  public String[] getDestinations() {
+    return destinations;
   }
 
-  public void setDest(String dest) {
-    this.dest = dest;
+  public void setDestinations(String[] destinations) {
+    this.destinations = destinations;
   }
 
   public boolean isReadonly() {
@@ -115,32 +114,6 @@ public class AddMountAttributes {
   }
 
   /**
-   * Retrieve mount table object with all attributes derived from this object.
-   * The returned mount table could be either new or existing one with updated attributes.
-   *
-   * @param existingEntry Existing mount table entry. If null, new mount table object is created,
-   * otherwise the existing mount table object is updated.
-   * @return MountTable object with updated attributes.
-   * @throws IOException If mount table instantiation fails.
-   */
-  public MountTable getNewOrUpdatedMountTableEntryWithAttributes(MountTable existingEntry)
-      throws IOException {
-    if (existingEntry == null) {
-      return getMountTableForAddRequest(this.mount);
-    } else {
-      // Update the existing entry if it exists
-      for (String nsId : this.getNss()) {
-        if (!existingEntry.addDestination(nsId, this.getDest())) {
-          System.err.println("Cannot add destination at " + nsId + " " + this.getDest());
-          return null;
-        }
-      }
-      updateCommonAttributes(existingEntry);
-      return existingEntry;
-    }
-  }
-
-  /**
    * Create a new mount table object from the given mount point and update its attributes.
    *
    * @param mountSrc mount point src.
@@ -148,10 +121,7 @@ public class AddMountAttributes {
    * @throws IOException If mount table instantiation fails.
    */
   private MountTable getMountTableForAddRequest(String mountSrc) throws IOException {
-    Map<String, String> destMap = new LinkedHashMap<>();
-    for (String ns : this.getNss()) {
-      destMap.put(ns, this.getDest());
-    }
+    Map<String, String> destMap = RouterAdmin.getDestMap(this.nss, this.destinations);
     MountTable newEntry = MountTable.newInstance(mountSrc, destMap);
     updateCommonAttributes(newEntry);
     return newEntry;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -446,8 +446,9 @@ Runs the DFS router. See [Router](../hadoop-hdfs-rbf/HDFSRouterFederation.html#R
 Usage:
 
       hdfs dfsrouteradmin
-          [-add <source> <nameservice1, nameservice2, ...> <destination> [-readonly] [-faulttolerant] [-order HASH|LOCAL|RANDOM|HASH_ALL] -owner <owner> -group <group> -mode <mode>]
-          [-update <source> [<nameservice1, nameservice2, ...> <destination>] [-readonly true|false] [-faulttolerant true|false] [-order HASH|LOCAL|RANDOM|HASH_ALL] -owner <owner> -group <group> -mode <mode>]
+          [-add <source> <nameservice1, nameservice2, ...> <one destination or the same number of destinations as nameservices> [-readonly] [-faulttolerant] [-order HASH|LOCAL|RANDOM|HASH_ALL] -owner <owner> -group <group> -mode <mode>]
+          [-addAll <source1> <nameservice1, nameservice2,...> <one destination or the same number of destinations as nameservices> [-readonly] [-faulttolerant] [-order HASH|LOCAL|RANDOM|HASH_ALL|SPACE] -owner <owner1> -group <group1> -mode <mode1> , <source2> <nameservice1,nameservice2,...> <one destination or the same number of destinations as nameservices> [-readonly] [-faulttolerant] [-order HASH|LOCAL|RANDOM|HASH_ALL|SPACE] -owner <owner2> -group <group2> -mode <mode2> , ...]
+          [-update <source> [<nameservice1, nameservice2, ...> <one destination or the same number of destinations as nameservices>] [-readonly true|false] [-faulttolerant true|false] [-order HASH|LOCAL|RANDOM|HASH_ALL] -owner <owner> -group <group> -mode <mode>]
           [-rm <source>]
           [-ls [-d] <path>]
           [-getDestination <path>]
@@ -465,7 +466,7 @@ Usage:
 
 | COMMAND\_OPTION | Description |
 |:---- |:---- |
-| `-add` *source* *nameservices* *destination* | Add a mount table entry or update if it exists. |
+| `-add` *source* *nameservices* *destination* | Add a mount table entry. |
 | `-update` *source* *nameservices* *destination* | Update a mount table entry attributes. |
 | `-rm` *source* | Remove mount point of specified path. |
 | `-ls` `[-d]` *path* | List mount points under specified path. Specify -d parameter to get detailed listing.|


### PR DESCRIPTION
### Description of PR

As discussed in [HDFS-13507](https://issues.apache.org/jira/browse/HDFS-13507), RouterAdmin should disable the update functionality in the add command and RouterAdmin should support add/update one mount table with multiple different namespace.

The fist commit is used to disable the update functionality in the add command.

The second commit is used to support add or update one mount table with multiple different destinations.

