### PR TITLE
YARN-11337. Upgrade Junit 4 to 5 in hadoop-yarn-applications-mawo

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/pom.xml
@@ -31,23 +31,28 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
 
-      <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-          <type>test-jar</type>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/src/test/java/org/apache/hadoop/applications/mawo/server/common/TestMaWoConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/src/test/java/org/apache/hadoop/applications/mawo/server/common/TestMaWoConfiguration.java
@@ -38,7 +38,7 @@ public class TestMaWoConfiguration {
     MawoConfiguration mawoConf = new MawoConfiguration();
 
     // validate Rpc server port
-    assertEquals(mawoConf.getRpcServerPort(), 5120);
+    assertEquals(5120, mawoConf.getRpcServerPort());
 
     // validate Rpc hostname
     assertEquals("localhost", mawoConf.getRpcHostName());
@@ -48,7 +48,7 @@ public class TestMaWoConfiguration {
     assertTrue(jobQueueStorage);
 
     // validate default teardownWorkerValidity Interval
-    assertEquals(mawoConf.getTeardownWorkerValidityInterval(), 120000);
+    assertEquals(120000, mawoConf.getTeardownWorkerValidityInterval());
 
     // validate Zk related configs
     assertEquals("/tmp/mawoRoot", mawoConf.getZKParentPath());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/src/test/java/org/apache/hadoop/applications/mawo/server/common/TestMaWoConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/src/test/java/org/apache/hadoop/applications/mawo/server/common/TestMaWoConfiguration.java
@@ -19,8 +19,10 @@
 package org.apache.hadoop.applications.mawo.server.common;
 
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test MaWo configuration.
@@ -31,29 +33,29 @@ public class TestMaWoConfiguration {
    * Validate default MaWo Configurations.
    */
   @Test
-  public void testMaWoConfiguration() {
+  void testMaWoConfiguration() {
 
     MawoConfiguration mawoConf = new MawoConfiguration();
 
     // validate Rpc server port
-    Assert.assertEquals(mawoConf.getRpcServerPort(), 5120);
+    assertEquals(mawoConf.getRpcServerPort(), 5120);
 
     // validate Rpc hostname
-    Assert.assertTrue("localhost".equals(mawoConf.getRpcHostName()));
+    assertEquals("localhost", mawoConf.getRpcHostName());
 
     // validate job queue storage conf
     boolean jobQueueStorage = mawoConf.getJobQueueStorageEnabled();
-    Assert.assertTrue(jobQueueStorage);
+    assertTrue(jobQueueStorage);
 
     // validate default teardownWorkerValidity Interval
-    Assert.assertEquals(mawoConf.getTeardownWorkerValidityInterval(), 120000);
+    assertEquals(mawoConf.getTeardownWorkerValidityInterval(), 120000);
 
     // validate Zk related configs
-    Assert.assertTrue("/tmp/mawoRoot".equals(mawoConf.getZKParentPath()));
-    Assert.assertTrue("localhost:2181".equals(mawoConf.getZKAddress()));
-    Assert.assertEquals(1000, mawoConf.getZKRetryIntervalMS());
-    Assert.assertEquals(10000, mawoConf.getZKSessionTimeoutMS());
-    Assert.assertEquals(1000, mawoConf.getZKRetriesNum());
+    assertEquals("/tmp/mawoRoot", mawoConf.getZKParentPath());
+    assertEquals("localhost:2181", mawoConf.getZKAddress());
+    assertEquals(1000, mawoConf.getZKRetryIntervalMS());
+    assertEquals(10000, mawoConf.getZKSessionTimeoutMS());
+    assertEquals(1000, mawoConf.getZKRetriesNum());
   }
 
 


### PR DESCRIPTION
### Description of PR

Upgrade Junit 4 to 5 in hadoop-yarn-applications-mawo

JIRA - YARN-11337

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

