### PR TITLE
YARN-11339. Upgrade Junit 4 to 5 in hadoop-yarn-services-api

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/pom.xml
@@ -198,6 +198,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
       <scope>test</scope>
@@ -211,7 +221,17 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minikdc</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestApiServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestApiServer.java
@@ -163,27 +163,29 @@ public class TestApiServer {
         actual.getStatus(),
         "Get service is ");
     ServiceStatus serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals(RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode(), "Response code don't match");
-    assertEquals("Service " + serviceName + " not found",
-        serviceStatus.getDiagnostics(),
+    assertEquals(RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode(),
+        "Response code don't match");
+    assertEquals("Service " + serviceName + " not found", serviceStatus.getDiagnostics(),
         "Response diagnostics don't match");
   }
 
   @Test
   void testBadGetService2() {
     final Response actual = apiServer.getService(request, null);
-    assertEquals(Response.status(Status.NOT_FOUND).build().getStatus(),
-        actual.getStatus(),
+    assertEquals(Response.status(Status.NOT_FOUND).build().getStatus(), actual.getStatus(),
         "Get service is ");
     ServiceStatus serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals(RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode(), "Response code don't match");
-    assertEquals("Service name cannot be null.", serviceStatus.getDiagnostics(), "Response diagnostics don't match");
+    assertEquals(RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode(),
+        "Response code don't match");
+    assertEquals("Service name cannot be null.", serviceStatus.getDiagnostics(),
+        "Response diagnostics don't match");
   }
 
   @Test
   void testGoodGetService() {
     final Response actual = apiServer.getService(request, "jenkins");
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "Get service is ");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "Get service is ");
   }
 
   @Test
@@ -223,14 +225,15 @@ public class TestApiServer {
   @Test
   void testGoodDeleteService() {
     final Response actual = apiServer.deleteService(request, "jenkins");
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "Delete service is ");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "Delete service is ");
   }
 
   @Test
   void testDeleteStoppedService() {
-    final Response actual = apiServer.deleteService(request,
-        "jenkins-already-stopped");
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "Delete service is ");
+    final Response actual = apiServer.deleteService(request, "jenkins-already-stopped");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "Delete service is ");
   }
 
   @Test
@@ -255,7 +258,8 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "update service is ");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "update service is ");
   }
 
   @Test
@@ -308,7 +312,8 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "flex service is ");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "flex service is ");
   }
 
   @Test
@@ -360,7 +365,8 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "start service is ");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "start service is ");
   }
 
   @Test
@@ -399,7 +405,8 @@ public class TestApiServer {
     System.out.println("before stop");
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "stop service is ");
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(),
+        "stop service is ");
   }
 
   @Test
@@ -455,7 +462,8 @@ public class TestApiServer {
     assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
         actual.getStatus(),
         "Update component should have failed with 400 bad request");
-    assertEquals("No component data provided", serviceStatus.getDiagnostics(), "Update component should have failed with no data error");
+    assertEquals("No component data provided", serviceStatus.getDiagnostics(),
+        "Update component should have failed with no data error");
 
     Component comp = new Component();
     actual = apiServer.updateComponent(request, "jenkins", "jenkins-master",
@@ -464,7 +472,8 @@ public class TestApiServer {
     assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
         actual.getStatus(),
         "Update component should have failed with 400 bad request");
-    assertEquals("No container count provided", serviceStatus.getDiagnostics(), "Update component should have failed with no count error");
+    assertEquals("No container count provided", serviceStatus.getDiagnostics(),
+        "Update component should have failed with no count error");
 
     comp.setNumberOfContainers(-1L);
     actual = apiServer.updateComponent(request, "jenkins", "jenkins-master",
@@ -473,7 +482,8 @@ public class TestApiServer {
     assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
         actual.getStatus(),
         "Update component should have failed with 400 bad request");
-    assertEquals("Invalid number of containers specified -1", serviceStatus.getDiagnostics(), "Update component should have failed with no count error");
+    assertEquals("Invalid number of containers specified -1", serviceStatus.getDiagnostics(),
+        "Update component should have failed with no count error");
 
     comp.setName("jenkins-slave");
     comp.setNumberOfContainers(1L);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestApiServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestApiServer.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.yarn.service;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -47,9 +47,9 @@ import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.api.records.ServiceStatus;
 import org.apache.hadoop.yarn.service.conf.RestApiConstants;
 import org.apache.hadoop.yarn.service.webapp.ApiServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -61,7 +61,7 @@ public class TestApiServer {
   private HttpServletRequest request;
   private ServiceClientTest mockServerClient;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     request = Mockito.mock(HttpServletRequest.class);
     Mockito.when(request.getRemoteUser())
@@ -74,40 +74,41 @@ public class TestApiServer {
     apiServer.setServiceClient(mockServerClient);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     mockServerClient.forceStop();
   }
 
   @Test
-  public void testPathAnnotation() {
+  void testPathAnnotation() {
     assertNotNull(this.apiServer.getClass().getAnnotation(Path.class));
-    assertTrue("The controller has the annotation Path",
-        this.apiServer.getClass().isAnnotationPresent(Path.class));
+    assertTrue(this.apiServer.getClass().isAnnotationPresent(Path.class),
+        "The controller has the annotation Path");
     final Path path = this.apiServer.getClass()
         .getAnnotation(Path.class);
-    assertEquals("The path has /v1 annotation", "/v1", path.value());
+    assertEquals("/v1", path.value(), "The path has /v1 annotation");
   }
 
   @Test
-  public void testGetVersion() {
+  void testGetVersion() {
     final Response actual = apiServer.getVersion();
-    assertEquals("Version number is", Response.ok().build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.ok().build().getStatus(),
+        actual.getStatus(),
+        "Version number is");
   }
 
   @Test
-  public void testBadCreateService() {
+  void testBadCreateService() {
     Service service = new Service();
     // Test for invalid argument
     final Response actual = apiServer.createService(request, service);
-    assertEquals("Create service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Create service is ");
   }
 
   @Test
-  public void testGoodCreateService() throws Exception {
+  void testGoodCreateService() throws Exception {
     String json = "{\"auths\": "
         + "{\"https://index.docker.io/v1/\": "
         + "{\"auth\": \"foobarbaz\"},"
@@ -122,13 +123,13 @@ public class TestApiServer {
     bw.close();
     Service service = ServiceClientTest.buildGoodService();
     final Response actual = apiServer.createService(request, service);
-    assertEquals("Create service is ",
-        Response.status(Status.ACCEPTED).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.ACCEPTED).build().getStatus(),
+        actual.getStatus(),
+        "Create service is ");
   }
 
   @Test
-  public void testInternalServerErrorDockerClientConfigMissingCreateService() {
+  void testInternalServerErrorDockerClientConfigMissingCreateService() {
     Service service = new Service();
     service.setName("jenkins");
     service.setVersion("v1");
@@ -149,97 +150,91 @@ public class TestApiServer {
     components.add(c);
     service.setComponents(components);
     final Response actual = apiServer.createService(request, service);
-    assertEquals("Create service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Create service is ");
   }
 
   @Test
-  public void testBadGetService() {
+  void testBadGetService() {
     final String serviceName = "nonexistent-jenkins";
     final Response actual = apiServer.getService(request, serviceName);
-    assertEquals("Get service is ",
-        Response.status(Status.NOT_FOUND).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.NOT_FOUND).build().getStatus(),
+        actual.getStatus(),
+        "Get service is ");
     ServiceStatus serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Response code don't match",
-        RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode());
-    assertEquals("Response diagnostics don't match",
-        "Service " + serviceName + " not found",
-        serviceStatus.getDiagnostics());
+    assertEquals(RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode(), "Response code don't match");
+    assertEquals("Service " + serviceName + " not found",
+        serviceStatus.getDiagnostics(),
+        "Response diagnostics don't match");
   }
 
   @Test
-  public void testBadGetService2() {
+  void testBadGetService2() {
     final Response actual = apiServer.getService(request, null);
-    assertEquals("Get service is ",
-        Response.status(Status.NOT_FOUND).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.NOT_FOUND).build().getStatus(),
+        actual.getStatus(),
+        "Get service is ");
     ServiceStatus serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Response code don't match",
-        RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode());
-    assertEquals("Response diagnostics don't match",
-        "Service name cannot be null.", serviceStatus.getDiagnostics());
+    assertEquals(RestApiConstants.ERROR_CODE_APP_NAME_INVALID, serviceStatus.getCode(), "Response code don't match");
+    assertEquals("Service name cannot be null.", serviceStatus.getDiagnostics(), "Response diagnostics don't match");
   }
 
   @Test
-  public void testGoodGetService() {
+  void testGoodGetService() {
     final Response actual = apiServer.getService(request, "jenkins");
-    assertEquals("Get service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "Get service is ");
   }
 
   @Test
-  public void testBadDeleteService() {
+  void testBadDeleteService() {
     final Response actual = apiServer.deleteService(request, "no-jenkins");
-    assertEquals("Delete service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Delete service is ");
   }
 
   @Test
-  public void testBadDeleteService2() {
+  void testBadDeleteService2() {
     final Response actual = apiServer.deleteService(request, null);
-    assertEquals("Delete service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Delete service is ");
   }
 
   @Test
-  public void testBadDeleteService3() {
+  void testBadDeleteService3() {
     final Response actual = apiServer.deleteService(request,
         "jenkins-doesn't-exist");
-    assertEquals("Delete service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Delete service is ");
   }
 
   @Test
-  public void testBadDeleteService4() {
+  void testBadDeleteService4() {
     final Response actual = apiServer.deleteService(request,
         "jenkins-error-cleaning-registry");
-    assertEquals("Delete service is ",
-        Response.status(Status.INTERNAL_SERVER_ERROR).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.INTERNAL_SERVER_ERROR).build().getStatus(),
+        actual.getStatus(),
+        "Delete service is ");
   }
 
   @Test
-  public void testGoodDeleteService() {
+  void testGoodDeleteService() {
     final Response actual = apiServer.deleteService(request, "jenkins");
-    assertEquals("Delete service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "Delete service is ");
   }
 
   @Test
-  public void testDeleteStoppedService() {
+  void testDeleteStoppedService() {
     final Response actual = apiServer.deleteService(request,
         "jenkins-already-stopped");
-    assertEquals("Delete service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "Delete service is ");
   }
 
   @Test
-  public void testDecreaseContainerAndStop() {
+  void testDecreaseContainerAndStop() {
     Service service = new Service();
     service.setState(ServiceState.STOPPED);
     service.setName("jenkins");
@@ -260,12 +255,11 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals("update service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "update service is ");
   }
 
   @Test
-  public void testBadDecreaseContainerAndStop() {
+  void testBadDecreaseContainerAndStop() {
     Service service = new Service();
     service.setState(ServiceState.STOPPED);
     service.setName("no-jenkins");
@@ -287,13 +281,13 @@ public class TestApiServer {
     System.out.println("before stop");
     final Response actual = apiServer.updateService(request, "no-jenkins",
         service);
-    assertEquals("flex service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "flex service is ");
   }
 
   @Test
-  public void testIncreaseContainersAndStart() {
+  void testIncreaseContainersAndStart() {
     Service service = new Service();
     service.setState(ServiceState.STARTED);
     service.setName("jenkins");
@@ -314,12 +308,11 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals("flex service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "flex service is ");
   }
 
   @Test
-  public void testBadStartServices() {
+  void testBadStartServices() {
     Service service = new Service();
     service.setState(ServiceState.STARTED);
     service.setName("no-jenkins");
@@ -340,13 +333,13 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "no-jenkins",
         service);
-    assertEquals("start service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "start service is ");
   }
 
   @Test
-  public void testGoodStartServices() {
+  void testGoodStartServices() {
     Service service = new Service();
     service.setState(ServiceState.STARTED);
     service.setName("jenkins");
@@ -367,12 +360,11 @@ public class TestApiServer {
     service.setComponents(components);
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals("start service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "start service is ");
   }
 
   @Test
-  public void testBadStopServices() {
+  void testBadStopServices() {
     Service service = new Service();
     service.setState(ServiceState.STOPPED);
     service.setName("no-jenkins");
@@ -394,25 +386,24 @@ public class TestApiServer {
     System.out.println("before stop");
     final Response actual = apiServer.updateService(request, "no-jenkins",
         service);
-    assertEquals("stop service is ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "stop service is ");
   }
 
   @Test
-  public void testGoodStopServices() {
+  void testGoodStopServices() {
     Service service = new Service();
     service.setState(ServiceState.STOPPED);
     service.setName("jenkins");
     System.out.println("before stop");
     final Response actual = apiServer.updateService(request, "jenkins",
         service);
-    assertEquals("stop service is ",
-        Response.status(Status.OK).build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.OK).build().getStatus(), actual.getStatus(), "stop service is ");
   }
 
   @Test
-  public void testBadSecondStopServices() throws Exception {
+  void testBadSecondStopServices() throws Exception {
     Service service = new Service();
     service.setState(ServiceState.STOPPED);
     service.setName("jenkins-second-stop");
@@ -420,17 +411,17 @@ public class TestApiServer {
     System.out.println("before second stop");
     final Response actual = apiServer.updateService(request,
         "jenkins-second-stop", service);
-    assertEquals("stop service should have thrown 400 Bad Request: ",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "stop service should have thrown 400 Bad Request: ");
     ServiceStatus serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Stop service should have failed with service already stopped",
-        "Service jenkins-second-stop is already stopped",
-        serviceStatus.getDiagnostics());
+    assertEquals("Service jenkins-second-stop is already stopped",
+        serviceStatus.getDiagnostics(),
+        "Stop service should have failed with service already stopped");
   }
 
   @Test
-  public void testUpdateService() {
+  void testUpdateService() {
     Service service = new Service();
     service.setState(ServiceState.STARTED);
     service.setName("no-jenkins");
@@ -452,72 +443,68 @@ public class TestApiServer {
     System.out.println("before stop");
     final Response actual = apiServer.updateService(request, "no-jenkins",
         service);
-    assertEquals("update service is ",
-        Response.status(Status.BAD_REQUEST)
-            .build().getStatus(), actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST)
+        .build().getStatus(), actual.getStatus(), "update service is ");
   }
 
   @Test
-  public void testUpdateComponent() {
+  void testUpdateComponent() {
     Response actual = apiServer.updateComponent(request, "jenkins",
         "jenkins-master", null);
     ServiceStatus serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Update component should have failed with 400 bad request",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
-    assertEquals("Update component should have failed with no data error",
-        "No component data provided", serviceStatus.getDiagnostics());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Update component should have failed with 400 bad request");
+    assertEquals("No component data provided", serviceStatus.getDiagnostics(), "Update component should have failed with no data error");
 
     Component comp = new Component();
     actual = apiServer.updateComponent(request, "jenkins", "jenkins-master",
         comp);
     serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Update component should have failed with 400 bad request",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
-    assertEquals("Update component should have failed with no count error",
-        "No container count provided", serviceStatus.getDiagnostics());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Update component should have failed with 400 bad request");
+    assertEquals("No container count provided", serviceStatus.getDiagnostics(), "Update component should have failed with no count error");
 
     comp.setNumberOfContainers(-1L);
     actual = apiServer.updateComponent(request, "jenkins", "jenkins-master",
         comp);
     serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Update component should have failed with 400 bad request",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
-    assertEquals("Update component should have failed with no count error",
-        "Invalid number of containers specified -1", serviceStatus.getDiagnostics());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Update component should have failed with 400 bad request");
+    assertEquals("Invalid number of containers specified -1", serviceStatus.getDiagnostics(), "Update component should have failed with no count error");
 
     comp.setName("jenkins-slave");
     comp.setNumberOfContainers(1L);
     actual = apiServer.updateComponent(request, "jenkins", "jenkins-master",
         comp);
     serviceStatus = (ServiceStatus) actual.getEntity();
-    assertEquals("Update component should have failed with 400 bad request",
-        Response.status(Status.BAD_REQUEST).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.BAD_REQUEST).build().getStatus(),
+        actual.getStatus(),
+        "Update component should have failed with 400 bad request");
     assertEquals(
-        "Update component should have failed with component name mismatch "
-            + "error",
         "Component name in the request object (jenkins-slave) does not match "
             + "that in the URI path (jenkins-master)",
-        serviceStatus.getDiagnostics());
+        serviceStatus.getDiagnostics(),
+        "Update component should have failed with component name mismatch "
+            + "error");
   }
 
   @Test
-  public void testInitiateUpgrade() {
+  void testInitiateUpgrade() {
     Service goodService = ServiceClientTest.buildLiveGoodService();
     goodService.setVersion("v2");
     goodService.setState(ServiceState.UPGRADING);
     final Response actual = apiServer.updateService(request,
         goodService.getName(), goodService);
-    assertEquals("Initiate upgrade is ",
-        Response.status(Status.ACCEPTED).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.ACCEPTED).build().getStatus(),
+        actual.getStatus(),
+        "Initiate upgrade is ");
   }
 
   @Test
-  public void testUpgradeSingleInstance() {
+  void testUpgradeSingleInstance() {
     Service goodService = ServiceClientTest.buildLiveGoodService();
     Component comp = goodService.getComponents().iterator().next();
     Container container = comp.getContainers().iterator().next();
@@ -536,13 +523,13 @@ public class TestApiServer {
     final Response actual = apiServer.updateComponentInstance(request,
         goodService.getName(), comp.getName(),
         container.getComponentInstanceName(), container);
-    assertEquals("Instance upgrade is ",
-        Response.status(Status.ACCEPTED).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.ACCEPTED).build().getStatus(),
+        actual.getStatus(),
+        "Instance upgrade is ");
   }
 
   @Test
-  public void testUpgradeMultipleInstances() {
+  void testUpgradeMultipleInstances() {
     Service goodService = ServiceClientTest.buildLiveGoodService();
     Component comp = goodService.getComponents().iterator().next();
     comp.getContainers().forEach(container ->
@@ -563,13 +550,13 @@ public class TestApiServer {
 
     final Response actual = apiServer.updateComponentInstances(request,
         goodService.getName(), comp.getContainers());
-    assertEquals("Instance upgrade is ",
-        Response.status(Status.ACCEPTED).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.ACCEPTED).build().getStatus(),
+        actual.getStatus(),
+        "Instance upgrade is ");
   }
 
   @Test
-  public void testUpgradeComponent() {
+  void testUpgradeComponent() {
     Service goodService = ServiceClientTest.buildLiveGoodService();
     Component comp = goodService.getComponents().iterator().next();
     comp.setState(ComponentState.UPGRADING);
@@ -589,13 +576,13 @@ public class TestApiServer {
 
     final Response actual = apiServer.updateComponent(request,
         goodService.getName(), comp.getName(), comp);
-    assertEquals("Component upgrade is ",
-        Response.status(Status.ACCEPTED).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.ACCEPTED).build().getStatus(),
+        actual.getStatus(),
+        "Component upgrade is ");
   }
 
   @Test
-  public void testUpgradeMultipleComps() {
+  void testUpgradeMultipleComps() {
     Service goodService = ServiceClientTest.buildLiveGoodService();
     goodService.getComponents().forEach(comp ->
         comp.setState(ComponentState.UPGRADING));
@@ -616,8 +603,8 @@ public class TestApiServer {
 
     final Response actual = apiServer.updateComponents(request,
         goodService.getName(), goodService.getComponents());
-    assertEquals("Component upgrade is ",
-        Response.status(Status.ACCEPTED).build().getStatus(),
-        actual.getStatus());
+    assertEquals(Response.status(Status.ACCEPTED).build().getStatus(),
+        actual.getStatus(),
+        "Component upgrade is ");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestCleanupAfterKill.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestCleanupAfterKill.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestCleanupAfterKill.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestCleanupAfterKill.java
@@ -51,9 +51,6 @@ public class TestCleanupAfterKill extends ServiceTestUtils {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestCleanupAfterKill.class);
 
-  @TempDir
-  public File tmpFolder;
-
   @BeforeEach
   public void setup() throws Exception {
     File tmpYarnDir = new File("target", "tmp");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestCleanupAfterKill.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/TestCleanupAfterKill.java
@@ -27,16 +27,20 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.client.ServiceClient;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 
 /**
@@ -47,22 +51,23 @@ public class TestCleanupAfterKill extends ServiceTestUtils {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestCleanupAfterKill.class);
 
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
+  @TempDir
+  public File tmpFolder;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     File tmpYarnDir = new File("target", "tmp");
     FileUtils.deleteQuietly(tmpYarnDir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     shutdown();
   }
 
-  @Test(timeout = 200000)
-  public void testRegistryCleanedOnLifetimeExceeded() throws Exception {
+  @Test
+  @Timeout(200000)
+  void testRegistryCleanedOnLifetimeExceeded() throws Exception {
     setupInternal(NUM_NMS);
     ServiceClient client = createClient(getConf());
     Service exampleApp = createExampleApplication();
@@ -71,8 +76,8 @@ public class TestCleanupAfterKill extends ServiceTestUtils {
     waitForServiceToBeStable(client, exampleApp);
     String serviceZKPath = RegistryUtils.servicePath(RegistryUtils
         .currentUser(), YarnServiceConstants.APP_TYPE, exampleApp.getName());
-    Assert.assertTrue("Registry ZK service path doesn't exist",
-        getCuratorService().zkPathExists(serviceZKPath));
+    assertTrue(getCuratorService().zkPathExists(serviceZKPath),
+        "Registry ZK service path doesn't exist");
 
     // wait for app to be killed by RM
     ApplicationId exampleAppId = ApplicationId.fromString(exampleApp.getId());
@@ -85,10 +90,10 @@ public class TestCleanupAfterKill extends ServiceTestUtils {
         throw new RuntimeException("while waiting", e);
       }
     }, 2000, 200000);
-    Assert.assertFalse("Registry ZK service path still exists after killed",
-        getCuratorService().zkPathExists(serviceZKPath));
+    assertFalse(getCuratorService().zkPathExists(serviceZKPath),
+        "Registry ZK service path still exists after killed");
 
     LOG.info("Destroy the service");
-    Assert.assertEquals(0, client.actionDestroy(exampleApp.getName()));
+    assertEquals(0, client.actionDestroy(exampleApp.getName()));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestApiServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestApiServiceClient.java
@@ -16,7 +16,7 @@
  */
 package org.apache.hadoop.yarn.service.client;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -35,9 +35,10 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import static org.apache.hadoop.yarn.service.exceptions.LauncherExitCodes.*;
 
 /**
@@ -88,7 +89,7 @@ public class TestApiServiceClient {
 
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     server = new Server(8088);
     ((QueuedThreadPool)server.getThreadPool()).setMaxThreads(20);
@@ -112,13 +113,13 @@ public class TestApiServiceClient {
     badAsc.serviceInit(conf2);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     server.stop();
   }
 
   @Test
-  public void testGetRMWebAddress() throws Exception {
+  void testGetRMWebAddress() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(YarnConfiguration.RM_HA_ENABLED, true);
     conf.set(YarnConfiguration.RM_HA_IDS, "rm1");
@@ -129,17 +130,17 @@ public class TestApiServiceClient {
     String diagnosticsMsg = null;
     try {
       String rmWebAddress = asc1.getRMWebAddress();
-    } catch (IOException e){
+    } catch (IOException e) {
       exceptionCaught = true;
       diagnosticsMsg = e.getMessage();
     }
-    assertTrue("ApiServiceClient failed to throw exception", exceptionCaught);
-    assertTrue("Exception Message does not match",
-        diagnosticsMsg.contains("Error connecting to localhost:0"));
+    assertTrue(exceptionCaught, "ApiServiceClient failed to throw exception");
+    assertTrue(diagnosticsMsg.contains("Error connecting to localhost:0"),
+        "Exception Message does not match");
   }
 
   @Test
-  public void testLaunch() {
+  void testLaunch() {
     String fileName = "target/test-classes/example-app.json";
     String appName = "example-app";
     long lifetime = 3600L;
@@ -153,7 +154,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testBadLaunch() {
+  void testBadLaunch() {
     String fileName = "unknown_file";
     String appName = "unknown_app";
     long lifetime = 3600L;
@@ -167,19 +168,18 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testStatus() {
+  void testStatus() {
     String appName = "nonexistent-app";
     try {
       String result = asc.getStatusString(appName);
-      assertEquals("Status reponse don't match",
-          " Service " + appName + " not found", result);
+      assertEquals(" Service " + appName + " not found", result, "Status reponse don't match");
     } catch (IOException | YarnException e) {
       fail();
     }
   }
 
   @Test
-  public void testStop() {
+  void testStop() {
     String appName = "example-app";
     try {
       int result = asc.actionStop(appName);
@@ -190,7 +190,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testBadStop() {
+  void testBadStop() {
     String appName = "unknown_app";
     try {
       int result = badAsc.actionStop(appName);
@@ -201,7 +201,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testStart() {
+  void testStart() {
     String appName = "example-app";
     try {
       int result = asc.actionStart(appName);
@@ -212,7 +212,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testBadStart() {
+  void testBadStart() {
     String appName = "unknown_app";
     try {
       int result = badAsc.actionStart(appName);
@@ -223,7 +223,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testSave() {
+  void testSave() {
     String fileName = "target/test-classes/example-app.json";
     String appName = "example-app";
     long lifetime = 3600L;
@@ -237,7 +237,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testBadSave() {
+  void testBadSave() {
     String fileName = "unknown_file";
     String appName = "unknown_app";
     long lifetime = 3600L;
@@ -251,7 +251,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testFlex() {
+  void testFlex() {
     String appName = "example-app";
     HashMap<String, String> componentCounts = new HashMap<String, String>();
     try {
@@ -263,7 +263,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testBadFlex() {
+  void testBadFlex() {
     String appName = "unknown_app";
     HashMap<String, String> componentCounts = new HashMap<String, String>();
     try {
@@ -275,7 +275,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testDestroy() {
+  void testDestroy() {
     String appName = "example-app";
     try {
       int result = asc.actionDestroy(appName);
@@ -286,7 +286,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testBadDestroy() {
+  void testBadDestroy() {
     String appName = "unknown_app";
     try {
       int result = badAsc.actionDestroy(appName);
@@ -297,7 +297,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testInitiateServiceUpgrade() {
+  void testInitiateServiceUpgrade() {
     String appName = "example-app";
     String upgradeFileName = "target/test-classes/example-app.json";
     try {
@@ -309,7 +309,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testInstancesUpgrade() {
+  void testInstancesUpgrade() {
     String appName = "example-app";
     try {
       int result = asc.actionUpgradeInstances(appName, Lists.newArrayList(
@@ -321,7 +321,7 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testComponentsUpgrade() {
+  void testComponentsUpgrade() {
     String appName = "example-app";
     try {
       int result = asc.actionUpgradeComponents(appName, Lists.newArrayList(
@@ -333,12 +333,12 @@ public class TestApiServiceClient {
   }
 
   @Test
-  public void testNoneSecureApiClient() throws IOException {
+  void testNoneSecureApiClient() throws IOException {
     String url = asc.getServicePath("/foobar");
-    assertTrue("User.name flag is missing in service path.",
-        url.contains("user.name"));
-    assertTrue("User.name flag is not matching JVM user.",
-        url.contains(System.getProperty("user.name")));
+    assertTrue(url.contains("user.name"),
+        "User.name flag is missing in service path.");
+    assertTrue(url.contains(System.getProperty("user.name")),
+        "User.name flag is not matching JVM user.");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestSecureApiServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestSecureApiServiceClient.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.yarn.service.client;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,9 +49,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Spnego Client Login.
@@ -129,8 +129,9 @@ public class TestSecureApiServiceClient extends KerberosSecurityTestcase {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
+    startMiniKdc();
     keytabFile = new File(getWorkDir(), "keytab");
     getKdc().createPrincipal(keytabFile, clientPrincipal, server1Principal,
         server2Principal);
@@ -163,13 +164,14 @@ public class TestSecureApiServiceClient extends KerberosSecurityTestcase {
     asc.serviceInit(testConf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
+    stopMiniKdc();
   }
 
   @Test
-  public void testHttpSpnegoChallenge() throws Exception {
+  void testHttpSpnegoChallenge() throws Exception {
     UserGroupInformation.loginUserFromKeytab(clientPrincipal, keytabFile
         .getCanonicalPath());
     String challenge = YarnClientUtils.generateToken("localhost");
@@ -177,7 +179,7 @@ public class TestSecureApiServiceClient extends KerberosSecurityTestcase {
   }
 
   @Test
-  public void testAuthorizationHeader() throws Exception {
+  void testAuthorizationHeader() throws Exception {
     UserGroupInformation.loginUserFromKeytab(clientPrincipal, keytabFile
         .getCanonicalPath());
     String rmAddress = asc.getRMWebAddress();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestSystemServiceManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestSystemServiceManagerImpl.java
@@ -29,22 +29,22 @@ import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.conf.SliderExitCodes;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
 import org.apache.hadoop.yarn.service.exceptions.SliderException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.fail;
 
 /**
  * Test class for system service manager.
@@ -62,7 +62,7 @@ public class TestSystemServiceManagerImpl {
   private static Map<String, Set<String>> savedServices = new HashMap<>();
   private static Map<String, Set<String>> submittedServices = new HashMap<>();
 
-  @Before
+  @BeforeEach
   public void setup() {
     File file = new File(
         getClass().getClassLoader().getResource(resourcePath).getFile());
@@ -80,30 +80,30 @@ public class TestSystemServiceManagerImpl {
     constructUserService(users[1], "example-app1", "example-app2");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     systemService.stop();
   }
 
   @Test
-  public void testSystemServiceSubmission() throws Exception {
+  void testSystemServiceSubmission() throws Exception {
     systemService.start();
 
     /* verify for ignored sevices count */
     Map<String, Integer> ignoredUserServices =
         systemService.getIgnoredUserServices();
-    Assert.assertEquals(1, ignoredUserServices.size());
-    Assert.assertTrue("User user1 doesn't exist.",
-        ignoredUserServices.containsKey(users[0]));
+    assertEquals(1, ignoredUserServices.size());
+    assertTrue(ignoredUserServices.containsKey(users[0]),
+        "User user1 doesn't exist.");
     int count = ignoredUserServices.get(users[0]);
-    Assert.assertEquals(1, count);
-    Assert.assertEquals(1,
+    assertEquals(1, count);
+    assertEquals(1,
         systemService.getBadFileNameExtensionSkipCounter());
-    Assert.assertEquals(1, systemService.getBadDirSkipCounter());
+    assertEquals(1, systemService.getBadDirSkipCounter());
 
     Map<String, Set<Service>> userServices =
         systemService.getSyncUserServices();
-    Assert.assertEquals(loadedServices.size(), userServices.size());
+    assertEquals(loadedServices.size(), userServices.size());
     verifyForScannedUserServices(userServices);
 
     verifyForLaunchedUserServices();
@@ -123,13 +123,13 @@ public class TestSystemServiceManagerImpl {
     for (String user : users) {
       Set<Service> services = userServices.get(user);
       Set<String> serviceNames = loadedServices.get(user);
-      Assert.assertEquals(serviceNames.size(), services.size());
+      assertEquals(serviceNames.size(), services.size());
       Iterator<Service> iterator = services.iterator();
       while (iterator.hasNext()) {
         Service next = iterator.next();
-        Assert.assertTrue(
-            "Service name doesn't exist in expected userService "
-                + serviceNames, serviceNames.contains(next.getName()));
+        assertTrue(
+            serviceNames.contains(next.getName()), "Service name doesn't exist in expected userService "
+                + serviceNames);
       }
     }
   }
@@ -203,19 +203,19 @@ public class TestSystemServiceManagerImpl {
   }
 
   private void verifyForLaunchedUserServices() {
-    Assert.assertEquals(loadedServices.size(), submittedServices.size());
+    assertEquals(loadedServices.size(), submittedServices.size());
     for (Map.Entry<String, Set<String>> entry : submittedServices.entrySet()) {
       String user = entry.getKey();
       Set<String> serviceSet = entry.getValue();
-      Assert.assertTrue(loadedServices.containsKey(user));
+      assertTrue(loadedServices.containsKey(user));
       Set<String> services = loadedServices.get(user);
-      Assert.assertEquals(services.size(), serviceSet.size());
-      Assert.assertTrue(services.containsAll(serviceSet));
+      assertEquals(services.size(), serviceSet.size());
+      assertTrue(services.containsAll(serviceSet));
     }
   }
 
   @Test
-  public void testFileSystemCloseWhenCleanUpService() throws Exception {
+  void testFileSystemCloseWhenCleanUpService() throws Exception {
     FileSystem fs = null;
     Path path = new Path("/tmp/servicedir");
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestSystemServiceManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/src/test/java/org/apache/hadoop/yarn/service/client/TestSystemServiceManagerImpl.java
@@ -127,9 +127,8 @@ public class TestSystemServiceManagerImpl {
       Iterator<Service> iterator = services.iterator();
       while (iterator.hasNext()) {
         Service next = iterator.next();
-        assertTrue(
-            serviceNames.contains(next.getName()), "Service name doesn't exist in expected userService "
-                + serviceNames);
+        assertTrue(serviceNames.contains(next.getName()),
+            "Service name doesn't exist in expected userService " + serviceNames);
       }
     }
   }


### PR DESCRIPTION
### Description of PR

Upgrade Junit 4 to 5 in hadoop-yarn-services-api

JIRA - YARN-11339


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

