### PR TITLE
HADOOP-18235. vulnerability: we may leak sensitive information in LocalKeyStoreProvider

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/LocalKeyStoreProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/LocalKeyStoreProvider.java
@@ -142,8 +142,8 @@ public abstract class LocalKeyStoreProvider extends
 
   @Override
   public void flush() throws IOException {
+    super.getWriteLock().lock();
     try {
-      super.getWriteLock().lock();
       file.createNewFile();
       if (LOG.isDebugEnabled()) {
         LOG.debug("Resetting permissions to '" + permissions + "'");
@@ -159,10 +159,10 @@ public abstract class LocalKeyStoreProvider extends
             "-" + PosixFilePermissions.toString(permissions));
         FileUtil.setPermission(file, fsPermission);
       }
+      super.flush();
     } finally {
       super.getWriteLock().unlock();
     }
-    super.flush();
   }
 
   private static Set<PosixFilePermission> modeToPosixFilePermission(


### PR DESCRIPTION
### Description of PR
It is to ensure we have a file and have set permissions on the file before writing out data. I simply worked to rearrange the current logic and was unaware if there may be a better pattern to follow else where in Hadoop.

### How was this patch tested?
This is an untested PR. I have merely verified it builds.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [N/A] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [N/A] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?