### PR TITLE
HADOOP-18491. Fixed negative data and throughput values in an output of class RawErasureCoderBenchmark

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/RawErasureCoderBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/RawErasureCoderBenchmark.java
@@ -320,6 +320,7 @@ public final class RawErasureCoderBenchmark {
     private ByteBuffer[] decodeInputs = new ByteBuffer[NUM_ALL_UNITS];
 
     public static void configure(int dataSizeMB, int chunkSizeKB) {
+      Preconditions.checkArgument(dataSizeMB > 0);
       chunkSize = chunkSizeKB * 1024;
       // buffer size needs to be a multiple of (numDataUnits * chunkSize)
       int round = (int) Math.round(

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestRawErasureCoderBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestRawErasureCoderBenchmark.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.io.erasurecode.rawcoder;
 
 import org.apache.hadoop.io.erasurecode.ErasureCodeNative;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -33,6 +34,14 @@ public class TestRawErasureCoderBenchmark {
         RawErasureCoderBenchmark.CODER.DUMMY_CODER, 2, 100, 1024);
     RawErasureCoderBenchmark.performBench("decode",
         RawErasureCoderBenchmark.CODER.DUMMY_CODER, 5, 150, 100);
+
+    try {
+      RawErasureCoderBenchmark.performBench("decode",
+          RawErasureCoderBenchmark.CODER.DUMMY_CODER, 5, -150, 100);
+      Assert.fail("should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // intentionally swallow exception
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
JIRA: [HADOOP-18491](https://issues.apache.org/jira/browse/HADOOP-18491)

### How was this patch tested?
Modified an existing unit test `testDummyCoder` of test class `TestRawErasureCoderBenchmark` to verify.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

