### PR TITLE
HADOOP-18492. upgrade commons-text to 1.10.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -310,7 +310,7 @@ org.apache.commons:commons-csv:1.0
 org.apache.commons:commons-digester:1.8.1
 org.apache.commons:commons-lang3:3.12.0
 org.apache.commons:commons-math3:3.6.1
-org.apache.commons:commons-text:1.9
+org.apache.commons:commons-text:1.10.0
 org.apache.commons:commons-validator:1.6
 org.apache.curator:curator-client:5.2.0
 org.apache.curator:curator-framework:5.2.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -124,7 +124,7 @@
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-net.version>3.8.0</commons-net.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
 
     <kerby.version>2.0.2</kerby.version>
     <jcache.version>1.0-alpha-1</jcache.version>


### PR DESCRIPTION
### Description of PR

upgrade commons-text to 1.10.0

JIRA - HADOOP-18492


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

