### PR TITLE
HADOOP-18494. Remove useless variable bindAddr from Client#setupConnection

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -713,7 +713,6 @@ public class Client implements AutoCloseable {
            * client, to ensure Server matching address of the client connection
            * to host name in principal passed.
            */
-          InetSocketAddress bindAddr = null;
           if (ticket != null && ticket.hasKerberosCredentials()) {
             KerberosInfo krbInfo = 
               remoteId.getProtocol().getAnnotation(KerberosInfo.class);
@@ -733,7 +732,7 @@ public class Client implements AutoCloseable {
             }
           }
           
-          NetUtils.connect(this.socket, server, bindAddr, connectionTimeout);
+          NetUtils.connect(this.socket, server, null, connectionTimeout);
           this.socket.setSoTimeout(soTimeout);
           return;
         } catch (ConnectTimeoutException toe) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2859,7 +2859,6 @@ public abstract class Server {
 
       // Save the priority level assignment by the scheduler
       call.setPriorityLevel(callQueue.getPriorityLevel(call));
-      call.markCallCoordinated(false);
       if(alignmentContext != null &&
           (call.rpcRequest instanceof ProtobufRpcEngine2.RpcProtobufRequest)) {
         // if call.rpcRequest is not RpcProtobufRequest, will skip the following

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2860,7 +2860,7 @@ public abstract class Server {
       // Save the priority level assignment by the scheduler
       call.setPriorityLevel(callQueue.getPriorityLevel(call));
       call.markCallCoordinated(false);
-      if(alignmentContext != null && call.rpcRequest != null &&
+      if(alignmentContext != null &&
           (call.rpcRequest instanceof ProtobufRpcEngine2.RpcProtobufRequest)) {
         // if call.rpcRequest is not RpcProtobufRequest, will skip the following
         // step and treat the call as uncoordinated. As currently only certain

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -797,7 +797,6 @@ public class TestSaslRPC extends TestRpcBase {
     TestTokenSecretManager sm = new TestTokenSecretManager();
     Server server = setupTestServer(conf, 1, sm);
     try {
-      final InetSocketAddress addr = NetUtils.getConnectAddress(server);
       final UserGroupInformation clientUgi =
           UserGroupInformation.createRemoteUser("client");
       clientUgi.setAuthenticationMethod(AuthenticationMethod.TOKEN);


### PR DESCRIPTION
JIRA: [HADOOP-18494](https://issues.apache.org/jira/browse/HADOOP-18494)
The variable bindAddr is always null in org.apache.hadoop.ipc.Client#setupConnection