### PR TITLE
HDFS-16802.Print options when accessing ClientProtocol#rename2().

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -248,8 +248,8 @@ class FSDirRenameOp {
     String src = srcArg;
     String dst = dstArg;
     if (NameNode.stateChangeLog.isDebugEnabled()) {
-      NameNode.stateChangeLog.debug("DIR* NameSystem.renameTo: with options -" +
-          " " + src + " to " + dst);
+      NameNode.stateChangeLog.debug("DIR* NameSystem.renameTo: with options={} {} to {}",
+          Arrays.toString(options), src, dst);
     }
 
     BlocksMapUpdateInfo collectedBlocks = new BlocksMapUpdateInfo();


### PR DESCRIPTION
### Description of PR
When accessing ClientProtocol#rename2(), we cannot see options in the log. The purpose of this PR is to improve it as much as possible.
Details: HDFS-16802

### How was this patch tested?
Not too stressful for testing.
