### PR TITLE
MAPREDUCE-7415. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-nativetask

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/pom.xml
@@ -56,6 +56,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <scope>test</scope>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/TestTaskContext.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/TestTaskContext.java
@@ -22,30 +22,32 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 
-import org.junit.Test;
-import org.junit.Assert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTaskContext {
 
   @Test
-  public void testTaskContext() {
+  void testTaskContext() {
     TaskContext context = new TaskContext(null, null, null, null, null, null,
         null);
-    
+
     context.setInputKeyClass(IntWritable.class);
-    Assert.assertEquals(IntWritable.class.getName(), context.getInputKeyClass
+    assertEquals(IntWritable.class.getName(), context.getInputKeyClass
         ().getName());
- 
+
     context.setInputValueClass(Text.class);
-    Assert.assertEquals(Text.class.getName(), context.getInputValueClass()
+    assertEquals(Text.class.getName(), context.getInputValueClass()
         .getName());
-   
+
     context.setOutputKeyClass(LongWritable.class);
-    Assert.assertEquals(LongWritable.class.getName(), context
+    assertEquals(LongWritable.class.getName(), context
         .getOutputKeyClass().getName());
 
     context.setOutputValueClass(FloatWritable.class);
-    Assert.assertEquals(FloatWritable.class.getName(), context
+    assertEquals(FloatWritable.class.getName(), context
         .getOutputValueClass().getName());
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestBufferPushPull.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestBufferPushPull.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapred.nativetask.buffer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -39,9 +41,8 @@ import org.apache.hadoop.mapred.nativetask.testutil.TestInput;
 import org.apache.hadoop.mapred.nativetask.testutil.TestInput.KV;
 import org.apache.hadoop.util.Progress;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "rawtypes", "unchecked"})
 public class TestBufferPushPull {
@@ -50,13 +51,13 @@ public class TestBufferPushPull {
   public static int INPUT_KV_COUNT = 1000;
   private KV<BytesWritable, BytesWritable>[] dataInput;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.dataInput = TestInput.getMapInputs(INPUT_KV_COUNT);
   }
 
   @Test
-  public void testPush() throws Exception {
+  void testPush() throws Exception {
     final byte[] buff = new byte[BUFFER_LENGTH];
 
     final InputBuffer input = new InputBuffer(buff);
@@ -70,8 +71,8 @@ public class TestBufferPushPull {
       @Override
       public void write(BytesWritable key, BytesWritable value) throws IOException {
         final KV expect = dataInput[count++];
-        Assert.assertEquals(expect.key.toString(), key.toString());
-        Assert.assertEquals(expect.value.toString(), value.toString());
+        assertEquals(expect.key.toString(), key.toString());
+        assertEquals(expect.value.toString(), value.toString());
       }
     };
 
@@ -99,7 +100,7 @@ public class TestBufferPushPull {
   }
 
   @Test
-  public void testPull() throws Exception {
+  void testPull() throws Exception {
     final byte[] buff = new byte[BUFFER_LENGTH];
 
     final InputBuffer input = new InputBuffer(buff);
@@ -130,8 +131,8 @@ public class TestBufferPushPull {
       keyBytes.readFields(key);
       valueBytes.readFields(value);
 
-      Assert.assertEquals(dataInput[count].key.toString(), keyBytes.toString());
-      Assert.assertEquals(dataInput[count].value.toString(), valueBytes.toString());
+      assertEquals(dataInput[count].key.toString(), keyBytes.toString());
+      assertEquals(dataInput[count].value.toString(), valueBytes.toString());
 
       count++;
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
@@ -23,7 +23,7 @@ import java.io.UnsupportedEncodingException;
 
 import org.apache.hadoop.mapred.nativetask.NativeDataTarget;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.mockito.Mockito;
 
@@ -32,15 +32,15 @@ import static org.assertj.core.api.Assertions.offset;
 
 public class TestByteBufferReadWrite {
   @Test
-  public void testReadWrite() throws IOException {
+  void testReadWrite() throws IOException {
     byte[] buff = new byte[10000];
 
     InputBuffer input = new InputBuffer(buff);
     MockDataTarget target = new MockDataTarget(buff);
     ByteBufferDataWriter writer = new ByteBufferDataWriter(target);
-    
+
     writer.write(1);
-    writer.write(new byte[] {2, 2}, 0, 2);
+    writer.write(new byte[]{2, 2}, 0, 2);
     writer.writeBoolean(true);
     writer.writeByte(4);
     writer.writeShort(5);
@@ -56,14 +56,14 @@ public class TestByteBufferReadWrite {
     int length = target.getOutputBuffer().length();
     input.rewind(0, length);
     ByteBufferDataReader reader = new ByteBufferDataReader(input);
-    
+
     assertThat(reader.read()).isOne();
     byte[] two = new byte[2];
     reader.read(two);
     assertThat(two[0]).isEqualTo(two[1]);
     assertThat(two[0]).isEqualTo((byte) 2);
-    
-    
+
+
     assertThat(reader.readBoolean()).isTrue();
     assertThat(reader.readByte()).isEqualTo((byte) 4);
     assertThat(reader.readShort()).isEqualTo((short) 5);
@@ -72,16 +72,16 @@ public class TestByteBufferReadWrite {
     assertThat(reader.readLong()).isEqualTo(8);
     assertThat(reader.readFloat()).isEqualTo(9f, offset(0.0001f));
     assertThat(reader.readDouble()).isEqualTo(10, offset(0.0001));
-    
+
     byte[] goodboy = new byte["goodboy".length()];
     reader.read(goodboy);
     assertThat(toString(goodboy)).isEqualTo("goodboy");
-    
+
     char[] hello = new char["hello".length()];
     for (int i = 0; i < hello.length; i++) {
       hello[i] = reader.readChar();
     }
-    
+
     String helloString = new String(hello);
     assertThat(helloString).isEqualTo("hello");
     assertThat(reader.readUTF()).isEqualTo("native task");
@@ -93,7 +93,7 @@ public class TestByteBufferReadWrite {
    * such as this cat face, are properly encoded.
    */
   @Test
-  public void testCatFace() throws IOException {
+  void testCatFace() throws IOException {
     byte[] buff = new byte[10];
     MockDataTarget target = new MockDataTarget(buff);
     ByteBufferDataWriter writer = new ByteBufferDataWriter(target);
@@ -112,28 +112,28 @@ public class TestByteBufferReadWrite {
   }
 
   @Test
-  public void testShortOfSpace() throws IOException {
+  void testShortOfSpace() throws IOException {
     byte[] buff = new byte[10];
     MockDataTarget target = new MockDataTarget(buff);
     ByteBufferDataWriter writer = new ByteBufferDataWriter(target);
     assertThat(writer.hasUnFlushedData()).isFalse();
-    
+
     writer.write(1);
-    writer.write(new byte[] {2, 2}, 0, 2);
+    writer.write(new byte[]{2, 2}, 0, 2);
     assertThat(writer.hasUnFlushedData()).isTrue();
-    
+
     assertThat(writer.shortOfSpace(100)).isTrue();
   }
 
 
   @Test
-  public void testFlush() throws IOException {
+  void testFlush() throws IOException {
     byte[] buff = new byte[10];
     MockDataTarget target = Mockito.spy(new MockDataTarget(buff));
 
     ByteBufferDataWriter writer = new ByteBufferDataWriter(target);
     assertThat(writer.hasUnFlushedData()).isFalse();
-    
+
     writer.write(1);
     writer.write(new byte[100]);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestInputBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestInputBuffer.java
@@ -18,14 +18,14 @@
 package org.apache.hadoop.mapred.nativetask.buffer;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInputBuffer {
 
   @Test
-  public void testInputBuffer() throws IOException {
+  void testInputBuffer() throws IOException {
     final int size = 100;
     final InputBuffer input1 = new InputBuffer(BufferType.DIRECT_BUFFER, size);
     assertThat(input1.getType()).isEqualTo(BufferType.DIRECT_BUFFER);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestOutputBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestOutputBuffer.java
@@ -17,14 +17,14 @@
  */
 package org.apache.hadoop.mapred.nativetask.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOutputBuffer {
 
   @Test
-  public void testOutputBuffer() {
+  void testOutputBuffer() {
     final int size = 100;
     final OutputBuffer output1 = new OutputBuffer(BufferType.DIRECT_BUFFER, size);
     assertThat(output1.getType()).isEqualTo(BufferType.DIRECT_BUFFER);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/CombinerTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/CombinerTest.java
@@ -35,11 +35,11 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import org.junit.AfterClass;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -50,7 +50,7 @@ public class CombinerTest {
   private String hadoopoutputpath;
 
   @Test
-  public void testWordCountCombiner() throws Exception {
+  void testWordCountCombiner() throws Exception {
     final Configuration nativeConf = ScenarioConfiguration.getNativeConfiguration();
     nativeConf.addResource(TestConstants.COMBINER_CONF_PATH);
     final Job nativejob = getJob("nativewordcount", nativeConf, inputpath, nativeoutputpath);
@@ -66,10 +66,10 @@ public class CombinerTest {
     ResultVerifier.verifyCounters(normaljob, nativejob, true);
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    Assumptions.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    Assumptions.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     conf.addcombinerConf();
 
@@ -90,7 +90,7 @@ public class CombinerTest {
       "/normalwordcount";
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMBINER_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/LargeKVCombinerTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/LargeKVCombinerTest.java
@@ -30,11 +30,12 @@ import org.apache.hadoop.mapred.nativetask.testutil.ResultVerifier;
 import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapreduce.Job;
-import org.junit.AfterClass;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,14 +45,14 @@ public class LargeKVCombinerTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(LargeKVCombinerTest.class);
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    Assumptions.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    Assumptions.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
   }
 
   @Test
-  public void testLargeValueCombiner() throws Exception {
+  void testLargeValueCombiner() throws Exception {
     final Configuration normalConf = ScenarioConfiguration.getNormalConfiguration();
     final Configuration nativeConf = ScenarioConfiguration.getNativeConfiguration();
     normalConf.addResource(TestConstants.COMBINER_CONF_PATH);
@@ -61,9 +62,9 @@ public class LargeKVCombinerTest {
         deafult_KVSize_Maximum);
     final String inputPath = TestConstants.NATIVETASK_COMBINER_TEST_INPUTDIR + "/largeKV";
     final String nativeOutputPath = TestConstants.NATIVETASK_COMBINER_TEST_NATIVE_OUTPUTDIR
-      + "/nativeLargeKV";
+        + "/nativeLargeKV";
     final String hadoopOutputPath = TestConstants.NATIVETASK_COMBINER_TEST_NORMAL_OUTPUTDIR
-      + "/normalLargeKV";
+        + "/normalLargeKV";
     final FileSystem fs = FileSystem.get(normalConf);
     for (int i = 65536; i <= KVSize_Maximum; i *= 4) {
 
@@ -78,13 +79,13 @@ public class LargeKVCombinerTest {
       nativeConf.set(TestConstants.NATIVETASK_KVSIZE_MAX, String.valueOf(max));
       fs.delete(new Path(inputPath), true);
       new TestInputFile(normalConf.getInt(TestConstants.NATIVETASK_COMBINER_WORDCOUNT_FILESIZE,
-        1000000), IntWritable.class.getName(),
-        Text.class.getName(), normalConf).createSequenceTestFile(inputPath, 1);
+              1000000), IntWritable.class.getName(),
+          Text.class.getName(), normalConf).createSequenceTestFile(inputPath, 1);
 
       final Job normaljob = CombinerTest.getJob("normalwordcount", normalConf,
-                                                inputPath, hadoopOutputPath);
+          inputPath, hadoopOutputPath);
       final Job nativejob = CombinerTest.getJob("nativewordcount", nativeConf,
-                                                inputPath, nativeOutputPath);
+          inputPath, nativeOutputPath);
 
       assertThat(nativejob.waitForCompletion(true)).isTrue();
 
@@ -93,8 +94,8 @@ public class LargeKVCombinerTest {
       final boolean compareRet = ResultVerifier.verify(nativeOutputPath, hadoopOutputPath);
 
       final String reason = "LargeKVCombinerTest failed with, min size: " + min +
-        ", max size: " + max + ", normal out: " + hadoopOutputPath +
-        ", native Out: " + nativeOutputPath;
+          ", max size: " + max + ", normal out: " + hadoopOutputPath +
+          ", native Out: " + nativeOutputPath;
 
       assertThat(compareRet).withFailMessage(reason).isTrue();
       ResultVerifier.verifyCounters(normaljob, nativejob, true);
@@ -102,7 +103,7 @@ public class LargeKVCombinerTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMBINER_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/OldAPICombinerTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/OldAPICombinerTest.java
@@ -38,11 +38,11 @@ import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.TaskCounter;
-import org.junit.AfterClass;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -51,26 +51,26 @@ public class OldAPICombinerTest {
   private String inputpath;
 
   @Test
-  public void testWordCountCombinerWithOldAPI() throws Exception {
+  void testWordCountCombinerWithOldAPI() throws Exception {
     final Configuration nativeConf = ScenarioConfiguration.getNativeConfiguration();
     nativeConf.addResource(TestConstants.COMBINER_CONF_PATH);
     final String nativeoutput = TestConstants.NATIVETASK_OLDAPI_COMBINER_TEST_NATIVE_OUTPUTPATH;
     final JobConf nativeJob = getOldAPIJobconf(nativeConf, "nativeCombinerWithOldAPI",
-                                               inputpath, nativeoutput);
+        inputpath, nativeoutput);
     RunningJob nativeRunning = JobClient.runJob(nativeJob);
 
     Counter nativeReduceGroups = nativeRunning.getCounters().findCounter(
-      TaskCounter.REDUCE_INPUT_RECORDS);
+        TaskCounter.REDUCE_INPUT_RECORDS);
 
     final Configuration normalConf = ScenarioConfiguration.getNormalConfiguration();
     normalConf.addResource(TestConstants.COMBINER_CONF_PATH);
     final String normaloutput = TestConstants.NATIVETASK_OLDAPI_COMBINER_TEST_NORMAL_OUTPUTPATH;
     final JobConf normalJob = getOldAPIJobconf(normalConf, "normalCombinerWithOldAPI",
-                                               inputpath, normaloutput);
+        inputpath, normaloutput);
 
     RunningJob normalRunning = JobClient.runJob(normalJob);
     Counter normalReduceGroups = normalRunning.getCounters().findCounter(
-      TaskCounter.REDUCE_INPUT_RECORDS);
+        TaskCounter.REDUCE_INPUT_RECORDS);
 
     final boolean compareRet = ResultVerifier.verify(nativeoutput, normaloutput);
     assertThat(compareRet)
@@ -83,10 +83,10 @@ public class OldAPICombinerTest {
         .isEqualTo(normalReduceGroups.getValue());
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    Assumptions.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    Assumptions.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     conf.addcombinerConf();
     this.fs = FileSystem.get(conf);
@@ -99,7 +99,7 @@ public class OldAPICombinerTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMBINER_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/compresstest/CompressTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/compresstest/CompressTest.java
@@ -30,11 +30,11 @@ import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.AfterClass;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -49,21 +49,21 @@ public class CompressTest {
   }
 
   @Test
-  public void testSnappyCompress() throws Exception {
+  void testSnappyCompress() throws Exception {
     final String snappyCodec = "org.apache.hadoop.io.compress.SnappyCodec";
 
     nativeConf.set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, snappyCodec);
     final String nativeOutputPath =
-      TestConstants.NATIVETASK_COMPRESS_TEST_NATIVE_OUTPUTDIR + "/snappy";
+        TestConstants.NATIVETASK_COMPRESS_TEST_NATIVE_OUTPUTDIR + "/snappy";
     final Job job = CompressMapper.getCompressJob("nativesnappy", nativeConf,
-      TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, nativeOutputPath);
+        TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, nativeOutputPath);
     assertThat(job.waitForCompletion(true)).isTrue();
 
     hadoopConf.set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, snappyCodec);
     final String hadoopOutputPath =
-      TestConstants.NATIVETASK_COMPRESS_TEST_NORMAL_OUTPUTDIR + "/snappy";
+        TestConstants.NATIVETASK_COMPRESS_TEST_NORMAL_OUTPUTDIR + "/snappy";
     final Job hadoopjob = CompressMapper.getCompressJob("hadoopsnappy", hadoopConf,
-      TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, hadoopOutputPath);
+        TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, hadoopOutputPath);
     assertThat(hadoopjob.waitForCompletion(true)).isTrue();
 
     final boolean compareRet = ResultVerifier.verify(nativeOutputPath, hadoopOutputPath);
@@ -75,21 +75,21 @@ public class CompressTest {
   }
 
   @Test
-  public void testGzipCompress() throws Exception {
+  void testGzipCompress() throws Exception {
     final String gzipCodec = "org.apache.hadoop.io.compress.GzipCodec";
 
     nativeConf.set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, gzipCodec);
     final String nativeOutputPath =
-      TestConstants.NATIVETASK_COMPRESS_TEST_NATIVE_OUTPUTDIR + "/gzip";
+        TestConstants.NATIVETASK_COMPRESS_TEST_NATIVE_OUTPUTDIR + "/gzip";
     final Job job = CompressMapper.getCompressJob("nativegzip", nativeConf,
-      TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, nativeOutputPath);
+        TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, nativeOutputPath);
     assertThat(job.waitForCompletion(true)).isTrue();
 
     hadoopConf.set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, gzipCodec);
     final String hadoopOutputPath =
-      TestConstants.NATIVETASK_COMPRESS_TEST_NORMAL_OUTPUTDIR + "/gzip";
+        TestConstants.NATIVETASK_COMPRESS_TEST_NORMAL_OUTPUTDIR + "/gzip";
     final Job hadoopjob = CompressMapper.getCompressJob("hadoopgzip", hadoopConf,
-      TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, hadoopOutputPath);
+        TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, hadoopOutputPath);
     assertThat(hadoopjob.waitForCompletion(true)).isTrue();
 
     final boolean compareRet = ResultVerifier.verify(nativeOutputPath, hadoopOutputPath);
@@ -101,21 +101,21 @@ public class CompressTest {
   }
 
   @Test
-  public void testLz4Compress() throws Exception {
+  void testLz4Compress() throws Exception {
     final String lz4Codec = "org.apache.hadoop.io.compress.Lz4Codec";
 
     nativeConf.set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, lz4Codec);
     final String nativeOutputPath =
-      TestConstants.NATIVETASK_COMPRESS_TEST_NATIVE_OUTPUTDIR + "/lz4";
+        TestConstants.NATIVETASK_COMPRESS_TEST_NATIVE_OUTPUTDIR + "/lz4";
     final Job nativeJob = CompressMapper.getCompressJob("nativelz4", nativeConf,
-      TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, nativeOutputPath);
+        TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, nativeOutputPath);
     assertThat(nativeJob.waitForCompletion(true)).isTrue();
 
     hadoopConf.set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, lz4Codec);
     final String hadoopOutputPath =
-      TestConstants.NATIVETASK_COMPRESS_TEST_NORMAL_OUTPUTDIR + "/lz4";
+        TestConstants.NATIVETASK_COMPRESS_TEST_NORMAL_OUTPUTDIR + "/lz4";
     final Job hadoopJob = CompressMapper.getCompressJob("hadooplz4", hadoopConf,
-      TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, hadoopOutputPath);
+        TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR, hadoopOutputPath);
     assertThat(hadoopJob.waitForCompletion(true)).isTrue();
     final boolean compareRet = ResultVerifier.verify(nativeOutputPath, hadoopOutputPath);
     assertThat(compareRet)
@@ -125,10 +125,10 @@ public class CompressTest {
     ResultVerifier.verifyCounters(hadoopJob, nativeJob);
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    Assumptions.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    Assumptions.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     final FileSystem fs = FileSystem.get(conf);
     final Path path = new Path(TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR);
@@ -142,7 +142,7 @@ public class CompressTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMPRESS_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestCombineHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestCombineHandler.java
@@ -24,8 +24,9 @@ import org.apache.hadoop.mapred.nativetask.Command;
 import org.apache.hadoop.mapred.nativetask.INativeHandler;
 import org.apache.hadoop.mapred.nativetask.buffer.BufferType;
 import org.apache.hadoop.mapred.nativetask.buffer.InputBuffer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +41,7 @@ public class TestCombineHandler {
   private BufferPuller puller;
   private CombinerRunner combinerRunner;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.nativeHandler = Mockito.mock(INativeHandler.class);
     this.pusher = Mockito.mock(BufferPusher.class);
@@ -52,7 +53,7 @@ public class TestCombineHandler {
   }
 
   @Test
-  public void testCommandDispatcherSetting() throws IOException {
+  void testCommandDispatcherSetting() throws IOException {
     this.handler = new CombinerHandler(nativeHandler, combinerRunner, puller, pusher);
     Mockito.verify(nativeHandler,
         Mockito.times(1)).setCommandDispatcher(eq(handler));
@@ -61,14 +62,14 @@ public class TestCombineHandler {
   }
 
   @Test
-  public void testCombine() throws IOException, InterruptedException, ClassNotFoundException {
+  void testCombine() throws IOException, InterruptedException, ClassNotFoundException {
     this.handler = new CombinerHandler(nativeHandler, combinerRunner, puller, pusher);
     assertThat(handler.onCall(CombinerHandler.COMBINE, null)).isNull();
     handler.close();
     handler.close();
 
     Mockito.verify(combinerRunner, Mockito.times(1))
-      .combine(eq(puller), eq(pusher));
+        .combine(eq(puller), eq(pusher));
 
     Mockito.verify(pusher, Mockito.times(1)).close();
     Mockito.verify(puller, Mockito.times(1)).close();
@@ -76,7 +77,7 @@ public class TestCombineHandler {
   }
 
   @Test
-  public void testOnCall() throws IOException {
+  void testOnCall() throws IOException {
     this.handler = new CombinerHandler(nativeHandler, combinerRunner, puller, pusher);
     assertThat(handler.onCall(new Command(-1), null)).isNull();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestNativeCollectorOnlyHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestNativeCollectorOnlyHandler.java
@@ -35,12 +35,14 @@ import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapred.nativetask.util.OutputUtil;
 import org.apache.hadoop.mapred.nativetask.util.ReadWriteBuffer;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 
@@ -54,7 +56,7 @@ public class TestNativeCollectorOnlyHandler {
   private TaskContext taskContext;
   private static final String LOCAL_DIR = TestConstants.NATIVETASK_TEST_DIR + "/local";
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.nativeHandler = Mockito.mock(INativeHandler.class);
     this.pusher = Mockito.mock(BufferPusher.class);
@@ -74,13 +76,13 @@ public class TestNativeCollectorOnlyHandler {
       new InputBuffer(BufferType.HEAP_BUFFER, 100));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     FileSystem.getLocal(new Configuration()).delete(new Path(LOCAL_DIR));
   }
 
   @Test
-  public void testCollect() throws IOException {
+  void testCollect() throws IOException {
     this.handler = new NativeCollectorOnlyHandler(taskContext, nativeHandler, pusher, combiner);
     handler.collect(new BytesWritable(), new BytesWritable(), 100);
     handler.close();
@@ -95,42 +97,42 @@ public class TestNativeCollectorOnlyHandler {
   }
 
   @Test
-  public void testGetCombiner() throws IOException {
+  void testGetCombiner() throws IOException {
     this.handler = new NativeCollectorOnlyHandler(taskContext, nativeHandler, pusher, combiner);
     Mockito.when(combiner.getId()).thenReturn(100L);
     final ReadWriteBuffer result = handler.onCall(
-      NativeCollectorOnlyHandler.GET_COMBINE_HANDLER, null);
-    Assert.assertEquals(100L, result.readLong());
+        NativeCollectorOnlyHandler.GET_COMBINE_HANDLER, null);
+    assertEquals(100L, result.readLong());
   }
 
   @Test
-  public void testOnCall() throws IOException {
+  void testOnCall() throws IOException {
     this.handler = new NativeCollectorOnlyHandler(taskContext, nativeHandler, pusher, combiner);
     boolean thrown = false;
     try {
       handler.onCall(new Command(-1), null);
-    } catch(final IOException e) {
+    } catch (final IOException e) {
       thrown = true;
     }
-    Assert.assertTrue("exception thrown", thrown);
+    assertTrue(thrown, "exception thrown");
 
     final String expectedOutputPath = StringUtils.join(File.separator,
-        new String[] {LOCAL_DIR, "output", "file.out"});
+        new String[]{LOCAL_DIR, "output", "file.out"});
     final String expectedOutputIndexPath = StringUtils.join(File.separator,
-        new String[] {LOCAL_DIR, "output", "file.out.index"});
+        new String[]{LOCAL_DIR, "output", "file.out.index"});
     final String expectedSpillPath = StringUtils.join(File.separator,
-        new String[] {LOCAL_DIR, "output", "spill0.out"});
+        new String[]{LOCAL_DIR, "output", "spill0.out"});
 
     final String outputPath = handler.onCall(
-      NativeCollectorOnlyHandler.GET_OUTPUT_PATH, null).readString();
-    Assert.assertEquals(expectedOutputPath, outputPath);
+        NativeCollectorOnlyHandler.GET_OUTPUT_PATH, null).readString();
+    assertEquals(expectedOutputPath, outputPath);
 
     final String outputIndexPath = handler.onCall(
-      NativeCollectorOnlyHandler.GET_OUTPUT_INDEX_PATH, null).readString();
-    Assert.assertEquals(expectedOutputIndexPath, outputIndexPath);
+        NativeCollectorOnlyHandler.GET_OUTPUT_INDEX_PATH, null).readString();
+    assertEquals(expectedOutputIndexPath, outputIndexPath);
 
     final String spillPath = handler.onCall(
-      NativeCollectorOnlyHandler.GET_SPILL_PATH, null).readString();
-    Assert.assertEquals(expectedSpillPath, spillPath);
+        NativeCollectorOnlyHandler.GET_SPILL_PATH, null).readString();
+    assertEquals(expectedSpillPath, spillPath);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/LargeKVTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/LargeKVTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.mapred.nativetask.kvtest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -31,21 +31,22 @@ import org.apache.hadoop.mapred.nativetask.NativeRuntime;
 import org.apache.hadoop.mapred.nativetask.testutil.ResultVerifier;
 import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
-import org.junit.AfterClass;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LargeKVTest {
   private static final Logger LOG = LoggerFactory.getLogger(LargeKVTest.class);
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    Assumptions.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    Assumptions.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
   }
 
   private static Configuration nativeConf = ScenarioConfiguration.getNativeConfiguration();
@@ -58,16 +59,16 @@ public class LargeKVTest {
   }
 
   @Test
-  public void testKeySize() throws Exception {
+  void testKeySize() throws Exception {
     runKVSizeTests(Text.class, IntWritable.class);
   }
 
   @Test
-  public void testValueSize() throws Exception {
+  void testValueSize() throws Exception {
     runKVSizeTests(IntWritable.class, Text.class);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_KVTEST_DIR), true);
@@ -106,7 +107,7 @@ public class LargeKVTest {
       final KVJob nativeJob = new KVJob("Test Large Value Size:"
           + String.valueOf(i), nativeConf, keyClass, valueClass, inputPath,
           nativeOutputPath);
-      assertTrue("job should complete successfully", nativeJob.runJob());
+      assertTrue(nativeJob.runJob(), "job should complete successfully");
 
       final String normalOutputPath = TestConstants.NATIVETASK_KVTEST_NORMAL_OUTPUTDIR
           + "/LargeKV/" + keyClass.getName() + "/" + valueClass.getName();
@@ -114,7 +115,7 @@ public class LargeKVTest {
       fs.delete(new Path(normalOutputPath), true);
       final KVJob normalJob = new KVJob("Test Large Key Size:" + String.valueOf(i),
           normalConf, keyClass, valueClass, inputPath, normalOutputPath);
-      assertTrue("job should complete successfully", normalJob.runJob());
+      assertTrue(normalJob.runJob(), "job should complete successfully");
 
       final boolean compareRet = ResultVerifier.verify(normalOutputPath,
           nativeOutputPath);
@@ -123,7 +124,7 @@ public class LargeKVTest {
           + (keyClass.equals(Text.class) ? "key" : "value") + ", min size: " + min
           + ", max size: " + max + ", normal out: " + normalOutputPath
           + ", native Out: " + nativeOutputPath;
-      assertEquals(reason, true, compareRet);
+      assertEquals(true, compareRet, reason);
       ResultVerifier.verifyCounters(normalJob.job, nativeJob.job);
     }
     fs.close();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/nonsorttest/NonSortTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/nonsorttest/NonSortTest.java
@@ -37,34 +37,34 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.AfterClass;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NonSortTest {
 
   @Test
-  public void nonSortTest() throws Exception {
+  void nonSortTest() throws Exception {
     Configuration nativeConf = ScenarioConfiguration.getNativeConfiguration();
     nativeConf.addResource(TestConstants.NONSORT_TEST_CONF);
     nativeConf.set(TestConstants.NATIVETASK_MAP_OUTPUT_SORT, "false");
     final Job nativeNonSort = getJob(nativeConf, "NativeNonSort",
-      TestConstants.NATIVETASK_NONSORT_TEST_INPUTDIR,
-      TestConstants.NATIVETASK_NONSORT_TEST_NATIVE_OUTPUT);
+        TestConstants.NATIVETASK_NONSORT_TEST_INPUTDIR,
+        TestConstants.NATIVETASK_NONSORT_TEST_NATIVE_OUTPUT);
     assertThat(nativeNonSort.waitForCompletion(true)).isTrue();
 
     Configuration normalConf = ScenarioConfiguration.getNormalConfiguration();
     normalConf.addResource(TestConstants.NONSORT_TEST_CONF);
     final Job hadoopWithSort = getJob(normalConf, "NormalJob",
-      TestConstants.NATIVETASK_NONSORT_TEST_INPUTDIR,
-      TestConstants.NATIVETASK_NONSORT_TEST_NORMAL_OUTPUT);
+        TestConstants.NATIVETASK_NONSORT_TEST_INPUTDIR,
+        TestConstants.NATIVETASK_NONSORT_TEST_NORMAL_OUTPUT);
     assertThat(hadoopWithSort.waitForCompletion(true)).isTrue();
 
     final boolean compareRet = ResultVerifier.verify(
-      TestConstants.NATIVETASK_NONSORT_TEST_NATIVE_OUTPUT,
-      TestConstants.NATIVETASK_NONSORT_TEST_NORMAL_OUTPUT);
+        TestConstants.NATIVETASK_NONSORT_TEST_NATIVE_OUTPUT,
+        TestConstants.NATIVETASK_NONSORT_TEST_NORMAL_OUTPUT);
     assertThat(compareRet)
         .withFailMessage(
             "file compare result: if they are the same ,then return true")
@@ -72,10 +72,10 @@ public class NonSortTest {
     ResultVerifier.verifyCounters(hadoopWithSort, nativeNonSort);
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    Assumptions.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    Assumptions.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     conf.addNonSortTestConf();
     final FileSystem fs = FileSystem.get(conf);
@@ -88,7 +88,7 @@ public class NonSortTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_NONSORT_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestKVSerializer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestKVSerializer.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapred.nativetask.serde;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.nativetask.Constants;
@@ -30,9 +30,10 @@ import org.apache.hadoop.mapred.nativetask.buffer.DataOutputStream;
 import org.apache.hadoop.mapred.nativetask.testutil.TestInput;
 import org.apache.hadoop.mapred.nativetask.testutil.TestInput.KV;
 import org.apache.hadoop.mapred.nativetask.util.SizedWritable;
-import org.junit.Assert;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 
@@ -48,7 +49,7 @@ public class TestKVSerializer {
   private SizedWritable value;
   private KVSerializer serializer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.inputArray = TestInput.getMapInputs(inputArraySize);
     this.key = new SizedWritable(BytesWritable.class);
@@ -62,7 +63,7 @@ public class TestKVSerializer {
   }
 
   @Test
-  public void testUpdateLength() throws IOException {
+  void testUpdateLength() throws IOException {
     Mockito.mock(DataOutputStream.class);
 
     int kvLength = 0;
@@ -72,18 +73,18 @@ public class TestKVSerializer {
       serializer.updateLength(key, value);
 
       // verify whether the size increase
-      Assert.assertTrue(key.length + value.length > kvLength);
+      assertTrue(key.length + value.length > kvLength);
       kvLength = key.length + value.length;
     }
   }
 
   @Test
-  public void testSerializeKV() throws IOException {
+  void testSerializeKV() throws IOException {
     final DataOutputStream dataOut = Mockito.mock(DataOutputStream.class);
 
     Mockito.when(dataOut.hasUnFlushedData()).thenReturn(true);
     Mockito.when(dataOut.shortOfSpace(key.length + value.length +
-                                      Constants.SIZEOF_KV_LENGTH)).thenReturn(true);
+        Constants.SIZEOF_KV_LENGTH)).thenReturn(true);
     final int written = serializer.serializeKV(dataOut, key, value);
 
     // flush once, write 4 int, and 2 byte array
@@ -92,11 +93,11 @@ public class TestKVSerializer {
     Mockito.verify(dataOut, Mockito.times(2)).write(any(byte[].class),
         anyInt(), anyInt());
 
-    Assert.assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
+    assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
   }
 
   @Test
-  public void testSerializeNoFlush() throws IOException {
+  void testSerializeNoFlush() throws IOException {
     final DataOutputStream dataOut = Mockito.mock(DataOutputStream.class);
 
     // suppose there are enough space
@@ -110,18 +111,18 @@ public class TestKVSerializer {
     Mockito.verify(dataOut, Mockito.times(2)).write(any(byte[].class),
         anyInt(), anyInt());
 
-    Assert.assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
+    assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
   }
 
   @Test
-  public void testSerializePartitionKV() throws IOException {
+  void testSerializePartitionKV() throws IOException {
     final DataOutputStream dataOut = Mockito.mock(DataOutputStream.class);
 
     Mockito.when(dataOut.hasUnFlushedData()).thenReturn(true);
     Mockito.when(
         dataOut
-        .shortOfSpace(key.length + value.length +
-                      Constants.SIZEOF_KV_LENGTH + Constants.SIZEOF_PARTITION_LENGTH))
+            .shortOfSpace(key.length + value.length +
+                Constants.SIZEOF_KV_LENGTH + Constants.SIZEOF_PARTITION_LENGTH))
         .thenReturn(true);
     final int written = serializer.serializePartitionKV(dataOut, 100, key, value);
 
@@ -131,22 +132,22 @@ public class TestKVSerializer {
     Mockito.verify(dataOut, Mockito.times(2)).write(any(byte[].class),
         anyInt(), anyInt());
 
-    Assert.assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH
+    assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH
         + Constants.SIZEOF_PARTITION_LENGTH);
   }
 
   @Test
-  public void testDeserializerNoData() throws IOException {
+  void testDeserializerNoData() throws IOException {
     final DataInputStream in = Mockito.mock(DataInputStream.class);
     Mockito.when(in.hasUnReadData()).thenReturn(false);
-    Assert.assertEquals(0, serializer.deserializeKV(in, key, value));
+    assertEquals(0, serializer.deserializeKV(in, key, value));
   }
 
   @Test
-  public void testDeserializer() throws IOException {
+  void testDeserializer() throws IOException {
     final DataInputStream in = Mockito.mock(DataInputStream.class);
     Mockito.when(in.hasUnReadData()).thenReturn(true);
-    Assert.assertTrue(serializer.deserializeKV(in, key, value) > 0);
+    assertTrue(serializer.deserializeKV(in, key, value) > 0);
 
     Mockito.verify(in, Mockito.times(4)).readInt();
     Mockito.verify(in, Mockito.times(2)).readFully(any(byte[].class),

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestNativeSerialization.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestNativeSerialization.java
@@ -17,29 +17,31 @@
  */
 package org.apache.hadoop.mapred.nativetask.serde;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.nativetask.INativeComparable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "rawtypes" })
 public class TestNativeSerialization {
   @Test
-  public void testRegisterAndGet() throws IOException {
+  void testRegisterAndGet() throws IOException {
     final NativeSerialization serialization = NativeSerialization.getInstance();
     serialization.reset();
 
     serialization.register(WritableKey.class.getName(), ComparableKeySerializer.class);
 
     INativeSerializer serializer = serialization.getSerializer(WritableKey.class);
-    Assert.assertEquals(ComparableKeySerializer.class.getName(), serializer.getClass().getName());
+    assertEquals(ComparableKeySerializer.class.getName(), serializer.getClass().getName());
 
     serializer = serialization.getSerializer(WritableValue.class);
-    Assert.assertEquals(DefaultSerializer.class.getName(), serializer.getClass().getName());
+    assertEquals(DefaultSerializer.class.getName(), serializer.getClass().getName());
 
     boolean ioExceptionThrown = false;
     try {
@@ -47,7 +49,7 @@ public class TestNativeSerialization {
     } catch (final IOException e) {
       ioExceptionThrown = true;
     }
-    Assert.assertTrue(ioExceptionThrown);
+    assertTrue(ioExceptionThrown);
   }
 
   public static class WritableKey implements Writable {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.mapred.nativetask.testutil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.zip.CRC32;
@@ -143,16 +143,16 @@ public class ResultVerifier {
       throws IOException {
     Counters normalCounters = normalJob.getCounters();
     Counters nativeCounters = nativeJob.getCounters();
-    assertEquals("Counter MAP_OUTPUT_RECORDS should be equal",
-        normalCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
-        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue());
-    assertEquals("Counter REDUCE_INPUT_GROUPS should be equal",
-        normalCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
-        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue());
+    assertEquals(normalCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
+        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
+        "Counter MAP_OUTPUT_RECORDS should be equal");
+    assertEquals(normalCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
+        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
+        "Counter REDUCE_INPUT_GROUPS should be equal");
     if (!hasCombiner) {
-      assertEquals("Counter REDUCE_INPUT_RECORDS should be equal",
-          normalCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
-          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue());
+      assertEquals(normalCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
+          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
+          "Counter REDUCE_INPUT_RECORDS should be equal");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestBytesUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestBytesUtil.java
@@ -20,50 +20,52 @@ package org.apache.hadoop.mapred.nativetask.utils;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Longs;
 
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.mapred.nativetask.util.BytesUtil;
 
 public class TestBytesUtil {
 
   @Test
-  public void testBytesIntConversion() {
+  void testBytesIntConversion() {
     final int a = 1000;
     final byte[] intBytes = Ints.toByteArray(a);
 
-    Assert.assertEquals(a, BytesUtil.toInt(intBytes, 0));
+    assertEquals(a, BytesUtil.toInt(intBytes, 0));
   }
 
   @Test
-  public void testBytesLongConversion() {
+  void testBytesLongConversion() {
     final long l = 1000000L;
     final byte[] longBytes = Longs.toByteArray(l);
 
-    Assert.assertEquals(l, BytesUtil.toLong(longBytes, 0));
+    assertEquals(l, BytesUtil.toLong(longBytes, 0));
   }
 
   @Test
-  public void testBytesFloatConversion() {
+  void testBytesFloatConversion() {
     final float f = 3.14f;
     final byte[] floatBytes = BytesUtil.toBytes(f);
 
-    Assert.assertEquals(f, BytesUtil.toFloat(floatBytes), 0.0f);
+    assertEquals(f, BytesUtil.toFloat(floatBytes), 0.0f);
   }
 
   @Test
-  public void testBytesDoubleConversion() {
+  void testBytesDoubleConversion() {
     final double d = 3.14;
     final byte[] doubleBytes = BytesUtil.toBytes(d);
 
-    Assert.assertEquals(d, BytesUtil.toDouble(doubleBytes), 0.0);
+    assertEquals(d, BytesUtil.toDouble(doubleBytes), 0.0);
   }
 
   @Test
-  public void testToStringBinary() {
-    Assert.assertEquals("\\x01\\x02ABC",
-        BytesUtil.toStringBinary(new byte[] { 1, 2, 65, 66, 67 }));
-    Assert.assertEquals("\\x10\\x11",
-        BytesUtil.toStringBinary(new byte[] { 16, 17 }));
+  void testToStringBinary() {
+    assertEquals("\\x01\\x02ABC",
+        BytesUtil.toStringBinary(new byte[]{1, 2, 65, 66, 67}));
+    assertEquals("\\x10\\x11",
+        BytesUtil.toStringBinary(new byte[]{16, 17}));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestReadWriteBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestReadWriteBuffer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.mapred.nativetask.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.mapred.nativetask.util.ReadWriteBuffer;
 
@@ -28,7 +28,7 @@ public class TestReadWriteBuffer {
   private static byte[] bytes = new byte[] { '0', 'a', 'b', 'c', 'd', '9' };
 
   @Test
-  public void testReadWriteBuffer() {
+  void testReadWriteBuffer() {
 
     final ReadWriteBuffer buffer = new ReadWriteBuffer();
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestSizedWritable.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestSizedWritable.java
@@ -17,19 +17,22 @@
  */
 package org.apache.hadoop.mapred.nativetask.utils;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.nativetask.util.SizedWritable;
-import org.junit.Assert;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class TestSizedWritable {
 
   @Test
-  public void testSizedWritable() {
+  void testSizedWritable() {
     final SizedWritable w = new SizedWritable(BytesWritable.class);
-    Assert.assertTrue(w.length == SizedWritable.INVALID_LENGTH);
-    Assert.assertFalse(w.v == null);
+    assertTrue(w.length == SizedWritable.INVALID_LENGTH);
+    assertFalse(w.v == null);
   }
 }


### PR DESCRIPTION
### Description of PR

Upgrade Junit 4 to 5 in hadoop-mapreduce-client-nativetask

JIRA - MAPREDUCE-7415


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

