### PR TITLE
MAPREDUCE-7418. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-app

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -99,7 +99,7 @@
       <artifactId>hadoop-yarn-server-tests</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
-   </dependency>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
@@ -107,6 +107,22 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -122,6 +138,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestLocalContainerLauncher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestLocalContainerLauncher.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapred;
 
 import static org.apache.hadoop.fs.CreateFlag.CREATE;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -53,10 +54,10 @@ import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -75,7 +76,7 @@ public class TestLocalContainerLauncher {
     fs.delete(p, true);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTestDirs() throws IOException {
     testWorkDir = new File("target",
         TestLocalContainerLauncher.class.getCanonicalName());
@@ -89,7 +90,7 @@ public class TestLocalContainerLauncher {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupTestDirs() throws IOException {
     if (testWorkDir != null) {
       delete(testWorkDir);
@@ -97,8 +98,9 @@ public class TestLocalContainerLauncher {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test(timeout=10000)
-  public void testKillJob() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testKillJob() throws Exception {
     JobConf conf = new JobConf();
     AppContext context = mock(AppContext.class);
     // a simple event handler solely to detect the container cleaned event
@@ -132,7 +134,7 @@ public class TestLocalContainerLauncher {
     Job job = mock(Job.class);
     when(job.getTotalMaps()).thenReturn(1);
     when(job.getTotalReduces()).thenReturn(0);
-    Map<JobId,Job> jobs = new HashMap<JobId,Job>();
+    Map<JobId, Job> jobs = new HashMap<JobId, Job>();
     jobs.put(jobId, job);
     // app context returns the one and only job
     when(context.getAllJobs()).thenReturn(jobs);
@@ -154,7 +156,7 @@ public class TestLocalContainerLauncher {
       public Void answer(InvocationOnMock invocation) throws Throwable {
         // sleep for a long time
         LOG.info("sleeping for 5 minutes...");
-        Thread.sleep(5*60*1000);
+        Thread.sleep(5 * 60 * 1000);
         return null;
       }
     }).when(mapTask).run(isA(JobConf.class), isA(TaskUmbilicalProtocol.class));
@@ -186,7 +188,7 @@ public class TestLocalContainerLauncher {
 
 
   @Test
-  public void testRenameMapOutputForReduce() throws Exception {
+  void testRenameMapOutputForReduce() throws Exception {
     final JobConf conf = new JobConf();
 
     final MROutputFiles mrOutputFiles = new MROutputFiles();
@@ -198,8 +200,7 @@ public class TestLocalContainerLauncher {
     final Path mapOut = mrOutputFiles.getOutputFileForWrite(1);
     conf.set(MRConfig.LOCAL_DIR, localDirs[1].toString());
     final Path mapOutIdx = mrOutputFiles.getOutputIndexFileForWrite(1);
-    Assert.assertNotEquals("Paths must be different!",
-        mapOut.getParent(), mapOutIdx.getParent());
+    assertNotEquals(mapOut.getParent(), mapOutIdx.getParent(), "Paths must be different!");
 
     // make both dirs part of LOCAL_DIR
     conf.setStrings(MRConfig.LOCAL_DIR, localDirs);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
@@ -37,15 +37,16 @@ import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.SystemClock;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestTaskAttemptFinishingMonitor {
 
   @Test
-  public void testFinshingAttemptTimeout()
+  void testFinshingAttemptTimeout()
       throws IOException, InterruptedException {
     SystemClock clock = SystemClock.getInstance();
     Configuration conf = new Configuration();
@@ -82,12 +83,12 @@ public class TestTaskAttemptFinishingMonitor {
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(tid, 0);
     appCtx.getTaskAttemptFinishingMonitor().register(attemptId);
     int check = 0;
-    while ( !eventHandler.timedOut &&  check++ < 10 ) {
+    while (!eventHandler.timedOut &&  check++ < 10) {
       Thread.sleep(100);
     }
     taskAttemptFinishingMonitor.stop();
 
-    assertTrue("Finishing attempt didn't time out.", eventHandler.timedOut);
+    assertTrue(eventHandler.timedOut, "Finishing attempt didn't time out.");
 
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
@@ -25,14 +25,14 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.Counters.Counter;
@@ -69,12 +69,7 @@ import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.SystemClock;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -87,7 +82,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests the behavior of TaskAttemptListenerImpl.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestTaskAttemptListenerImpl {
   private static final String ATTEMPT1_ID =
       "attempt_123456789012_0001_m_000001_0";
@@ -172,7 +167,7 @@ public class TestTaskAttemptListenerImpl {
     }
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     if (listener != null) {
       listener.close();
@@ -180,8 +175,9 @@ public class TestTaskAttemptListenerImpl {
     }
   }
 
-  @Test  (timeout=5000)
-  public void testGetTask() throws IOException {
+  @Test
+  @Timeout(5000)
+  void testGetTask() throws IOException {
     configureMocks();
     startListener(false);
 
@@ -189,7 +185,7 @@ public class TestTaskAttemptListenerImpl {
     //The JVM ID has not been registered yet so we should kill it.
     JvmContext context = new JvmContext();
 
-    context.jvmId = id; 
+    context.jvmId = id;
     JvmTask result = listener.getTask(context);
     assertNotNull(result);
     assertTrue(result.shouldDie);
@@ -238,8 +234,9 @@ public class TestTaskAttemptListenerImpl {
 
   }
 
-  @Test (timeout=5000)
-  public void testJVMId() {
+  @Test
+  @Timeout(5000)
+  void testJVMId() {
 
     JVMId jvmid = new JVMId("test", 1, true, 2);
     JVMId jvmid1 = JVMId.forName("jvm_test_0001_m_000002");
@@ -247,22 +244,17 @@ public class TestTaskAttemptListenerImpl {
     assertEquals(0, jvmid.compareTo(jvmid1));
   }
 
-  @Test (timeout=10000)
-  public void testGetMapCompletionEvents() throws IOException {
+  @Test
+  @Timeout(10000)
+  void testGetMapCompletionEvents() throws IOException {
     TaskAttemptCompletionEvent[] empty = {};
     TaskAttemptCompletionEvent[] taskEvents = {
         createTce(0, true, TaskAttemptCompletionEventStatus.OBSOLETE),
         createTce(1, false, TaskAttemptCompletionEventStatus.FAILED),
         createTce(2, true, TaskAttemptCompletionEventStatus.SUCCEEDED),
-        createTce(3, false, TaskAttemptCompletionEventStatus.FAILED) };
-    TaskAttemptCompletionEvent[] mapEvents = { taskEvents[0], taskEvents[2] };
+        createTce(3, false, TaskAttemptCompletionEventStatus.FAILED)};
+    TaskAttemptCompletionEvent[] mapEvents = {taskEvents[0], taskEvents[2]};
     Job mockJob = mock(Job.class);
-    when(mockJob.getTaskAttemptCompletionEvents(0, 100))
-      .thenReturn(taskEvents);
-    when(mockJob.getTaskAttemptCompletionEvents(0, 2))
-      .thenReturn(Arrays.copyOfRange(taskEvents, 0, 2));
-    when(mockJob.getTaskAttemptCompletionEvents(2, 100))
-      .thenReturn(Arrays.copyOfRange(taskEvents, 2, 4));
     when(mockJob.getMapAttemptCompletionEvents(0, 100)).thenReturn(
         TypeConverter.fromYarn(mapEvents));
     when(mockJob.getMapAttemptCompletionEvents(0, 2)).thenReturn(
@@ -312,8 +304,9 @@ public class TestTaskAttemptListenerImpl {
     return tce;
   }
 
-  @Test (timeout=10000)
-  public void testCommitWindow() throws IOException {
+  @Test
+  @Timeout(10000)
+  void testCommitWindow() throws IOException {
     SystemClock clock = SystemClock.getInstance();
 
     configureMocks();
@@ -346,15 +339,15 @@ public class TestTaskAttemptListenerImpl {
 
     // verify commit allowed when RM heartbeat is recent
     when(rmHeartbeatHandler.getLastHeartbeatTime())
-      .thenReturn(clock.getTime());
+        .thenReturn(clock.getTime());
     canCommit = listener.canCommit(tid);
     assertTrue(canCommit);
     verify(mockTask, times(1)).canCommit(any(TaskAttemptId.class));
   }
 
   @Test
-  public void testCheckpointIDTracking()
-    throws IOException, InterruptedException{
+  void testCheckpointIDTracking()
+      throws IOException, InterruptedException {
     configureMocks();
     listener = new MockTaskAttemptListenerImpl(
         appCtx, secret, rmHeartbeatHandler, policy) {
@@ -392,7 +385,7 @@ public class TestTaskAttemptListenerImpl {
 
     // propagating a taskstatus that contains a checkpoint id
     TaskCheckpointID incid = new TaskCheckpointID(new FSCheckpointID(
-          CLOC), partialOut, counters);
+        CLOC), partialOut, counters);
     listener.setCheckpointID(
         org.apache.hadoop.mapred.TaskID.downgrade(tid.getTaskID()), incid);
 
@@ -409,7 +402,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testStatusUpdateProgress()
+  void testStatusUpdateProgress()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -430,7 +423,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testPingUpdateProgress() throws IOException, InterruptedException {
+  void testPingUpdateProgress() throws IOException, InterruptedException {
     configureMocks();
     Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.MR_TASK_ENABLE_PING_FOR_LIVELINESS_CHECK, true);
@@ -447,7 +440,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testSingleStatusUpdate()
+  void testSingleStatusUpdate()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -465,7 +458,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testStatusUpdateEventCoalescing()
+  void testStatusUpdateEventCoalescing()
       throws IOException, InterruptedException {
     configureMocks();
     startListener(true);
@@ -486,7 +479,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testCoalescedStatusUpdatesCleared()
+  void testCoalescedStatusUpdatesCleared()
       throws IOException, InterruptedException {
     // First two events are coalesced, the third is not
     configureMocks();
@@ -510,7 +503,7 @@ public class TestTaskAttemptListenerImpl {
   }
 
   @Test
-  public void testStatusUpdateFromUnregisteredTask() throws Exception {
+  void testStatusUpdateFromUnregisteredTask() throws Exception {
     configureMocks();
     ControlledClock clock = new ControlledClock();
     clock.setTime(0);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestYarnChild.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ClusterStorageCapacityExceededException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
@@ -36,7 +36,7 @@ public class TestYarnChild {
   final static private String KILL_LIMIT_EXCEED_CONF_NAME =
       "mapreduce.job.dfs.storage.capacity.kill-limit-exceed";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     task = mock(Task.class);
     umbilical = mock(TaskUmbilicalProtocol.class);
@@ -45,7 +45,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionNotHappenByDefault()
+  void testReportErrorWhenCapacityExceptionNotHappenByDefault()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
 
@@ -53,7 +53,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionNotHappenAndFastFailDisabled()
+  void testReportErrorWhenCapacityExceptionNotHappenAndFastFailDisabled()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, false);
@@ -62,7 +62,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionNotHappenAndFastFailEnabled()
+  void testReportErrorWhenCapacityExceptionNotHappenAndFastFailEnabled()
       throws IOException {
     Exception exception = new RuntimeException(new IOException());
     conf.setBoolean(KILL_LIMIT_EXCEED_CONF_NAME, true);
@@ -71,7 +71,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenByDefault()
+  void testReportErrorWhenCapacityExceptionHappenByDefault()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -80,7 +80,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenAndFastFailDisabled()
+  void testReportErrorWhenCapacityExceptionHappenAndFastFailDisabled()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -90,7 +90,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenAndFastFailEnabled()
+  void testReportErrorWhenCapacityExceptionHappenAndFastFailEnabled()
       throws IOException {
     Exception exception =
         new RuntimeException(new ClusterStorageCapacityExceededException());
@@ -100,7 +100,7 @@ public class TestYarnChild {
   }
 
   @Test
-  public void testReportErrorWhenCapacityExceptionHappenInThirdOfExceptionChain()
+  void testReportErrorWhenCapacityExceptionHappenInThirdOfExceptionChain()
       throws IOException {
     Exception exception = new RuntimeException(new IllegalStateException(
         new ClusterStorageCapacityExceededException()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestEvents.java
@@ -19,9 +19,7 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -40,18 +38,21 @@ import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.v2.app.job.impl.JobImpl;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestEvents {
 
   private static final String taskId = "task_1_2_r_3";
+
   /**
    * test a getters of TaskAttemptFinishedEvent and TaskAttemptFinished
    * 
    * @throws Exception
    */
-  @Test(timeout = 10000)
-  public void testTaskAttemptFinishedEvent() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testTaskAttemptFinishedEvent() throws Exception {
 
     JobID jid = new JobID("001", 1);
     TaskID tid = new TaskID(jid, TaskType.REDUCE, 2);
@@ -79,8 +80,9 @@ public class TestEvents {
    * @throws Exception
    */
 
-  @Test(timeout = 10000)
-  public void testJobPriorityChange() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testJobPriorityChange() throws Exception {
     org.apache.hadoop.mapreduce.JobID jid = new JobID("001", 1);
     JobPriorityChangeEvent test = new JobPriorityChangeEvent(jid,
         JobPriority.LOW);
@@ -88,9 +90,10 @@ public class TestEvents {
     assertThat(test.getPriority()).isEqualTo(JobPriority.LOW);
 
   }
-  
-  @Test(timeout = 10000)
-  public void testJobQueueChange() throws Exception {
+
+  @Test
+  @Timeout(10000)
+  void testJobQueueChange() throws Exception {
     org.apache.hadoop.mapreduce.JobID jid = new JobID("001", 1);
     JobQueueChangeEvent test = new JobQueueChangeEvent(jid,
         "newqueue");
@@ -103,8 +106,9 @@ public class TestEvents {
    * 
    * @throws Exception
    */
-  @Test(timeout = 10000)
-  public void testTaskUpdated() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testTaskUpdated() throws Exception {
     JobID jid = new JobID("001", 1);
     TaskID tid = new TaskID(jid, TaskType.REDUCE, 2);
     TaskUpdatedEvent test = new TaskUpdatedEvent(tid, 1234L);
@@ -118,70 +122,71 @@ public class TestEvents {
    * instance of HistoryEvent Different HistoryEvent should have a different
    * datum.
    */
-  @Test(timeout = 10000)
-  public void testEvents() throws Exception {
+  @Test
+  @Timeout(10000)
+  void testEvents() throws Exception {
 
     EventReader reader = new EventReader(new DataInputStream(
         new ByteArrayInputStream(getEvents())));
     HistoryEvent e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.JOB_PRIORITY_CHANGED));
+    assertEquals(e.getEventType(), EventType.JOB_PRIORITY_CHANGED);
     assertEquals("ID", ((JobPriorityChange) e.getDatum()).getJobid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.JOB_STATUS_CHANGED));
+    assertEquals(e.getEventType(), EventType.JOB_STATUS_CHANGED);
     assertEquals("ID", ((JobStatusChanged) e.getDatum()).getJobid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.TASK_UPDATED));
+    assertEquals(e.getEventType(), EventType.TASK_UPDATED);
     assertEquals("ID", ((TaskUpdated) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_KILLED);
     assertEquals(taskId,
         ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.JOB_KILLED));
+    assertEquals(e.getEventType(), EventType.JOB_KILLED);
     assertEquals("ID",
         ((JobUnsuccessfulCompletion) e.getDatum()).getJobid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_STARTED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_STARTED);
     assertEquals(taskId,
         ((TaskAttemptStarted) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_FINISHED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_FINISHED);
     assertEquals(taskId,
         ((TaskAttemptFinished) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_KILLED);
     assertEquals(taskId,
         ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_KILLED);
     assertEquals(taskId,
         ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_STARTED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_STARTED);
     assertEquals(taskId,
         ((TaskAttemptStarted) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_FINISHED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_FINISHED);
     assertEquals(taskId,
         ((TaskAttemptFinished) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_KILLED);
     assertEquals(taskId,
         ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
 
     e = reader.getNextEvent();
-    assertTrue(e.getEventType().equals(EventType.REDUCE_ATTEMPT_KILLED));
+    assertEquals(e.getEventType(), EventType.REDUCE_ATTEMPT_KILLED);
     assertEquals(taskId,
         ((TaskAttemptUnsuccessfulCompletion) e.getDatum()).getTaskid().toString());
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
@@ -19,9 +19,7 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -81,11 +79,11 @@ import org.apache.hadoop.yarn.event.DrainDispatcher;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
 import org.apache.hadoop.yarn.server.timeline.TimelineStore;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -101,7 +99,7 @@ public class TestJobHistoryEventHandler {
   private static MiniDFSCluster dfsCluster = null;
   private static String coreSitePath;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     coreSitePath = "." + File.separator + "target" + File.separator +
             "test-classes" + File.separator + "core-site.xml";
@@ -109,18 +107,19 @@ public class TestJobHistoryEventHandler {
     dfsCluster = new MiniDFSCluster.Builder(conf).build();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUpClass() throws Exception {
     dfsCluster.shutdown();
   }
 
-  @After
+  @AfterEach
   public void cleanTest() throws Exception {
     new File(coreSitePath).delete();
   }
 
-  @Test (timeout=50000)
-  public void testFirstFlushOnCompletionEvent() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testFirstFlushOnCompletionEvent() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -162,8 +161,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test (timeout=50000)
-  public void testMaxUnflushedCompletionEvents() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testMaxUnflushedCompletionEvents() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -187,7 +187,7 @@ public class TestJobHistoryEventHandler {
       mockWriter = jheh.getEventWriter();
       verify(mockWriter).write(any(HistoryEvent.class));
 
-      for (int i = 0 ; i < 100 ; i++) {
+      for (int i = 0; i < 100; i++) {
         queueEvent(jheh, new JobHistoryEvent(t.jobId, new TaskFinishedEvent(
             t.taskID, t.taskAttemptID, 0, TaskType.MAP, "", null, 0)));
       }
@@ -207,8 +207,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test (timeout=50000)
-  public void testUnflushedTimer() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testUnflushedTimer() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -232,26 +233,27 @@ public class TestJobHistoryEventHandler {
       mockWriter = jheh.getEventWriter();
       verify(mockWriter).write(any(HistoryEvent.class));
 
-      for (int i = 0 ; i < 100 ; i++) {
+      for (int i = 0; i < 100; i++) {
         queueEvent(jheh, new JobHistoryEvent(t.jobId, new TaskFinishedEvent(
             t.taskID, t.taskAttemptID, 0, TaskType.MAP, "", null, 0)));
       }
 
       handleNextNEvents(jheh, 9);
-      Assert.assertTrue(jheh.getFlushTimerStatus());
+      assertTrue(jheh.getFlushTimerStatus());
       verify(mockWriter, times(0)).flush();
 
       Thread.sleep(2 * 4 * 1000l); // 4 seconds should be enough. Just be safe.
       verify(mockWriter).flush();
-      Assert.assertFalse(jheh.getFlushTimerStatus());
+      assertFalse(jheh.getFlushTimerStatus());
     } finally {
       jheh.stop();
       verify(mockWriter).close();
     }
   }
 
-  @Test (timeout=50000)
-  public void testBatchedFlushJobEndMultiplier() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testBatchedFlushJobEndMultiplier() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.workDir);
@@ -275,7 +277,7 @@ public class TestJobHistoryEventHandler {
       mockWriter = jheh.getEventWriter();
       verify(mockWriter).write(any(HistoryEvent.class));
 
-      for (int i = 0 ; i < 100 ; i++) {
+      for (int i = 0; i < 100; i++) {
         queueEvent(jheh, new JobHistoryEvent(t.jobId, new TaskFinishedEvent(
             t.taskID, t.taskAttemptID, 0, TaskType.MAP, "", null, 0)));
       }
@@ -295,8 +297,9 @@ public class TestJobHistoryEventHandler {
   }
 
   // In case of all types of events, process Done files if it's last AM retry
-  @Test (timeout=50000)
-  public void testProcessDoneFilesOnLastAMRetry() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testProcessDoneFilesOnLastAMRetry() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -309,12 +312,12 @@ public class TestJobHistoryEventHandler {
     try {
       jheh.start();
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new AMStartedEvent(
-        t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
+          t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
       verify(jheh, times(0)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
       verify(jheh, times(1)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new JobFinishedEvent(
@@ -323,13 +326,13 @@ public class TestJobHistoryEventHandler {
       verify(jheh, times(2)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
       verify(jheh, times(3)).processDoneFiles(any(JobId.class));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
       verify(jheh, times(4)).processDoneFiles(any(JobId.class));
 
       mockWriter = jheh.getEventWriter();
@@ -341,8 +344,9 @@ public class TestJobHistoryEventHandler {
   }
 
   // Skip processing Done files in case of ERROR, if it's not last AM retry
-  @Test (timeout=50000)
-  public void testProcessDoneFilesNotLastAMRetry() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testProcessDoneFilesNotLastAMRetry() throws Exception {
     TestParams t = new TestParams(false);
     Configuration conf = new Configuration();
     JHEvenHandlerForTest realJheh =
@@ -354,13 +358,13 @@ public class TestJobHistoryEventHandler {
     try {
       jheh.start();
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new AMStartedEvent(
-        t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
+          t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1)));
       verify(jheh, times(0)).processDoneFiles(t.jobId);
 
       // skip processing done files
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.ERROR.toString())));
       verify(jheh, times(0)).processDoneFiles(t.jobId);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new JobFinishedEvent(
@@ -369,13 +373,13 @@ public class TestJobHistoryEventHandler {
       verify(jheh, times(1)).processDoneFiles(t.jobId);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
       verify(jheh, times(2)).processDoneFiles(t.jobId);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString())));
       verify(jheh, times(3)).processDoneFiles(t.jobId);
 
       mockWriter = jheh.getEventWriter();
@@ -387,7 +391,7 @@ public class TestJobHistoryEventHandler {
   }
 
   @Test
-  public void testPropertyRedactionForJHS() throws Exception {
+  void testPropertyRedactionForJHS() throws Exception {
     final Configuration conf = new Configuration();
 
     String sensitivePropertyName = "aws.fake.credentials.name";
@@ -411,7 +415,7 @@ public class TestJobHistoryEventHandler {
               "nmhost", 3000, 4000, -1)));
       handleEvent(jheh, new JobHistoryEvent(params.jobId,
           new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(
-              params.jobId), 0, 0, 0, 0, 0, 0, 0,
+                  params.jobId), 0, 0, 0, 0, 0, 0, 0,
               JobStateInternal.FAILED.toString())));
 
       // verify the value of the sensitive property in job.xml is restored.
@@ -421,16 +425,16 @@ public class TestJobHistoryEventHandler {
 
       // load the job_conf.xml in JHS directory and verify property redaction.
       Path jhsJobConfFile = getJobConfInIntermediateDoneDir(conf, params.jobId);
-      Assert.assertTrue("The job_conf.xml file is not in the JHS directory",
-          FileContext.getFileContext(conf).util().exists(jhsJobConfFile));
+      assertTrue(FileContext.getFileContext(conf).util().exists(jhsJobConfFile),
+          "The job_conf.xml file is not in the JHS directory");
       Configuration jhsJobConf = new Configuration();
 
       try (InputStream input = FileSystem.get(conf).open(jhsJobConfFile)) {
         jhsJobConf.addResource(input);
-        Assert.assertEquals(
-            sensitivePropertyName + " is not redacted in HDFS.",
+        assertEquals(
             MRJobConfUtil.REDACTION_REPLACEMENT_VAL,
-            jhsJobConf.get(sensitivePropertyName));
+            jhsJobConf.get(sensitivePropertyName),
+            sensitivePropertyName + " is not redacted in HDFS.");
       }
     } finally {
       jheh.stop();
@@ -456,19 +460,20 @@ public class TestJobHistoryEventHandler {
     fs.delete(new Path(intermDoneDirPrefix), true);
   }
 
-  @Test (timeout=50000)
-  public void testDefaultFsIsUsedForHistory() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testDefaultFsIsUsedForHistory() throws Exception {
     // Create default configuration pointing to the minicluster
     Configuration conf = new Configuration();
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
-            dfsCluster.getURI().toString());
+        dfsCluster.getURI().toString());
     FileOutputStream os = new FileOutputStream(coreSitePath);
     conf.writeXml(os);
     os.close();
 
     // simulate execution under a non-default namenode
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
-            "file:///");
+        "file:///");
 
     TestParams t = new TestParams();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, t.dfsWorkDir);
@@ -490,11 +495,11 @@ public class TestJobHistoryEventHandler {
       // If we got here then event handler worked but we don't know with which
       // file system. Now we check that history stuff was written to minicluster
       FileSystem dfsFileSystem = dfsCluster.getFileSystem();
-      assertTrue("Minicluster contains some history files",
-          dfsFileSystem.globStatus(new Path(t.dfsWorkDir + "/*")).length != 0);
+      assertTrue(dfsFileSystem.globStatus(new Path(t.dfsWorkDir + "/*")).length != 0,
+          "Minicluster contains some history files");
       FileSystem localFileSystem = LocalFileSystem.get(conf);
-      assertFalse("No history directory on non-default file system",
-          localFileSystem.exists(new Path(t.dfsWorkDir)));
+      assertFalse(localFileSystem.exists(new Path(t.dfsWorkDir)),
+          "No history directory on non-default file system");
     } finally {
       jheh.stop();
       purgeHdfsHistoryIntermediateDoneDirectory(conf);
@@ -502,14 +507,14 @@ public class TestJobHistoryEventHandler {
   }
 
   @Test
-  public void testGetHistoryIntermediateDoneDirForUser() throws IOException {
+  void testGetHistoryIntermediateDoneDirForUser() throws IOException {
     // Test relative path
     Configuration conf = new Configuration();
     conf.set(JHAdminConfig.MR_HISTORY_INTERMEDIATE_DONE_DIR,
         "/mapred/history/done_intermediate");
     conf.set(MRJobConfig.USER_NAME, System.getProperty("user.name"));
     String pathStr = JobHistoryUtils.getHistoryIntermediateDoneDirForUser(conf);
-    Assert.assertEquals("/mapred/history/done_intermediate/" +
+    assertEquals("/mapred/history/done_intermediate/" +
         System.getProperty("user.name"), pathStr);
 
     // Test fully qualified path
@@ -521,16 +526,17 @@ public class TestJobHistoryEventHandler {
     os.close();
     // Simulate execution under a non-default namenode
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
-            "file:///");
+        "file:///");
     pathStr = JobHistoryUtils.getHistoryIntermediateDoneDirForUser(conf);
-    Assert.assertEquals(dfsCluster.getURI().toString() +
+    assertEquals(dfsCluster.getURI().toString() +
         "/mapred/history/done_intermediate/" + System.getProperty("user.name"),
         pathStr);
   }
 
   // test AMStartedEvent for submitTime and startTime
-  @Test (timeout=50000)
-  public void testAMStartedEvent() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testAMStartedEvent() throws Exception {
     TestParams t = new TestParams();
     Configuration conf = new Configuration();
 
@@ -553,8 +559,8 @@ public class TestJobHistoryEventHandler {
       assertThat(mi.getJobSummary().getJobLaunchTime()).isEqualTo(200);
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-        new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
-          0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId), 0,
+              0, 0, 0, 0, 0, 0, JobStateInternal.FAILED.toString())));
 
       assertThat(mi.getJobIndexInfo().getSubmitTime()).isEqualTo(100);
       assertThat(mi.getJobIndexInfo().getJobStartTime()).isEqualTo(200);
@@ -571,8 +577,9 @@ public class TestJobHistoryEventHandler {
 
   // Have JobHistoryEventHandler handle some events and make sure they get
   // stored to the Timeline store
-  @Test (timeout=50000)
-  public void testTimelineEventHandling() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testTimelineEventHandling() throws Exception {
     TestParams t = new TestParams(RunningAppContext.class, false);
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -585,174 +592,175 @@ public class TestJobHistoryEventHandler {
       confJHEH.setBoolean(MRJobConfig.MAPREDUCE_JOB_EMIT_TIMELINE_DATA, true);
       confJHEH.set(YarnConfiguration.TIMELINE_SERVICE_WEBAPP_ADDRESS,
           MiniYARNCluster.getHostname() + ":" +
-          yarnCluster.getApplicationHistoryServer().getPort());
+              yarnCluster.getApplicationHistoryServer().getPort());
       JHEvenHandlerForTest jheh = new JHEvenHandlerForTest(t.mockAppContext, 0);
       jheh.init(confJHEH);
       jheh.start();
       TimelineStore ts = yarnCluster.getApplicationHistoryServer()
-              .getTimelineStore();
+          .getTimelineStore();
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId, new AMStartedEvent(
               t.appAttemptId, 200, t.containerId, "nmhost", 3000, 4000, -1),
-              currentTime - 10));
+          currentTime - 10));
       jheh.getDispatcher().await();
       TimelineEntities entities = ts.getEntities("MAPREDUCE_JOB", null, null,
-              null, null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       TimelineEntity tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(1, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
-              tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(currentTime - 10,
-              tEntity.getEvents().get(0).getTimestamp());
+      assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      assertEquals(1, tEntity.getEvents().size());
+      assertEquals(EventType.AM_STARTED.toString(),
+          tEntity.getEvents().get(0).getEventType());
+      assertEquals(currentTime - 10,
+          tEntity.getEvents().get(0).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-              new JobSubmittedEvent(TypeConverter.fromYarn(t.jobId), "name",
+          new JobSubmittedEvent(TypeConverter.fromYarn(t.jobId), "name",
               "user", 200, "/foo/job.xml",
               new HashMap<JobACL, AccessControlList>(), "default"),
-              currentTime + 10));
+          currentTime + 10));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(2, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
-              tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
-              tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(currentTime + 10,
-              tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
-              tEntity.getEvents().get(1).getTimestamp());
+      assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      assertEquals(2, tEntity.getEvents().size());
+      assertEquals(EventType.JOB_SUBMITTED.toString(),
+          tEntity.getEvents().get(0).getEventType());
+      assertEquals(EventType.AM_STARTED.toString(),
+          tEntity.getEvents().get(1).getEventType());
+      assertEquals(currentTime + 10,
+          tEntity.getEvents().get(0).getTimestamp());
+      assertEquals(currentTime - 10,
+          tEntity.getEvents().get(1).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-              new JobQueueChangeEvent(TypeConverter.fromYarn(t.jobId), "q2"),
-              currentTime - 20));
+          new JobQueueChangeEvent(TypeConverter.fromYarn(t.jobId), "q2"),
+          currentTime - 20));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(3, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
-              tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
-              tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
-              tEntity.getEvents().get(2).getEventType());
-      Assert.assertEquals(currentTime + 10,
-              tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
-              tEntity.getEvents().get(1).getTimestamp());
-      Assert.assertEquals(currentTime - 20,
-              tEntity.getEvents().get(2).getTimestamp());
+      assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      assertEquals(3, tEntity.getEvents().size());
+      assertEquals(EventType.JOB_SUBMITTED.toString(),
+          tEntity.getEvents().get(0).getEventType());
+      assertEquals(EventType.AM_STARTED.toString(),
+          tEntity.getEvents().get(1).getEventType());
+      assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
+          tEntity.getEvents().get(2).getEventType());
+      assertEquals(currentTime + 10,
+          tEntity.getEvents().get(0).getTimestamp());
+      assertEquals(currentTime - 10,
+          tEntity.getEvents().get(1).getTimestamp());
+      assertEquals(currentTime - 20,
+          tEntity.getEvents().get(2).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-              new JobFinishedEvent(TypeConverter.fromYarn(t.jobId), 0, 0, 0, 0,
+          new JobFinishedEvent(TypeConverter.fromYarn(t.jobId), 0, 0, 0, 0,
               0, 0, 0, new Counters(), new Counters(), new Counters()), currentTime));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(4, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
-              tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.JOB_FINISHED.toString(),
-              tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
-              tEntity.getEvents().get(2).getEventType());
-      Assert.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
-              tEntity.getEvents().get(3).getEventType());
-      Assert.assertEquals(currentTime + 10,
-              tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime,
-              tEntity.getEvents().get(1).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
-              tEntity.getEvents().get(2).getTimestamp());
-      Assert.assertEquals(currentTime - 20,
-              tEntity.getEvents().get(3).getTimestamp());
+      assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      assertEquals(4, tEntity.getEvents().size());
+      assertEquals(EventType.JOB_SUBMITTED.toString(),
+          tEntity.getEvents().get(0).getEventType());
+      assertEquals(EventType.JOB_FINISHED.toString(),
+          tEntity.getEvents().get(1).getEventType());
+      assertEquals(EventType.AM_STARTED.toString(),
+          tEntity.getEvents().get(2).getEventType());
+      assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
+          tEntity.getEvents().get(3).getEventType());
+      assertEquals(currentTime + 10,
+          tEntity.getEvents().get(0).getTimestamp());
+      assertEquals(currentTime,
+          tEntity.getEvents().get(1).getTimestamp());
+      assertEquals(currentTime - 10,
+          tEntity.getEvents().get(2).getTimestamp());
+      assertEquals(currentTime - 20,
+          tEntity.getEvents().get(3).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-            new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId),
-            0, 0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString()),
-            currentTime + 20));
+          new JobUnsuccessfulCompletionEvent(TypeConverter.fromYarn(t.jobId),
+              0, 0, 0, 0, 0, 0, 0, JobStateInternal.KILLED.toString()),
+          currentTime + 20));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.jobId.toString(), tEntity.getEntityId());
-      Assert.assertEquals(5, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.JOB_KILLED.toString(),
-              tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(EventType.JOB_SUBMITTED.toString(),
-              tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(EventType.JOB_FINISHED.toString(),
-              tEntity.getEvents().get(2).getEventType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
-              tEntity.getEvents().get(3).getEventType());
-      Assert.assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
-              tEntity.getEvents().get(4).getEventType());
-      Assert.assertEquals(currentTime + 20,
-              tEntity.getEvents().get(0).getTimestamp());
-      Assert.assertEquals(currentTime + 10,
-              tEntity.getEvents().get(1).getTimestamp());
-      Assert.assertEquals(currentTime,
-              tEntity.getEvents().get(2).getTimestamp());
-      Assert.assertEquals(currentTime - 10,
-              tEntity.getEvents().get(3).getTimestamp());
-      Assert.assertEquals(currentTime - 20,
-              tEntity.getEvents().get(4).getTimestamp());
+      assertEquals(t.jobId.toString(), tEntity.getEntityId());
+      assertEquals(5, tEntity.getEvents().size());
+      assertEquals(EventType.JOB_KILLED.toString(),
+          tEntity.getEvents().get(0).getEventType());
+      assertEquals(EventType.JOB_SUBMITTED.toString(),
+          tEntity.getEvents().get(1).getEventType());
+      assertEquals(EventType.JOB_FINISHED.toString(),
+          tEntity.getEvents().get(2).getEventType());
+      assertEquals(EventType.AM_STARTED.toString(),
+          tEntity.getEvents().get(3).getEventType());
+      assertEquals(EventType.JOB_QUEUE_CHANGED.toString(),
+          tEntity.getEvents().get(4).getEventType());
+      assertEquals(currentTime + 20,
+          tEntity.getEvents().get(0).getTimestamp());
+      assertEquals(currentTime + 10,
+          tEntity.getEvents().get(1).getTimestamp());
+      assertEquals(currentTime,
+          tEntity.getEvents().get(2).getTimestamp());
+      assertEquals(currentTime - 10,
+          tEntity.getEvents().get(3).getTimestamp());
+      assertEquals(currentTime - 20,
+          tEntity.getEvents().get(4).getTimestamp());
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-            new TaskStartedEvent(t.taskID, 0, TaskType.MAP, "")));
+          new TaskStartedEvent(t.taskID, 0, TaskType.MAP, "")));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_TASK", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.taskID.toString(), tEntity.getEntityId());
-      Assert.assertEquals(1, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.TASK_STARTED.toString(),
-              tEntity.getEvents().get(0).getEventType());
-      Assert.assertEquals(TaskType.MAP.toString(),
-              tEntity.getEvents().get(0).getEventInfo().get("TASK_TYPE"));
+      assertEquals(t.taskID.toString(), tEntity.getEntityId());
+      assertEquals(1, tEntity.getEvents().size());
+      assertEquals(EventType.TASK_STARTED.toString(),
+          tEntity.getEvents().get(0).getEventType());
+      assertEquals(TaskType.MAP.toString(),
+          tEntity.getEvents().get(0).getEventInfo().get("TASK_TYPE"));
 
       handleEvent(jheh, new JobHistoryEvent(t.jobId,
-            new TaskStartedEvent(t.taskID, 0, TaskType.REDUCE, "")));
+          new TaskStartedEvent(t.taskID, 0, TaskType.REDUCE, "")));
       jheh.getDispatcher().await();
       entities = ts.getEntities("MAPREDUCE_TASK", null, null, null,
-              null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+          null, null, null, null, null, null);
+      assertEquals(1, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(t.taskID.toString(), tEntity.getEntityId());
-      Assert.assertEquals(2, tEntity.getEvents().size());
-      Assert.assertEquals(EventType.TASK_STARTED.toString(),
-              tEntity.getEvents().get(1).getEventType());
-      Assert.assertEquals(TaskType.REDUCE.toString(),
-              tEntity.getEvents().get(0).getEventInfo().get("TASK_TYPE"));
-      Assert.assertEquals(TaskType.MAP.toString(),
-              tEntity.getEvents().get(1).getEventInfo().get("TASK_TYPE"));
+      assertEquals(t.taskID.toString(), tEntity.getEntityId());
+      assertEquals(2, tEntity.getEvents().size());
+      assertEquals(EventType.TASK_STARTED.toString(),
+          tEntity.getEvents().get(1).getEventType());
+      assertEquals(TaskType.REDUCE.toString(),
+          tEntity.getEvents().get(0).getEventInfo().get("TASK_TYPE"));
+      assertEquals(TaskType.MAP.toString(),
+          tEntity.getEvents().get(1).getEventInfo().get("TASK_TYPE"));
     }
   }
 
-  @Test (timeout=50000)
-  public void testCountersToJSON() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testCountersToJSON() throws Exception {
     JobHistoryEventHandler jheh = new JobHistoryEventHandler(null, 0);
     Counters counters = new Counters();
     CounterGroup group1 = counters.addGroup("DOCTORS",
-            "Incarnations of the Doctor");
+        "Incarnations of the Doctor");
     group1.addCounter("PETER_CAPALDI", "Peter Capaldi", 12);
     group1.addCounter("MATT_SMITH", "Matt Smith", 11);
     group1.addCounter("DAVID_TENNANT", "David Tennant", 10);
     CounterGroup group2 = counters.addGroup("COMPANIONS",
-            "Companions of the Doctor");
+        "Companions of the Doctor");
     group2.addCounter("CLARA_OSWALD", "Clara Oswald", 6);
     group2.addCounter("RORY_WILLIAMS", "Rory Williams", 5);
     group2.addCounter("AMY_POND", "Amy Pond", 4);
@@ -775,30 +783,31 @@ public class TestJobHistoryEventHandler {
         + "{\"NAME\":\"MATT_SMITH\",\"DISPLAY_NAME\":\"Matt Smith\",\"VALUE\":"
         + "11},{\"NAME\":\"PETER_CAPALDI\",\"DISPLAY_NAME\":\"Peter Capaldi\","
         + "\"VALUE\":12}]}]";
-    Assert.assertEquals(expected, jsonStr);
+    assertEquals(expected, jsonStr);
   }
 
-  @Test (timeout=50000)
-  public void testCountersToJSONEmpty() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testCountersToJSONEmpty() throws Exception {
     JobHistoryEventHandler jheh = new JobHistoryEventHandler(null, 0);
     Counters counters = null;
     JsonNode jsonNode = JobHistoryEventUtils.countersToJSON(counters);
     String jsonStr = new ObjectMapper().writeValueAsString(jsonNode);
     String expected = "[]";
-    Assert.assertEquals(expected, jsonStr);
+    assertEquals(expected, jsonStr);
 
     counters = new Counters();
     jsonNode = JobHistoryEventUtils.countersToJSON(counters);
     jsonStr = new ObjectMapper().writeValueAsString(jsonNode);
     expected = "[]";
-    Assert.assertEquals(expected, jsonStr);
+    assertEquals(expected, jsonStr);
 
     counters.addGroup("DOCTORS", "Incarnations of the Doctor");
     jsonNode = JobHistoryEventUtils.countersToJSON(counters);
     jsonStr = new ObjectMapper().writeValueAsString(jsonNode);
     expected = "[{\"NAME\":\"DOCTORS\",\"DISPLAY_NAME\":\"Incarnations of the "
         + "Doctor\",\"COUNTERS\":[]}]";
-    Assert.assertEquals(expected, jsonStr);
+    assertEquals(expected, jsonStr);
   }
 
   private void queueEvent(JHEvenHandlerForTest jheh, JobHistoryEvent event) {
@@ -888,17 +897,17 @@ public class TestJobHistoryEventHandler {
     return new JobHistoryEvent(jobId, toReturn);
   }
 
-  @Test
   /**
    * Tests that in case of SIGTERM, the JHEH stops without processing its event
    * queue (because we must stop quickly lest we get SIGKILLed) and processes
    * a JobUnsuccessfulEvent for jobs which were still running (so that they may
    * show up in the JobHistoryServer)
    */
-  public void testSigTermedFunctionality() throws IOException {
+  @Test
+  void testSigTermedFunctionality() throws IOException {
     AppContext mockedContext = Mockito.mock(AppContext.class);
     JHEventHandlerForSigtermTest jheh =
-      new JHEventHandlerForSigtermTest(mockedContext, 0);
+        new JHEventHandlerForSigtermTest(mockedContext, 0);
 
     JobId jobId = Mockito.mock(JobId.class);
     jheh.addToFileMap(jobId);
@@ -906,14 +915,14 @@ public class TestJobHistoryEventHandler {
     //Submit 4 events and check that they're handled in the absence of a signal
     final int numEvents = 4;
     JobHistoryEvent events[] = new JobHistoryEvent[numEvents];
-    for(int i=0; i < numEvents; ++i) {
+    for (int i = 0; i < numEvents; ++i) {
       events[i] = getEventToEnqueue(jobId);
       jheh.handle(events[i]);
     }
     jheh.stop();
     //Make sure events were handled
-    assertTrue("handleEvent should've been called only 4 times but was "
-      + jheh.eventsHandled, jheh.eventsHandled == 4);
+    assertTrue(jheh.eventsHandled == 4, "handleEvent should've been called only 4 times but was "
+        + jheh.eventsHandled);
 
     //Create a new jheh because the last stop closed the eventWriter etc.
     jheh = new JHEventHandlerForSigtermTest(mockedContext, 0);
@@ -928,21 +937,22 @@ public class TestJobHistoryEventHandler {
 
     jheh.addToFileMap(jobId);
     jheh.setForcejobCompletion(true);
-    for(int i=0; i < numEvents; ++i) {
+    for (int i = 0; i < numEvents; ++i) {
       events[i] = getEventToEnqueue(jobId);
       jheh.handle(events[i]);
     }
     jheh.stop();
     //Make sure events were handled, 4 + 1 finish event
-    assertTrue("handleEvent should've been called only 5 times but was "
-        + jheh.eventsHandled, jheh.eventsHandled == 5);
-    assertTrue("Last event handled wasn't JobUnsuccessfulCompletionEvent",
-        jheh.lastEventHandled.getHistoryEvent()
-        instanceof JobUnsuccessfulCompletionEvent);
+    assertTrue(jheh.eventsHandled == 5, "handleEvent should've been called only 5 times but was "
+        + jheh.eventsHandled);
+    assertTrue(jheh.lastEventHandled.getHistoryEvent()
+            instanceof JobUnsuccessfulCompletionEvent,
+        "Last event handled wasn't JobUnsuccessfulCompletionEvent");
   }
 
-  @Test (timeout=50000)
-  public void testSetTrackingURLAfterHistoryIsWritten() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testSetTrackingURLAfterHistoryIsWritten() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -972,8 +982,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test (timeout=50000)
-  public void testDontSetTrackingURLIfHistoryWriteFailed() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testDontSetTrackingURLIfHistoryWriteFailed() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -1003,8 +1014,10 @@ public class TestJobHistoryEventHandler {
       jheh.stop();
     }
   }
-  @Test (timeout=50000)
-  public void testDontSetTrackingURLIfHistoryWriteThrows() throws Exception {
+
+  @Test
+  @Timeout(50000)
+  void testDontSetTrackingURLIfHistoryWriteThrows() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
 
@@ -1039,8 +1052,9 @@ public class TestJobHistoryEventHandler {
     }
   }
 
-  @Test(timeout = 50000)
-  public void testJobHistoryFilePermissions() throws Exception {
+  @Test
+  @Timeout(50000)
+  void testJobHistoryFilePermissions() throws Exception {
     TestParams t = new TestParams(true);
     Configuration conf = new Configuration();
     String setFilePermission = "777";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobSummary.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobSummary.java
@@ -19,12 +19,13 @@
 package org.apache.hadoop.mapreduce.jobhistory;
 
 import org.apache.hadoop.mapreduce.v2.api.records.JobId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +35,7 @@ public class TestJobSummary {
       LoggerFactory.getLogger(TestJobSummary.class);
   private JobSummary summary = new JobSummary();
 
-  @Before
+  @BeforeEach
   public void before() {
     JobId mockJobId = mock(JobId.class);
     when(mockJobId.toString()).thenReturn("testJobId");
@@ -59,13 +60,13 @@ public class TestJobSummary {
   }
 
   @Test
-  public void testEscapeJobSummary() {
+  void testEscapeJobSummary() {
     // verify newlines are escaped
     summary.setJobName("aa\rbb\ncc\r\ndd");
     String out = summary.getJobSummaryString();
     LOG.info("summary: " + out);
-    Assert.assertFalse(out.contains("\r"));
-    Assert.assertFalse(out.contains("\n"));
-    Assert.assertTrue(out.contains("aa\\rbb\\ncc\\r\\ndd"));
+    assertFalse(out.contains("\r"));
+    assertFalse(out.contains("\n"));
+    assertTrue(out.contains("aa\\rbb\\ncc\\r\\ndd"));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskAttemptReport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskAttemptReport.java
@@ -24,17 +24,15 @@ import org.apache.hadoop.mapreduce.v2.app.MockJobs;
 import org.apache.hadoop.mapreduce.v2.proto.MRProtos;
 import org.apache.hadoop.yarn.util.Records;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTaskAttemptReport {
 
   @Test
-  public void testSetRawCounters() {
+  void testSetRawCounters() {
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     report.setRawCounters(rCounters);
@@ -43,7 +41,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testBuildImplicitRawCounters() {
+  void testBuildImplicitRawCounters() {
     TaskAttemptReportPBImpl report = new TaskAttemptReportPBImpl();
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     report.setRawCounters(rCounters);
@@ -53,7 +51,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testCountersOverRawCounters() {
+  void testCountersOverRawCounters() {
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
     Counters altCounters = TypeConverter.toYarn(rCounters);
@@ -66,7 +64,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testUninitializedCounters() {
+  void testUninitializedCounters() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Verify properties initialized to null
@@ -75,7 +73,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetRawCountersToNull() {
+  void testSetRawCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters to null
@@ -87,7 +85,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetCountersToNull() {
+  void testSetCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters to null
@@ -98,7 +96,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetNonNullCountersToNull() {
+  void testSetNonNullCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters
@@ -114,7 +112,7 @@ public class TestTaskAttemptReport {
   }
 
   @Test
-  public void testSetNonNullRawCountersToNull() {
+  void testSetNonNullRawCountersToNull() {
     // Create basic class
     TaskAttemptReport report = Records.newRecord(TaskAttemptReport.class);
     // Set raw counters

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskReport.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/api/records/TestTaskReport.java
@@ -24,17 +24,15 @@ import org.apache.hadoop.mapreduce.v2.app.MockJobs;
 import org.apache.hadoop.mapreduce.v2.proto.MRProtos;
 import org.apache.hadoop.yarn.util.Records;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTaskReport {
 
   @Test
-  public void testSetRawCounters() {
+  void testSetRawCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -46,7 +44,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testBuildImplicitRawCounters() {
+  void testBuildImplicitRawCounters() {
     // Create basic class
     TaskReportPBImpl report = new TaskReportPBImpl();
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -58,7 +56,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testCountersOverRawCounters() {
+  void testCountersOverRawCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     org.apache.hadoop.mapreduce.Counters rCounters = MockJobs.newCounters();
@@ -75,7 +73,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testUninitializedCounters() {
+  void testUninitializedCounters() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Verify properties initialized to null
@@ -84,7 +82,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetRawCountersToNull() {
+  void testSetRawCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters to null
@@ -96,7 +94,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetCountersToNull() {
+  void testSetCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters to null
@@ -107,7 +105,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetNonNullCountersToNull() {
+  void testSetNonNullCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters
@@ -123,7 +121,7 @@ public class TestTaskReport {
   }
 
   @Test
-  public void testSetNonNullRawCountersToNull() {
+  void testSetNonNullRawCountersToNull() {
     // Create basic class
     TaskReport report = Records.newRecord(TaskReport.class);
     // Set raw counters

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -98,7 +101,6 @@ import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -326,8 +328,7 @@ public class MRApp extends MRAppMaster {
       iState = job.getInternalState();
     }
     LOG.info("Job {} Internal State is : {}", job.getID(), iState);
-    Assert.assertEquals("Task Internal state is not correct (timedout)",
-        finalState, iState);
+    assertEquals(finalState, iState, "Task Internal state is not correct (timedout)");
   }
 
   public void waitForInternalState(TaskImpl task,
@@ -339,8 +340,7 @@ public class MRApp extends MRAppMaster {
       iState = task.getInternalState();
     }
     LOG.info("Task {} Internal State is : {}", task.getID(), iState);
-    Assert.assertEquals("Task Internal state is not correct (timedout)",
-        finalState, iState);
+    assertEquals(finalState, iState, "Task Internal state is not correct (timedout)");
   }
 
   public void waitForInternalState(TaskAttemptImpl attempt,
@@ -352,8 +352,7 @@ public class MRApp extends MRAppMaster {
       iState = attempt.getInternalState();
     }
     LOG.info("TaskAttempt {} Internal State is : {}", attempt.getID(), iState);
-    Assert.assertEquals("TaskAttempt Internal state is not correct (timedout)",
-        finalState, iState);
+    assertEquals(finalState, iState, "TaskAttempt Internal state is not correct (timedout)");
   }
 
   public void waitForState(TaskAttempt attempt, 
@@ -367,9 +366,9 @@ public class MRApp extends MRAppMaster {
     }
     LOG.info("TaskAttempt {} State is : {}", attempt.getID(),
         report.getTaskAttemptState());
-    Assert.assertEquals("TaskAttempt state is not correct (timedout)",
-        finalState,
-        report.getTaskAttemptState());
+    assertEquals(finalState,
+        report.getTaskAttemptState(),
+        "TaskAttempt state is not correct (timedout)");
   }
 
   public void waitForState(Task task, TaskState finalState) throws Exception {
@@ -381,8 +380,9 @@ public class MRApp extends MRAppMaster {
       report = task.getReport();
     }
     LOG.info("Task {} State is : {}", task.getID(), report.getTaskState());
-    Assert.assertEquals("Task state is not correct (timedout)", finalState,
-        report.getTaskState());
+    assertEquals(finalState,
+        report.getTaskState(),
+        "Task state is not correct (timedout)");
   }
 
   public void waitForState(Job job, JobState finalState) throws Exception {
@@ -394,14 +394,15 @@ public class MRApp extends MRAppMaster {
       Thread.sleep(WAIT_FOR_STATE_INTERVAL);
     }
     LOG.info("Job {} State is : {}", job.getID(), report.getJobState());
-    Assert.assertEquals("Job state is not correct (timedout)", finalState, 
-        job.getState());
+    assertEquals(finalState, 
+        job.getState(), 
+        "Job state is not correct (timedout)");
   }
 
   public void waitForState(Service.STATE finalState) throws Exception {
     if (finalState == Service.STATE.STOPPED) {
-       Assert.assertTrue("Timeout while waiting for MRApp to stop",
-           waitForServiceToStop(20 * 1000));
+       assertTrue(waitForServiceToStop(20 * 1000),
+           "Timeout while waiting for MRApp to stop");
     } else {
       int timeoutSecs = 0;
       while (!finalState.equals(getServiceState())
@@ -409,8 +410,9 @@ public class MRApp extends MRAppMaster {
         Thread.sleep(WAIT_FOR_STATE_INTERVAL);
       }
       LOG.info("MRApp State is : {}", getServiceState());
-      Assert.assertEquals("MRApp state is not correct (timedout)", finalState,
-          getServiceState());
+      assertEquals(finalState,
+          getServiceState(),
+          "MRApp state is not correct (timedout)");
     }
   }
 
@@ -419,22 +421,22 @@ public class MRApp extends MRAppMaster {
       JobReport jobReport = job.getReport();
       LOG.info("Job start time :{}", jobReport.getStartTime());
       LOG.info("Job finish time :", jobReport.getFinishTime());
-      Assert.assertTrue("Job start time is not less than finish time",
-          jobReport.getStartTime() <= jobReport.getFinishTime());
-      Assert.assertTrue("Job finish time is in future",
-          jobReport.getFinishTime() <= System.currentTimeMillis());
+      assertTrue(jobReport.getStartTime() <= jobReport.getFinishTime(),
+          "Job start time is not less than finish time");
+      assertTrue(jobReport.getFinishTime() <= System.currentTimeMillis(),
+          "Job finish time is in future");
       for (Task task : job.getTasks().values()) {
         TaskReport taskReport = task.getReport();
         LOG.info("Task {} start time : {}", task.getID(),
             taskReport.getStartTime());
         LOG.info("Task {} finish time : {}", task.getID(),
             taskReport.getFinishTime());
-        Assert.assertTrue("Task start time is not less than finish time",
-            taskReport.getStartTime() <= taskReport.getFinishTime());
+        assertTrue(taskReport.getStartTime() <= taskReport.getFinishTime(),
+            "Task start time is not less than finish time");
         for (TaskAttempt attempt : task.getAttempts().values()) {
           TaskAttemptReport attemptReport = attempt.getReport();
-          Assert.assertTrue("Attempt start time is not less than finish time",
-              attemptReport.getStartTime() <= attemptReport.getFinishTime());
+          assertTrue(attemptReport.getStartTime() <= attemptReport.getFinishTime(),
+              "Attempt start time is not less than finish time");
         }
       }
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRAppBenchmark.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRAppBenchmark.java
@@ -56,7 +56,8 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 public class MRAppBenchmark {
@@ -196,12 +197,13 @@ public class MRAppBenchmark {
     }
   }
 
-  @Test(timeout = 60000)
-  public void benchmark1() throws Exception {
+  @Test
+  @Timeout(60000)
+  void benchmark1() throws Exception {
     int maps = 100; // Adjust for benchmarking. Start with thousands.
     int reduces = 0;
-    System.out.println("Running benchmark with maps:"+maps +
-        " reduces:"+reduces);
+    System.out.println("Running benchmark with maps:" + maps +
+        " reduces:" + reduces);
     run(new MRApp(maps, reduces, true, this.getClass().getName(), true) {
 
       @Override
@@ -215,14 +217,13 @@ public class MRAppBenchmark {
             return new ApplicationMasterProtocol() {
 
               @Override
-              public RegisterApplicationMasterResponse
-                  registerApplicationMaster(
-                      RegisterApplicationMasterRequest request)
-                      throws IOException {
+              public RegisterApplicationMasterResponse registerApplicationMaster(
+                  RegisterApplicationMasterRequest request)
+                  throws IOException {
                 RegisterApplicationMasterResponse response =
                     Records.newRecord(RegisterApplicationMasterResponse.class);
                 response.setMaximumResourceCapability(Resource.newInstance(
-                  10240, 1));
+                    10240, 1));
                 response.setQueue("queue1");
                 return response;
               }
@@ -252,8 +253,8 @@ public class MRAppBenchmark {
                   for (int i = 0; i < numContainers; i++) {
                     ContainerId containerId =
                         ContainerId.newContainerId(
-                          getContext().getApplicationAttemptId(),
-                          request.getResponseId() + i);
+                            getContext().getApplicationAttemptId(),
+                            request.getResponseId() + i);
                     containers.add(Container.newInstance(containerId,
                         NodeId.newInstance(
                             "host" + containerId.getContainerId(), 2345),
@@ -275,12 +276,13 @@ public class MRAppBenchmark {
     });
   }
 
-  @Test(timeout = 60000)
-  public void benchmark2() throws Exception {
+  @Test
+  @Timeout(60000)
+  void benchmark2() throws Exception {
     int maps = 100; // Adjust for benchmarking, start with a couple of thousands
     int reduces = 50;
     int maxConcurrentRunningTasks = 500;
-    
+
     System.out.println("Running benchmark with throttled running tasks with " +
         "maxConcurrentRunningTasks:" + maxConcurrentRunningTasks +
         " maps:" + maps + " reduces:" + reduces);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestAMInfos.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestAMInfos.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Iterator;
 import java.util.List;
-
-import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -33,16 +33,16 @@ import org.apache.hadoop.mapreduce.v2.app.TestRecovery.MRAppWithHistory;
 import org.apache.hadoop.mapreduce.v2.app.job.Job;
 import org.apache.hadoop.mapreduce.v2.app.job.Task;
 import org.apache.hadoop.mapreduce.v2.app.job.TaskAttempt;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestAMInfos {
 
   @Test
-  public void testAMInfosWithoutRecoveryEnabled() throws Exception {
+  void testAMInfosWithoutRecoveryEnabled() throws Exception {
     int runCount = 0;
     MRApp app =
         new MRAppWithHistory(1, 0, false, this.getClass().getName(), true,
-          ++runCount);
+            ++runCount);
     Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
     Job job = app.submit(conf);
@@ -50,7 +50,7 @@ public class TestAMInfos {
 
     long am1StartTime = app.getAllAMInfos().get(0).getStartTime();
 
-    Assert.assertEquals("No of tasks not correct", 1, job.getTasks().size());
+    assertEquals(1, job.getTasks().size(), "No of tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask = it.next();
     app.waitForState(mapTask, TaskState.RUNNING);
@@ -63,7 +63,7 @@ public class TestAMInfos {
     // rerun
     app =
         new MRAppWithHistory(1, 0, false, this.getClass().getName(), false,
-          ++runCount);
+            ++runCount);
     conf = new Configuration();
     // in rerun the AMInfo will be recovered from previous run even if recovery
     // is not enabled.
@@ -71,14 +71,14 @@ public class TestAMInfos {
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
     job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 1, job.getTasks().size());
+    assertEquals(1, job.getTasks().size(), "No of tasks not correct");
     it = job.getTasks().values().iterator();
     mapTask = it.next();
     // There should be two AMInfos
     List<AMInfo> amInfos = app.getAllAMInfos();
-    Assert.assertEquals(2, amInfos.size());
+    assertEquals(2, amInfos.size());
     AMInfo amInfoOne = amInfos.get(0);
-    Assert.assertEquals(am1StartTime, amInfoOne.getStartTime());
+    assertEquals(am1StartTime, amInfoOne.getStartTime());
     app.stop();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestCheckpointPreemptionPolicy.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestCheckpointPreemptionPolicy.java
@@ -22,8 +22,9 @@ import org.apache.hadoop.yarn.api.records.PreemptionMessage;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,8 +59,8 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Allocation;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCheckpointPreemptionPolicy {
 
@@ -77,7 +78,7 @@ public class TestCheckpointPreemptionPolicy {
 
   private int minAlloc = 1024;
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("rawtypes") // mocked generics
   public void setup() {
     ApplicationId appId = ApplicationId.newInstance(200, 1);
@@ -110,9 +111,9 @@ public class TestCheckpointPreemptionPolicy {
   }
 
   @Test
-  public void testStrictPreemptionContract() {
+  void testStrictPreemptionContract() {
 
-    final Map<ContainerId,TaskAttemptId> containers = assignedContainers;
+    final Map<ContainerId, TaskAttemptId> containers = assignedContainers;
     AMPreemptionPolicy.Context mPctxt = new AMPreemptionPolicy.Context() {
       @Override
       public TaskAttemptId getTaskAttempt(ContainerId cId) {
@@ -121,7 +122,7 @@ public class TestCheckpointPreemptionPolicy {
       @Override
       public List<Container> getContainers(TaskType t) {
         List<Container> p = new ArrayList<Container>();
-        for (Map.Entry<ContainerId,TaskAttemptId> ent :
+        for (Map.Entry<ContainerId, TaskAttemptId> ent :
             assignedContainers.entrySet()) {
           if (ent.getValue().getTaskId().getTaskType().equals(t)) {
             p.add(Container.newInstance(ent.getKey(), null, null,
@@ -153,8 +154,8 @@ public class TestCheckpointPreemptionPolicy {
 
 
   @Test
-  public void testPreemptionContract() {
-    final Map<ContainerId,TaskAttemptId> containers = assignedContainers;
+  void testPreemptionContract() {
+    final Map<ContainerId, TaskAttemptId> containers = assignedContainers;
     AMPreemptionPolicy.Context mPctxt = new AMPreemptionPolicy.Context() {
       @Override
       public TaskAttemptId getTaskAttempt(ContainerId cId) {
@@ -164,9 +165,9 @@ public class TestCheckpointPreemptionPolicy {
       @Override
       public List<Container> getContainers(TaskType t) {
         List<Container> p = new ArrayList<Container>();
-        for (Map.Entry<ContainerId,TaskAttemptId> ent :
-            assignedContainers.entrySet()){
-          if(ent.getValue().getTaskId().getTaskType().equals(t)){
+        for (Map.Entry<ContainerId, TaskAttemptId> ent :
+            assignedContainers.entrySet()) {
+          if (ent.getValue().getTaskId().getTaskType().equals(t)) {
             p.add(Container.newInstance(ent.getKey(), null, null,
                 contToResourceMap.get(ent.getKey()),
                 Priority.newInstance(0), null));
@@ -190,12 +191,12 @@ public class TestCheckpointPreemptionPolicy {
     // first round of preemption
     policy.preempt(mPctxt, pM);
     List<TaskAttemptId> preempting =
-      validatePreemption(pM, policy, supposedMemPreemption);
+        validatePreemption(pM, policy, supposedMemPreemption);
 
     // redundant message
     policy.preempt(mPctxt, pM);
     List<TaskAttemptId> preempting2 =
-      validatePreemption(pM, policy, supposedMemPreemption);
+        validatePreemption(pM, policy, supposedMemPreemption);
 
     // check that nothing got added
     assert preempting2.equals(preempting);
@@ -205,12 +206,12 @@ public class TestCheckpointPreemptionPolicy {
     policy.handleCompletedContainer(preempting.get(1));
 
     // remove from assignedContainers
-    Iterator<Map.Entry<ContainerId,TaskAttemptId>> it =
-      assignedContainers.entrySet().iterator();
+    Iterator<Map.Entry<ContainerId, TaskAttemptId>> it =
+        assignedContainers.entrySet().iterator();
     while (it.hasNext()) {
-      Map.Entry<ContainerId,TaskAttemptId> ent = it.next();
+      Map.Entry<ContainerId, TaskAttemptId> ent = it.next();
       if (ent.getValue().equals(preempting.get(0)) ||
-        ent.getValue().equals(preempting.get(1)))
+          ent.getValue().equals(preempting.get(1)))
         it.remove();
     }
 
@@ -219,7 +220,7 @@ public class TestCheckpointPreemptionPolicy {
 
     // triggers preemption of 2 more containers (i.e., the preemption set changes)
     List<TaskAttemptId> preempting3 =
-      validatePreemption(pM, policy, supposedMemPreemption);
+        validatePreemption(pM, policy, supposedMemPreemption);
     assert preempting3.equals(preempting2) == false;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -59,8 +60,7 @@ import org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMHeartbeatHandler;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests job end notification
@@ -74,18 +74,18 @@ public class TestJobEndNotifier extends JobEndNotifier {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "0");
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "10");
     setConf(conf);
-    Assert.assertTrue("Expected numTries to be 0, but was " + numTries,
-      numTries == 0 );
+    assertTrue(numTries == 0 ,
+      "Expected numTries to be 0, but was " + numTries);
 
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "1");
     setConf(conf);
-    Assert.assertTrue("Expected numTries to be 1, but was " + numTries,
-      numTries == 1 );
+    assertTrue(numTries == 1 ,
+      "Expected numTries to be 1, but was " + numTries);
 
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "20");
     setConf(conf);
-    Assert.assertTrue("Expected numTries to be 11, but was " + numTries,
-      numTries == 11 ); //11 because number of _retries_ is 10
+    assertTrue(numTries == 11 ,
+      "Expected numTries to be 11, but was " + numTries); //11 because number of _retries_ is 10
   }
 
   //Test maximum retry interval is capped by
@@ -94,53 +94,49 @@ public class TestJobEndNotifier extends JobEndNotifier {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_RETRY_INTERVAL, "5000");
     conf.set(MRJobConfig.MR_JOB_END_RETRY_INTERVAL, "1000");
     setConf(conf);
-    Assert.assertTrue("Expected waitInterval to be 1000, but was "
-      + waitInterval, waitInterval == 1000);
+    assertTrue(waitInterval == 1000, "Expected waitInterval to be 1000, but was "
+      + waitInterval);
 
     conf.set(MRJobConfig.MR_JOB_END_RETRY_INTERVAL, "10000");
     setConf(conf);
-    Assert.assertTrue("Expected waitInterval to be 5000, but was "
-      + waitInterval, waitInterval == 5000);
+    assertTrue(waitInterval == 5000, "Expected waitInterval to be 5000, but was "
+      + waitInterval);
 
     //Test negative numbers are set to default
     conf.set(MRJobConfig.MR_JOB_END_RETRY_INTERVAL, "-10");
     setConf(conf);
-    Assert.assertTrue("Expected waitInterval to be 5000, but was "
-      + waitInterval, waitInterval == 5000);
+    assertTrue(waitInterval == 5000, "Expected waitInterval to be 5000, but was "
+      + waitInterval);
   }
 
   private void testTimeout(Configuration conf) {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_TIMEOUT, "1000");
     setConf(conf);
-    Assert.assertTrue("Expected timeout to be 1000, but was "
-      + timeout, timeout == 1000);
+    assertTrue(timeout == 1000, "Expected timeout to be 1000, but was "
+      + timeout);
   }
 
   private void testProxyConfiguration(Configuration conf) {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost");
     setConf(conf);
-    Assert.assertTrue("Proxy shouldn't be set because port wasn't specified",
-      proxyToUse.type() == Proxy.Type.DIRECT);
+    assertTrue(proxyToUse.type() == Proxy.Type.DIRECT,
+      "Proxy shouldn't be set because port wasn't specified");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost:someport");
     setConf(conf);
-    Assert.assertTrue("Proxy shouldn't be set because port wasn't numeric",
-      proxyToUse.type() == Proxy.Type.DIRECT);
+    assertTrue(proxyToUse.type() == Proxy.Type.DIRECT,
+      "Proxy shouldn't be set because port wasn't numeric");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been set but wasn't ",
-      "HTTP @ somehost:1000", proxyToUse.toString());
+    assertEquals("HTTP @ somehost:1000", proxyToUse.toString(), "Proxy should have been set but wasn't ");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "socks@somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been socks but wasn't ",
-      "SOCKS @ somehost:1000", proxyToUse.toString());
+    assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(), "Proxy should have been socks but wasn't ");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "SOCKS@somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been socks but wasn't ",
-      "SOCKS @ somehost:1000", proxyToUse.toString());
+    assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(), "Proxy should have been socks but wasn't ");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "sfafn@somehost:1000");
     setConf(conf);
-    Assert.assertEquals("Proxy should have been http but wasn't ",
-      "HTTP @ somehost:1000", proxyToUse.toString());
+    assertEquals("HTTP @ somehost:1000", proxyToUse.toString(), "Proxy should have been http but wasn't ");
     
   }
 
@@ -148,7 +144,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
    * Test that setting parameters has the desired effect
    */
   @Test
-  public void checkConfiguration() {
+  void checkConfiguration() {
     Configuration conf = new Configuration();
     testNumRetries(conf);
     testWaitInterval(conf);
@@ -166,7 +162,7 @@ public class TestJobEndNotifier extends JobEndNotifier {
 
   //Check retries happen as intended
   @Test
-  public void testNotifyRetries() throws InterruptedException {
+  void testNotifyRetries() throws InterruptedException {
     JobConf conf = new JobConf();
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "0");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "1");
@@ -175,16 +171,16 @@ public class TestJobEndNotifier extends JobEndNotifier {
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_RETRY_INTERVAL, "5000");
 
     JobReport jobReport = mock(JobReport.class);
- 
+
     long startTime = System.currentTimeMillis();
     this.notificationCount = 0;
     this.setConf(conf);
     this.notify(jobReport);
     long endTime = System.currentTimeMillis();
-    Assert.assertEquals("Only 1 try was expected but was : "
-      + this.notificationCount, 1, this.notificationCount);
-    Assert.assertTrue("Should have taken more than 5 seconds it took "
-      + (endTime - startTime), endTime - startTime > 5000);
+    assertEquals(1, this.notificationCount, "Only 1 try was expected but was : "
+        + this.notificationCount);
+    assertTrue(endTime - startTime > 5000, "Should have taken more than 5 seconds it took "
+        + (endTime - startTime));
 
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_MAX_ATTEMPTS, "3");
     conf.set(MRJobConfig.MR_JOB_END_RETRY_ATTEMPTS, "3");
@@ -196,10 +192,10 @@ public class TestJobEndNotifier extends JobEndNotifier {
     this.setConf(conf);
     this.notify(jobReport);
     endTime = System.currentTimeMillis();
-    Assert.assertEquals("Only 3 retries were expected but was : "
-      + this.notificationCount, 3, this.notificationCount);
-    Assert.assertTrue("Should have taken more than 9 seconds it took "
-      + (endTime - startTime), endTime - startTime > 9000);
+    assertEquals(3, this.notificationCount, "Only 3 retries were expected but was : "
+        + this.notificationCount);
+    assertTrue(endTime - startTime > 9000, "Should have taken more than 9 seconds it took "
+        + (endTime - startTime));
 
   }
 
@@ -222,28 +218,28 @@ public class TestJobEndNotifier extends JobEndNotifier {
       doThrow(runtimeException).when(app).stop();
     }
     app.shutDownJob();
-    Assert.assertTrue(app.isLastAMRetry());
-    Assert.assertEquals(1, JobEndServlet.calledTimes);
-    Assert.assertEquals("jobid=" + job.getID() + "&status=SUCCEEDED",
+    assertTrue(app.isLastAMRetry());
+    assertEquals(1, JobEndServlet.calledTimes);
+    assertEquals("jobid=" + job.getID() + "&status=SUCCEEDED",
         JobEndServlet.requestUri.getQuery());
-    Assert.assertEquals(JobState.SUCCEEDED.toString(),
+    assertEquals(JobState.SUCCEEDED.toString(),
         JobEndServlet.foundJobState);
     server.stop();
   }
 
   @Test
-  public void testNotificationOnLastRetryNormalShutdown() throws Exception {
+  void testNotificationOnLastRetryNormalShutdown() throws Exception {
     testNotificationOnLastRetry(false);
   }
 
   @Test
-  public void testNotificationOnLastRetryShutdownWithRuntimeException()
+  void testNotificationOnLastRetryShutdownWithRuntimeException()
       throws Exception {
     testNotificationOnLastRetry(true);
   }
 
   @Test
-  public void testAbsentNotificationOnNotLastRetryUnregistrationFailure()
+  void testAbsentNotificationOnNotLastRetryUnregistrationFailure()
       throws Exception {
     HttpServer2 server = startHttpServer();
     MRApp app = spy(new MRAppWithCustomContainerAllocator(2, 2, false,
@@ -252,25 +248,25 @@ public class TestJobEndNotifier extends JobEndNotifier {
     JobConf conf = new JobConf();
     conf.set(JobContext.MR_JOB_END_NOTIFICATION_URL,
         JobEndServlet.baseUrl + "jobend?jobid=$jobId&status=$jobStatus");
-    JobImpl job = (JobImpl)app.submit(conf);
+    JobImpl job = (JobImpl) app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     app.getContext().getEventHandler()
-      .handle(new JobEvent(app.getJobId(), JobEventType.JOB_AM_REBOOT));
+        .handle(new JobEvent(app.getJobId(), JobEventType.JOB_AM_REBOOT));
     app.waitForInternalState(job, JobStateInternal.REBOOT);
     // Now shutdown.
     // Unregistration fails: isLastAMRetry is recalculated, this is not
     app.shutDownJob();
     // Not the last AM attempt. So user should that the job is still running.
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertFalse(app.isLastAMRetry());
-    Assert.assertEquals(0, JobEndServlet.calledTimes);
-    Assert.assertNull(JobEndServlet.requestUri);
-    Assert.assertNull(JobEndServlet.foundJobState);
+    assertFalse(app.isLastAMRetry());
+    assertEquals(0, JobEndServlet.calledTimes);
+    assertNull(JobEndServlet.requestUri);
+    assertNull(JobEndServlet.foundJobState);
     server.stop();
   }
 
   @Test
-  public void testNotificationOnLastRetryUnregistrationFailure()
+  void testNotificationOnLastRetryUnregistrationFailure()
       throws Exception {
     HttpServer2 server = startHttpServer();
     MRApp app = spy(new MRAppWithCustomContainerAllocator(2, 2, false,
@@ -285,30 +281,30 @@ public class TestJobEndNotifier extends JobEndNotifier {
     JobConf conf = new JobConf();
     conf.set(JobContext.MR_JOB_END_NOTIFICATION_URL,
         JobEndServlet.baseUrl + "jobend?jobid=$jobId&status=$jobStatus");
-    JobImpl job = (JobImpl)app.submit(conf);
+    JobImpl job = (JobImpl) app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     app.getContext().getEventHandler()
-      .handle(new JobEvent(app.getJobId(), JobEventType.JOB_AM_REBOOT));
+        .handle(new JobEvent(app.getJobId(), JobEventType.JOB_AM_REBOOT));
     app.waitForInternalState(job, JobStateInternal.REBOOT);
     // Now shutdown. User should see FAILED state.
     // Unregistration fails: isLastAMRetry is recalculated, this is
     ///reboot will stop service internally, we don't need to shutdown twice
     app.waitForServiceToStop(10000);
-    Assert.assertFalse(app.isLastAMRetry());
+    assertFalse(app.isLastAMRetry());
     // Since it's not last retry, JobEndServlet didn't called
-    Assert.assertEquals(0, JobEndServlet.calledTimes);
-    Assert.assertNull(JobEndServlet.requestUri);
-    Assert.assertNull(JobEndServlet.foundJobState);
+    assertEquals(0, JobEndServlet.calledTimes);
+    assertNull(JobEndServlet.requestUri);
+    assertNull(JobEndServlet.foundJobState);
     server.stop();
   }
 
   @Test
-  public void testCustomNotifierClass() throws InterruptedException {
+  void testCustomNotifierClass() throws InterruptedException {
     JobConf conf = new JobConf();
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_URL,
-             "http://example.com?jobId=$jobId&jobStatus=$jobStatus");
+        "http://example.com?jobId=$jobId&jobStatus=$jobStatus");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_CUSTOM_NOTIFIER_CLASS,
-             CustomNotifier.class.getName());
+        CustomNotifier.class.getName());
     this.setConf(conf);
 
     JobReport jobReport = mock(JobReport.class);
@@ -321,8 +317,8 @@ public class TestJobEndNotifier extends JobEndNotifier {
     this.notify(jobReport);
     final URL urlToNotify = CustomNotifier.urlToNotify;
 
-    Assert.assertEquals("http://example.com?jobId=mock-Id&jobStatus=SUCCEEDED",
-                        urlToNotify.toString());
+    assertEquals("http://example.com?jobId=mock-Id&jobStatus=SUCCEEDED",
+        urlToNotify.toString());
   }
 
   public static final class CustomNotifier implements CustomJobEndNotifier {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKillAMPreemptionPolicy.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestKillAMPreemptionPolicy.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestKillAMPreemptionPolicy {
   private final RecordFactory recordFactory = RecordFactoryProvider
@@ -55,7 +55,7 @@ public class TestKillAMPreemptionPolicy {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testKillAMPreemptPolicy() {
+  void testKillAMPreemptPolicy() {
 
     ApplicationId appId = ApplicationId.newInstance(123456789, 1);
     ContainerId container = ContainerId.newContainerId(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRApp.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import java.util.function.Supplier;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -68,7 +69,7 @@ import org.apache.hadoop.yarn.event.AsyncDispatcher;
 import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -78,35 +79,35 @@ import org.mockito.Mockito;
 public class TestMRApp {
 
   @Test
-  public void testMapReduce() throws Exception {
+  void testMapReduce() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
-    Assert.assertEquals(System.getProperty("user.name"),job.getUserName());
+    assertEquals(System.getProperty("user.name"), job.getUserName());
   }
 
   @Test
-  public void testZeroMaps() throws Exception {
+  void testZeroMaps() throws Exception {
     MRApp app = new MRApp(0, 1, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
   }
-  
+
   @Test
-  public void testZeroMapReduces() throws Exception{
+  void testZeroMapReduces() throws Exception {
     MRApp app = new MRApp(0, 0, true, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
   }
-  
+
   @Test
-  public void testCommitPending() throws Exception {
+  void testCommitPending() throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    assertEquals(1, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -151,7 +152,7 @@ public class TestMRApp {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     //all maps would be running
-    Assert.assertEquals("Num tasks not correct", 3, job.getTasks().size());
+    assertEquals(3, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -170,8 +171,7 @@ public class TestMRApp {
     app.waitForState(task2Attempt, TaskAttemptState.RUNNING);
     
     // reduces must be in NEW state
-    Assert.assertEquals("Reduce Task state not correct",
-        TaskState.NEW, reduceTask.getReport().getTaskState());
+    assertEquals(TaskState.NEW, reduceTask.getReport().getTaskState(), "Reduce Task state not correct");
     
     //send the done signal to the 1st map task
     app.getContext().getEventHandler().handle(
@@ -198,7 +198,7 @@ public class TestMRApp {
     
     app.waitForState(job, JobState.SUCCEEDED);
   }
-  
+
   /**
    * The test verifies that the AM re-runs maps that have run on bad nodes. It
    * also verifies that the AM records all success/killed events so that reduces
@@ -206,7 +206,7 @@ public class TestMRApp {
    * re-run information is preserved across AM restart
    */
   @Test
-  public void testUpdatedNodes() throws Exception {
+  void testUpdatedNodes() throws Exception {
     int runCount = 0;
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(new Configuration());
@@ -224,7 +224,7 @@ public class TestMRApp {
 
     final Job job1 = app.submit(conf);
     app.waitForState(job1, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 4, job1.getTasks().size());
+    assertEquals(4, job1.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job1.getTasks().values().iterator();
     Task mapTask1 = it.next();
     Task mapTask2 = it.next();
@@ -239,7 +239,7 @@ public class TestMRApp {
         .next();
     NodeId node1 = task1Attempt.getNodeId();
     NodeId node2 = task2Attempt.getNodeId();
-    Assert.assertEquals(node1, node2);
+    assertEquals(node1, node2);
 
     // send the done signal to the task
     app.getContext()
@@ -271,8 +271,9 @@ public class TestMRApp {
 
     TaskAttemptCompletionEvent[] events = job1.getTaskAttemptCompletionEvents
         (0, 100);
-    Assert.assertEquals("Expecting 2 completion events for success", 2,
-        events.length);
+    assertEquals(2,
+        events.length,
+        "Expecting 2 completion events for success");
 
     // send updated nodes info
     ArrayList<NodeReport> updatedNodes = new ArrayList<NodeReport>();
@@ -297,8 +298,9 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job1.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 2 more completion events for killed", 4,
-        events.length);
+    assertEquals(4,
+        events.length,
+        "Expecting 2 more completion events for killed");
     // 2 map task attempts which were killed above should be requested from
     // container allocator with the previous map task marked as failed. If
     // this happens allocator will request the container for this mapper from
@@ -335,8 +337,9 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job1.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 1 more completion events for success", 5,
-        events.length);
+    assertEquals(5,
+        events.length,
+        "Expecting 1 more completion events for success");
 
     // Crash the app again.
     app.stop();
@@ -344,14 +347,14 @@ public class TestMRApp {
     // rerun
     // in rerun the 1st map will be recovered from previous run
     app = new MRAppWithHistory(2, 2, false, this.getClass().getName(), false,
-        ++runCount, (Dispatcher)new AsyncDispatcher());
+        ++runCount, (Dispatcher) new AsyncDispatcher());
     conf = new Configuration();
     conf.setBoolean(MRJobConfig.MR_AM_JOB_RECOVERY_ENABLE, true);
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false);
 
     final Job job2 = app.submit(conf);
     app.waitForState(job2, JobState.RUNNING);
-    Assert.assertEquals("No of tasks not correct", 4, job2.getTasks().size());
+    assertEquals(4, job2.getTasks().size(), "No of tasks not correct");
     it = job2.getTasks().values().iterator();
     mapTask1 = it.next();
     mapTask2 = it.next();
@@ -372,9 +375,10 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job2.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals(
-        "Expecting 2 completion events for killed & success of map1", 2,
-        events.length);
+    assertEquals(
+        2,
+        events.length,
+        "Expecting 2 completion events for killed & success of map1");
 
     task2Attempt = mapTask2.getAttempts().values().iterator().next();
     app.getContext()
@@ -394,8 +398,9 @@ public class TestMRApp {
     }, checkIntervalMillis, waitForMillis);
 
     events = job2.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 1 more completion events for success", 3,
-        events.length);
+    assertEquals(3,
+        events.length,
+        "Expecting 1 more completion events for success");
 
     app.waitForState(reduceTask1, TaskState.RUNNING);
     app.waitForState(reduceTask2, TaskState.RUNNING);
@@ -409,12 +414,12 @@ public class TestMRApp {
                 TaskAttemptEventType.TA_DONE));
     app.waitForState(reduceTask1, TaskState.SUCCEEDED);
     app.getContext()
-    .getEventHandler()
-    .handle(
-        new TaskAttemptEvent(task3Attempt.getID(),
-            TaskAttemptEventType.TA_KILL));
+        .getEventHandler()
+        .handle(
+            new TaskAttemptEvent(task3Attempt.getID(),
+                TaskAttemptEventType.TA_KILL));
     app.waitForState(reduceTask1, TaskState.SUCCEEDED);
-    
+
     TaskAttempt task4Attempt = reduceTask2.getAttempts().values().iterator()
         .next();
     app.getContext()
@@ -433,8 +438,7 @@ public class TestMRApp {
       }
     }, checkIntervalMillis, waitForMillis);
     events = job2.getTaskAttemptCompletionEvents(0, 100);
-    Assert.assertEquals("Expecting 2 more completion events for reduce success",
-        5, events.length);
+    assertEquals(5, events.length, "Expecting 2 more completion events for reduce success");
 
     // job succeeds
     app.waitForState(job2, JobState.SUCCEEDED);
@@ -468,11 +472,11 @@ public class TestMRApp {
   }
 
   @Test
-  public void testJobError() throws Exception {
+  void testJobError() throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    assertEquals(1, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
@@ -488,31 +492,31 @@ public class TestMRApp {
 
   @SuppressWarnings("resource")
   @Test
-  public void testJobSuccess() throws Exception {
+  void testJobSuccess() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true, false);
     JobImpl job = (JobImpl) app.submit(new Configuration());
     app.waitForInternalState(job, JobStateInternal.SUCCEEDED);
     // AM is not unregistered
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    assertEquals(JobState.RUNNING, job.getState());
     // imitate that AM is unregistered
     app.successfullyUnregistered.set(true);
     app.waitForState(job, JobState.SUCCEEDED);
   }
 
   @Test
-  public void testJobRebootNotLastRetryOnUnregistrationFailure()
+  void testJobRebootNotLastRetryOnUnregistrationFailure()
       throws Exception {
     MRApp app = new MRApp(1, 0, false, this.getClass().getName(), true);
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    assertEquals(1, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
 
     //send an reboot event
     app.getContext().getEventHandler().handle(new JobEvent(job.getID(),
-      JobEventType.JOB_AM_REBOOT));
+        JobEventType.JOB_AM_REBOOT));
 
     // return exteranl state as RUNNING since otherwise the JobClient will
     // prematurely exit.
@@ -520,7 +524,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void testJobRebootOnLastRetryOnUnregistrationFailure()
+  void testJobRebootOnLastRetryOnUnregistrationFailure()
       throws Exception {
     // make startCount as 2 since this is last retry which equals to
     // DEFAULT_MAX_AM_RETRY
@@ -530,14 +534,14 @@ public class TestMRApp {
     Configuration conf = new Configuration();
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
-    Assert.assertEquals("Num tasks not correct", 1, job.getTasks().size());
+    assertEquals(1, job.getTasks().size(), "Num tasks not correct");
     Iterator<Task> it = job.getTasks().values().iterator();
     Task task = it.next();
     app.waitForState(task, TaskState.RUNNING);
 
     //send an reboot event
     app.getContext().getEventHandler().handle(new JobEvent(job.getID(),
-      JobEventType.JOB_AM_REBOOT));
+        JobEventType.JOB_AM_REBOOT));
 
     app.waitForInternalState((JobImpl) job, JobStateInternal.REBOOT);
     // return exteranl state as RUNNING if this is the last retry while
@@ -563,10 +567,10 @@ public class TestMRApp {
   }
 
   @Test
-  public void testCountersOnJobFinish() throws Exception {
+  void testCountersOnJobFinish() throws Exception {
     MRAppWithSpiedJob app =
         new MRAppWithSpiedJob(1, 1, true, this.getClass().getName(), true);
-    JobImpl job = (JobImpl)app.submit(new Configuration());
+    JobImpl job = (JobImpl) app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
     System.out.println(job.getAllCounters());
@@ -578,7 +582,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void checkJobStateTypeConversion() {
+  void checkJobStateTypeConversion() {
     //verify that all states can be converted without 
     // throwing an exception
     for (JobState state : JobState.values()) {
@@ -587,7 +591,7 @@ public class TestMRApp {
   }
 
   @Test
-  public void checkTaskStateTypeConversion() {
+  void checkTaskStateTypeConversion() {
     //verify that all states can be converted without 
     // throwing an exception
     for (TaskState state : TaskState.values()) {
@@ -596,8 +600,9 @@ public class TestMRApp {
   }
 
   private Container containerObtainedByContainerLauncher;
+
   @Test
-  public void testContainerPassThrough() throws Exception {
+  void testContainerPassThrough() throws Exception {
     MRApp app = new MRApp(0, 1, true, this.getClass().getName(), true) {
       @Override
       protected ContainerLauncher createContainerLauncher(AppContext context) {
@@ -611,7 +616,7 @@ public class TestMRApp {
             super.handle(event);
           }
         };
-      };
+      }
     };
     Job job = app.submit(new Configuration());
     app.waitForState(job, JobState.SUCCEEDED);
@@ -624,8 +629,8 @@ public class TestMRApp {
         (TaskAttemptImpl) taskAttempts.iterator().next();
     // Container from RM should pass through to the launcher. Container object
     // should be the same.
-   Assert.assertTrue(taskAttempt.container 
-     == containerObtainedByContainerLauncher);
+   assertTrue(taskAttempt.container
+        == containerObtainedByContainerLauncher);
   }
 
   private final class MRAppWithHistory extends MRApp {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppComponentDependencies.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppComponentDependencies.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
-import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
+import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.jobhistory.JobHistoryEvent;
@@ -35,12 +35,14 @@ import org.apache.hadoop.mapreduce.v2.app.job.impl.JobImpl;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRAppComponentDependencies {
 
-  @Test(timeout = 20000)
-  public void testComponentStopOrder() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testComponentStopOrder() throws Exception {
     @SuppressWarnings("resource")
     TestMRApp app = new TestMRApp(1, 1, true, this.getClass().getName(), true);
     JobImpl job = (JobImpl) app.submit(new Configuration());
@@ -54,8 +56,8 @@ public class TestMRAppComponentDependencies {
     }
 
     // assert JobHistoryEventHandlerStopped and then clientServiceStopped
-    Assert.assertEquals(1, app.JobHistoryEventHandlerStopped);
-    Assert.assertEquals(2, app.clientServiceStopped);
+    assertEquals(1, app.JobHistoryEventHandlerStopped);
+    assertEquals(2, app.clientServiceStopped);
   }
 
   private final class TestMRApp extends MRApp {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
@@ -18,9 +18,7 @@
 package org.apache.hadoop.mapreduce.v2.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -40,7 +38,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -84,10 +81,11 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
@@ -104,7 +102,7 @@ public class TestMRAppMaster {
   static String stagingDir = new Path(testDir, "staging").toString();
   private static FileContext localFS = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws AccessControlException,
       FileNotFoundException, IllegalArgumentException, IOException {
     //Do not error out if metrics are inited multiple times
@@ -116,7 +114,7 @@ public class TestMRAppMaster {
     new File(testDir.toString()).mkdir();
   }
 
-  @Before
+  @BeforeEach
   public void prepare() throws IOException {
     File dir = new File(stagingDir);
     if(dir.exists()) {
@@ -125,13 +123,13 @@ public class TestMRAppMaster {
     dir.mkdirs();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     localFS.delete(testDir, true);
   }
 
   @Test
-  public void testMRAppMasterForDifferentUser() throws IOException,
+  void testMRAppMasterForDifferentUser() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000001";
     String containerIdStr = "container_1317529182569_0004_000001_1";
@@ -149,11 +147,11 @@ public class TestMRAppMaster {
     Path userPath = new Path(stagingDir, userName);
     Path userStagingPath = new Path(userPath, ".staging");
     assertEquals(userStagingPath.toString(),
-      appMaster.stagingDirPath.toString());
+        appMaster.stagingDirPath.toString());
   }
 
   @Test
-  public void testMRAppMasterMidLock() throws IOException,
+  void testMRAppMasterMidLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -188,11 +186,11 @@ public class TestMRAppMaster {
     appMaster.stop();
 
     // verify the final status is FAILED
-    verifyFailedStatus((MRAppMasterTest)appMaster, "FAILED");
+    verifyFailedStatus((MRAppMasterTest) appMaster, "FAILED");
   }
 
   @Test
-  public void testMRAppMasterJobLaunchTime() throws IOException,
+  void testMRAppMasterJobLaunchTime() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -226,12 +224,12 @@ public class TestMRAppMaster {
             "host", -1, -1, System.currentTimeMillis());
     MRAppMaster.initAndStartAppMaster(appMaster, conf, userName);
     appMaster.stop();
-    assertTrue("Job launch time should not be negative.",
-            appMaster.jobLaunchTime.get() >= 0);
+    assertTrue(appMaster.jobLaunchTime.get() >= 0,
+        "Job launch time should not be negative.");
   }
 
   @Test
-  public void testMRAppMasterSuccessLock() throws IOException,
+  void testMRAppMasterSuccessLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -265,11 +263,11 @@ public class TestMRAppMaster {
     appMaster.stop();
 
     // verify the final status is SUCCEEDED
-    verifyFailedStatus((MRAppMasterTest)appMaster, "SUCCEEDED");
+    verifyFailedStatus((MRAppMasterTest) appMaster, "SUCCEEDED");
   }
 
   @Test
-  public void testMRAppMasterFailLock() throws IOException,
+  void testMRAppMasterFailLock() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -303,11 +301,11 @@ public class TestMRAppMaster {
     appMaster.stop();
 
     // verify the final status is FAILED
-    verifyFailedStatus((MRAppMasterTest)appMaster, "FAILED");
+    verifyFailedStatus((MRAppMasterTest) appMaster, "FAILED");
   }
 
   @Test
-  public void testMRAppMasterMissingStaging() throws IOException,
+  void testMRAppMasterMissingStaging() throws IOException,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -319,7 +317,7 @@ public class TestMRAppMaster {
 
     //Delete the staging directory
     File dir = new File(stagingDir);
-    if(dir.exists()) {
+    if (dir.exists()) {
       FileUtils.deleteDirectory(dir);
     }
 
@@ -343,12 +341,13 @@ public class TestMRAppMaster {
     appMaster.stop();
   }
 
-  @Test (timeout = 30000)
-  public void testMRAppMasterMaxAppAttempts() throws IOException,
+  @Test
+  @Timeout(30000)
+  void testMRAppMasterMaxAppAttempts() throws IOException,
       InterruptedException {
     // No matter what's the maxAppAttempt or attempt id, the isLastRetry always
     // equals to false
-    Boolean[] expectedBools = new Boolean[]{ false, false, false };
+    Boolean[] expectedBools = new Boolean[]{false, false, false};
 
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -368,8 +367,9 @@ public class TestMRAppMaster {
           new MRAppMasterTest(applicationAttemptId, containerId, "host", -1, -1,
               System.currentTimeMillis(), false, true);
       MRAppMaster.initAndStartAppMaster(appMaster, conf, userName);
-      assertEquals("isLastAMRetry is correctly computed.", expectedBools[i],
-          appMaster.isLastAMRetry());
+      assertEquals(expectedBools[i],
+          appMaster.isLastAMRetry(),
+          "isLastAMRetry is correctly computed.");
     }
   }
 
@@ -407,7 +407,7 @@ public class TestMRAppMaster {
   }
 
   @Test
-  public void testMRAppMasterCredentials() throws Exception {
+  void testMRAppMasterCredentials() throws Exception {
 
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
 
@@ -438,7 +438,7 @@ public class TestMRAppMaster {
     Path tokenFilePath = new Path(testDir, "tokens-file");
     Map<String, String> newEnv = new HashMap<String, String>();
     newEnv.put(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, tokenFilePath
-      .toUri().getPath());
+        .toUri().getPath());
     setNewEnvironmentHack(newEnv);
     credentials.writeTokenStorageFile(tokenFilePath, conf);
 
@@ -460,49 +460,49 @@ public class TestMRAppMaster {
 
     MRAppMasterTest appMaster =
         new MRAppMasterTest(applicationAttemptId, containerId, "host", -1, -1,
-          System.currentTimeMillis(), false, true);
+            System.currentTimeMillis(), false, true);
     MRAppMaster.initAndStartAppMaster(appMaster, conf, userName);
 
     // Now validate the task credentials
     Credentials appMasterCreds = appMaster.getCredentials();
-    Assert.assertNotNull(appMasterCreds);
-    Assert.assertEquals(1, appMasterCreds.numberOfSecretKeys());
-    Assert.assertEquals(1, appMasterCreds.numberOfTokens());
+    assertNotNull(appMasterCreds);
+    assertEquals(1, appMasterCreds.numberOfSecretKeys());
+    assertEquals(1, appMasterCreds.numberOfTokens());
 
     // Validate the tokens - app token should not be present
     Token<? extends TokenIdentifier> usedToken =
         appMasterCreds.getToken(tokenAlias);
-    Assert.assertNotNull(usedToken);
-    Assert.assertEquals(storedToken, usedToken);
+    assertNotNull(usedToken);
+    assertEquals(storedToken, usedToken);
 
     // Validate the keys
     byte[] usedKey = appMasterCreds.getSecretKey(keyAlias);
-    Assert.assertNotNull(usedKey);
-    Assert.assertEquals("mySecretKey", new String(usedKey));
+    assertNotNull(usedKey);
+    assertEquals("mySecretKey", new String(usedKey));
 
     // The credentials should also be added to conf so that OuputCommitter can
     // access it - app token should not be present
     Credentials confCredentials = conf.getCredentials();
-    Assert.assertEquals(1, confCredentials.numberOfSecretKeys());
-    Assert.assertEquals(1, confCredentials.numberOfTokens());
-    Assert.assertEquals(storedToken, confCredentials.getToken(tokenAlias));
-    Assert.assertEquals("mySecretKey",
-      new String(confCredentials.getSecretKey(keyAlias)));
+    assertEquals(1, confCredentials.numberOfSecretKeys());
+    assertEquals(1, confCredentials.numberOfTokens());
+    assertEquals(storedToken, confCredentials.getToken(tokenAlias));
+    assertEquals("mySecretKey",
+        new String(confCredentials.getSecretKey(keyAlias)));
 
     // Verify the AM's ugi - app token should be present
     Credentials ugiCredentials = appMaster.getUgi().getCredentials();
-    Assert.assertEquals(1, ugiCredentials.numberOfSecretKeys());
-    Assert.assertEquals(2, ugiCredentials.numberOfTokens());
-    Assert.assertEquals(storedToken, ugiCredentials.getToken(tokenAlias));
-    Assert.assertEquals(appToken, ugiCredentials.getToken(appTokenService));
-    Assert.assertEquals("mySecretKey",
-      new String(ugiCredentials.getSecretKey(keyAlias)));
+    assertEquals(1, ugiCredentials.numberOfSecretKeys());
+    assertEquals(2, ugiCredentials.numberOfTokens());
+    assertEquals(storedToken, ugiCredentials.getToken(tokenAlias));
+    assertEquals(appToken, ugiCredentials.getToken(appTokenService));
+    assertEquals("mySecretKey",
+        new String(ugiCredentials.getSecretKey(keyAlias)));
 
 
   }
 
   @Test
-  public void testMRAppMasterShutDownJob() throws Exception,
+  void testMRAppMasterShutDownJob() throws Exception,
       InterruptedException {
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
@@ -525,21 +525,19 @@ public class TestMRAppMaster {
     doNothing().when(appMaster).serviceStop();
     // Test normal shutdown.
     appMaster.shutDownJob();
-    Assert.assertTrue("Expected shutDownJob to terminate.",
-                      ExitUtil.terminateCalled());
-    Assert.assertEquals("Expected shutDownJob to exit with status code of 0.",
-        0, ExitUtil.getFirstExitException().status);
+    assertTrue(ExitUtil.terminateCalled(),
+        "Expected shutDownJob to terminate.");
+    assertEquals(0, ExitUtil.getFirstExitException().status, "Expected shutDownJob to exit with status code of 0.");
 
     // Test shutdown with exception.
     ExitUtil.resetFirstExitException();
     String msg = "Injected Exception";
     doThrow(new RuntimeException(msg))
-            .when(appMaster).notifyIsLastAMRetry(anyBoolean());
+        .when(appMaster).notifyIsLastAMRetry(anyBoolean());
     appMaster.shutDownJob();
-    assertTrue("Expected message from ExitUtil.ExitException to be " + msg,
-        ExitUtil.getFirstExitException().getMessage().contains(msg));
-    Assert.assertEquals("Expected shutDownJob to exit with status code of 1.",
-        1, ExitUtil.getFirstExitException().status);
+    assertTrue(ExitUtil.getFirstExitException().getMessage().contains(msg),
+        "Expected message from ExitUtil.ExitException to be " + msg);
+    assertEquals(1, ExitUtil.getFirstExitException().status, "Expected shutDownJob to exit with status code of 1.");
   }
 
   private void verifyFailedStatus(MRAppMasterTest appMaster,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
@@ -78,13 +78,13 @@ import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class TestRuntimeEstimators {
@@ -152,16 +152,13 @@ public class TestRuntimeEstimators {
     conf.setDouble(MRJobConfig.SPECULATIVECAP_TOTAL_TASKS, 0.001);
     conf.setInt(MRJobConfig.SPECULATIVE_MINIMUM_ALLOWED_TASKS, 5);
     speculator = new DefaultSpeculator(conf, myAppContext, estimator, clock);
-    Assert.assertEquals("wrong SPECULATIVE_RETRY_AFTER_NO_SPECULATE value",
-        500L, speculator.getSoonestRetryAfterNoSpeculate());
-    Assert.assertEquals("wrong SPECULATIVE_RETRY_AFTER_SPECULATE value",
-        5000L, speculator.getSoonestRetryAfterSpeculate());
+    assertEquals(500L, speculator.getSoonestRetryAfterNoSpeculate(), "wrong SPECULATIVE_RETRY_AFTER_NO_SPECULATE value");
+    assertEquals(5000L, speculator.getSoonestRetryAfterSpeculate(), "wrong SPECULATIVE_RETRY_AFTER_SPECULATE value");
     assertThat(speculator.getProportionRunningTasksSpeculatable())
         .isCloseTo(0.1, offset(0.00001));
     assertThat(speculator.getProportionTotalTasksSpeculatable())
         .isCloseTo(0.001, offset(0.00001));
-    Assert.assertEquals("wrong SPECULATIVE_MINIMUM_ALLOWED_TASKS value",
-        5, speculator.getMinimumAllowedSpeculativeTasks());
+    assertEquals(5, speculator.getMinimumAllowedSpeculativeTasks(), "wrong SPECULATIVE_MINIMUM_ALLOWED_TASKS value");
 
     dispatcher.register(Speculator.EventType.class, speculator);
 
@@ -244,25 +241,24 @@ public class TestRuntimeEstimators {
       }
     }
 
-    Assert.assertEquals("We got the wrong number of successful speculations.",
-        expectedSpeculations, successfulSpeculations.get());
+    assertEquals(expectedSpeculations, successfulSpeculations.get(), "We got the wrong number of successful speculations.");
   }
 
   @Test
-  public void testLegacyEstimator() throws Exception {
+  void testLegacyEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator = new LegacyTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
   }
 
   @Test
-  public void testExponentialEstimator() throws Exception {
+  void testExponentialEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator
         = new ExponentiallySmoothedTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
   }
 
   @Test
-  public void testSimpleExponentialEstimator() throws Exception {
+  void testSimpleExponentialEstimator() throws Exception {
     TaskRuntimeEstimator specificEstimator
         = new SimpleExponentialTaskRuntimeEstimator();
     coreTestEstimator(specificEstimator, 3);
@@ -279,8 +275,8 @@ public class TestRuntimeEstimators {
       TaskId taskID = event.getTaskID();
       Task task = myJob.getTask(taskID);
 
-      Assert.assertEquals
-          ("Wrong type event", TaskEventType.T_ADD_SPEC_ATTEMPT, event.getType());
+      assertEquals
+          (TaskEventType.T_ADD_SPEC_ATTEMPT, event.getType(), "Wrong type event");
 
       System.out.println("SpeculationRequestEventHandler.handle adds a speculation task for " + taskID);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
@@ -18,8 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -61,9 +60,9 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 /**
@@ -78,13 +77,13 @@ import org.junit.Test;
    private final static RecordFactory recordFactory = RecordFactoryProvider.
        getRecordFactory(null);
 
-   @After
+   @AfterEach
    public void tearDown() {
      conf.setBoolean(MRJobConfig.PRESERVE_FAILED_TASK_FILES, false);
    }
 
    @Test
-   public void testDeletionofStagingOnUnregistrationFailure()
+   void testDeletionofStagingOnUnregistrationFailure()
        throws IOException {
      testDeletionofStagingOnUnregistrationFailure(2, false);
      testDeletionofStagingOnUnregistrationFailure(1, false);
@@ -121,7 +120,7 @@ import org.junit.Test;
    }
 
    @Test
-   public void testDeletionofStaging() throws IOException {
+   void testDeletionofStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
@@ -130,27 +129,28 @@ import org.junit.Test;
      Path stagingDir = MRApps.getStagingAreaDir(conf, user);
      when(fs.exists(stagingDir)).thenReturn(true);
      ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(),
-        0);
+         0);
      ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
      JobId jobid = recordFactory.newRecordInstance(JobId.class);
      jobid.setAppId(appId);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
          JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
      appMaster.start();
      appMaster.shutDownJob();
      //test whether notifyIsLastAMRetry called
-     assertTrue(((TestMRApp)appMaster).getTestIsLastAMRetry());
+     assertTrue(((TestMRApp) appMaster).getTestIsLastAMRetry());
      verify(fs).delete(stagingJobPath, true);
    }
 
-   @Test (timeout = 30000)
-   public void testNoDeletionofStagingOnReboot() throws IOException {
+   @Test
+   @Timeout(30000)
+   void testNoDeletionofStagingOnReboot() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
-     when(fs.delete(any(Path.class),anyBoolean())).thenReturn(true);
+     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
      String user = UserGroupInformation.getCurrentUser().getShortUserName();
      Path stagingDir = MRApps.getStagingAreaDir(conf, user);
      when(fs.exists(stagingDir)).thenReturn(true);
@@ -158,7 +158,7 @@ import org.junit.Test;
          0);
      ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
          JobStateInternal.REBOOT, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
@@ -166,7 +166,7 @@ import org.junit.Test;
      //shutdown the job, not the lastRetry
      appMaster.shutDownJob();
      //test whether notifyIsLastAMRetry called
-     assertFalse(((TestMRApp)appMaster).getTestIsLastAMRetry());
+     assertFalse(((TestMRApp) appMaster).getTestIsLastAMRetry());
      verify(fs, times(0)).delete(stagingJobPath, true);
    }
 
@@ -196,9 +196,10 @@ import org.junit.Test;
      assertTrue(((TestMRApp)appMaster).getTestIsLastAMRetry());
      verify(fs).delete(stagingJobPath, true);
    }
-   
-   @Test (timeout = 30000)
-   public void testDeletionofStagingOnKill() throws IOException {
+
+   @Test
+   @Timeout(30000)
+   void testDeletionofStagingOnKill() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      fs = mock(FileSystem.class);
      when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
@@ -215,8 +216,8 @@ import org.junit.Test;
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc);
      appMaster.init(conf);
      //simulate the process being killed
-     MRAppMaster.MRAppMasterShutdownHook hook = 
-       new MRAppMaster.MRAppMasterShutdownHook(appMaster);
+     MRAppMaster.MRAppMasterShutdownHook hook =
+         new MRAppMaster.MRAppMasterShutdownHook(appMaster);
      hook.run();
      verify(fs, times(0)).delete(stagingJobPath, true);
    }
@@ -242,18 +243,18 @@ import org.junit.Test;
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc); //no retry
      appMaster.init(conf);
-     assertTrue("appMaster.isLastAMRetry() is false", appMaster.isLastAMRetry());
+     assertTrue(appMaster.isLastAMRetry(), "appMaster.isLastAMRetry() is false");
      //simulate the process being killed
      MRAppMaster.MRAppMasterShutdownHook hook = 
        new MRAppMaster.MRAppMasterShutdownHook(appMaster);
      hook.run();
-     assertTrue("MRAppMaster isn't stopped",
-                appMaster.isInState(Service.STATE.STOPPED));
+     assertTrue(appMaster.isInState(Service.STATE.STOPPED),
+                "MRAppMaster isn't stopped");
      verify(fs).delete(stagingJobPath, true);
    }
 
    @Test
-   public void testByPreserveFailedStaging() throws IOException {
+   void testByPreserveFailedStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      // TODO: Decide which failed task files that should
      // be kept are in application log directory.
@@ -270,9 +271,9 @@ import org.junit.Test;
      JobId jobid = recordFactory.newRecordInstance(JobId.class);
      jobid.setAppId(appId);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
-             JobStateInternal.FAILED, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
+         JobStateInternal.FAILED, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
      appMaster.start();
      appMaster.shutDownJob();
@@ -282,7 +283,7 @@ import org.junit.Test;
    }
 
    @Test
-   public void testPreservePatternMatchedStaging() throws IOException {
+   void testPreservePatternMatchedStaging() throws IOException {
      conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
      // The staging files that are matched to the pattern
      // should not be deleted
@@ -298,9 +299,9 @@ import org.junit.Test;
      JobId jobid = recordFactory.newRecordInstance(JobId.class);
      jobid.setAppId(appId);
      ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-     Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
      MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
-             JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
+         JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
      appMaster.init(conf);
      appMaster.start();
      appMaster.shutDownJob();
@@ -309,62 +310,62 @@ import org.junit.Test;
      verify(fs, times(0)).delete(stagingJobPath, true);
    }
 
-  @Test
-  public void testNotPreserveNotPatternMatchedStaging() throws IOException {
-    conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
-    conf.set(MRJobConfig.PRESERVE_FILES_PATTERN, "NotMatching");
-    fs = mock(FileSystem.class);
-    when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
-    //Staging Dir exists
-    String user = UserGroupInformation.getCurrentUser().getShortUserName();
-    Path stagingDir = MRApps.getStagingAreaDir(conf, user);
-    when(fs.exists(stagingDir)).thenReturn(true);
-    ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 0);
-    ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
-    JobId jobid = recordFactory.newRecordInstance(JobId.class);
-    jobid.setAppId(appId);
-    ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-    Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
-    MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
-            JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
-    appMaster.init(conf);
-    appMaster.start();
-    appMaster.shutDownJob();
-    //test whether notifyIsLastAMRetry called
-    assertTrue(((TestMRApp) appMaster).getTestIsLastAMRetry());
-    //Staging dir should be deleted because it is not matched with
-    //PRESERVE_FILES_PATTERN
-    verify(fs, times(1)).delete(stagingJobPath, true);
-  }
+   @Test
+   void testNotPreserveNotPatternMatchedStaging() throws IOException {
+     conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
+     conf.set(MRJobConfig.PRESERVE_FILES_PATTERN, "NotMatching");
+     fs = mock(FileSystem.class);
+     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
+     //Staging Dir exists
+     String user = UserGroupInformation.getCurrentUser().getShortUserName();
+     Path stagingDir = MRApps.getStagingAreaDir(conf, user);
+     when(fs.exists(stagingDir)).thenReturn(true);
+     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 0);
+     ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
+     JobId jobid = recordFactory.newRecordInstance(JobId.class);
+     jobid.setAppId(appId);
+     ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
+     assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
+         JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
+     appMaster.init(conf);
+     appMaster.start();
+     appMaster.shutDownJob();
+     //test whether notifyIsLastAMRetry called
+     assertTrue(((TestMRApp) appMaster).getTestIsLastAMRetry());
+     //Staging dir should be deleted because it is not matched with
+     //PRESERVE_FILES_PATTERN
+     verify(fs, times(1)).delete(stagingJobPath, true);
+   }
 
-  @Test
-  public void testPreservePatternMatchedAndFailedStaging() throws IOException {
-    conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
-    // When RESERVE_FILES_PATTERN and PRESERVE_FAILED_TASK_FILES are set,
-    // files in staging dir are always kept.
-    conf.set(MRJobConfig.PRESERVE_FILES_PATTERN, "JobDir");
-    conf.setBoolean(MRJobConfig.PRESERVE_FAILED_TASK_FILES, true);
-    fs = mock(FileSystem.class);
-    when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
-    //Staging Dir exists
-    String user = UserGroupInformation.getCurrentUser().getShortUserName();
-    Path stagingDir = MRApps.getStagingAreaDir(conf, user);
-    when(fs.exists(stagingDir)).thenReturn(true);
-    ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 0);
-    ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
-    JobId jobid = recordFactory.newRecordInstance(JobId.class);
-    jobid.setAppId(appId);
-    ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
-    Assert.assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
-    MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
-            JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
-    appMaster.init(conf);
-    appMaster.start();
-    appMaster.shutDownJob();
-    //test whether notifyIsLastAMRetry called
-    assertTrue(((TestMRApp) appMaster).getTestIsLastAMRetry());
-    verify(fs, times(0)).delete(stagingJobPath, true);
-  }
+   @Test
+   void testPreservePatternMatchedAndFailedStaging() throws IOException {
+     conf.set(MRJobConfig.MAPREDUCE_JOB_DIR, stagingJobDir);
+     // When RESERVE_FILES_PATTERN and PRESERVE_FAILED_TASK_FILES are set,
+     // files in staging dir are always kept.
+     conf.set(MRJobConfig.PRESERVE_FILES_PATTERN, "JobDir");
+     conf.setBoolean(MRJobConfig.PRESERVE_FAILED_TASK_FILES, true);
+     fs = mock(FileSystem.class);
+     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
+     //Staging Dir exists
+     String user = UserGroupInformation.getCurrentUser().getShortUserName();
+     Path stagingDir = MRApps.getStagingAreaDir(conf, user);
+     when(fs.exists(stagingDir)).thenReturn(true);
+     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 0);
+     ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
+     JobId jobid = recordFactory.newRecordInstance(JobId.class);
+     jobid.setAppId(appId);
+     ContainerAllocator mockAlloc = mock(ContainerAllocator.class);
+     assertTrue(MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS > 1);
+     MRAppMaster appMaster = new TestMRApp(attemptId, mockAlloc,
+         JobStateInternal.RUNNING, MRJobConfig.DEFAULT_MR_AM_MAX_ATTEMPTS);
+     appMaster.init(conf);
+     appMaster.start();
+     appMaster.shutDownJob();
+     //test whether notifyIsLastAMRetry called
+     assertTrue(((TestMRApp) appMaster).getTestIsLastAMRetry());
+     verify(fs, times(0)).delete(stagingJobPath, true);
+   }
 
    private class TestMRApp extends MRAppMaster {
      ContainerAllocator allocator;
@@ -583,22 +584,23 @@ import org.junit.Test;
     };
   }
 
-  @Test(timeout=20000)
-  public void testStagingCleanupOrder() throws Exception {
-    MRAppTestCleanup app = new MRAppTestCleanup(1, 1, true,
-        this.getClass().getName(), true);
-    JobImpl job = (JobImpl)app.submit(new Configuration());
-    app.waitForState(job, JobState.SUCCEEDED);
-    app.verifyCompleted();
+   @Test
+   @Timeout(20000)
+   void testStagingCleanupOrder() throws Exception {
+     MRAppTestCleanup app = new MRAppTestCleanup(1, 1, true,
+         this.getClass().getName(), true);
+     JobImpl job = (JobImpl) app.submit(new Configuration());
+     app.waitForState(job, JobState.SUCCEEDED);
+     app.verifyCompleted();
 
-    int waitTime = 20 * 1000;
-    while (waitTime > 0 && app.numStops < 2) {
-      Thread.sleep(100);
-      waitTime -= 100;
-    }
+     int waitTime = 20 * 1000;
+     while (waitTime > 0 && app.numStops < 2) {
+       Thread.sleep(100);
+       waitTime -= 100;
+     }
 
-    // assert ContainerAllocatorStopped and then tagingDirCleanedup
-    Assert.assertEquals(1, app.ContainerAllocatorStopped);
-    Assert.assertEquals(2, app.stagingDirCleanedup);
-  }
+     // assert ContainerAllocatorStopped and then tagingDirCleanedup
+     assertEquals(1, app.ContainerAllocatorStopped);
+     assertEquals(2, app.stagingDirCleanedup);
+   }
  }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -40,23 +41,22 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 
 public class TestTaskHeartbeatHandler {
-  
+
   @SuppressWarnings("unchecked")
   @Test
-  public void testTaskTimeout() throws InterruptedException {
+  void testTaskTimeout() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
-    
-    
+
+
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.TASK_TIMEOUT, 10); //10 ms
     // set TASK_PROGRESS_REPORT_INTERVAL to a value smaller than TASK_TIMEOUT
@@ -64,7 +64,7 @@ public class TestTaskHeartbeatHandler {
     conf.setLong(MRJobConfig.TASK_PROGRESS_REPORT_INTERVAL, 5);
     conf.setInt(MRJobConfig.TASK_TIMEOUT_CHECK_INTERVAL_MS, 10); //10 ms
     conf.setDouble(MRJobConfig.TASK_LOG_PROGRESS_DELTA_THRESHOLD, 0.01);
-    
+
     hb.init(conf);
     hb.start();
     try {
@@ -85,7 +85,7 @@ public class TestTaskHeartbeatHandler {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testTaskTimeoutDisable() throws InterruptedException {
+  void testTaskTimeoutDisable() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -125,7 +125,7 @@ public class TestTaskHeartbeatHandler {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testTaskStuck() throws InterruptedException {
+  void testTaskStuck() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
@@ -169,7 +169,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is set bigger than the task timeout in the configuration.
    */
   @Test
-  public void testTaskTimeoutConfigSmallerThanTaskProgressReportInterval() {
+  void testTaskTimeoutConfigSmallerThanTaskProgressReportInterval() {
     testTaskTimeoutWrtProgressReportInterval(1000L, 5000L);
   }
 
@@ -178,7 +178,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is set smaller than the task timeout in the configuration.
    */
   @Test
-  public void testTaskTimeoutConfigBiggerThanTaskProgressReportInterval() {
+  void testTaskTimeoutConfigBiggerThanTaskProgressReportInterval() {
     testTaskTimeoutWrtProgressReportInterval(5000L, 1000L);
   }
 
@@ -187,7 +187,7 @@ public class TestTaskHeartbeatHandler {
    * report interval is not set in the configuration.
    */
   @Test
-  public void testTaskTimeoutConfigWithoutTaskProgressReportInterval() {
+  void testTaskTimeoutConfigWithoutTaskProgressReportInterval() {
     final long taskTimeoutConfiged = 2000L;
 
     final Configuration conf = new Configuration();
@@ -198,7 +198,7 @@ public class TestTaskHeartbeatHandler {
   }
 
   @Test
-  public void testTaskUnregistered() throws Exception {
+  void testTaskUnregistered() throws Exception {
     EventHandler mockHandler = mock(EventHandler.class);
     ControlledClock clock = new ControlledClock();
     clock.setTime(0);
@@ -214,11 +214,11 @@ public class TestTaskHeartbeatHandler {
       JobId jobId = MRBuilderUtils.newJobId(appId, 4);
       TaskId tid = MRBuilderUtils.newTaskId(jobId, 3, TaskType.MAP);
       final TaskAttemptId taid = MRBuilderUtils.newTaskAttemptId(tid, 2);
-      Assert.assertFalse(hb.hasRecentlyUnregistered(taid));
+      assertFalse(hb.hasRecentlyUnregistered(taid));
       hb.register(taid);
-      Assert.assertFalse(hb.hasRecentlyUnregistered(taid));
+      assertFalse(hb.hasRecentlyUnregistered(taid));
       hb.unregister(taid);
-      Assert.assertTrue(hb.hasRecentlyUnregistered(taid));
+      assertTrue(hb.hasRecentlyUnregistered(taid));
       long unregisterTimeout = conf.getLong(MRJobConfig.TASK_EXIT_TIMEOUT,
           MRJobConfig.TASK_EXIT_TIMEOUT_DEFAULT);
       clock.setTime(unregisterTimeout + 1);
@@ -260,7 +260,7 @@ public class TestTaskHeartbeatHandler {
         new TaskHeartbeatHandler(null, SystemClock.getInstance(), 1);
     hb.init(conf);
 
-    Assert.assertTrue("The value of the task timeout is incorrect.",
-        hb.getTaskTimeOut() == expectedTimeout);
+    assertTrue(hb.getTaskTimeOut() == expectedTimeout,
+        "The value of the task timeout is incorrect.");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -105,10 +106,10 @@ import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 
@@ -120,13 +121,13 @@ public class TestJobImpl {
   
   static String stagingDir = "target/test-staging/";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {    
     File dir = new File(stagingDir);
     stagingDir = dir.getAbsolutePath();
   }
 
-  @Before
+  @BeforeEach
   public void cleanup() throws IOException {
     File dir = new File(stagingDir);
     if(dir.exists()) {
@@ -134,9 +135,9 @@ public class TestJobImpl {
     }
     dir.mkdirs();
   }
-  
+
   @Test
-  public void testJobNoTasks() {
+  void testJobNoTasks() {
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.NUM_REDUCES, 0);
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
@@ -146,8 +147,8 @@ public class TestJobImpl {
     conf.set(MRJobConfig.WORKFLOW_ADJACENCY_PREFIX_STRING + "key1", "value1");
     conf.set(MRJobConfig.WORKFLOW_ADJACENCY_PREFIX_STRING + "key2", "value2");
     conf.set(MRJobConfig.WORKFLOW_TAGS, "tag1,tag2");
-    
- 
+
+
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
     dispatcher.start();
@@ -169,14 +170,15 @@ public class TestJobImpl {
     dispatcher.stop();
     commitHandler.stop();
     try {
-      Assert.assertTrue(jseHandler.getAssertValue());
+      assertTrue(jseHandler.getAssertValue());
     } catch (InterruptedException e) {
-      Assert.fail("Workflow related attributes are not tested properly");
+      fail("Workflow related attributes are not tested properly");
     }
   }
 
-  @Test(timeout=20000)
-  public void testCommitJobFailsJob() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testCommitJobFailsJob() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -200,8 +202,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testCheckJobCompleteSuccess() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testCheckJobCompleteSuccess() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     DrainDispatcher dispatcher = new DrainDispatcher();
@@ -234,12 +237,12 @@ public class TestJobImpl {
     // let the committer complete and verify the job succeeds
     syncBarrier.await();
     assertJobState(job, JobStateInternal.SUCCEEDED);
-    
+
     job.handle(new JobEvent(job.getID(),
         JobEventType.JOB_TASK_ATTEMPT_COMPLETED));
     assertJobState(job, JobStateInternal.SUCCEEDED);
 
-    job.handle(new JobEvent(job.getID(), 
+    job.handle(new JobEvent(job.getID(),
         JobEventType.JOB_MAP_TASK_RESCHEDULED));
     assertJobState(job, JobStateInternal.SUCCEEDED);
 
@@ -247,13 +250,14 @@ public class TestJobImpl {
         JobEventType.JOB_TASK_COMPLETED));
     dispatcher.await();
     assertJobState(job, JobStateInternal.SUCCEEDED);
-    
+
     dispatcher.stop();
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testRebootedDuringSetup() throws Exception{
+  @Test
+  @Timeout(20000)
+  void testRebootedDuringSetup() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -263,10 +267,10 @@ public class TestJobImpl {
       @Override
       public synchronized void setupJob(JobContext jobContext)
           throws IOException {
-        while(!Thread.interrupted()){
-          try{
+        while (!Thread.interrupted()) {
+          try {
             wait();
-          }catch (InterruptedException e) {
+          } catch (InterruptedException e) {
           }
         }
       }
@@ -289,14 +293,15 @@ public class TestJobImpl {
     assertJobState(job, JobStateInternal.REBOOT);
     // return the external state as RUNNING since otherwise JobClient will
     // exit when it polls the AM for job state
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    assertEquals(JobState.RUNNING, job.getState());
 
     dispatcher.stop();
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testRebootedDuringCommit() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testRebootedDuringCommit() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.setInt(MRJobConfig.MR_AM_MAX_ATTEMPTS, 2);
@@ -321,16 +326,17 @@ public class TestJobImpl {
     job.handle(new JobEvent(job.getID(), JobEventType.JOB_AM_REBOOT));
     assertJobState(job, JobStateInternal.REBOOT);
     // return the external state as ERROR since this is last retry.
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    assertEquals(JobState.RUNNING, job.getState());
     when(mockContext.hasSuccessfullyUnregistered()).thenReturn(true);
-    Assert.assertEquals(JobState.ERROR, job.getState());
+    assertEquals(JobState.ERROR, job.getState());
 
     dispatcher.stop();
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringSetup() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringSetup() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -366,8 +372,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringCommit() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringCommit() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -392,7 +399,7 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testAbortJobCalledAfterKillingTasks() throws IOException {
+  void testAbortJobCalledAfterKillingTasks() throws IOException {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.set(MRJobConfig.MR_AM_COMMITTER_CANCEL_TIMEOUT_MS, "1000");
@@ -408,27 +415,28 @@ public class TestJobImpl {
 
     //Fail one task. This should land the JobImpl in the FAIL_WAIT state
     job.handle(new JobTaskEvent(
-      MRBuilderUtils.newTaskId(job.getID(), 1, TaskType.MAP),
-      TaskState.FAILED));
+        MRBuilderUtils.newTaskId(job.getID(), 1, TaskType.MAP),
+        TaskState.FAILED));
     //Verify abort job hasn't been called
     Mockito.verify(committer, Mockito.never())
-      .abortJob((JobContext) Mockito.any(), (State) Mockito.any());
+        .abortJob((JobContext) Mockito.any(), (State) Mockito.any());
     assertJobState(job, JobStateInternal.FAIL_WAIT);
 
     //Verify abortJob is called once and the job failed
     Mockito.verify(committer, Mockito.timeout(2000).times(1))
-      .abortJob((JobContext) Mockito.any(), (State) Mockito.any());
+        .abortJob((JobContext) Mockito.any(), (State) Mockito.any());
     assertJobState(job, JobStateInternal.FAILED);
 
     dispatcher.stop();
   }
 
-  @Test (timeout=10000)
-  public void testFailAbortDoesntHang() throws IOException {
+  @Test
+  @Timeout(10000)
+  void testFailAbortDoesntHang() throws IOException {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.set(MRJobConfig.MR_AM_COMMITTER_CANCEL_TIMEOUT_MS, "1000");
-    
+
     DrainDispatcher dispatcher = new DrainDispatcher();
     dispatcher.init(conf);
     dispatcher.start();
@@ -444,10 +452,10 @@ public class TestJobImpl {
 
     //Fail / finish all the tasks. This should land the JobImpl directly in the
     //FAIL_ABORT state
-    for(Task t: job.tasks.values()) {
+    for (Task t : job.tasks.values()) {
       TaskImpl task = (TaskImpl) t;
       task.handle(new TaskEvent(task.getID(), TaskEventType.T_SCHEDULE));
-      for(TaskAttempt ta: task.getAttempts().values()) {
+      for (TaskAttempt ta : task.getAttempts().values()) {
         task.handle(new TaskTAttemptFailedEvent(ta.getID()));
       }
     }
@@ -455,14 +463,15 @@ public class TestJobImpl {
     dispatcher.await();
     //Verify abortJob is called once and the job failed
     Mockito.verify(committer, Mockito.timeout(2000).times(1))
-      .abortJob((JobContext) Mockito.any(), (State) Mockito.any());
+        .abortJob((JobContext) Mockito.any(), (State) Mockito.any());
     assertJobState(job, JobStateInternal.FAILED);
 
     dispatcher.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringFailAbort() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringFailAbort() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
@@ -503,8 +512,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testKilledDuringKillAbort() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testKilledDuringKillAbort() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     // not initializing dispatcher to avoid potential race condition between
@@ -546,8 +556,9 @@ public class TestJobImpl {
     commitHandler.stop();
   }
 
-  @Test(timeout=20000)
-  public void testUnusableNodeTransition() throws Exception {
+  @Test
+  @Timeout(20000)
+  void testUnusableNodeTransition() throws Exception {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, stagingDir);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
@@ -566,13 +577,13 @@ public class TestJobImpl {
     // of task rescheduling/killing
     EventHandler<TaskAttemptEvent> taskAttemptEventHandler =
         new EventHandler<TaskAttemptEvent>() {
-      @Override
-      public void handle(TaskAttemptEvent event) {
-        if (event.getType() == TaskAttemptEventType.TA_KILL) {
-          job.decrementSucceededMapperCount();
-        }
-      }
-    };
+          @Override
+          public void handle(TaskAttemptEvent event) {
+            if (event.getType() == TaskAttemptEventType.TA_KILL) {
+              job.decrementSucceededMapperCount();
+            }
+          }
+        };
     dispatcher.register(TaskAttemptEventType.class, taskAttemptEventHandler);
 
     // replace the tasks with spied versions to return the right attempts
@@ -587,7 +598,7 @@ public class TestJobImpl {
     job.tasks.putAll(spiedTasks);
 
     // complete all mappers first
-    for (TaskId taskId: job.tasks.keySet()) {
+    for (TaskId taskId : job.tasks.keySet()) {
       if (taskId.getTaskType() == TaskType.MAP) {
         // generate a task attempt completed event first to populate the
         // nodes-to-succeeded-attempts map
@@ -599,7 +610,7 @@ public class TestJobImpl {
         job.handle(new JobTaskAttemptCompletedEvent(tce));
         // complete the task itself
         job.handle(new JobTaskEvent(taskId, TaskState.SUCCEEDED));
-        Assert.assertEquals(JobState.RUNNING, job.getState());
+        assertEquals(JobState.RUNNING, job.getState());
       }
     }
 
@@ -610,7 +621,7 @@ public class TestJobImpl {
         Collections.singletonList(firstMapperNodeReport)));
     dispatcher.await();
     // complete the reducer
-    for (TaskId taskId: job.tasks.keySet()) {
+    for (TaskId taskId : job.tasks.keySet()) {
       if (taskId.getTaskType() == TaskType.REDUCE) {
         job.handle(new JobTaskEvent(taskId, TaskState.SUCCEEDED));
       }
@@ -634,13 +645,13 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testJobNCompletedWhenAllReducersAreFinished()
+  void testJobNCompletedWhenAllReducersAreFinished()
       throws Exception {
     testJobCompletionWhenReducersAreFinished(true);
   }
 
   @Test
-  public void testJobNotCompletedWhenAllReducersAreFinished()
+  void testJobNotCompletedWhenAllReducersAreFinished()
       throws Exception {
     testJobCompletionWhenReducersAreFinished(false);
   }
@@ -699,13 +710,15 @@ public class TestJobImpl {
      * much value. Instead, we validate the T_KILL events.
      */
     if (killMappers) {
-      Assert.assertEquals("Number of killed events", 2, killedEvents.size());
-      Assert.assertEquals("AttemptID", "task_1234567890000_0001_m_000000",
-          killedEvents.get(0).getTaskID().toString());
-      Assert.assertEquals("AttemptID", "task_1234567890000_0001_m_000001",
-          killedEvents.get(1).getTaskID().toString());
+      assertEquals(2, killedEvents.size(), "Number of killed events");
+      assertEquals("task_1234567890000_0001_m_000000",
+          killedEvents.get(0).getTaskID().toString(),
+          "AttemptID");
+      assertEquals("task_1234567890000_0001_m_000001",
+          killedEvents.get(1).getTaskID().toString(),
+          "AttemptID");
     } else {
-      Assert.assertEquals("Number of killed events", 0, killedEvents.size());
+      assertEquals(0, killedEvents.size(), "Number of killed events");
     }
   }
 
@@ -719,7 +732,7 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testCheckAccess() {
+  void testCheckAccess() {
     // Create two unique users
     String user1 = System.getProperty("user.name");
     String user2 = user1 + "1234";
@@ -738,8 +751,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job1 = new JobImpl(jobId, null, conf1, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job1.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertFalse(job1.checkAccess(ugi2, JobACL.VIEW_JOB));
+    assertTrue(job1.checkAccess(ugi1, JobACL.VIEW_JOB));
+    assertFalse(job1.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access to the user1 (owner) and user2
     Configuration conf2 = new Configuration();
@@ -749,8 +762,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job2 = new JobImpl(jobId, null, conf2, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job2.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertTrue(job2.checkAccess(ugi2, JobACL.VIEW_JOB));
+    assertTrue(job2.checkAccess(ugi1, JobACL.VIEW_JOB));
+    assertTrue(job2.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access with security enabled and access to all
     Configuration conf3 = new Configuration();
@@ -760,8 +773,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job3 = new JobImpl(jobId, null, conf3, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job3.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertTrue(job3.checkAccess(ugi2, JobACL.VIEW_JOB));
+    assertTrue(job3.checkAccess(ugi1, JobACL.VIEW_JOB));
+    assertTrue(job3.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access without security enabled
     Configuration conf4 = new Configuration();
@@ -771,8 +784,8 @@ public class TestJobImpl {
     // Verify access
     JobImpl job4 = new JobImpl(jobId, null, conf4, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job4.checkAccess(ugi1, JobACL.VIEW_JOB));
-    Assert.assertTrue(job4.checkAccess(ugi2, JobACL.VIEW_JOB));
+    assertTrue(job4.checkAccess(ugi1, JobACL.VIEW_JOB));
+    assertTrue(job4.checkAccess(ugi2, JobACL.VIEW_JOB));
 
     // Setup configuration access without security enabled
     Configuration conf5 = new Configuration();
@@ -782,12 +795,12 @@ public class TestJobImpl {
     // Verify access
     JobImpl job5 = new JobImpl(jobId, null, conf5, null, null, null, null, null,
         null, null, null, true, user1, 0, null, null, null, null);
-    Assert.assertTrue(job5.checkAccess(ugi1, null));
-    Assert.assertTrue(job5.checkAccess(ugi2, null));
+    assertTrue(job5.checkAccess(ugi1, null));
+    assertTrue(job5.checkAccess(ugi2, null));
   }
 
   @Test
-  public void testReportDiagnostics() throws Exception {
+  void testReportDiagnostics() throws Exception {
     JobID jobID = JobID.forName("job_1234567890000_0001");
     JobId jobId = TypeConverter.toYarn(jobID);
     final String diagMsg = "some diagnostic message";
@@ -797,18 +810,18 @@ public class TestJobImpl {
     AppContext mockContext = mock(AppContext.class);
     when(mockContext.hasSuccessfullyUnregistered()).thenReturn(true);
     JobImpl job = new JobImpl(jobId, Records
-        .newRecord(ApplicationAttemptId.class), new Configuration(),
+            .newRecord(ApplicationAttemptId.class), new Configuration(),
         mock(EventHandler.class),
         null, mock(JobTokenSecretManager.class), null,
         SystemClock.getInstance(), null,
         mrAppMetrics, null, true, null, 0, null, mockContext, null, null);
     job.handle(diagUpdateEvent);
     String diagnostics = job.getReport().getDiagnostics();
-    Assert.assertNotNull(diagnostics);
-    Assert.assertTrue(diagnostics.contains(diagMsg));
+    assertNotNull(diagnostics);
+    assertTrue(diagnostics.contains(diagMsg));
 
     job = new JobImpl(jobId, Records
-        .newRecord(ApplicationAttemptId.class), new Configuration(),
+            .newRecord(ApplicationAttemptId.class), new Configuration(),
         mock(EventHandler.class),
         null, mock(JobTokenSecretManager.class), null,
         SystemClock.getInstance(), null,
@@ -816,23 +829,23 @@ public class TestJobImpl {
     job.handle(new JobEvent(jobId, JobEventType.JOB_KILL));
     job.handle(diagUpdateEvent);
     diagnostics = job.getReport().getDiagnostics();
-    Assert.assertNotNull(diagnostics);
-    Assert.assertTrue(diagnostics.contains(diagMsg));
+    assertNotNull(diagnostics);
+    assertTrue(diagnostics.contains(diagMsg));
   }
 
   @Test
-  public void testUberDecision() throws Exception {
+  void testUberDecision() throws Exception {
 
     // with default values, no of maps is 2
     Configuration conf = new Configuration();
     boolean isUber = testUberDecision(conf);
-    Assert.assertFalse(isUber);
+    assertFalse(isUber);
 
     // enable uber mode, no of maps is 2
     conf = new Configuration();
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);
     isUber = testUberDecision(conf);
-    Assert.assertTrue(isUber);
+    assertTrue(isUber);
 
     // enable uber mode, no of maps is 2, no of reduces is 1 and uber task max
     // reduces is 0
@@ -841,7 +854,7 @@ public class TestJobImpl {
     conf.setInt(MRJobConfig.JOB_UBERTASK_MAXREDUCES, 0);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
     isUber = testUberDecision(conf);
-    Assert.assertFalse(isUber);
+    assertFalse(isUber);
 
     // enable uber mode, no of maps is 2, no of reduces is 1 and uber task max
     // reduces is 1
@@ -850,23 +863,23 @@ public class TestJobImpl {
     conf.setInt(MRJobConfig.JOB_UBERTASK_MAXREDUCES, 1);
     conf.setInt(MRJobConfig.NUM_REDUCES, 1);
     isUber = testUberDecision(conf);
-    Assert.assertTrue(isUber);
+    assertTrue(isUber);
 
     // enable uber mode, no of maps is 2 and uber task max maps is 0
     conf = new Configuration();
     conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);
     conf.setInt(MRJobConfig.JOB_UBERTASK_MAXMAPS, 1);
     isUber = testUberDecision(conf);
-    Assert.assertFalse(isUber);
-    
- // enable uber mode of 0 reducer no matter how much memory assigned to reducer
+    assertFalse(isUber);
+
+    // enable uber mode of 0 reducer no matter how much memory assigned to reducer
     conf = new Configuration();
-    conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);  
-    conf.setInt(MRJobConfig.NUM_REDUCES, 0);           
+    conf.setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);
+    conf.setInt(MRJobConfig.NUM_REDUCES, 0);
     conf.setInt(MRJobConfig.REDUCE_MEMORY_MB, 2048);
     conf.setInt(MRJobConfig.REDUCE_CPU_VCORES, 10);
     isUber = testUberDecision(conf);
-    Assert.assertTrue(isUber);
+    assertTrue(isUber);
   }
 
   private boolean testUberDecision(Configuration conf) {
@@ -900,7 +913,7 @@ public class TestJobImpl {
   }
 
   @Test
-  public void testTransitionsAtFailed() throws IOException {
+  void testTransitionsAtFailed() throws IOException {
     Configuration conf = new Configuration();
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
@@ -908,7 +921,7 @@ public class TestJobImpl {
 
     OutputCommitter committer = mock(OutputCommitter.class);
     doThrow(new IOException("forcefail"))
-      .when(committer).setupJob(any(JobContext.class));
+        .when(committer).setupJob(any(JobContext.class));
     CommitterEventHandler commitHandler =
         createCommitterEventHandler(dispatcher, committer);
     commitHandler.init(conf);
@@ -931,45 +944,45 @@ public class TestJobImpl {
     assertJobState(job, JobStateInternal.FAILED);
     job.handle(new JobEvent(jobId, JobEventType.JOB_TASK_ATTEMPT_FETCH_FAILURE));
     assertJobState(job, JobStateInternal.FAILED);
-    Assert.assertEquals(JobState.RUNNING, job.getState());
+    assertEquals(JobState.RUNNING, job.getState());
     when(mockContext.hasSuccessfullyUnregistered()).thenReturn(true);
-    Assert.assertEquals(JobState.FAILED, job.getState());
+    assertEquals(JobState.FAILED, job.getState());
 
     dispatcher.stop();
     commitHandler.stop();
   }
 
   static final String EXCEPTIONMSG = "Splits max exceeded";
+
   @Test
-  public void testMetaInfoSizeOverMax() throws Exception {
+  void testMetaInfoSizeOverMax() throws Exception {
     Configuration conf = new Configuration();
     JobID jobID = JobID.forName("job_1234567890000_0001");
     JobId jobId = TypeConverter.toYarn(jobID);
     MRAppMetrics mrAppMetrics = MRAppMetrics.create();
     JobImpl job =
         new JobImpl(jobId, ApplicationAttemptId.newInstance(
-          ApplicationId.newInstance(0, 0), 0), conf, mock(EventHandler.class),
-          null, new JobTokenSecretManager(), new Credentials(), null, null,
-          mrAppMetrics, null, true, null, 0, null, null, null, null);
+                ApplicationId.newInstance(0, 0), 0), conf, mock(EventHandler.class),
+            null, new JobTokenSecretManager(), new Credentials(), null, null,
+            mrAppMetrics, null, true, null, 0, null, null, null, null);
     InitTransition initTransition = new InitTransition() {
-        @Override
-        protected TaskSplitMetaInfo[] createSplits(JobImpl job, JobId jobId) {
-          throw new YarnRuntimeException(EXCEPTIONMSG);
-        }
-      };
+      @Override
+      protected TaskSplitMetaInfo[] createSplits(JobImpl job, JobId jobId) {
+        throw new YarnRuntimeException(EXCEPTIONMSG);
+      }
+    };
     JobEvent mockJobEvent = mock(JobEvent.class);
 
     JobStateInternal jobSI = initTransition.transition(job, mockJobEvent);
-    Assert.assertTrue("When init fails, return value from InitTransition.transition should equal NEW.",
-                      jobSI.equals(JobStateInternal.NEW));
-    Assert.assertTrue("Job diagnostics should contain YarnRuntimeException",
-                      job.getDiagnostics().toString().contains("YarnRuntimeException"));
-    Assert.assertTrue("Job diagnostics should contain " + EXCEPTIONMSG,
-                      job.getDiagnostics().toString().contains(EXCEPTIONMSG));
+    assertEquals(jobSI, JobStateInternal.NEW);
+    assertTrue(job.getDiagnostics().toString().contains("YarnRuntimeException"),
+        "Job diagnostics should contain YarnRuntimeException");
+    assertTrue(job.getDiagnostics().toString().contains(EXCEPTIONMSG),
+        "Job diagnostics should contain " + EXCEPTIONMSG);
   }
 
   @Test
-  public void testJobPriorityUpdate() throws Exception {
+  void testJobPriorityUpdate() throws Exception {
     Configuration conf = new Configuration();
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
@@ -986,7 +999,7 @@ public class TestJobImpl {
     assertJobState(job, JobStateInternal.SETUP);
     // Update priority of job to 5, and it will be updated
     job.setJobPriority(submittedPriority);
-    Assert.assertEquals(submittedPriority, job.getReport().getJobPriority());
+    assertEquals(submittedPriority, job.getReport().getJobPriority());
 
     job.handle(new JobSetupCompletedEvent(jobId));
     assertJobState(job, JobStateInternal.RUNNING);
@@ -996,14 +1009,14 @@ public class TestJobImpl {
     job.setJobPriority(updatedPriority);
     assertJobState(job, JobStateInternal.RUNNING);
     Priority jobPriority = job.getReport().getJobPriority();
-    Assert.assertNotNull(jobPriority);
+    assertNotNull(jobPriority);
 
     // Verify whether changed priority is same as what is set in Job.
-    Assert.assertEquals(updatedPriority, jobPriority);
+    assertEquals(updatedPriority, jobPriority);
   }
 
   @Test
-  public void testCleanupSharedCacheUploadPolicies() {
+  void testCleanupSharedCacheUploadPolicies() {
     Configuration config = new Configuration();
     Map<String, Boolean> archivePolicies = new HashMap<>();
     archivePolicies.put("archive1", true);
@@ -1013,14 +1026,14 @@ public class TestJobImpl {
     filePolicies.put("file1", true);
     filePolicies.put("jar1", true);
     Job.setFileSharedCacheUploadPolicies(config, filePolicies);
-    Assert.assertEquals(
+    assertEquals(
         2, Job.getArchiveSharedCacheUploadPolicies(config).size());
-    Assert.assertEquals(
+    assertEquals(
         2, Job.getFileSharedCacheUploadPolicies(config).size());
     JobImpl.cleanupSharedCacheUploadPolicies(config);
-    Assert.assertEquals(
+    assertEquals(
         0, Job.getArchiveSharedCacheUploadPolicies(config).size());
-    Assert.assertEquals(
+    assertEquals(
         0, Job.getFileSharedCacheUploadPolicies(config).size());
   }
 
@@ -1088,14 +1101,14 @@ public class TestJobImpl {
       job.handle(new JobTaskEvent(
           MRBuilderUtils.newTaskId(job.getID(), 1, TaskType.MAP),
           TaskState.SUCCEEDED));
-      Assert.assertEquals(JobState.RUNNING, job.getState());
+      assertEquals(JobState.RUNNING, job.getState());
     }
     int numReduces = job.getTotalReduces();
     for (int i = 0; i < numReduces; ++i) {
       job.handle(new JobTaskEvent(
           MRBuilderUtils.newTaskId(job.getID(), 1, TaskType.MAP),
           TaskState.SUCCEEDED));
-      Assert.assertEquals(JobState.RUNNING, job.getState());
+      assertEquals(JobState.RUNNING, job.getState());
     }
   }
 
@@ -1109,7 +1122,7 @@ public class TestJobImpl {
         break;
       }
     }
-    Assert.assertEquals(state, job.getInternalState());
+    assertEquals(state, job.getInternalState());
   }
 
   private void createSpiedMapTasks(Map<NodeReport, TaskId>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestMapReduceChildJVM.java
@@ -18,11 +18,12 @@
 
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -37,7 +38,8 @@ import org.apache.hadoop.mapreduce.v2.app.launcher.ContainerLauncherEvent;
 import org.apache.hadoop.mapreduce.v2.app.launcher.ContainerRemoteLaunchEvent;
 import org.apache.hadoop.mapreduce.v2.util.MRApps;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +48,9 @@ public class TestMapReduceChildJVM {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMapReduceChildJVM.class);
 
-  @Test (timeout = 30000)
-  public void testCommandLine() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testCommandLine() throws Exception {
 
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
@@ -56,40 +59,42 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
 
-    Assert.assertEquals(
-      "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
-      " -Djava.net.preferIPv4Stack=true" +
-      " -Dhadoop.metrics.log.level=WARN " +
-      "  -Xmx820m -Djava.io.tmpdir=" + MRApps.crossPlatformify("PWD") + "/tmp" +
-      " -Dlog4j.configuration=container-log4j.properties" +
-      " -Dyarn.app.container.log.dir=<LOG_DIR>" +
-      " -Dyarn.app.container.log.filesize=0" +
-      " -Dhadoop.root.logger=INFO,CLA -Dhadoop.root.logfile=syslog" +
-      " org.apache.hadoop.mapred.YarnChild 127.0.0.1" +
-      " 54321" +
-      " attempt_0_0000_m_000000_0" +
-      " 0" +
-      " 1><LOG_DIR>/stdout" +
-      " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
-    
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-      app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("INFO,console",
-      app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
-    Assert.assertTrue("HADOOP_CLIENT_OPTS not set for job",
-      app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"));
-    Assert.assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
+    assertEquals(
+        "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
+            " -Djava.net.preferIPv4Stack=true" +
+            " -Dhadoop.metrics.log.level=WARN " +
+            "  -Xmx820m -Djava.io.tmpdir=" + MRApps.crossPlatformify("PWD") + "/tmp" +
+            " -Dlog4j.configuration=container-log4j.properties" +
+            " -Dyarn.app.container.log.dir=<LOG_DIR>" +
+            " -Dyarn.app.container.log.filesize=0" +
+            " -Dhadoop.root.logger=INFO,CLA -Dhadoop.root.logfile=syslog" +
+            " org.apache.hadoop.mapred.YarnChild 127.0.0.1" +
+            " 54321" +
+            " attempt_0_0000_m_000000_0" +
+            " 0" +
+            " 1><LOG_DIR>/stdout" +
+            " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
+
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    assertEquals("INFO,console",
+        app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"),
+        "HADOOP_CLIENT_OPTS not set for job");
+    assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
   }
 
-  @Test (timeout = 30000)
-  public void testReduceCommandLineWithSeparateShuffle() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReduceCommandLineWithSeparateShuffle() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.REDUCE_SEPARATE_SHUFFLE_LOG, true);
     testReduceCommandLine(conf);
   }
 
-  @Test (timeout = 30000)
-  public void testReduceCommandLineWithSeparateCRLAShuffle() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReduceCommandLineWithSeparateCRLAShuffle() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.REDUCE_SEPARATE_SHUFFLE_LOG, true);
     conf.setLong(MRJobConfig.SHUFFLE_LOG_KB, 1L);
@@ -97,8 +102,9 @@ public class TestMapReduceChildJVM {
     testReduceCommandLine(conf);
   }
 
-  @Test (timeout = 30000)
-  public void testReduceCommandLine() throws Exception {
+  @Test
+  @Timeout(30000)
+  void testReduceCommandLine() throws Exception {
     final Configuration conf = new Configuration();
     testReduceCommandLine(conf);
   }
@@ -119,7 +125,7 @@ public class TestMapReduceChildJVM {
         ? "shuffleCRLA"
         : "shuffleCLA";
 
-    Assert.assertEquals(
+    assertEquals(
         "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
             " -Djava.net.preferIPv4Stack=true" +
             " -Dhadoop.metrics.log.level=WARN " +
@@ -139,47 +145,48 @@ public class TestMapReduceChildJVM {
             " 1><LOG_DIR>/stdout" +
             " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
 
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("INFO,console",
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    assertEquals("INFO,console",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
-    Assert.assertTrue("HADOOP_CLIENT_OPTS not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"));
-    Assert.assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"),
+        "HADOOP_CLIENT_OPTS not set for job");
+    assertEquals("", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
   }
-  
-  @Test (timeout = 30000)
-  public void testCommandLineWithLog4JConifg() throws Exception {
+
+  @Test
+  @Timeout(30000)
+  void testCommandLineWithLog4JConifg() throws Exception {
 
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.MAPREDUCE_APP_SUBMISSION_CROSS_PLATFORM, true);
     String testLogPropertieFile = "test-log4j.properties";
-    String testLogPropertiePath = "../"+"test-log4j.properties";
+    String testLogPropertiePath = "../" + "test-log4j.properties";
     conf.set(MRJobConfig.MAPREDUCE_JOB_LOG4J_PROPERTIES_FILE, testLogPropertiePath);
     Job job = app.submit(conf);
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
 
-    Assert.assertEquals(
-      "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
-      " -Djava.net.preferIPv4Stack=true" +
-      " -Dhadoop.metrics.log.level=WARN " +
-      "  -Xmx820m -Djava.io.tmpdir=" + MRApps.crossPlatformify("PWD") + "/tmp" +
-      " -Dlog4j.configuration=" + testLogPropertieFile +
-      " -Dyarn.app.container.log.dir=<LOG_DIR>" +
-      " -Dyarn.app.container.log.filesize=0" +
-      " -Dhadoop.root.logger=INFO,CLA -Dhadoop.root.logfile=syslog" +
-      " org.apache.hadoop.mapred.YarnChild 127.0.0.1" +
-      " 54321" +
-      " attempt_0_0000_m_000000_0" +
-      " 0" +
-      " 1><LOG_DIR>/stdout" +
-      " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
+    assertEquals(
+        "[" + MRApps.crossPlatformify("JAVA_HOME") + "/bin/java" +
+            " -Djava.net.preferIPv4Stack=true" +
+            " -Dhadoop.metrics.log.level=WARN " +
+            "  -Xmx820m -Djava.io.tmpdir=" + MRApps.crossPlatformify("PWD") + "/tmp" +
+            " -Dlog4j.configuration=" + testLogPropertieFile +
+            " -Dyarn.app.container.log.dir=<LOG_DIR>" +
+            " -Dyarn.app.container.log.filesize=0" +
+            " -Dhadoop.root.logger=INFO,CLA -Dhadoop.root.logfile=syslog" +
+            " org.apache.hadoop.mapred.YarnChild 127.0.0.1" +
+            " 54321" +
+            " attempt_0_0000_m_000000_0" +
+            " 0" +
+            " 1><LOG_DIR>/stdout" +
+            " 2><LOG_DIR>/stderr ]", app.launchCmdList.get(0));
   }
 
   @Test
-  public void testAutoHeapSizes() throws Exception {
+  void testAutoHeapSizes() throws Exception {
     // Don't specify heap size or memory-mb
     testAutoHeapSize(-1, -1, null);
 
@@ -203,10 +210,10 @@ public class TestMapReduceChildJVM {
         MRJobConfig.DEFAULT_HEAP_MEMORY_MB_RATIO);
 
     // Verify map and reduce java opts are not set by default
-    Assert.assertNull("Default map java opts!",
-        conf.get(MRJobConfig.MAP_JAVA_OPTS));
-    Assert.assertNull("Default reduce java opts!",
-        conf.get(MRJobConfig.REDUCE_JAVA_OPTS));
+    assertNull(conf.get(MRJobConfig.MAP_JAVA_OPTS),
+        "Default map java opts!");
+    assertNull(conf.get(MRJobConfig.REDUCE_JAVA_OPTS),
+        "Default reduce java opts!");
     // Set the memory-mbs and java-opts
     if (mapMb > 0) {
       conf.setInt(MRJobConfig.MAP_MEMORY_MB, mapMb);
@@ -242,8 +249,7 @@ public class TestMapReduceChildJVM {
             : MRJobConfig.REDUCE_JAVA_OPTS);
         heapMb = JobConf.parseMaximumHeapSizeMB(javaOpts);
       }
-      Assert.assertEquals("Incorrect heapsize in the command opts",
-          heapMb, JobConf.parseMaximumHeapSizeMB(cmd));
+      assertEquals(heapMb, JobConf.parseMaximumHeapSizeMB(cmd), "Incorrect heapsize in the command opts");
     }
   }
 
@@ -276,9 +282,9 @@ public class TestMapReduceChildJVM {
       };
     }
   }
-  
+
   @Test
-  public void testEnvironmentVariables() throws Exception {
+  void testEnvironmentVariables() throws Exception {
     MyMRApp app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
     Configuration conf = new Configuration();
     conf.set(JobConf.MAPRED_MAP_TASK_ENV, "HADOOP_CLIENT_OPTS=test");
@@ -287,14 +293,14 @@ public class TestMapReduceChildJVM {
     Job job = app.submit(conf);
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
-    
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("WARN,console",
+
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    assertEquals("WARN,console",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
-    Assert.assertTrue("HADOOP_CLIENT_OPTS not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"));
-    Assert.assertEquals("test", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_CLIENT_OPTS"),
+        "HADOOP_CLIENT_OPTS not set for job");
+    assertEquals("test", app.cmdEnvironment.get("HADOOP_CLIENT_OPTS"));
 
     // Try one more.
     app = new MyMRApp(1, 0, true, this.getClass().getName(), true);
@@ -303,10 +309,10 @@ public class TestMapReduceChildJVM {
     job = app.submit(conf);
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
-    
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("trace",
+
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    assertEquals("trace",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
 
     // Try one using the mapreduce.task.env.var=value syntax
@@ -318,9 +324,9 @@ public class TestMapReduceChildJVM {
     app.waitForState(job, JobState.SUCCEEDED);
     app.verifyCompleted();
 
-    Assert.assertTrue("HADOOP_ROOT_LOGGER not set for job",
-        app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"));
-    Assert.assertEquals("DEBUG,console",
+    assertTrue(app.cmdEnvironment.containsKey("HADOOP_ROOT_LOGGER"),
+        "HADOOP_ROOT_LOGGER not set for job");
+    assertEquals("DEBUG,console",
         app.cmdEnvironment.get("HADOOP_ROOT_LOGGER"));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,13 +55,12 @@ import org.apache.hadoop.yarn.server.api.AuxiliaryService;
 import org.apache.hadoop.yarn.server.api.ApplicationInitializationContext;
 import org.apache.hadoop.yarn.server.api.ApplicationTerminationContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 public class TestShuffleProvider {
 
   @Test
-  public void testShuffleProviders() throws Exception {
+  void testShuffleProviders() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 1);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
@@ -75,8 +76,8 @@ public class TestShuffleProvider {
     jobConf.set(JobConf.MAPRED_MAP_TASK_ENV, "");
 
     jobConf.set(YarnConfiguration.NM_AUX_SERVICES,
-      TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID + "," +
-      TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID);
+        TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID + "," +
+            TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID);
 
     String serviceName = TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID;
     String serviceStr = String.format(YarnConfiguration.NM_AUX_SERVICE_FMT, serviceName);
@@ -87,8 +88,8 @@ public class TestShuffleProvider {
     jobConf.set(serviceStr, TestShuffleHandler2.class.getName());
 
     jobConf.set(MRJobConfig.MAPREDUCE_JOB_SHUFFLE_PROVIDER_SERVICES,
-                  TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID
-                     + "," + TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID);
+        TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID
+            + "," + TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID);
 
     Credentials credentials = new Credentials();
     Token<JobTokenIdentifier> jobToken = new Token<JobTokenIdentifier>(
@@ -110,9 +111,9 @@ public class TestShuffleProvider {
             credentials);
 
     Map<String, ByteBuffer> serviceDataMap = launchCtx.getServiceData();
-    Assert.assertNotNull("TestShuffleHandler1 is missing", serviceDataMap.get(TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID));
-    Assert.assertNotNull("TestShuffleHandler2 is missing", serviceDataMap.get(TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID));
-    Assert.assertTrue("mismatch number of services in map", serviceDataMap.size() == 3); // 2 that we entered + 1 for the built-in shuffle-provider
+    assertNotNull(serviceDataMap.get(TestShuffleHandler1.MAPREDUCE_TEST_SHUFFLE_SERVICEID), "TestShuffleHandler1 is missing");
+    assertNotNull(serviceDataMap.get(TestShuffleHandler2.MAPREDUCE_TEST_SHUFFLE_SERVICEID), "TestShuffleHandler2 is missing");
+    assertTrue(serviceDataMap.size() == 3, "mismatch number of services in map"); // 2 that we entered + 1 for the built-in shuffle-provider
   }
 
   static public class StubbedFS extends RawLocalFileSystem {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -20,9 +20,7 @@ package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
 import static org.apache.hadoop.test.GenericTestUtils.waitFor;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -41,10 +39,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptFailEvent;
 import org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -111,7 +105,10 @@ import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
@@ -151,23 +148,23 @@ public class TestTaskAttempt{
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupBeforeClass() {
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     TaskAttemptImpl.RESOURCE_REQUEST_CACHE.clear();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
   @Test
-  public void testMRAppHistoryForMap() throws Exception {
+  void testMRAppHistoryForMap() throws Exception {
     MRApp app = null;
     try {
       app = new FailingAttemptsMRApp(1, 0);
@@ -178,7 +175,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testMRAppHistoryForReduce() throws Exception {
+  void testMRAppHistoryForReduce() throws Exception {
     MRApp app = null;
     try {
       app = new FailingAttemptsMRApp(0, 1);
@@ -189,7 +186,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testMRAppHistoryForTAFailedInAssigned() throws Exception {
+  void testMRAppHistoryForTAFailedInAssigned() throws Exception {
     // test TA_CONTAINER_LAUNCH_FAILED for map
     FailingAttemptsDuringAssignedMRApp app = null;
 
@@ -268,7 +265,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testSingleRackRequest() throws Exception {
+  void testSingleRackRequest() throws Exception {
     TaskAttemptImpl.RequestContainerTransition rct =
         new TaskAttemptImpl.RequestContainerTransition(false);
 
@@ -289,7 +286,7 @@ public class TestTaskAttempt{
     ArgumentCaptor<Event> arg = ArgumentCaptor.forClass(Event.class);
     verify(eventHandler, times(2)).handle(arg.capture());
     if (!(arg.getAllValues().get(1) instanceof ContainerRequestEvent)) {
-      Assert.fail("Second Event not of type ContainerRequestEvent");
+      fail("Second Event not of type ContainerRequestEvent");
     }
     ContainerRequestEvent cre =
         (ContainerRequestEvent) arg.getAllValues().get(1);
@@ -299,7 +296,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testHostResolveAttempt() throws Exception {
+  void testHostResolveAttempt() throws Exception {
     TaskAttemptImpl.RequestContainerTransition rct =
         new TaskAttemptImpl.RequestContainerTransition(false);
 
@@ -323,7 +320,7 @@ public class TestTaskAttempt{
     ArgumentCaptor<Event> arg = ArgumentCaptor.forClass(Event.class);
     verify(eventHandler, times(2)).handle(arg.capture());
     if (!(arg.getAllValues().get(1) instanceof ContainerRequestEvent)) {
-      Assert.fail("Second Event not of type ContainerRequestEvent");
+      fail("Second Event not of type ContainerRequestEvent");
     }
     Map<String, Boolean> expected = new HashMap<String, Boolean>();
     expected.put("host1", true);
@@ -339,7 +336,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testMillisCountersUpdate() throws Exception {
+  void testMillisCountersUpdate() throws Exception {
     verifyMillisCounters(Resource.newInstance(1024, 1), 512);
     verifyMillisCounters(Resource.newInstance(2048, 4), 1024);
     verifyMillisCounters(Resource.newInstance(10240, 8), 2048);
@@ -361,16 +358,16 @@ public class TestTaskAttempt{
     Job job = app.submit(conf);
     app.waitForState(job, JobState.RUNNING);
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", 2, tasks.size());
+    assertEquals(2, tasks.size(), "Num tasks is not correct");
     Iterator<Task> taskIter = tasks.values().iterator();
     Task mTask = taskIter.next();
     app.waitForState(mTask, TaskState.RUNNING);
     Task rTask = taskIter.next();
     app.waitForState(rTask, TaskState.RUNNING);
     Map<TaskAttemptId, TaskAttempt> mAttempts = mTask.getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 1, mAttempts.size());
+    assertEquals(1, mAttempts.size(), "Num attempts is not correct");
     Map<TaskAttemptId, TaskAttempt> rAttempts = rTask.getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 1, rAttempts.size());
+    assertEquals(1, rAttempts.size(), "Num attempts is not correct");
     TaskAttempt mta = mAttempts.values().iterator().next();
     TaskAttempt rta = rAttempts.values().iterator().next();
     app.waitForState(mta, TaskAttemptState.RUNNING);
@@ -392,21 +389,21 @@ public class TestTaskAttempt{
 
     int memoryMb = (int) containerResource.getMemorySize();
     int vcores = containerResource.getVirtualCores();
-    Assert.assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
+    assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
         counters.findCounter(JobCounter.SLOTS_MILLIS_MAPS).getValue());
-    Assert.assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
+    assertEquals((int) Math.ceil((float) memoryMb / minContainerSize),
         counters.findCounter(JobCounter.SLOTS_MILLIS_REDUCES).getValue());
-    Assert.assertEquals(1,
+    assertEquals(1,
         counters.findCounter(JobCounter.MILLIS_MAPS).getValue());
-    Assert.assertEquals(1,
+    assertEquals(1,
         counters.findCounter(JobCounter.MILLIS_REDUCES).getValue());
-    Assert.assertEquals(memoryMb,
+    assertEquals(memoryMb,
         counters.findCounter(JobCounter.MB_MILLIS_MAPS).getValue());
-    Assert.assertEquals(memoryMb,
+    assertEquals(memoryMb,
         counters.findCounter(JobCounter.MB_MILLIS_REDUCES).getValue());
-    Assert.assertEquals(vcores,
+    assertEquals(vcores,
         counters.findCounter(JobCounter.VCORES_MILLIS_MAPS).getValue());
-    Assert.assertEquals(vcores,
+    assertEquals(vcores,
         counters.findCounter(JobCounter.VCORES_MILLIS_REDUCES).getValue());
   }
 
@@ -452,23 +449,24 @@ public class TestTaskAttempt{
     app.waitForState(job, JobState.FAILED);
     Map<TaskId, Task> tasks = job.getTasks();
 
-    Assert.assertEquals("Num tasks is not correct", 1, tasks.size());
+    assertEquals(1, tasks.size(), "Num tasks is not correct");
     Task task = tasks.values().iterator().next();
-    Assert.assertEquals("Task state not correct", TaskState.FAILED, task
-        .getReport().getTaskState());
+    assertEquals(TaskState.FAILED, task
+        .getReport().getTaskState(), "Task state not correct");
     Map<TaskAttemptId, TaskAttempt> attempts = tasks.values().iterator().next()
         .getAttempts();
-    Assert.assertEquals("Num attempts is not correct", 4, attempts.size());
+    assertEquals(4, attempts.size(), "Num attempts is not correct");
 
     Iterator<TaskAttempt> it = attempts.values().iterator();
     TaskAttemptReport report = it.next().getReport();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.FAILED,
-        report.getTaskAttemptState());
-    Assert.assertEquals("Diagnostic Information is not Correct",
-        "Test Diagnostic Event", report.getDiagnosticInfo());
+    assertEquals(TaskAttemptState.FAILED,
+        report.getTaskAttemptState(),
+        "Attempt state not correct");
+    assertEquals("Test Diagnostic Event", report.getDiagnosticInfo(), "Diagnostic Information is not Correct");
     report = it.next().getReport();
-    Assert.assertEquals("Attempt state not correct", TaskAttemptState.FAILED,
-        report.getTaskAttemptState());
+    assertEquals(TaskAttemptState.FAILED,
+        report.getTaskAttemptState(),
+        "Attempt state not correct");
   }
 
   private void testTaskAttemptAssignedFailHistory
@@ -477,8 +475,8 @@ public class TestTaskAttempt{
     Job job = app.submit(conf);
     app.waitForState(job, JobState.FAILED);
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertTrue("No Ta Started JH Event", app.getTaStartJHEvent());
-    Assert.assertTrue("No Ta Failed JH Event", app.getTaFailedJHEvent());
+    assertTrue(app.getTaStartJHEvent(), "No Ta Started JH Event");
+    assertTrue(app.getTaFailedJHEvent(), "No Ta Failed JH Event");
   }
 
   private void testTaskAttemptAssignedKilledHistory
@@ -518,8 +516,7 @@ public class TestTaskAttempt{
           if (event.getType() == org.apache.hadoop.mapreduce.jobhistory.EventType.MAP_ATTEMPT_FAILED) {
             TaskAttemptUnsuccessfulCompletion datum = (TaskAttemptUnsuccessfulCompletion) event
                 .getHistoryEvent().getDatum();
-            Assert.assertEquals("Diagnostic Information is not Correct",
-                "Test Diagnostic Event", datum.get(8).toString());
+            assertEquals("Test Diagnostic Event", datum.get(8).toString(), "Diagnostic Information is not Correct");
           }
         }
       };
@@ -593,10 +590,10 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testLaunchFailedWhileKilling() throws Exception {
+  void testLaunchFailedWhileKilling() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
-      ApplicationAttemptId.newInstance(appId, 0);
+        ApplicationAttemptId.newInstance(appId, 0);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(taskId, 0);
@@ -613,13 +610,13 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] {"127.0.0.1"});
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     TaskAttemptImpl taImpl =
-      new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
-          splits, jobConf, taListener,
-          new Token(), new Credentials(),
-          SystemClock.getInstance(), null);
+        new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
+            splits, jobConf, taListener,
+            new Token(), new Credentials(),
+            SystemClock.getInstance(), null);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -638,15 +635,14 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_CONTAINER_LAUNCH_FAILED));
     assertFalse(eventHandler.internalError);
-    assertEquals("Task attempt is not assigned on the local node", 
-        Locality.NODE_LOCAL, taImpl.getLocality());
+    assertEquals(Locality.NODE_LOCAL, taImpl.getLocality(), "Task attempt is not assigned on the local node");
   }
 
   @Test
-  public void testContainerCleanedWhileRunning() throws Exception {
+  void testContainerCleanedWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
-      ApplicationAttemptId.newInstance(appId, 0);
+        ApplicationAttemptId.newInstance(appId, 0);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(taskId, 0);
@@ -663,7 +659,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] {"127.0.0.1"});
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -673,10 +669,10 @@ public class TestTaskAttempt{
     setupTaskAttemptFinishingMonitor(eventHandler, jobConf, appCtx);
 
     TaskAttemptImpl taImpl =
-      new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
-          splits, jobConf, taListener,
-          new Token(), new Credentials(),
-          SystemClock.getInstance(), appCtx);
+        new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
+            splits, jobConf, taListener,
+            new Token(), new Credentials(),
+            SystemClock.getInstance(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.2", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -695,17 +691,16 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptState.RUNNING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-        eventHandler.internalError);
-    assertEquals("Task attempt is not assigned on the local rack",
-        Locality.RACK_LOCAL, taImpl.getLocality());
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
+    assertEquals(Locality.RACK_LOCAL, taImpl.getLocality(), "Task attempt is not assigned on the local rack");
   }
 
   @Test
-  public void testContainerCleanedWhileCommitting() throws Exception {
+  void testContainerCleanedWhileCommitting() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
-      ApplicationAttemptId.newInstance(appId, 0);
+        ApplicationAttemptId.newInstance(appId, 0);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(taskId, 0);
@@ -722,7 +717,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] {});
+    when(splits.getLocations()).thenReturn(new String[]{});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -732,10 +727,10 @@ public class TestTaskAttempt{
     setupTaskAttemptFinishingMonitor(eventHandler, jobConf, appCtx);
 
     TaskAttemptImpl taImpl =
-      new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
-          splits, jobConf, taListener,
-          new Token(), new Credentials(),
-          SystemClock.getInstance(), appCtx);
+        new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
+            splits, jobConf, taListener,
+            new Token(), new Credentials(),
+            SystemClock.getInstance(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -757,17 +752,18 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptState.COMMIT_PENDING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-        eventHandler.internalError);
-    assertEquals("Task attempt is assigned locally", Locality.OFF_SWITCH,
-        taImpl.getLocality());
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
+    assertEquals(Locality.OFF_SWITCH,
+        taImpl.getLocality(),
+        "Task attempt is assigned locally");
   }
 
   @Test
-  public void testDoubleTooManyFetchFailure() throws Exception {
+  void testDoubleTooManyFetchFailure() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
-      ApplicationAttemptId.newInstance(appId, 0);
+        ApplicationAttemptId.newInstance(appId, 0);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(taskId, 0);
@@ -787,7 +783,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] {"127.0.0.1"});
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -797,10 +793,10 @@ public class TestTaskAttempt{
     setupTaskAttemptFinishingMonitor(eventHandler, jobConf, appCtx);
 
     TaskAttemptImpl taImpl =
-      new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
-          splits, jobConf, taListener,
-          new Token(), new Credentials(),
-          SystemClock.getInstance(), appCtx);
+        new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
+            splits, jobConf, taListener,
+            new Token(), new Credentials(),
+            SystemClock.getInstance(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -832,14 +828,13 @@ public class TestTaskAttempt{
     assertThat(taImpl.getState())
         .withFailMessage("Task attempt is not in FAILED state, still")
         .isEqualTo(TaskAttemptState.FAILED);
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
   }
 
 
-
   @Test
-  public void testAppDiagnosticEventOnUnassignedTask() {
+  void testAppDiagnosticEventOnUnassignedTask() {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         appId, 0);
@@ -860,7 +855,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] { "127.0.0.1" });
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -884,23 +879,23 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptDiagnosticsUpdateEvent(attemptId,
         "Task got killed"));
     assertFalse(
-        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task",
-        eventHandler.internalError);
+        eventHandler.internalError,
+        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task");
     try {
       taImpl.handle(new TaskAttemptEvent(attemptId,
           TaskAttemptEventType.TA_KILL));
-      Assert.assertTrue("No exception on UNASSIGNED STATE KILL event", true);
+      assertTrue(true, "No exception on UNASSIGNED STATE KILL event");
     } catch (Exception e) {
-      Assert.assertFalse(
-          "Exception not expected for UNASSIGNED STATE KILL event", true);
+      assertFalse(
+          true, "Exception not expected for UNASSIGNED STATE KILL event");
     }
   }
 
   @Test
-  public void testTooManyFetchFailureAfterKill() throws Exception {
+  void testTooManyFetchFailureAfterKill() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
-      ApplicationAttemptId.newInstance(appId, 0);
+        ApplicationAttemptId.newInstance(appId, 0);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(taskId, 0);
@@ -917,7 +912,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] {"127.0.0.1"});
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -927,10 +922,10 @@ public class TestTaskAttempt{
     setupTaskAttemptFinishingMonitor(eventHandler, jobConf, appCtx);
 
     TaskAttemptImpl taImpl =
-      new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
-        splits, jobConf, taListener,
-        mock(Token.class), new Credentials(),
-        SystemClock.getInstance(), appCtx);
+        new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
+            splits, jobConf, taListener,
+            mock(Token.class), new Credentials(),
+            SystemClock.getInstance(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -940,34 +935,34 @@ public class TestTaskAttempt{
     when(container.getNodeHttpAddress()).thenReturn("localhost:0");
 
     taImpl.handle(new TaskAttemptEvent(attemptId,
-      TaskAttemptEventType.TA_SCHEDULE));
+        TaskAttemptEventType.TA_SCHEDULE));
     taImpl.handle(new TaskAttemptContainerAssignedEvent(attemptId,
-      container, mock(Map.class)));
+        container, mock(Map.class)));
     taImpl.handle(new TaskAttemptContainerLaunchedEvent(attemptId, 0));
     taImpl.handle(new TaskAttemptEvent(attemptId,
-      TaskAttemptEventType.TA_DONE));
+        TaskAttemptEventType.TA_DONE));
     taImpl.handle(new TaskAttemptEvent(attemptId,
-      TaskAttemptEventType.TA_CONTAINER_COMPLETED));
+        TaskAttemptEventType.TA_CONTAINER_COMPLETED));
 
     assertThat(taImpl.getState())
         .withFailMessage("Task attempt is not in SUCCEEDED state")
         .isEqualTo(TaskAttemptState.SUCCEEDED);
     taImpl.handle(new TaskAttemptEvent(attemptId,
-      TaskAttemptEventType.TA_KILL));
+        TaskAttemptEventType.TA_KILL));
     assertThat(taImpl.getState())
         .withFailMessage("Task attempt is not in KILLED state")
         .isEqualTo(TaskAttemptState.KILLED);
     taImpl.handle(new TaskAttemptEvent(attemptId,
-      TaskAttemptEventType.TA_TOO_MANY_FETCH_FAILURE));
+        TaskAttemptEventType.TA_TOO_MANY_FETCH_FAILURE));
     assertThat(taImpl.getState())
         .withFailMessage("Task attempt is not in KILLED state, still")
         .isEqualTo(TaskAttemptState.KILLED);
-    assertFalse("InternalError occurred trying to handle TA_CONTAINER_CLEANED",
-      eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_CONTAINER_CLEANED");
   }
 
   @Test
-  public void testAppDiagnosticEventOnNewTask() {
+  void testAppDiagnosticEventOnNewTask() {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         appId, 0);
@@ -988,7 +983,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] { "127.0.0.1" });
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -1010,15 +1005,15 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptDiagnosticsUpdateEvent(attemptId,
         "Task got killed"));
     assertFalse(
-        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task",
-        eventHandler.internalError);
+        eventHandler.internalError,
+        "InternalError occurred trying to handle TA_DIAGNOSTICS_UPDATE on assigned task");
   }
-    
+
   @Test
-  public void testFetchFailureAttemptFinishTime() throws Exception{
+  void testFetchFailureAttemptFinishTime() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId =
-    ApplicationAttemptId.newInstance(appId, 0);
+        ApplicationAttemptId.newInstance(appId, 0);
     JobId jobId = MRBuilderUtils.newJobId(appId, 1);
     TaskId taskId = MRBuilderUtils.newTaskId(jobId, 1, TaskType.MAP);
     TaskAttemptId attemptId = MRBuilderUtils.newTaskAttemptId(taskId, 0);
@@ -1039,7 +1034,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] {"127.0.0.1"});
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -1047,9 +1042,9 @@ public class TestTaskAttempt{
     setupTaskAttemptFinishingMonitor(eventHandler, jobConf, appCtx);
 
     TaskAttemptImpl taImpl =
-      new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
-      splits, jobConf, taListener,mock(Token.class), new Credentials(),
-      SystemClock.getInstance(), appCtx);
+        new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
+            splits, jobConf, taListener, mock(Token.class), new Credentials(),
+            SystemClock.getInstance(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -1072,8 +1067,8 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in SUCCEEDED state")
         .isEqualTo(TaskAttemptState.SUCCEEDED);
 
-    assertTrue("Task Attempt finish time is not greater than 0",
-        taImpl.getFinishTime() > 0);
+    assertTrue(taImpl.getFinishTime() > 0,
+        "Task Attempt finish time is not greater than 0");
 
     Long finishTime = taImpl.getFinishTime();
     Thread.sleep(5);
@@ -1084,9 +1079,8 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in FAILED state")
         .isEqualTo(TaskAttemptState.FAILED);
 
-    assertEquals("After TA_TOO_MANY_FETCH_FAILURE,"
-        + " Task attempt finish time is not the same ",
-        finishTime, Long.valueOf(taImpl.getFinishTime()));
+    assertEquals(finishTime, Long.valueOf(taImpl.getFinishTime()), "After TA_TOO_MANY_FETCH_FAILURE,"
+        + " Task attempt finish time is not the same ");
   }
 
   private void containerKillBeforeAssignment(boolean scheduleAttempt)
@@ -1114,7 +1108,7 @@ public class TestTaskAttempt{
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task attempt's internal state is not KILLED")
         .isEqualTo(TaskAttemptStateInternal.KILLED);
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
     TaskEvent event = eventHandler.lastTaskEvent;
     assertEquals(TaskEventType.T_ATTEMPT_KILLED, event.getType());
     // In NEW state, new map attempt should not be rescheduled.
@@ -1122,17 +1116,17 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testContainerKillOnNew() throws Exception {
+  void testContainerKillOnNew() throws Exception {
     containerKillBeforeAssignment(false);
   }
 
   @Test
-  public void testContainerKillOnUnassigned() throws Exception {
+  void testContainerKillOnUnassigned() throws Exception {
     containerKillBeforeAssignment(true);
   }
 
   @Test
-  public void testContainerKillAfterAssigned() throws Exception {
+  void testContainerKillAfterAssigned() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1153,7 +1147,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] { "127.0.0.1" });
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -1188,7 +1182,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testContainerKillWhileRunning() throws Exception {
+  void testContainerKillWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1209,7 +1203,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] { "127.0.0.1" });
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -1238,15 +1232,15 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptState.RUNNING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_KILL));
-    assertFalse("InternalError occurred trying to handle TA_KILL",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_KILL");
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task should be in KILL_CONTAINER_CLEANUP state")
         .isEqualTo(TaskAttemptStateInternal.KILL_CONTAINER_CLEANUP);
   }
 
   @Test
-  public void testContainerKillWhileCommitPending() throws Exception {
+  void testContainerKillWhileCommitPending() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId,
         0);
@@ -1267,7 +1261,7 @@ public class TestTaskAttempt{
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, "10");
 
     TaskSplitMetaInfo splits = mock(TaskSplitMetaInfo.class);
-    when(splits.getLocations()).thenReturn(new String[] { "127.0.0.1" });
+    when(splits.getLocations()).thenReturn(new String[]{"127.0.0.1"});
 
     AppContext appCtx = mock(AppContext.class);
     ClusterInfo clusterInfo = mock(ClusterInfo.class);
@@ -1301,15 +1295,15 @@ public class TestTaskAttempt{
         .isEqualTo(TaskAttemptStateInternal.COMMIT_PENDING);
     taImpl.handle(new TaskAttemptEvent(attemptId,
         TaskAttemptEventType.TA_KILL));
-    assertFalse("InternalError occurred trying to handle TA_KILL",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_KILL");
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task should be in KILL_CONTAINER_CLEANUP state")
         .isEqualTo(TaskAttemptStateInternal.KILL_CONTAINER_CLEANUP);
   }
 
   @Test
-  public void testKillMapTaskWhileSuccessFinishing() throws Exception {
+  void testKillMapTaskWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1348,47 +1342,43 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in KILLED state")
         .isEqualTo(TaskAttemptState.KILLED);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testKillMapOnlyTaskWhileSuccessFinishing() throws Exception {
+  void testKillMapOnlyTaskWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createMapOnlyTaskAttemptImpl(eventHandler);
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not " +
-            "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     // If the map only task is killed when it is in SUCCESS_FINISHING_CONTAINER
     // state, the state will move to SUCCESS_CONTAINER_CLEANUP
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_KILL));
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not " +
-            "SUCCESS_CONTAINER_CLEANUP",
-        TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not SUCCEEDED state",
-        TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState(), "Task attempt's internal state is not SUCCEEDED state");
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testKillMapTaskAfterSuccess() throws Exception {
+  void testKillMapTaskAfterSuccess() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1414,44 +1404,41 @@ public class TestTaskAttempt{
     assertThat(taImpl.getInternalState())
         .withFailMessage("Task attempt's internal state is not KILLED")
         .isEqualTo(TaskAttemptStateInternal.KILLED);
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
     TaskEvent event = eventHandler.lastTaskEvent;
     assertEquals(TaskEventType.T_ATTEMPT_KILLED, event.getType());
     // Send an attempt killed event to TaskImpl forwarding the same reschedule
     // flag we received in task attempt kill event.
-    assertTrue(((TaskTAttemptKilledEvent)event).getRescheduleAttempt());
+    assertTrue(((TaskTAttemptKilledEvent) event).getRescheduleAttempt());
   }
 
   @Test
-  public void testKillMapOnlyTaskAfterSuccess() throws Exception {
+  void testKillMapOnlyTaskAfterSuccess() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createMapOnlyTaskAttemptImpl(eventHandler);
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not " +
-            "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_CONTAINER_CLEANED));
     // Succeeded
-    taImpl.handle(new TaskAttemptKillEvent(taImpl.getID(),"", true));
-    assertEquals("Task attempt is not in SUCCEEDED state",
-        TaskAttemptState.SUCCEEDED, taImpl.getState());
-    assertEquals("Task attempt's internal state is not SUCCEEDED",
-        TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState());
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    taImpl.handle(new TaskAttemptKillEvent(taImpl.getID(), "", true));
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in SUCCEEDED state");
+    assertEquals(TaskAttemptStateInternal.SUCCEEDED, taImpl.getInternalState(), "Task attempt's internal state is not SUCCEEDED");
+    assertFalse(eventHandler.internalError, "InternalError occurred");
     TaskEvent event = eventHandler.lastTaskEvent;
     assertEquals(TaskEventType.T_ATTEMPT_SUCCEEDED, event.getType());
   }
 
   @Test
-  public void testKillMapTaskWhileFailFinishing() throws Exception {
+  void testKillMapTaskWhileFailFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1498,11 +1485,11 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in FAILED state")
         .isEqualTo(TaskAttemptState.FAILED);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testFailMapTaskByClient() throws Exception {
+  void testFailMapTaskByClient() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1531,11 +1518,11 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in FAILED state")
         .isEqualTo(TaskAttemptState.FAILED);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testTaskAttemptDiagnosticEventOnFinishing() throws Exception {
+  void testTaskAttemptDiagnosticEventOnFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1561,11 +1548,11 @@ public class TestTaskAttempt{
             "SUCCESS_FINISHING_CONTAINER")
         .isEqualTo(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testTimeoutWhileSuccessFinishing() throws Exception {
+  void testTimeoutWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1588,15 +1575,15 @@ public class TestTaskAttempt{
         .withFailMessage("Task attempt is not in SUCCEEDED state")
         .isEqualTo(TaskAttemptState.SUCCEEDED);
     assertThat(taImpl.getInternalState())
-            .withFailMessage("Task attempt's internal state is not " +
-                "SUCCESS_CONTAINER_CLEANUP")
-            .isEqualTo(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP);
+        .withFailMessage("Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP")
+        .isEqualTo(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testTimeoutWhileFailFinishing() throws Exception {
+  void testTimeoutWhileFailFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
 
@@ -1619,11 +1606,11 @@ public class TestTaskAttempt{
             "FAIL_CONTAINER_CLEANUP")
         .isEqualTo(TaskAttemptStateInternal.FAIL_CONTAINER_CLEANUP);
 
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   @Test
-  public void testMapperCustomResourceTypes() {
+  void testMapperCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     TaskSplitMetaInfo taskSplitMetaInfo = new TaskSplitMetaInfo();
@@ -1635,14 +1622,13 @@ public class TestTaskAttempt{
         taskSplitMetaInfo, clock, jobConf);
     ResourceInformation resourceInfo =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getResourceInformation(CUSTOM_RESOURCE_NAME);
-    assertEquals("Expecting the default unit (G)",
-        "G", resourceInfo.getUnits());
+            getResourceInformation(CUSTOM_RESOURCE_NAME);
+    assertEquals("G", resourceInfo.getUnits(), "Expecting the default unit (G)");
     assertEquals(7L, resourceInfo.getValue());
   }
 
   @Test
-  public void testReducerCustomResourceTypes() {
+  void testReducerCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
@@ -1653,14 +1639,13 @@ public class TestTaskAttempt{
         createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
     ResourceInformation resourceInfo =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getResourceInformation(CUSTOM_RESOURCE_NAME);
-    assertEquals("Expecting the specified unit (m)",
-        "m", resourceInfo.getUnits());
+            getResourceInformation(CUSTOM_RESOURCE_NAME);
+    assertEquals("m", resourceInfo.getUnits(), "Expecting the specified unit (m)");
     assertEquals(3L, resourceInfo.getValue());
   }
 
   @Test
-  public void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
+  void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1669,12 +1654,12 @@ public class TestTaskAttempt{
         createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
     long memorySize =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getMemorySize();
+            getMemorySize();
     assertEquals(2048, memorySize);
   }
 
   @Test
-  public void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
+  void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1684,24 +1669,24 @@ public class TestTaskAttempt{
         createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
     long memorySize =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getMemorySize();
+            getMemorySize();
     assertEquals(2048, memorySize);
   }
 
   @Test
-  public void testReducerMemoryRequestDefaultMemory() {
+  void testReducerMemoryRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskAttemptImpl taImpl =
         createReduceTaskAttemptImplForTest(eventHandler, clock, new JobConf());
     long memorySize =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getMemorySize();
+            getMemorySize();
     assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB, memorySize);
   }
 
   @Test
-  public void testReducerMemoryRequestWithoutUnits() {
+  void testReducerMemoryRequestWithoutUnits() {
     Clock clock = SystemClock.getInstance();
     for (String memoryResourceName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
@@ -1714,13 +1699,13 @@ public class TestTaskAttempt{
           createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
       long memorySize =
           getResourceInfoFromContainerRequest(taImpl, eventHandler).
-          getMemorySize();
+              getMemorySize();
       assertEquals(2048, memorySize);
     }
   }
 
   @Test
-  public void testReducerMemoryRequestOverriding() {
+  void testReducerMemoryRequestOverriding() {
     for (String memoryName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
         MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
@@ -1739,35 +1724,37 @@ public class TestTaskAttempt{
             createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
         long memorySize =
             getResourceInfoFromContainerRequest(taImpl, eventHandler).
-            getMemorySize();
+                getMemorySize();
         assertEquals(3072, memorySize);
         assertTrue(testAppender.getLogEvents().stream()
             .anyMatch(e -> e.getLevel() == Level.WARN && ("Configuration " +
                 "mapreduce.reduce.resource." + memoryName + "=3Gi is " +
                 "overriding the mapreduce.reduce.memory.mb=2048 configuration")
-                    .equals(e.getMessage())));
+                .equals(e.getMessage())));
       } finally {
         logger.removeAppender(testAppender);
       }
     }
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testReducerMemoryRequestMultipleName() {
-    EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
-    JobConf jobConf = new JobConf();
-    for (String memoryName : ImmutableList.of(
+  @Test
+  void testReducerMemoryRequestMultipleName() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      EventHandler eventHandler = mock(EventHandler.class);
+      Clock clock = SystemClock.getInstance();
+      JobConf jobConf = new JobConf();
+      for (String memoryName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
         MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
-      jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX + memoryName,
-          "3Gi");
-    }
-    createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+        jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX + memoryName,
+            "3Gi");
+      }
+      createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+    });
   }
 
   @Test
-  public void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
+  void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1776,12 +1763,12 @@ public class TestTaskAttempt{
         createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
     int vCores =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getVirtualCores();
+            getVirtualCores();
     assertEquals(3, vCores);
   }
 
   @Test
-  public void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
+  void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     JobConf jobConf = new JobConf();
@@ -1791,24 +1778,24 @@ public class TestTaskAttempt{
         createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
     int vCores =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getVirtualCores();
+            getVirtualCores();
     assertEquals(5, vCores);
   }
 
   @Test
-  public void testReducerCpuRequestDefaultMemory() {
+  void testReducerCpuRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
     Clock clock = SystemClock.getInstance();
     TaskAttemptImpl taImpl =
         createReduceTaskAttemptImplForTest(eventHandler, clock, new JobConf());
     int vCores =
         getResourceInfoFromContainerRequest(taImpl, eventHandler).
-        getVirtualCores();
+            getVirtualCores();
     assertEquals(MRJobConfig.DEFAULT_REDUCE_CPU_VCORES, vCores);
   }
 
   @Test
-  public void testReducerCpuRequestOverriding() {
+  void testReducerCpuRequestOverriding() {
     TestAppender testAppender = new TestAppender();
     final Logger logger = Logger.getLogger(TaskAttemptImpl.class);
     try {
@@ -1823,13 +1810,13 @@ public class TestTaskAttempt{
           createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
       long vCores =
           getResourceInfoFromContainerRequest(taImpl, eventHandler).
-          getVirtualCores();
+              getVirtualCores();
       assertEquals(7, vCores);
       assertTrue(testAppender.getLogEvents().stream().anyMatch(
           e -> e.getLevel() == Level.WARN && ("Configuration " +
               "mapreduce.reduce.resource.vcores=7 is overriding the " +
               "mapreduce.reduce.cpu.vcores=9 configuration").equals(
-                  e.getMessage())));
+              e.getMessage())));
     } finally {
       logger.removeAppender(testAppender);
     }
@@ -1853,25 +1840,27 @@ public class TestTaskAttempt{
         containerRequestEvents.add((ContainerRequestEvent) e);
       }
     }
-    assertEquals("Expected one ContainerRequestEvent after scheduling "
-        + "task attempt", 1, containerRequestEvents.size());
+    assertEquals(1, containerRequestEvents.size(), "Expected one ContainerRequestEvent after scheduling "
+        + "task attempt");
 
     return containerRequestEvents.get(0).getCapability();
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testReducerCustomResourceTypeWithInvalidUnit() {
-    initResourceTypes();
-    EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
-    JobConf jobConf = new JobConf();
-    jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX
-        + CUSTOM_RESOURCE_NAME, "3z");
-    createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+  @Test
+  void testReducerCustomResourceTypeWithInvalidUnit() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      initResourceTypes();
+      EventHandler eventHandler = mock(EventHandler.class);
+      Clock clock = SystemClock.getInstance();
+      JobConf jobConf = new JobConf();
+      jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX
+          + CUSTOM_RESOURCE_NAME, "3z");
+      createReduceTaskAttemptImplForTest(eventHandler, clock, jobConf);
+    });
   }
 
   @Test
-  public void testKillingTaskWhenContainerCleanup() {
+  void testKillingTaskWhenContainerCleanup() {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId maptaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1882,26 +1871,26 @@ public class TestTaskAttempt{
     // move in two steps to the desired state (cannot get there directly)
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_TIMED_OUT));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_CONTAINER_CLEANUP",
-        TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP");
 
     taImpl.handle(new TaskAttemptKillEvent(mapTAId, "", true));
-    assertEquals("Task attempt is not in KILLED state",
-        TaskAttemptState.KILLED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.KILLED,
+        taImpl.getState(),
+        "Task attempt is not in KILLED state");
   }
 
   @Test
-  public void testTooManyFetchFailureWhileContainerCleanup() {
+  void testTooManyFetchFailureWhileContainerCleanup() {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1912,24 +1901,24 @@ public class TestTaskAttempt{
     // move in two steps to the desired state (cannot get there directly)
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_TIMED_OUT));
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_CONTAINER_CLEANUP",
-        TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_CONTAINER_CLEANUP,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_CONTAINER_CLEANUP");
 
     taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
         reduceTAId, "Host"));
-    assertEquals("Task attempt is not in FAILED state",
-        TaskAttemptState.FAILED,
-        taImpl.getState());
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertEquals(TaskAttemptState.FAILED,
+        taImpl.getState(),
+        "Task attempt is not in FAILED state");
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   private void initResourceTypes() {
@@ -1940,7 +1929,7 @@ public class TestTaskAttempt{
   }
 
   @Test
-  public void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
+  void testTooManyFetchFailureWhileSuccessFinishing() throws Exception {
     MockEventHandler eventHandler = new MockEventHandler();
     TaskAttemptImpl taImpl = createTaskAttemptImpl(eventHandler);
     TaskId reducetaskId = MRBuilderUtils.newTaskId(taImpl.getID().getTaskId()
@@ -1951,17 +1940,17 @@ public class TestTaskAttempt{
     taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
         TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt's internal state is not " +
-        "SUCCESS_FINISHING_CONTAINER",
-        TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
-        taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCESS_FINISHING_CONTAINER,
+        taImpl.getInternalState(),
+        "Task attempt's internal state is not " +
+            "SUCCESS_FINISHING_CONTAINER");
 
     taImpl.handle(new TaskAttemptTooManyFetchFailureEvent(taImpl.getID(),
         reduceTAId, "Host"));
-    assertEquals("Task attempt is not in FAILED state",
-        TaskAttemptState.FAILED,
-        taImpl.getState());
-    assertFalse("InternalError occurred", eventHandler.internalError);
+    assertEquals(TaskAttemptState.FAILED,
+        taImpl.getState(),
+        "Task attempt is not in FAILED state");
+    assertFalse(eventHandler.internalError, "InternalError occurred");
   }
 
   private void setupTaskAttemptFinishingMonitor(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,9 +28,6 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.After;
-import org.junit.Assert;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileStatus;
@@ -58,18 +57,19 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"rawtypes"})
 public class TestTaskAttemptContainerRequest {
 
-  @After
+  @AfterEach
   public void cleanup() {
     UserGroupInformation.reset();
   }
 
   @Test
-  public void testAttemptContainerRequest() throws Exception {
+  void testAttemptContainerRequest() throws Exception {
     final Text SECRET_KEY_ALIAS = new Text("secretkeyalias");
     final byte[] SECRET_KEY = ("secretkey").getBytes();
     Map<ApplicationAccessType, String> acls =
@@ -114,7 +114,7 @@ public class TestTaskAttemptContainerRequest {
             mock(WrappedJvmID.class), taListener,
             credentials);
 
-    Assert.assertEquals("ACLs mismatch", acls, launchCtx.getApplicationACLs());
+    assertEquals(acls, launchCtx.getApplicationACLs(), "ACLs mismatch");
     Credentials launchCredentials = new Credentials();
 
     DataInputByteBuffer dibb = new DataInputByteBuffer();
@@ -125,16 +125,15 @@ public class TestTaskAttemptContainerRequest {
     for (Token<? extends TokenIdentifier> token : credentials.getAllTokens()) {
       Token<? extends TokenIdentifier> launchToken =
           launchCredentials.getToken(token.getService());
-      Assert.assertNotNull("Token " + token.getService() + " is missing",
-          launchToken);
-      Assert.assertEquals("Token " + token.getService() + " mismatch",
-          token, launchToken);
+      assertNotNull(launchToken,
+          "Token " + token.getService() + " is missing");
+      assertEquals(token, launchToken, "Token " + token.getService() + " mismatch");
     }
 
     // verify the secret key is in the launch context
-    Assert.assertNotNull("Secret key missing",
-        launchCredentials.getSecretKey(SECRET_KEY_ALIAS));
-    Assert.assertTrue("Secret key mismatch", Arrays.equals(SECRET_KEY,
+    assertNotNull(launchCredentials.getSecretKey(SECRET_KEY_ALIAS),
+        "Secret key missing");
+    assertEquals("Secret key mismatch", Arrays.equals(SECRET_KEY,
         launchCredentials.getSecretKey(SECRET_KEY_ALIAS)));
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
@@ -17,10 +17,7 @@
  */
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,9 +62,9 @@ import org.apache.hadoop.yarn.event.InlineDispatcher;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.SystemClock;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -234,7 +231,7 @@ public class TestTaskImpl {
     
   }
   
-  @Before 
+  @BeforeEach 
   @SuppressWarnings("unchecked")
   public void setup() {
      dispatcher = new InlineDispatcher();
@@ -273,7 +270,7 @@ public class TestTaskImpl {
         startCount, metrics, appContext, taskType);
   }
 
-  @After 
+  @AfterEach 
   public void teardown() {
     taskAttempts.clear();
   }
@@ -397,44 +394,44 @@ public class TestTaskImpl {
     fail("There is no " + (avataar == Avataar.VIRGIN ? "virgin" : "speculative")
         + "task attempt");
   }
-  
+
   @Test
-  public void testInit() {
+  void testInit() {
     LOG.info("--- START: testInit ---");
-    mockTask = createMockTask(TaskType.MAP);        
+    mockTask = createMockTask(TaskType.MAP);
     assertTaskNewState();
     assert(taskAttempts.size() == 0);
   }
 
-  @Test
   /**
    * {@link TaskState#NEW}->{@link TaskState#SCHEDULED}
    */
-  public void testScheduleTask() {
+  @Test
+  void testScheduleTask() {
     LOG.info("--- START: testScheduleTask ---");
-    mockTask = createMockTask(TaskType.MAP);        
+    mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
   }
-  
-  @Test 
+
   /**
    * {@link TaskState#SCHEDULED}->{@link TaskState#KILL_WAIT}
    */
-  public void testKillScheduledTask() {
+  @Test
+  void testKillScheduledTask() {
     LOG.info("--- START: testKillScheduledTask ---");
-    mockTask = createMockTask(TaskType.MAP);        
+    mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
     killTask(taskId);
   }
-  
-  @Test 
+
   /**
    * Kill attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#SCHEDULED}
    */
-  public void testKillScheduledTaskAttempt() {
+  @Test
+  void testKillScheduledTaskAttempt() {
     LOG.info("--- START: testKillScheduledTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -443,26 +440,26 @@ public class TestTaskImpl {
     assertEquals(TaskAttemptEventType.TA_RESCHEDULE,
         taskAttemptEventHandler.lastTaskAttemptEvent.getType());
   }
-  
-  @Test 
+
   /**
    * Launch attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#RUNNING}
    */
-  public void testLaunchTaskAttempt() {
+  @Test
+  void testLaunchTaskAttempt() {
     LOG.info("--- START: testLaunchTaskAttempt ---");
-    mockTask = createMockTask(TaskType.MAP);        
+    mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
     launchTaskAttempt(getLastAttempt().getAttemptId());
   }
 
-  @Test
   /**
    * Kill running attempt
    * {@link TaskState#RUNNING}->{@link TaskState#RUNNING} 
    */
-  public void testKillRunningTaskAttempt() {
+  @Test
+  void testKillRunningTaskAttempt() {
     LOG.info("--- START: testKillRunningTaskAttempt ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -474,7 +471,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testKillSuccessfulTask() {
+  void testKillSuccessfulTask() {
     LOG.info("--- START: testKillSuccesfulTask ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -488,12 +485,12 @@ public class TestTaskImpl {
     assertTaskSucceededState();
   }
 
-  @Test
   /**
    * Kill map attempt for succeeded map task
    * {@link TaskState#SUCCEEDED}->{@link TaskState#SCHEDULED}
    */
-  public void testKillAttemptForSuccessfulTask() {
+  @Test
+  void testKillAttemptForSuccessfulTask() {
     LOG.info("--- START: testKillAttemptForSuccessfulTask ---");
     mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
@@ -510,18 +507,18 @@ public class TestTaskImpl {
     assertTaskScheduledState();
   }
 
-  @Test 
-  public void testTaskProgress() {
+  @Test
+  void testTaskProgress() {
     LOG.info("--- START: testTaskProgress ---");
-    mockTask = createMockTask(TaskType.MAP);        
-        
+    mockTask = createMockTask(TaskType.MAP);
+
     // launch task
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
     float progress = 0f;
     assert(mockTask.getProgress() == progress);
-    launchTaskAttempt(getLastAttempt().getAttemptId());    
-    
+    launchTaskAttempt(getLastAttempt().getAttemptId());
+
     // update attempt1 
     progress = 50f;
     updateLastAttemptProgress(progress);
@@ -529,7 +526,7 @@ public class TestTaskImpl {
     progress = 100f;
     updateLastAttemptProgress(progress);
     assert(mockTask.getProgress() == progress);
-    
+
     progress = 0f;
     // mark first attempt as killed
     updateLastAttemptState(TaskAttemptState.KILLED);
@@ -540,22 +537,22 @@ public class TestTaskImpl {
     // as no successful attempts 
     killRunningTaskAttempt(getLastAttempt().getAttemptId());
     assert(taskAttempts.size() == 2);
-    
+
     assert(mockTask.getProgress() == 0f);
     launchTaskAttempt(getLastAttempt().getAttemptId());
     progress = 50f;
     updateLastAttemptProgress(progress);
     assert(mockTask.getProgress() == progress);
-        
+
   }
 
-  
+
   @Test
-  public void testKillDuringTaskAttemptCommit() {
-    mockTask = createMockTask(TaskType.REDUCE);        
+  void testKillDuringTaskAttemptCommit() {
+    mockTask = createMockTask(TaskType.REDUCE);
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
-    
+
     launchTaskAttempt(getLastAttempt().getAttemptId());
     updateLastAttemptState(TaskAttemptState.COMMIT_PENDING);
     commitTaskAttempt(getLastAttempt().getAttemptId());
@@ -568,8 +565,8 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testFailureDuringTaskAttemptCommit() {
-    mockTask = createMockTask(TaskType.MAP);        
+  void testFailureDuringTaskAttemptCommit() {
+    mockTask = createMockTask(TaskType.MAP);
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
     launchTaskAttempt(getLastAttempt().getAttemptId());
@@ -584,13 +581,13 @@ public class TestTaskImpl {
     assertEquals(2, taskAttempts.size());
     updateLastAttemptState(TaskAttemptState.SUCCEEDED);
     commitTaskAttempt(getLastAttempt().getAttemptId());
-    mockTask.handle(new TaskTAttemptEvent(getLastAttempt().getAttemptId(), 
+    mockTask.handle(new TaskTAttemptEvent(getLastAttempt().getAttemptId(),
         TaskEventType.T_ATTEMPT_SUCCEEDED));
-    
-    assertFalse("First attempt should not commit",
-        mockTask.canCommit(taskAttempts.get(0).getAttemptId()));
-    assertTrue("Second attempt should commit",
-        mockTask.canCommit(getLastAttempt().getAttemptId()));
+
+    assertFalse(mockTask.canCommit(taskAttempts.get(0).getAttemptId()),
+        "First attempt should not commit");
+    assertTrue(mockTask.canCommit(getLastAttempt().getAttemptId()),
+        "Second attempt should commit");
 
     assertTaskSucceededState();
   }
@@ -628,45 +625,45 @@ public class TestTaskImpl {
     // The task should contain speculative a task attempt
     assertTaskAttemptAvataar(Avataar.SPECULATIVE);
   }
-  
+
   @Test
-  public void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
-    mockTask = createMockTask(TaskType.MAP);        
+  void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
+    mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
   }
 
   @Test
-  public void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
-    mockTask = createMockTask(TaskType.REDUCE);        
+  void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstFails() {
+    mockTask = createMockTask(TaskType.REDUCE);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
   }
-  
+
   @Test
-  public void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
-    mockTask = createMockTask(TaskType.MAP);        
+  void testMapSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
+    mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
   }
 
   @Test
-  public void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
-    mockTask = createMockTask(TaskType.REDUCE);        
+  void testReduceSpeculativeTaskAttemptSucceedsEvenIfFirstIsKilled() {
+    mockTask = createMockTask(TaskType.REDUCE);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
   }
 
   @Test
-  public void testMultipleTaskAttemptsSucceed() {
+  void testMultipleTaskAttemptsSucceed() {
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_SUCCEEDED);
   }
 
   @Test
-  public void testCommitAfterSucceeds() {
+  void testCommitAfterSucceeds() {
     mockTask = createMockTask(TaskType.REDUCE);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_COMMIT_PENDING);
   }
 
   @Test
-  public void testSpeculativeMapFetchFailure() {
+  void testSpeculativeMapFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt killed
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_KILLED);
@@ -681,7 +678,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testSpeculativeMapMultipleSucceedFetchFailure() {
+  void testSpeculativeMapMultipleSucceedFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt succeeds
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_SUCCEEDED);
@@ -696,7 +693,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testSpeculativeMapFailedFetchFailure() {
+  void testSpeculativeMapFailedFetchFailure() {
     // Setup a scenario where speculative task wins, first attempt succeeds
     mockTask = createMockTask(TaskType.MAP);
     runSpeculativeTaskAttemptSucceeds(TaskEventType.T_ATTEMPT_FAILED);
@@ -711,14 +708,14 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testFailedTransitions() {
+  void testFailedTransitions() {
     mockTask = new MockTaskImpl(jobId, partition, dispatcher.getEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
-          @Override
-          protected int getMaxAttempts() {
-            return 1;
-          }
+      @Override
+      protected int getMaxAttempts() {
+        return 1;
+      }
     };
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -789,7 +786,7 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testFailedTransitionWithHangingSpeculativeMap() {
+  void testFailedTransitionWithHangingSpeculativeMap() {
     mockTask = new MockTaskImpl(jobId, partition, new PartialAttemptEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
@@ -840,14 +837,14 @@ public class TestTaskImpl {
   }
 
   @Test
-  public void testCountersWithSpeculation() {
+  void testCountersWithSpeculation() {
     mockTask = new MockTaskImpl(jobId, partition, dispatcher.getEventHandler(),
         remoteJobConfFile, conf, taskAttemptListener, jobToken,
         credentials, clock, startCount, metrics, appContext, TaskType.MAP) {
-          @Override
-          protected int getMaxAttempts() {
-            return 1;
-          }
+      @Override
+      protected int getMaxAttempts() {
+        return 1;
+      }
     };
     TaskId taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -879,7 +876,7 @@ public class TestTaskImpl {
     baseAttempt.setProgress(1.0f);
 
     Counters taskCounters = mockTask.getCounters();
-    assertEquals("wrong counters for task", specAttemptCounters, taskCounters);
+    assertEquals(specAttemptCounters, taskCounters, "wrong counters for task");
   }
 
   public static class MockTaskAttemptEventHandler implements EventHandler {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/local/TestLocalContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/local/TestLocalContainerAllocator.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapreduce.v2.app.local;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -69,20 +70,19 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.ipc.RPCUtil;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class TestLocalContainerAllocator {
 
   @Test
-  public void testRMConnectionRetry() throws Exception {
+  void testRMConnectionRetry() throws Exception {
     // verify the connection exception is thrown
     // if we haven't exhausted the retry interval
     ApplicationMasterProtocol mockScheduler =
         mock(ApplicationMasterProtocol.class);
     when(mockScheduler.allocate(isA(AllocateRequest.class)))
-      .thenThrow(RPCUtil.getRemoteException(new IOException("forcefail")));
+        .thenThrow(RPCUtil.getRemoteException(new IOException("forcefail")));
     Configuration conf = new Configuration();
     LocalContainerAllocator lca =
         new StubbedLocalContainerAllocator(mockScheduler);
@@ -90,7 +90,7 @@ public class TestLocalContainerAllocator {
     lca.start();
     try {
       lca.heartbeat();
-      Assert.fail("heartbeat was supposed to throw");
+      fail("heartbeat was supposed to throw");
     } catch (YarnException e) {
       // YarnException is expected
     } finally {
@@ -104,7 +104,7 @@ public class TestLocalContainerAllocator {
     lca.start();
     try {
       lca.heartbeat();
-      Assert.fail("heartbeat was supposed to throw");
+      fail("heartbeat was supposed to throw");
     } catch (YarnRuntimeException e) {
       // YarnRuntimeException is expected
     } finally {
@@ -113,7 +113,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  public void testAllocResponseId() throws Exception {
+  void testAllocResponseId() throws Exception {
     ApplicationMasterProtocol scheduler = new MockScheduler();
     Configuration conf = new Configuration();
     LocalContainerAllocator lca =
@@ -128,7 +128,7 @@ public class TestLocalContainerAllocator {
   }
 
   @Test
-  public void testAMRMTokenUpdate() throws Exception {
+  void testAMRMTokenUpdate() throws Exception {
     Configuration conf = new Configuration();
     ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(
         ApplicationId.newInstance(1, 1), 1);
@@ -153,11 +153,11 @@ public class TestLocalContainerAllocator {
         "someuser", new String[0]);
     testUgi.addToken(oldToken);
     testUgi.doAs(new PrivilegedExceptionAction<Void>() {
-          @Override
-          public Void run() throws Exception {
-            lca.heartbeat();
-            return null;
-          }
+      @Override
+      public Void run() throws Exception {
+        lca.heartbeat();
+        return null;
+      }
     });
     lca.close();
 
@@ -172,18 +172,16 @@ public class TestLocalContainerAllocator {
       }
     }
 
-    Assert.assertEquals("too many AMRM tokens", 1, tokenCount);
-    Assert.assertArrayEquals("token identifier not updated",
-        newToken.getIdentifier(), ugiToken.getIdentifier());
-    Assert.assertArrayEquals("token password not updated",
-        newToken.getPassword(), ugiToken.getPassword());
-    Assert.assertEquals("AMRM token service not updated",
-        new Text(ClientRMProxy.getAMRMTokenService(conf)),
-        ugiToken.getService());
+    assertEquals(1, tokenCount, "too many AMRM tokens");
+    assertArrayEquals(newToken.getIdentifier(), ugiToken.getIdentifier(), "token identifier not updated");
+    assertArrayEquals(newToken.getPassword(), ugiToken.getPassword(), "token password not updated");
+    assertEquals(new Text(ClientRMProxy.getAMRMTokenService(conf)),
+        ugiToken.getService(),
+        "AMRM token service not updated");
   }
 
   @Test
-  public void testAllocatedContainerResourceIsNotNull() {
+  void testAllocatedContainerResourceIsNotNull() {
     ArgumentCaptor<TaskAttemptContainerAssignedEvent> containerAssignedCaptor
         = ArgumentCaptor.forClass(TaskAttemptContainerAssignedEvent.class);
     @SuppressWarnings("unchecked")
@@ -202,7 +200,7 @@ public class TestLocalContainerAllocator {
     verify(eventHandler, times(1)).handle(containerAssignedCaptor.capture());
     Container container = containerAssignedCaptor.getValue().getContainer();
     Resource containerResource = container.getResource();
-    Assert.assertNotNull(containerResource);
+    assertNotNull(containerResource);
     assertThat(containerResource.getMemorySize()).isEqualTo(0);
     assertThat(containerResource.getVirtualCores()).isEqualTo(0);
   }
@@ -282,8 +280,7 @@ public class TestLocalContainerAllocator {
     @Override
     public AllocateResponse allocate(AllocateRequest request)
         throws YarnException, IOException {
-      Assert.assertEquals("response ID mismatch",
-          responseId, request.getResponseId());
+      assertEquals(responseId, request.getResponseId(), "response ID mismatch");
       ++responseId;
       org.apache.hadoop.yarn.api.records.Token yarnToken = null;
       if (amToken != null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/metrics/TestMRAppMetrics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/metrics/TestMRAppMetrics.java
@@ -25,19 +25,21 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import static org.apache.hadoop.test.MetricsAsserts.*;
 
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestMRAppMetrics {
 
-  @After
+  @AfterEach
   public void tearDown() {
     DefaultMetricsSystem.shutdown();
   }
 
-  @Test public void testNames() {
+  @Test
+  void testNames() {
     Job job = mock(Job.class);
     Task mapTask = mock(Task.class);
     when(mapTask.getType()).thenReturn(TaskType.MAP);
@@ -92,8 +94,8 @@ public class TestMRAppMetrics {
     metrics.completedJob(job);
 
     checkMetrics(/*job*/3, 1, 1, 1, 0, 0,
-                 /*map*/3, 1, 1, 1, 0, 0,
-                 /*reduce*/1, 1, 0, 0, 0, 0);
+        /*map*/3, 1, 1, 1, 0, 0,
+        /*reduce*/1, 1, 0, 0, 0, 0);
   }
 
   private void checkMetrics(int jobsSubmitted, int jobsCompleted,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
@@ -23,7 +23,8 @@ import org.apache.hadoop.mapreduce.v2.app.client.ClientService;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator.AllocatorRunnable;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.util.Clock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.stubbing.Answer;
 
 import static org.mockito.Mockito.doThrow;
@@ -45,8 +46,9 @@ public class TestRMCommunicator {
     }
   }
 
-  @Test(timeout = 2000)
-  public void testRMContainerAllocatorExceptionIsHandled() throws Exception {
+  @Test
+  @Timeout(2000)
+  void testRMContainerAllocatorExceptionIsHandled() throws Exception {
     ClientService mockClientService = mock(ClientService.class);
     AppContext mockContext = mock(AppContext.class);
     MockRMCommunicator mockRMCommunicator =
@@ -60,14 +62,15 @@ public class TestRMCommunicator {
 
     when(mockClock.getTime()).thenReturn(1L).thenThrow(new AssertionError(
         "GetClock called second time, when it should not have since the " +
-        "thread should have quit"));
+            "thread should have quit"));
 
     AllocatorRunnable testRunnable = communicator.new AllocatorRunnable();
     testRunnable.run();
   }
 
-  @Test(timeout = 2000)
-  public void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
+  @Test
+  @Timeout(2000)
+  void testRMContainerAllocatorYarnRuntimeExceptionIsHandled()
       throws Exception {
     ClientService mockClientService = mock(ClientService.class);
     AppContext mockContext = mock(AppContext.class);
@@ -82,11 +85,11 @@ public class TestRMCommunicator {
 
     when(mockClock.getTime()).thenReturn(1L).thenAnswer(
         (Answer<Long>) invocation -> {
-        communicator.stop();
-        return 2L;
-      }).thenThrow(new AssertionError(
-          "GetClock called second time, when it should not " +
-              "have since the thread should have quit"));
+          communicator.stop();
+          return 2L;
+        }).thenThrow(new AssertionError(
+        "GetClock called second time, when it should not " +
+            "have since the thread should have quit"));
 
     AllocatorRunnable testRunnable = communicator.new AllocatorRunnable();
     testRunnable.run();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestResourceCalculatorUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestResourceCalculatorUtils.java
@@ -19,16 +19,16 @@
 package org.apache.hadoop.mapreduce.v2.app.rm;
 
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 
 import static org.apache.hadoop.yarn.proto.YarnServiceProtos.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestResourceCalculatorUtils {
   @Test
-  public void testComputeAvailableContainers() throws Exception {
+  void testComputeAvailableContainers() throws Exception {
     Resource clusterAvailableResources = Resource.newInstance(81920, 40);
 
     Resource nonZeroResource = Resource.newInstance(1024, 2);
@@ -59,17 +59,17 @@ public class TestResourceCalculatorUtils {
       Resource nonZeroResource, int expectedNumberOfContainersForMemoryOnly,
       int expectedNumberOfContainersOverall) {
 
-    Assert.assertEquals("Incorrect number of available containers for Memory",
-        expectedNumberOfContainersForMemoryOnly,
+    assertEquals(expectedNumberOfContainersForMemoryOnly,
         ResourceCalculatorUtils.computeAvailableContainers(
             clusterAvailableResources, nonZeroResource,
-            EnumSet.of(SchedulerResourceTypes.MEMORY)));
+            EnumSet.of(SchedulerResourceTypes.MEMORY)),
+        "Incorrect number of available containers for Memory");
 
-    Assert.assertEquals("Incorrect number of available containers overall",
-        expectedNumberOfContainersOverall,
+    assertEquals(expectedNumberOfContainersOverall,
         ResourceCalculatorUtils.computeAvailableContainers(
             clusterAvailableResources, nonZeroResource,
             EnumSet.of(SchedulerResourceTypes.CPU,
-                SchedulerResourceTypes.MEMORY)));
+                SchedulerResourceTypes.MEMORY)),
+        "Incorrect number of available containers overall");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
@@ -18,56 +18,57 @@
 
 package org.apache.hadoop.mapreduce.v2.app.speculate;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class TestDataStatistics {
 
   private static final double TOL = 0.001;
 
   @Test
-  public void testEmptyDataStatistics() throws Exception {
+  void testEmptyDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
-    Assert.assertEquals(0, statistics.count(), TOL);
-    Assert.assertEquals(0, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
-    Assert.assertEquals(0, statistics.std(), TOL);
-    Assert.assertEquals(0, statistics.outlier(1.0f), TOL);
+    assertEquals(0, statistics.count(), TOL);
+    assertEquals(0, statistics.mean(), TOL);
+    assertEquals(0, statistics.var(), TOL);
+    assertEquals(0, statistics.std(), TOL);
+    assertEquals(0, statistics.outlier(1.0f), TOL);
   }
-  
+
   @Test
-  public void testSingleEntryDataStatistics() throws Exception {
+  void testSingleEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17.29);
-    Assert.assertEquals(1, statistics.count(), TOL);
-    Assert.assertEquals(17.29, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
-    Assert.assertEquals(0, statistics.std(), TOL);
-    Assert.assertEquals(17.29, statistics.outlier(1.0f), TOL);
+    assertEquals(1, statistics.count(), TOL);
+    assertEquals(17.29, statistics.mean(), TOL);
+    assertEquals(0, statistics.var(), TOL);
+    assertEquals(0, statistics.std(), TOL);
+    assertEquals(17.29, statistics.outlier(1.0f), TOL);
   }
-  
+
   @Test
-  public void testMutiEntryDataStatistics() throws Exception {
+  void testMutiEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
     statistics.add(17);
     statistics.add(29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
-    Assert.assertEquals(6.0, statistics.std(), TOL);
-    Assert.assertEquals(29.0, statistics.outlier(1.0f), TOL);
- }
-  
+    assertEquals(2, statistics.count(), TOL);
+    assertEquals(23.0, statistics.mean(), TOL);
+    assertEquals(36.0, statistics.var(), TOL);
+    assertEquals(6.0, statistics.std(), TOL);
+    assertEquals(29.0, statistics.outlier(1.0f), TOL);
+  }
+
   @Test
-  public void testUpdateStatistics() throws Exception {
+  void testUpdateStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17);
     statistics.add(29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
+    assertEquals(2, statistics.count(), TOL);
+    assertEquals(23.0, statistics.mean(), TOL);
+    assertEquals(36.0, statistics.var(), TOL);
 
     statistics.updateStatistics(17, 29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(29.0, statistics.mean(), TOL);
-    Assert.assertEquals(0.0, statistics.var(), TOL);
+    assertEquals(2, statistics.count(), TOL);
+    assertEquals(29.0, statistics.mean(), TOL);
+    assertEquals(0.0, statistics.var(), TOL);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
@@ -18,11 +18,12 @@
 
 package org.apache.hadoop.mapreduce.v2.app.speculate.forecast;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testing the statistical model of simple exponential estimator.
@@ -98,23 +99,20 @@ public class TestSimpleExponentialForecast {
   }
 
   @Test
-  public void testSimpleExponentialForecastLinearInc() throws Exception {
+  void testSimpleExponentialForecastLinearInc() throws Exception {
     int res = incTestSimpleExponentialForecast();
-    Assert.assertEquals("We got the wrong estimate from simple exponential.",
-        res, 0);
+    assertEquals(res, 0, "We got the wrong estimate from simple exponential.");
   }
 
   @Test
-  public void testSimpleExponentialForecastLinearDec() throws Exception {
+  void testSimpleExponentialForecastLinearDec() throws Exception {
     int res = decTestSimpleExponentialForecast();
-    Assert.assertEquals("We got the wrong estimate from simple exponential.",
-        res, 0);
+    assertEquals(res, 0, "We got the wrong estimate from simple exponential.");
   }
 
   @Test
-  public void testSimpleExponentialForecastZeros() throws Exception {
+  void testSimpleExponentialForecastZeros() throws Exception {
     int res = zeroTestSimpleExponentialForecast();
-    Assert.assertEquals("We got the wrong estimate from simple exponential.",
-        res, 0);
+    assertEquals(res, 0, "We got the wrong estimate from simple exponential.");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/AppControllerForTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/AppControllerForTest.java
@@ -31,7 +31,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.webapp.ResponseInfo;
 import org.apache.hadoop.yarn.webapp.View;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Class AppControllerForTest overrides some methods of AppController for test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebApp.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.mapreduce.v2.app.webapp.AMParams.APP_ID;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -39,7 +39,6 @@ import javax.net.ssl.SSLException;
 
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpConfig.Policy;
@@ -65,13 +64,13 @@ import org.apache.hadoop.yarn.webapp.WebApps;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import org.apache.http.HttpStatus;
-import org.junit.After;
 import org.junit.Rule;
-import org.junit.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.net.HttpHeaders;
 import com.google.inject.Injector;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class TestAMWebApp {
 
@@ -80,38 +79,42 @@ public class TestAMWebApp {
           System.getProperty("java.io.tmpdir")),
       TestAMWebApp.class.getName());
 
-  @After
+  @AfterEach
   public void tearDown() {
     TEST_DIR.delete();
   }
 
-  @Test public void testAppControllerIndex() {
+  @Test
+  void testAppControllerIndex() {
     AppContext ctx = new MockAppContext(0, 1, 1, 1);
     Injector injector = WebAppTests.createMockInjector(AppContext.class, ctx);
     AppController controller = injector.getInstance(AppController.class);
     controller.index();
-    assertEquals(ctx.getApplicationID().toString(), controller.get(APP_ID,""));
+    assertEquals(ctx.getApplicationID().toString(), controller.get(APP_ID, ""));
   }
 
-  @Test public void testAppView() {
+  @Test
+  void testAppView() {
     WebAppTests.testPage(AppView.class, AppContext.class, new MockAppContext(0, 1, 1, 1));
   }
 
 
-  
-  @Test public void testJobView() {
+  @Test
+  void testJobView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getJobParams(appContext);
     WebAppTests.testPage(JobPage.class, AppContext.class, appContext, params);
   }
 
-  @Test public void testTasksView() {
+  @Test
+  void testTasksView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     WebAppTests.testPage(TasksPage.class, AppContext.class, appContext, params);
   }
 
-  @Test public void testTaskView() {
+  @Test
+  void testTaskView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     App app = new App(appContext);
@@ -138,47 +141,52 @@ public class TestAMWebApp {
     return params;
   }
 
-  @Test public void testConfView() {
+  @Test
+  void testConfView() {
     WebAppTests.testPage(JobConfPage.class, AppContext.class,
-                         new MockAppContext(0, 1, 1, 1));
+        new MockAppContext(0, 1, 1, 1));
   }
 
-  @Test public void testCountersView() {
+  @Test
+  void testCountersView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getJobParams(appContext);
     WebAppTests.testPage(CountersPage.class, AppContext.class,
-                         appContext, params);
+        appContext, params);
   }
-  
-  @Test public void testSingleCounterView() {
+
+  @Test
+  void testSingleCounterView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Job job = appContext.getAllJobs().values().iterator().next();
     // add a failed task to the job without any counters
     Task failedTask = MockJobs.newTask(job.getID(), 2, 1, true);
-    Map<TaskId,Task> tasks = job.getTasks();
+    Map<TaskId, Task> tasks = job.getTasks();
     tasks.put(failedTask.getID(), failedTask);
     Map<String, String> params = getJobParams(appContext);
-    params.put(AMParams.COUNTER_GROUP, 
+    params.put(AMParams.COUNTER_GROUP,
         "org.apache.hadoop.mapreduce.FileSystemCounter");
     params.put(AMParams.COUNTER_NAME, "HDFS_WRITE_OPS");
     WebAppTests.testPage(SingleCounterPage.class, AppContext.class,
-                         appContext, params);
+        appContext, params);
   }
 
-  @Test public void testTaskCountersView() {
+  @Test
+  void testTaskCountersView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 1);
     Map<String, String> params = getTaskParams(appContext);
     WebAppTests.testPage(CountersPage.class, AppContext.class,
-                         appContext, params);
+        appContext, params);
   }
 
-  @Test public void testSingleTaskCounterView() {
+  @Test
+  void testSingleTaskCounterView() {
     AppContext appContext = new MockAppContext(0, 1, 1, 2);
     Map<String, String> params = getTaskParams(appContext);
-    params.put(AMParams.COUNTER_GROUP, 
+    params.put(AMParams.COUNTER_GROUP,
         "org.apache.hadoop.mapreduce.FileSystemCounter");
     params.put(AMParams.COUNTER_NAME, "HDFS_WRITE_OPS");
-    
+
     // remove counters from one task attempt
     // to test handling of missing counters
     TaskId taskID = MRApps.toTaskID(params.get(AMParams.TASK_ID));
@@ -186,13 +194,13 @@ public class TestAMWebApp {
     Task task = job.getTask(taskID);
     TaskAttempt attempt = task.getAttempts().values().iterator().next();
     attempt.getReport().setCounters(null);
-    
+
     WebAppTests.testPage(SingleCounterPage.class, AppContext.class,
-                         appContext, params);
+        appContext, params);
   }
 
   @Test
-  public void testMRWebAppSSLDisabled() throws Exception {
+  void testMRWebAppSSLDisabled() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -206,14 +214,14 @@ public class TestAMWebApp {
 
     String hostPort =
         NetUtils.getHostPortString(((MRClientService) app.getClientService())
-          .getWebApp().getListenerAddress());
+            .getWebApp().getListenerAddress());
     // http:// should be accessible
     URL httpUrl = new URL("http://" + hostPort);
     HttpURLConnection conn = (HttpURLConnection) httpUrl.openConnection();
     InputStream in = conn.getInputStream();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     IOUtils.copyBytes(in, out, 1024);
-    Assert.assertTrue(out.toString().contains("MapReduce Application"));
+    assertTrue(out.toString().contains("MapReduce Application"));
 
     // https:// is not accessible.
     URL httpsUrl = new URL("https://" + hostPort);
@@ -221,7 +229,7 @@ public class TestAMWebApp {
       HttpURLConnection httpsConn =
           (HttpURLConnection) httpsUrl.openConnection();
       httpsConn.getInputStream();
-      Assert.fail("https:// is not accessible, expected to fail");
+      fail("https:// is not accessible, expected to fail");
     } catch (SSLException e) {
       // expected
     }
@@ -235,7 +243,7 @@ public class TestAMWebApp {
       = new EnvironmentVariables();
 
   @Test
-  public void testMRWebAppSSLEnabled() throws Exception {
+  void testMRWebAppSSLEnabled() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -270,7 +278,7 @@ public class TestAMWebApp {
     InputStream in = httpsConn.getInputStream();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     IOUtils.copyBytes(in, out, 1024);
-    Assert.assertTrue(out.toString().contains("MapReduce Application"));
+    assertTrue(out.toString().contains("MapReduce Application"));
 
     // http:// is not accessible.
     URL httpUrl = new URL("http://" + hostPort);
@@ -278,7 +286,7 @@ public class TestAMWebApp {
       HttpURLConnection httpConn =
           (HttpURLConnection) httpUrl.openConnection();
       httpConn.getResponseCode();
-      Assert.fail("http:// is not accessible, expected to fail");
+      fail("http:// is not accessible, expected to fail");
     } catch (SocketException e) {
       // expected
     }
@@ -290,7 +298,7 @@ public class TestAMWebApp {
   }
 
   @Test
-  public void testMRWebAppSSLEnabledWithClientAuth() throws Exception {
+  void testMRWebAppSSLEnabledWithClientAuth() throws Exception {
     MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
       @Override
       protected ClientService createClientService(AppContext context) {
@@ -337,7 +345,7 @@ public class TestAMWebApp {
     InputStream in = httpsConn.getInputStream();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     IOUtils.copyBytes(in, out, 1024);
-    Assert.assertTrue(out.toString().contains("MapReduce Application"));
+    assertTrue(out.toString().contains("MapReduce Application"));
 
     // Try with wrong client cert
     KeyPair otherClientKeyPair = KeyStoreTestUtil.generateKeyPair("RSA");
@@ -349,7 +357,7 @@ public class TestAMWebApp {
       HttpURLConnection httpConn =
           (HttpURLConnection) httpsUrl.openConnection();
       httpConn.getResponseCode();
-      Assert.fail("Wrong client certificate, expected to fail");
+      fail("Wrong client certificate, expected to fail");
     } catch (SSLException e) {
       // expected
     }
@@ -371,10 +379,10 @@ public class TestAMWebApp {
   }
 
   @Test
-  public void testMRWebAppRedirection() throws Exception {
+  void testMRWebAppRedirection() throws Exception {
 
     String[] schemePrefix =
-        { WebAppUtils.HTTP_PREFIX, WebAppUtils.HTTPS_PREFIX };
+        {WebAppUtils.HTTP_PREFIX, WebAppUtils.HTTPS_PREFIX};
     for (String scheme : schemePrefix) {
       MRApp app = new MRApp(2, 2, true, this.getClass().getName(), true) {
         @Override
@@ -385,15 +393,15 @@ public class TestAMWebApp {
       Configuration conf = new Configuration();
       conf.set(YarnConfiguration.PROXY_ADDRESS, "9.9.9.9");
       conf.set(YarnConfiguration.YARN_HTTP_POLICY_KEY, scheme
-        .equals(WebAppUtils.HTTPS_PREFIX) ? Policy.HTTPS_ONLY.name()
+          .equals(WebAppUtils.HTTPS_PREFIX) ? Policy.HTTPS_ONLY.name()
           : Policy.HTTP_ONLY.name());
       webProxyBase = "/proxy/" + app.getAppID();
       conf.set("hadoop.http.filter.initializers",
-        TestAMFilterInitializer.class.getName());
+          TestAMFilterInitializer.class.getName());
       Job job = app.submit(conf);
       String hostPort =
           NetUtils.getHostPortString(((MRClientService) app.getClientService())
-            .getWebApp().getListenerAddress());
+              .getWebApp().getListenerAddress());
       URL httpUrl = new URL("http://" + hostPort + "/mapreduce");
 
       HttpURLConnection conn = (HttpURLConnection) httpUrl.openConnection();
@@ -404,10 +412,10 @@ public class TestAMWebApp {
       String expectedURL = scheme + conf.get(YarnConfiguration.PROXY_ADDRESS)
           + ProxyUriUtils.getPath(app.getAppID(), "/mapreduce", true);
 
-      Assert.assertEquals(expectedURL,
-        conn.getHeaderField(HttpHeaders.LOCATION));
-      Assert.assertEquals(HttpStatus.SC_MOVED_TEMPORARILY,
-        conn.getResponseCode());
+      assertEquals(expectedURL,
+          conn.getHeaderField(HttpHeaders.LOCATION));
+      assertEquals(HttpStatus.SC_MOVED_TEMPORARILY,
+          conn.getResponseCode());
       app.waitForState(job, JobState.SUCCEEDED);
       app.verifyCompleted();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServices.java
@@ -19,9 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.StringReader;
 import java.util.Set;
@@ -42,8 +40,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -92,7 +90,7 @@ public class TestAMWebServices extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -109,43 +107,43 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testAM() throws JSONException, Exception {
+  void testAM() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testAMSlash() throws JSONException, Exception {
+  void testAMSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce/")
         .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testAMDefault() throws JSONException, Exception {
+  void testAMDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce/")
         .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testAMXML() throws JSONException, Exception {
+  void testAMXML() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .accept(MediaType.APPLICATION_XML).get(ClientResponse.class);
@@ -156,7 +154,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInfo() throws JSONException, Exception {
+  void testInfo() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info").accept(MediaType.APPLICATION_JSON)
@@ -164,12 +162,12 @@ public class TestAMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testInfoSlash() throws JSONException, Exception {
+  void testInfoSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").accept(MediaType.APPLICATION_JSON)
@@ -177,24 +175,24 @@ public class TestAMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testInfoDefault() throws JSONException, Exception {
+  void testInfoDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAMInfo(json.getJSONObject("info"), appContext);
   }
 
   @Test
-  public void testInfoXML() throws JSONException, Exception {
+  void testInfoXML() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("info/").accept(MediaType.APPLICATION_XML)
@@ -206,7 +204,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInvalidUri() throws JSONException, Exception {
+  void testInvalidUri() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -222,7 +220,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInvalidUri2() throws JSONException, Exception {
+  void testInvalidUri2() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -238,7 +236,7 @@ public class TestAMWebServices extends JerseyTestBase {
   }
 
   @Test
-  public void testInvalidAccept() throws JSONException, Exception {
+  void testInvalidAccept() throws JSONException, Exception {
     WebResource r = resource();
     String responseStr = "";
     try {
@@ -253,9 +251,9 @@ public class TestAMWebServices extends JerseyTestBase {
           "error string exists and shouldn't", "", responseStr);
     }
   }
-  
+
   @Test
-  public void testBlacklistedNodes() throws JSONException, Exception {
+  void testBlacklistedNodes() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("blacklistednodes").accept(MediaType.APPLICATION_JSON)
@@ -263,12 +261,12 @@ public class TestAMWebServices extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyBlacklistedNodesInfo(json, appContext);
   }
-  
+
   @Test
-  public void testBlacklistedNodesXML() throws Exception {
+  void testBlacklistedNodesXML() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("blacklistednodes").accept(MediaType.APPLICATION_XML)
@@ -281,7 +279,7 @@ public class TestAMWebServices extends JerseyTestBase {
 
   public void verifyAMInfo(JSONObject info, AppContext ctx)
       throws JSONException {
-    assertEquals("incorrect number of elements", 5, info.length());
+    assertEquals(5, info.length(), "incorrect number of elements");
 
     verifyAMInfoGeneric(ctx, info.getString("appId"), info.getString("user"),
         info.getString("name"), info.getLong("startedOn"),
@@ -296,7 +294,7 @@ public class TestAMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("info");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -319,8 +317,8 @@ public class TestAMWebServices extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("name", ctx.getApplicationName(),
         name);
 
-    assertEquals("startedOn incorrect", ctx.getStartTime(), startedOn);
-    assertTrue("elapsedTime not greater then 0", (elapsedTime > 0));
+    assertEquals(ctx.getStartTime(), startedOn, "startedOn incorrect");
+    assertTrue((elapsedTime > 0), "elapsedTime not greater then 0");
 
   }
   
@@ -341,11 +339,12 @@ public class TestAMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList infonodes = dom.getElementsByTagName("blacklistednodesinfo");
-    assertEquals("incorrect number of elements", 1, infonodes.getLength());
+    assertEquals(1, infonodes.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("blacklistedNodes");
     Set<String> blacklistedNodes = ctx.getBlacklistedNodes();
-    assertEquals("incorrect number of elements", blacklistedNodes.size(),
-        nodes.getLength());
+    assertEquals(blacklistedNodes.size(),
+        nodes.getLength(),
+        "incorrect number of elements");
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
       assertTrue(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempt.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 import java.util.Enumeration;
@@ -49,8 +49,8 @@ import org.apache.hadoop.yarn.webapp.GuiceServletConfig;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -117,7 +117,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -134,7 +134,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testGetTaskAttemptIdState() throws Exception {
+  void testGetTaskAttemptIdState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -154,9 +154,9 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
               .queryParam("user.name", webserviceUserName)
               .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
-                  + JettyUtils.UTF_8, response.getType().toString());
+              + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           assertEquals(att.getState().toString(), json.get("state"));
         }
       }
@@ -164,7 +164,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testGetTaskAttemptIdXMLState() throws Exception {
+  void testGetTaskAttemptIdXMLState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -201,7 +201,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testPutTaskAttemptIdState() throws Exception {
+  void testPutTaskAttemptIdState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -223,9 +223,9 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
               .type(MediaType.APPLICATION_JSON)
               .put(ClientResponse.class, "{\"state\":\"KILLED\"}");
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
-                  + JettyUtils.UTF_8, response.getType().toString());
+              + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           assertEquals(TaskAttemptState.KILLED.toString(), json.get("state"));
         }
       }
@@ -233,7 +233,7 @@ public class TestAMWebServicesAttempt extends JerseyTestBase {
   }
 
   @Test
-  public void testPutTaskAttemptIdXMLState() throws Exception {
+  void testPutTaskAttemptIdXMLState() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesAttempts.java
@@ -19,11 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.StringReader;
 import java.util.List;
@@ -51,8 +47,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -100,7 +96,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -117,7 +113,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttempts() throws JSONException, Exception {
+  void testTaskAttempts() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -137,7 +133,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptsSlash() throws JSONException, Exception {
+  void testTaskAttemptsSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -157,7 +153,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptsDefault() throws JSONException, Exception {
+  void testTaskAttemptsDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -177,7 +173,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptsXML() throws JSONException, Exception {
+  void testTaskAttemptsXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -198,7 +194,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
         is.setCharacterStream(new StringReader(xml));
         Document dom = db.parse(is);
         NodeList attempts = dom.getElementsByTagName("taskAttempts");
-        assertEquals("incorrect number of elements", 1, attempts.getLength());
+        assertEquals(1, attempts.getLength(), "incorrect number of elements");
 
         NodeList nodes = dom.getElementsByTagName("taskAttempt");
         verifyAMTaskAttemptsXML(nodes, task);
@@ -207,7 +203,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptId() throws JSONException, Exception {
+  void testTaskAttemptId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -226,9 +222,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
               .path("attempts").path(attid).accept(MediaType.APPLICATION_JSON)
               .get(ClientResponse.class);
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
-                  + JettyUtils.UTF_8, response.getType().toString());
+              + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("taskAttempt");
           verifyAMTaskAttempt(info, att, task.getType());
         }
@@ -237,7 +233,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdSlash() throws JSONException, Exception {
+  void testTaskAttemptIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -256,9 +252,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
               .path("attempts").path(attid + "/")
               .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
-                  + JettyUtils.UTF_8, response.getType().toString());
+              + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("taskAttempt");
           verifyAMTaskAttempt(info, att, task.getType());
         }
@@ -267,7 +263,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdDefault() throws JSONException, Exception {
+  void testTaskAttemptIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -285,9 +281,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
               .path("jobs").path(jobId).path("tasks").path(tid)
               .path("attempts").path(attid).get(ClientResponse.class);
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
-                  + JettyUtils.UTF_8, response.getType().toString());
+              + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("taskAttempt");
           verifyAMTaskAttempt(info, att, task.getType());
         }
@@ -296,7 +292,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdXML() throws JSONException, Exception {
+  void testTaskAttemptIdXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -332,14 +328,14 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdBogus() throws JSONException, Exception {
+  void testTaskAttemptIdBogus() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("bogusid",
         "java.lang.Exception: TaskAttemptId string : bogusid is not properly formed");
   }
 
   @Test
-  public void testTaskAttemptIdNonExist() throws JSONException, Exception {
+  void testTaskAttemptIdNonExist() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric(
         "attempt_0_12345_m_000000_0",
@@ -347,21 +343,21 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdInvalid() throws JSONException, Exception {
+  void testTaskAttemptIdInvalid() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_d_000000_0",
         "java.lang.Exception: Bad TaskType identifier. TaskAttemptId string : attempt_0_12345_d_000000_0 is not properly formed.");
   }
 
   @Test
-  public void testTaskAttemptIdInvalid2() throws JSONException, Exception {
+  void testTaskAttemptIdInvalid2() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_12345_m_000000_0",
         "java.lang.Exception: TaskAttemptId string : attempt_12345_m_000000_0 is not properly formed");
   }
 
   @Test
-  public void testTaskAttemptIdInvalid3() throws JSONException, Exception {
+  void testTaskAttemptIdInvalid3() throws JSONException, Exception {
 
     testTaskAttemptIdErrorGeneric("attempt_0_12345_m_000000",
         "java.lang.Exception: TaskAttemptId string : attempt_0_12345_m_000000 is not properly formed");
@@ -390,7 +386,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
                   + JettyUtils.UTF_8, response.getType().toString());
           JSONObject msg = response.getEntity(JSONObject.class);
           JSONObject exception = msg.getJSONObject("RemoteException");
-          assertEquals("incorrect number of elements", 3, exception.length());
+          assertEquals(3, exception.length(), "incorrect number of elements");
           String message = exception.getString("message");
           String type = exception.getString("exception");
           String classname = exception.getString("javaClassName");
@@ -433,9 +429,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   public void verifyAMTaskAttempt(JSONObject info, TaskAttempt att,
       TaskType ttype) throws JSONException {
     if (ttype == TaskType.REDUCE) {
-      assertEquals("incorrect number of elements", 17, info.length());
+      assertEquals(17, info.length(), "incorrect number of elements");
     } else {
-      assertEquals("incorrect number of elements", 12, info.length());
+      assertEquals(12, info.length(), "incorrect number of elements");
     }
 
     verifyTaskAttemptGeneric(att, ttype, info.getString("id"),
@@ -454,9 +450,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
 
   public void verifyAMTaskAttempts(JSONObject json, Task task)
       throws JSONException {
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject attempts = json.getJSONObject("taskAttempts");
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONArray arr = attempts.getJSONArray("taskAttempt");
     for (TaskAttempt att : task.getAttempts().values()) {
       TaskAttemptId id = att.getID();
@@ -470,13 +466,13 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
           verifyAMTaskAttempt(info, att, task.getType());
         }
       }
-      assertTrue("task attempt with id: " + attid
-          + " not in web service output", found);
+      assertTrue(found, "task attempt with id: " + attid
+          + " not in web service output");
     }
   }
 
   public void verifyAMTaskAttemptsXML(NodeList nodes, Task task) {
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (TaskAttempt att : task.getAttempts().values()) {
       TaskAttemptId id = att.getID();
@@ -484,15 +480,15 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
       Boolean found = false;
       for (int i = 0; i < nodes.getLength(); i++) {
         Element element = (Element) nodes.item(i);
-        assertFalse("task attempt should not contain any attributes, it can lead to incorrect JSON marshaling",
-            element.hasAttributes());
+        assertFalse(element.hasAttributes(),
+            "task attempt should not contain any attributes, it can lead to incorrect JSON marshaling");
 
         if (attid.matches(WebServicesTestUtils.getXmlString(element, "id"))) {
           found = true;
           verifyAMTaskAttemptXML(element, att, task.getType());
         }
       }
-      assertTrue("task with id: " + attid + " not in web service output", found);
+      assertTrue(found, "task with id: " + attid + " not in web service output");
     }
   }
 
@@ -527,30 +523,29 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
         ta.getAssignedContainerID().toString(),
         assignedContainerId);
 
-    assertEquals("startTime wrong", ta.getLaunchTime(), startTime);
-    assertEquals("finishTime wrong", ta.getFinishTime(), finishTime);
-    assertEquals("elapsedTime wrong", finishTime - startTime, elapsedTime);
-    assertEquals("progress wrong", ta.getProgress() * 100, progress, 1e-3f);
+    assertEquals(ta.getLaunchTime(), startTime, "startTime wrong");
+    assertEquals(ta.getFinishTime(), finishTime, "finishTime wrong");
+    assertEquals(finishTime - startTime, elapsedTime, "elapsedTime wrong");
+    assertEquals(ta.getProgress() * 100, progress, 1e-3f, "progress wrong");
   }
 
   public void verifyReduceTaskAttemptGeneric(TaskAttempt ta,
       long shuffleFinishTime, long mergeFinishTime, long elapsedShuffleTime,
       long elapsedMergeTime, long elapsedReduceTime) {
 
-    assertEquals("shuffleFinishTime wrong", ta.getShuffleFinishTime(),
-        shuffleFinishTime);
-    assertEquals("mergeFinishTime wrong", ta.getSortFinishTime(),
-        mergeFinishTime);
-    assertEquals("elapsedShuffleTime wrong",
-        ta.getShuffleFinishTime() - ta.getLaunchTime(), elapsedShuffleTime);
-    assertEquals("elapsedMergeTime wrong",
-        ta.getSortFinishTime() - ta.getShuffleFinishTime(), elapsedMergeTime);
-    assertEquals("elapsedReduceTime wrong",
-        ta.getFinishTime() - ta.getSortFinishTime(), elapsedReduceTime);
+    assertEquals(ta.getShuffleFinishTime(),
+        shuffleFinishTime,
+        "shuffleFinishTime wrong");
+    assertEquals(ta.getSortFinishTime(),
+        mergeFinishTime,
+        "mergeFinishTime wrong");
+    assertEquals(ta.getShuffleFinishTime() - ta.getLaunchTime(), elapsedShuffleTime, "elapsedShuffleTime wrong");
+    assertEquals(ta.getSortFinishTime() - ta.getShuffleFinishTime(), elapsedMergeTime, "elapsedMergeTime wrong");
+    assertEquals(ta.getFinishTime() - ta.getSortFinishTime(), elapsedReduceTime, "elapsedReduceTime wrong");
   }
 
   @Test
-  public void testTaskAttemptIdCounters() throws JSONException, Exception {
+  void testTaskAttemptIdCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
 
@@ -569,9 +564,9 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
               .path("attempts").path(attid).path("counters")
               .accept(MediaType.APPLICATION_JSON).get(ClientResponse.class);
           assertEquals(MediaType.APPLICATION_JSON_TYPE + "; "
-                  + JettyUtils.UTF_8, response.getType().toString());
+              + JettyUtils.UTF_8, response.getType().toString());
           JSONObject json = response.getEntity(JSONObject.class);
-          assertEquals("incorrect number of elements", 1, json.length());
+          assertEquals(1, json.length(), "incorrect number of elements");
           JSONObject info = json.getJSONObject("jobTaskAttemptCounters");
           verifyAMJobTaskAttemptCounters(info, att);
         }
@@ -580,7 +575,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskAttemptIdXMLCounters() throws JSONException, Exception {
+  void testTaskAttemptIdXMLCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -616,7 +611,7 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
   public void verifyAMJobTaskAttemptCounters(JSONObject info, TaskAttempt att)
       throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("id", MRApps.toString(att.getID()),
         info.getString("id"));
@@ -627,15 +622,15 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
     for (int i = 0; i < counterGroups.length(); i++) {
       JSONObject counterGroup = counterGroups.getJSONObject(i);
       String name = counterGroup.getString("counterGroupName");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
       JSONArray counters = counterGroup.getJSONArray("counter");
       for (int j = 0; j < counters.length(); j++) {
         JSONObject counter = counters.getJSONObject(j);
         String counterName = counter.getString("name");
-        assertTrue("name not set",
-            (counterName != null && !counterName.isEmpty()));
+        assertTrue((counterName != null && !counterName.isEmpty()),
+            "name not set");
         long value = counter.getLong("value");
-        assertTrue("value  >= 0", value >= 0);
+        assertTrue(value >= 0, "value  >= 0");
       }
     }
   }
@@ -653,20 +648,20 @@ public class TestAMWebServicesAttempts extends JerseyTestBase {
 
       for (int j = 0; j < groups.getLength(); j++) {
         Element counters = (Element) groups.item(j);
-        assertNotNull("should have counters in the web service info", counters);
+        assertNotNull(counters, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(counters,
             "counterGroupName");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
         NodeList counterArr = counters.getElementsByTagName("counter");
         for (int z = 0; z < counterArr.getLength(); z++) {
           Element counter = (Element) counterArr.item(z);
           String counterName = WebServicesTestUtils.getXmlString(counter,
               "name");
-          assertTrue("counter name not set",
-              (counterName != null && !counterName.isEmpty()));
+          assertTrue((counterName != null && !counterName.isEmpty()),
+              "counter name not set");
 
           long value = WebServicesTestUtils.getXmlLong(counter, "value");
-          assertTrue("value not >= 0", value >= 0);
+          assertTrue(value >= 0, "value not >= 0");
 
         }
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobConf.java
@@ -18,10 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,9 +48,9 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -125,7 +122,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -134,7 +131,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @AfterClass
+  @AfterAll
   static public void stop() {
     FileUtil.fullyDelete(testConfDir);
   }
@@ -148,7 +145,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
   }
 
   @Test
-  public void testJobConf() throws JSONException, Exception {
+  void testJobConf() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -160,14 +157,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("conf");
       verifyAMJobConf(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobConfSlash() throws JSONException, Exception {
+  void testJobConfSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -179,14 +176,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("conf");
       verifyAMJobConf(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobConfDefault() throws JSONException, Exception {
+  void testJobConfDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -197,14 +194,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("conf");
       verifyAMJobConf(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobConfXML() throws JSONException, Exception {
+  void testJobConfXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -228,7 +225,7 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
 
   public void verifyAMJobConf(JSONObject info, Job job) throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("path", job.getConfFile().toString(),
         info.getString("path"));
@@ -239,14 +236,14 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
       JSONObject prop = properties.getJSONObject(i);
       String name = prop.getString("name");
       String value = prop.getString("value");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
-      assertTrue("value not set", (value != null && !value.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
+      assertTrue((value != null && !value.isEmpty()), "value not set");
     }
   }
 
   public void verifyAMJobConfXML(NodeList nodes, Job job) {
 
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -259,11 +256,11 @@ public class TestAMWebServicesJobConf extends JerseyTestBase {
 
       for (int j = 0; j < properties.getLength(); j++) {
         Element property = (Element) properties.item(j);
-        assertNotNull("should have counters in the web service info", property);
+        assertNotNull(property, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(property, "name");
         String value = WebServicesTestUtils.getXmlString(property, "value");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
-        assertTrue("name not set", (value != null && !value.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
+        assertTrue((value != null && !value.isEmpty()), "name not set");
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesJobs.java
@@ -20,10 +20,7 @@ package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.util.StringHelper.ujoin;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.StringReader;
 import java.util.List;
@@ -53,8 +50,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -102,7 +99,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -119,7 +116,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobs() throws JSONException, Exception {
+  void testJobs() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").accept(MediaType.APPLICATION_JSON)
@@ -127,7 +124,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jobs = json.getJSONObject("jobs");
     JSONArray arr = jobs.getJSONArray("job");
     JSONObject info = arr.getJSONObject(0);
@@ -137,7 +134,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobsSlash() throws JSONException, Exception {
+  void testJobsSlash() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs/").accept(MediaType.APPLICATION_JSON)
@@ -145,7 +142,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jobs = json.getJSONObject("jobs");
     JSONArray arr = jobs.getJSONArray("job");
     JSONObject info = arr.getJSONObject(0);
@@ -155,14 +152,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobsDefault() throws JSONException, Exception {
+  void testJobsDefault() throws JSONException, Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
         response.getType().toString());
     JSONObject json = response.getEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jobs = json.getJSONObject("jobs");
     JSONArray arr = jobs.getJSONArray("job");
     JSONObject info = arr.getJSONObject(0);
@@ -172,7 +169,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobsXML() throws Exception {
+  void testJobsXML() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("mapreduce")
         .path("jobs").accept(MediaType.APPLICATION_XML)
@@ -186,15 +183,15 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList jobs = dom.getElementsByTagName("jobs");
-    assertEquals("incorrect number of elements", 1, jobs.getLength());
+    assertEquals(1, jobs.getLength(), "incorrect number of elements");
     NodeList job = dom.getElementsByTagName("job");
-    assertEquals("incorrect number of elements", 1, job.getLength());
+    assertEquals(1, job.getLength(), "incorrect number of elements");
     verifyAMJobXML(job, appContext);
 
   }
 
   @Test
-  public void testJobId() throws JSONException, Exception {
+  void testJobId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -206,7 +203,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("job");
       verifyAMJob(info, jobsMap.get(id));
     }
@@ -214,7 +211,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdSlash() throws JSONException, Exception {
+  void testJobIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -226,14 +223,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("job");
       verifyAMJob(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobIdDefault() throws JSONException, Exception {
+  void testJobIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -244,7 +241,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("job");
       verifyAMJob(info, jobsMap.get(id));
     }
@@ -252,7 +249,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdNonExist() throws JSONException, Exception {
+  void testJobIdNonExist() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -266,7 +263,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -280,7 +277,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdInvalid() throws JSONException, Exception {
+  void testJobIdInvalid() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -294,7 +291,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -304,7 +301,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   // verify the exception output default is JSON
   @Test
-  public void testJobIdInvalidDefault() throws JSONException, Exception {
+  void testJobIdInvalidDefault() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -318,7 +315,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -328,7 +325,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   // test that the exception output works in XML
   @Test
-  public void testJobIdInvalidXML() throws JSONException, Exception {
+  void testJobIdInvalidXML() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -368,7 +365,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdInvalidBogus() throws JSONException, Exception {
+  void testJobIdInvalidBogus() throws JSONException, Exception {
     WebResource r = resource();
 
     try {
@@ -382,7 +379,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           response.getType().toString());
       JSONObject msg = response.getEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -399,7 +396,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   }
 
   @Test
-  public void testJobIdXML() throws Exception {
+  void testJobIdXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -424,7 +421,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   public void verifyAMJob(JSONObject info, Job job) throws JSONException {
 
-    assertEquals("incorrect number of elements", 31, info.length());
+    assertEquals(31, info.length(), "incorrect number of elements");
 
     // everyone access fields
     verifyAMJobGeneric(job, info.getString("id"), info.getString("user"),
@@ -475,8 +472,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
         } else {
           fail("should have acls in the web service info");
         }
-        assertTrue("acl: " + expectName + " not found in webservice output",
-            found);
+        assertTrue(found,
+            "acl: " + expectName + " not found in webservice output");
       }
     }
 
@@ -484,14 +481,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   public void verifyAMJobXML(NodeList nodes, AppContext appContext) {
 
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
 
       Job job = appContext.getJob(MRApps.toJobID(WebServicesTestUtils
           .getXmlString(element, "id")));
-      assertNotNull("Job not found - output incorrect", job);
+      assertNotNull(job, "Job not found - output incorrect");
 
       verifyAMJobGeneric(job, WebServicesTestUtils.getXmlString(element, "id"),
           WebServicesTestUtils.getXmlString(element, "user"),
@@ -550,8 +547,8 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
           } else {
             fail("should have acls in the web service info");
           }
-          assertTrue("acl: " + expectName + " not found in webservice output",
-              found);
+          assertTrue(found,
+              "acl: " + expectName + " not found in webservice output");
         }
       }
     }
@@ -571,21 +568,23 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("state", job.getState().toString(),
         state);
 
-    assertEquals("startTime incorrect", report.getStartTime(), startTime);
-    assertEquals("finishTime incorrect", report.getFinishTime(), finishTime);
-    assertEquals("elapsedTime incorrect",
-        Times.elapsed(report.getStartTime(), report.getFinishTime()),
-        elapsedTime);
-    assertEquals("mapsTotal incorrect", job.getTotalMaps(), mapsTotal);
-    assertEquals("mapsCompleted incorrect", job.getCompletedMaps(),
-        mapsCompleted);
-    assertEquals("reducesTotal incorrect", job.getTotalReduces(), reducesTotal);
-    assertEquals("reducesCompleted incorrect", job.getCompletedReduces(),
-        reducesCompleted);
-    assertEquals("mapProgress incorrect", report.getMapProgress() * 100,
-        mapProgress, 0);
-    assertEquals("reduceProgress incorrect", report.getReduceProgress() * 100,
-        reduceProgress, 0);
+    assertEquals(report.getStartTime(), startTime, "startTime incorrect");
+    assertEquals(report.getFinishTime(), finishTime, "finishTime incorrect");
+    assertEquals(Times.elapsed(report.getStartTime(), report.getFinishTime()),
+        elapsedTime,
+        "elapsedTime incorrect");
+    assertEquals(job.getTotalMaps(), mapsTotal, "mapsTotal incorrect");
+    assertEquals(job.getCompletedMaps(),
+        mapsCompleted,
+        "mapsCompleted incorrect");
+    assertEquals(job.getTotalReduces(), reducesTotal, "reducesTotal incorrect");
+    assertEquals(job.getCompletedReduces(),
+        reducesCompleted,
+        "reducesCompleted incorrect");
+    assertEquals(report.getMapProgress() * 100,
+        mapProgress, 0, "mapProgress incorrect");
+    assertEquals(report.getReduceProgress() * 100,
+        reduceProgress, 0, "reduceProgress incorrect");
   }
 
   public void verifyAMJobGenericSecure(Job job, int mapsPending,
@@ -608,33 +607,33 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("diagnostics", diagString,
         diagnostics);
 
-    assertEquals("isUber incorrect", job.isUber(), uberized);
+    assertEquals(job.isUber(), uberized, "isUber incorrect");
 
     // unfortunately the following fields are all calculated in JobInfo
     // so not easily accessible without doing all the calculations again.
     // For now just make sure they are present.
-    assertTrue("mapsPending not >= 0", mapsPending >= 0);
-    assertTrue("mapsRunning not >= 0", mapsRunning >= 0);
-    assertTrue("reducesPending not >= 0", reducesPending >= 0);
-    assertTrue("reducesRunning not >= 0", reducesRunning >= 0);
+    assertTrue(mapsPending >= 0, "mapsPending not >= 0");
+    assertTrue(mapsRunning >= 0, "mapsRunning not >= 0");
+    assertTrue(reducesPending >= 0, "reducesPending not >= 0");
+    assertTrue(reducesRunning >= 0, "reducesRunning not >= 0");
 
-    assertTrue("newReduceAttempts not >= 0", newReduceAttempts >= 0);
-    assertTrue("runningReduceAttempts not >= 0", runningReduceAttempts >= 0);
-    assertTrue("failedReduceAttempts not >= 0", failedReduceAttempts >= 0);
-    assertTrue("killedReduceAttempts not >= 0", killedReduceAttempts >= 0);
-    assertTrue("successfulReduceAttempts not >= 0",
-        successfulReduceAttempts >= 0);
+    assertTrue(newReduceAttempts >= 0, "newReduceAttempts not >= 0");
+    assertTrue(runningReduceAttempts >= 0, "runningReduceAttempts not >= 0");
+    assertTrue(failedReduceAttempts >= 0, "failedReduceAttempts not >= 0");
+    assertTrue(killedReduceAttempts >= 0, "killedReduceAttempts not >= 0");
+    assertTrue(successfulReduceAttempts >= 0,
+        "successfulReduceAttempts not >= 0");
 
-    assertTrue("newMapAttempts not >= 0", newMapAttempts >= 0);
-    assertTrue("runningMapAttempts not >= 0", runningMapAttempts >= 0);
-    assertTrue("failedMapAttempts not >= 0", failedMapAttempts >= 0);
-    assertTrue("killedMapAttempts not >= 0", killedMapAttempts >= 0);
-    assertTrue("successfulMapAttempts not >= 0", successfulMapAttempts >= 0);
+    assertTrue(newMapAttempts >= 0, "newMapAttempts not >= 0");
+    assertTrue(runningMapAttempts >= 0, "runningMapAttempts not >= 0");
+    assertTrue(failedMapAttempts >= 0, "failedMapAttempts not >= 0");
+    assertTrue(killedMapAttempts >= 0, "killedMapAttempts not >= 0");
+    assertTrue(successfulMapAttempts >= 0, "successfulMapAttempts not >= 0");
 
   }
 
   @Test
-  public void testJobCounters() throws JSONException, Exception {
+  void testJobCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -646,14 +645,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobCounters");
       verifyAMJobCounters(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobCountersSlash() throws JSONException, Exception {
+  void testJobCountersSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -665,14 +664,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobCounters");
       verifyAMJobCounters(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobCountersDefault() throws JSONException, Exception {
+  void testJobCountersDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -683,14 +682,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobCounters");
       verifyAMJobCounters(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobCountersXML() throws Exception {
+  void testJobCountersXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -715,7 +714,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
   public void verifyAMJobCounters(JSONObject info, Job job)
       throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("id", MRApps.toString(job.getID()),
         info.getString("id"));
@@ -725,22 +724,22 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     for (int i = 0; i < counterGroups.length(); i++) {
       JSONObject counterGroup = counterGroups.getJSONObject(i);
       String name = counterGroup.getString("counterGroupName");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
       JSONArray counters = counterGroup.getJSONArray("counter");
       for (int j = 0; j < counters.length(); j++) {
         JSONObject counter = counters.getJSONObject(j);
         String counterName = counter.getString("name");
-        assertTrue("counter name not set",
-            (counterName != null && !counterName.isEmpty()));
+        assertTrue((counterName != null && !counterName.isEmpty()),
+            "counter name not set");
 
         long mapValue = counter.getLong("mapCounterValue");
-        assertTrue("mapCounterValue  >= 0", mapValue >= 0);
+        assertTrue(mapValue >= 0, "mapCounterValue  >= 0");
 
         long reduceValue = counter.getLong("reduceCounterValue");
-        assertTrue("reduceCounterValue  >= 0", reduceValue >= 0);
+        assertTrue(reduceValue >= 0, "reduceCounterValue  >= 0");
 
         long totalValue = counter.getLong("totalCounterValue");
-        assertTrue("totalCounterValue  >= 0", totalValue >= 0);
+        assertTrue(totalValue >= 0, "totalCounterValue  >= 0");
 
       }
     }
@@ -751,7 +750,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
 
-      assertNotNull("Job not found - output incorrect", job);
+      assertNotNull(job, "Job not found - output incorrect");
 
       WebServicesTestUtils.checkStringMatch("id", MRApps.toString(job.getID()),
           WebServicesTestUtils.getXmlString(element, "id"));
@@ -761,36 +760,36 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
       for (int j = 0; j < groups.getLength(); j++) {
         Element counters = (Element) groups.item(j);
-        assertNotNull("should have counters in the web service info", counters);
+        assertNotNull(counters, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(counters,
             "counterGroupName");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
         NodeList counterArr = counters.getElementsByTagName("counter");
         for (int z = 0; z < counterArr.getLength(); z++) {
           Element counter = (Element) counterArr.item(z);
           String counterName = WebServicesTestUtils.getXmlString(counter,
               "name");
-          assertTrue("counter name not set",
-              (counterName != null && !counterName.isEmpty()));
+          assertTrue((counterName != null && !counterName.isEmpty()),
+              "counter name not set");
 
           long mapValue = WebServicesTestUtils.getXmlLong(counter,
               "mapCounterValue");
-          assertTrue("mapCounterValue not >= 0", mapValue >= 0);
+          assertTrue(mapValue >= 0, "mapCounterValue not >= 0");
 
           long reduceValue = WebServicesTestUtils.getXmlLong(counter,
               "reduceCounterValue");
-          assertTrue("reduceCounterValue  >= 0", reduceValue >= 0);
+          assertTrue(reduceValue >= 0, "reduceCounterValue  >= 0");
 
           long totalValue = WebServicesTestUtils.getXmlLong(counter,
               "totalCounterValue");
-          assertTrue("totalCounterValue  >= 0", totalValue >= 0);
+          assertTrue(totalValue >= 0, "totalCounterValue  >= 0");
         }
       }
     }
   }
 
   @Test
-  public void testJobAttempts() throws JSONException, Exception {
+  void testJobAttempts() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -802,14 +801,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobAttempts");
       verifyJobAttempts(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobAttemptsSlash() throws JSONException, Exception {
+  void testJobAttemptsSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -821,14 +820,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobAttempts");
       verifyJobAttempts(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobAttemptsDefault() throws JSONException, Exception {
+  void testJobAttemptsDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -840,14 +839,14 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject info = json.getJSONObject("jobAttempts");
       verifyJobAttempts(info, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testJobAttemptsXML() throws Exception {
+  void testJobAttemptsXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -865,7 +864,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       is.setCharacterStream(new StringReader(xml));
       Document dom = db.parse(is);
       NodeList attempts = dom.getElementsByTagName("jobAttempts");
-      assertEquals("incorrect number of elements", 1, attempts.getLength());
+      assertEquals(1, attempts.getLength(), "incorrect number of elements");
       NodeList info = dom.getElementsByTagName("jobAttempt");
       verifyJobAttemptsXML(info, jobsMap.get(id));
     }
@@ -875,7 +874,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
       throws JSONException {
 
     JSONArray attempts = info.getJSONArray("jobAttempt");
-    assertEquals("incorrect number of elements", 2, attempts.length());
+    assertEquals(2, attempts.length(), "incorrect number of elements");
     for (int i = 0; i < attempts.length(); i++) {
       JSONObject attempt = attempts.getJSONObject(i);
       verifyJobAttemptsGeneric(job, attempt.getString("nodeHttpAddress"),
@@ -887,7 +886,7 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
 
   public void verifyJobAttemptsXML(NodeList nodes, Job job) {
 
-    assertEquals("incorrect number of elements", 2, nodes.getLength());
+    assertEquals(2, nodes.getLength(), "incorrect number of elements");
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
       verifyJobAttemptsGeneric(job,
@@ -913,17 +912,17 @@ public class TestAMWebServicesJobs extends JerseyTestBase {
             + nmHttpPort, nodeHttpAddress);
         WebServicesTestUtils.checkStringMatch("nodeId",
             NodeId.newInstance(nmHost, nmPort).toString(), nodeId);
-        assertTrue("startime not greater than 0", startTime > 0);
+        assertTrue(startTime > 0, "startime not greater than 0");
         WebServicesTestUtils.checkStringMatch("containerId", amInfo
             .getContainerId().toString(), containerId);
 
         String localLogsLink =ujoin("node", "containerlogs", containerId,
             job.getUserName());
 
-        assertTrue("logsLink", logsLink.contains(localLogsLink));
+        assertTrue(logsLink.contains(localLogsLink), "logsLink");
       }
     }
-    assertTrue("attempt: " + id + " was not found", attemptFound);
+    assertTrue(attemptFound, "attempt: " + id + " was not found");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAMWebServicesTasks.java
@@ -19,10 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.StringReader;
 import java.util.Map;
@@ -49,8 +46,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -98,7 +95,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         Guice.createInjector(new WebServletModule()));
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -115,7 +112,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTasks() throws JSONException, Exception {
+  void testTasks() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -126,17 +123,17 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 2, arr.length());
+      assertEquals(2, arr.length(), "incorrect number of elements");
 
       verifyAMTask(arr, jobsMap.get(id), null);
     }
   }
 
   @Test
-  public void testTasksDefault() throws JSONException, Exception {
+  void testTasksDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -146,17 +143,17 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 2, arr.length());
+      assertEquals(2, arr.length(), "incorrect number of elements");
 
       verifyAMTask(arr, jobsMap.get(id), null);
     }
   }
 
   @Test
-  public void testTasksSlash() throws JSONException, Exception {
+  void testTasksSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -167,17 +164,17 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 2, arr.length());
+      assertEquals(2, arr.length(), "incorrect number of elements");
 
       verifyAMTask(arr, jobsMap.get(id), null);
     }
   }
 
   @Test
-  public void testTasksXML() throws JSONException, Exception {
+  void testTasksXML() throws JSONException, Exception {
 
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
@@ -195,14 +192,14 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       is.setCharacterStream(new StringReader(xml));
       Document dom = db.parse(is);
       NodeList tasks = dom.getElementsByTagName("tasks");
-      assertEquals("incorrect number of elements", 1, tasks.getLength());
+      assertEquals(1, tasks.getLength(), "incorrect number of elements");
       NodeList task = dom.getElementsByTagName("task");
       verifyAMTaskXML(task, jobsMap.get(id));
     }
   }
 
   @Test
-  public void testTasksQueryMap() throws JSONException, Exception {
+  void testTasksQueryMap() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -214,16 +211,16 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 1, arr.length());
+      assertEquals(1, arr.length(), "incorrect number of elements");
       verifyAMTask(arr, jobsMap.get(id), type);
     }
   }
 
   @Test
-  public void testTasksQueryReduce() throws JSONException, Exception {
+  void testTasksQueryReduce() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -235,16 +232,16 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
           response.getType().toString());
       JSONObject json = response.getEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject tasks = json.getJSONObject("tasks");
       JSONArray arr = tasks.getJSONArray("task");
-      assertEquals("incorrect number of elements", 1, arr.length());
+      assertEquals(1, arr.length(), "incorrect number of elements");
       verifyAMTask(arr, jobsMap.get(id), type);
     }
   }
 
   @Test
-  public void testTasksQueryInvalid() throws JSONException, Exception {
+  void testTasksQueryInvalid() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -264,7 +261,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -279,7 +276,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskId() throws JSONException, Exception {
+  void testTaskId() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -293,7 +290,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("task");
         verifyAMSingleTask(info, task);
       }
@@ -301,7 +298,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdSlash() throws JSONException, Exception {
+  void testTaskIdSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -315,7 +312,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("task");
         verifyAMSingleTask(info, task);
       }
@@ -323,7 +320,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdDefault() throws JSONException, Exception {
+  void testTaskIdDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -337,7 +334,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("task");
         verifyAMSingleTask(info, task);
       }
@@ -345,7 +342,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdBogus() throws JSONException, Exception {
+  void testTaskIdBogus() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -362,7 +359,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -380,7 +377,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdNonExist() throws JSONException, Exception {
+  void testTaskIdNonExist() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -397,7 +394,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -413,7 +410,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdInvalid() throws JSONException, Exception {
+  void testTaskIdInvalid() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -430,7 +427,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -448,7 +445,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdInvalid2() throws JSONException, Exception {
+  void testTaskIdInvalid2() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -465,7 +462,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -483,7 +480,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdInvalid3() throws JSONException, Exception {
+  void testTaskIdInvalid3() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -500,7 +497,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             response.getType().toString());
         JSONObject msg = response.getEntity(JSONObject.class);
         JSONObject exception = msg.getJSONObject("RemoteException");
-        assertEquals("incorrect number of elements", 3, exception.length());
+        assertEquals(3, exception.length(), "incorrect number of elements");
         String message = exception.getString("message");
         String type = exception.getString("exception");
         String classname = exception.getString("javaClassName");
@@ -518,7 +515,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdXML() throws JSONException, Exception {
+  void testTaskIdXML() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -549,7 +546,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
 
   public void verifyAMSingleTask(JSONObject info, Task task)
       throws JSONException {
-    assertEquals("incorrect number of elements", 9, info.length());
+    assertEquals(9, info.length(), "incorrect number of elements");
 
     verifyTaskGeneric(task, info.getString("id"), info.getString("state"),
         info.getString("type"), info.getString("successfulAttempt"),
@@ -573,7 +570,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
             verifyAMSingleTask(info, task);
           }
         }
-        assertTrue("task with id: " + tid + " not in web service output", found);
+        assertTrue(found, "task with id: " + tid + " not in web service output");
       }
     }
   }
@@ -592,12 +589,12 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("state", report.getTaskState()
         .toString(), state);
     // not easily checked without duplicating logic, just make sure its here
-    assertNotNull("successfulAttempt null", successfulAttempt);
-    assertEquals("startTime wrong", report.getStartTime(), startTime);
-    assertEquals("finishTime wrong", report.getFinishTime(), finishTime);
-    assertEquals("elapsedTime wrong", finishTime - startTime, elapsedTime);
-    assertEquals("progress wrong", report.getProgress() * 100, progress, 1e-3f);
-    assertEquals("status wrong", report.getStatus(), status);
+    assertNotNull(successfulAttempt, "successfulAttempt null");
+    assertEquals(report.getStartTime(), startTime, "startTime wrong");
+    assertEquals(report.getFinishTime(), finishTime, "finishTime wrong");
+    assertEquals(finishTime - startTime, elapsedTime, "elapsedTime wrong");
+    assertEquals(report.getProgress() * 100, progress, 1e-3f, "progress wrong");
+    assertEquals(report.getStatus(), status, "status wrong");
   }
 
   public void verifyAMSingleTaskXML(Element element, Task task) {
@@ -614,7 +611,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
 
   public void verifyAMTaskXML(NodeList nodes, Job job) {
 
-    assertEquals("incorrect number of elements", 2, nodes.getLength());
+    assertEquals(2, nodes.getLength(), "incorrect number of elements");
 
     for (Task task : job.getTasks().values()) {
       TaskId id = task.getID();
@@ -628,12 +625,12 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
           verifyAMSingleTaskXML(element, task);
         }
       }
-      assertTrue("task with id: " + tid + " not in web service output", found);
+      assertTrue(found, "task with id: " + tid + " not in web service output");
     }
   }
 
   @Test
-  public void testTaskIdCounters() throws JSONException, Exception {
+  void testTaskIdCounters() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -647,7 +644,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("jobTaskCounters");
         verifyAMJobTaskCounters(info, task);
       }
@@ -655,7 +652,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdCountersSlash() throws JSONException, Exception {
+  void testTaskIdCountersSlash() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -669,7 +666,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("jobTaskCounters");
         verifyAMJobTaskCounters(info, task);
       }
@@ -677,7 +674,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testTaskIdCountersDefault() throws JSONException, Exception {
+  void testTaskIdCountersDefault() throws JSONException, Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -691,7 +688,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
         assertEquals(MediaType.APPLICATION_JSON_TYPE + "; " + JettyUtils.UTF_8,
             response.getType().toString());
         JSONObject json = response.getEntity(JSONObject.class);
-        assertEquals("incorrect number of elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of elements");
         JSONObject info = json.getJSONObject("jobTaskCounters");
         verifyAMJobTaskCounters(info, task);
       }
@@ -699,7 +696,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   }
 
   @Test
-  public void testJobTaskCountersXML() throws Exception {
+  void testJobTaskCountersXML() throws Exception {
     WebResource r = resource();
     Map<JobId, Job> jobsMap = appContext.getAllJobs();
     for (JobId id : jobsMap.keySet()) {
@@ -727,7 +724,7 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
   public void verifyAMJobTaskCounters(JSONObject info, Task task)
       throws JSONException {
 
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
 
     WebServicesTestUtils.checkStringMatch("id", MRApps.toString(task.getID()),
         info.getString("id"));
@@ -737,15 +734,15 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
     for (int i = 0; i < counterGroups.length(); i++) {
       JSONObject counterGroup = counterGroups.getJSONObject(i);
       String name = counterGroup.getString("counterGroupName");
-      assertTrue("name not set", (name != null && !name.isEmpty()));
+      assertTrue((name != null && !name.isEmpty()), "name not set");
       JSONArray counters = counterGroup.getJSONArray("counter");
       for (int j = 0; j < counters.length(); j++) {
         JSONObject counter = counters.getJSONObject(j);
         String counterName = counter.getString("name");
-        assertTrue("name not set",
-            (counterName != null && !counterName.isEmpty()));
+        assertTrue((counterName != null && !counterName.isEmpty()),
+            "name not set");
         long value = counter.getLong("value");
-        assertTrue("value  >= 0", value >= 0);
+        assertTrue(value >= 0, "value  >= 0");
       }
     }
   }
@@ -764,20 +761,20 @@ public class TestAMWebServicesTasks extends JerseyTestBase {
 
       for (int j = 0; j < groups.getLength(); j++) {
         Element counters = (Element) groups.item(j);
-        assertNotNull("should have counters in the web service info", counters);
+        assertNotNull(counters, "should have counters in the web service info");
         String name = WebServicesTestUtils.getXmlString(counters,
             "counterGroupName");
-        assertTrue("name not set", (name != null && !name.isEmpty()));
+        assertTrue((name != null && !name.isEmpty()), "name not set");
         NodeList counterArr = counters.getElementsByTagName("counter");
         for (int z = 0; z < counterArr.getLength(); z++) {
           Element counter = (Element) counterArr.item(z);
           String counterName = WebServicesTestUtils.getXmlString(counter,
               "name");
-          assertTrue("counter name not set",
-              (counterName != null && !counterName.isEmpty()));
+          assertTrue((counterName != null && !counterName.isEmpty()),
+              "counter name not set");
 
           long value = WebServicesTestUtils.getXmlLong(counter, "value");
-          assertTrue("value not >= 0", value >= 0);
+          assertTrue(value >= 0, "value not >= 0");
 
         }
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
@@ -37,9 +37,10 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.webapp.Controller.RequestContext;
 import org.apache.hadoop.yarn.webapp.MimeType;
 import org.apache.hadoop.yarn.webapp.ResponseInfo;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestAppController {
 
@@ -48,7 +49,7 @@ public class TestAppController {
   private Job job;
   private static final String taskId = "task_01_01_m_01";
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     AppContext context = mock(AppContext.class);
     when(context.getApplicationID()).thenReturn(
@@ -82,14 +83,14 @@ public class TestAppController {
    * test bad request should be status 400...
    */
   @Test
-  public void testBadRequest() {
+  void testBadRequest() {
     String message = "test string";
     appController.badRequest(message);
     verifyExpectations(message);
   }
 
   @Test
-  public void testBadRequestWithNullMessage() {
+  void testBadRequestWithNullMessage() {
     // It should not throw NullPointerException
     appController.badRequest(null);
     verifyExpectations(StringUtils.EMPTY);
@@ -108,7 +109,7 @@ public class TestAppController {
    * Test the method 'info'.
    */
   @Test
-  public void testInfo() {
+  void testInfo() {
 
     appController.info();
     Iterator<ResponseInfo.Item> iterator = appController.getResponseInfo()
@@ -134,7 +135,7 @@ public class TestAppController {
    *  Test method 'job'. Should print message about error or set JobPage class for rendering
    */
   @Test
-  public void testGetJob() {
+  void testGetJob() {
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
 
@@ -161,7 +162,7 @@ public class TestAppController {
    *  Test method 'jobCounters'. Should print message about error or set CountersPage class for rendering
    */
   @Test
-  public void testGetJobCounters() {
+  void testGetJobCounters() {
 
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
@@ -189,7 +190,7 @@ public class TestAppController {
    *  Test method 'taskCounters'. Should print message about error or set CountersPage class for rendering
    */
   @Test
-  public void testGetTaskCounters() {
+  void testGetTaskCounters() {
 
     when(job.checkAccess(any(UserGroupInformation.class), any(JobACL.class)))
         .thenReturn(false);
@@ -213,12 +214,13 @@ public class TestAppController {
     appController.taskCounters();
     assertEquals(CountersPage.class, appController.getClazz());
   }
+
   /**
    *  Test method 'singleJobCounter'. Should set SingleCounterPage class for rendering
    */
 
   @Test
-  public void testGetSingleJobCounter() throws IOException {
+  void testGetSingleJobCounter() throws IOException {
     appController.singleJobCounter();
     assertEquals(SingleCounterPage.class, appController.getClazz());
   }
@@ -227,31 +229,33 @@ public class TestAppController {
    *  Test method 'singleTaskCounter'. Should set SingleCounterPage class for rendering
    */
   @Test
-  public void testGetSingleTaskCounter() throws IOException {
+  void testGetSingleTaskCounter() throws IOException {
     appController.singleTaskCounter();
     assertEquals(SingleCounterPage.class, appController.getClazz());
     assertNotNull(appController.getProperty().get(AppController.COUNTER_GROUP));
     assertNotNull(appController.getProperty().get(AppController.COUNTER_NAME));
   }
+
   /**
    *  Test method 'tasks'. Should set TasksPage class for rendering
    */
 
   @Test
-  public void testTasks() {
- 
+  void testTasks() {
+
     appController.tasks();
- 
+
     assertEquals(TasksPage.class, appController.getClazz());
   }
+
   /**
    *  Test method 'task'. Should set TaskPage class for rendering and information for title
    */
   @Test
-  public void testTask() {
- 
+  void testTask() {
+
     appController.task();
-    assertEquals("Attempts for " + taskId ,
+    assertEquals("Attempts for " + taskId,
         appController.getProperty().get("title"));
 
     assertEquals(TaskPage.class, appController.getClazz());
@@ -261,8 +265,8 @@ public class TestAppController {
    *   Test method 'conf'. Should set JobConfPage class for rendering
    */
   @Test
-  public void testConfiguration() {
- 
+  void testConfiguration() {
+
     appController.conf();
 
     assertEquals(JobConfPage.class, appController.getClazz());
@@ -272,18 +276,18 @@ public class TestAppController {
    * Test downloadConf request handling.
    */
   @Test
-  public void testDownloadConfiguration() {
+  void testDownloadConfiguration() {
     appController.downloadConf();
     String jobConfXml = appController.getData();
-    assertTrue("Error downloading the job configuration file.",
-        !jobConfXml.contains("Error"));
+    assertTrue(!jobConfXml.contains("Error"),
+        "Error downloading the job configuration file.");
   }
 
   /**
    *   Test method 'conf'. Should set AttemptsPage class for rendering or print information about error
    */
   @Test
-  public void testAttempts() {
+  void testAttempts() {
 
     appController.getProperty().remove(AMParams.TASK_TYPE);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestBlocks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestBlocks.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.util.MRJobConfUtil;
 import org.apache.hadoop.yarn.webapp.View;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.v2.api.records.JobId;
@@ -52,7 +52,8 @@ import org.apache.hadoop.yarn.webapp.view.HtmlBlock;
 import org.apache.hadoop.yarn.webapp.view.HtmlBlock.Block;
 
 import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBlocks {
   private ByteArrayOutputStream data = new ByteArrayOutputStream();
@@ -61,7 +62,7 @@ public class TestBlocks {
    * Test rendering for ConfBlock
    */
   @Test
-  public void testConfigurationBlock() throws Exception {
+  void testConfigurationBlock() throws Exception {
     AppContext ctx = mock(AppContext.class);
     Job job = mock(Job.class);
     Path path = new Path("conf");
@@ -83,7 +84,7 @@ public class TestBlocks {
     configurationBlock.render(html);
     pWriter.flush();
     assertTrue(data.toString().contains(
-            "Sorry, can't do anything without a JobID"));
+        "Sorry, can't do anything without a JobID"));
 
     configurationBlock.addParameter(AMParams.JOB_ID, "job_01_01");
     data.reset();
@@ -100,7 +101,7 @@ public class TestBlocks {
    * Test rendering for TasksBlock
    */
   @Test
-  public void testTasksBlock() throws Exception {
+  void testTasksBlock() throws Exception {
 
     ApplicationId appId = ApplicationIdPBImpl.newInstance(0, 1);
     JobId jobId = new JobIdPBImpl();
@@ -155,13 +156,13 @@ public class TestBlocks {
    * test AttemptsBlock's rendering.
    */
   @Test
-  public void testAttemptsBlock() {
+  void testAttemptsBlock() {
     AppContext ctx = mock(AppContext.class);
     AppForTest app = new AppForTest(ctx);
 
     JobId jobId = new JobIdPBImpl();
     jobId.setId(0);
-    jobId.setAppId(ApplicationIdPBImpl.newInstance(0,1));
+    jobId.setAppId(ApplicationIdPBImpl.newInstance(0, 1));
 
     TaskId taskId = new TaskIdPBImpl();
     taskId.setId(0);
@@ -209,12 +210,12 @@ public class TestBlocks {
     block.render(html);
     pWriter.flush();
     assertTrue(data.toString().contains(
-        "<a href='" + block.url("task",task.getID().toString()) +"'>"
-        +"attempt_0_0001_r_000000_0</a>"));
+        "<a href='" + block.url("task", task.getID().toString()) + "'>"
+            + "attempt_0_0001_r_000000_0</a>"));
   }
 
   @Test
-  public void testSingleCounterBlock() {
+  void testSingleCounterBlock() {
     AppContext appCtx = mock(AppContext.class);
     View.ViewContext ctx = mock(View.ViewContext.class);
     JobId jobId = new JobIdPBImpl();
@@ -242,7 +243,7 @@ public class TestBlocks {
     when(reduceTask.getType()).thenReturn(TaskType.REDUCE);
 
     Map<TaskId, Task> tasks =
-            new HashMap<TaskId, Task>();
+        new HashMap<TaskId, Task>();
     tasks.put(mapTaskId, mapTask);
     tasks.put(reduceTaskId, reduceTask);
 
@@ -252,10 +253,10 @@ public class TestBlocks {
 
     // SingleCounter for map task
     SingleCounterBlockForMapTest blockForMapTest
-            = spy(new SingleCounterBlockForMapTest(appCtx, ctx));
+        = spy(new SingleCounterBlockForMapTest(appCtx, ctx));
     PrintWriter pWriterForMapTest = new PrintWriter(data);
     Block htmlForMapTest = new BlockForTest(new HtmlBlockForTest(),
-            pWriterForMapTest, 0, false);
+        pWriterForMapTest, 0, false);
     blockForMapTest.render(htmlForMapTest);
     pWriterForMapTest.flush();
     assertTrue(data.toString().contains("task_0_0001_m_000000"));
@@ -264,10 +265,10 @@ public class TestBlocks {
     data.reset();
     // SingleCounter for reduce task
     SingleCounterBlockForReduceTest blockForReduceTest
-            = spy(new SingleCounterBlockForReduceTest(appCtx, ctx));
+        = spy(new SingleCounterBlockForReduceTest(appCtx, ctx));
     PrintWriter pWriterForReduceTest = new PrintWriter(data);
     Block htmlForReduceTest = new BlockForTest(new HtmlBlockForTest(),
-            pWriterForReduceTest, 0, false);
+        pWriterForReduceTest, 0, false);
     blockForReduceTest.render(htmlForReduceTest);
     pWriterForReduceTest.flush();
     System.out.println(data.toString());


### PR DESCRIPTION
### Description of PR

Upgrade Junit 4 to 5 in hadoop-mapreduce-client-app

JIRA - MAPREDUCE-7418

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

