### PR TITLE
MAPREDUCE-7420. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-core

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/pom.xml
@@ -72,6 +72,32 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>3.12.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestClock.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestClock.java
@@ -18,17 +18,20 @@
  */
 package org.apache.hadoop.mapred;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  *  test Clock class
  *
  */
 public class TestClock {
 
-  @Test  (timeout=10000)
-  public void testClock(){
+  @Test
+  @Timeout(10000)
+  public void testClock() {
     Clock clock= new Clock();
     long templateTime=System.currentTimeMillis();
     long time=clock.getTime();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestClusterStatus.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestClusterStatus.java
@@ -17,25 +17,29 @@
  */
 package org.apache.hadoop.mapred;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestClusterStatus {
 
   private ClusterStatus clusterStatus = new ClusterStatus();
 
   @SuppressWarnings("deprecation")
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testGraylistedTrackers() {
-    Assert.assertEquals(0, clusterStatus.getGraylistedTrackers());
-    Assert.assertTrue(clusterStatus.getGraylistedTrackerNames().isEmpty());
+    assertEquals(0, clusterStatus.getGraylistedTrackers());
+    assertTrue(clusterStatus.getGraylistedTrackerNames().isEmpty());
   }
 
   @SuppressWarnings("deprecation")
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testJobTrackerState() {
-    Assert.assertEquals(JobTracker.State.RUNNING,
+    assertEquals(JobTracker.State.RUNNING,
         clusterStatus.getJobTrackerState());
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestCounters.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestCounters.java
@@ -17,17 +17,11 @@
  */
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Random;
-
-import org.junit.Assert;
 
 import org.apache.hadoop.mapred.Counters.Counter;
 import org.apache.hadoop.mapred.Counters.CountersExceededException;
@@ -38,9 +32,17 @@ import org.apache.hadoop.mapreduce.JobCounter;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.counters.FrameworkCounterGroup;
 import org.apache.hadoop.mapreduce.counters.CounterGroupFactory.FrameworkGroupFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * TestCounters checks the sanity and recoverability of {@code Counters}
@@ -85,14 +87,13 @@ public class TestCounters {
    */
   private void testCounter(Counters counter) throws ParseException {
     String compactEscapedString = counter.makeEscapedCompactString();
-    assertFalse("compactEscapedString should not contain null",
-                compactEscapedString.contains("null"));
+    assertFalse(compactEscapedString.contains("null"),
+        "compactEscapedString should not contain null");
     
     Counters recoveredCounter = 
       Counters.fromEscapedCompactString(compactEscapedString);
     // Check for recovery from string
-    assertEquals("Recovered counter does not match on content", 
-                 counter, recoveredCounter);
+    assertEquals(counter, recoveredCounter, "Recovered counter does not match on content");
   }
   
   @Test
@@ -134,19 +135,17 @@ public class TestCounters {
       long expectedValue = initValue;
       Counter counter = counters.findCounter("foo", "bar");
       counter.setValue(initValue);
-      assertEquals("Counter value is not initialized correctly",
-                   expectedValue, counter.getValue());
+      assertEquals(expectedValue, counter.getValue(), "Counter value is not initialized correctly");
       for (int j = 0; j < NUMBER_INC; j++) {
         int incValue = rand.nextInt();
         counter.increment(incValue);
         expectedValue += incValue;
-        assertEquals("Counter value is not incremented correctly",
-                     expectedValue, counter.getValue());
+        assertEquals(expectedValue, counter.getValue(),
+            "Counter value is not incremented correctly");
       }
       expectedValue = rand.nextInt();
       counter.setValue(expectedValue);
-      assertEquals("Counter value is not set correctly",
-                   expectedValue, counter.getValue());
+      assertEquals(expectedValue, counter.getValue(), "Counter value is not set correctly");
     }
   }
   
@@ -174,29 +173,29 @@ public class TestCounters {
 
   @SuppressWarnings("deprecation")
   private void checkLegacyNames(Counters counters) {
-    assertEquals("New name", 1, counters.findCounter(
-        TaskCounter.class.getName(), "MAP_INPUT_RECORDS").getValue());
-    assertEquals("Legacy name", 1, counters.findCounter(
+    assertEquals(1, counters.findCounter(
+        TaskCounter.class.getName(), "MAP_INPUT_RECORDS").getValue(), "New name");
+    assertEquals(1, counters.findCounter(
         "org.apache.hadoop.mapred.Task$Counter",
-        "MAP_INPUT_RECORDS").getValue());
-    assertEquals("Legacy enum", 1,
-        counters.findCounter(Task.Counter.MAP_INPUT_RECORDS).getValue());
+        "MAP_INPUT_RECORDS").getValue(), "Legacy name");
+    assertEquals(1,
+        counters.findCounter(Task.Counter.MAP_INPUT_RECORDS).getValue(), "Legacy enum");
 
-    assertEquals("New name", 1, counters.findCounter(
-        JobCounter.class.getName(), "DATA_LOCAL_MAPS").getValue());
-    assertEquals("Legacy name", 1, counters.findCounter(
+    assertEquals(1, counters.findCounter(JobCounter.class.getName(), "DATA_LOCAL_MAPS").getValue(),
+        "New name");
+    assertEquals(1, counters.findCounter(
         "org.apache.hadoop.mapred.JobInProgress$Counter",
-        "DATA_LOCAL_MAPS").getValue());
-    assertEquals("Legacy enum", 1,
-        counters.findCounter(JobInProgress.Counter.DATA_LOCAL_MAPS).getValue());
+        "DATA_LOCAL_MAPS").getValue(), "Legacy name");
+    assertEquals(1, counters.findCounter(JobInProgress.Counter.DATA_LOCAL_MAPS).getValue(),
+        "Legacy enum");
 
-    assertEquals("New name", 1, counters.findCounter(
-        FileSystemCounter.class.getName(), "FILE_BYTES_READ").getValue());
-    assertEquals("New name and method", 1, counters.findCounter("file",
-        FileSystemCounter.BYTES_READ).getValue());
-    assertEquals("Legacy name", 1, counters.findCounter(
-        "FileSystemCounters",
-        "FILE_BYTES_READ").getValue());
+    assertEquals(1,
+        counters.findCounter(FileSystemCounter.class.getName(), "FILE_BYTES_READ").getValue(),
+        "New name");
+    assertEquals(1, counters.findCounter("file", FileSystemCounter.BYTES_READ).getValue(),
+        "New name and method");
+    assertEquals(1, counters.findCounter("FileSystemCounters", "FILE_BYTES_READ").getValue(),
+        "Legacy name");
   }
   
   @SuppressWarnings("deprecation")
@@ -266,8 +265,7 @@ public class TestCounters {
     assertEquals("group1.counter1:1", counters.makeCompactString());
     counters.incrCounter("group2", "counter2", 3);
     String cs = counters.makeCompactString();
-    assertTrue("Bad compact string",
-        cs.equals(GC1 + ',' + GC2) || cs.equals(GC2 + ',' + GC1));
+    assertTrue(cs.equals(GC1 + ',' + GC2) || cs.equals(GC2 + ',' + GC1), "Bad compact string");
   }
   
   @Test
@@ -321,7 +319,7 @@ public class TestCounters {
     } catch (CountersExceededException e) {
       return;
     }
-    Assert.fail("Should've thrown " + ecls.getSimpleName());
+    fail("Should've thrown " + ecls.getSimpleName());
   }
 
   public static void main(String[] args) throws IOException {
@@ -341,12 +339,12 @@ public class TestCounters {
   
     org.apache.hadoop.mapreduce.Counter count1 = 
         counterGroup.findCounter(JobCounter.NUM_FAILED_MAPS.toString());
-    Assert.assertNotNull(count1);
+    assertNotNull(count1);
     
     // Verify no exception get thrown when finding an unknown counter
     org.apache.hadoop.mapreduce.Counter count2 = 
         counterGroup.findCounter("Unknown");
-    Assert.assertNull(count2);
+    assertNull(count2);
   }
 
   @SuppressWarnings("rawtypes")
@@ -363,19 +361,19 @@ public class TestCounters {
     org.apache.hadoop.mapreduce.Counter count1 =
         counterGroup.findCounter(
             TaskCounter.PHYSICAL_MEMORY_BYTES.toString());
-    Assert.assertNotNull(count1);
+    assertNotNull(count1);
     count1.increment(10);
     count1.increment(10);
-    Assert.assertEquals(20, count1.getValue());
+    assertEquals(20, count1.getValue());
 
     // Verify no exception get thrown when finding an unknown counter
     org.apache.hadoop.mapreduce.Counter count2 =
         counterGroup.findCounter(
             TaskCounter.MAP_PHYSICAL_MEMORY_BYTES_MAX.toString());
-    Assert.assertNotNull(count2);
+    assertNotNull(count2);
     count2.increment(5);
     count2.increment(10);
-    Assert.assertEquals(10, count2.getValue());
+    assertEquals(10, count2.getValue());
   }
 
   @Test
@@ -385,12 +383,12 @@ public class TestCounters {
   
     org.apache.hadoop.mapreduce.Counter count1 = 
         fsGroup.findCounter("ANY_BYTES_READ");
-    Assert.assertNotNull(count1);
+    assertNotNull(count1);
     
     // Verify no exception get thrown when finding an unknown counter
     org.apache.hadoop.mapreduce.Counter count2 = 
         fsGroup.findCounter("Unknown");
-    Assert.assertNull(count2);
+    assertNull(count2);
   }
   
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileInputFormat.java
@@ -34,55 +34,58 @@ import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.util.Lists;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(value = Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 public class TestFileInputFormat {
-  
+
   private static final Logger LOG =
       LoggerFactory.getLogger(TestFileInputFormat.class);
-  
+
   private static String testTmpDir = System.getProperty("test.build.data", "/tmp");
   private static final Path TEST_ROOT_DIR = new Path(testTmpDir, "TestFIF");
-  
+
   private static FileSystem localFs;
-  
+
   private int numThreads;
-  
-  public TestFileInputFormat(int numThreads) {
+
+  public void initTestFileInputFormat(int numThreads) {
     this.numThreads = numThreads;
     LOG.info("Running with numThreads: " + numThreads);
   }
-  
-  @Parameters
+
   public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] { { 1 }, { 5 }};
+    Object[][] data = new Object[][]{{1}, {5}};
     return Arrays.asList(data);
   }
-  
-  @Before
+
+  @BeforeEach
   public void setup() throws IOException {
     LOG.info("Using Test Dir: " + TEST_ROOT_DIR);
     localFs = FileSystem.getLocal(new Configuration());
     localFs.delete(TEST_ROOT_DIR, true);
     localFs.mkdirs(TEST_ROOT_DIR);
   }
-  
-  @After
+
+  @AfterEach
   public void cleanup() throws IOException {
     localFs.delete(TEST_ROOT_DIR, true);
   }
-  
-  @Test
-  public void testListLocatedStatus() throws Exception {
+
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testListLocatedStatus(int numThreads) throws Exception {
+    initTestFileInputFormat(numThreads);
     Configuration conf = getConfiguration();
     conf.setBoolean("fs.test.impl.disable.cache", false);
     conf.setInt(FileInputFormat.LIST_STATUS_NUM_THREADS, numThreads);
@@ -90,20 +93,20 @@ public class TestFileInputFormat {
         "test:///a1/a2");
     MockFileSystem mockFs =
         (MockFileSystem) new Path("test:///").getFileSystem(conf);
-    Assert.assertEquals("listLocatedStatus already called",
-        0, mockFs.numListLocatedStatusCalls);
+    assertEquals(0, mockFs.numListLocatedStatusCalls, "listLocatedStatus already called");
     JobConf job = new JobConf(conf);
     TextInputFormat fileInputFormat = new TextInputFormat();
     fileInputFormat.configure(job);
     InputSplit[] splits = fileInputFormat.getSplits(job, 1);
-    Assert.assertEquals("Input splits are not correct", 2, splits.length);
-    Assert.assertEquals("listLocatedStatuss calls",
-        1, mockFs.numListLocatedStatusCalls);
+    assertEquals(2, splits.length, "Input splits are not correct");
+    assertEquals(1, mockFs.numListLocatedStatusCalls, "listLocatedStatuss calls");
     FileSystem.closeAll();
   }
 
-  @Test
-  public void testIgnoreDirs() throws Exception {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testIgnoreDirs(int numThreads) throws Exception {
+    initTestFileInputFormat(numThreads);
     Configuration conf = getConfiguration();
     conf.setBoolean(FileInputFormat.INPUT_DIR_NONRECURSIVE_IGNORE_SUBDIRS, true);
     conf.setInt(FileInputFormat.LIST_STATUS_NUM_THREADS, numThreads);
@@ -113,12 +116,14 @@ public class TestFileInputFormat {
     TextInputFormat fileInputFormat = new TextInputFormat();
     fileInputFormat.configure(job);
     InputSplit[] splits = fileInputFormat.getSplits(job, 1);
-    Assert.assertEquals("Input splits are not correct", 1, splits.length);
+    assertEquals(1, splits.length, "Input splits are not correct");
     FileSystem.closeAll();
   }
 
-  @Test
-  public void testSplitLocationInfo() throws Exception {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testSplitLocationInfo(int numThreads) throws Exception {
+    initTestFileInputFormat(numThreads);
     Configuration conf = getConfiguration();
     conf.set(org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR,
         "test:///a1/a2");
@@ -127,21 +132,23 @@ public class TestFileInputFormat {
     fileInputFormat.configure(job);
     FileSplit[] splits = (FileSplit[]) fileInputFormat.getSplits(job, 1);
     String[] locations = splits[0].getLocations();
-    Assert.assertEquals(2, locations.length);
+    assertEquals(2, locations.length);
     SplitLocationInfo[] locationInfo = splits[0].getLocationInfo();
-    Assert.assertEquals(2, locationInfo.length);
+    assertEquals(2, locationInfo.length);
     SplitLocationInfo localhostInfo = locations[0].equals("localhost") ?
         locationInfo[0] : locationInfo[1];
     SplitLocationInfo otherhostInfo = locations[0].equals("otherhost") ?
         locationInfo[0] : locationInfo[1];
-    Assert.assertTrue(localhostInfo.isOnDisk());
-    Assert.assertTrue(localhostInfo.isInMemory());
-    Assert.assertTrue(otherhostInfo.isOnDisk());
-    Assert.assertFalse(otherhostInfo.isInMemory());
+    assertTrue(localhostInfo.isOnDisk());
+    assertTrue(localhostInfo.isInMemory());
+    assertTrue(otherhostInfo.isOnDisk());
+    assertFalse(otherhostInfo.isInMemory());
   }
-  
-  @Test
-  public void testListStatusSimple() throws IOException {
+
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testListStatusSimple(int numThreads) throws IOException {
+    initTestFileInputFormat(numThreads);
     Configuration conf = new Configuration();
     conf.setInt(FileInputFormat.LIST_STATUS_NUM_THREADS, numThreads);
 
@@ -158,8 +165,10 @@ public class TestFileInputFormat {
             localFs);
   }
 
-  @Test
-  public void testListStatusNestedRecursive() throws IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testListStatusNestedRecursive(int numThreads) throws IOException {
+    initTestFileInputFormat(numThreads);
     Configuration conf = new Configuration();
     conf.setInt(FileInputFormat.LIST_STATUS_NUM_THREADS, numThreads);
 
@@ -175,8 +184,10 @@ public class TestFileInputFormat {
             localFs);
   }
 
-  @Test
-  public void testListStatusNestedNonRecursive() throws IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testListStatusNestedNonRecursive(int numThreads) throws IOException {
+    initTestFileInputFormat(numThreads);
     Configuration conf = new Configuration();
     conf.setInt(FileInputFormat.LIST_STATUS_NUM_THREADS, numThreads);
 
@@ -192,8 +203,10 @@ public class TestFileInputFormat {
             localFs);
   }
 
-  @Test
-  public void testListStatusErrorOnNonExistantDir() throws IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testListStatusErrorOnNonExistantDir(int numThreads) throws IOException {
+    initTestFileInputFormat(numThreads);
     Configuration conf = new Configuration();
     conf.setInt(FileInputFormat.LIST_STATUS_NUM_THREADS, numThreads);
 
@@ -204,12 +217,12 @@ public class TestFileInputFormat {
     fif.configure(jobConf);
     try {
       fif.listStatus(jobConf);
-      Assert.fail("Expecting an IOException for a missing Input path");
+      fail("Expecting an IOException for a missing Input path");
     } catch (IOException e) {
       Path expectedExceptionPath = new Path(TEST_ROOT_DIR, "input2");
       expectedExceptionPath = localFs.makeQualified(expectedExceptionPath);
-      Assert.assertTrue(e instanceof InvalidInputException);
-      Assert.assertEquals(
+      assertTrue(e instanceof InvalidInputException);
+      assertEquals(
           "Input path does not exist: " + expectedExceptionPath.toString(),
           e.getMessage());
     }
@@ -231,15 +244,15 @@ public class TestFileInputFormat {
     public FileStatus[] listStatus(Path f) throws FileNotFoundException,
         IOException {
       if (f.toString().equals("test:/a1")) {
-        return new FileStatus[] {
+        return new FileStatus[]{
             new FileStatus(0, true, 1, 150, 150, new Path("test:/a1/a2")),
-            new FileStatus(10, false, 1, 150, 150, new Path("test:/a1/file1")) };
+            new FileStatus(10, false, 1, 150, 150, new Path("test:/a1/file1"))};
       } else if (f.toString().equals("test:/a1/a2")) {
-        return new FileStatus[] {
+        return new FileStatus[]{
             new FileStatus(10, false, 1, 150, 150,
                 new Path("test:/a1/a2/file2")),
             new FileStatus(10, false, 1, 151, 150,
-                new Path("test:/a1/a2/file3")) };
+                new Path("test:/a1/a2/file3"))};
       }
       return new FileStatus[0];
     }
@@ -247,8 +260,8 @@ public class TestFileInputFormat {
     @Override
     public FileStatus[] globStatus(Path pathPattern, PathFilter filter)
         throws IOException {
-      return new FileStatus[] { new FileStatus(10, true, 1, 150, 150,
-          pathPattern) };
+      return new FileStatus[]{new FileStatus(10, true, 1, 150, 150,
+          pathPattern)};
     }
 
     @Override
@@ -260,10 +273,10 @@ public class TestFileInputFormat {
     @Override
     public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len)
         throws IOException {
-      return new BlockLocation[] {
-          new BlockLocation(new String[] { "localhost:9866", "otherhost:9866" },
-              new String[] { "localhost", "otherhost" }, new String[] { "localhost" },
-              new String[0], 0, len, false) };
+      return new BlockLocation[]{
+          new BlockLocation(new String[]{"localhost:9866", "otherhost:9866"},
+              new String[]{"localhost", "otherhost"}, new String[]{"localhost"},
+              new String[0], 0, len, false)};
     }
 
     @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestFileOutputCommitter.java
@@ -23,10 +23,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -117,10 +121,10 @@ public class TestFileOutputCommitter {
     Path jobTempDir1 = committer.getCommittedTaskPath(tContext);
     File jtd1 = new File(jobTempDir1.toUri().getPath());
     if (commitVersion == 1) {
-      assertTrue("Version 1 commits to temporary dir " + jtd1, jtd1.exists());
+      assertTrue(jtd1.exists(), "Version 1 commits to temporary dir " + jtd1);
       validateContent(jobTempDir1);
     } else {
-      assertFalse("Version 2 commits to output dir " + jtd1, jtd1.exists());
+      assertFalse(jtd1.exists(), "Version 2 commits to output dir " + jtd1);
     }
 
     //now while running the second app attempt,
@@ -141,15 +145,14 @@ public class TestFileOutputCommitter {
     Path jobTempDir2 = committer2.getCommittedTaskPath(tContext2);
     File jtd2 = new File(jobTempDir2.toUri().getPath());
     if (recoveryVersion == 1) {
-      assertTrue("Version 1 recovers to " + jtd2, jtd2.exists());
+      assertTrue(jtd2.exists(), "Version 1 recovers to " + jtd2);
       validateContent(jobTempDir2);
     } else {
-        assertFalse("Version 2 commits to output dir " + jtd2, jtd2.exists());
-        if (commitVersion == 1) {
-          assertTrue("Version 2  recovery moves to output dir from "
-              + jtd1 , jtd1.list().length == 0);
-        }
+      assertFalse(jtd2.exists(), "Version 2 commits to output dir " + jtd2);
+      if (commitVersion == 1) {
+        assertTrue(jtd1.list().length == 0, "Version 2  recovery moves to output dir from " + jtd1);
       }
+    }
 
     committer2.commitJob(jContext2);
     validateContent(outDir);
@@ -252,12 +255,12 @@ public class TestFileOutputCommitter {
       committer.commitJob(jContext);
       // (1,1), (1,2), (2,1) shouldn't reach to here.
       if (version == 1 || maxAttempts <= 1) {
-        Assert.fail("Commit successful: wrong behavior for version 1.");
+        fail("Commit successful: wrong behavior for version 1.");
       }
     } catch (IOException e) {
       // (2,2) shouldn't reach to here.
       if (version == 2 && maxAttempts > 2) {
-        Assert.fail("Commit failed: wrong behavior for version 2.");
+        fail("Commit failed: wrong behavior for version 2.");
       }
     }
 
@@ -308,12 +311,12 @@ public class TestFileOutputCommitter {
     try {
       committer.commitJob(jContext);
       if (version == 1) {
-        Assert.fail("Duplicate commit successful: wrong behavior " +
+        fail("Duplicate commit successful: wrong behavior " +
             "for version 1.");
       }
     } catch (IOException e) {
       if (version == 2) {
-        Assert.fail("Duplicate commit failed: wrong behavior for version 2.");
+        fail("Duplicate commit failed: wrong behavior for version 2.");
       }
     }
     FileUtil.fullyDelete(new File(outDir.toString()));
@@ -463,12 +466,12 @@ public class TestFileOutputCommitter {
     Path workPath = committer.getWorkPath(tContext, outDir);
     File wp = new File(workPath.toUri().getPath());
     File expectedFile = new File(wp, partFile);
-    assertFalse("task temp dir still exists", expectedFile.exists());
+    assertFalse(expectedFile.exists(), "task temp dir still exists");
 
     committer.abortJob(jContext, JobStatus.State.FAILED);
     expectedFile = new File(out, FileOutputCommitter.TEMP_DIR_NAME);
-    assertFalse("job temp dir still exists", expectedFile.exists());
-    assertEquals("Output directory not empty", 0, out.listFiles().length);
+    assertFalse(expectedFile.exists(), "job temp dir still exists");
+    assertEquals(0, out.listFiles().length, "Output directory not empty");
     FileUtil.fullyDelete(out);
   }
 
@@ -540,7 +543,7 @@ public class TestFileOutputCommitter {
     assertNotNull(th);
     assertTrue(th instanceof IOException);
     assertTrue(th.getMessage().contains("fake delete failed"));
-    assertTrue(expectedFile + " does not exists", expectedFile.exists());
+    assertTrue(expectedFile.exists(), expectedFile + " does not exists");
 
     th = null;
     try {
@@ -551,7 +554,7 @@ public class TestFileOutputCommitter {
     assertNotNull(th);
     assertTrue(th instanceof IOException);
     assertTrue(th.getMessage().contains("fake delete failed"));
-    assertTrue("job temp dir does not exists", jobTmpDir.exists());
+    assertTrue(jobTmpDir.exists(), "job temp dir does not exists");
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestIndexCache.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestIndexCache.java
@@ -32,16 +32,19 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.mapreduce.server.tasktracker.TTConfig;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestIndexCache {
   private JobConf conf;
   private FileSystem fs;
   private Path p;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new JobConf();
     fs = FileSystem.getLocal(conf).getRaw();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobAclsManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobAclsManager.java
@@ -17,9 +17,6 @@
  */
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +25,10 @@ import org.apache.hadoop.mapreduce.JobACL;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test the job acls manager
@@ -56,10 +56,10 @@ public class TestJobAclsManager {
     // cluster admin should have access
     boolean val = aclsManager.checkAccess(callerUGI, JobACL.VIEW_JOB, jobOwner,
         jobACLs.get(JobACL.VIEW_JOB));
-    assertTrue("cluster admin should have view access", val);
+    assertTrue(val, "cluster admin should have view access");
     val = aclsManager.checkAccess(callerUGI, JobACL.MODIFY_JOB, jobOwner,
         jobACLs.get(JobACL.MODIFY_JOB));
-    assertTrue("cluster admin should have modify access", val);
+    assertTrue(val, "cluster admin should have modify access");
   }
 
   @Test
@@ -80,20 +80,20 @@ public class TestJobAclsManager {
     // random user should not have access
     boolean val = aclsManager.checkAccess(callerUGI, JobACL.VIEW_JOB, jobOwner,
         jobACLs.get(JobACL.VIEW_JOB));
-    assertFalse("random user should not have view access", val);
+    assertFalse(val, "random user should not have view access");
     val = aclsManager.checkAccess(callerUGI, JobACL.MODIFY_JOB, jobOwner,
         jobACLs.get(JobACL.MODIFY_JOB));
-    assertFalse("random user should not have modify access", val);
+    assertFalse(val, "random user should not have modify access");
 
     callerUGI = UserGroupInformation.createUserForTesting(jobOwner,
         new String[] {});
     // Owner should have access
     val = aclsManager.checkAccess(callerUGI, JobACL.VIEW_JOB, jobOwner,
         jobACLs.get(JobACL.VIEW_JOB));
-    assertTrue("owner should have view access", val);
+    assertTrue(val, "owner should have view access");
     val = aclsManager.checkAccess(callerUGI, JobACL.MODIFY_JOB, jobOwner,
         jobACLs.get(JobACL.MODIFY_JOB));
-    assertTrue("owner should have modify access", val);
+    assertTrue(val, "owner should have modify access");
   }
 
   @Test
@@ -114,7 +114,7 @@ public class TestJobAclsManager {
     // acls off so anyone should have access
     boolean val = aclsManager.checkAccess(callerUGI, JobACL.VIEW_JOB, jobOwner,
         jobACLs.get(JobACL.VIEW_JOB));
-    assertTrue("acls off so anyone should have access", val);
+    assertTrue(val, "acls off so anyone should have access");
   }
 
   @Test
@@ -137,6 +137,6 @@ public class TestJobAclsManager {
     // acls off so anyone should have access
     boolean val = aclsManager.checkAccess(callerUGI, JobACL.VIEW_JOB, jobOwner,
         jobACLs.get(JobACL.VIEW_JOB));
-    assertTrue("user in admin group should have access", val);
+    assertTrue(val, "user in admin group should have access");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobConf.java
@@ -20,12 +20,16 @@ package org.apache.hadoop.mapred;
 
 import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * test JobConf
@@ -37,7 +41,8 @@ public class TestJobConf {
    * test getters and setters of JobConf
    */
   @SuppressWarnings("deprecation")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testJobConf() {
     JobConf conf = new JobConf();
     // test default value
@@ -164,30 +169,31 @@ public class TestJobConf {
    * old property names
    */
   @SuppressWarnings("deprecation")
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testDeprecatedPropertyNameForTaskVmem() {
     JobConf configuration = new JobConf();
 
     configuration.setLong(JobConf.MAPRED_JOB_MAP_MEMORY_MB_PROPERTY, 1024);
     configuration.setLong(JobConf.MAPRED_JOB_REDUCE_MEMORY_MB_PROPERTY, 1024);
-    Assert.assertEquals(1024, configuration.getMemoryForMapTask());
-    Assert.assertEquals(1024, configuration.getMemoryForReduceTask());
+    assertEquals(1024, configuration.getMemoryForMapTask());
+    assertEquals(1024, configuration.getMemoryForReduceTask());
     // Make sure new property names aren't broken by the old ones
     configuration.setLong(JobConf.MAPREDUCE_JOB_MAP_MEMORY_MB_PROPERTY, 1025);
     configuration.setLong(JobConf.MAPREDUCE_JOB_REDUCE_MEMORY_MB_PROPERTY, 1025);
-    Assert.assertEquals(1025, configuration.getMemoryForMapTask());
-    Assert.assertEquals(1025, configuration.getMemoryForReduceTask());
+    assertEquals(1025, configuration.getMemoryForMapTask());
+    assertEquals(1025, configuration.getMemoryForReduceTask());
 
     configuration.setMemoryForMapTask(2048);
     configuration.setMemoryForReduceTask(2048);
-    Assert.assertEquals(2048, configuration.getLong(
+    assertEquals(2048, configuration.getLong(
         JobConf.MAPRED_JOB_MAP_MEMORY_MB_PROPERTY, -1));
-    Assert.assertEquals(2048, configuration.getLong(
+    assertEquals(2048, configuration.getLong(
         JobConf.MAPRED_JOB_REDUCE_MEMORY_MB_PROPERTY, -1));
     // Make sure new property names aren't broken by the old ones
-    Assert.assertEquals(2048, configuration.getLong(
+    assertEquals(2048, configuration.getLong(
         JobConf.MAPREDUCE_JOB_MAP_MEMORY_MB_PROPERTY, -1));
-    Assert.assertEquals(2048, configuration.getLong(
+    assertEquals(2048, configuration.getLong(
         JobConf.MAPREDUCE_JOB_REDUCE_MEMORY_MB_PROPERTY, -1));
   }
 
@@ -196,9 +202,9 @@ public class TestJobConf {
   public void testProfileParamsDefaults() {
     JobConf configuration = new JobConf();
     String result = configuration.getProfileParams();
-    Assert.assertNotNull(result);
-    Assert.assertTrue(result.contains("file=%s"));
-    Assert.assertTrue(result.startsWith("-agentlib:hprof"));
+    assertNotNull(result);
+    assertTrue(result.contains("file=%s"));
+    assertTrue(result.startsWith("-agentlib:hprof"));
   }
 
   @Test
@@ -206,7 +212,7 @@ public class TestJobConf {
     JobConf configuration = new JobConf();
 
     configuration.setProfileParams("test");
-    Assert.assertEquals("test", configuration.get(MRJobConfig.TASK_PROFILE_PARAMS));
+    assertEquals("test", configuration.get(MRJobConfig.TASK_PROFILE_PARAMS));
   }
 
   @Test
@@ -214,7 +220,7 @@ public class TestJobConf {
     JobConf configuration = new JobConf();
 
     configuration.set(MRJobConfig.TASK_PROFILE_PARAMS, "test");
-    Assert.assertEquals("test", configuration.getProfileParams());
+    assertEquals("test", configuration.getProfileParams());
   }
 
   /**
@@ -275,15 +281,15 @@ public class TestJobConf {
     JobConf configuration = new JobConf();
 
     configuration.set(JobConf.MAPRED_TASK_MAXVMEM_PROPERTY, "-3");
-    Assert.assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
+    assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
         configuration.getMemoryForMapTask());
-    Assert.assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
+    assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
         configuration.getMemoryForReduceTask());
 
     configuration.set(MRJobConfig.MAP_MEMORY_MB, "4");
     configuration.set(MRJobConfig.REDUCE_MEMORY_MB, "5");
-    Assert.assertEquals(4, configuration.getMemoryForMapTask());
-    Assert.assertEquals(5, configuration.getMemoryForReduceTask());
+    assertEquals(4, configuration.getMemoryForMapTask());
+    assertEquals(5, configuration.getMemoryForReduceTask());
 
   }
 
@@ -296,9 +302,9 @@ public class TestJobConf {
 
     configuration.set(MRJobConfig.MAP_MEMORY_MB, "-5");
     configuration.set(MRJobConfig.REDUCE_MEMORY_MB, "-6");
-    Assert.assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
+    assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
         configuration.getMemoryForMapTask());
-    Assert.assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
+    assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
         configuration.getMemoryForReduceTask());
   }
 
@@ -357,11 +363,10 @@ public class TestJobConf {
   @Test
   public void testMaxTaskFailuresPerTracker() {
     JobConf jobConf = new JobConf(true);
-    Assert.assertTrue("By default JobContext.MAX_TASK_FAILURES_PER_TRACKER was "
-      + "not less than JobContext.MAP_MAX_ATTEMPTS and REDUCE_MAX_ATTEMPTS"
-      ,jobConf.getMaxTaskFailuresPerTracker() < jobConf.getMaxMapAttempts() &&
-      jobConf.getMaxTaskFailuresPerTracker() < jobConf.getMaxReduceAttempts()
-      );
+    assertTrue(jobConf.getMaxTaskFailuresPerTracker() < jobConf.getMaxMapAttempts()
+            && jobConf.getMaxTaskFailuresPerTracker() < jobConf.getMaxReduceAttempts(),
+        "By default JobContext.MAX_TASK_FAILURES_PER_TRACKER was "
+            + "not less than JobContext.MAP_MAX_ATTEMPTS and REDUCE_MAX_ATTEMPTS");
   }
 
   /**
@@ -370,14 +375,14 @@ public class TestJobConf {
   @Test
   public void testParseMaximumHeapSizeMB() {
     // happy cases
-    Assert.assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4294967296"));
-    Assert.assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4194304k"));
-    Assert.assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4096m"));
-    Assert.assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4g"));
+    assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4294967296"));
+    assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4194304k"));
+    assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4096m"));
+    assertEquals(4096, JobConf.parseMaximumHeapSizeMB("-Xmx4g"));
 
     // sad cases
-    Assert.assertEquals(-1, JobConf.parseMaximumHeapSizeMB("-Xmx4?"));
-    Assert.assertEquals(-1, JobConf.parseMaximumHeapSizeMB(""));
+    assertEquals(-1, JobConf.parseMaximumHeapSizeMB("-Xmx4?"));
+    assertEquals(-1, JobConf.parseMaximumHeapSizeMB(""));
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobEndNotifier.java
@@ -31,13 +31,14 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.junit.After;
-import org.junit.Before;
-import static org.junit.Assert.*;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpServer2;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJobEndNotifier {
   HttpServer2 server;
@@ -84,7 +85,7 @@ public class TestJobEndNotifier {
       } catch (InterruptedException e) {
         timedOut = true;
       }
-      assertTrue("DelayServlet should be interrupted", timedOut);
+      assertTrue(timedOut, "DelayServlet should be interrupted");
     }
   }
 
@@ -102,7 +103,7 @@ public class TestJobEndNotifier {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     new File(System.getProperty("build.webapps", "build/webapps") + "/test"
         ).mkdirs();
@@ -122,7 +123,7 @@ public class TestJobEndNotifier {
     FailServlet.calledTimes = 0;
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobInfo.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobInfo.java
@@ -30,18 +30,20 @@ import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.JobStatus.State;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * test class JobInfo
- * 
- * 
+ *  
+ *
  */
 public class TestJobInfo {
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testJobInfo() throws IOException {
     JobID jid = new JobID("001", 1);
     Text user = new Text("User");
@@ -59,8 +61,9 @@ public class TestJobInfo {
     assertEquals(info.getUser().toString(), copyinfo.getUser().toString());
 
   }
-  
-  @Test(timeout = 5000)
+
+  @Test
+  @Timeout(5000)
   public void testTaskID() throws IOException, InterruptedException {
     JobID jobid = new JobID("1014873536921", 6);
     TaskID tid = new TaskID(jobid, TaskType.MAP, 0);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobQueueClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestJobQueueClient.java
@@ -23,10 +23,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJobQueueClient {
   /**
@@ -47,8 +46,8 @@ public class TestJobQueueClient {
     PrintWriter writer = new PrintWriter(bbos);
     queueClient.printJobQueueInfo(parent, writer);
 
-    Assert.assertTrue("printJobQueueInfo did not print grandchild's name",
-      bbos.toString().contains("GrandChildQueue"));
+    assertTrue(bbos.toString().contains("GrandChildQueue"),
+        "printJobQueueInfo did not print grandchild's name");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestLocatedFileStatusFetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestLocatedFileStatusFetcher.java
@@ -22,10 +22,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -36,6 +35,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 import org.apache.hadoop.test.GenericTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *  Test that the executor service has been shut down
@@ -49,14 +50,14 @@ public class TestLocatedFileStatusFetcher extends AbstractHadoopTestBase {
   private File dir = GenericTestUtils.getTestDir("test-lfs-fetcher");
   private static final CountDownLatch LATCH = new CountDownLatch(1);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new Configuration(false);
     conf.set("fs.file.impl", MockFileSystem.class.getName());
     fileSys = FileSystem.getLocal(conf);
   }
 
-  @After
+  @AfterEach
   public void after() {
     if (mkdirs) {
       FileUtil.fullyDelete(dir);
@@ -83,7 +84,7 @@ public class TestLocatedFileStatusFetcher extends AbstractHadoopTestBase {
           fetcher.getFileStatuses();
         } catch (Exception e) {
           // This should interrupt condition.await()
-          Assert.assertTrue(e instanceof InterruptedException);
+          assertTrue(e instanceof InterruptedException);
         }
       }
     };
@@ -94,8 +95,8 @@ public class TestLocatedFileStatusFetcher extends AbstractHadoopTestBase {
     t.interrupt();
     t.join();
     // Check the status for executor service
-    Assert.assertTrue("The executor service should have been shut down",
-        fetcher.getListeningExecutorService().isShutdown());
+    assertTrue(fetcher.getListeningExecutorService().isShutdown(),
+        "The executor service should have been shut down");
   }
 
   static class MockFileSystem extends LocalFileSystem {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapFileOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapFileOutputFormat.java
@@ -18,15 +18,16 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertTrue;
-
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.MapFile.Reader;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMapFileOutputFormat {
 
@@ -38,10 +39,10 @@ public class TestMapFileOutputFormat {
     Reader reader = Mockito.mock(Reader.class);
     Reader[] readers = new Reader[]{reader};
     outputFormat.getEntry(readers, new MyPartitioner(), new Text(), new Text());
-    assertTrue(!MyPartitioner.isGetPartitionCalled());
+    assertFalse(MyPartitioner.isGetPartitionCalled());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     MyPartitioner.setGetPartitionCalled(false);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
@@ -30,12 +30,12 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.util.Progress;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -46,7 +46,7 @@ public class TestMapTask {
           System.getProperty("java.io.tmpdir", "/tmp")),
       TestMapTask.class.getName());
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     FileUtil.fullyDelete(TEST_ROOT_DIR);
   }
@@ -77,11 +77,9 @@ public class TestMapTask {
     Path outputFile = mof.getOutputFile();
     FileSystem lfs = FileSystem.getLocal(conf);
     FsPermission perms = lfs.getFileStatus(outputFile).getPermission();
-    Assert.assertEquals("Incorrect output file perms",
-        (short)0640, perms.toShort());
+    assertEquals((short) 0640, perms.toShort(), "Incorrect output file perms");
     Path indexFile = mof.getOutputIndexFile();
     perms = lfs.getFileStatus(indexFile).getPermission();
-    Assert.assertEquals("Incorrect index file perms",
-        (short)0640, perms.toShort());
+    assertEquals((short) 0640, perms.toShort(), "Incorrect index file perms");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMaster.java
@@ -22,8 +22,9 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
 
 public class TestMaster {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestOldMethodsJobID.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestOldMethodsJobID.java
@@ -26,10 +26,12 @@ import java.io.IOException;
 
 import org.apache.hadoop.mapred.TaskCompletionEvent.Status;
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test deprecated methods
@@ -42,7 +44,8 @@ public class TestOldMethodsJobID {
    * @throws IOException
    */
   @SuppressWarnings("deprecation")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testDepricatedMethods() throws IOException {
     JobID jid = new JobID();
     TaskID test = new TaskID(jid, true, 1);
@@ -68,25 +71,28 @@ public class TestOldMethodsJobID {
         TaskID.getTaskIDsPatternWOPrefix("003", 1, TaskType.MAP, 4).toString());
    
   }
-  
+
   /**
    * test JobID
    * @throws IOException 
    */
   @SuppressWarnings("deprecation")
-  @Test (timeout=5000)
-  public void testJobID() throws IOException{
+  @Test
+  @Timeout(5000)
+  public void testJobID() throws IOException {
     JobID jid = new JobID("001",2);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     jid.write(new DataOutputStream(out));
    assertEquals(jid,JobID.read(new DataInputStream(new ByteArrayInputStream(out.toByteArray()))));
    assertEquals("job_001_0001",JobID.getJobIDsPattern("001",1));
   }
+
   /**
    * test deprecated methods of TaskCompletionEvent
    */
   @SuppressWarnings("deprecation")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testTaskCompletionEvent() {
     TaskAttemptID taid = new TaskAttemptID("001", 1, TaskType.REDUCE, 2, 3);
     TaskCompletionEvent template = new TaskCompletionEvent(12, taid, 13, true,
@@ -113,7 +119,8 @@ public class TestOldMethodsJobID {
    * @throws IOException
    */
   @SuppressWarnings("deprecation")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testJobProfile() throws IOException {
 
     JobProfile profile = new JobProfile("user", "job_001_03", "jobFile", "uri",
@@ -134,12 +141,14 @@ public class TestOldMethodsJobID {
     assertEquals(profile2.url, profile.url);
     assertEquals(profile2.user, profile.user);
   }
+
   /**
    * test TaskAttemptID 
    */
-  @SuppressWarnings( "deprecation" )
-  @Test (timeout=5000)
-  public void testTaskAttemptID (){
+  @SuppressWarnings("deprecation")
+  @Test
+  @Timeout(5000)
+  public void testTaskAttemptID() {
     TaskAttemptID task  = new TaskAttemptID("001",2,true,3,4);
     assertEquals("attempt_001_0002_m_000003_4", TaskAttemptID.getTaskAttemptIDsPattern("001", 2, true, 3, 4));
     assertEquals("task_001_0002_m_000003", task.getTaskID().toString());
@@ -147,14 +156,15 @@ public class TestOldMethodsJobID {
     assertEquals("001_0001_m_000001_2", TaskAttemptID.getTaskAttemptIDsPatternWOPrefix("001",1, TaskType.MAP, 1, 2).toString());
     
   }
-  
+
   /**
    * test Reporter.NULL
    * 
    */
   
-  @Test (timeout=5000)
-  public void testReporter(){
+  @Test
+  @Timeout(5000)
+  public void testReporter() {
     Reporter nullReporter=Reporter.NULL;
     assertNull(nullReporter.getCounter(null));
     assertNull(nullReporter.getCounter("group", "name"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestQueue.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestQueue.java
@@ -31,13 +31,18 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * TestCounters checks the sanity and recoverability of Queue
@@ -46,12 +51,12 @@ public class TestQueue {
   private static File testDir = new File(System.getProperty("test.build.data",
       "/tmp"), TestJobConf.class.getSimpleName());
 
-  @Before
+  @BeforeEach
   public void setup() {
     testDir.mkdirs();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(testDir);
   }
@@ -62,7 +67,8 @@ public class TestQueue {
    * 
    * @throws IOException
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testQueue() throws IOException {
     File f = null;
     try {
@@ -194,7 +200,8 @@ public class TestQueue {
     return conf;
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testDefaultConfig() {
     QueueManager manager = new QueueManager(true);
     assertThat(manager.getRoot().getChildren().size()).isEqualTo(2);
@@ -206,7 +213,8 @@ public class TestQueue {
    * @throws IOException
    */
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void test2Queue() throws IOException {
     Configuration conf = getConfiguration();
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestSkipBadRecords.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestSkipBadRecords.java
@@ -19,16 +19,22 @@ package org.apache.hadoop.mapred;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * test SkipBadRecords
- * 
- * 
+ *  
+ *
  */
 public class TestSkipBadRecords {
-  @Test (timeout=5000)
+  @Test
+  @Timeout(5000)
   public void testSkipBadRecords() {
     // test default values
     Configuration conf = new Configuration();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTask.java
@@ -18,21 +18,22 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ExitUtil.ExitException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 public class TestTask {
   @Mock
   private TaskUmbilicalProtocol umbilical;
@@ -42,7 +43,7 @@ public class TestTask {
 
   private Task task;
 
-  @Before
+  @BeforeEach
   public void setup() {
     task = new StubTask();
     ExitUtil.disableSystemExit();
@@ -55,11 +56,13 @@ public class TestTask {
     task.statusUpdate(umbilical);
   }
 
-  @Test(expected = ExitException.class)
+  @Test
   public void testStatusUpdateExitsInNonUberMode() throws Exception {
-    setupTest(false);
+    assertThrows(ExitException.class, () -> {
+      setupTest(false);
 
-    task.statusUpdate(umbilical);
+      task.statusUpdate(umbilical);
+    });
   }
 
   private void setupTest(boolean uberized)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskLog.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskLog.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.mapred;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,8 +30,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.mapred.TaskLog.LogName;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * TestCounters checks the sanity and recoverability of Queue
@@ -43,7 +44,7 @@ public class TestTaskLog {
       "target" + File.separatorChar + "test-dir")
       + File.separatorChar + testDirName;
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() {
     FileUtil.fullyDelete(new File(testDir));
   }
@@ -53,7 +54,8 @@ public class TestTaskLog {
    * 
    * @throws IOException
    */
-  @Test (timeout=50000)
+  @Test
+  @Timeout(50000)
   public void testTaskLog() throws IOException {
     // test TaskLog
     System.setProperty(
@@ -130,7 +132,8 @@ public class TestTaskLog {
    * 
    * @throws IOException
    */
-  @Test (timeout=50000)
+  @Test
+  @Timeout(50000)
   public void testTaskLogWithoutTaskLogDir() throws IOException {
     // TaskLog tasklog= new TaskLog();
     System.clearProperty(YarnConfiguration.YARN_APP_CONTAINER_LOG_DIR);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskLogAppender.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskLogAppender.java
@@ -28,19 +28,21 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.Priority;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTaskLogAppender {
-/**
- * test TaskLogAppender 
- */
+  /**
+   * test TaskLogAppender 
+   */
   @SuppressWarnings("deprecation")
-  @Test (timeout=5000)
-  public void testTaskLogAppender(){
+  @Test
+  @Timeout(5000)
+  public void testTaskLogAppender() {
     TaskLogAppender appender= new TaskLogAppender();
     
     System.setProperty(TaskLogAppender.TASKID_PROPERTY,"attempt_01_02_m03_04_001");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestTaskProgressReporter.java
@@ -34,11 +34,12 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.checkpoint.TaskCheckpointID;
 import org.apache.hadoop.util.ExitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTaskProgressReporter {
   private static int statusUpdateTimes = 0;
@@ -180,12 +181,13 @@ public class TestTaskProgressReporter {
     }
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileSystem.clearStatistics();
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(60000)
   public void testScratchDirSize() throws Exception {
     String tmpPath = TEST_DIR + "/testBytesWrittenLimit-tmpFile-"
         + new Random(System.currentTimeMillis()).nextInt();
@@ -254,10 +256,11 @@ public class TestTaskProgressReporter {
     task.done(fakeUmbilical, reporter);
     reporter.resetDoneFlag();
     t.join(1000L);
-    Assert.assertEquals(fastFail, threadExited);
+    assertEquals(fastFail, threadExited);
   }
 
-  @Test (timeout=10000)
+  @Test
+  @Timeout(10000)
   public void testTaskProgress() throws Exception {
     JobConf job = new JobConf();
     job.setLong(MRJobConfig.TASK_PROGRESS_REPORT_INTERVAL, 1000);
@@ -273,13 +276,15 @@ public class TestTaskProgressReporter {
     assertThat(statusUpdateTimes).isEqualTo(2);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(10000)
   public void testBytesWrittenRespectingLimit() throws Exception {
     // add 1024 to the limit to account for writes not controlled by the test
     testBytesWrittenLimit(LOCAL_BYTES_WRITTEN + 1024, false);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(10000)
   public void testBytesWrittenExceedingLimit() throws Exception {
     testBytesWrittenLimit(LOCAL_BYTES_WRITTEN - 1, true);
   }
@@ -329,6 +334,6 @@ public class TestTaskProgressReporter {
     task.setTaskDone();
     reporter.resetDoneFlag();
     t.join();
-    Assert.assertEquals(failFast, threadExited);
+    assertEquals(failFast, threadExited);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/lib/TestCombineFileRecordReader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/lib/TestCombineFileRecordReader.java
@@ -30,12 +30,12 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.fs.FileUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.junit.Assert;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -77,7 +77,7 @@ public class TestCombineFileRecordReader {
       CombineFileRecordReader cfrr = new CombineFileRecordReader(conf, combineFileSplit,
         reporter,  TextRecordReaderWrapper.class);
       verify(reporter).progress();
-      Assert.assertFalse(cfrr.next(key,value));
+      assertFalse(cfrr.next(key,value));
       verify(reporter, times(3)).progress();
     } finally {
       FileUtil.fullyDelete(new File(outDir.toString()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/lib/db/TestDBInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/lib/db/TestDBInputFormat.java
@@ -31,10 +31,13 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapred.lib.db.DBConfiguration;
 import org.apache.hadoop.mapreduce.lib.db.DriverForTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
 
 public class TestDBInputFormat {
 
@@ -42,7 +45,8 @@ public class TestDBInputFormat {
    * test DBInputFormat class. Class should split result for chunks
    * @throws Exception
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testDBInputFormat() throws Exception {
     JobConf configuration = new JobConf();
     setupDriver(configuration);
@@ -66,11 +70,12 @@ public class TestDBInputFormat {
     assertEquals(0, reader.getProgress(), 0.001);
     reader.close();
   }
-  
+
   /** 
    * test configuration for db. should works DBConfiguration.* parameters. 
    */
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testSetInput() {
     JobConf configuration = new JobConf();
 
@@ -125,7 +130,8 @@ public class TestDBInputFormat {
    * test DBRecordReader. This reader should creates keys, values, know about position.. 
    */
   @SuppressWarnings("unchecked")
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testDBRecordReader() throws Exception {
 
     JobConf job = mock(JobConf.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestCluster.java
@@ -19,20 +19,20 @@ package org.apache.hadoop.mapreduce;
 
 import org.apache.hadoop.conf.Configuration;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.junit.Assert.assertNotNull;
-
 import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
 import org.apache.hadoop.mapreduce.protocol.ClientProtocolProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.ServiceConfigurationError;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Testing the Cluster initialization.
@@ -55,7 +55,7 @@ public class TestCluster {
 
     // Check that we get the acceptable client, even after
     // failure in instantiation.
-    assertNotNull("ClientProtocol is expected", testCluster.getClient());
+    assertNotNull(testCluster.getClient(), "ClientProtocol is expected");
     // Check if we do not try to load the providers after a failure.
     verify(iterator, times(2)).next();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestContextFactory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestContextFactory.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.mapreduce.lib.map.WrappedMapper;
 import org.apache.hadoop.mapreduce.task.JobContextImpl;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestContextFactory {
 
@@ -31,7 +31,7 @@ public class TestContextFactory {
   Configuration conf;
   JobContext jobContext;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     jobId = new JobID("test", 1);
@@ -56,7 +56,7 @@ public class TestContextFactory {
     ContextFactory.cloneMapContext(mapperContext, conf, null, null);
   }
 
-  @Before
+  @BeforeEach
   public void tearDown() throws Exception {
     
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJob.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.mapreduce;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import java.io.IOException;
 
 import org.apache.hadoop.io.Text;
@@ -31,8 +28,14 @@ import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestJob {
   @Test
@@ -52,7 +55,7 @@ public class TestJob {
     when(client.getTaskCompletionEvents(jobid, 0, 10)).thenReturn(
         TaskCompletionEvent.EMPTY_ARRAY);
     Job job = Job.getInstance(cluster, status, new JobConf());
-    Assert.assertNotNull(job.toString());
+    assertNotNull(job.toString());
   }
 
   @Test
@@ -68,8 +71,8 @@ public class TestJob {
     Job job = Job.getInstance(cluster, status, new JobConf());
 
     // ensurer job status is RUNNING
-    Assert.assertNotNull(job.getStatus());
-    Assert.assertTrue(job.getStatus().getState() == State.RUNNING);
+    assertNotNull(job.getStatus());
+    assertTrue(job.getStatus().getState() == State.RUNNING);
 
     // when updating job status, job client could not retrieve
     // job status, and status reset to null
@@ -78,15 +81,15 @@ public class TestJob {
     try {
       job.updateStatus();
     } catch (IOException e) {
-      Assert.assertTrue(e != null
+      assertTrue(e != null
           && e.getMessage().contains("Job status not available"));
     }
 
     try {
       ControlledJob cj = new ControlledJob(job, null);
-      Assert.assertNotNull(cj.toString());
+      assertNotNull(cj.toString());
     } catch (NullPointerException e) {
-      Assert.fail("job API fails with NPE");
+      fail("job API fails with NPE");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobMonitorAndPrint.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobMonitorAndPrint.java
@@ -19,23 +19,14 @@
 package org.apache.hadoop.mapreduce;
 
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.StringReader;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.TaskReport;
@@ -45,7 +36,16 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.WriterAppender;
-import org.mockito.stubbing.Answer;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Test to make sure that command line output for 
@@ -57,7 +57,7 @@ public class TestJobMonitorAndPrint {
   private Configuration conf;
   private ClientProtocol clientProtocol;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new Configuration();
     clientProtocol = mock(ClientProtocol.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobResourceUploaderWithSharedCache.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobResourceUploaderWithSharedCache.java
@@ -18,15 +18,6 @@
 
 package org.apache.hadoop.mapreduce;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -50,14 +41,24 @@ import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.client.api.SharedCacheClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the JobResourceUploader class with the shared cache.
@@ -74,12 +75,12 @@ public class TestJobResourceUploaderWithSharedCache {
       new Path(MRJobConfig.DEFAULT_MR_AM_STAGING_DIR);
   private String input = "roses.are.red\nviolets.are.blue\nbunnies.are.pink\n";
 
-  @Before
+  @BeforeEach
   public void cleanup() throws Exception {
     remoteFs.delete(remoteStagingDir, true);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     // create configuration, dfs, file system
     localFs = FileSystem.getLocal(conf);
@@ -91,7 +92,7 @@ public class TestJobResourceUploaderWithSharedCache {
     remoteFs = dfs.getFileSystem();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     try {
       if (localFs != null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobSubmissionFiles.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestJobSubmissionFiles.java
@@ -25,13 +25,14 @@ import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.io.IOException;
 
 /**
  * Tests for JobSubmissionFiles Utility class.
@@ -77,25 +78,27 @@ public class TestJobSubmissionFiles {
         JobSubmissionFiles.getStagingDir(cluster, conf, user));
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void testGetStagingWhenFileOwnerNameAndCurrentUserNameDoesNotMatch()
       throws IOException, InterruptedException {
-    Cluster cluster = mock(Cluster.class);
-    Configuration conf = new Configuration();
-    String stagingDirOwner = "someuser";
-    Path stagingPath = mock(Path.class);
-    UserGroupInformation user = UserGroupInformation
-        .createUserForTesting(USER_1, GROUP_NAMES);
-    assertEquals(USER_1, user.getUserName());
-    FileSystem fs = new FileSystemTestHelper.MockFileSystem();
-    FileStatus fileStatus = new FileStatus(1, true, 1, 1, 100L, 100L,
-        FsPermission.getDefault(), stagingDirOwner, stagingDirOwner,
-        stagingPath);
-    when(stagingPath.getFileSystem(conf)).thenReturn(fs);
-    when(fs.getFileStatus(stagingPath)).thenReturn(fileStatus);
-    when(cluster.getStagingAreaDir()).thenReturn(stagingPath);
-    assertEquals(stagingPath,
-        JobSubmissionFiles.getStagingDir(cluster, conf, user));
+    assertThrows(IOException.class, () -> {
+      Cluster cluster = mock(Cluster.class);
+      Configuration conf = new Configuration();
+      String stagingDirOwner = "someuser";
+      Path stagingPath = mock(Path.class);
+      UserGroupInformation user = UserGroupInformation
+          .createUserForTesting(USER_1, GROUP_NAMES);
+      assertEquals(USER_1, user.getUserName());
+      FileSystem fs = new FileSystemTestHelper.MockFileSystem();
+      FileStatus fileStatus = new FileStatus(1, true, 1, 1, 100L, 100L,
+          FsPermission.getDefault(), stagingDirOwner, stagingDirOwner,
+          stagingPath);
+      when(stagingPath.getFileSystem(conf)).thenReturn(fs);
+      when(fs.getFileStatus(stagingPath)).thenReturn(fileStatus);
+      when(cluster.getStagingAreaDir()).thenReturn(stagingPath);
+      assertEquals(stagingPath,
+          JobSubmissionFiles.getStagingDir(cluster, conf, user));
+    });
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestShufflePlugin.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestShufflePlugin.java
@@ -18,9 +18,8 @@
 
 package org.apache.hadoop.mapreduce;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.Task.CombineOutputCollector;
@@ -38,6 +37,10 @@ import org.apache.hadoop.mapred.TaskStatus;
 import org.apache.hadoop.mapred.TaskUmbilicalProtocol;
 import org.apache.hadoop.mapred.ShuffleConsumerPlugin;
 import org.apache.hadoop.mapred.RawKeyValueIterator;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
   * A JUnit for testing availability and accessibility of shuffle related API.
@@ -104,14 +107,13 @@ public class TestShufflePlugin<K, V> {
       ShuffleConsumerPlugin shuffleConsumerPlugin = null;
       Class<? extends ShuffleConsumerPlugin> clazz =
         jobConf.getClass(MRConfig.SHUFFLE_CONSUMER_PLUGIN, Shuffle.class, ShuffleConsumerPlugin.class);
-      assertNotNull("Unable to get " + MRConfig.SHUFFLE_CONSUMER_PLUGIN, clazz);
+      assertNotNull(clazz, "Unable to get " + MRConfig.SHUFFLE_CONSUMER_PLUGIN);
 
       // load 3rd party plugin through core's factory method
       shuffleConsumerPlugin = ReflectionUtils.newInstance(clazz, jobConf);
-      assertNotNull("Unable to load " + MRConfig.SHUFFLE_CONSUMER_PLUGIN, shuffleConsumerPlugin);
-    }
-    catch (Exception e) {
-      assertTrue("Threw exception:" + e, false);
+      assertNotNull(shuffleConsumerPlugin, "Unable to load " + MRConfig.SHUFFLE_CONSUMER_PLUGIN);
+    } catch (Exception e) {
+      assertTrue(false, "Threw exception:" + e);
     }
   }
 
@@ -159,9 +161,8 @@ public class TestShufflePlugin<K, V> {
       shuffleConsumerPlugin.init(context);
       shuffleConsumerPlugin.run();
       shuffleConsumerPlugin.close();
-    }
-    catch (Exception e) {
-      assertTrue("Threw exception:" + e, false);
+    } catch (Exception e) {
+      assertTrue(false, "Threw exception:" + e);
     }
 
     // verify that these APIs are available for 3rd party plugins
@@ -182,9 +183,8 @@ public class TestShufflePlugin<K, V> {
     JobConf mockJobConf = mock(JobConf.class);
     try {
       mockLocalDirAllocator.getLocalPathToRead("", mockJobConf);
-    }
-    catch (Exception e) {
-      assertTrue("Threw exception:" + e, false);
+    } catch (Exception e) {
+      assertTrue(false, "Threw exception:" + e);
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestTaskID.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/TestTaskID.java
@@ -23,8 +23,14 @@ import java.nio.ByteBuffer;
 
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.WritableUtils;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the {@link TaskID} class.
@@ -38,13 +44,12 @@ public class TestTaskID {
     JobID jobId = new JobID("1234", 0);
     TaskID taskId = new TaskID(jobId, TaskType.MAP, 0);
 
-    assertSame("TaskID did not store the JobID correctly",
-        jobId, taskId.getJobID());
+    assertSame(jobId, taskId.getJobID(), "TaskID did not store the JobID correctly");
 
     taskId = new TaskID();
 
-    assertEquals("Job ID was set unexpectedly in default contsructor",
-        "", taskId.getJobID().getJtIdentifier());
+    assertEquals("", taskId.getJobID().getJtIdentifier(),
+        "Job ID was set unexpectedly in default contsructor");
   }
 
   /**
@@ -58,18 +63,18 @@ public class TestTaskID {
       TaskID taskId = new TaskID(jobId, type, 0);
 
       if (type == TaskType.MAP) {
-        assertTrue("TaskID for map task did not correctly identify itself "
-            + "as a map task", taskId.isMap());
+        assertTrue(taskId.isMap(), "TaskID for map task did not correctly identify itself "
+            + "as a map task");
       } else {
-        assertFalse("TaskID for " + type + " task incorrectly identified "
-            + "itself as a map task", taskId.isMap());
+        assertFalse(taskId.isMap(),
+            "TaskID for " + type + " task incorrectly identified " + "itself as a map task");
       }
     }
 
     TaskID taskId = new TaskID();
 
-    assertFalse("TaskID of default type incorrectly identified itself as a "
-        + "map task", taskId.isMap());
+    assertFalse(taskId.isMap(),
+        "TaskID of default type incorrectly identified itself as a " + "map task");
   }
 
   /**
@@ -82,14 +87,13 @@ public class TestTaskID {
     for (TaskType type : TaskType.values()) {
       TaskID taskId = new TaskID(jobId, type, 0);
 
-      assertEquals("TaskID incorrectly reported its type",
-          type, taskId.getTaskType());
+      assertEquals(type, taskId.getTaskType(), "TaskID incorrectly reported its type");
     }
 
     TaskID taskId = new TaskID();
 
-    assertEquals("TaskID of default type incorrectly reported its type",
-        TaskType.REDUCE, taskId.getTaskType());
+    assertEquals(TaskType.REDUCE, taskId.getTaskType(),
+        "TaskID of default type incorrectly reported its type");
   }
 
   /**
@@ -102,18 +106,18 @@ public class TestTaskID {
     TaskID taskId1 = new TaskID(jobId1, TaskType.MAP, 0);
     TaskID taskId2 = new TaskID(jobId1, TaskType.MAP, 0);
 
-    assertTrue("The equals() method reported two equal task IDs were not equal",
-        taskId1.equals(taskId2));
+    assertTrue(taskId1.equals(taskId2),
+        "The equals() method reported two equal task IDs were not equal");
 
     taskId2 = new TaskID(jobId2, TaskType.MAP, 0);
 
-    assertFalse("The equals() method reported two task IDs with different "
-        + "job IDs were equal", taskId1.equals(taskId2));
+    assertFalse(taskId1.equals(taskId2),
+        "The equals() method reported two task IDs with different " + "job IDs were equal");
 
     taskId2 = new TaskID(jobId1, TaskType.MAP, 1);
 
-    assertFalse("The equals() method reported two task IDs with different IDs "
-        + "were equal", taskId1.equals(taskId2));
+    assertFalse(taskId1.equals(taskId2),
+        "The equals() method reported two task IDs with different IDs " + "were equal");
 
     TaskType[] types = TaskType.values();
 
@@ -123,20 +127,18 @@ public class TestTaskID {
         taskId2 = new TaskID(jobId1, types[j], 0);
 
         if (i == j) {
-          assertTrue("The equals() method reported two equal task IDs were not "
-              + "equal", taskId1.equals(taskId2));
+          assertTrue(taskId1.equals(taskId2),
+              "The equals() method reported two equal task IDs were not " + "equal");
         } else {
-          assertFalse("The equals() method reported two task IDs with "
-              + "different types were equal", taskId1.equals(taskId2));
+          assertFalse(taskId1.equals(taskId2),
+              "The equals() method reported two task IDs with " + "different types were equal");
         }
       }
     }
 
-    assertFalse("The equals() method matched against a JobID object",
-        taskId1.equals(jobId1));
+    assertFalse(taskId1.equals(jobId1), "The equals() method matched against a JobID object");
 
-    assertFalse("The equals() method matched against a null object",
-        taskId1.equals(null));
+    assertFalse(taskId1.equals(null), "The equals() method matched against a null object");
   }
 
   /**
@@ -148,13 +150,13 @@ public class TestTaskID {
     TaskID taskId1 = new TaskID(jobId, TaskType.REDUCE, 0);
     TaskID taskId2 = new TaskID(jobId, TaskType.REDUCE, 0);
 
-    assertEquals("The compareTo() method returned non-zero for two equal "
-        + "task IDs", 0, taskId1.compareTo(taskId2));
+    assertEquals(0, taskId1.compareTo(taskId2),
+        "The compareTo() method returned non-zero for two equal " + "task IDs");
 
     taskId2 = new TaskID(jobId, TaskType.MAP, 1);
 
-    assertTrue("The compareTo() method did not weigh task type more than task "
-        + "ID", taskId1.compareTo(taskId2) > 0);
+    assertTrue(taskId1.compareTo(taskId2) > 0,
+        "The compareTo() method did not weigh task type more than task " + "ID");
 
     TaskType[] types = TaskType.values();
 
@@ -164,14 +166,14 @@ public class TestTaskID {
         taskId2 = new TaskID(jobId, types[j], 0);
 
         if (i == j) {
-          assertEquals("The compareTo() method returned non-zero for two equal "
-              + "task IDs", 0, taskId1.compareTo(taskId2));
+          assertEquals(0, taskId1.compareTo(taskId2),
+              "The compareTo() method returned non-zero for two equal " + "task IDs");
         } else if (i < j) {
-          assertTrue("The compareTo() method did not order " + types[i]
-              + " before " + types[j], taskId1.compareTo(taskId2) < 0);
+          assertTrue(taskId1.compareTo(taskId2) < 0,
+              "The compareTo() method did not order " + types[i] + " before " + types[j]);
         } else {
-          assertTrue("The compareTo() method did not order " + types[i]
-              + " after " + types[j], taskId1.compareTo(taskId2) > 0);
+          assertTrue(taskId1.compareTo(taskId2) > 0,
+              "The compareTo() method did not order " + types[i] + " after " + types[j]);
         }
       }
     }
@@ -203,8 +205,7 @@ public class TestTaskID {
       String str = String.format("task_1234_0001_%c_000000",
           TaskID.getRepresentingCharacter(type));
 
-      assertEquals("The toString() method returned the wrong value",
-          str, taskId.toString());
+      assertEquals(str, taskId.toString(), "The toString() method returned the wrong value");
     }
   }
 
@@ -222,8 +223,8 @@ public class TestTaskID {
       String str = String.format("_1234_0001_%c_000000",
           TaskID.getRepresentingCharacter(type));
 
-      assertEquals("The appendTo() method appended the wrong value",
-          str, taskId.appendTo(builder).toString());
+      assertEquals(str, taskId.appendTo(builder).toString(),
+          "The appendTo() method appended the wrong value");
     }
 
     try {
@@ -246,8 +247,8 @@ public class TestTaskID {
       TaskID taskId1 = new TaskID(jobId, types[i], i);
       TaskID taskId2 = new TaskID(jobId, types[i], i);
 
-      assertTrue("The hashcode() method gave unequal hash codes for two equal "
-          + "task IDs", taskId1.hashCode() == taskId2.hashCode());
+      assertTrue(taskId1.hashCode() == taskId2.hashCode(),
+          "The hashcode() method gave unequal hash codes for two equal " + "task IDs");
     }
   }
 
@@ -273,8 +274,8 @@ public class TestTaskID {
 
     instance.readFields(in);
 
-    assertEquals("The readFields() method did not produce the expected task ID",
-        "task_1234_0001_r_000000", instance.toString());
+    assertEquals("task_1234_0001_r_000000", instance.toString(),
+        "The readFields() method did not produce the expected task ID");
   }
 
   /**
@@ -294,17 +295,16 @@ public class TestTaskID {
 
     in.reset(ByteBuffer.wrap(baos.toByteArray()));
 
-    assertEquals("The write() method did not write the expected task ID",
-        0, in.readInt());
-    assertEquals("The write() method did not write the expected job ID",
-        1, in.readInt());
-    assertEquals("The write() method did not write the expected job "
-        + "identifier length", 4, WritableUtils.readVInt(in));
+    assertEquals(
+        0, in.readInt(), "The write() method did not write the expected task ID");
+    assertEquals(1, in.readInt(), "The write() method did not write the expected job ID");
+    assertEquals(4, WritableUtils.readVInt(in),
+        "The write() method did not write the expected job " + "identifier length");
     in.readFully(buffer, 0, 4);
-    assertEquals("The write() method did not write the expected job "
-        + "identifier length", "1234", new String(buffer));
-    assertEquals("The write() method did not write the expected task type",
-        TaskType.JOB_SETUP, WritableUtils.readEnum(in, TaskType.class));
+    assertEquals("1234", new String(buffer),
+        "The write() method did not write the expected job " + "identifier length");
+    assertEquals(TaskType.JOB_SETUP, WritableUtils.readEnum(in, TaskType.class),
+        "The write() method did not write the expected task type");
   }
 
   /**
@@ -312,21 +312,17 @@ public class TestTaskID {
    */
   @Test
   public void testForName() {
-    assertEquals("The forName() method did not parse the task ID string "
-        + "correctly", "task_1_0001_m_000000",
-        TaskID.forName("task_1_0001_m_000").toString());
-    assertEquals("The forName() method did not parse the task ID string "
-        + "correctly", "task_23_0002_r_000001",
-        TaskID.forName("task_23_0002_r_0001").toString());
-    assertEquals("The forName() method did not parse the task ID string "
-        + "correctly", "task_345_0003_s_000002",
-        TaskID.forName("task_345_0003_s_00002").toString());
-    assertEquals("The forName() method did not parse the task ID string "
-        + "correctly", "task_6789_0004_c_000003",
-        TaskID.forName("task_6789_0004_c_000003").toString());
-    assertEquals("The forName() method did not parse the task ID string "
-        + "correctly", "task_12345_0005_t_4000000",
-        TaskID.forName("task_12345_0005_t_4000000").toString());
+    assertEquals("task_1_0001_m_000000", TaskID.forName("task_1_0001_m_000").toString(),
+        "The forName() method did not parse the task ID string " + "correctly");
+    assertEquals("task_23_0002_r_000001", TaskID.forName("task_23_0002_r_0001").toString(),
+        "The forName() method did not parse the task ID string " + "correctly");
+    assertEquals("task_345_0003_s_000002", TaskID.forName("task_345_0003_s_00002").toString(),
+        "The forName() method did not parse the task ID string " + "correctly");
+    assertEquals("task_6789_0004_c_000003", TaskID.forName("task_6789_0004_c_000003").toString(),
+        "The forName() method did not parse the task ID string " + "correctly");
+    assertEquals("task_12345_0005_t_4000000",
+        TaskID.forName("task_12345_0005_t_4000000").toString(),
+        "The forName() method did not parse the task ID string " + "correctly");
 
     try {
       TaskID.forName("tisk_12345_0005_t_4000000");
@@ -414,21 +410,16 @@ public class TestTaskID {
    */
   @Test
   public void testGetRepresentingCharacter() {
-    assertEquals("The getRepresentingCharacter() method did not return the "
-        + "expected character", 'm',
-        TaskID.getRepresentingCharacter(TaskType.MAP));
-    assertEquals("The getRepresentingCharacter() method did not return the "
-        + "expected character", 'r',
-        TaskID.getRepresentingCharacter(TaskType.REDUCE));
-    assertEquals("The getRepresentingCharacter() method did not return the "
-        + "expected character", 's',
-        TaskID.getRepresentingCharacter(TaskType.JOB_SETUP));
-    assertEquals("The getRepresentingCharacter() method did not return the "
-        + "expected character", 'c',
-        TaskID.getRepresentingCharacter(TaskType.JOB_CLEANUP));
-    assertEquals("The getRepresentingCharacter() method did not return the "
-        + "expected character", 't',
-        TaskID.getRepresentingCharacter(TaskType.TASK_CLEANUP));
+    assertEquals('m', TaskID.getRepresentingCharacter(TaskType.MAP),
+        "The getRepresentingCharacter() method did not return the " + "expected character");
+    assertEquals('r', TaskID.getRepresentingCharacter(TaskType.REDUCE),
+        "The getRepresentingCharacter() method did not return the " + "expected character");
+    assertEquals('s', TaskID.getRepresentingCharacter(TaskType.JOB_SETUP),
+        "The getRepresentingCharacter() method did not return the " + "expected character");
+    assertEquals('c', TaskID.getRepresentingCharacter(TaskType.JOB_CLEANUP),
+        "The getRepresentingCharacter() method did not return the " + "expected character");
+    assertEquals('t', TaskID.getRepresentingCharacter(TaskType.TASK_CLEANUP),
+        "The getRepresentingCharacter() method did not return the " + "expected character");
   }
 
   /**
@@ -436,23 +427,18 @@ public class TestTaskID {
    */
   @Test
   public void testGetTaskTypeChar() {
-    assertEquals("The getTaskType() method did not return the expected type",
-        TaskType.MAP,
-        TaskID.getTaskType('m'));
-    assertEquals("The getTaskType() method did not return the expected type",
-        TaskType.REDUCE,
-        TaskID.getTaskType('r'));
-    assertEquals("The getTaskType() method did not return the expected type",
-        TaskType.JOB_SETUP,
-        TaskID.getTaskType('s'));
-    assertEquals("The getTaskType() method did not return the expected type",
-        TaskType.JOB_CLEANUP,
-        TaskID.getTaskType('c'));
-    assertEquals("The getTaskType() method did not return the expected type",
-        TaskType.TASK_CLEANUP,
-        TaskID.getTaskType('t'));
-    assertNull("The getTaskType() method did not return null for an unknown "
-        + "type", TaskID.getTaskType('x'));
+    assertEquals(TaskType.MAP, TaskID.getTaskType('m'),
+        "The getTaskType() method did not return the expected type");
+    assertEquals(TaskType.REDUCE, TaskID.getTaskType('r'),
+        "The getTaskType() method did not return the expected type");
+    assertEquals(TaskType.JOB_SETUP, TaskID.getTaskType('s'),
+        "The getTaskType() method did not return the expected type");
+    assertEquals(TaskType.JOB_CLEANUP, TaskID.getTaskType('c'),
+        "The getTaskType() method did not return the expected type");
+    assertEquals(TaskType.TASK_CLEANUP, TaskID.getTaskType('t'),
+        "The getTaskType() method did not return the expected type");
+    assertNull(TaskID.getTaskType('x'),
+        "The getTaskType() method did not return null for an unknown " + "type");
   }
 
   /**
@@ -460,7 +446,7 @@ public class TestTaskID {
    */
   @Test
   public void testGetAllTaskTypes() {
-    assertEquals("The getAllTaskTypes method did not return the expected "
-        + "string", "(m|r|s|c|t)", TaskID.getAllTaskTypes());
+    assertEquals("(m|r|s|c|t)", TaskID.getAllTaskTypes(),
+        "The getAllTaskTypes method did not return the expected " + "string");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/checkpoint/TestFSCheckpointID.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/checkpoint/TestFSCheckpointID.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestFSCheckpointID {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/checkpoint/TestFSCheckpointService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/checkpoint/TestFSCheckpointService.java
@@ -27,10 +27,18 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.mapreduce.checkpoint.CheckpointService.CheckpointWriteChannel;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import org.mockito.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestFSCheckpointService {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/filecache/TestClientDistributedCacheManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/filecache/TestClientDistributedCacheManager.java
@@ -35,16 +35,17 @@ import org.apache.hadoop.io.SequenceFile.CompressionType;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestClientDistributedCacheManager {
   private static final Logger LOG =
@@ -69,7 +70,7 @@ public class TestClientDistributedCacheManager {
   private Path secondCacheFile;
   private Configuration conf;
   
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     fs = FileSystem.get(conf);
@@ -79,7 +80,7 @@ public class TestClientDistributedCacheManager {
     createTempFile(secondCacheFile, conf);
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (fs.delete(TEST_ROOT_DIR, true)) {
       LOG.warn("Failed to delete test root dir and its content under "
@@ -99,13 +100,10 @@ public class TestClientDistributedCacheManager {
     
     FileStatus firstStatus = statCache.get(firstCacheFile.toUri());
     FileStatus secondStatus = statCache.get(secondCacheFile.toUri());
-    
-    assertNotNull(firstCacheFile + " was not found in the stats cache",
-        firstStatus);
-    assertNotNull(secondCacheFile + " was not found in the stats cache",
-        secondStatus);
-    assertEquals("Missing/extra entries found in the stats cache",
-        2, statCache.size());
+
+    assertNotNull(firstStatus, firstCacheFile + " was not found in the stats cache");
+    assertNotNull(secondStatus, secondCacheFile + " was not found in the stats cache");
+    assertEquals(2, statCache.size(), "Missing/extra entries found in the stats cache");
     String expected = firstStatus.getModificationTime() + ","
         + secondStatus.getModificationTime();
     assertEquals(expected, jobConf.get(MRJobConfig.CACHE_FILE_TIMESTAMPS));
@@ -118,13 +116,11 @@ public class TestClientDistributedCacheManager {
 
     FileStatus thirdStatus = statCache.get(TEST_VISIBILITY_CHILD_DIR.toUri());
 
-    assertEquals("Missing/extra entries found in the stats cache",
-        1, statCache.size());
-    assertNotNull(TEST_VISIBILITY_CHILD_DIR
-        + " was not found in the stats cache", thirdStatus);
+    assertEquals(1, statCache.size(), "Missing/extra entries found in the stats cache");
+    assertNotNull(thirdStatus, TEST_VISIBILITY_CHILD_DIR + " was not found in the stats cache");
     expected = Long.toString(thirdStatus.getModificationTime());
-    assertEquals("Incorrect timestamp for " + TEST_VISIBILITY_CHILD_DIR,
-        expected, jobConf.get(MRJobConfig.CACHE_FILE_TIMESTAMPS));
+    assertEquals(expected, jobConf.get(MRJobConfig.CACHE_FILE_TIMESTAMPS),
+        "Incorrect timestamp for " + TEST_VISIBILITY_CHILD_DIR);
   }
   
   @Test
@@ -145,17 +141,16 @@ public class TestClientDistributedCacheManager {
     jobConf = job.getConfiguration();
 
     // skip test if scratch dir is not PUBLIC
-    assumeTrue(TEST_VISIBILITY_PARENT_DIR + " is not public",
-        ClientDistributedCacheManager.isPublic(
-            jobConf, TEST_VISIBILITY_PARENT_DIR.toUri(), statCache));
+    assumeTrue(ClientDistributedCacheManager.isPublic(jobConf, TEST_VISIBILITY_PARENT_DIR.toUri(),
+        statCache), TEST_VISIBILITY_PARENT_DIR + " is not public");
 
     ClientDistributedCacheManager.determineCacheVisibilities(jobConf,
         statCache);
     // We use get() instead of getBoolean() so we can tell the difference
     // between wrong and missing
-    assertEquals("The file paths were not found to be publicly visible "
-        + "even though the full path is publicly accessible",
-        "true,true", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES));
+    assertEquals("true,true", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES),
+        "The file paths were not found to be publicly visible "
+            + "even though the full path is publicly accessible");
     checkCacheEntries(statCache, null, firstCacheFile, relativePath);
 
     job = Job.getInstance(conf);
@@ -167,9 +162,9 @@ public class TestClientDistributedCacheManager {
         statCache);
     // We use get() instead of getBoolean() so we can tell the difference
     // between wrong and missing
-    assertEquals("The file path was not found to be publicly visible "
-        + "even though the full path is publicly accessible",
-        "true", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES));
+    assertEquals("true", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES),
+        "The file path was not found to be publicly visible "
+            + "even though the full path is publicly accessible");
     checkCacheEntries(statCache, null, wildcardPath.getParent());
 
     Path qualifiedParent = fs.makeQualified(TEST_VISIBILITY_PARENT_DIR);
@@ -185,9 +180,9 @@ public class TestClientDistributedCacheManager {
         statCache);
     // We use get() instead of getBoolean() so we can tell the difference
     // between wrong and missing
-    assertEquals("The file paths were found to be publicly visible "
-        + "even though the parent directory is not publicly accessible",
-        "false,false", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES));
+    assertEquals("false,false", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES),
+        "The file paths were found to be publicly visible "
+            + "even though the parent directory is not publicly accessible");
     checkCacheEntries(statCache, qualifiedParent,
         firstCacheFile, relativePath);
 
@@ -200,9 +195,9 @@ public class TestClientDistributedCacheManager {
         statCache);
     // We use get() instead of getBoolean() so we can tell the difference
     // between wrong and missing
-    assertEquals("The file path was found to be publicly visible "
-        + "even though the parent directory is not publicly accessible",
-        "false", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES));
+    assertEquals("false", jobConf.get(MRJobConfig.CACHE_FILE_VISIBILITIES),
+        "The file path was found to be publicly visible "
+            + "even though the parent directory is not publicly accessible");
     checkCacheEntries(statCache, qualifiedParent, wildcardPath.getParent());
   }
 
@@ -236,10 +231,8 @@ public class TestClientDistributedCacheManager {
     missing.removeAll(expected);
     extra.removeAll(uris);
 
-    assertTrue("File status cache does not contain an entries for " + missing,
-        missing.isEmpty());
-    assertTrue("File status cache contains extra extries: " + extra,
-        extra.isEmpty());
+    assertTrue(missing.isEmpty(), "File status cache does not contain an entries for " + missing);
+    assertTrue(extra.isEmpty(), "File status cache contains extra extries: " + extra);
   }
 
   @SuppressWarnings("deprecation")

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/filecache/TestDistributedCache.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/filecache/TestDistributedCache.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the {@link DistributedCache} class.
@@ -44,18 +46,16 @@ public class TestDistributedCache {
     }
 
     DistributedCache.addFileToClassPath(new Path("file:///a"), conf);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a", conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "file:///a", conf.get(MRJobConfig.CACHE_FILES));
+    assertEquals("file:/a", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("file:///a", conf.get(MRJobConfig.CACHE_FILES),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     DistributedCache.addFileToClassPath(new Path("file:///b"), conf);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a,file:/b",
-        conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "file:///a,file:///b",
-        conf.get(MRJobConfig.CACHE_FILES));
+    assertEquals("file:/a,file:/b", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("file:///a,file:///b", conf.get(MRJobConfig.CACHE_FILES),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     // Now test with 3 args
     FileSystem fs = FileSystem.newInstance(conf);
@@ -69,18 +69,16 @@ public class TestDistributedCache {
     }
 
     DistributedCache.addFileToClassPath(new Path("file:///a"), conf, fs);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a", conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "file:///a", conf.get(MRJobConfig.CACHE_FILES));
+    assertEquals("file:/a", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("file:///a", conf.get(MRJobConfig.CACHE_FILES),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     DistributedCache.addFileToClassPath(new Path("file:///b"), conf, fs);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a,file:/b",
-        conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "file:///a,file:///b",
-        conf.get(MRJobConfig.CACHE_FILES));
+    assertEquals("file:/a,file:/b", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("file:///a,file:///b", conf.get(MRJobConfig.CACHE_FILES),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     // Now test with 4th arg true
     conf.clear();
@@ -93,18 +91,16 @@ public class TestDistributedCache {
     }
 
     DistributedCache.addFileToClassPath(new Path("file:///a"), conf, fs, true);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a", conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "file:///a", conf.get(MRJobConfig.CACHE_FILES));
+    assertEquals("file:/a", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("file:///a", conf.get(MRJobConfig.CACHE_FILES),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     DistributedCache.addFileToClassPath(new Path("file:///b"), conf, fs, true);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a,file:/b",
-        conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "file:///a,file:///b",
-        conf.get(MRJobConfig.CACHE_FILES));
+    assertEquals("file:/a,file:/b", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("file:///a,file:///b", conf.get(MRJobConfig.CACHE_FILES),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     // And finally with 4th arg false
     conf.clear();
@@ -117,16 +113,15 @@ public class TestDistributedCache {
     }
 
     DistributedCache.addFileToClassPath(new Path("file:///a"), conf, fs, false);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a", conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "", conf.get(MRJobConfig.CACHE_FILES, ""));
+    assertEquals("file:/a", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("", conf.get(MRJobConfig.CACHE_FILES, ""),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
 
     DistributedCache.addFileToClassPath(new Path("file:///b"), conf, fs, false);
-    assertEquals("The mapreduce.job.classpath.files property was not "
-        + "set correctly", "file:/a,file:/b",
-        conf.get(MRJobConfig.CLASSPATH_FILES));
-    assertEquals("The mapreduce.job.cache.files property was not set "
-        + "correctly", "", conf.get(MRJobConfig.CACHE_FILES, ""));
+    assertEquals("file:/a,file:/b", conf.get(MRJobConfig.CLASSPATH_FILES),
+        "The mapreduce.job.classpath.files property was not " + "set correctly");
+    assertEquals("", conf.get(MRJobConfig.CACHE_FILES, ""),
+        "The mapreduce.job.cache.files property was not set " + "correctly");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestHistoryViewerPrinter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestHistoryViewerPrinter.java
@@ -24,10 +24,10 @@ import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.slf4j.Logger;
@@ -39,6 +39,9 @@ import java.util.HashMap;
 import java.util.TimeZone;
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 public class TestHistoryViewerPrinter {
 
   private static final Logger LOG =
@@ -48,12 +51,12 @@ public class TestHistoryViewerPrinter {
 
   private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     Locale.setDefault(DEFAULT_LOCALE);
   }
@@ -65,7 +68,7 @@ public class TestHistoryViewerPrinter {
         new HumanReadableHistoryViewerPrinter(job, false, "http://",
             TimeZone.getTimeZone("GMT"));
     String outStr = run(printer);
-    Assert.assertEquals("\n" +
+    assertEquals("\n" +
         "Hadoop job: job_1317928501754_0001\n" +
         "=====================================\n" +
         "User: rkanter\n" +
@@ -168,7 +171,7 @@ public class TestHistoryViewerPrinter {
             TimeZone.getTimeZone("GMT"));
     String outStr = run(printer);
     if (System.getProperty("java.version").startsWith("1.7")) {
-      Assert.assertEquals("\n" +
+      assertEquals("\n" +
           "Hadoop job: job_1317928501754_0001\n" +
           "=====================================\n" +
           "User: rkanter\n" +
@@ -356,7 +359,7 @@ public class TestHistoryViewerPrinter {
           "localhost\ttask_1317928501754_0001_m_000002, " +
           LINE_SEPARATOR, outStr);
     } else {
-      Assert.assertEquals("\n" +
+      assertEquals("\n" +
           "Hadoop job: job_1317928501754_0001\n" +
           "=====================================\n" +
           "User: rkanter\n" +
@@ -1018,12 +1021,11 @@ public class TestHistoryViewerPrinter {
     // We are not interested in anything but the duplicate counter
     int count1 = outStr.indexOf(
         "|Map-Reduce Framework          |Map input records             |");
-    Assert.assertNotEquals("First counter occurrence not found", -1, count1);
+    assertNotEquals(-1, count1, "First counter occurrence not found");
     int count2 = outStr.indexOf(
         "|Map-Reduce Framework          |Map input records             |",
         count1 + 1);
-    Assert.assertEquals("Duplicate counter found at: " + count1 +
-        " and " + count2, -1, count2);
+    assertEquals(-1, count2, "Duplicate counter found at: " + count1 + " and " + count2);
   }
 
   @Test
@@ -1038,12 +1040,11 @@ public class TestHistoryViewerPrinter {
     // We are not interested in anything but the duplicate counter
     int count1 = outStr.indexOf(
         "\"counterName\":\"MAP_INPUT_RECORDS\"");
-    Assert.assertNotEquals("First counter occurrence not found", -1, count1);
+    assertNotEquals(-1, count1, "First counter occurrence not found");
     int count2 = outStr.indexOf(
         "\"counterName\":\"MAP_INPUT_RECORDS\"",
         count1 + 1);
-    Assert.assertEquals("Duplicate counter found at: " + count1 +
-        " and " + count2, -1, count2);
+    assertEquals(-1, count2, "Duplicate counter found at: " + count1 + " and " + count2);
   }
 
   private String run(HistoryViewerPrinter printer) throws Exception {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/db/DriverForTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/db/DriverForTest.java
@@ -30,7 +30,10 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * class emulates a connection to database

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestDbClasses.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestDbClasses.java
@@ -29,17 +29,21 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.lib.db.DBInputFormat.DBInputSplit;
 import org.apache.hadoop.mapreduce.lib.db.DBInputFormat.NullDBWritable;
 import org.apache.hadoop.mapreduce.lib.db.DataDrivenDBInputFormat.DataDrivenDBInputSplit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestDbClasses {
   /**
    * test splitters from DataDrivenDBInputFormat. For different data types may
    * be different splitter
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testDataDrivenDBInputFormatSplitter() {
     DataDrivenDBInputFormat<NullDBWritable> format = new DataDrivenDBInputFormat<NullDBWritable>();
     testCommonSplitterTypes(format);
@@ -49,7 +53,8 @@ public class TestDbClasses {
     assertEquals(DateSplitter.class, format.getSplitter(Types.TIME).getClass());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testDataDrivenDBInputFormat() throws Exception {
     JobContext jobContext = mock(JobContext.class);
     Configuration configuration = new Configuration();
@@ -79,7 +84,8 @@ public class TestDbClasses {
         configuration.get(DBConfiguration.INPUT_BOUNDING_QUERY));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testOracleDataDrivenDBInputFormat() throws Exception {
     OracleDataDrivenDBInputFormat<NullDBWritable> format = 
         new OracleDataDrivenDBInputFormatForTest();
@@ -96,7 +102,8 @@ public class TestDbClasses {
    * test generate sql script for OracleDBRecordReader.
    */
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(20000)
   public void testOracleDBRecordReader() throws Exception {
     DBInputSplit splitter = new DBInputSplit(1, 10);
     Configuration configuration = new Configuration();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestSplitters.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestSplitters.java
@@ -18,11 +18,6 @@
 
 package org.apache.hadoop.mapreduce.lib.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
@@ -33,8 +28,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.lib.db.DataDrivenDBInputFormat.DataDrivenDBInputSplit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test Splitters. Splitters should build parts of sql sentences for split result. 
@@ -43,14 +44,15 @@ public class TestSplitters {
 
   private Configuration configuration;
   
-  @Before
+  @BeforeEach
   public void setup() {
     configuration = new Configuration();
     configuration.setInt(MRJobConfig.NUM_MAPS, 2);
   }
-  
-  @Test(timeout=2000)
-  public void testBooleanSplitter() throws Exception{
+
+  @Test
+  @Timeout(2000)
+  public void testBooleanSplitter() throws Exception {
     BooleanSplitter splitter = new BooleanSplitter();
     ResultSet result = mock(ResultSet.class);
     when(result.getString(1)).thenReturn("result1");
@@ -76,9 +78,10 @@ public class TestSplitters {
     assertSplits(new String[] {
         "column = FALSE column = FALSE", ".*column = TRUE"}, splits);
   }
-  
-  @Test(timeout=2000)
-  public void testFloatSplitter() throws Exception{
+
+  @Test
+  @Timeout(2000)
+  public void testFloatSplitter() throws Exception {
     FloatSplitter splitter = new FloatSplitter();
     
     ResultSet results = mock(ResultSet.class);
@@ -96,8 +99,9 @@ public class TestSplitters {
         "column1 >= 6.0 column1 <= 7.0"}, splits);
   }
 
-  @Test(timeout=2000)
-  public void testBigDecimalSplitter() throws Exception{
+  @Test
+  @Timeout(2000)
+  public void testBigDecimalSplitter() throws Exception {
     BigDecimalSplitter splitter = new BigDecimalSplitter();
     ResultSet result = mock(ResultSet.class);
     
@@ -114,8 +118,9 @@ public class TestSplitters {
         "column1 >= 11 column1 <= 12"}, splits);
   }
 
-  @Test(timeout=2000)
-  public void testIntegerSplitter() throws Exception{
+  @Test
+  @Timeout(2000)
+  public void testIntegerSplitter() throws Exception {
     IntegerSplitter splitter = new IntegerSplitter();
     ResultSet result = mock(ResultSet.class);
     
@@ -132,8 +137,9 @@ public class TestSplitters {
         "column1 >= 13 column1 < 18", "column1 >= 18 column1 <= 19"}, splits);
   }
 
-  @Test(timeout=2000)
-  public void testTextSplitter() throws Exception{
+  @Test
+  @Timeout(2000)
+  public void testTextSplitter() throws Exception {
     TextSplitter splitter = new TextSplitter();
     ResultSet result = mock(ResultSet.class);
     
@@ -154,10 +160,9 @@ public class TestSplitters {
     for (int i = 0; i < expectedSplitRE.length; i++) {
       DataDrivenDBInputSplit split = (DataDrivenDBInputSplit) splits.get(i);
       String actualExpr = split.getLowerClause() + " " + split.getUpperClause();
-      assertTrue("Split #" + (i+1) + " expression is wrong."
-          + " Expected " + expectedSplitRE[i]
-          + " Actual " + actualExpr,
-          Pattern.matches(expectedSplitRE[i], actualExpr));
+      assertTrue(Pattern.matches(expectedSplitRE[i], actualExpr),
+          "Split #" + (i + 1) + " expression is wrong." + " Expected " + expectedSplitRE[i]
+              + " Actual " + actualExpr);
     }
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/BaseTestLineRecordReaderBZip2.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/BaseTestLineRecordReaderBZip2.java
@@ -24,9 +24,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -37,7 +37,7 @@ import org.apache.hadoop.io.compress.bzip2.BZip2Utils;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
 import static org.apache.hadoop.io.compress.bzip2.BZip2TextFileWriter.BLOCK_SIZE;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class BaseTestLineRecordReaderBZip2 {
 
@@ -63,7 +63,7 @@ public abstract class BaseTestLineRecordReaderBZip2 {
     return tempFile;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
 
@@ -77,7 +77,7 @@ public abstract class BaseTestLineRecordReaderBZip2 {
     tempFile = new Path(inputDir, "test.txt.bz2");
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fs.delete(tempFile, /* recursive */ false);
   }
@@ -409,7 +409,7 @@ public abstract class BaseTestLineRecordReaderBZip2 {
     private void assertSplit(SplitRange splitRange) throws IOException {
       String message = splitRange.toString();
       long actual = reader.countRecords(splitRange.start, splitRange.length);
-      assertEquals(message, splitRange.expectedNumRecords, actual);
+      assertEquals(splitRange.expectedNumRecords, actual, message);
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineFileRecordReader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineFileRecordReader.java
@@ -22,7 +22,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.File;
 
-import org.junit.Assert;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
@@ -33,10 +32,10 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapred.Task.TaskReporter;
 
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import org.junit.Test;
-
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -86,7 +85,7 @@ public class TestCombineFileRecordReader {
       cfrr.initialize(combineFileSplit,taskAttemptContext);
 
       verify(reporter).progress();
-      Assert.assertFalse(cfrr.nextKeyValue());
+      assertFalse(cfrr.nextKeyValue());
       verify(reporter, times(3)).progress();
     } finally {
       FileUtil.fullyDelete(new File(outDir.toString()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestJobControl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestJobControl.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.mapreduce.lib.jobcontrol;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJobControl {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputFormat.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.mapreduce.lib.output;
 
 import java.io.IOException;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,6 +28,9 @@ import org.apache.hadoop.mapred.FileAlreadyExistsException;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFileOutputFormat {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMapFileOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMapFileOutputFormat.java
@@ -18,16 +18,16 @@
 
 package org.apache.hadoop.mapreduce.lib.output;
 
-import static org.junit.Assert.assertTrue;
-
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.MapFile.Reader;
 import org.apache.hadoop.mapreduce.Partitioner;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMapFileOutputFormat {
 
@@ -42,7 +42,7 @@ public class TestMapFileOutputFormat {
     assertTrue(!MyPartitioner.isGetPartitionCalled());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     MyPartitioner.setGetPartitionCalled(false);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPathOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPathOutputCommitter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPathOutputCommitterFactory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPathOutputCommitterFactory.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.mapreduce.lib.output;
 import java.io.IOException;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPreemptableFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestPreemptableFileOutputCommitter.java
@@ -22,8 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.hadoop.mapreduce.task.annotation.Checkpointable;
-import org.junit.Test;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -33,6 +32,16 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestPreemptableFileOutputCommitter {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/AbstractManifestCommitterTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.mapreduce.lib.output.committer.manifest;
 
+import org.junit.jupiter.api.AfterAll;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -36,7 +38,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -436,7 +437,7 @@ public abstract class AbstractManifestCommitterTest
   /**
    * Make sure there's no thread leakage.
    */
-  @AfterClass
+  @AfterAll
   public static void threadLeakage() {
     THREAD_LEAK_TRACKER.assertNoThreadLeakage();
   }
@@ -444,7 +445,7 @@ public abstract class AbstractManifestCommitterTest
   /**
    * Dump the filesystem statistics after the class.
    */
-  @AfterClass
+  @AfterAll
   public static void dumpFileSystemIOStatistics() {
     LOG.info("Aggregate FileSystem Statistics {}",
         ioStatisticsToPrettyString(FILESYSTEM_IOSTATS));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCleanupStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCleanupStage.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.mapreduce.lib.output.committer.manifest;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCommitTaskStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCommitTaskStage.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.mapreduce.lib.output.committer.manifest;
 import java.io.FileNotFoundException;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.ManifestSuccessData;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCreateOutputDirectoriesStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestCreateOutputDirectoriesStage.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestJobThroughManifestCommitter.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
@@ -80,7 +80,7 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * after each test case.
  * The last test case MUST perform the cleanup.
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TestJobThroughManifestCommitter
     extends AbstractManifestCommitterTest {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestLoadManifestsStage.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.TaskManifest;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestManifestCommitProtocol.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestManifestCommitProtocol.java
@@ -29,8 +29,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -254,7 +255,7 @@ public class TestManifestCommitProtocol
     super.teardown();
   }
 
-  @AfterClass
+  @AfterAll
   public static void logAggregateIOStatistics() {
     LOG.info("Final IOStatistics {}",
         ioStatisticsToPrettyString(IOSTATISTICS));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestRenameStageFailure.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.CommonPathCapabilities;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestTaskManifestFileIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/committer/manifest/TestTaskManifestFileIO.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.mapreduce.lib.output.committer.manifest;
 import java.io.IOException;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.output.committer.manifest.files.DirEntry;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestRehashPartitioner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestRehashPartitioner.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.mapreduce.lib.partition;
 
-import static org.junit.Assert.*;
-
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -26,7 +24,9 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.NullWritable;
 
-import org.junit.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRehashPartitioner {
 
@@ -66,6 +66,6 @@ public class TestRehashPartitioner {
         badbuckets++;
     }
     System.out.println(badbuckets + " of "+PARTITIONS+" are too small or large buckets");
-    assertTrue("too many overflow buckets", badbuckets < PARTITIONS * MAX_BADBUCKETS);
+    assertTrue(badbuckets < PARTITIONS * MAX_BADBUCKETS, "too many overflow buckets");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/security/TestTokenCache.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/security/TestTokenCache.java
@@ -19,9 +19,16 @@
 package org.apache.hadoop.mapreduce.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URI;
@@ -38,8 +45,8 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -47,7 +54,7 @@ public class TestTokenCache {
   private static Configuration conf;
   private static String renewer;
   
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf = new Configuration();
     conf.set(YarnConfiguration.RM_PRINCIPAL, "mapred/host@REALM");
@@ -206,6 +213,6 @@ public class TestTokenCache {
     TokenCache.obtainTokensForNamenodesInternal(fs1, creds, conf, renewer);
     String fs_addr = fs1.getCanonicalServiceName();
     Token<?> nnt = TokenCache.getDelegationToken(creds, fs_addr);
-    assertNotNull("Token for nn is null", nnt);
+    assertNotNull(nnt, "Token for nn is null");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/split/TestJobSplitWriter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/split/TestJobSplitWriter.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.mapreduce.split;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 
 import org.apache.hadoop.conf.Configuration;
@@ -29,7 +27,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestJobSplitWriter {
 
@@ -52,9 +52,8 @@ public class TestJobSplitWriter {
       JobSplit.TaskSplitMetaInfo[] infos =
           SplitMetaInfoReader.readSplitMetaInfo(new JobID(), fs, conf,
               submitDir);
-      assertEquals("unexpected number of splits", 1, infos.length);
-      assertEquals("unexpected number of split locations",
-          4, infos[0].getLocations().length);
+      assertEquals(1, infos.length, "unexpected number of splits");
+      assertEquals(4, infos[0].getLocations().length, "unexpected number of split locations");
     } finally {
       FileUtil.fullyDelete(TEST_DIR);
     }
@@ -76,9 +75,8 @@ public class TestJobSplitWriter {
       JobSplit.TaskSplitMetaInfo[] infos =
           SplitMetaInfoReader.readSplitMetaInfo(new JobID(), fs, conf,
               submitDir);
-      assertEquals("unexpected number of splits", 1, infos.length);
-      assertEquals("unexpected number of split locations",
-          4, infos[0].getLocations().length);
+      assertEquals(1, infos.length, "unexpected number of splits");
+      assertEquals(4, infos[0].getLocations().length, "unexpected number of split locations");
     } finally {
       FileUtil.fullyDelete(TEST_DIR);
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/split/TestJobSplitWriterWithEC.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/split/TestJobSplitWriterWithEC.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.mapreduce.split;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -40,10 +38,11 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests that maxBlockLocations default value is sufficient for RS-10-4.
@@ -60,7 +59,7 @@ public class TestJobSplitWriterWithEC {
   private Path submitDir;
   private Path testFile;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration hdfsConf = new HdfsConfiguration();
     hdfsConf.setLong(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, 0);
@@ -84,7 +83,7 @@ public class TestJobSplitWriterWithEC {
         fs.getUri().toString() + testFile.toString());
   }
 
-  @After
+  @AfterEach
   public void after() {
     cluster.close();
   }
@@ -121,8 +120,7 @@ public class TestJobSplitWriterWithEC {
         SplitMetaInfoReader.readSplitMetaInfo(new JobID(), fs, conf,
             submitDir);
 
-    assertEquals("Number of splits", 1, splitInfo.length);
-    assertEquals("Number of block locations", 14,
-        splitInfo[0].getLocations().length);
+    assertEquals(1, splitInfo.length, "Number of splits");
+    assertEquals(14, splitInfo[0].getLocations().length, "Number of block locations");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestEventFetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestEventFetcher.java
@@ -17,18 +17,11 @@
  */
 package org.apache.hadoop.mapreduce.task.reduce;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapred.MapTaskCompletionEventsUpdate;
@@ -36,8 +29,16 @@ import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.mapred.TaskCompletionEvent;
 import org.apache.hadoop.mapred.TaskUmbilicalProtocol;
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Test;
-import org.mockito.InOrder;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestEventFetcher {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMergeManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMergeManager.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.mapreduce.task.reduce;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -45,12 +45,13 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.reduce.MergeManagerImpl.CompressAwarePath;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMergeManager {
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(10000)
   public void testMemoryMerge() throws Exception {
     final int TOTAL_MEM_BYTES = 10000;
     final int OUTPUT_SIZE = 7950;
@@ -67,13 +68,11 @@ public class TestMergeManager {
 
     // reserve enough map output to cause a merge when it is committed
     MapOutput<Text, Text> out1 = mgr.reserve(null, OUTPUT_SIZE, 0);
-    Assert.assertTrue("Should be a memory merge",
-                      (out1 instanceof InMemoryMapOutput));
+    assertTrue((out1 instanceof InMemoryMapOutput), "Should be a memory merge");
     InMemoryMapOutput<Text, Text> mout1 = (InMemoryMapOutput<Text, Text>)out1;
     fillOutput(mout1);
     MapOutput<Text, Text> out2 = mgr.reserve(null, OUTPUT_SIZE, 0);
-    Assert.assertTrue("Should be a memory merge",
-                      (out2 instanceof InMemoryMapOutput));
+    assertTrue((out2 instanceof InMemoryMapOutput), "Should be a memory merge");
     InMemoryMapOutput<Text, Text> mout2 = (InMemoryMapOutput<Text, Text>)out2;
     fillOutput(mout2);
 
@@ -87,17 +86,15 @@ public class TestMergeManager {
     mout2.commit();
     mergeStart.await();
 
-    Assert.assertEquals(1, mgr.getNumMerges());
+    assertEquals(1, mgr.getNumMerges());
 
     // reserve enough map output to cause another merge when committed
     out1 = mgr.reserve(null, OUTPUT_SIZE, 0);
-    Assert.assertTrue("Should be a memory merge",
-                       (out1 instanceof InMemoryMapOutput));
+    assertTrue((out1 instanceof InMemoryMapOutput), "Should be a memory merge");
     mout1 = (InMemoryMapOutput<Text, Text>)out1;
     fillOutput(mout1);
     out2 = mgr.reserve(null, OUTPUT_SIZE, 0);
-    Assert.assertTrue("Should be a memory merge",
-                       (out2 instanceof InMemoryMapOutput));
+    assertTrue((out2 instanceof InMemoryMapOutput), "Should be a memory merge");
     mout2 = (InMemoryMapOutput<Text, Text>)out2;
     fillOutput(mout2);
 
@@ -114,14 +111,13 @@ public class TestMergeManager {
 
     // start the second merge and verify
     mergeStart.await();
-    Assert.assertEquals(2, mgr.getNumMerges());
+    assertEquals(2, mgr.getNumMerges());
 
     // trigger the end of the second merge
     mergeComplete.await();
 
-    Assert.assertEquals(2, mgr.getNumMerges());
-    Assert.assertEquals("exception reporter invoked",
-        0, reporter.getNumExceptions());
+    assertEquals(2, mgr.getNumMerges());
+    assertEquals(0, reporter.getNumExceptions(), "exception reporter invoked");
   }
 
   private void fillOutput(InMemoryMapOutput<Text, Text> output) throws IOException {
@@ -215,8 +211,9 @@ public class TestMergeManager {
     assertEquals(100, jobConf.getInt(MRJobConfig.IO_SORT_MB, 10));
   }
 
-  @SuppressWarnings({ "unchecked", "deprecation" })
-  @Test(timeout=10000)
+  @SuppressWarnings({"unchecked", "deprecation"})
+  @Test
+  @Timeout(10000)
   public void testOnDiskMerger() throws IOException, URISyntaxException,
     InterruptedException {
     JobConf jobConf = new JobConf();
@@ -255,16 +252,14 @@ public class TestMergeManager {
     LinkedList<List<CompressAwarePath>> pendingToBeMerged =
       (LinkedList<List<CompressAwarePath>>) Whitebox.getInternalState(
         onDiskMerger, "pendingToBeMerged");
-    assertTrue("No inputs were added to list pending to merge",
-      pendingToBeMerged.size() > 0);
+    assertTrue(pendingToBeMerged.size() > 0, "No inputs were added to list pending to merge");
     for(int i = 0; i < pendingToBeMerged.size(); ++i) {
       List<CompressAwarePath> inputs = pendingToBeMerged.get(i);
       for(int j = 1; j < inputs.size(); ++j) {
-        assertTrue("Not enough / too many inputs were going to be merged",
-          inputs.size() > 0 && inputs.size() <= SORT_FACTOR);
-        assertTrue("Inputs to be merged were not sorted according to size: ",
-          inputs.get(j).getCompressedSize()
-          >= inputs.get(j-1).getCompressedSize());
+        assertTrue(inputs.size() > 0 && inputs.size() <= SORT_FACTOR,
+            "Not enough / too many inputs were going to be merged");
+        assertTrue(inputs.get(j).getCompressedSize() >= inputs.get(j - 1).getCompressedSize(),
+            "Inputs to be merged were not sorted according to size: ");
       }
     }
 
@@ -292,13 +287,13 @@ public class TestMergeManager {
     final MergeManagerImpl<Text, Text> mgr = new MergeManagerImpl<Text, Text>(
         null, conf, mock(LocalFileSystem.class), null, null, null, null, null,
         null, null, null, null, null, new MROutputFiles());
-    assertTrue("Large shuffle area unusable: " + mgr.memoryLimit,
-        mgr.memoryLimit > Integer.MAX_VALUE);
+    assertTrue(mgr.memoryLimit > Integer.MAX_VALUE,
+        "Large shuffle area unusable: " + mgr.memoryLimit);
     final long maxInMemReduce = mgr.getMaxInMemReduceLimit();
-    assertTrue("Large in-memory reduce area unusable: " + maxInMemReduce,
-        maxInMemReduce > Integer.MAX_VALUE);
-    assertEquals("maxSingleShuffleLimit to be capped at Integer.MAX_VALUE",
-        Integer.MAX_VALUE, mgr.maxSingleShuffleLimit);
+    assertTrue(maxInMemReduce > Integer.MAX_VALUE,
+        "Large in-memory reduce area unusable: " + maxInMemReduce);
+    assertEquals(Integer.MAX_VALUE, mgr.maxSingleShuffleLimit,
+        "maxSingleShuffleLimit to be capped at Integer.MAX_VALUE");
     verifyReservedMapOutputType(mgr, 10L, "MEMORY");
     verifyReservedMapOutputType(mgr, 1L + Integer.MAX_VALUE, "DISK");
   }
@@ -307,8 +302,8 @@ public class TestMergeManager {
       long size, String expectedShuffleMode) throws IOException {
     final TaskAttemptID mapId = TaskAttemptID.forName("attempt_0_1_m_1_1");
     final MapOutput<Text, Text> mapOutput = mgr.reserve(mapId, size, 1);
-    assertEquals("Shuffled bytes: " + size, expectedShuffleMode,
-        mapOutput.getDescription());
+    assertEquals(expectedShuffleMode,
+        mapOutput.getDescription(), "Shuffled bytes: " + size);
     mgr.unreserve(size);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestMerger.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.mapreduce.task.reduce;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -65,11 +68,10 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Progress;
 import org.apache.hadoop.util.Progressable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -82,7 +84,7 @@ public class TestMerger {
   private JobConf jobConf;
   private FileSystem fs;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     // setup the test root directory
     testRootDir =
@@ -90,7 +92,7 @@ public class TestMerger {
             TestMerger.class);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     unitTestDir = new File(testRootDir, unitTestName.getMethodName());
     unitTestDir.mkdirs();
@@ -154,7 +156,7 @@ public class TestMerger {
 
     inMemoryMerger.merge(mapOutputs1);
 
-    Assert.assertEquals(1, mergeManager.onDiskMapOutputs.size());
+    assertEquals(1, mergeManager.onDiskMapOutputs.size());
 
     TaskAttemptID reduceId2 = new TaskAttemptID(
         new TaskID(jobId, TaskType.REDUCE, 3), 0);
@@ -189,7 +191,7 @@ public class TestMerger {
 
     inMemoryMerger2.merge(mapOutputs2);
 
-    Assert.assertEquals(2, mergeManager.onDiskMapOutputs.size());
+    assertEquals(2, mergeManager.onDiskMapOutputs.size());
 
     List<CompressAwarePath> paths = new ArrayList<CompressAwarePath>();
     Iterator<CompressAwarePath> iterator =
@@ -214,7 +216,7 @@ public class TestMerger {
     MergeThread<CompressAwarePath,Text,Text> onDiskMerger = mergeManager.createOnDiskMerger();
     onDiskMerger.merge(paths);
 
-    Assert.assertEquals(1, mergeManager.onDiskMapOutputs.size());
+    assertEquals(1, mergeManager.onDiskMapOutputs.size());
 
     keys = new ArrayList<String>();
     values = new ArrayList<String>();
@@ -226,9 +228,9 @@ public class TestMerger {
             "pretty good", "bla", "amazing", "delicious"));
 
     mergeManager.close();
-    Assert.assertEquals(0, mergeManager.inMemoryMapOutputs.size());
-    Assert.assertEquals(0, mergeManager.inMemoryMergedMapOutputs.size());
-    Assert.assertEquals(0, mergeManager.onDiskMapOutputs.size());
+    assertEquals(0, mergeManager.inMemoryMapOutputs.size());
+    assertEquals(0, mergeManager.inMemoryMergedMapOutputs.size());
+    assertEquals(0, mergeManager.onDiskMapOutputs.size());
   }
 
   private byte[] writeMapOutput(Configuration conf, Map<String, String> keysToValues)
@@ -295,35 +297,35 @@ public class TestMerger {
     // Reading 6 keys total, 3 each in 2 segments, so each key read moves the
     // progress forward 1/6th of the way. Initially the first keys from each
     // segment have been read as part of the merge setup, so progress = 2/6.
-    Assert.assertEquals(2/6.0f, mergeQueue.getProgress().get(), epsilon);
+    assertEquals(2/6.0f, mergeQueue.getProgress().get(), epsilon);
 
     // The first next() returns one of the keys already read during merge setup
-    Assert.assertTrue(mergeQueue.next());
-    Assert.assertEquals(2/6.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.next());
+    assertEquals(2/6.0f, mergeQueue.getProgress().get(), epsilon);
 
     // Subsequent next() calls should read one key and move progress
-    Assert.assertTrue(mergeQueue.next());
-    Assert.assertEquals(3/6.0f, mergeQueue.getProgress().get(), epsilon);
-    Assert.assertTrue(mergeQueue.next());
-    Assert.assertEquals(4/6.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.next());
+    assertEquals(3/6.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.next());
+    assertEquals(4/6.0f, mergeQueue.getProgress().get(), epsilon);
 
     // At this point we've exhausted all of the keys in one segment
     // so getting the next key will return the already cached key from the
     // other segment
-    Assert.assertTrue(mergeQueue.next());
-    Assert.assertEquals(4/6.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.next());
+    assertEquals(4/6.0f, mergeQueue.getProgress().get(), epsilon);
 
     // Subsequent next() calls should read one key and move progress
-    Assert.assertTrue(mergeQueue.next());
-    Assert.assertEquals(5/6.0f, mergeQueue.getProgress().get(), epsilon);
-    Assert.assertTrue(mergeQueue.next());
-    Assert.assertEquals(1.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.next());
+    assertEquals(5/6.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.next());
+    assertEquals(1.0f, mergeQueue.getProgress().get(), epsilon);
 
     // Now there should be no more input
-    Assert.assertFalse(mergeQueue.next());
-    Assert.assertEquals(1.0f, mergeQueue.getProgress().get(), epsilon);
-    Assert.assertTrue(mergeQueue.getKey() == null);
-    Assert.assertEquals(0, mergeQueue.getValue().getData().length);
+    assertFalse(mergeQueue.next());
+    assertEquals(1.0f, mergeQueue.getProgress().get(), epsilon);
+    assertTrue(mergeQueue.getKey() == null);
+    assertEquals(0, mergeQueue.getValue().getData().length);
   }
 
   private Progressable getReporter() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestShuffleClientMetrics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestShuffleClientMetrics.java
@@ -21,9 +21,9 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.metrics2.MetricsTag;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestShuffleScheduler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/TestShuffleScheduler.java
@@ -17,9 +17,6 @@
  */
 package org.apache.hadoop.mapreduce.task.reduce;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -37,8 +34,13 @@ import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.util.Progress;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class TestShuffleScheduler {
 
@@ -69,15 +71,15 @@ public class TestShuffleScheduler {
     TaskID taskId1 = new TaskID(jobId, TaskType.REDUCE, 1);
     scheduler.tipFailed(taskId1);
 
-    Assert.assertEquals("Progress should be 0.5", 0.5f, progress.getProgress(),
-        0.0f);
-    Assert.assertFalse(scheduler.waitUntilDone(1));
+    assertEquals(0.5f, progress.getProgress(),
+        0.0f, "Progress should be 0.5");
+    assertFalse(scheduler.waitUntilDone(1));
 
     TaskID taskId0 = new TaskID(jobId, TaskType.REDUCE, 0);
     scheduler.tipFailed(taskId0);
-    Assert.assertEquals("Progress should be 1.0", 1.0f, progress.getProgress(),
-        0.0f);
-    Assert.assertTrue(scheduler.waitUntilDone(1));
+    assertEquals(1.0f, progress.getProgress(),
+        0.0f, "Progress should be 1.0");
+    assertTrue(scheduler.waitUntilDone(1));
   }
 
   @SuppressWarnings("rawtypes")
@@ -134,7 +136,7 @@ public class TestShuffleScheduler {
     //adding the 1st interval, 40MB from 60s to 100s
     long bytes = (long)40 * 1024 * 1024;
     scheduler.copySucceeded(attemptID0, new MapHost(null, null), bytes, 60000, 100000, output);
-    Assert.assertEquals(copyMessage(1, 1, 1), progress.toString());
+    assertEquals(copyMessage(1, 1, 1), progress.toString());
 
     TaskAttemptID attemptID1 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -143,7 +145,7 @@ public class TestShuffleScheduler {
     //adding the 2nd interval before the 1st interval, 50MB from 0s to 50s
     bytes = (long)50 * 1024 * 1024;
     scheduler.copySucceeded(attemptID1, new MapHost(null, null), bytes, 0, 50000, output);
-    Assert.assertEquals(copyMessage(2, 1, 1), progress.toString());
+    assertEquals(copyMessage(2, 1, 1), progress.toString());
 
     TaskAttemptID attemptID2 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -153,7 +155,7 @@ public class TestShuffleScheduler {
     //110MB from 25s to 80s
     bytes = (long)110 * 1024 * 1024;
     scheduler.copySucceeded(attemptID2, new MapHost(null, null), bytes, 25000, 80000, output);
-    Assert.assertEquals(copyMessage(3, 2, 2), progress.toString());
+    assertEquals(copyMessage(3, 2, 2), progress.toString());
 
     TaskAttemptID attemptID3 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -162,7 +164,7 @@ public class TestShuffleScheduler {
     //adding the 4th interval just after the 2nd interval, 100MB from 100s to 300s
     bytes = (long)100 * 1024 * 1024;
     scheduler.copySucceeded(attemptID3, new MapHost(null, null), bytes, 100000, 300000, output);
-    Assert.assertEquals(copyMessage(4, 0.5, 1), progress.toString());
+    assertEquals(copyMessage(4, 0.5, 1), progress.toString());
 
     TaskAttemptID attemptID4 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -171,7 +173,7 @@ public class TestShuffleScheduler {
     //adding the 5th interval between after 4th, 50MB from 350s to 400s
     bytes = (long)50 * 1024 * 1024;
     scheduler.copySucceeded(attemptID4, new MapHost(null, null), bytes, 350000, 400000, output);
-    Assert.assertEquals(copyMessage(5, 1, 1), progress.toString());
+    assertEquals(copyMessage(5, 1, 1), progress.toString());
 
 
     TaskAttemptID attemptID5 = new TaskAttemptID(
@@ -180,7 +182,7 @@ public class TestShuffleScheduler {
     //adding the 6th interval between after 5th, 50MB from 450s to 500s
     bytes = (long)50 * 1024 * 1024;
     scheduler.copySucceeded(attemptID5, new MapHost(null, null), bytes, 450000, 500000, output);
-    Assert.assertEquals(copyMessage(6, 1, 1), progress.toString());
+    assertEquals(copyMessage(6, 1, 1), progress.toString());
 
     TaskAttemptID attemptID6 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -188,7 +190,7 @@ public class TestShuffleScheduler {
     //adding the 7th interval between after 5th and 6th interval, 20MB from 320s to 340s
     bytes = (long)20 * 1024 * 1024;
     scheduler.copySucceeded(attemptID6, new MapHost(null, null), bytes, 320000, 340000, output);
-    Assert.assertEquals(copyMessage(7, 1, 1), progress.toString());
+    assertEquals(copyMessage(7, 1, 1), progress.toString());
 
     TaskAttemptID attemptID7 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -196,7 +198,7 @@ public class TestShuffleScheduler {
     //adding the 8th interval overlapping with 4th, 5th, and 7th 30MB from 290s to 350s
     bytes = (long)30 * 1024 * 1024;
     scheduler.copySucceeded(attemptID7, new MapHost(null, null), bytes, 290000, 350000, output);
-    Assert.assertEquals(copyMessage(8, 0.5, 1), progress.toString());
+    assertEquals(copyMessage(8, 0.5, 1), progress.toString());
 
     TaskAttemptID attemptID8 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -204,7 +206,7 @@ public class TestShuffleScheduler {
     //adding the 9th interval overlapping with 5th and 6th, 50MB from 400s to 450s
     bytes = (long)50 * 1024 * 1024;
     scheduler.copySucceeded(attemptID8, new MapHost(null, null), bytes, 400000, 450000, output);
-    Assert.assertEquals(copyMessage(9, 1, 1), progress.toString());
+    assertEquals(copyMessage(9, 1, 1), progress.toString());
 
     TaskAttemptID attemptID9 = new TaskAttemptID(
         new org.apache.hadoop.mapred.TaskID(
@@ -212,7 +214,7 @@ public class TestShuffleScheduler {
     //adding the 10th interval overlapping with all intervals, 500MB from 0s to 500s
     bytes = (long)500 * 1024 * 1024;
     scheduler.copySucceeded(attemptID9, new MapHost(null, null), bytes, 0, 500000, output);
-    Assert.assertEquals(copyMessage(10, 1, 2), progress.toString());
+    assertEquals(copyMessage(10, 1, 2), progress.toString());
   }
 
   @SuppressWarnings("rawtypes")

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/tools/TestCLI.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/tools/TestCLI.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.mapreduce.tools;
 
-import static org.junit.Assert.*;
-
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -31,16 +29,17 @@ import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.JobPriority;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.JobStatus.State;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 public class TestCLI {
   private static String jobIdStr = "job_1015298225799_0015";
@@ -71,13 +70,12 @@ public class TestCLI {
     int retCode_completed = cli.run(new String[] { "-list-attempt-ids",
         jobIdStr, "REDUCE", "completed" });
 
-    assertEquals("MAP is a valid input,exit code should be 0", 0, retCode_MAP);
-    assertEquals("map is a valid input,exit code should be 0", 0, retCode_map);
-    assertEquals("REDUCE is a valid input,exit code should be 0", 0,
-        retCode_REDUCE);
-    assertEquals(
-        "REDUCE and completed are a valid inputs to -list-attempt-ids,exit code should be 0",
-        0, retCode_completed);
+    assertEquals(0, retCode_MAP, "MAP is a valid input,exit code should be 0");
+    assertEquals(0, retCode_map, "map is a valid input,exit code should be 0");
+    assertEquals(0,
+        retCode_REDUCE, "REDUCE is a valid input,exit code should be 0");
+    assertEquals(0, retCode_completed,
+        "REDUCE and completed are a valid inputs to -list-attempt-ids,exit code should be 0");
 
     verify(job, times(2)).getTaskReports(TaskType.MAP);
     verify(job, times(2)).getTaskReports(TaskType.REDUCE);
@@ -106,14 +104,11 @@ public class TestCLI {
     int retCode_invalidJobId = cli.run(new String[] { "-list-attempt-ids",
         jobIdStr2, "MAP", "running" });
 
-    assertEquals("JOB_SETUP is an invalid input,exit code should be -1", -1,
-        retCode_JOB_SETUP);
-    assertEquals("JOB_CLEANUP is an invalid input,exit code should be -1", -1,
-        retCode_JOB_CLEANUP);
-    assertEquals("complete is an invalid input,exit code should be -1", -1,
-        retCode_invalidTaskState);
-    assertEquals("Non existing job id should be skippted with -1", -1,
-        retCode_invalidJobId);
+    assertEquals(-1, retCode_JOB_SETUP, "JOB_SETUP is an invalid input,exit code should be -1");
+    assertEquals(-1, retCode_JOB_CLEANUP, "JOB_CLEANUP is an invalid input,exit code should be -1");
+    assertEquals(-1, retCode_invalidTaskState,
+        "complete is an invalid input,exit code should be -1");
+    assertEquals(-1, retCode_invalidJobId, "Non existing job id should be skippted with -1");
 
   }
 
@@ -173,7 +168,7 @@ public class TestCLI {
     cli.cluster = mockCluster;
 
     Job job = cli.getJob(JobID.forName("job_1234654654_001"));
-    Assert.assertTrue("job is not null", job == null);
+    assertTrue(job == null, "job is not null");
   }
 
   @Test
@@ -189,7 +184,7 @@ public class TestCLI {
     cli.cluster = mockCluster;
 
     Job job = cli.getJob(JobID.forName("job_1234654654_001"));
-    Assert.assertTrue("job is null", job != null);
+    assertTrue(job != null, "job is null");
   }
 
   @Test


### PR DESCRIPTION
### Description of PR [WIP]

Upgrade Junit 4 to 5 in hadoop-mapreduce-client-core

JIRA - MAPREDUCE-7420

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

