### PR TITLE
HDFS-16804. AddVolume contains a race condition with shutdown block pool

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3183,7 +3183,7 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   }
 
   @Override
-  public void addBlockPool(String bpid, Configuration conf)
+  public synchronized void addBlockPool(String bpid, Configuration conf)
       throws IOException {
     LOG.info("Adding block pool " + bpid);
     AddBlockPoolException volumeExceptions = new AddBlockPoolException();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -166,13 +167,17 @@ class ReplicaMap {
   /**
    * Merge all entries from the given replica map into the local replica map.
    */
-  void mergeAll(ReplicaMap other) {
+  void mergeAll(ReplicaMap other) throws IOException {
     Set<String> bplist = other.map.keySet();
     for (String bp : bplist) {
       checkBlockPool(bp);
       try (AutoCloseDataSetLock l = lockManager.writeLock(LockLevel.BLOCK_POOl, bp)) {
         LightWeightResizableGSet<Block, ReplicaInfo> replicaInfos = other.map.get(bp);
         LightWeightResizableGSet<Block, ReplicaInfo> curSet = map.get(bp);
+        if (curSet == null) {
+          // Can't find the block pool id in the replicaMap. Maybe it has been removed.
+          throw new IOException("Can't find " + bp + " in the replicaMap.");
+        }
         HashSet<ReplicaInfo> replicaSet = new HashSet<>();
         //Can't add to GSet while in another GSet iterator may cause endlessLoop
         for (ReplicaInfo replicaInfo : replicaInfos) {
@@ -180,11 +185,6 @@ class ReplicaMap {
         }
         for (ReplicaInfo replicaInfo : replicaSet) {
           checkBlock(replicaInfo);
-          if (curSet == null) {
-            // Add an entry for block pool if it does not exist already
-            curSet = new LightWeightResizableGSet<>();
-            map.put(bp, curSet);
-          }
           curSet.put(replicaInfo);
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaMap.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.hdfs.server.datanode.FinalizedReplica;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 
 /**
  * Unit test for ReplicasMap class
@@ -110,7 +112,7 @@ public class TestReplicaMap {
   }
 
   @Test
-  public void testMergeAll() {
+  public void testMergeAll() throws IOException {
     ReplicaMap temReplicaMap = new ReplicaMap();
     Block tmpBlock = new Block(5678, 5678, 5678);
     temReplicaMap.add(bpid, new FinalizedReplica(tmpBlock, null, null));


### PR DESCRIPTION
Jira: [HDFS-16804](https://issues.apache.org/jira/browse/HDFS-16804) 

Add Volume contains a race condition with shutdown block pool, causing the ReplicaMap still contains some blocks belong to the removed block pool.

And the new volume still contains one unused BlockPoolSlice belongs to the removed block pool, caused some problems, such as: incorrect dfsUsed, incorrect numBlocks of the volume.

Let's review the logic of addVolume and shutdownBlockPool respectively.

AddVolume Logic:

- Step1: Get all namespaceInfo from blockPoolManager
- Step2: Create one temporary FsVolumeImpl object
- Step3: Create some blockPoolSlice according to the namespaceInfo and add them to the temporary FsVolumeImpl object
- Step4: Scan all blocks of the namespaceInfo from the volume and store them by one temporary ReplicaMap
- Step5: Active the temporary FsVolumeImpl which created before (with FsDatasetImpl synchronized lock)
- Step5.1: Merge all blocks of the temporary ReplicaMap to the global ReplicaMap
- Step5.2: Add the FsVolumeImpl to the volumes

ShutdownBlockPool Logic:(with blockPool write lock)

- Step1: Cleanup the blockPool from the global ReplicaMap
- Step2: Shutdown the block pool from all the volumes
- Step2.1: do some clean operations for the block pool, such as saveReplica, saveDfsUsed, etc
- Step2.2: remove the blockPool from bpSlices

The race condition can be reproduced by the following steps:
- AddVolume Step1: Get all namespaceInfo from blockPoolManager
- ShutdownBlockPool Step1: Cleanup the blockPool from the global ReplicaMap
- ShutdownBlockPool Step2: Shutdown the block pool from all the volumes
- AddVolume Step 2~5

And result:
- The global replicaMap contains some blocks belong to the removed blockPool
- The bpSlices of the FsVolumeImpl contains one blockPoolSlice belong to the removed blockPool

Expected result:
- The global replicaMap shouldn't contain any blocks belong to the removed blockPool
- The bpSlices of any FsVolumeImpl shouldn't contain any blockPoolSlice belong to the removed blockPool