### PR TITLE
HDFS-3570. Balancer shouldn't rely on "DFS Space Used %" as that ignores non-DFS used space

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Balancer.java
@@ -187,7 +187,8 @@ public class Balancer {
   private static final String USAGE = "Usage: hdfs balancer"
       + "\n\t[-policy <policy>]\tthe balancing policy: "
       + BalancingPolicy.Node.INSTANCE.getName() + " or "
-      + BalancingPolicy.Pool.INSTANCE.getName()
+      + BalancingPolicy.Pool.INSTANCE.getName() + " or "
+      + BalancingPolicy.NodeActual.INSTANCE.getName()
       + "\n\t[-threshold <threshold>]\tPercentage of disk capacity"
       + "\n\t[-exclude [-f <hosts-file> | <comma-separated list of hosts>]]"
       + "\tExcludes the specified datanodes."

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancingPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancingPolicy.java
@@ -79,7 +79,8 @@ abstract class BalancingPolicy {
   /** Get all {@link BalancingPolicy} instances*/
   static BalancingPolicy parse(String s) {
     final BalancingPolicy [] all = {BalancingPolicy.Node.INSTANCE,
-                                    BalancingPolicy.Pool.INSTANCE};
+                                    BalancingPolicy.Pool.INSTANCE,
+                                    NodeActual.INSTANCE};
     for(BalancingPolicy p : all) {
       if (p.getName().equalsIgnoreCase(s))
         return p;
@@ -115,6 +116,45 @@ abstract class BalancingPolicy {
       for(StorageReport s : r.getStorageReports()) {
         if (s.getStorage().getStorageType() == t) {
           capacity += s.getCapacity();
+          dfsUsed += s.getDfsUsed();
+        }
+      }
+      return capacity == 0L? null: dfsUsed*100.0/capacity;
+    }
+  }
+
+  /**
+   * Cluster is balanced if each node is balanced. Unlike {@link Node},
+   * The policy take into account non-DFS used spaces.
+   * <p>
+   * Actual DFS capacity (capacity - non-DFS used) is calculated by
+   * (DFS used + remaining).
+   */
+  static class NodeActual extends BalancingPolicy {
+    static final NodeActual INSTANCE = new NodeActual();
+    private NodeActual() {}
+
+    @Override
+    String getName() {
+      return "datanode-actual";
+    }
+
+    @Override
+    void accumulateSpaces(DatanodeStorageReport r) {
+      for(StorageReport s : r.getStorageReports()) {
+        final StorageType t = s.getStorage().getStorageType();
+        totalCapacities.add(t, s.getDfsUsed() + s.getRemaining());
+        totalUsedSpaces.add(t, s.getDfsUsed());
+      }
+    }
+
+    @Override
+    Double getUtilization(DatanodeStorageReport r, final StorageType t) {
+      long capacity = 0L;
+      long dfsUsed = 0L;
+      for(StorageReport s : r.getStorageReports()) {
+        if (s.getStorage().getStorageType() == t) {
+          capacity += s.getDfsUsed() + s.getRemaining();
           dfsUsed += s.getDfsUsed();
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancingPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/BalancingPolicy.java
@@ -130,7 +130,7 @@ abstract class BalancingPolicy {
    * Actual DFS capacity (capacity - non-DFS used) is calculated by
    * (DFS used + remaining).
    */
-  static class NodeActual extends BalancingPolicy {
+  static final class NodeActual extends BalancingPolicy {
     static final NodeActual INSTANCE = new NodeActual();
     private NodeActual() {}
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -292,7 +292,7 @@ Usage:
 
 | COMMAND\_OPTION | Description |
 |:---- |:---- |
-| `-policy` \<policy\> | `datanode` (default): Cluster is balanced if each datanode is balanced.<br/> `blockpool`: Cluster is balanced if each block pool in each datanode is balanced. |
+| `-policy` \<policy\> | `datanode` (default): Cluster is balanced if each datanode is balanced.<br/> `blockpool`: Cluster is balanced if each block pool in each datanode is balanced.<br/> `datanode-actual`: Cluster is balanced if each datanode is balanced. Unlike `datanode`, this policy take into account non-DFS usage. |
 | `-threshold` \<threshold\> | Percentage of disk capacity. This overwrites the default threshold. |
 | `-exclude -f` \<hosts-file\> \| \<comma-separated list of hosts\> | Excludes the specified datanodes from being balanced by the balancer. |
 | `-include -f` \<hosts-file\> \| \<comma-separated list of hosts\> | Includes only the specified datanodes to be balanced by the balancer. |


### PR DESCRIPTION
### Description of PR

HDFS-3570 - **Balancer shouldn't rely on "DFS Space Used %" as that ignores non-DFS used space**


Report from a user here: https://groups.google.com/a/cloudera.org/d/msg/cdh-user/pIhNyDVxdVY/b7ENZmEvBjIJ (Not available now) , post archived at http://pastebin.com/eVFkk0A0

This user had a specific DN that had a large non-DFS usage among dfs.data.dirs, and very little DFS usage (which is computed against total possible capacity).

Balancer apparently only looks at the usage, and ignores to consider that non-DFS usage may also be high on a DN/cluster. Hence, it thinks that if a DFS Usage report from DN is 8% only, its got a lot of free space to write more blocks, when that isn't true as shown by the case of this user. It went on scheduling writes to the DN to balance it out, but the DN simply can't accept any more blocks as a result of its disks' state.

It would be better if we computed the actual utilization based on (100-(actual remaining space))/(capacity), as opposed to the current (dfs used)/(capacity). Thoughts?

This isn't very critical, however, cause it is very rare to see DN space being used for non DN data, but it does expose a valid bug.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

