### PR TITLE
HADOOP-18500: Upgrade maven-shade-plugin to 3.3.0

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -174,7 +174,7 @@
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
     <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <maven-source-plugin.version>2.3</maven-source-plugin.version>


### PR DESCRIPTION
### Description of PR
Upgrade maven-shade-plugin to 3.3.0. This avoids unnecessary rewrites of class files during relocation. 

### How was this patch tested?
I built Hadoop locally and compared the byte code of the class files before and after the upgrade. Before, the byte code is different between classes inside relocated JARs and non-relocated JARs (e.g. in `hadoop-client-runtime` vs `hadoop-shaded-guava`). After, the byte code is the same.

