### PR TITLE
HADOOP-17705. S3A to add Config to set AWS region

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -781,5 +781,17 @@ public final class Constants {
    */
   public static final String STORE_CAPABILITY_DIRECTORY_MARKER_ACTION_DELETE
       = "fs.s3a.capability.directory.marker.action.delete";
+  
+  /**
+   * AWS S3 region for the bucket. When set bypasses the construction of
+   * region through endpoint url.
+   */
+  public static final String AWS_REGION = "fs.s3a.endpoint.region";
+
+  /**
+   * The special S3 region which can be used to talk to any bucket.
+   * Value {@value}.
+   */
+  public static final String AWS_S3_CENTRAL_REGION = "us-east-1";
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -23,14 +23,27 @@ import java.net.URI;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.S3ClientOptions;
-import org.slf4j.Logger;
+import com.amazonaws.client.builder.AwsClientBuilder;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Builder;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.S3ClientOptions;
+import com.amazonaws.services.s3.internal.ServiceUtils;
+import com.amazonaws.util.AwsHostNameUtils;
+import com.amazonaws.util.RuntimeHttpUtils;
+
+import org.slf4j.Logger;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.s3a.impl.LogExactlyOnce;
+import com.google.common.annotations.VisibleForTesting;
 
+
+import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CENTRAL_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.PATH_STYLE_ACCESS;
 
@@ -42,7 +55,23 @@ import static org.apache.hadoop.fs.s3a.Constants.PATH_STYLE_ACCESS;
 public class DefaultS3ClientFactory extends Configured
     implements S3ClientFactory {
 
+  private static final String S3_SERVICE_NAME = "s3";
+
+	
   protected static final Logger LOG = S3AFileSystem.LOG;
+  
+  /**
+   * A one-off warning of default region chains in use.
+   */
+  private static final LogExactlyOnce WARN_OF_DEFAULT_REGION_CHAIN =
+      new LogExactlyOnce(LOG);
+
+  /**
+   * Warning message printed when the SDK Region chain is in use.
+   */
+  private static final String SDK_REGION_CHAIN_IN_USE =
+      "S3A filesystem client is using"
+          + " the SDK region resolution chain.";
 
   @Override
   public AmazonS3 createS3Client(URI name,
@@ -50,8 +79,7 @@ public class DefaultS3ClientFactory extends Configured
       final AWSCredentialsProvider credentials) throws IOException {
     Configuration conf = getConf();
     final ClientConfiguration awsConf = S3AUtils.createAwsConf(getConf(), bucket);
-    return configureAmazonS3Client(
-        newAmazonS3Client(credentials, awsConf), conf);
+    return buildAmazonS3Client(credentials, awsConf, conf);
   }
 
   /**
@@ -65,21 +93,65 @@ public class DefaultS3ClientFactory extends Configured
       AWSCredentialsProvider credentials, ClientConfiguration awsConf) {
     return new AmazonS3Client(credentials, awsConf);
   }
-
+  
   /**
-   * Configure S3 client from the Hadoop configuration.
+   * Use the Builder API to create an AWS S3 client.
+   * <p>
+   * This has a more complex endpoint configuration mechanism
+   * which initially caused problems; the
+   * {@code withForceGlobalBucketAccessEnabled(true)}
+   * command is critical here.
+   * @param awsConf  AWS configuration
+   * @param parameters parameters
+   * @return new AmazonS3 client
+   * @throws SdkClientException if the configuration is invalid.
+   */
+  protected AmazonS3 buildAmazonS3Client(
+      final AWSCredentialsProvider credentials,
+      final ClientConfiguration awsConf, Configuration conf) {
+    AmazonS3ClientBuilder b = AmazonS3Client.builder();
+    configureBasicParams(b, awsConf, conf, credentials);
+
+    // endpoint set up is a PITA
+    AwsClientBuilder.EndpointConfiguration epr
+        = createEndpointConfiguration(conf.getTrimmed(ENDPOINT, ""),
+        awsConf, getConf().getTrimmed(AWS_REGION));
+    configureEndpoint(b, epr);
+    final AmazonS3 client = b.build();
+    return client;
+  }
+  
+  /**
+   * A method to configure basic AmazonS3Builder parameters.
    *
+   * @param builder    Instance of AmazonS3Builder used.
+   * @param awsConf    ClientConfiguration used.
+   * @param parameters Parameters used to set in the builder.
+   */
+  private void configureBasicParams(AmazonS3Builder builder,
+      ClientConfiguration awsConf, Configuration conf, AWSCredentialsProvider credentials) {
+    builder.withCredentials(credentials);
+    builder.withClientConfiguration(awsConf);
+    builder.withPathStyleAccessEnabled(conf.getBoolean(PATH_STYLE_ACCESS, false));
+
+  }
+  
+  /**
+   * Configure classic S3 client.
+   * <p>
    * This includes: endpoint, Path Access and possibly other
    * options.
    *
-   * @param conf Hadoop configuration
+   * @param s3 S3 Client.
+   * @param endPoint s3 endpoint, may be empty
+   * @param pathStyleAccess enable path style access?
    * @return S3 client
    * @throws IllegalArgumentException if misconfigured
    */
-  private static AmazonS3 configureAmazonS3Client(AmazonS3 s3,
-      Configuration conf)
+  protected static AmazonS3 configureAmazonS3Client(AmazonS3 s3,
+      final String endPoint,
+      final boolean pathStyleAccess)
       throws IllegalArgumentException {
-    String endPoint = conf.getTrimmed(ENDPOINT, "");
     if (!endPoint.isEmpty()) {
       try {
         s3.setEndpoint(endPoint);
@@ -89,31 +161,6 @@ public class DefaultS3ClientFactory extends Configured
         throw new IllegalArgumentException(msg, e);
       }
     }
-    return applyS3ClientOptions(s3, conf);
-  }
-
-  /**
-   * Perform any tuning of the {@code S3ClientOptions} settings based on
-   * the Hadoop configuration.
-   * This is different from the general AWS configuration creation as
-   * it is unique to S3 connections.
-   *
-   * The {@link Constants#PATH_STYLE_ACCESS} option enables path-style access
-   * to S3 buckets if configured.  By default, the
-   * behavior is to use virtual hosted-style access with URIs of the form
-   * {@code http://bucketname.s3.amazonaws.com}
-   * Enabling path-style access and a
-   * region-specific endpoint switches the behavior to use URIs of the form
-   * {@code http://s3-eu-west-1.amazonaws.com/bucketname}.
-   * It is common to use this when connecting to private S3 servers, as it
-   * avoids the need to play with DNS entries.
-   * @param s3 S3 client
-   * @param conf Hadoop configuration
-   * @return the S3 client
-   */
-  private static AmazonS3 applyS3ClientOptions(AmazonS3 s3,
-      Configuration conf) {
-    final boolean pathStyleAccess = conf.getBoolean(PATH_STYLE_ACCESS, false);
     if (pathStyleAccess) {
       LOG.debug("Enabling path style access!");
       s3.setS3ClientOptions(S3ClientOptions.builder()
@@ -121,5 +168,92 @@ public class DefaultS3ClientFactory extends Configured
           .build());
     }
     return s3;
+  }
+
+  /**
+   * A method to configure endpoint and Region for an AmazonS3Builder.
+   *
+   * @param builder Instance of AmazonS3Builder used.
+   * @param epr     EndpointConfiguration used to set in builder.
+   */
+  private void configureEndpoint(
+      AmazonS3Builder builder,
+      AmazonS3Builder.EndpointConfiguration epr) {
+    if (epr != null) {
+      // an endpoint binding was constructed: use it.
+      builder.withEndpointConfiguration(epr);
+    } else {
+      // no idea what the endpoint is, so tell the SDK
+      // to work it out at the cost of an extra HEAD request
+      builder.withForceGlobalBucketAccessEnabled(true);
+      // HADOOP-17771 force set the region so the build process doesn't halt.
+      String region = getConf().getTrimmed(AWS_REGION, AWS_S3_CENTRAL_REGION);
+      LOG.debug("fs.s3a.endpoint.region=\"{}\"", region);
+      if (!region.isEmpty()) {
+        // there's either an explicit region or we have fallen back
+        // to the central one.
+        LOG.debug("Using default endpoint; setting region to {}", region);
+        builder.setRegion(region);
+      } else {
+        // no region.
+        // allow this if people really want it; it is OK to rely on this
+        // when deployed in EC2.
+        WARN_OF_DEFAULT_REGION_CHAIN.warn(SDK_REGION_CHAIN_IN_USE);
+        LOG.debug(SDK_REGION_CHAIN_IN_USE);
+      }
+    }
+  }
+  /**
+   * Given an endpoint string, return an endpoint config, or null, if none
+   * is needed.
+   * <p>
+   * This is a pretty painful piece of code. It is trying to replicate
+   * what AwsClient.setEndpoint() does, because you can't
+   * call that setter on an AwsClient constructed via
+   * the builder, and you can't pass a metrics collector
+   * down except through the builder.
+   * <p>
+   * Note also that AWS signing is a mystery which nobody fully
+   * understands, especially given all problems surface in a
+   * "400 bad request" response, which, like all security systems,
+   * provides minimal diagnostics out of fear of leaking
+   * secrets.
+   *
+   * @param endpoint possibly null endpoint.
+   * @param awsConf config to build the URI from.
+   * @param awsRegion AWS S3 Region if the corresponding config is set.
+   * @return a configuration for the S3 client builder.
+   */
+  @VisibleForTesting
+  public static AwsClientBuilder.EndpointConfiguration
+      createEndpointConfiguration(
+      final String endpoint, final ClientConfiguration awsConf,
+      String awsRegion) {
+    LOG.debug("Creating endpoint configuration for \"{}\"", endpoint);
+    if (endpoint == null || endpoint.isEmpty()) {
+      // the default endpoint...we should be using null at this point.
+      LOG.debug("Using default endpoint -no need to generate a configuration");
+      return null;
+    }
+
+    final URI epr = RuntimeHttpUtils.toUri(endpoint, awsConf);
+    LOG.debug("Endpoint URI = {}", epr);
+    String region = awsRegion;
+    if (StringUtils.isBlank(region)) {
+      if (!ServiceUtils.isS3USStandardEndpoint(endpoint)) {
+        LOG.debug("Endpoint {} is not the default; parsing", epr);
+        region = AwsHostNameUtils.parseRegion(
+            epr.getHost(),
+            S3_SERVICE_NAME);
+      } else {
+        // US-east, set region == null.
+        LOG.debug("Endpoint {} is the standard one; declare region as null",
+            epr);
+        region = null;
+      }
+    }
+    LOG.debug("Region for endpoint {}, URI {} is determined as {}",
+        endpoint, epr, region);
+    return new AwsClientBuilder.EndpointConfiguration(endpoint, region);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
@@ -22,30 +22,38 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 
+import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.PATH_STYLE_ACCESS;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * S3 Client factory used for testing with eventual consistency fault injection.
  * This client is for testing <i>only</i>; it is in the production
- * {@code hadoop-aws} module to enable integration tests to use this
- * just by editing the Hadoop configuration used to bring up the client.
+ * {@code hadoop-aws} module to enable integration tests to use this just by
+ * editing the Hadoop configuration used to bring up the client.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class InconsistentS3ClientFactory extends DefaultS3ClientFactory {
 
-  /**
-   * Create the inconsistent client.
-   * Logs a warning that this is being done.
-   * @param credentials credentials to use
-   * @param awsConf  AWS configuration
-   * @return an inconsistent client.
-   */
-  @Override
-  protected AmazonS3 newAmazonS3Client(AWSCredentialsProvider credentials,
-      ClientConfiguration awsConf) {
-    LOG.warn("** FAILURE INJECTION ENABLED.  Do not run in production! **");
-    return new InconsistentAmazonS3Client(credentials, awsConf, getConf());
-  }
+	/**
+	 * Create the inconsistent client. Logs a warning that this is being done.
+	 * 
+	 * @param credentials credentials to use
+	 * @param awsConf     AWS configuration
+	 * @return an inconsistent client.
+	 */
+	@Override
+	protected AmazonS3 buildAmazonS3Client(final AWSCredentialsProvider credentials,
+		      final ClientConfiguration awsConf, Configuration conf) {
+		LOG.warn("** FAILURE INJECTION ENABLED.  Do not run in production! **");
+		LOG.warn("List inconsistency is no longer emulated; only throttling and read errors");
+		InconsistentAmazonS3Client s3 = new InconsistentAmazonS3Client(credentials, awsConf,
+				getConf());
+		configureAmazonS3Client(s3, conf.getTrimmed(ENDPOINT, ""), conf.getBoolean(PATH_STYLE_ACCESS, false));
+		return s3;
+	}
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEndpointRegion.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.util.AwsHostNameUtils;
+import org.junit.Test;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
+
+/**
+ * Test to check correctness of S3A endpoint regions in
+ * {@link DefaultS3ClientFactory}.
+ */
+public class ITestS3AEndpointRegion extends AbstractS3ATestBase {
+
+  private static final String AWS_REGION_TEST = "test-region";
+  private static final String AWS_ENDPOINT_TEST = "test-endpoint";
+  private static final String AWS_ENDPOINT_TEST_WITH_REGION =
+      "test-endpoint.some-region.amazonaws.com";
+
+  /**
+   * Test to verify that setting a region with the config would bypass the
+   * construction of region from endpoint.
+   */
+  @Test
+  public void testWithRegionConfig() {
+    String msg = "There is a region mismatch";
+    getFileSystem().getConf().set(AWS_REGION, AWS_REGION_TEST);
+
+    //Creating an endpoint config with a custom endpoint.
+    AwsClientBuilder.EndpointConfiguration epr = createEpr(AWS_ENDPOINT_TEST,
+        getFileSystem().getConf().getTrimmed(AWS_REGION));
+    //Checking if setting region config bypasses the endpoint region.
+    assertEquals(msg,epr.getSigningRegion(),getFileSystem().getConf().get(AWS_REGION));
+  }
+
+  /**
+   * Test to verify that not setting the region config, would lead to using
+   * endpoint to construct the region.
+   */
+  @Test
+  public void testWithoutRegionConfig() {
+    String msg_true = "The Region matches";
+
+    getFileSystem().getConf().unset(AWS_REGION);
+
+    //Creating an endpoint config with a custom endpoint containing a region.
+    AwsClientBuilder.EndpointConfiguration eprRandom =
+        createEpr(AWS_ENDPOINT_TEST_WITH_REGION,
+            getFileSystem().getConf().getTrimmed(AWS_REGION));
+    String regionFromEndpoint =
+        AwsHostNameUtils
+            .parseRegionFromAwsPartitionPattern(AWS_ENDPOINT_TEST_WITH_REGION);
+    //Checking if not setting region config leads to constructing the region
+    // from endpoint.
+    assertEquals(msg_true,eprRandom.getSigningRegion(),regionFromEndpoint);
+  }
+
+  /**
+   * Method to create EndpointConfiguration using an endpoint.
+   *
+   * @param endpoint the endpoint to be used for EndpointConfiguration creation.
+   * @return an instance of EndpointConfiguration.
+   */
+  private AwsClientBuilder.EndpointConfiguration createEpr(String endpoint,
+      String awsRegion) {
+    return DefaultS3ClientFactory.createEndpointConfiguration(endpoint,
+        new ClientConfiguration(), awsRegion);
+  }
+}


### PR DESCRIPTION

### Description of PR
Currently, AWS region is either constructed via the endpoint URL, by making an assumption that the 2nd component after delimiter "." is the region in endpoint URL, which doesn't work for private links and sets the default to us-east-1 thus causing authorization issue w.r.t the private link.

The option fs.s3a.endpoint.region allows this to be explicitly set

### How was this patch tested?
~/apache-maven-3.8.6/bin/mvn integration-test -Dparallel-tests -DtestsThreadCount=50 -Dscale -Ptests-on
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: x86_64
[INFO] os.detected.version: 4.18
[INFO] os.detected.version.major: 4
[INFO] os.detected.version.minor: 18
[INFO] os.detected.release: centos
[INFO] os.detected.release.version: 8
[INFO] os.detected.release.like.centos: true
[INFO] os.detected.release.like.rhel: true
[INFO] os.detected.release.like.fedora: true
[INFO] os.detected.classifier: linux-x86_64
[INFO] 
[INFO] --------------------< org.apache.hadoop:hadoop-aws >--------------------
[INFO] Building Apache Hadoop Amazon Web Services support 3.2.5-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-antrun-plugin:1.7:run (create-testdirs) @ hadoop-aws ---
[INFO] Executing tasks

main:
[INFO] Executed tasks
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ hadoop-aws ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ hadoop-aws ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.2:list (deplist1) @ hadoop-aws ---
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.2:list (deplist2) @ hadoop-aws ---
[INFO] 
[INFO] --- hadoop-maven-plugins:3.2.5-SNAPSHOT:parallel-tests-createdir (parallel-tests-createdir) @ hadoop-aws ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ hadoop-aws ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 4 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ hadoop-aws ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.2:copy-dependencies (copy) @ hadoop-aws ---
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M1:test (default-test) @ hadoop-aws ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.s3a.TestDataBlocks
[INFO] Running org.apache.hadoop.mapreduce.filecache.TestS3AResourceScope
[INFO] Running org.apache.hadoop.fs.s3a.commit.TestTasks
[INFO] Running org.apache.hadoop.fs.s3a.TestInvoker
[INFO] Running org.apache.hadoop.fs.s3a.commit.TestMagicCommitPaths
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.TestPaths
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.TestStagingDirectoryOutputCommitter
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestPathMetadataDynamoDBTranslation
[INFO] Running org.apache.hadoop.fs.s3a.TestS3AInputPolicies
[INFO] Running org.apache.hadoop.fs.s3a.TestS3AMultipartUploaderSupport
[INFO] Running org.apache.hadoop.fs.s3a.TestS3AExceptionTranslation
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.TestStagingPartitionedJobCommit
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.TestStagingPartitionedTaskCommit
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.TestStagingPartitionedFileListing
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestS3GuardCLI
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestNullMetadataStore
[INFO] Running org.apache.hadoop.fs.s3a.TestListing
[INFO] Running org.apache.hadoop.fs.s3a.TestSSEConfiguration
[INFO] Running org.apache.hadoop.fs.s3a.TestS3ABlockOutputStream
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestDirListingMetadata
[INFO] Running org.apache.hadoop.fs.s3a.impl.TestDirectoryMarkerPolicy
[INFO] Running org.apache.hadoop.fs.s3a.TestS3AGetFileStatus
[INFO] Running org.apache.hadoop.fs.s3native.TestS3xLoginHelper
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.TestStagingCommitter
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestS3Guard
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestLocalMetadataStore
[INFO] Running org.apache.hadoop.fs.s3a.TestStreamChangeTracker
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.TestDynamoDBMiscOperations
[INFO] Running org.apache.hadoop.fs.s3a.TestS3AAWSCredentialsProvider
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.105 s - in org.apache.hadoop.fs.s3native.TestS3xLoginHelper
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.1 s - in org.apache.hadoop.fs.s3a.s3guard.TestS3Guard
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 s - in org.apache.hadoop.fs.s3a.TestS3AInputPolicies
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.126 s - in org.apache.hadoop.fs.s3a.TestDataBlocks
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.121 s - in org.apache.hadoop.fs.s3a.TestS3AMultipartUploaderSupport
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.173 s - in org.apache.hadoop.fs.s3a.s3guard.TestDynamoDBMiscOperations
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.165 s - in org.apache.hadoop.fs.s3a.TestS3AExceptionTranslation
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.173 s - in org.apache.hadoop.fs.s3a.s3guard.TestDirListingMetadata
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.202 s - in org.apache.hadoop.fs.s3a.commit.TestMagicCommitPaths
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.21 s - in org.apache.hadoop.mapreduce.filecache.TestS3AResourceScope
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.195 s - in org.apache.hadoop.fs.s3a.TestStreamChangeTracker
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.233 s - in org.apache.hadoop.fs.s3a.s3guard.TestS3GuardCLI
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.253 s - in org.apache.hadoop.fs.s3a.impl.TestDirectoryMarkerPolicy
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.507 s - in org.apache.hadoop.fs.s3a.commit.staging.TestPaths
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.52 s - in org.apache.hadoop.fs.s3a.TestS3AAWSCredentialsProvider
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.559 s - in org.apache.hadoop.fs.s3a.s3guard.TestPathMetadataDynamoDBTranslation
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.746 s - in org.apache.hadoop.fs.s3a.TestInvoker
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.909 s - in org.apache.hadoop.fs.s3a.s3guard.TestLocalMetadataStore
[INFO] Tests run: 60, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.007 s - in org.apache.hadoop.fs.s3a.commit.TestTasks
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.076 s - in org.apache.hadoop.fs.s3a.TestListing
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.159 s - in org.apache.hadoop.fs.s3a.TestS3ABlockOutputStream
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.275 s - in org.apache.hadoop.fs.s3a.TestS3AGetFileStatus
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.411 s - in org.apache.hadoop.fs.s3a.commit.staging.TestStagingPartitionedJobCommit
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.424 s - in org.apache.hadoop.fs.s3a.commit.staging.TestStagingDirectoryOutputCommitter
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.545 s - in org.apache.hadoop.fs.s3a.commit.staging.TestStagingPartitionedFileListing
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.591 s - in org.apache.hadoop.fs.s3a.TestSSEConfiguration
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.032 s - in org.apache.hadoop.fs.s3a.commit.staging.TestStagingPartitionedTaskCommit
[WARNING] Tests run: 26, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.079 s - in org.apache.hadoop.fs.s3a.s3guard.TestNullMetadataStore
[INFO] Tests run: 48, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 235.418 s - in org.apache.hadoop.fs.s3a.commit.staging.TestStagingCommitter
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 390, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:2.5:jar (default-jar) @ hadoop-aws ---
[INFO] 
[INFO] --- maven-site-plugin:3.6:attach-descriptor (attach-descriptor) @ hadoop-aws ---
[INFO] Skipping because packaging 'jar' is not pom.
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.2:copy-dependencies (default) @ hadoop-aws ---
[INFO] org.apache.hadoop:hadoop-common:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-annotations:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] jdk.tools:jdk.tools:jar:1.8 already exists in destination.
[INFO] com.google.guava:guava:jar:27.0-jre already exists in destination.
[INFO] com.google.guava:failureaccess:jar:1.0 already exists in destination.
[INFO] com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava already exists in destination.
[INFO] org.checkerframework:checker-qual:jar:2.5.2 already exists in destination.
[INFO] com.google.errorprone:error_prone_annotations:jar:2.2.0 already exists in destination.
[INFO] com.google.j2objc:j2objc-annotations:jar:1.1 already exists in destination.
[INFO] org.codehaus.mojo:animal-sniffer-annotations:jar:1.17 already exists in destination.
[INFO] commons-cli:commons-cli:jar:1.2 already exists in destination.
[INFO] org.apache.commons:commons-math3:jar:3.1.1 already exists in destination.
[INFO] org.apache.httpcomponents:httpclient:jar:4.5.13 already exists in destination.
[INFO] org.apache.httpcomponents:httpcore:jar:4.4.13 already exists in destination.
[INFO] commons-codec:commons-codec:jar:1.11 already exists in destination.
[INFO] commons-io:commons-io:jar:2.8.0 already exists in destination.
[INFO] commons-net:commons-net:jar:3.6 already exists in destination.
[INFO] commons-collections:commons-collections:jar:3.2.2 already exists in destination.
[INFO] javax.servlet:javax.servlet-api:jar:3.1.0 already exists in destination.
[INFO] javax.activation:javax.activation-api:jar:1.2.0 already exists in destination.
[INFO] org.eclipse.jetty:jetty-server:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-http:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-io:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-util:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-servlet:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-security:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-webapp:jar:9.4.43.v20210629 already exists in destination.
[INFO] org.eclipse.jetty:jetty-xml:jar:9.4.43.v20210629 already exists in destination.
[INFO] javax.servlet.jsp:jsp-api:jar:2.1 already exists in destination.
[INFO] com.sun.jersey:jersey-core:jar:1.19 already exists in destination.
[INFO] javax.ws.rs:jsr311-api:jar:1.1.1 already exists in destination.
[INFO] com.sun.jersey:jersey-servlet:jar:1.19 already exists in destination.
[INFO] com.sun.jersey:jersey-json:jar:1.19 already exists in destination.
[INFO] org.codehaus.jettison:jettison:jar:1.1 already exists in destination.
[INFO] com.sun.xml.bind:jaxb-impl:jar:2.2.3-1 already exists in destination.
[INFO] org.codehaus.jackson:jackson-core-asl:jar:1.9.13 already exists in destination.
[INFO] org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13 already exists in destination.
[INFO] org.codehaus.jackson:jackson-jaxrs:jar:1.9.13 already exists in destination.
[INFO] org.codehaus.jackson:jackson-xc:jar:1.9.13 already exists in destination.
[INFO] com.sun.jersey:jersey-server:jar:1.19 already exists in destination.
[INFO] commons-logging:commons-logging:jar:1.1.3 already exists in destination.
[INFO] ch.qos.reload4j:reload4j:jar:1.2.18.3 already exists in destination.
[INFO] commons-beanutils:commons-beanutils:jar:1.9.4 already exists in destination.
[INFO] org.apache.commons:commons-configuration2:jar:2.8.0 already exists in destination.
[INFO] org.apache.commons:commons-lang3:jar:3.7 already exists in destination.
[INFO] org.apache.commons:commons-text:jar:1.9 already exists in destination.
[INFO] org.slf4j:slf4j-api:jar:1.7.35 already exists in destination.
[INFO] org.apache.avro:avro:jar:1.7.7 already exists in destination.
[INFO] com.thoughtworks.paranamer:paranamer:jar:2.3 already exists in destination.
[INFO] org.xerial.snappy:snappy-java:jar:1.0.5 already exists in destination.
[INFO] com.google.re2j:re2j:jar:1.1 already exists in destination.
[INFO] com.google.protobuf:protobuf-java:jar:2.5.0 already exists in destination.
[INFO] com.google.code.gson:gson:jar:2.9.0 already exists in destination.
[INFO] org.apache.hadoop:hadoop-auth:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] com.nimbusds:nimbus-jose-jwt:jar:9.8.1 already exists in destination.
[INFO] com.github.stephenc.jcip:jcip-annotations:jar:1.0-1 already exists in destination.
[INFO] net.minidev:json-smart:jar:2.4.7 already exists in destination.
[INFO] net.minidev:accessors-smart:jar:2.4.7 already exists in destination.
[INFO] org.ow2.asm:asm:jar:5.0.4 already exists in destination.
[INFO] org.apache.curator:curator-framework:jar:2.13.0 already exists in destination.
[INFO] com.jcraft:jsch:jar:0.1.55 already exists in destination.
[INFO] org.apache.curator:curator-client:jar:2.13.0 already exists in destination.
[INFO] org.apache.curator:curator-recipes:jar:2.13.0 already exists in destination.
[INFO] com.google.code.findbugs:jsr305:jar:3.0.2 already exists in destination.
[INFO] org.apache.htrace:htrace-core4:jar:4.1.0-incubating already exists in destination.
[INFO] org.apache.zookeeper:zookeeper:jar:3.4.14 already exists in destination.
[INFO] com.github.spotbugs:spotbugs-annotations:jar:3.1.9 already exists in destination.
[INFO] org.apache.yetus:audience-annotations:jar:0.5.0 already exists in destination.
[INFO] org.apache.commons:commons-compress:jar:1.21 already exists in destination.
[INFO] org.apache.kerby:kerb-simplekdc:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-client:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerby-config:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-core:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerby-pkix:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerby-asn1:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerby-util:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-common:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-crypto:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-util:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:token-provider:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-admin:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-server:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerb-identity:jar:1.0.1 already exists in destination.
[INFO] org.apache.kerby:kerby-xdr:jar:1.0.1 already exists in destination.
[INFO] com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1 already exists in destination.
[INFO] com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5 already exists in destination.
[INFO] com.fasterxml.jackson.core:jackson-core:jar:2.10.5 already exists in destination.
[INFO] org.codehaus.woodstox:stax2-api:jar:4.2.1 already exists in destination.
[INFO] com.fasterxml.woodstox:woodstox-core:jar:5.3.0 already exists in destination.
[INFO] dnsjava:dnsjava:jar:2.1.7 already exists in destination.
[INFO] org.apache.hadoop:hadoop-common:test-jar:tests:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.slf4j:slf4j-reload4j:jar:1.7.35 already exists in destination.
[INFO] com.amazonaws:aws-java-sdk-bundle:jar:1.11.901 already exists in destination.
[INFO] junit:junit:jar:4.13.2 already exists in destination.
[INFO] org.hamcrest:hamcrest-core:jar:1.3 already exists in destination.
[INFO] org.mockito:mockito-all:jar:1.8.5 already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-core:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-client:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-common:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] javax.xml.bind:jaxb-api:jar:2.2.11 already exists in destination.
[INFO] com.sun.jersey:jersey-client:jar:1.19 already exists in destination.
[INFO] com.google.inject:guice:jar:4.0 already exists in destination.
[INFO] javax.inject:javax.inject:jar:1 already exists in destination.
[INFO] aopalliance:aopalliance:jar:1.0 already exists in destination.
[INFO] com.sun.jersey.contribs:jersey-guice:jar:1.19 already exists in destination.
[INFO] com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.10.5 already exists in destination.
[INFO] jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2 already exists in destination.
[INFO] jakarta.activation:jakarta.activation-api:jar:1.2.1 already exists in destination.
[INFO] com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.10.5 already exists in destination.
[INFO] com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.10.5 already exists in destination.
[INFO] org.apache.hadoop:hadoop-hdfs-client:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] com.squareup.okhttp:okhttp:jar:2.7.5 already exists in destination.
[INFO] com.squareup.okio:okio:jar:1.6.0 already exists in destination.
[INFO] com.google.inject.extensions:guice-servlet:jar:4.0 already exists in destination.
[INFO] io.netty:netty:jar:3.10.6.Final already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-tests:test-jar:tests:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-common:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-registry:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.geronimo.specs:geronimo-jcache_1.0_spec:jar:1.0-alpha-1 already exists in destination.
[INFO] org.ehcache:ehcache:jar:3.3.1 already exists in destination.
[INFO] com.zaxxer:HikariCP-java7:jar:2.4.12 already exists in destination.
[INFO] com.microsoft.sqlserver:mssql-jdbc:jar:6.2.1.jre7 already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-nodemanager:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] io.dropwizard.metrics:metrics-core:jar:3.2.4 already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-resourcemanager:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-applicationhistoryservice:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.objenesis:objenesis:jar:1.0 already exists in destination.
[INFO] de.ruedigermoeller:fst:jar:2.50 already exists in destination.
[INFO] com.cedarsoftware:java-util:jar:1.9.0 already exists in destination.
[INFO] com.cedarsoftware:json-io:jar:2.5.1 already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-timelineservice:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.commons:commons-csv:jar:1.0 already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-api:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-hs:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-hdfs:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-common:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.fusesource.leveldbjni:leveldbjni-all:jar:1.8 already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-examples:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-hdfs:test-jar:tests:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.eclipse.jetty:jetty-util-ajax:jar:9.4.43.v20210629 already exists in destination.
[INFO] commons-daemon:commons-daemon:jar:1.0.13 already exists in destination.
[INFO] io.netty:netty-all:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-buffer:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-dns:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-haproxy:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-http:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-http2:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-memcache:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-mqtt:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-redis:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-smtp:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-socks:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-stomp:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-codec-xml:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-common:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-handler:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-handler-proxy:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-resolver:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-resolver-dns:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-rxtx:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-sctp:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-udt:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-classes-epoll:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-native-unix-common:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-classes-kqueue:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-resolver-dns-classes-macos:jar:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.77.Final already exists in destination.
[INFO] io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.77.Final already exists in destination.
[INFO] org.apache.hadoop:hadoop-distcp:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-distcp:test-jar:tests:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-app:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-yarn-server-web-proxy:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-shuffle:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-app:test-jar:tests:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-jobclient:jar:3.2.5-SNAPSHOT already exists in destination.
[INFO] org.apache.hadoop:hadoop-mapreduce-client-jobclient:test-jar:tests:3.2.5-SNAPSHOT already exists in destination.
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M1:integration-test (default-integration-test) @ hadoop-aws ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3ADeleteManyFiles
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AMetrics
[INFO] Running org.apache.hadoop.fs.s3a.commit.ITestS3ACommitterFactory
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestDirectoryCommitMRJob
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3ADeleteFilesOneByOne
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSUserDefinedKey
[INFO] Running org.apache.hadoop.fs.s3a.commit.ITestCommitOperations
[INFO] Running org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextUtil
[INFO] Running org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextCreateMkdir
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.ITestS3GuardToolLocal
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ABlockOutputArray
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestStagingCommitProtocol
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3ADirectoryPerformance
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AFileSystemContract
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3GuardEmptyDirs
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestStagingCommitMRJobBadDest
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSES3
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AContractGetFileStatusV1List
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ABlocksize
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.ITestS3GuardToolDynamoDB
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.ITestDynamoDBMetadataStore
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestLocalMetadataStoreScale
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSDefaultKey
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ARemoteFileChanged
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AMiscOperations
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ABlockOutputDisk
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AFailureHandling
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ACopyFromLocalFile
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3ACreatePerformance
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSES3BlockOutputStream
[INFO] Running org.apache.hadoop.fs.s3a.commit.magic.ITestMagicCommitProtocol
[INFO] Running org.apache.hadoop.fs.s3a.auth.ITestAssumedRoleCommitOperations
[INFO] Running org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContext
[INFO] Running org.apache.hadoop.fs.s3a.ITestBlockingThreadPoolExecutorService
[INFO] Running org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextURI
[INFO] Running org.apache.hadoop.fs.s3a.auth.ITestAssumeRole
[INFO] Running org.apache.hadoop.fs.s3a.commit.magic.ITestMagicCommitMRJob
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3AConcurrentOps
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AAWSCredentialsProvider
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ATestUtils
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3GuardListConsistency
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AClosedFS
[INFO] Running org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextMainOperations
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestPartitionCommitMRJob
[INFO] Running org.apache.hadoop.fs.s3a.performance.ITestDirectoryMarkerListing
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestPartitionedCommitProtocol
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3AInputStreamPerformance
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestDirectoryCommitProtocol
[INFO] Running org.apache.hadoop.fs.s3a.commit.staging.integration.ITestStagingCommitMRJob
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.ITestS3GuardConcurrentOps
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.345 s - in org.apache.hadoop.fs.s3a.ITestS3ATestUtils
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.508 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSUserDefinedKey
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.573 s - in org.apache.hadoop.fs.s3a.s3guard.ITestDynamoDBMetadataStore
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.892 s - in org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContext
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.037 s - in org.apache.hadoop.fs.s3a.ITestBlockingThreadPoolExecutorService
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSUserDefinedKeyBlockOutputStream
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ATemporaryCredentials
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.324 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSUserDefinedKeyBlockOutputStream
[INFO] Running org.apache.hadoop.fs.s3a.yarn.ITestS3AMiniYarnCluster
[INFO] Running org.apache.hadoop.fs.s3a.yarn.ITestS3A
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEndpointRegion
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3GuardCreate
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.344 s - in org.apache.hadoop.fs.s3a.ITestS3GuardEmptyDirs
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.662 s - in org.apache.hadoop.fs.s3a.s3guard.ITestS3GuardConcurrentOps
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.783 s - in org.apache.hadoop.fs.s3a.ITestS3AAWSCredentialsProvider
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.282 s - in org.apache.hadoop.fs.s3a.commit.ITestS3ACommitterFactory
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEmptyDirectory
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AConfiguration
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AMultipartUtils
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3GuardWriteBack
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.926 s - in org.apache.hadoop.fs.s3a.ITestS3AClosedFS
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.306 s - in org.apache.hadoop.fs.s3a.ITestS3ABlocksize
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.937 s - in org.apache.hadoop.fs.s3a.ITestS3GuardCreate
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionAlgorithmValidation
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.016 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionAlgorithmValidation
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AInconsistency
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.231 s - in org.apache.hadoop.fs.s3a.yarn.ITestS3A
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ADelayedFNF
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.154 s - in org.apache.hadoop.fs.s3a.ITestS3AMetrics
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.082 s - in org.apache.hadoop.fs.s3a.ITestS3AEndpointRegion
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3ABlockOutputByteBuffer
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.467 s - in org.apache.hadoop.fs.s3a.scale.ITestLocalMetadataStoreScale
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractMultipartUploader
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AFileOperationCost
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.565 s - in org.apache.hadoop.fs.s3a.ITestS3AFailureHandling
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractCreate
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractOpen
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractGetFileStatus
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.133 s - in org.apache.hadoop.fs.s3a.ITestS3GuardWriteBack
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.652 s - in org.apache.hadoop.fs.s3a.ITestS3AMultipartUtils
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractSeek
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.404 s - in org.apache.hadoop.fs.s3a.ITestS3ABlockOutputArray
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.435 s - in org.apache.hadoop.fs.s3a.ITestS3ADelayedFNF
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.812 s - in org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextUtil
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractMkdir
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.853 s - in org.apache.hadoop.fs.s3a.ITestS3AEmptyDirectory
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractDistCp
[WARNING] Tests run: 5, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 13.392 s - in org.apache.hadoop.fs.s3a.ITestS3ABlockOutputDisk
[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractDelete
[WARNING] Tests run: 8, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 13.607 s - in org.apache.hadoop.fs.s3a.ITestS3ACopyFromLocalFile
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 14.875 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.ITestS3ATemporaryCredentials
[ERROR] testSTS(org.apache.hadoop.fs.s3a.ITestS3ATemporaryCredentials)  Time elapsed: 13.688 s  <<< ERROR!
com.amazonaws.SdkClientException: Unable to find a region via the region provider chain. Must provide an explicit region in the builder or setup environment to supply a region.
	at com.amazonaws.client.builder.AwsClientBuilder.setRegion(AwsClientBuilder.java:462)
	at com.amazonaws.client.builder.AwsClientBuilder.configureMutableProperties(AwsClientBuilder.java:424)
	at com.amazonaws.client.builder.AwsSyncClientBuilder.build(AwsSyncClientBuilder.java:46)
	at org.apache.hadoop.fs.s3a.ITestS3ATemporaryCredentials.testSTS(ITestS3ATemporaryCredentials.java:90)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.413 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestStagingCommitMRJobBadDest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.885 s - in org.apache.hadoop.fs.s3a.yarn.ITestS3AMiniYarnCluster
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.92 s - in org.apache.hadoop.fs.s3a.ITestS3AConfiguration
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.109 s - in org.apache.hadoop.fs.s3a.ITestS3ABlockOutputByteBuffer
[WARNING] Tests run: 15, Failures: 0, Errors: 0, Skipped: 15, Time elapsed: 18.536 s - in org.apache.hadoop.fs.s3a.s3guard.ITestS3GuardToolDynamoDB
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.02 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSES3
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.965 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSES3BlockOutputStream
[WARNING] Tests run: 16, Failures: 0, Errors: 0, Skipped: 16, Time elapsed: 19.741 s - in org.apache.hadoop.fs.s3a.auth.ITestAssumedRoleCommitOperations
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.116 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractOpen
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.679 s - in org.apache.hadoop.fs.s3a.ITestS3AInconsistency
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.979 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEKMSDefaultKey
[ERROR] Tests run: 12, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 21.691 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.ITestS3AMiscOperations
[ERROR] testEmptyFileChecksums(org.apache.hadoop.fs.s3a.ITestS3AMiscOperations)  Time elapsed: 1.898 s  <<< FAILURE!
java.lang.AssertionError: checksums expected:<etag: "dfaef4b43256ea0b1b561c4122394ed5"> but was:<etag: "86eff4cc793bef257ef202f7f2ffcd64">
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.apache.hadoop.fs.s3a.ITestS3AMiscOperations.testEmptyFileChecksums(ITestS3AMiscOperations.java:152)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[ERROR] testNonEmptyFileChecksumsUnencrypted(org.apache.hadoop.fs.s3a.ITestS3AMiscOperations)  Time elapsed: 1.814 s  <<< FAILURE!
java.lang.AssertionError: checksums expected:<etag: "95144225d0bd3b6039e89c70563eb37a"> but was:<etag: "b58a8ddec34ab0e88aac27fb92593c5c">
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.apache.hadoop.fs.s3a.ITestS3AMiscOperations.testNonEmptyFileChecksumsUnencrypted(ITestS3AMiscOperations.java:206)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 8, Time elapsed: 22.509 s - in org.apache.hadoop.fs.s3a.ITestS3GuardListConsistency
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.647 s - in org.apache.hadoop.fs.s3a.ITestS3AFileOperationCost
[WARNING] Tests run: 27, Failures: 0, Errors: 0, Skipped: 27, Time elapsed: 28.688 s - in org.apache.hadoop.fs.s3a.s3guard.ITestS3GuardToolLocal
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.901 s - in org.apache.hadoop.fs.s3a.scale.ITestS3AInputStreamPerformance
[WARNING] Tests run: 27, Failures: 0, Errors: 0, Skipped: 27, Time elapsed: 29.26 s - in org.apache.hadoop.fs.s3a.auth.ITestAssumeRole
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.579 s - in org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextCreateMkdir
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.046 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractDelete
[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 22.876 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractCreate
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.582 s - in org.apache.hadoop.fs.s3a.scale.ITestS3AConcurrentOps
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.986 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename
[WARNING] Tests run: 15, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 29.564 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractMultipartUploader
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.446 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractMkdir
[WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 44.144 s - in org.apache.hadoop.fs.s3a.ITestS3ARemoteFileChanged
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 51.486 s - in org.apache.hadoop.fs.s3a.performance.ITestDirectoryMarkerListing
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 57.699 s - in org.apache.hadoop.fs.s3a.ITestS3AContractGetFileStatusV1List
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 53.863 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractGetFileStatus
[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 68.518 s - in org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextURI
[INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 76.039 s - in org.apache.hadoop.fs.s3a.ITestS3AFileSystemContract
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 77.757 s - in org.apache.hadoop.fs.s3a.commit.ITestCommitOperations
[INFO] Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 82.777 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractSeek
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 96.155 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestPartitionCommitMRJob
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 96.705 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestDirectoryCommitMRJob
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 97.507 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestStagingCommitMRJob
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 103.474 s - in org.apache.hadoop.fs.s3a.commit.magic.ITestMagicCommitMRJob
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 117.119 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractDistCp
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 140.138 s - in org.apache.hadoop.fs.s3a.commit.magic.ITestMagicCommitProtocol
[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 187.09 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestPartitionedCommitProtocol
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 193.478 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestStagingCommitProtocol
[WARNING] Tests run: 68, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 193.373 s - in org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextMainOperations
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 194.498 s - in org.apache.hadoop.fs.s3a.commit.staging.integration.ITestDirectoryCommitProtocol
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 472.911 s - in org.apache.hadoop.fs.s3a.scale.ITestS3ADeleteManyFiles
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 570.166 s - in org.apache.hadoop.fs.s3a.scale.ITestS3ADirectoryPerformance
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 659.08 s - in org.apache.hadoop.fs.s3a.scale.ITestS3ADeleteFilesOneByOne
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 945.972 s - in org.apache.hadoop.fs.s3a.scale.ITestS3ACreatePerformance
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ITestS3AMiscOperations.testEmptyFileChecksums:152->Assert.assertEquals:120->Assert.failNotEquals:835->Assert.fail:89 checksums expected:<etag: "dfaef4b43256ea0b1b561c4122394ed5"> but was:<etag: "86eff4cc793bef257ef202f7f2ffcd64">
[ERROR]   ITestS3AMiscOperations.testNonEmptyFileChecksumsUnencrypted:206->Assert.assertEquals:120->Assert.failNotEquals:835->Assert.fail:89 checksums expected:<etag: "95144225d0bd3b6039e89c70563eb37a"> but was:<etag: "b58a8ddec34ab0e88aac27fb92593c5c">
[ERROR] Errors: 
[ERROR]   ITestS3ATemporaryCredentials.testSTS:90 » SdkClient Unable to find a region vi...
[INFO] 
[ERROR] Tests run: 676, Failures: 2, Errors: 1, Skipped: 119
[INFO] 
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M1:integration-test (sequential-integration-tests) @ hadoop-aws ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesArrayBlocks
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.666 s - in org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesArrayBlocks
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesDiskBlocks
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.908 s - in org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesDiskBlocks
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesSSECDiskBlocks
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.083 s - in org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesSSECDiskBlocks
[INFO] Running org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesByteBufferBlocks
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.366 s - in org.apache.hadoop.fs.s3a.scale.ITestS3AHugeFilesByteBufferBlocks
[INFO] Running org.apache.hadoop.fs.s3a.commit.magic.ITestS3AHugeMagicCommits
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.101 s - in org.apache.hadoop.fs.s3a.commit.magic.ITestS3AHugeMagicCommits
[INFO] Running org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortDirectoryCommitter
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 108.862 s - in org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortDirectoryCommitter
[INFO] Running org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortMagicCommitter
[ERROR] Tests run: 6, Failures: 1, Errors: 2, Skipped: 0, Time elapsed: 51.54 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortMagicCommitter
[ERROR] test_110_teragen(org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortMagicCommitter)  Time elapsed: 8.329 s  <<< FAILURE!
java.lang.AssertionError: Teragen(1000, s3a://techgssclasstest20221004/terasort-ITestTerasortMagicCommitter/sortin) failed expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.apache.hadoop.fs.s3a.commit.terasort.AbstractCommitTerasortIT.executeStage(AbstractCommitTerasortIT.java:143)
	at org.apache.hadoop.fs.s3a.commit.terasort.AbstractCommitTerasortIT.test_110_teragen(AbstractCommitTerasortIT.java:167)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[ERROR] test_120_terasort(org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortMagicCommitter)  Time elapsed: 0.656 s  <<< ERROR!
java.io.FileNotFoundException: No such file or directory: s3a://techgssclasstest20221004/terasort-ITestTerasortMagicCommitter/sortin/_SUCCESS
	at org.apache.hadoop.fs.s3a.S3AFileSystem.s3GetFileStatus(S3AFileSystem.java:2344)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.innerGetFileStatus(S3AFileSystem.java:2226)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:2160)
	at org.apache.hadoop.fs.s3a.commit.AbstractCommitITest.loadSuccessFile(AbstractCommitITest.java:498)
	at org.apache.hadoop.fs.s3a.commit.terasort.AbstractCommitTerasortIT.test_120_terasort(AbstractCommitTerasortIT.java:177)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[ERROR] test_130_teravalidate(org.apache.hadoop.fs.s3a.commit.terasort.ITestTerasortMagicCommitter)  Time elapsed: 0.768 s  <<< ERROR!
java.io.FileNotFoundException: No such file or directory: s3a://techgssclasstest20221004/terasort-ITestTerasortMagicCommitter/sortout/_SUCCESS
	at org.apache.hadoop.fs.s3a.S3AFileSystem.s3GetFileStatus(S3AFileSystem.java:2344)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.innerGetFileStatus(S3AFileSystem.java:2226)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:2160)
	at org.apache.hadoop.fs.s3a.commit.AbstractCommitITest.loadSuccessFile(AbstractCommitITest.java:498)
	at org.apache.hadoop.fs.s3a.commit.terasort.AbstractCommitTerasortIT.test_130_teravalidate(AbstractCommitTerasortIT.java:192)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[INFO] Running org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextStatistics
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.339 s - in org.apache.hadoop.fs.s3a.fileContext.ITestS3AFileContextStatistics
[INFO] Running org.apache.hadoop.fs.s3a.s3guard.ITestDynamoDBMetadataStoreScale
[WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 5.127 s - in org.apache.hadoop.fs.s3a.s3guard.ITestDynamoDBMetadataStoreScale
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSECBlockOutputStream
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.562 s - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSECBlockOutputStream
[INFO] Running org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC
[ERROR] Tests run: 10, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 25.129 s <<< FAILURE! - in org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC
[ERROR] testListStatusEncryptedDir(org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC)  Time elapsed: 1.654 s  <<< FAILURE!
java.lang.AssertionError: Expecting java.nio.file.AccessDeniedException with text Service: Amazon S3; Status Code: 403; but got : void
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:492)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:522)
	at org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC.testListStatusEncryptedDir(ITestS3AEncryptionSSEC.java:253)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[ERROR] testListEncryptedDir(org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC)  Time elapsed: 1.615 s  <<< FAILURE!
java.lang.AssertionError: Expecting java.nio.file.AccessDeniedException with text Service: Amazon S3; Status Code: 403; but got : void
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:492)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:522)
	at org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC.testListEncryptedDir(ITestS3AEncryptionSSEC.java:208)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[ERROR] testCreateSubdirWithDifferentKey(org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC)  Time elapsed: 1.51 s  <<< FAILURE!
java.lang.AssertionError: Expected a java.nio.file.AccessDeniedException to be thrown, but got the result: : S3AFileStatus{path=s3a://techgssclasstest20221004/test/testCreateSubdirWithDifferentKey/nestedDir; isDirectory=true; modification_time=0; access_time=0; owner=gss2002; group=gss2002; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=true; isErasureCoded=false} isEmptyDirectory=FALSE
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:492)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:377)
	at org.apache.hadoop.test.LambdaTestUtils.intercept(LambdaTestUtils.java:446)
	at org.apache.hadoop.fs.s3a.ITestS3AEncryptionSSEC.testCreateSubdirWithDifferentKey(ITestS3AEncryptionSSEC.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)

[INFO] Running org.apache.hadoop.fs.contract.s3a.ITestS3AContractRootDir
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.291 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractRootDir
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ITestS3AEncryptionSSEC.testCreateSubdirWithDifferentKey:124 Expected a java.nio.file.AccessDeniedException to be thrown, but got the result: : S3AFileStatus{path=s3a://techgssclasstest20221004/test/testCreateSubdirWithDifferentKey/nestedDir; isDirectory=true; modification_time=0; access_time=0; owner=gss2002; group=gss2002; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=true; isErasureCoded=false} isEmptyDirectory=FALSE
[ERROR]   ITestS3AEncryptionSSEC.testListEncryptedDir:208 Expecting java.nio.file.AccessDeniedException with text Service: Amazon S3; Status Code: 403; but got : void
[ERROR]   ITestS3AEncryptionSSEC.testListStatusEncryptedDir:253 Expecting java.nio.file.AccessDeniedException with text Service: Amazon S3; Status Code: 403; but got : void
[ERROR]   ITestTerasortMagicCommitter>AbstractCommitTerasortIT.test_110_teragen:167->AbstractCommitTerasortIT.executeStage:143->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 Teragen(1000, s3a://techgssclasstest20221004/terasort-ITestTerasortMagicCommitter/sortin) failed expected:<0> but was:<1>
[ERROR] Errors: 
[ERROR]   ITestTerasortMagicCommitter>AbstractCommitTerasortIT.test_120_terasort:177->AbstractCommitITest.loadSuccessFile:498 » FileNotFound
[ERROR]   ITestTerasortMagicCommitter>AbstractCommitTerasortIT.test_130_teravalidate:192->AbstractCommitITest.loadSuccessFile:498 » FileNotFound
[INFO] 
[ERROR] Tests run: 80, Failures: 4, Errors: 2, Skipped: 9
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24:30 min
[INFO] Finished at: 2022-10-19T16:37:20-04:00
[INFO] ------------------------------------------------------------------------