### PR TITLE
HADOOP-18499. S3A to support HTTPS web proxies 

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -213,7 +213,7 @@ public final class Constants {
   public static final String PROXY_DOMAIN = "fs.s3a.proxy.domain";
   public static final String PROXY_WORKSTATION = "fs.s3a.proxy.workstation";
   /** Is the proxy secured(proxyProtocol = HTTPS)? */
-  public static final String PROXY_SECURED = "fs.s3a.proxy.secured";
+  public static final String PROXY_SECURED = "fs.s3a.proxy.ssl.enabled";
 
   /**
    * Number of times the AWS client library should retry errors before

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -212,6 +212,8 @@ public final class Constants {
   public static final String PROXY_PASSWORD = "fs.s3a.proxy.password";
   public static final String PROXY_DOMAIN = "fs.s3a.proxy.domain";
   public static final String PROXY_WORKSTATION = "fs.s3a.proxy.workstation";
+  /** Is the proxy secured(proxyProtocol = HTTPS)? */
+  public static final String PROXY_SECURED = "fs.s3a.proxy.secured";
 
   /**
    * Number of times the AWS client library should retry errors before

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1351,13 +1351,17 @@ public final class S3AUtils {
         LOG.error(msg);
         throw new IllegalArgumentException(msg);
       }
+      boolean isProxySecured = conf.getBoolean(PROXY_SECURED, false);
       awsConf.setProxyUsername(proxyUsername);
       awsConf.setProxyPassword(proxyPassword);
       awsConf.setProxyDomain(conf.getTrimmed(PROXY_DOMAIN));
       awsConf.setProxyWorkstation(conf.getTrimmed(PROXY_WORKSTATION));
+      awsConf.setProxyProtocol(isProxySecured ? Protocol.HTTPS : Protocol.HTTP);
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Using proxy server {}:{} as user {} with password {} on " +
-                "domain {} as workstation {}", awsConf.getProxyHost(),
+        LOG.debug("Using proxy server {}://{}:{} as user {} with password {} "
+                + "on domain {} as workstation {}",
+            awsConf.getProxyProtocol(),
+            awsConf.getProxyHost(),
             awsConf.getProxyPort(),
             String.valueOf(awsConf.getProxyUsername()),
             awsConf.getProxyPassword(), awsConf.getProxyDomain(),

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AProxy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AProxy.java
@@ -26,6 +26,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 
 import static org.apache.hadoop.fs.s3a.Constants.PROXY_HOST;
 import static org.apache.hadoop.fs.s3a.Constants.PROXY_PORT;
@@ -35,11 +36,11 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides
 import static org.apache.hadoop.fs.s3a.S3AUtils.initProxySupport;
 
 /**
- * Unit tests to verify {@link S3AUtils} translates the proxy configurations
+ * Tests to verify {@link S3AUtils} translates the proxy configurations
  * are set correctly to Client configurations which are later used to construct
  * the proxy in AWS SDK.
  */
-public class TestS3AProxy extends AbstractS3ATestBase{
+public class ITestS3AProxy extends AbstractHadoopTestBase {
 
   /**
    * Verify Http proxy protocol.
@@ -73,17 +74,17 @@ public class TestS3AProxy extends AbstractS3ATestBase{
   /**
    * Assert that the configuration set for a proxy gets translated to Client
    * configuration with the correct protocol to be used by AWS SDK.
-   * @param proxyConfigForHttp Configurations used to set the proxy configs.
+   * @param proxyConfig Configuration used to set the proxy configs.
    * @param isExpectedSecured What is the expected protocol for the proxy to
    *                          be? true for https, and false for http.
    * @throws IOException
    */
-  private void verifyProxy(Configuration proxyConfigForHttp,
+  private void verifyProxy(Configuration proxyConfig,
       boolean isExpectedSecured)
       throws IOException {
     ClientConfiguration awsConf = new ClientConfiguration();
-    initProxySupport(proxyConfigForHttp,
-        getTestBucketName(getConfiguration()), awsConf);
+    initProxySupport(proxyConfig,
+        getTestBucketName(proxyConfig), awsConf);
     Assertions.assertThat(awsConf.getProxyProtocol())
         .describedAs("Proxy protocol not as expected")
         .isEqualTo(isExpectedSecured ? Protocol.HTTPS : Protocol.HTTP);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
@@ -80,7 +80,7 @@ public class TestS3AProxy extends AbstractHadoopTestBase {
       boolean isExpectedSecured)
       throws IOException {
     ClientConfiguration awsConf = new ClientConfiguration();
-    initProxySupport(proxyConfig,"test-bucket", awsConf);
+    initProxySupport(proxyConfig, "test-bucket", awsConf);
     Assertions.assertThat(awsConf.getProxyProtocol())
         .describedAs("Proxy protocol not as expected")
         .isEqualTo(isExpectedSecured ? Protocol.HTTPS : Protocol.HTTP);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
@@ -40,7 +40,7 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.initProxySupport;
  * are set correctly to Client configurations which are later used to construct
  * the proxy in AWS SDK.
  */
-public class ITestS3AProxy extends AbstractHadoopTestBase {
+public class TestS3AProxy extends AbstractHadoopTestBase {
 
   /**
    * Verify Http proxy protocol.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.test.AbstractHadoopTestBase;
 import static org.apache.hadoop.fs.s3a.Constants.PROXY_HOST;
 import static org.apache.hadoop.fs.s3a.Constants.PROXY_PORT;
 import static org.apache.hadoop.fs.s3a.Constants.PROXY_SECURED;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3AUtils.initProxySupport;
 
 /**
@@ -66,7 +64,6 @@ public class TestS3AProxy extends AbstractHadoopTestBase {
   @Test
   public void testProxyDefault() throws IOException {
     Configuration proxyConfigDefault = new Configuration();
-    removeBaseAndBucketOverrides(proxyConfigDefault, PROXY_SECURED);
     proxyConfigDefault.set(PROXY_HOST, "testProxyDefault");
     verifyProxy(proxyConfigDefault, false);
   }
@@ -83,8 +80,7 @@ public class TestS3AProxy extends AbstractHadoopTestBase {
       boolean isExpectedSecured)
       throws IOException {
     ClientConfiguration awsConf = new ClientConfiguration();
-    initProxySupport(proxyConfig,
-        getTestBucketName(proxyConfig), awsConf);
+    initProxySupport(proxyConfig,"test-bucket", awsConf);
     Assertions.assertThat(awsConf.getProxyProtocol())
         .describedAs("Proxy protocol not as expected")
         .isEqualTo(isExpectedSecured ? Protocol.HTTPS : Protocol.HTTP);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AProxy.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.apache.hadoop.fs.s3a.Constants.PROXY_HOST;
+import static org.apache.hadoop.fs.s3a.Constants.PROXY_PORT;
+import static org.apache.hadoop.fs.s3a.Constants.PROXY_SECURED;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.apache.hadoop.fs.s3a.S3AUtils.initProxySupport;
+
+/**
+ * Unit tests to verify {@link S3AUtils} translates the proxy configurations
+ * are set correctly to Client configurations which are later used to construct
+ * the proxy in AWS SDK.
+ */
+public class TestS3AProxy extends AbstractS3ATestBase{
+
+  /**
+   * Verify Http proxy protocol.
+   */
+  @Test
+  public void testProxyHttp() throws IOException {
+    Configuration proxyConfigForHttp = createProxyConfig(false);
+    verifyProxy(proxyConfigForHttp, false);
+  }
+
+  /**
+   * Verify Https proxy protocol.
+   */
+  @Test
+  public void testProxyHttps() throws IOException {
+    Configuration proxyConfigForHttps = createProxyConfig(true);
+    verifyProxy(proxyConfigForHttps, true);
+  }
+
+  /**
+   * Verify default proxy protocol.
+   */
+  @Test
+  public void testProxyDefault() throws IOException {
+    Configuration proxyConfigDefault = new Configuration();
+    removeBaseAndBucketOverrides(proxyConfigDefault, PROXY_SECURED);
+    proxyConfigDefault.set(PROXY_HOST, "testProxyDefault");
+    verifyProxy(proxyConfigDefault, false);
+  }
+
+  /**
+   * Assert that the configuration set for a proxy gets translated to Client
+   * configuration with the correct protocol to be used by AWS SDK.
+   * @param proxyConfigForHttp Configurations used to set the proxy configs.
+   * @param isExpectedSecured What is the expected protocol for the proxy to
+   *                          be? true for https, and false for http.
+   * @throws IOException
+   */
+  private void verifyProxy(Configuration proxyConfigForHttp,
+      boolean isExpectedSecured)
+      throws IOException {
+    ClientConfiguration awsConf = new ClientConfiguration();
+    initProxySupport(proxyConfigForHttp,
+        getTestBucketName(getConfiguration()), awsConf);
+    Assertions.assertThat(awsConf.getProxyProtocol())
+        .describedAs("Proxy protocol not as expected")
+        .isEqualTo(isExpectedSecured ? Protocol.HTTPS : Protocol.HTTP);
+  }
+
+  /**
+   * Create a configuration file with proxy configs.
+   * @param isSecured Should the configured proxy be secured or not?
+   * @return configuration.
+   */
+  private Configuration createProxyConfig(boolean isSecured) {
+    Configuration conf = new Configuration();
+    conf.set(PROXY_HOST, "testProxy");
+    conf.set(PROXY_PORT, "1234");
+    conf.setBoolean(PROXY_SECURED, isSecured);
+    return conf;
+  }
+}


### PR DESCRIPTION
### Description of PR
Support proxy protocol setting in S3A. 
Adding a config `fs.s3a.proxy.secured` which when set to `true` would set the proxyProtocol to "HTTPS", else "HTTP".

### How was this patch tested?
- Tested locally on an "HTTPS" proxy and connection was established.
- Unit test added.
- Full test suite tested successfully.
Region: `ap-south-1`
Command: `mvn clean verify -Dparallel-tests -DtestsThreadCount=4 -Dscale`
All tests passed.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

