### PR TITLE
YARN-11357. Fix FederationClientInterceptor#submitApplication Can't Update SubClusterId

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -543,7 +543,7 @@ public class FederationClientInterceptor
       ApplicationHomeSubCluster appHomeSubCluster =
           ApplicationHomeSubCluster.newInstance(applicationId, subClusterId);
 
-      if (exists || retryCount == 0) {
+      if (!exists || retryCount == 0) {
         addApplicationHomeSubCluster(applicationId, appHomeSubCluster);
       } else {
         updateApplicationHomeSubCluster(subClusterId, applicationId, appHomeSubCluster);
@@ -563,7 +563,7 @@ public class FederationClientInterceptor
     } catch (Exception e) {
       RouterAuditLogger.logFailure(user.getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, e.getMessage(), applicationId, subClusterId);
-      LOG.warn("Unable to submitApplication appId {} try #{} on SubCluster {} error = {}.",
+      LOG.warn("Unable to submitApplication appId {} try #{} on SubCluster {}.",
           applicationId, subClusterId, e);
       if (subClusterId != null) {
         blackList.add(subClusterId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -314,7 +314,7 @@ public class FederationClientInterceptor
     // Try calling the getNewApplication method
     List<SubClusterId> blacklist = new ArrayList<>();
     int activeSubClustersCount = getActiveSubClustersCount();
-    int actualRetryNums = Math.min(activeSubClustersCount, numSubmitRetries) + 1;
+    int actualRetryNums = Math.min(activeSubClustersCount, numSubmitRetries);
 
     try {
       GetNewApplicationResponse response =
@@ -470,7 +470,7 @@ public class FederationClientInterceptor
       // but if the number of Active SubClusters is less than this number at this time,
       // we should provide a high number of retry according to the number of Active SubClusters.
       int activeSubClustersCount = getActiveSubClustersCount();
-      int actualRetryNums = Math.min(activeSubClustersCount, numSubmitRetries) + 1;
+      int actualRetryNums = Math.min(activeSubClustersCount, numSubmitRetries);
 
       // Try calling the SubmitApplication method
       SubmitApplicationResponse response =
@@ -484,7 +484,7 @@ public class FederationClientInterceptor
         return response;
       }
 
-    } catch (Exception e){
+    } catch (Exception e) {
       routerMetrics.incrAppsFailedSubmitted();
       RouterServerUtil.logAndThrowException(e.getMessage(), e);
     }
@@ -564,7 +564,7 @@ public class FederationClientInterceptor
       RouterAuditLogger.logFailure(user.getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, e.getMessage(), applicationId, subClusterId);
       LOG.warn("Unable to submitApplication appId {} try #{} on SubCluster {}.",
-          applicationId, subClusterId, e);
+          applicationId, retryCount, subClusterId, e);
       if (subClusterId != null) {
         blackList.add(subClusterId);
       }
@@ -1947,5 +1947,10 @@ public class FederationClientInterceptor
             reservationId);
       }
     }
+  }
+
+  @VisibleForTesting
+  public void setNumSubmitRetries(int numSubmitRetries) {
+    this.numSubmitRetries = numSubmitRetries;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -330,7 +330,7 @@ public class TestFederationClientInterceptorRetry
     // We will get bad1
     checkSubmitSubCluster(appId, bad1);
 
-    // Set the retryNum to 1
+    // Set the retryNum to 2
     // 1st time will use bad2, 2nd time will use bad1, 3rd good
     interceptor.setNumSubmitRetries(2);
     SubmitApplicationResponse submitAppResponse = interceptor.submitApplication(request);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.server.federation.policies.manager.UniformBroadcastPolicyManager;
 import org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.store.records.GetApplicationHomeSubClusterRequest;
@@ -290,7 +289,7 @@ public class TestFederationClientInterceptorRetry
     LOG.info("Test submitApplication with two bad, one good SC.");
     setupCluster(Arrays.asList(bad1, bad2, good));
     final ApplicationId appId =
-       ApplicationId.newInstance(System.currentTimeMillis(), 1);
+        ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
     // Use the TestSequentialRouterPolicy strategy,
     // which will sort the SubClusterId because good=0, bad1=1, bad2=2
@@ -324,7 +323,8 @@ public class TestFederationClientInterceptorRetry
         stateStore.getApplicationHomeSubCluster(getAppRequest);
     Assert.assertNotNull(getAppResponse);
     Assert.assertNotNull(getAppResponse);
-    ApplicationHomeSubCluster responseHomeSubCluster = getAppResponse.getApplicationHomeSubCluster();
+    ApplicationHomeSubCluster responseHomeSubCluster =
+        getAppResponse.getApplicationHomeSubCluster();
     Assert.assertNotNull(responseHomeSubCluster);
     SubClusterId respSubClusterId = responseHomeSubCluster.getHomeSubCluster();
     Assert.assertEquals(expectSubCluster, respSubClusterId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.router.clientrm;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.FEDERATION_POLICY_MANAGER;
+import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -27,7 +28,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.MockApps;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationRequest;
@@ -51,6 +51,7 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUt
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -307,10 +308,8 @@ public class TestFederationClientInterceptorRetry
     LOG.info("Test submitApplication with two bad, one good SC.");
 
     // This test must require the TestSequentialRouterPolicy policy
-    if (StringUtils.equals(routerPolicyManagerName,
-        UniformBroadcastPolicyManager.class.getName())) {
-      return;
-    }
+    Assume.assumeThat(routerPolicyManagerName,
+        is(TestSequentialBroadcastPolicyManager.class.getName()));
 
     setupCluster(Arrays.asList(bad1, bad2, good));
     final ApplicationId appId =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -88,8 +88,6 @@ public class TestFederationClientInterceptorRetry
   @Override
   public void setUp() throws IOException {
     super.setUpConfig();
-    this.getConf().setStrings(FEDERATION_POLICY_MANAGER,
-        "org.apache.hadoop.yarn.server.router.clientrm.TestSequentialBroadcastPolicyManager");
     interceptor = new TestableFederationClientInterceptor();
 
     stateStore = new MemoryFederationStateStore();
@@ -154,7 +152,7 @@ public class TestFederationClientInterceptorRetry
             + "," + TestableFederationClientInterceptor.class.getName());
 
     conf.set(FEDERATION_POLICY_MANAGER,
-        UniformBroadcastPolicyManager.class.getName());
+        TestSequentialBroadcastPolicyManager.class.getName());
 
     // Disable StateStoreFacade cache
     conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 0);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialBroadcastPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialBroadcastPolicyManager.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.router.clientrm;
+
+import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.BroadcastAMRMProxyPolicy;
+import org.apache.hadoop.yarn.server.federation.policies.manager.AbstractPolicyManager;
+
+public class TestSequentialBroadcastPolicyManager extends AbstractPolicyManager {
+  public TestSequentialBroadcastPolicyManager() {
+    // this structurally hard-codes two compatible policies for Router and
+    // AMRMProxy.
+    routerFederationPolicy = TestSequentialRouterPolicy.class;
+    amrmProxyFederationPolicy = BroadcastAMRMProxyPolicy.class;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialBroadcastPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialBroadcastPolicyManager.java
@@ -21,6 +21,14 @@ package org.apache.hadoop.yarn.server.router.clientrm;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.BroadcastAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.manager.AbstractPolicyManager;
 
+/**
+ * This PolicyManager is used for testing and will contain the
+ * {@link TestSequentialRouterPolicy} policy.
+ *
+ * When we test FederationClientInterceptor Retry,
+ * we hope that SubCluster can return in a certain order, not randomly.
+ * We can view the policy description by linking to TestSequentialRouterPolicy.
+ */
 public class TestSequentialBroadcastPolicyManager extends AbstractPolicyManager {
   public TestSequentialBroadcastPolicyManager() {
     // this structurally hard-codes two compatible policies for Router and

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
@@ -43,7 +43,8 @@ import java.util.Map;
  * We have 4 subClusters, 2 normal subClusters, 2 bad subClusters.
  * We expect to select badSubClusters first and then goodSubClusters during testing.
  * We can set the subCluster like this, good1 = [0], good2 = [1], bad1 = [2], bad2 = [3].
- * This strategy will return [3, 2, 1, 0], The selection order of subCluster is bad2, bad1, good2, good1.
+ * This strategy will return [3, 2, 1, 0],
+ * The selection order of subCluster is bad2, bad1, good2, good1.
  */
 public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
@@ -31,6 +31,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This is a test strategy,
+ * the purpose of this strategy is to return subClusters in descending order of subClusterId.
+ *
+ * This strategy is to verify the situation of Retry during the use of FederationClientInterceptor.
+ * The conditions of use are as follows:
+ * 1.We require subClusterId to be an integer.
+ * 2.The larger the subCluster, the sooner the representative is selected.
+ *
+ * We have 4 subClusters, 2 normal subClusters, 2 bad subClusters.
+ * We expect to select badSubClusters first and then goodSubClusters during testing.
+ * We can set the subCluster like this, good1 = [0], good2 = [1], bad1 = [2], bad2 = [3].
+ * This strategy will return [3, 2, 1, 0], The selection order of subCluster is bad2, bad1, good2, good1.
+ */
 public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
 
   @Override
@@ -52,7 +66,7 @@ public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
       * Return to badCluster first.
       */
     List<SubClusterId> subClusterIds = new ArrayList<>(preSelectSubClusters.keySet());
-    if(subClusterIds.size() > 1){
+    if (subClusterIds.size() > 1) {
       subClusterIds.sort((o1, o2) -> Integer.parseInt(o2.getId()) - Integer.parseInt(o1.getId()));
     }
     if(CollectionUtils.isNotEmpty(subClusterIds)){

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
@@ -35,7 +35,7 @@ public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
 
   @Override
   public void reinitialize(FederationPolicyInitializationContext policyContext)
-    throws FederationPolicyInitializationException {
+      throws FederationPolicyInitializationException {
     FederationPolicyInitializationContextValidator.validate(policyContext,
         this.getClass().getCanonicalName());
     setPolicyContext(policyContext);
@@ -43,7 +43,7 @@ public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
 
   @Override
   protected SubClusterId chooseSubCluster(String queue,
-    Map<SubClusterId, SubClusterInfo> preSelectSubClusters) throws YarnException {
+      Map<SubClusterId, SubClusterInfo> preSelectSubClusters) throws YarnException {
     /**
       * This strategy is only suitable for testing. We need to obtain subClusters sequentially.
       * We have 3 subClusters, 1 goodSubCluster and 2 badSubClusters.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestSequentialRouterPolicy.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.router.clientrm;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
+import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContextValidator;
+import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
+import org.apache.hadoop.yarn.server.federation.policies.router.AbstractRouterPolicy;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
+import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TestSequentialRouterPolicy extends AbstractRouterPolicy {
+
+  @Override
+  public void reinitialize(FederationPolicyInitializationContext policyContext)
+    throws FederationPolicyInitializationException {
+    FederationPolicyInitializationContextValidator.validate(policyContext,
+        this.getClass().getCanonicalName());
+    setPolicyContext(policyContext);
+  }
+
+  @Override
+  protected SubClusterId chooseSubCluster(String queue,
+    Map<SubClusterId, SubClusterInfo> preSelectSubClusters) throws YarnException {
+    /**
+      * This strategy is only suitable for testing. We need to obtain subClusters sequentially.
+      * We have 3 subClusters, 1 goodSubCluster and 2 badSubClusters.
+      * The sc-id of goodSubCluster is 0, and the sc-id of badSubCluster is 1 and 2.
+      * We hope Return in reverse order, that is, return 2, 1, 0
+      * Return to badCluster first.
+      */
+    List<SubClusterId> subClusterIds = new ArrayList<>(preSelectSubClusters.keySet());
+    if(subClusterIds.size() > 1){
+      subClusterIds.sort((o1, o2) -> Integer.parseInt(o2.getId()) - Integer.parseInt(o1.getId()));
+    }
+    if(CollectionUtils.isNotEmpty(subClusterIds)){
+      return subClusterIds.get(0);
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
JIRA: YARN-11357. Fix FederationClientInterceptor#submitApplication Can't Update SubClusterId.

**The reason for the test failure:**

In [YARN-11342](https://issues.apache.org/jira/browse/YARN-11342) (#5005), I refactored the getNewApplication, submitApplication method, but in the process of implementation, the judgment condition of if was written incorrectly.

If subCluster does not exist, we should add subCluster, if subCluster exists, we should update subCluster.

```
...
// Step2. Query homeSubCluster according to ApplicationId.
Boolean exists = existsApplicationHomeSubCluster(applicationId);

ApplicationHomeSubCluster appHomeSubCluster =
ApplicationHomeSubCluster.newInstance(applicationId, subClusterId);

// should be !exists
if (exists || retryCount == 0){ 
    addApplicationHomeSubCluster(applicationId, appHomeSubCluster); 
}
else{ 
   updateApplicationHomeSubCluster(subClusterId, applicationId, appHomeSubCluster); 
}
```

**Q1：Why is the unit test for YARN-11342 passing?**

In this test report(#4982 [TestReport](https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-4982/11/testReport/)).

I found that `TestFederationClientInterceptorRetry#testSubmitApplicationOneBadOneGood` was abnormal.
In this test(`testSubmitApplicationOneBadOneGood`), we should get good subCluster, but it returns bad SubCluster.
When I tested it locally, I found that this unit test sometimes succeeded and sometimes failed.

```
@Test
public void testSubmitApplicationOneBadOneGood()
      throws YarnException, IOException, InterruptedException {
    ....
    ApplicationHomeSubCluster responseHomeSubCluster =
        getAppResponse.getApplicationHomeSubCluster();
    Assert.assertNotNull(responseHomeSubCluster);
    SubClusterId respSubClusterId = responseHomeSubCluster.getHomeSubCluster();
    Assert.assertEquals(good, respSubClusterId);
}
```


This is related to the `UniformBroadcastPolicyManager`, `UniformRandomRouterPolicy` is used, this policy will randomly 
Select 1 SubCluster from Active SubClusters.

```
public class UniformBroadcastPolicyManager extends AbstractPolicyManager {
  public UniformBroadcastPolicyManager() {
    // this structurally hard-codes two compatible policies for Router and
    // AMRMProxy.
    routerFederationPolicy = UniformRandomRouterPolicy.class;
    amrmProxyFederationPolicy = BroadcastAMRMProxyPolicy.class;
  }
}
```

If we get the good subCluster for the first time, then this test can be executed successfully, but if we get the bad subCluster for the first time, then we will retry 3 times, because the judgment of `FederationClientInterceptor#submitApplication` is wrong, As a result, the good subcluster cannot be updated to the stateStore. So We get the wrong subcluster.

**Q2: How can we verify that this part of the code is accurate after modification.**
For unit testing, I redesigned a new RouterPolicy#TestSequentialRouterPolicy, which can return SubClusterId in order.

**Example:**
We have 3 subClusters, 1 goodSubCluster and 2 badSubClusters.
The scId of goodSubCluster is 0, and the scId of badSubCluster is 1 and 2. We hope  Return to badSubCluster first.
We want to return the badSubCluster first, we can sort the subClusterId in reverse order, so we can get [2, 1, 0], which is [bad2,bad1,good]

**Test case 1:**
We set the number of retries to 1, and then `submitApplication` will be executed 2 times. 
The 1st , `bad2` will be selected, The 2nd, `bad1` will be selected. 

If we query the StateStore we should get `bad1`.

**Test case 2:**
We set the number of retries to 2, and then `submitApplication` will be executed 3 times. 
The 1st , `bad2` will be selected, The 2nd, `bad1` will be selected, The 3rd good cluster will be selected.

If we query the StateStore we should get `good`.